### PR TITLE
fix: specify buy amount for swap page

### DIFF
--- a/apps/app.mento.org/app/components/swap/swap-form.tsx
+++ b/apps/app.mento.org/app/components/swap/swap-form.tsx
@@ -81,6 +81,7 @@ export default function SwapForm() {
   const [formValues, setFormValues] = useAtom(formValuesAtom);
   const [, setConfirmView] = useAtom(confirmViewAtom);
   const [isApprovalProcessing, setIsApprovalProcessing] = useState(false);
+  const [direction, setDirection] = useState<"in" | "out">("in");
 
   const { data: balancesFromHook } = useAccountBalances({ address, chainId });
   const balances = balancesFromHook || defaultEmptyBalances;
@@ -90,6 +91,7 @@ export default function SwapForm() {
   const amountRef = useRef<HTMLInputElement>(null);
   const quoteRef = useRef<HTMLInputElement>(null);
   const prevTradingSuspensionErrorRef = useRef<string | null>(null);
+  const latestRateRef = useRef<number | null>(null);
 
   const form = useForm<FormValues>({
     resolver: zodResolver(formSchema),
@@ -341,6 +343,12 @@ export default function SwapForm() {
     form.setValue("tokenOutSymbol", currentTokenInSymbol);
     form.setValue("amount", currentAmount);
     form.setValue("quote", "");
+    setDirection("in");
+    if (latestRateRef.current && latestRateRef.current > 0) {
+      latestRateRef.current = 1 / latestRateRef.current;
+    } else {
+      latestRateRef.current = null;
+    }
   };
 
   const handleUseMaxBalance = () => {
@@ -356,6 +364,7 @@ export default function SwapForm() {
       false,
     );
     form.setValue("amount", formattedAmountWithMaxDecimals);
+    setDirection("in");
 
     if (tokenInSymbol === "CELO") {
       toast.success("Max balance used", {
@@ -404,6 +413,14 @@ export default function SwapForm() {
     tokenInSymbol,
     tokenOutSymbol,
   );
+
+  useEffect(() => {
+    const numAmount = Number(amount);
+    const numQuote = Number(quote);
+    if (numAmount > 0 && numQuote > 0) {
+      latestRateRef.current = numAmount / numQuote;
+    }
+  }, [rate, amount, quote]);
 
   useEffect(() => {
     setTradingLimitError(null);
@@ -552,7 +569,6 @@ export default function SwapForm() {
     ],
   );
 
-  // Direction is always "in" - selling exact amount of tokenIn to receive tokenOut
   const sellUSDValue = useMemo(() => {
     return tokenInSymbol === "USDm" ? amount || "0" : fromTokenUSDValue || "0";
   }, [tokenInSymbol, amount, fromTokenUSDValue]);
@@ -632,7 +648,7 @@ export default function SwapForm() {
     });
 
   useEffect(() => {
-    if (quote !== undefined) {
+    if (quote !== undefined && direction !== "out") {
       const formattedQuote = formatWithMaxDecimals(quote, 4, false);
       if (formQuote !== formattedQuote) {
         form.setValue("quote", formattedQuote, {
@@ -640,7 +656,7 @@ export default function SwapForm() {
         });
       }
     }
-  }, [quote, form, formQuote]);
+  }, [quote, form, formQuote, direction]);
 
   // Show error toasts based on form errors
   useEffect(() => {
@@ -759,6 +775,9 @@ export default function SwapForm() {
                           const val =
                             typeof e === "string" ? e : e.target.value;
                           field.onChange(val);
+                          if (direction !== "in") {
+                            setDirection("in");
+                          }
                         }}
                         onBlur={field.onBlur}
                       />
@@ -861,12 +880,49 @@ export default function SwapForm() {
                         data-testid="buyAmountInput"
                         placeholder="0"
                         value={
-                          formQuote && formQuote !== "0" && formQuote !== "0.00"
-                            ? formQuote
-                            : ""
+                          direction === "out"
+                            ? (field.value ?? "")
+                            : formQuote &&
+                                formQuote !== "0" &&
+                                formQuote !== "0.00"
+                              ? formQuote
+                              : ""
                         }
-                        readOnly
-                        disabled
+                        onChange={(e) => {
+                          const val =
+                            typeof e === "string" ? e : e.target.value;
+                          field.onChange(val);
+                          if (direction !== "out") {
+                            setDirection("out");
+                          }
+
+                          const currentRate = latestRateRef.current;
+                          if (
+                            currentRate &&
+                            currentRate > 0 &&
+                            val &&
+                            Number(val) > 0
+                          ) {
+                            const estimatedSell = Number(val) * currentRate;
+                            form.setValue(
+                              "amount",
+                              formatWithMaxDecimals(
+                                String(estimatedSell),
+                                4,
+                                false,
+                              ),
+                              { shouldValidate: true },
+                            );
+                          } else if (val && Number(val) > 0) {
+                            form.setValue("amount", val, {
+                              shouldValidate: true,
+                            });
+                          } else {
+                            form.setValue("amount", "", {
+                              shouldValidate: true,
+                            });
+                          }
+                        }}
                         onBlur={field.onBlur}
                       />
                     </FormControl>

--- a/apps/app.mento.org/app/components/swap/swap-form/buy-token-input.tsx
+++ b/apps/app.mento.org/app/components/swap/swap-form/buy-token-input.tsx
@@ -1,0 +1,175 @@
+"use client";
+
+import { TokenIcon } from "@repo/ui";
+import {
+  CoinInput,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@repo/ui";
+import { type TokenWithBalance, formatWithMaxDecimals } from "@repo/web3";
+import type { TokenSymbol } from "@mento-protocol/mento-sdk";
+import { ChevronDown } from "lucide-react";
+import { useCallback, type MutableRefObject, type RefObject } from "react";
+import { Controller, type UseFormReturn } from "react-hook-form";
+import TokenDialog from "../token-dialog";
+import type { FormValues } from "./types";
+import { tokenButtonClassName } from "./types";
+
+interface BuyTokenInputProps {
+  form: UseFormReturn<FormValues>;
+  direction: "in" | "out";
+  setDirection: (d: "in" | "out") => void;
+  quoteRef: RefObject<HTMLInputElement | null>;
+  formQuote: string;
+  latestRateRef: MutableRefObject<number | null>;
+  buyUSDValue: string;
+  toTokenBalance: string;
+  tokenInSymbol: TokenSymbol;
+  allTokenOptions: TokenWithBalance[];
+  setLastChangedToken: (t: "from" | "to" | null) => void;
+  handleUseMaxBuyBalance: () => void;
+}
+
+export function BuyTokenInput({
+  form,
+  direction,
+  setDirection,
+  quoteRef,
+  formQuote,
+  latestRateRef,
+  buyUSDValue,
+  toTokenBalance,
+  tokenInSymbol,
+  allTokenOptions,
+  setLastChangedToken,
+  handleUseMaxBuyBalance,
+}: BuyTokenInputProps) {
+  const handleBuyAmountChange = useCallback(
+    (
+      e: React.ChangeEvent<HTMLInputElement> | string,
+      fieldOnChange: (value: string) => void,
+    ) => {
+      const value = typeof e === "string" ? e : e.target.value;
+      fieldOnChange(value);
+      if (direction !== "out") {
+        setDirection("out");
+      }
+
+      const currentRate = latestRateRef.current;
+      if (currentRate && currentRate > 0 && value && Number(value) > 0) {
+        const estimatedSell = Number(value) * currentRate;
+        form.setValue(
+          "amount",
+          formatWithMaxDecimals(String(estimatedSell), 4, false),
+          { shouldValidate: true },
+        );
+      } else if (value && Number(value) > 0) {
+        form.setValue("amount", value, { shouldValidate: true });
+      } else {
+        form.setValue("amount", "", { shouldValidate: true });
+      }
+    },
+    [direction, setDirection, latestRateRef, form],
+  );
+
+  return (
+    <div
+      className="maybe-hover:border-border-secondary gap-4 p-4 grid grid-cols-12 border border-border bg-incard transition-colors focus-within:!border-primary dark:border-input dark:focus-within:!border-primary"
+      onClick={() => {
+        quoteRef.current?.focus();
+      }}
+    >
+      <div className="col-span-8">
+        <Controller
+          control={form.control}
+          name="quote"
+          render={({ field, fieldState }) => (
+            <FormItem>
+              <FormLabel>Buy</FormLabel>
+              <FormControl>
+                <CoinInput
+                  ref={quoteRef}
+                  data-testid="buyAmountInput"
+                  placeholder="0"
+                  value={
+                    direction === "out"
+                      ? (field.value ?? "")
+                      : formQuote && formQuote !== "0" && formQuote !== "0.00"
+                        ? formQuote
+                        : ""
+                  }
+                  onChange={(e) => handleBuyAmountChange(e, field.onChange)}
+                  onBlur={field.onBlur}
+                />
+              </FormControl>
+              <FormDescription data-testid="buyUsdAmountLabel">
+                ~${formatWithMaxDecimals(buyUSDValue)}
+              </FormDescription>
+              <FormMessage>{fieldState.error?.message}</FormMessage>
+            </FormItem>
+          )}
+        />
+      </div>
+
+      <div className="col-span-4 flex flex-row items-center justify-end">
+        <FormField
+          control={form.control}
+          name="tokenOutSymbol"
+          render={({ field }) => (
+            <FormItem className="flex flex-col items-end justify-end">
+              <FormControl>
+                <TokenDialog
+                  value={field.value}
+                  onValueChange={(value) => {
+                    field.onChange(value);
+                    setLastChangedToken("to");
+                  }}
+                  title="Select asset to buy"
+                  excludeTokenSymbol={tokenInSymbol}
+                  filterByTokenSymbol={tokenInSymbol}
+                  onClose={() => {
+                    setTimeout(() => {
+                      quoteRef.current?.focus();
+                    }, 500);
+                  }}
+                  trigger={
+                    <button
+                      type="button"
+                      className={tokenButtonClassName}
+                      data-testid="selectBuyTokenButton"
+                    >
+                      <TokenIcon
+                        token={allTokenOptions.find(
+                          (token) => token.symbol === field.value,
+                        )}
+                        className="mr-2"
+                        size={20}
+                      />
+                      <span>{field.value || "Select"}</span>
+                      <ChevronDown className="h-4 w-4 opacity-50" />
+                    </button>
+                  }
+                />
+              </FormControl>
+              <FormDescription className="w-fit whitespace-nowrap">
+                Balance: {toTokenBalance}{" "}
+                <button
+                  type="button"
+                  className="p-0 cursor-pointer border-none bg-transparent text-inherit underline"
+                  onClick={handleUseMaxBuyBalance}
+                >
+                  MAX
+                </button>
+              </FormDescription>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/app.mento.org/app/components/swap/swap-form/buy-token-input.tsx
+++ b/apps/app.mento.org/app/components/swap/swap-form/buy-token-input.tsx
@@ -62,14 +62,14 @@ export function BuyTokenInput({
       const currentRate = latestRateRef.current;
       if (currentRate && currentRate > 0 && value && Number(value) > 0) {
         const estimatedSell = Number(value) * currentRate;
-        form.setValue(
-          "amount",
-          formatWithMaxDecimals(String(estimatedSell), 4, false),
-          { shouldValidate: true },
-        );
-      } else if (value && Number(value) > 0) {
-        form.setValue("amount", value, { shouldValidate: true });
-      } else {
+        if (Number.isFinite(estimatedSell) && estimatedSell < 1e18) {
+          form.setValue(
+            "amount",
+            formatWithMaxDecimals(String(estimatedSell), 4, false),
+            { shouldValidate: true },
+          );
+        }
+      } else if (!value || Number(value) <= 0) {
         form.setValue("amount", "", { shouldValidate: true });
       }
     },

--- a/apps/app.mento.org/app/components/swap/swap-form/index.tsx
+++ b/apps/app.mento.org/app/components/swap/swap-form/index.tsx
@@ -1,0 +1,1 @@
+export { default } from "./swap-form";

--- a/apps/app.mento.org/app/components/swap/swap-form/sell-token-input.tsx
+++ b/apps/app.mento.org/app/components/swap/swap-form/sell-token-input.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+import { TokenIcon } from "@repo/ui";
+import {
+  CoinInput,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@repo/ui";
+import { type TokenWithBalance, formatWithMaxDecimals } from "@repo/web3";
+import type { TokenSymbol } from "@mento-protocol/mento-sdk";
+import { ChevronDown } from "lucide-react";
+import type { RefObject } from "react";
+import { Controller, type UseFormReturn } from "react-hook-form";
+import TokenDialog from "../token-dialog";
+import type { FormValues } from "./types";
+import { tokenButtonClassName } from "./types";
+
+interface SellTokenInputProps {
+  form: UseFormReturn<FormValues>;
+  direction: "in" | "out";
+  setDirection: (d: "in" | "out") => void;
+  amountRef: RefObject<HTMLInputElement | null>;
+  validateAmount: (value: string) => Promise<string | true>;
+  sellUSDValue: string;
+  fromTokenBalance: string;
+  handleUseMaxBalance: () => void;
+  tokenOutSymbol: TokenSymbol;
+  allTokenOptions: TokenWithBalance[];
+  setLastChangedToken: (t: "from" | "to" | null) => void;
+}
+
+export function SellTokenInput({
+  form,
+  direction,
+  setDirection,
+  amountRef,
+  validateAmount,
+  sellUSDValue,
+  fromTokenBalance,
+  handleUseMaxBalance,
+  tokenOutSymbol,
+  allTokenOptions,
+  setLastChangedToken,
+}: SellTokenInputProps) {
+  return (
+    <div
+      className="maybe-hover:border-border-secondary gap-4 p-4 grid grid-cols-12 border border-border bg-incard transition-colors focus-within:!border-primary dark:border-input dark:focus-within:!border-primary"
+      onClick={() => {
+        amountRef.current?.focus();
+      }}
+    >
+      <div className="col-span-8">
+        <Controller
+          control={form.control}
+          name="amount"
+          rules={{
+            validate: validateAmount,
+          }}
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Sell</FormLabel>
+              <FormControl>
+                <CoinInput
+                  ref={amountRef}
+                  data-testid="sellAmountInput"
+                  placeholder="0"
+                  value={field.value}
+                  onChange={(e) => {
+                    const val = typeof e === "string" ? e : e.target.value;
+                    field.onChange(val);
+                    if (direction !== "in") {
+                      setDirection("in");
+                    }
+                  }}
+                  onBlur={field.onBlur}
+                />
+              </FormControl>
+              <FormDescription data-testid="sellUsdAmountLabel">
+                ~${formatWithMaxDecimals(sellUSDValue)}
+              </FormDescription>
+            </FormItem>
+          )}
+        />
+      </div>
+
+      <div className="col-span-4 flex flex-row items-center justify-end">
+        <FormField
+          control={form.control}
+          name="tokenInSymbol"
+          render={({ field }) => (
+            <FormItem className="flex flex-col items-end justify-end">
+              <FormControl>
+                <TokenDialog
+                  value={field.value}
+                  onValueChange={(value) => {
+                    field.onChange(value);
+                    setLastChangedToken("from");
+                  }}
+                  title="Select asset to sell"
+                  excludeTokenSymbol={tokenOutSymbol}
+                  filterByTokenSymbol={tokenOutSymbol}
+                  onClose={() => {
+                    setTimeout(() => {
+                      amountRef.current?.focus();
+                    }, 500);
+                  }}
+                  trigger={
+                    <button
+                      type="button"
+                      className={tokenButtonClassName}
+                      data-testid="selectSellTokenButton"
+                    >
+                      <TokenIcon
+                        token={allTokenOptions.find(
+                          (token) => token.symbol === field.value,
+                        )}
+                        className="mr-2"
+                        size={20}
+                      />
+                      <span>{field.value || "Select"}</span>
+                      <ChevronDown className="h-4 w-4 opacity-50" />
+                    </button>
+                  }
+                />
+              </FormControl>
+              <FormDescription className="w-fit whitespace-nowrap">
+                Balance: {fromTokenBalance}{" "}
+                <button
+                  type="button"
+                  className="p-0 cursor-pointer border-none bg-transparent text-inherit underline"
+                  onClick={handleUseMaxBalance}
+                >
+                  MAX
+                </button>
+              </FormDescription>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/app.mento.org/app/components/swap/swap-form/swap-form.tsx
+++ b/apps/app.mento.org/app/components/swap/swap-form/swap-form.tsx
@@ -1,0 +1,120 @@
+"use client";
+
+import { Button, Form } from "@repo/ui";
+import { ArrowUpDown } from "lucide-react";
+import { BuyTokenInput } from "./buy-token-input";
+import { SellTokenInput } from "./sell-token-input";
+import { SwapSubmitButton } from "./swap-submit-button";
+import { useSwapForm } from "./use-swap-form";
+
+export default function SwapForm() {
+  const swap = useSwapForm();
+
+  return (
+    <Form {...swap.form}>
+      <form
+        onSubmit={swap.form.handleSubmit(swap.onSubmit)}
+        className="max-w-3xl gap-6 flex h-full flex-col"
+      >
+        <div className="gap-0 flex flex-col">
+          <SellTokenInput
+            form={swap.form}
+            direction={swap.direction}
+            setDirection={swap.setDirection}
+            amountRef={swap.amountRef}
+            validateAmount={swap.validateAmount}
+            sellUSDValue={swap.sellUSDValue}
+            fromTokenBalance={swap.fromTokenBalance}
+            handleUseMaxBalance={swap.handleUseMaxBalance}
+            tokenOutSymbol={swap.tokenOutSymbol}
+            allTokenOptions={swap.allTokenOptions}
+            setLastChangedToken={swap.setLastChangedToken}
+          />
+
+          <SwapDirectionButton onReverse={swap.handleReverseTokens} />
+
+          <BuyTokenInput
+            form={swap.form}
+            direction={swap.direction}
+            setDirection={swap.setDirection}
+            quoteRef={swap.quoteRef}
+            formQuote={swap.formQuote}
+            latestRateRef={swap.latestRateRef}
+            buyUSDValue={swap.buyUSDValue}
+            toTokenBalance={swap.toTokenBalance}
+            tokenInSymbol={swap.tokenInSymbol}
+            allTokenOptions={swap.allTokenOptions}
+            setLastChangedToken={swap.setLastChangedToken}
+            handleUseMaxBuyBalance={swap.handleUseMaxBuyBalance}
+          />
+        </div>
+
+        <SwapRateDisplay
+          rate={swap.rate}
+          tokenInSymbol={swap.tokenInSymbol}
+          tokenOutSymbol={swap.tokenOutSymbol}
+        />
+
+        <SwapSubmitButton
+          isConnected={swap.isConnected}
+          hasAmount={swap.hasAmount}
+          tokenInSymbol={swap.tokenInSymbol}
+          tokenOutSymbol={swap.tokenOutSymbol}
+          quote={swap.quote}
+          errors={swap.errors}
+          isButtonLoading={swap.isButtonLoading}
+          isApproveTxLoading={swap.isApproveTxLoading}
+          isApprovalProcessing={swap.isApprovalProcessing}
+          tradingLimitError={swap.tradingLimitError}
+          balanceError={swap.balanceError}
+          isTradingSuspended={swap.isTradingSuspended}
+          isSuspensionCheckLoading={swap.isSuspensionCheckLoading}
+          isError={swap.isError}
+          canQuote={swap.canQuote}
+          shouldApprove={swap.shouldApprove}
+          allTokenOptions={swap.allTokenOptions}
+        />
+      </form>
+    </Form>
+  );
+}
+
+function SwapDirectionButton({ onReverse }: { onReverse: () => void }) {
+  return (
+    <div className="flex w-full items-center justify-center border-x border-border dark:border-input">
+      <Button
+        data-testid="swapInputsButton"
+        variant="outline"
+        onClick={onReverse}
+        size="icon"
+        className="!border-y-0"
+        type="button"
+      >
+        <ArrowUpDown className="rotate-180 transition-transform" />
+      </Button>
+    </div>
+  );
+}
+
+function SwapRateDisplay({
+  rate,
+  tokenInSymbol,
+  tokenOutSymbol,
+}: {
+  rate: string | undefined;
+  tokenInSymbol: string;
+  tokenOutSymbol: string;
+}) {
+  if (!rate) return null;
+
+  return (
+    <div className="gap-2 flex flex-col">
+      <div className="space-y-2 flex w-full flex-col items-start justify-start">
+        <div className="flex w-full flex-row items-center justify-between">
+          <span className="text-muted-foreground">Rate</span>
+          <span data-testid="rateLabel">{`${rate && Number(rate) > 0 ? Number(rate).toFixed(4) : "0"} ${tokenInSymbol} ~ 1 ${tokenOutSymbol}`}</span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/app.mento.org/app/components/swap/swap-form/swap-submit-button.tsx
+++ b/apps/app.mento.org/app/components/swap/swap-form/swap-submit-button.tsx
@@ -1,0 +1,148 @@
+"use client";
+
+import { IconLoading } from "@repo/ui";
+import { Button } from "@repo/ui";
+import { ConnectButton } from "@repo/web3";
+
+import type { TokenWithBalance } from "@repo/web3";
+
+interface SwapSubmitButtonProps {
+  isConnected: boolean;
+  hasAmount: boolean;
+  tokenInSymbol: string;
+  tokenOutSymbol: string;
+  quote: string | undefined;
+  errors: { amount?: { message?: string } };
+  isButtonLoading: boolean;
+  isApproveTxLoading: boolean;
+  isApprovalProcessing: boolean;
+  tradingLimitError: string | null;
+  balanceError: string | null;
+  isTradingSuspended: boolean;
+  isSuspensionCheckLoading: boolean;
+  isError: boolean;
+  canQuote: boolean;
+  shouldApprove: string | boolean;
+  allTokenOptions: TokenWithBalance[];
+}
+
+export function SwapSubmitButton({
+  isConnected,
+  hasAmount,
+  tokenInSymbol,
+  tokenOutSymbol,
+  quote,
+  errors,
+  isButtonLoading,
+  isApproveTxLoading,
+  isApprovalProcessing,
+  tradingLimitError,
+  balanceError,
+  isTradingSuspended,
+  isSuspensionCheckLoading,
+  isError,
+  canQuote,
+  shouldApprove,
+  allTokenOptions,
+}: SwapSubmitButtonProps) {
+  if (!isConnected) {
+    return (
+      <ConnectButton
+        size="lg"
+        text="Connect"
+        fullWidth
+        shouldShowAddress={false}
+      />
+    );
+  }
+
+  return (
+    <Button
+      data-testid={defineButtonLocator({
+        balanceError,
+        tradingLimitError,
+        isTradingSuspended,
+        shouldApprove,
+        tokenInSymbol,
+        tokenOutSymbol,
+      })}
+      className="mt-auto w-full"
+      size="lg"
+      clipped="lg"
+      type="submit"
+      disabled={
+        !hasAmount ||
+        !tokenOutSymbol ||
+        !tokenInSymbol ||
+        !quote ||
+        !!(errors.amount && errors.amount.message !== "Amount is required") ||
+        isButtonLoading ||
+        isApproveTxLoading ||
+        isApprovalProcessing ||
+        !!tradingLimitError ||
+        !!balanceError ||
+        isTradingSuspended ||
+        isSuspensionCheckLoading ||
+        (isError && hasAmount && canQuote)
+      }
+    >
+      {isButtonLoading ? (
+        <IconLoading />
+      ) : !tokenInSymbol ? (
+        "Select token to sell"
+      ) : !tokenOutSymbol ? (
+        "Select token to buy"
+      ) : isTradingSuspended ? (
+        `Trading suspended for ${tokenInSymbol} -> ${tokenOutSymbol}`
+      ) : tradingLimitError ? (
+        "Swap exceeds trading limits"
+      ) : balanceError ? (
+        "Insufficient balance"
+      ) : isError && hasAmount && canQuote ? (
+        "Unable to fetch quote"
+      ) : errors.amount?.message &&
+        errors.amount?.message !== "Amount is required" ? (
+        errors.amount?.message
+      ) : isApproveTxLoading || isApprovalProcessing ? (
+        <IconLoading />
+      ) : shouldApprove ? (
+        `Approve ${allTokenOptions.find((t) => t.symbol === tokenInSymbol)?.symbol || tokenInSymbol}`
+      ) : (
+        "Swap"
+      )}
+    </Button>
+  );
+}
+
+function defineButtonLocator({
+  balanceError,
+  tradingLimitError,
+  isTradingSuspended,
+  shouldApprove,
+  tokenInSymbol,
+  tokenOutSymbol,
+}: {
+  balanceError: string | null;
+  tradingLimitError: string | null;
+  isTradingSuspended: boolean;
+  shouldApprove: string | boolean;
+  tokenInSymbol: string;
+  tokenOutSymbol: string;
+}) {
+  switch (true) {
+    case Boolean(isTradingSuspended):
+      return "tradingSuspendedButton";
+    case Boolean(balanceError && !tradingLimitError):
+      return "insufficientBalanceButton";
+    case Boolean(tradingLimitError):
+      return "swapsExceedsTradingLimitButton";
+    case Boolean(shouldApprove && tokenInSymbol && tokenOutSymbol):
+      return "approveButton";
+    case !tokenInSymbol:
+      return "selectTokenToSellButton";
+    case !tokenOutSymbol:
+      return "selectTokenToBuyButton";
+    default:
+      return "swapButton";
+  }
+}

--- a/apps/app.mento.org/app/components/swap/swap-form/types.ts
+++ b/apps/app.mento.org/app/components/swap/swap-form/types.ts
@@ -1,0 +1,24 @@
+import { parseAmount } from "@repo/web3";
+import * as z from "zod";
+
+export const formSchema = z.object({
+  amount: z
+    .string()
+    .min(1, { message: "Amount is required" })
+    .refine((v) => {
+      if (v === "0." || v === "0") return true;
+      const parsed = parseAmount(v);
+      return parsed !== null && parsed.gt(0);
+    }),
+  tokenInSymbol: z.string().min(1, { message: "From token is required" }),
+  quote: z.string(),
+  tokenOutSymbol: z.string().min(1, { message: "To token is required" }),
+  slippage: z.string().optional(),
+});
+
+export type FormValues = z.infer<typeof formSchema>;
+
+export const defaultEmptyBalances = {};
+
+export const tokenButtonClassName =
+  "ring-offset-background placeholder:text-muted-foreground focus:ring-ring bg-outlier hover:border-border-secondary mt-[22px] flex h-10 w-full max-w-32 min-w-[116px] items-center justify-between gap-2 rounded-none border-solid border-1 border-[var(--border)] px-3 py-2 text-sm transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-50";

--- a/apps/app.mento.org/app/components/swap/swap-form/use-swap-form.tsx
+++ b/apps/app.mento.org/app/components/swap/swap-form/use-swap-form.tsx
@@ -340,11 +340,13 @@ export function useSwapForm() {
     const numericBuy = Number(formattedAmountWithMaxDecimals);
     if (currentRate && currentRate > 0 && numericBuy > 0) {
       const estimatedSell = numericBuy * currentRate;
-      form.setValue(
-        "amount",
-        formatWithMaxDecimals(String(estimatedSell), 4, false),
-        { shouldValidate: true },
-      );
+      if (Number.isFinite(estimatedSell) && estimatedSell < 1e18) {
+        form.setValue(
+          "amount",
+          formatWithMaxDecimals(String(estimatedSell), 4, false),
+          { shouldValidate: true },
+        );
+      }
     }
   };
 
@@ -386,15 +388,56 @@ export function useSwapForm() {
     tokenOutSymbol,
   );
 
+  // Seed quote: fetch initial rate with amountIn=1 when no rate is available yet
+  const needsSeedRate =
+    !latestRateRef.current &&
+    direction === "out" &&
+    !!tokenInSymbol &&
+    !!tokenOutSymbol &&
+    !isTradingSuspended &&
+    !canQuote;
+
+  const { quote: seedQuote } = useOptimizedSwapQuote(
+    needsSeedRate ? "1" : "",
+    tokenInSymbol,
+    tokenOutSymbol,
+  );
+
   // ── Side effects ────────────────────────────────────────────────────
 
   useEffect(() => {
     const numAmount = Number(amount);
     const numQuote = Number(quote);
     if (numAmount > 0 && numQuote > 0) {
-      latestRateRef.current = numAmount / numQuote;
+      const newRate = numAmount / numQuote;
+      if (Number.isFinite(newRate) && newRate < 1e18) {
+        latestRateRef.current = newRate;
+      }
     }
   }, [rate, amount, quote]);
+
+  // Bootstrap rate from seed quote (amountIn=1), then calculate sell amount
+  useEffect(() => {
+    if (latestRateRef.current || direction !== "out") return;
+    const numSeedQuote = Number(seedQuote);
+    if (numSeedQuote <= 0) return;
+
+    const seedRate = 1 / numSeedQuote;
+    if (!Number.isFinite(seedRate) || seedRate >= 1e18) return;
+    latestRateRef.current = seedRate;
+
+    const buyAmount = Number(formQuote);
+    if (buyAmount > 0) {
+      const estimatedSell = buyAmount * seedRate;
+      if (Number.isFinite(estimatedSell) && estimatedSell < 1e18) {
+        form.setValue(
+          "amount",
+          formatWithMaxDecimals(String(estimatedSell), 4, false),
+          { shouldValidate: true },
+        );
+      }
+    }
+  }, [seedQuote, direction, formQuote, form]);
 
   useEffect(() => {
     setTradingLimitError(null);

--- a/apps/app.mento.org/app/components/swap/swap-form/use-swap-form.tsx
+++ b/apps/app.mento.org/app/components/swap/swap-form/use-swap-form.tsx
@@ -1,30 +1,15 @@
 "use client";
+
 import { zodResolver } from "@hookform/resolvers/zod";
-import { IconLoading, TokenIcon } from "@repo/ui";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { Controller, useForm, useWatch } from "react-hook-form";
+import { useForm, useWatch } from "react-hook-form";
 import { toast } from "sonner";
-import * as z from "zod";
 
-import {
-  Button,
-  Form,
-  FormControl,
-  FormDescription,
-  FormField,
-  FormItem,
-  FormLabel,
-  FormMessage,
-} from "@repo/ui";
-
-import { CoinInput } from "@repo/ui";
-
-import { TokenSymbol } from "@mento-protocol/mento-sdk";
+import type { TokenSymbol } from "@mento-protocol/mento-sdk";
 import {
   CELO_EXPLORER,
   chainIdToChain,
   confirmViewAtom,
-  ConnectButton,
   formatBalance,
   formatWithMaxDecimals,
   formValuesAtom,
@@ -34,7 +19,7 @@ import {
   MIN_ROUNDED_VALUE,
   parseAmount,
   parseAmountWithDefault,
-  SwapFormValues,
+  type SwapFormValues,
   toWei,
   useAccountBalances,
   useApproveTransaction,
@@ -47,37 +32,13 @@ import {
 } from "@repo/web3";
 import { useAccount, useChainId } from "@repo/web3/wagmi";
 import { useAtom } from "jotai";
-import { ArrowUpDown, ChevronDown, OctagonAlert } from "lucide-react";
-import TokenDialog from "./token-dialog";
+import { OctagonAlert } from "lucide-react";
 
-// Layer 1: Keep Zod for static checks only
-const formSchema = z.object({
-  amount: z
-    .string()
-    .min(1, { message: "Amount is required" })
-    .refine((v) => {
-      // Allow "0." as valid input (user is typing)
-      if (v === "0." || v === "0") return true;
-      const parsed = parseAmount(v);
-      return parsed !== null && parsed.gt(0);
-    }),
-  tokenInSymbol: z.string().min(1, { message: "From token is required" }),
-  quote: z.string(),
-  tokenOutSymbol: z.string().min(1, { message: "To token is required" }),
-  slippage: z.string().optional(),
-});
+import { defaultEmptyBalances, formSchema, type FormValues } from "./types";
 
-type FormValues = z.infer<typeof formSchema>;
-
-// Default empty balances object
-const defaultEmptyBalances = {};
-
-const tokenButtonClassName =
-  "ring-offset-background placeholder:text-muted-foreground focus:ring-ring bg-outlier hover:border-border-secondary mt-[22px] flex h-10 w-full max-w-32 min-w-[116px] items-center justify-between gap-2 rounded-none border-solid border-1 border-[var(--border)] px-3 py-2 text-sm transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-50";
-
-export default function SwapForm() {
+export function useSwapForm() {
   const { address, isConnected } = useAccount();
-  const chainId = useChainId() ?? 42220; // Default to Celo mainnet
+  const chainId = useChainId() ?? 42220;
   const [formValues, setFormValues] = useAtom(formValuesAtom);
   const [, setConfirmView] = useAtom(confirmViewAtom);
   const [isApprovalProcessing, setIsApprovalProcessing] = useState(false);
@@ -102,7 +63,7 @@ export default function SwapForm() {
       tokenOutSymbol: formValues?.tokenOutSymbol || "USDm",
       slippage: formValues?.slippage || "0.5",
     },
-    mode: "onChange", // Important for field-level validation
+    mode: "onChange",
   });
 
   const tokenInSymbol = useWatch({
@@ -116,7 +77,7 @@ export default function SwapForm() {
   const amount = useWatch({ control: form.control, name: "amount" });
   const formQuote = useWatch({ control: form.control, name: "quote" });
 
-  // Get token balances
+  // Token balances
   const fromTokenBalance = useMemo(() => {
     const balanceValue = balances[tokenInSymbol as keyof typeof balances];
     const balance = formatBalance(
@@ -135,32 +96,29 @@ export default function SwapForm() {
     return formatWithMaxDecimals(balance || "0.00");
   }, [balances, tokenOutSymbol, chainId]);
 
-  // Get trading limits
+  // Trading limits
   const { data: limits, isLoading: limitsLoading } = useTradingLimits(
     tokenInSymbol,
     tokenOutSymbol,
     chainId,
   );
 
-  // Check for trading suspension
+  // Trading suspension
   const {
     isSuspended: isTradingSuspended,
     isLoading: isSuspensionCheckLoading,
   } = useTradingSuspensionCheck(tokenInSymbol, tokenOutSymbol);
 
-  // Balance validation
+  // ── Validation ──────────────────────────────────────────────────────
+
   const validateBalance = useCallback(
     (value: string) => {
       if (!value || !tokenInSymbol) return true;
-
-      // Allow "0" or "0." while user is typing
       if (value === "0." || value === "0") return true;
 
-      // Parse the amount
       const parsedAmount = parseAmount(value);
       if (!parsedAmount) return true;
 
-      // Check minimum amount
       if (parsedAmount.lte(MIN_ROUNDED_VALUE) && !parsedAmount.isZero()) {
         return "Amount too small";
       }
@@ -174,7 +132,6 @@ export default function SwapForm() {
       const amountInWei = toWei(parsedAmount, tokenInfo.decimals || 18);
       const balanceInWei = parseAmountWithDefault(balance, "0");
 
-      // Check if amount exceeds balance
       if (
         amountInWei.gt(0) &&
         (balanceInWei.isZero() || balanceInWei.lt(amountInWei))
@@ -187,8 +144,6 @@ export default function SwapForm() {
     [balances, tokenInSymbol, allTokenOptions],
   );
 
-  // Shared function for limit validation logic
-  // Only supports "in" direction - selling exact amount of tokenIn to receive tokenOut
   const checkTradingLimitViolation = useCallback(
     (
       numericAmount: number,
@@ -208,7 +163,6 @@ export default function SwapForm() {
       let isImplicitLimit = false;
 
       if (tokenToCheck === tokenInSymbol) {
-        // Direct limit on input token - check the sell amount
         amountToCheck = numericAmount;
         if (LG?.maxIn && amountToCheck > LG.maxIn) {
           exceeds = true;
@@ -230,10 +184,8 @@ export default function SwapForm() {
           total = L0.total || 0;
         }
       } else if (tokenToCheck === tokenOutSymbol) {
-        // Limit on output token - check the quote amount (how much we'll receive)
         amountToCheck = numericQuote;
 
-        // Selling tokenIn for tokenOut - check if we're trying to take out too much tokenOut
         if (LG?.maxOut && amountToCheck > LG.maxOut) {
           exceeds = true;
           limit = LG.maxOut;
@@ -257,9 +209,7 @@ export default function SwapForm() {
       }
 
       if (exceeds) {
-        // Adjust message based on whether it's an implicit limit
         if (isImplicitLimit) {
-          // For implicit limits, explain that you can't get more than X tokenOut
           if (exceededTier === "LG") {
             return `Cannot buy more than ${limit.toLocaleString()} ${tokenToCheck}. This exceeds the global trading limit.`;
           } else {
@@ -268,7 +218,6 @@ export default function SwapForm() {
             return `Cannot buy more than ${limit.toLocaleString()} ${tokenToCheck} within ${timeframe}. The limit will reset to ${total.toLocaleString()} ${tokenToCheck} at ${date}.`;
           }
         } else {
-          // Direct limit message (existing logic)
           if (exceededTier === "LG") {
             return `The ${tokenToCheck} amount exceeds the global trading limit of ${limit.toLocaleString()} ${tokenToCheck}.`;
           } else {
@@ -279,18 +228,15 @@ export default function SwapForm() {
         }
       }
 
-      return null; // No violation
+      return null;
     },
     [],
   );
 
-  // Layer 3: Field-level async validation (trading limits)
   const validateLimits = useCallback(
     async (value: string) => {
       if (!value || limitsLoading || !limits || !limits.tokenToCheck)
         return true;
-
-      // Allow "0." as user is typing
       if (value === "0." || value === "0") return true;
 
       const parsedAmount = parseAmount(value);
@@ -319,7 +265,6 @@ export default function SwapForm() {
     ],
   );
 
-  // Combined validation for amount field
   const validateAmount = useCallback(
     async (value: string) => {
       const balanceCheck = validateBalance(value);
@@ -333,7 +278,8 @@ export default function SwapForm() {
     [validateBalance, validateLimits],
   );
 
-  // Function to handle token swap
+  // ── Handlers ────────────────────────────────────────────────────────
+
   const handleReverseTokens = () => {
     const currentTokenInSymbol = form.getValues("tokenInSymbol");
     const currentTokenOutSymbol = form.getValues("tokenOutSymbol");
@@ -375,7 +321,35 @@ export default function SwapForm() {
     }
   };
 
-  // Get form state
+  const handleUseMaxBuyBalance = () => {
+    const maxAmountInWei =
+      balances[tokenOutSymbol as keyof typeof balances] || "0";
+    const maxAmountBigInt = BigInt(maxAmountInWei);
+    const decimals = getTokenDecimals(tokenOutSymbol, chainId);
+
+    const formattedAmount = formatBalance(maxAmountBigInt.toString(), decimals);
+    const formattedAmountWithMaxDecimals = formatWithMaxDecimals(
+      formattedAmount,
+      4,
+      false,
+    );
+    form.setValue("quote", formattedAmountWithMaxDecimals);
+    setDirection("out");
+
+    const currentRate = latestRateRef.current;
+    const numericBuy = Number(formattedAmountWithMaxDecimals);
+    if (currentRate && currentRate > 0 && numericBuy > 0) {
+      const estimatedSell = numericBuy * currentRate;
+      form.setValue(
+        "amount",
+        formatWithMaxDecimals(String(estimatedSell), 4, false),
+        { shouldValidate: true },
+      );
+    }
+  };
+
+  // ── Derived state ───────────────────────────────────────────────────
+
   const { errors } = form.formState;
   const hasAmount =
     !!amount &&
@@ -384,22 +358,20 @@ export default function SwapForm() {
     amount !== "0." &&
     Number(amount) > 0;
 
-  // Check if we have a trading limit error
   const [tradingLimitError, setTradingLimitError] = useState<string | null>(
     null,
   );
-
-  // Check for balance error
   const [balanceError, setBalanceError] = useState<string | null>(null);
 
-  // Trading suspension error message
   const tradingSuspensionError = useMemo(() => {
     if (!isTradingSuspended) return null;
     return `Trading temporarily paused for ${tokenInSymbol} -> ${tokenOutSymbol}. Unable to determine accurate exchange rate now. Please try again later.`;
   }, [isTradingSuspended, tokenInSymbol, tokenOutSymbol]);
 
   const canQuote =
-    !!hasAmount && !errors.amount && !limitsLoading && !isTradingSuspended; // Don't fetch quotes for suspended pairs
+    !!hasAmount && !errors.amount && !limitsLoading && !isTradingSuspended;
+
+  // ── Quote ───────────────────────────────────────────────────────────
 
   const {
     isFetching: quoteFetching,
@@ -414,6 +386,8 @@ export default function SwapForm() {
     tokenOutSymbol,
   );
 
+  // ── Side effects ────────────────────────────────────────────────────
+
   useEffect(() => {
     const numAmount = Number(amount);
     const numQuote = Number(quote);
@@ -426,14 +400,12 @@ export default function SwapForm() {
     setTradingLimitError(null);
   }, [amount, quote]);
 
-  // Check balance in real-time
   useEffect(() => {
     const checkBalance = async () => {
       if (!hasAmount || !tokenInSymbol) {
         setBalanceError(null);
         return;
       }
-
       const balanceCheck = validateBalance(amount);
       if (balanceCheck !== true) {
         setBalanceError(balanceCheck);
@@ -441,7 +413,6 @@ export default function SwapForm() {
         setBalanceError(null);
       }
     };
-
     checkBalance();
   }, [amount, hasAmount, tokenInSymbol, validateBalance]);
 
@@ -473,45 +444,34 @@ export default function SwapForm() {
 
   useEffect(() => {
     if (tradingLimitError) {
-      toast.error(tradingLimitError, {
-        duration: 20000,
-      });
+      toast.error(tradingLimitError, { duration: 20000 });
     }
   }, [tradingLimitError]);
 
-  // Show trading suspension error toast and dismiss it when switching to a tradable pair
   useEffect(() => {
     const prevError = prevTradingSuspensionErrorRef.current;
     const hasError = tradingSuspensionError !== null;
     const errorChanged = prevError !== tradingSuspensionError;
 
-    // Only show toast if error changed (not on every render)
     if (hasError && errorChanged) {
-      toast.error(tradingSuspensionError, {
-        duration: 20000,
-      });
+      toast.error(tradingSuspensionError, { duration: 20000 });
     } else if (prevError !== null && !hasError) {
-      // Dismiss error toast when switching from suspended to tradable pair
       toast.dismiss();
     }
 
     prevTradingSuspensionErrorRef.current = tradingSuspensionError;
   }, [tradingSuspensionError]);
 
-  // Override loading state when we have validation errors
   const isLoading =
     quoteFetching && canQuote && !tradingLimitError && !limitsLoading;
 
-  // Track previous token pair to detect token changes and manage waiting state
   const prevTokenPairRef = useRef<{
     tokenInSymbol: TokenSymbol | undefined;
     tokenOutSymbol: TokenSymbol | undefined;
   }>({ tokenInSymbol: undefined, tokenOutSymbol: undefined });
 
-  // Track if we're waiting for quote after token change
   const [isWaitingForQuote, setIsWaitingForQuote] = useState(false);
 
-  // Handle token changes and quote arrival
   useEffect(() => {
     const tokensChanged =
       prevTokenPairRef.current.tokenInSymbol !== tokenInSymbol ||
@@ -519,18 +479,15 @@ export default function SwapForm() {
 
     if (tokensChanged) {
       prevTokenPairRef.current = { tokenInSymbol, tokenOutSymbol };
-      // Start waiting when tokens change and we have inputs
       if (hasAmount && !!tokenInSymbol && !!tokenOutSymbol) {
         setIsWaitingForQuote(true);
       }
     }
 
-    // Clear waiting flag when trading is suspended (no quote will be fetched)
     if (isTradingSuspended && isWaitingForQuote) {
       setIsWaitingForQuote(false);
     }
 
-    // Clear waiting flag when we have a valid quote and fetching is done
     if (
       isWaitingForQuote &&
       quote &&
@@ -550,8 +507,6 @@ export default function SwapForm() {
     isTradingSuspended,
   ]);
 
-  // Button loading state: show loading when quote is being fetched or waiting after token change
-  // Don't show loading when trading is suspended (no quote will be fetched)
   const isButtonLoading = useMemo(
     () =>
       !isTradingSuspended &&
@@ -581,13 +536,13 @@ export default function SwapForm() {
 
   const amountInWei = useMemo(() => {
     if (!tokenInSymbol) return "0";
-
     return amount
       ? toWei(amount, getTokenDecimals(tokenInSymbol, chainId)).toFixed(0)
       : "0";
   }, [amount, tokenInSymbol, chainId]);
 
-  // Check if approval is needed
+  // ── Allowance & approval ────────────────────────────────────────────
+
   const { skipApprove } = useSwapAllowance({
     chainId,
     tokenInSymbol,
@@ -596,7 +551,6 @@ export default function SwapForm() {
     address,
   });
 
-  // Approval transaction hook
   const { sendApproveTx, isApproveTxLoading, approveTxHash } =
     useApproveTransaction({
       chainId,
@@ -647,20 +601,17 @@ export default function SwapForm() {
       },
     });
 
+  // Sync quote from API → form field (only when direction is "in")
   useEffect(() => {
     if (quote !== undefined && direction !== "out") {
       const formattedQuote = formatWithMaxDecimals(quote, 4, false);
       if (formQuote !== formattedQuote) {
-        form.setValue("quote", formattedQuote, {
-          shouldValidate: true,
-        });
+        form.setValue("quote", formattedQuote, { shouldValidate: true });
       }
     }
   }, [quote, form, formQuote, direction]);
 
-  // Show error toasts based on form errors
   useEffect(() => {
-    // Don't show toast for "0." input
     if (
       errors.amount?.message &&
       errors.amount.message !== "Invalid input" &&
@@ -671,7 +622,9 @@ export default function SwapForm() {
     }
   }, [errors.amount, hasAmount, amount]);
 
-  const onSubmit = async (values: z.infer<typeof formSchema>) => {
+  // ── Submit ──────────────────────────────────────────────────────────
+
+  const onSubmit = async (values: FormValues) => {
     try {
       if (!skipApprove && sendApproveTx) {
         setIsApprovalProcessing(true);
@@ -708,7 +661,8 @@ export default function SwapForm() {
   const shouldApprove =
     !skipApprove && hasAmount && quote && !isLoading && !balanceError;
 
-  // Get tradable pairs for both tokens
+  // ── Token pair validation ───────────────────────────────────────────
+
   const { data: fromTokenTradablePairs } = useTradablePairs(tokenInSymbol);
   const { data: toTokenTradablePairs } = useTradablePairs(tokenOutSymbol);
 
@@ -716,7 +670,6 @@ export default function SwapForm() {
     "from" | "to" | null
   >(null);
 
-  // Handle token pair validation - reset opposite token if an invalid pair is selected
   useEffect(() => {
     if (!tokenInSymbol || !tokenOutSymbol || !lastChangedToken) return;
 
@@ -724,7 +677,6 @@ export default function SwapForm() {
       fromTokenTradablePairs?.includes(tokenOutSymbol) ||
       toTokenTradablePairs?.includes(tokenInSymbol);
 
-    // If an invalid pair is selected, reset the opposite token
     if (!isValidPair) {
       if (lastChangedToken === "from") {
         form.setValue("tokenOutSymbol", "", { shouldValidate: false });
@@ -742,360 +694,66 @@ export default function SwapForm() {
     form,
   ]);
 
-  return (
-    <Form {...form}>
-      <form
-        onSubmit={form.handleSubmit(onSubmit)}
-        className="max-w-3xl gap-6 flex h-full flex-col"
-      >
-        <div className="gap-0 flex flex-col">
-          <div
-            className="maybe-hover:border-border-secondary gap-4 p-4 grid grid-cols-12 border border-border bg-incard transition-colors focus-within:!border-primary dark:border-input dark:focus-within:!border-primary"
-            onClick={() => {
-              amountRef.current?.focus();
-            }}
-          >
-            <div className="col-span-8">
-              <Controller
-                control={form.control}
-                name="amount"
-                rules={{
-                  validate: validateAmount,
-                }}
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Sell</FormLabel>
-                    <FormControl>
-                      <CoinInput
-                        ref={amountRef}
-                        data-testid="sellAmountInput"
-                        placeholder="0"
-                        value={field.value}
-                        onChange={(e) => {
-                          const val =
-                            typeof e === "string" ? e : e.target.value;
-                          field.onChange(val);
-                          if (direction !== "in") {
-                            setDirection("in");
-                          }
-                        }}
-                        onBlur={field.onBlur}
-                      />
-                    </FormControl>
-                    <FormDescription data-testid="sellUsdAmountLabel">
-                      ~${formatWithMaxDecimals(sellUSDValue)}
-                    </FormDescription>
-                  </FormItem>
-                )}
-              />
-            </div>
+  // ── Return ──────────────────────────────────────────────────────────
 
-            <div className="col-span-4 flex flex-row items-center justify-end">
-              <FormField
-                control={form.control}
-                name="tokenInSymbol"
-                render={({ field }) => (
-                  <FormItem className="flex flex-col items-end justify-end">
-                    <FormControl>
-                      <TokenDialog
-                        value={field.value}
-                        onValueChange={(value) => {
-                          field.onChange(value);
-                          setLastChangedToken("from");
-                        }}
-                        title="Select asset to sell"
-                        excludeTokenSymbol={tokenOutSymbol}
-                        filterByTokenSymbol={tokenOutSymbol}
-                        onClose={() => {
-                          setTimeout(() => {
-                            amountRef.current?.focus();
-                          }, 500);
-                        }}
-                        trigger={
-                          <button
-                            type="button"
-                            className={tokenButtonClassName}
-                            data-testid="selectSellTokenButton"
-                          >
-                            <TokenIcon
-                              token={allTokenOptions.find(
-                                (token) => token.symbol === field.value,
-                              )}
-                              className="mr-2"
-                              size={20}
-                            />
+  return {
+    form,
+    direction,
+    setDirection,
+    isConnected,
 
-                            <span>{field.value || "Select"}</span>
-                            <ChevronDown className="h-4 w-4 opacity-50" />
-                          </button>
-                        }
-                      />
-                    </FormControl>
-                    <FormDescription className="w-fit whitespace-nowrap">
-                      Balance: {fromTokenBalance}{" "}
-                      <button
-                        type="button"
-                        className="p-0 cursor-pointer border-none bg-transparent text-inherit underline"
-                        onClick={handleUseMaxBalance}
-                      >
-                        MAX
-                      </button>
-                    </FormDescription>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-            </div>
-          </div>
+    // Refs
+    amountRef,
+    quoteRef,
+    latestRateRef,
 
-          <div className="flex w-full items-center justify-center border-x border-border dark:border-input">
-            <Button
-              data-testid="swapInputsButton"
-              variant="outline"
-              onClick={handleReverseTokens}
-              size="icon"
-              className="!border-y-0"
-              type="button"
-            >
-              <ArrowUpDown className="rotate-180 transition-transform" />
-            </Button>
-          </div>
+    // Token symbols & options
+    tokenInSymbol,
+    tokenOutSymbol,
+    allTokenOptions,
 
-          <div
-            className="maybe-hover:border-border-secondary gap-4 p-4 grid grid-cols-12 border border-border bg-incard transition-colors focus-within:!border-primary dark:border-input dark:focus-within:!border-primary"
-            onClick={() => {
-              quoteRef.current?.focus();
-            }}
-          >
-            <div className="col-span-8">
-              <Controller
-                control={form.control}
-                name="quote"
-                render={({ field, fieldState }) => (
-                  <FormItem>
-                    <FormLabel>Buy</FormLabel>
-                    <FormControl>
-                      <CoinInput
-                        ref={quoteRef}
-                        data-testid="buyAmountInput"
-                        placeholder="0"
-                        value={
-                          direction === "out"
-                            ? (field.value ?? "")
-                            : formQuote &&
-                                formQuote !== "0" &&
-                                formQuote !== "0.00"
-                              ? formQuote
-                              : ""
-                        }
-                        onChange={(e) => {
-                          const val =
-                            typeof e === "string" ? e : e.target.value;
-                          field.onChange(val);
-                          if (direction !== "out") {
-                            setDirection("out");
-                          }
+    // Watched values
+    amount,
+    formQuote,
 
-                          const currentRate = latestRateRef.current;
-                          if (
-                            currentRate &&
-                            currentRate > 0 &&
-                            val &&
-                            Number(val) > 0
-                          ) {
-                            const estimatedSell = Number(val) * currentRate;
-                            form.setValue(
-                              "amount",
-                              formatWithMaxDecimals(
-                                String(estimatedSell),
-                                4,
-                                false,
-                              ),
-                              { shouldValidate: true },
-                            );
-                          } else if (val && Number(val) > 0) {
-                            form.setValue("amount", val, {
-                              shouldValidate: true,
-                            });
-                          } else {
-                            form.setValue("amount", "", {
-                              shouldValidate: true,
-                            });
-                          }
-                        }}
-                        onBlur={field.onBlur}
-                      />
-                    </FormControl>
-                    <FormDescription data-testid="buyUsdAmountLabel">
-                      ~${formatWithMaxDecimals(buyUSDValue)}
-                    </FormDescription>
-                    <FormMessage>{fieldState.error?.message}</FormMessage>
-                  </FormItem>
-                )}
-              />
-            </div>
+    // Balances
+    fromTokenBalance,
+    toTokenBalance,
 
-            <div className="col-span-4 flex flex-row items-center justify-end">
-              <FormField
-                control={form.control}
-                name="tokenOutSymbol"
-                render={({ field }) => (
-                  <FormItem className="flex flex-col items-end justify-end">
-                    <FormControl>
-                      <TokenDialog
-                        value={field.value}
-                        onValueChange={(value) => {
-                          field.onChange(value);
-                          setLastChangedToken("to");
-                        }}
-                        title="Select asset to buy"
-                        excludeTokenSymbol={tokenInSymbol}
-                        filterByTokenSymbol={tokenInSymbol}
-                        onClose={() => {
-                          setTimeout(() => {
-                            quoteRef.current?.focus();
-                          }, 500);
-                        }}
-                        trigger={
-                          <button
-                            type="button"
-                            className={tokenButtonClassName}
-                            data-testid="selectBuyTokenButton"
-                          >
-                            <TokenIcon
-                              token={allTokenOptions.find(
-                                (token) => token.symbol === field.value,
-                              )}
-                              className="mr-2"
-                              size={20}
-                            />
-                            <span>{field.value || "Select"}</span>
-                            <ChevronDown className="h-4 w-4 opacity-50" />
-                          </button>
-                        }
-                      />
-                    </FormControl>
-                    <FormDescription className="w-fit whitespace-nowrap">
-                      Balance: {toTokenBalance}
-                    </FormDescription>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-            </div>
-          </div>
-        </div>
+    // USD values
+    sellUSDValue,
+    buyUSDValue,
 
-        <div className="gap-2 flex flex-col">
-          {rate && (
-            <div className="space-y-2 flex w-full flex-col items-start justify-start">
-              <div className="flex w-full flex-row items-center justify-between">
-                <span className="text-muted-foreground">Rate</span>
-                <span data-testid="rateLabel">{`${rate && Number(rate) > 0 ? Number(rate).toFixed(4) : "0"} ${tokenInSymbol} ~ 1 ${tokenOutSymbol}`}</span>
-              </div>
-            </div>
-          )}
-        </div>
+    // Quote data
+    quote,
+    rate,
+    isError,
+    canQuote,
 
-        {isConnected ? (
-          <Button
-            data-testid={defineButtonLocator({
-              balanceError,
-              tradingLimitError,
-              isTradingSuspended,
-              shouldApprove,
-              tokenInSymbol: tokenInSymbol,
-              tokenOutSymbol: tokenOutSymbol,
-            })}
-            className="mt-auto w-full"
-            size="lg"
-            clipped="lg"
-            type="submit"
-            disabled={
-              !hasAmount ||
-              !tokenOutSymbol ||
-              !tokenInSymbol ||
-              !quote || // Require quote to be fetched
-              !!(
-                errors.amount && errors.amount.message !== "Amount is required"
-              ) ||
-              isButtonLoading || // Disable button when quote is loading
-              isApproveTxLoading ||
-              isApprovalProcessing ||
-              !!tradingLimitError ||
-              !!balanceError ||
-              isTradingSuspended || // Disable when trading is suspended
-              isSuspensionCheckLoading || // Disable while checking suspension
-              (isError && hasAmount && canQuote) // Disable when unable to fetch quote
-            }
-          >
-            {isButtonLoading ? ( // Show loading when quote is being fetched
-              <IconLoading />
-            ) : !tokenInSymbol ? (
-              "Select token to sell"
-            ) : !tokenOutSymbol ? (
-              "Select token to buy"
-            ) : isTradingSuspended ? (
-              `Trading suspended for ${tokenInSymbol} -> ${tokenOutSymbol}`
-            ) : tradingLimitError ? (
-              "Swap exceeds trading limits"
-            ) : balanceError ? (
-              "Insufficient balance"
-            ) : isError && hasAmount && canQuote ? (
-              "Unable to fetch quote"
-            ) : errors.amount?.message &&
-              errors.amount?.message !== "Amount is required" ? (
-              errors.amount?.message
-            ) : isApproveTxLoading || isApprovalProcessing ? (
-              <IconLoading />
-            ) : shouldApprove ? (
-              `Approve ${allTokenOptions.find((t) => t.symbol === tokenInSymbol)?.symbol || tokenInSymbol}`
-            ) : (
-              "Swap"
-            )}
-          </Button>
-        ) : (
-          <ConnectButton
-            size="lg"
-            text="Connect"
-            fullWidth
-            shouldShowAddress={false}
-          />
-        )}
-      </form>
-    </Form>
-  );
-}
+    // Validation
+    validateAmount,
+    errors,
+    hasAmount,
+    tradingLimitError,
+    balanceError,
+    isTradingSuspended,
+    isSuspensionCheckLoading,
 
-function defineButtonLocator({
-  balanceError,
-  tradingLimitError,
-  isTradingSuspended,
-  shouldApprove,
-  tokenInSymbol,
-  tokenOutSymbol,
-}: {
-  balanceError: string | null;
-  tradingLimitError: string | null;
-  isTradingSuspended: boolean;
-  shouldApprove: string | boolean;
-  tokenInSymbol: string;
-  tokenOutSymbol: string;
-}) {
-  switch (true) {
-    case Boolean(isTradingSuspended):
-      return "tradingSuspendedButton";
-    case Boolean(balanceError && !tradingLimitError):
-      return "insufficientBalanceButton";
-    case Boolean(tradingLimitError):
-      return "swapsExceedsTradingLimitButton";
-    case Boolean(shouldApprove && tokenInSymbol && tokenOutSymbol):
-      return "approveButton";
-    case !tokenInSymbol:
-      return "selectTokenToSellButton";
-    case !tokenOutSymbol:
-      return "selectTokenToBuyButton";
-    default:
-      return "swapButton";
-  }
+    // Loading
+    isLoading,
+    isButtonLoading,
+    isApproveTxLoading,
+    isApprovalProcessing,
+
+    // Approval
+    shouldApprove,
+    skipApprove,
+
+    // Handlers
+    handleReverseTokens,
+    handleUseMaxBalance,
+    handleUseMaxBuyBalance,
+    onSubmit,
+    setLastChangedToken,
+  };
 }


### PR DESCRIPTION
# Description
Restored the ability to specify a desired buy amount on the swap page. Since the Mento SDK (v3) only supports getAmountOut (exact input swaps), the buy-side input estimates the required sell amount using the latest exchange rate, then passes that estimate to the SDK for a real quote.

Also decomposed the monolithic swap-form.tsx (1,099 lines) into a folder of focused modules for better readability and maintainability.

# Other changes
* Extracted all form state, effects, validation, and handlers into a useSwapForm custom hook
* Split the UI into dedicated components: SellTokenInput, BuyTokenInput, SwapSubmitButton, plus inlined SwapDirectionButton and SwapRateDisplay
* Moved Zod schema, FormValues type, and shared constants into types.ts
* Cleaned up imports: removed unused zod namespace import, switched TokenSymbol and SwapFormValues to type-only imports
* Added a MAX button to the buy-side token input (mirrors the sell-side MAX)

# Testing
* Enter a sell amount — verify buy amount is calculated correctly
* Enter a buy amount — verify sell amount is estimated, and a quote is fetched
* Click MAX on the sell side — verify full balance is used
* Click MAX on the buy side — verify full balance is used and the sell amount is estimated
* Click the swap direction button — verify tokens and amounts update correctly
* After swapping direction, type a buy amount — verify the rate is correct (inverted)
* Select different token pairs — verify invalid pairs, reset the opposite token
* Verify submit button states: loading, insufficient balance, limits exceeded, suspended, approve, swap

## Checklist before requesting a review

- [ ] PR title follows the [conventions](https://www.notion.so/Git-Branching-and-Commit-Message-Conventions-18f66f7d06444cfcbac5725ffbc7c04a?pvs=4#9355048863c549ef92fe210a8a1298aa)
- [ ] Performed a self-review of my own code changes
- [ ] Smoke Test Run/s passed on the CI
