### PR TITLE
feat(gov): add 'canceled' state for proposals

### DIFF
--- a/apps/governance.mento.org/app/components/proposal-list.tsx
+++ b/apps/governance.mento.org/app/components/proposal-list.tsx
@@ -164,7 +164,7 @@ export const ProposalList = () => {
                 case ProposalState.Executed:
                   return "executed";
                 case ProposalState.Canceled:
-                  return "defeated";
+                  return "canceled";
                 case ProposalState.Expired:
                   return "default";
                 default:

--- a/apps/governance.mento.org/app/components/voting/vote-card.tsx
+++ b/apps/governance.mento.org/app/components/voting/vote-card.tsx
@@ -325,6 +325,7 @@ export const VoteCard = ({
     proposalState === ProposalState.Queued ||
     proposalState === ProposalState.Executed;
   const isRejected = proposalState === ProposalState.Defeated;
+  const isCanceled = proposalState === ProposalState.Canceled;
   const isAbstained =
     proposalState === ProposalState.Defeated &&
     abstainVotes > forVotes &&
@@ -370,6 +371,8 @@ export const VoteCard = ({
           return "succeeded";
         case ProposalState.Defeated:
           return "defeated";
+        case ProposalState.Canceled:
+          return "canceled";
         case ProposalState.Expired:
           return "expired";
         case ProposalState.Pending:
@@ -420,6 +423,8 @@ export const VoteCard = ({
         if (isAbstained) return "Majority Abstained";
         if (!hasQuorum) return "Quorum Not Met";
         return "Proposal Defeated";
+      case "canceled":
+        return "Proposal Canceled";
       case "expired":
         return "Proposal Expired";
       case "pending":
@@ -993,6 +998,7 @@ export const VoteCard = ({
               >
                 {isApproved && <CircleCheck size={32} />}
                 {isRejected && <XCircle size={32} />}
+                {isCanceled && <XCircle size={32} />}
                 {title}
               </CardTitle>
 

--- a/apps/governance.mento.org/app/proposals/[id]/page.tsx
+++ b/apps/governance.mento.org/app/proposals/[id]/page.tsx
@@ -212,7 +212,7 @@ export default function ProposalPage() {
       case ProposalState.Executed:
         return "executed";
       case ProposalState.Canceled:
-        return "defeated";
+        return "canceled";
       case ProposalState.Expired:
         return "default";
       default:

--- a/packages/ui/src/components/ui/proposal-status.tsx
+++ b/packages/ui/src/components/ui/proposal-status.tsx
@@ -16,6 +16,7 @@ const proposalStatusVariants = cva(
         queued: "bg-[var(--queued)]",
         succeeded: "bg-[var(--succeeded)]",
         defeated: "bg-[var(--defeated)]",
+        canceled: "bg-[var(--canceled)]",
       },
     },
     defaultVariants: {

--- a/packages/ui/src/theme.css
+++ b/packages/ui/src/theme.css
@@ -51,6 +51,7 @@
   --queued: oklch(0.5717 0.099255 211.0725);
   --succeeded: oklch(0.5717 0.099255 255.0725);
   --defeated: oklch(0.476 0.216863 330.1079);
+  --canceled: oklch(0.5474 0.1933 26.43);
   --expired: oklch(0.2613 0.0288 302.75);
   --expired-text: oklch(0.7429 0.0118 303.05);
   --index: oklch(0.6416 0.0108 305.31);
@@ -111,6 +112,7 @@
   --queued: oklch(0.5717 0.099255 211.0725);
   --succeeded: oklch(0.5717 0.099255 255.0725);
   --defeated: oklch(0.476 0.216863 330.1079);
+  --canceled: oklch(0.5474 0.1933 26.43);
   --expired: oklch(0.2613 0.0288 302.75);
   --expired-text: oklch(0.7429 0.0118 303.05);
   --index: oklch(0.6416 0.0108 305.31);


### PR DESCRIPTION
we didn't have an explicit "cancelled" state for proposals so far, we were just commingling them with the "defeated" state

### How to test
- [ ] Check out the preview deployment
- [ ] See that the cancelled state makes sense on both proposal list and details page for MGP-7
- [ ] Check the code
- [ ] Rejoice