### PR TITLE
feat: add EURm bridging between Celo and Monad

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -4,3 +4,5 @@ apps/app.mento.org/app/components/bridge/bridge-config.ts:generic-api-key:33
 apps/app.mento.org/app/components/bridge/bridge-config.ts:generic-api-key:45
 apps/app.mento.org/app/components/bridge/bridge-config.ts:generic-api-key:58
 apps/app.mento.org/app/components/bridge/bridge-config.ts:generic-api-key:70
+apps/app.mento.org/app/components/bridge/bridge-config.ts:generic-api-key:83
+apps/app.mento.org/app/components/bridge/bridge-config.ts:generic-api-key:95

--- a/apps/app.mento.org/app/components/bridge/bridge-config.ts
+++ b/apps/app.mento.org/app/components/bridge/bridge-config.ts
@@ -76,13 +76,38 @@ const nttConfig: NttRoute.Config = {
         ],
       },
     ],
+    EURm: [
+      {
+        chain: "Celo",
+        manager: "0x5F8a1e50F83f53951B89Fc73Ead80b27045C67fd",
+        token: "0xd8763cba276a3738e6de85b4b3bf5fded6d6ca73",
+        transceiver: [
+          {
+            address: "0x6467cfCA82184657F32F1195F9a26b5578399479",
+            type: "wormhole",
+          },
+        ],
+        eta: 1_200_000, // ~20 min for Celo → Monad
+      },
+      {
+        chain: "Monad",
+        manager: "0x5F8a1e50F83f53951B89Fc73Ead80b27045C67fd",
+        token: "0x4D502d735B4C574B487Ed641ae87cEaE884731C7",
+        transceiver: [
+          {
+            address: "0x6467cfCA82184657F32F1195F9a26b5578399479",
+            type: "wormhole",
+          },
+        ],
+      },
+    ],
   },
 };
 
 export const bridgeConfig: config.WormholeConnectConfig = {
   network: "Mainnet",
   chains: ["Celo", "Monad"],
-  tokens: ["USDm", "GBPm"],
+  tokens: ["USDm", "GBPm", "EURm"],
   tokensConfig: {
     USDm_celo: {
       symbol: "USDm",
@@ -118,6 +143,24 @@ export const bridgeConfig: config.WormholeConnectConfig = {
       tokenId: {
         chain: "Monad",
         address: "0x39bb4E0a204412bB98e821d25e7d955e69d40Fd1",
+      },
+    },
+    EURm_celo: {
+      symbol: "EURm",
+      decimals: 18,
+      icon: "/tokens/EURm.svg",
+      tokenId: {
+        chain: "Celo",
+        address: "0xd8763cba276a3738e6de85b4b3bf5fded6d6ca73",
+      },
+    },
+    EURm_monad: {
+      symbol: "EURm",
+      decimals: 18,
+      icon: "/tokens/EURm.svg",
+      tokenId: {
+        chain: "Monad",
+        address: "0x4D502d735B4C574B487Ed641ae87cEaE884731C7",
       },
     },
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,8 +10,8 @@ catalogs:
       specifier: ^9.39.2
       version: 9.39.2
     '@mento-protocol/mento-sdk':
-      specifier: 3.2.3
-      version: 3.2.3
+      specifier: 3.2.4
+      version: 3.2.4
     '@metamask/jazzicon':
       specifier: github:jmrossy/jazzicon#7a8df28
       version: 2.1.0
@@ -201,7 +201,7 @@ importers:
         version: 5.2.2(react-hook-form@7.71.1(react@19.2.3))
       '@mento-protocol/mento-sdk':
         specifier: 'catalog:'
-        version: 3.2.3(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)
+        version: 3.2.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)
       '@mui/icons-material':
         specifier: ^7.3.2
         version: 7.3.9(@mui/material@7.3.9(@emotion/react@11.14.0(@types/react@19.2.9)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.9)(react@19.2.3))(@types/react@19.2.9)(react@19.2.3))(@types/react@19.2.9)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(@types/react@19.2.9)(react@19.2.3)
@@ -806,7 +806,7 @@ importers:
         version: 5.8.0
       '@mento-protocol/mento-sdk':
         specifier: 'catalog:'
-        version: 3.2.3(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)
+        version: 3.2.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)
       '@metamask/jazzicon':
         specifier: 'catalog:'
         version: https://codeload.github.com/jmrossy/jazzicon/tar.gz/7a8df28
@@ -2900,8 +2900,8 @@ packages:
   '@mayanfinance/swap-sdk@12.2.5':
     resolution: {integrity: sha512-ZPk4QF3eDdh/jv3h+2J7XUNZaT5i5ix9UeH6QX9GkBEG6NqQmdSqRapZx52Z6JZi3BR0ixMBMjsIiGZ1KdjkkA==}
 
-  '@mento-protocol/mento-sdk@3.2.3':
-    resolution: {integrity: sha512-2hS8MqtgFQRYfJYDA2XN+K2bt58sxb9zNN1ym4CloW/4tQPKAIzGbiH+3EV+oqVQcfKUAlFV9TNI0CKiIoElEw==}
+  '@mento-protocol/mento-sdk@3.2.4':
+    resolution: {integrity: sha512-Aj16uuiPRQ4JGOJ72N6O21VQk5d5UVarQT/+AqqHSEgXbZ4rWWEc2/BrIRpaZppxnYTBPqh6r5Tmoi5OjtJB6g==}
     engines: {node: '>=18', pnpm: '>=9'}
 
   '@metamask/detect-provider@2.0.0':
