### PR TITLE
fix: format balance by rounding down

### DIFF
--- a/apps/app.mento.org/app/components/swap/swap-form.tsx
+++ b/apps/app.mento.org/app/components/swap/swap-form.tsx
@@ -377,10 +377,7 @@ export default function SwapForm() {
     const maxAmountBigInt = BigInt(maxAmountInWei);
     const decimals = getTokenDecimals(tokenInId);
 
-    const formattedAmount = formatBalance(
-      maxAmountBigInt.toString(),
-      decimals,
-    );
+    const formattedAmount = formatBalance(maxAmountBigInt.toString(), decimals);
     form.setValue("amount", formattedAmount);
     form.setValue("direction", "in");
 

--- a/apps/app.mento.org/app/components/swap/swap-form.tsx
+++ b/apps/app.mento.org/app/components/swap/swap-form.tsx
@@ -25,6 +25,7 @@ import {
   confirmViewAtom,
   ConnectButton,
   formatWithMaxDecimals,
+  formatBalance,
   formValuesAtom,
   fromWeiRounded,
   logger,
@@ -117,8 +118,7 @@ export default function SwapForm() {
   // Get token balances
   const fromTokenBalance = useMemo(() => {
     const balanceValue = balances[tokenInId as keyof typeof balances];
-    const balance = fromWeiRounded(balanceValue, getTokenDecimals(tokenInId));
-    return formatWithMaxDecimals(balance || "0.00");
+    return formatBalance(balanceValue, getTokenDecimals(tokenInId));
   }, [balances, tokenInId]);
 
   const toTokenBalance = useMemo(() => {
@@ -377,11 +377,11 @@ export default function SwapForm() {
     const maxAmountBigInt = BigInt(maxAmountInWei);
     const decimals = getTokenDecimals(tokenInId);
 
-    const formattedAmount = fromWeiRounded(
+    const formattedAmount = formatBalance(
       maxAmountBigInt.toString(),
       decimals,
     );
-    form.setValue("amount", formatWithMaxDecimals(formattedAmount, 4, false));
+    form.setValue("amount", formattedAmount);
     form.setValue("direction", "in");
 
     if (tokenInId === "CELO") {

--- a/packages/web3/src/features/swap/utils.ts
+++ b/packages/web3/src/features/swap/utils.ts
@@ -59,15 +59,16 @@ export function invertExchangeRate(rate: NumberT) {
   }
 }
 
-export const formatBalance = (
-  value: string,
-  decimals: number,
-): string => {
-  const formatted = ethers.utils.formatUnits(value, decimals);
-  const decimalPoint = formatted.indexOf('.');
-  if (decimalPoint === -1) return formatted;
-  return formatted.slice(0, decimalPoint + 5);
-}
+export const formatBalance = (value: string, decimals: number): string => {
+  try {
+    const formatted = ethers.utils.formatUnits(value, decimals);
+    const decimalPoint = formatted.indexOf(".");
+    if (decimalPoint === -1) return formatted;
+    return formatted.slice(0, decimalPoint + 5);
+  } catch {
+    return "0";
+  }
+};
 
 export const formatWithMaxDecimals = (
   value: string,

--- a/packages/web3/src/features/swap/utils.ts
+++ b/packages/web3/src/features/swap/utils.ts
@@ -59,6 +59,16 @@ export function invertExchangeRate(rate: NumberT) {
   }
 }
 
+export const formatBalance = (
+  value: string,
+  decimals: number,
+): string => {
+  const formatted = ethers.utils.formatUnits(value, decimals);
+  const decimalPoint = formatted.indexOf('.');
+  if (decimalPoint === -1) return formatted;
+  return formatted.slice(0, decimalPoint + 5);
+}
+
 export const formatWithMaxDecimals = (
   value: string,
   maxDecimals = 4,


### PR DESCRIPTION
Before:

- Have a balance of `97878850000000000` Celo (in wei)
- Click "Max amount" when swapping out of celo
- The field gets filled with 0.0979 (it's rounded up, the transaction will fail because balance is insufficient)

After:

- Have a balance of `97878850000000000` Celo (in wei)
- Click "Max amount" when swapping out of celo
- The field gets filled with 0.0978 (it's rounded down, the transaction will pass because balance is sufficient)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce `formatBalance` and use it in swap form to truncate balances to 4 decimals (no rounding up), fixing Max amount precision issues.
> 
> - **Swap UI**:
>   - **`apps/app.mento.org/app/components/swap/swap-form.tsx`**:
>     - Use `formatBalance` for `fromTokenBalance` display and when setting Max amount, ensuring truncation (no rounding up).
> - **Utils**:
>   - **`packages/web3/src/features/swap/utils.ts`**:
>     - Add `formatBalance(value, decimals)` to format units and truncate to 4 decimals.
>     - Keep existing `formatWithMaxDecimals` for other cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3a43a9e397620ad81212dd7139e8debe4e3043fd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->