### PR TITLE
fix: unhandled allowance error

### DIFF
--- a/packages/web3/src/config/wagmi.ts
+++ b/packages/web3/src/config/wagmi.ts
@@ -60,6 +60,14 @@ export const wagmiConfig: Config = createConfig({
     [Monad.id]: http(Monad.rpcUrls.default.http[0]),
     [MonadTestnet.id]: http(MonadTestnet.rpcUrls.default.http[0]),
   },
+  // Viem v2.44+ derives pollingInterval from chain.blockTime (blockTime/2, min 500ms).
+  // Monad has blockTime: 400ms → 500ms default, which is far too aggressive for HTTP RPC.
+  // Override Monad chains to 4s; Celo chains default to 4s via their blockTime (5s → 2500ms
+  // clamped to 4000ms), so no explicit override is needed there.
+  pollingInterval: {
+    [Monad.id]: 4_000,
+    [MonadTestnet.id]: 4_000,
+  },
   ssr: true,
   storage: createStorage({
     storage: cookieStorage,

--- a/packages/web3/src/features/polling/polling-worker.tsx
+++ b/packages/web3/src/features/polling/polling-worker.tsx
@@ -57,7 +57,7 @@ export function PollingWorker() {
   }, [address, isConnected, chainId, queryClient, status, setLatestBlock]);
 
   useEffect(() => {
-    onPoll();
+    void onPoll();
   }, [onPoll]);
 
   useInterval(onPoll, FAST_INTERVAL);

--- a/packages/web3/src/features/swap/hooks/use-allowance.tsx
+++ b/packages/web3/src/features/swap/hooks/use-allowance.tsx
@@ -23,15 +23,27 @@ async function fetchAllowance(
 
   const routerAddress = getContractAddress(chainId, "Router");
 
-  // For Debugging
-  // logger.info(`Fetching allowance for token ${tokenAddr} on chain ${chainId}`);
   const provider = getProvider(chainId);
   const contract = new Contract(tokenAddr, ERC20_ABI, provider);
 
-  const allowance = await contract.allowance(accountAddress, routerAddress);
-  // For Debugging
-  // logger.info(`Allowance: ${allowance.toString()}`);
-  return allowance.toString();
+  try {
+    const allowance = await contract.allowance(accountAddress, routerAddress);
+    return allowance.toString();
+  } catch (error) {
+    // Ethers.js can throw plain objects ({code, data, message}) for RPC errors.
+    // Wrap them so callers always receive proper Error instances, preventing
+    // Sentry from capturing transient "unhandled" rejections before React Query
+    // has a chance to process them.
+    if (error instanceof Error) throw error;
+    const message =
+      typeof error === "object" &&
+      error !== null &&
+      "message" in error &&
+      typeof (error as { message: unknown }).message === "string"
+        ? (error as { message: string }).message
+        : `Failed to fetch allowance for ${tokenInSymbol}`;
+    throw new Error(message);
+  }
 }
 
 export function useAppAllowance(


### PR DESCRIPTION
## Description
Fixes two issues observed when connected to Monad via the swap page.

**Excessive RPC polling on Monad chains**
Viem v2.44 introduced a blockTime-aware default polling interval formula:
Math.min(Math.max(Math.floor(blockTime / 2), 500), 4_000)
Monad's chain definition sets blockTime: 400ms, which resolves to a 500ms polling interval. Because wagmiConfig didn't set an explicit pollingInterval, all wagmi-internal watchers (e.g. watchBlockNumber) inherited this value for Monad — resulting in eth_blockNumber being called every ~500ms and dependent useReadContracts queries being refetched as a multicall on every detected block change (~every 1s). Added a per-chain pollingInterval override of 4_000ms for Monad and MonadTestnet in wagmiConfig.

**Unhandled promise rejection with {code, data, message} keys**
fetchAllowance in use-allowance.tsx had no error handling around the ethers.js contract.allowance() call. Ethers.js v5 can throw a plain object {code, data, message} (not an Error instance) for JSON-RPC failures. When a plain object propagates out of a React Query queryFn, Sentry's global unhandledrejection handler captures it before React Query's internal catch processes it, causing the "Object captured as promise rejection with keys: code, data, message" error. Wrapped the call in a try-catch that always re-throws a proper Error.

Also added void to the floating onPoll() promise in PollingWorker's useEffect to make the intent explicit.

## Other changes
PollingWorker: changed onPoll() to void onPoll() in the useEffect to suppress the unhandled-promise lint warning and make the fire-and-forget intent explicit.
## Testing

## Checklist before requesting a review

- [ ] PR title follows the [conventions](https://www.notion.so/Git-Branching-and-Commit-Message-Conventions-18f66f7d06444cfcbac5725ffbc7c04a?pvs=4#9355048863c549ef92fe210a8a1298aa)
- [ ] Performed a self-review of my own code changes
- [ ] Smoke Test Run/s passed on the CI
