### PR TITLE
chore: update sdk version in web3 package

### DIFF
--- a/packages/web3/package.json
+++ b/packages/web3/package.json
@@ -24,7 +24,7 @@
     "@celo/rainbowkit-celo": "^0.11.2",
     "@ethersproject/address": "^5.8.0",
     "@ethersproject/units": "^5.8.0",
-    "@mento-protocol/mento-sdk": "^1.10.1",
+    "@mento-protocol/mento-sdk": "^1.10.3",
     "@metamask/jazzicon": "https://github.com/jmrossy/jazzicon#7a8df28",
     "@rainbow-me/rainbowkit": "0.12.16",
     "@repo/typescript-config": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -666,8 +666,8 @@ importers:
         specifier: ^5.8.0
         version: 5.8.0
       '@mento-protocol/mento-sdk':
-        specifier: ^1.10.1
-        version: 1.10.2(ethers@5.8.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+        specifier: ^1.10.3
+        version: 1.10.3(ethers@5.8.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       '@metamask/jazzicon':
         specifier: https://github.com/jmrossy/jazzicon#7a8df28
         version: https://codeload.github.com/jmrossy/jazzicon/tar.gz/7a8df28


### PR DESCRIPTION
## Description
The reason for the failing swaps was that the sdk routed didn't came from the local sdk package in the app.mento.org app but from the web3 package in this repo. This package was still referencing the old sdk version.

## Tested
performed a celo -> cREAL swap through the ui 
https://celoscan.io/tx/0xaa44879b28808bddd1fe5ce2ea8c78d8d75f1fb4e314c03c819688064b90ea28