### PR TITLE
fix: align swap liquidity validation with router hop order

### DIFF
--- a/packages/web3/src/features/swap/hooks/use-swap-quote.ts
+++ b/packages/web3/src/features/swap/hooks/use-swap-quote.ts
@@ -70,30 +70,51 @@ async function validateRouteLiquidity(params: {
 }) {
   const { mento, route, amounts, routerRoutes } = params;
 
-  if (route.path.length === 0) return;
-  if (amounts.length !== route.path.length + 1) {
+  if (routerRoutes.length === 0) return;
+  if (amounts.length !== routerRoutes.length + 1) {
     throw new Error("Unable to validate swap liquidity.");
   }
 
-  const poolDetails = await Promise.all(
-    route.path.map((pool) => mento.pools.getPoolDetails(pool.poolAddr)),
+  const poolDetailsByAddr = new Map(
+    await Promise.all(
+      route.path.map(
+        async (pool) =>
+          [
+            pool.poolAddr.toLowerCase(),
+            await mento.pools.getPoolDetails(pool.poolAddr),
+          ] as const,
+      ),
+    ),
   );
 
-  for (const [hopIndex, pool] of route.path.entries()) {
-    const hopTokenOut = routerRoutes[hopIndex]?.to;
-    if (!hopTokenOut) {
+  // routerRoutes is the authoritative, direction-aware order of hops; route.path
+  // is only consulted to resolve (factory, {from,to}) → poolAddr.
+  const remainingPools = [...route.path];
+
+  for (const [hopIndex, hop] of routerRoutes.entries()) {
+    const poolIdx = remainingPools.findIndex(
+      (p) =>
+        isSameAddress(p.factoryAddr, hop.factory) &&
+        ((isSameAddress(p.token0, hop.from) &&
+          isSameAddress(p.token1, hop.to)) ||
+          (isSameAddress(p.token1, hop.from) &&
+            isSameAddress(p.token0, hop.to))),
+    );
+    const pool = poolIdx === -1 ? undefined : remainingPools[poolIdx];
+    if (!pool) {
       throw new Error("Unable to validate swap liquidity.");
     }
+    remainingPools.splice(poolIdx, 1);
 
-    const details = poolDetails[hopIndex];
+    const details = poolDetailsByAddr.get(pool.poolAddr.toLowerCase());
     const hopAmountOut = amounts[hopIndex + 1];
     if (!details || hopAmountOut == null) {
       throw new Error("Unable to validate swap liquidity.");
     }
 
-    const reserveOut = isSameAddress(hopTokenOut, pool.token0)
+    const reserveOut = isSameAddress(hop.to, pool.token0)
       ? details.reserve0
-      : isSameAddress(hopTokenOut, pool.token1)
+      : isSameAddress(hop.to, pool.token1)
         ? details.reserve1
         : null;
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,8 +10,8 @@ catalogs:
       specifier: ^9.39.2
       version: 9.39.2
     '@mento-protocol/mento-sdk':
-      specifier: 3.2.4
-      version: 3.2.4
+      specifier: 3.2.5
+      version: 3.2.5
     '@metamask/jazzicon':
       specifier: github:jmrossy/jazzicon#7a8df28
       version: 2.1.0
@@ -201,7 +201,7 @@ importers:
         version: 5.2.2(react-hook-form@7.71.1(react@19.2.3))
       '@mento-protocol/mento-sdk':
         specifier: 'catalog:'
-        version: 3.2.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)
+        version: 3.2.5(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)
       '@mui/icons-material':
         specifier: ^7.3.2
         version: 7.3.9(@mui/material@7.3.9(@emotion/react@11.14.0(@types/react@19.2.9)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.9)(react@19.2.3))(@types/react@19.2.9)(react@19.2.3))(@types/react@19.2.9)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(@types/react@19.2.9)(react@19.2.3)
@@ -806,7 +806,7 @@ importers:
         version: 5.8.0
       '@mento-protocol/mento-sdk':
         specifier: 'catalog:'
-        version: 3.2.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)
+        version: 3.2.5(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)
       '@metamask/jazzicon':
         specifier: 'catalog:'
         version: https://codeload.github.com/jmrossy/jazzicon/tar.gz/7a8df28
@@ -2900,8 +2900,8 @@ packages:
   '@mayanfinance/swap-sdk@12.2.5':
     resolution: {integrity: sha512-ZPk4QF3eDdh/jv3h+2J7XUNZaT5i5ix9UeH6QX9GkBEG6NqQmdSqRapZx52Z6JZi3BR0ixMBMjsIiGZ1KdjkkA==}
 
-  '@mento-protocol/mento-sdk@3.2.4':
-    resolution: {integrity: sha512-Aj16uuiPRQ4JGOJ72N6O21VQk5d5UVarQT/+AqqHSEgXbZ4rWWEc2/BrIRpaZppxnYTBPqh6r5Tmoi5OjtJB6g==}
+  '@mento-protocol/mento-sdk@3.2.5':
+    resolution: {integrity: sha512-ckScM4iHuqb6EG8eOR/FjUR896z4GOqr2Z6EjRi5PBIpeG24Typz4rminMlMOcSWxybxjCuczrYnauO0F2TDMw==}
     engines: {node: '>=18', pnpm: '>=9'}
 
   '@metamask/detect-provider@2.0.0':
@@ -16354,7 +16354,7 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@mento-protocol/mento-sdk@3.2.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)':
+  '@mento-protocol/mento-sdk@3.2.5(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)':
     dependencies:
       viem: 2.44.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)
     transitivePeerDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,7 +5,7 @@ packages:
 catalog:
   "@wagmi/core": ^2.22.1
   "@eslint/js": ^9.39.2
-  "@mento-protocol/mento-sdk": 3.2.4
+  "@mento-protocol/mento-sdk": 3.2.5
   "@metamask/jazzicon": github:jmrossy/jazzicon#7a8df28
   "@rainbow-me/rainbowkit": ^2.2.10
   "@sentry/nextjs": ^10.35.0


### PR DESCRIPTION
## Summary

- `validateRouteLiquidity` iterated `route.path` in its canonical order while indexing `routerRoutes` and `amounts` positionally. When `encodeRoutePath` reverses the path (e.g. `KESm → USD₮`, where the first canonical pool doesn't contain `tokenIn`), the pool at index `i` no longer matches `routerRoutes[i]`, producing a spurious "Unable to validate swap liquidity" error and blocking otherwise valid swaps.
- Rework the loop to iterate `routerRoutes` (the authoritative, direction-aware hop order the router actually executes) and resolve each hop's pool metadata from `route.path` by matching `(factory, {from, to})`. `getPoolDetails` is still prefetched in parallel, keyed by `poolAddr`.

## Test plan

- [ ] `KESm → USD₮` quote loads without the liquidity-validation error
- [ ] Other multi-hop routes whose canonical path gets reversed by `encodeRoutePath` (any route where `tokenIn` sits in the second canonical pool) still quote correctly
- [ ] Single-hop routes still quote correctly
- [ ] Non-reversed multi-hop routes (e.g. `USDm → KESm → …`) still quote correctly
- [ ] Forcing an over-reserve amount still surfaces `SWAP_INSUFFICIENT_LIQUIDITY_LABEL`