@@ -16354,7 +16354,7 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@mento-protocol/mento-sdk@3.2.3(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)':
+  '@mento-protocol/mento-sdk@3.2.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)':
     dependencies:
       viem: 2.44.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)
     transitivePeerDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,8 +10,8 @@ catalogs:
       specifier: ^9.39.2
       version: 9.39.2
     '@mento-protocol/mento-sdk':
-      specifier: 3.2.2
-      version: 3.2.2
+      specifier: 3.2.3
+      version: 3.2.3
     '@metamask/jazzicon':
       specifier: github:jmrossy/jazzicon#7a8df28
       version: 2.1.0
@@ -201,7 +201,7 @@ importers:
         version: 5.2.2(react-hook-form@7.71.1(react@19.2.3))
       '@mento-protocol/mento-sdk':
         specifier: 'catalog:'
-        version: 3.2.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)
+        version: 3.2.3(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)
       '@mui/icons-material':
         specifier: ^7.3.2
         version: 7.3.9(@mui/material@7.3.9(@emotion/react@11.14.0(@types/react@19.2.9)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.9)(react@19.2.3))(@types/react@19.2.9)(react@19.2.3))(@types/react@19.2.9)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(@types/react@19.2.9)(react@19.2.3)
@@ -806,7 +806,7 @@ importers:
         version: 5.8.0
       '@mento-protocol/mento-sdk':
         specifier: 'catalog:'
-        version: 3.2.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)
+        version: 3.2.3(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)
       '@metamask/jazzicon':
         specifier: 'catalog:'
         version: https://codeload.github.com/jmrossy/jazzicon/tar.gz/7a8df28
@@ -2900,8 +2900,8 @@ packages:
   '@mayanfinance/swap-sdk@12.2.5':
     resolution: {integrity: sha512-ZPk4QF3eDdh/jv3h+2J7XUNZaT5i5ix9UeH6QX9GkBEG6NqQmdSqRapZx52Z6JZi3BR0ixMBMjsIiGZ1KdjkkA==}
 
-  '@mento-protocol/mento-sdk@3.2.2':
-    resolution: {integrity: sha512-LuouKBeY8PkDfiXaLyfQHAhr9yIwsl9EhVG3cFJpJXI6SJVTByb6tz0QwJc0bZO9IcmbkLQYHX/o7/Xw1bZ2yw==}
+  '@mento-protocol/mento-sdk@3.2.3':
+    resolution: {integrity: sha512-2hS8MqtgFQRYfJYDA2XN+K2bt58sxb9zNN1ym4CloW/4tQPKAIzGbiH+3EV+oqVQcfKUAlFV9TNI0CKiIoElEw==}
     engines: {node: '>=18', pnpm: '>=9'}
 
   '@metamask/detect-provider@2.0.0':
@@ -16354,7 +16354,7 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@mento-protocol/mento-sdk@3.2.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)':
+  '@mento-protocol/mento-sdk@3.2.3(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)':
     dependencies:
       viem: 2.44.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)
     transitivePeerDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,7 +5,7 @@ packages:
 catalog:
   "@wagmi/core": ^2.22.1
   "@eslint/js": ^9.39.2
-  "@mento-protocol/mento-sdk": 3.2.2
+  "@mento-protocol/mento-sdk": 3.2.3
   "@metamask/jazzicon": github:jmrossy/jazzicon#7a8df28
   "@rainbow-me/rainbowkit": ^2.2.10
   "@sentry/nextjs": ^10.35.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,7 +5,7 @@ packages:
 catalog:
   "@wagmi/core": ^2.22.1
   "@eslint/js": ^9.39.2
-  "@mento-protocol/mento-sdk": 3.2.3
+  "@mento-protocol/mento-sdk": 3.2.4
   "@metamask/jazzicon": github:jmrossy/jazzicon#7a8df28
   "@rainbow-me/rainbowkit": ^2.2.10
   "@sentry/nextjs": ^10.35.0


### PR DESCRIPTION
## Summary
- Adds EURm to the Wormhole NTT bridge config alongside USDm and GBPm
- Configures NTTManager, WormholeTransceiver, and EURm token addresses on Celo and Monad
- Registers `EURm_celo` and `EURm_monad` entries in `tokensConfig`

## Addresses
- NTTManager: `0x5F8a1e50F83f53951B89Fc73Ead80b27045C67fd`
- WormholeTransceiver: `0x6467cfCA82184657F32F1195F9a26b5578399479`
- EURm on Celo: `0xd8763cba276a3738e6de85b4b3bf5fded6d6ca73`
- EURm on Monad: `0x4D502d735B4C574B487Ed641ae87cEaE884731C7`

## Test plan
- [ ] Open bridge UI and confirm EURm appears in the token dropdown for both Celo and Monad
- [ ] Execute a Celo → Monad EURm transfer on mainnet
- [ ] Execute a Monad → Celo EURm transfer on mainnet