### PR TITLE
fix: replace explorer url for sepolia chain

### DIFF
--- a/packages/web3/src/config/chains.ts
+++ b/packages/web3/src/config/chains.ts
@@ -11,6 +11,13 @@ export enum ChainId {
 
 export const CeloSepolia: MentoChain = {
   ...celoSepolia,
+  blockExplorers: {
+    default: {
+      name: "Celo Sepolia Explorer",
+      url: "https://sepolia.celoscan.io",
+      apiUrl: "https://sepolia.celoscan.io/api",
+    },
+  },
   contracts: {
     ...celoSepolia.contracts,
     ...transformToChainContracts(addresses[celoSepolia.id]),


### PR DESCRIPTION
# Description
We were using the Blockscout Explorer for the Sepolia chain; I replaced it with the Sepolia Celo Scan.

`https://celo-sepolia.blockscout.com/` ---> `https://sepolia.celoscan.io/`

# Testing
App-Mento:
Successfully swap and check its TX's link in the notification toast.

Governance:
Open any of the Contract Addresses on the root page.