### PR TITLE
fix: set passWithNoTests to false in shared vitest config

### DIFF
--- a/packages/vitest-config/vitest.shared.js
+++ b/packages/vitest-config/vitest.shared.js
@@ -30,7 +30,7 @@ export default defineConfig({
       "**/.trunk/**",
     ],
     globals: false,
-    passWithNoTests: true,
+    passWithNoTests: false,
     coverage: {
       provider: "v8",
       reporter: ["text", "json", "html"],


### PR DESCRIPTION
## Summary

Fixes QA finding **C-3** from the mento-frontend-monorepo QA readiness audit (MEN-15).

The shared vitest config had `passWithNoTests: true`, which means the test runner exits with code 0 even when **no test files are found at all**. In a monorepo with per-package vitest configs all inheriting from this shared config, this creates a silent failure mode: an entire package's test suite could be accidentally deleted and CI would still report green.

## Change

```diff
-    passWithNoTests: true,
+    passWithNoTests: false,
```

`false` is the vitest default. This change makes explicit that test suites are expected to exist — a run with zero matching test files will now fail the job.

## Impact

- All packages inheriting from `@repo/vitest-config/shared` will now fail CI if no test files are found
- No test behavior changes for packages that have tests (only zero-test runs are affected)
- One-line change, no risk of behavioral regression

## Related

- Fixes C-3 from the QA readiness audit
- Linked Paperclip issue: MEN-19

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single config flag change affecting only zero-test runs; minimal behavioral impact for packages with tests present.
> 
> **Overview**
> Updates the shared Vitest config (`packages/vitest-config/vitest.shared.js`) to set `passWithNoTests: false`, so runs with zero matching test files now fail instead of exiting successfully.
> 
> This removes a silent-green CI scenario for packages inheriting the shared config when tests are missing or misconfigured.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 205c3341a8ee1643ec3e0240881a3976db2a8c67. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->