### PR TITLE
chore(osv): ignore GHSA-w5hq-g745-h8pq (unreachable uuid advisory)

### DIFF
--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -72,3 +72,42 @@ id = "GHSA-xq3m-2v4x-88gg"
 # removed from the dep tree or a safe fix path exists upstream.
 ignoreUntil = 2026-06-01T00:00:00Z
 reason = "protobufjs 6.x advisory — no safe fix path; @confio/ics23@0.6.8 is deprecated and 7.x is an unsafe major jump for Cosmos proof parsing."
+
+[[IgnoredVulns]]
+id = "GHSA-w5hq-g745-h8pq"
+# uuid: missing buffer bounds check in v3/v5/v6 when a `buf` argument is provided.
+# Fixed upstream in uuid@14.0.0, but uuid@14 is ESM-only. CJS transitive
+# consumers in the wallet/RPC stack still do `require("uuid")` and would throw
+# ERR_REQUIRE_ESM at runtime if upgraded.
+#
+# Full audit of every package in pnpm-lock.yaml that declares a pre-14 `uuid`
+# dependency (16 unique entries), with the uuid APIs each actually calls in
+# its installed build:
+#
+#   Package                              | APIs used                       | Vulnerable path?
+#   -------------------------------------|---------------------------------|-----------------
+#   @aptos-connect/web-transport 0.2.0   | stringify                       | no
+#   @identity-connect/dapp-sdk 0.10.5    | parse, stringify                | no
+#   @keystonehq/bc-ur-registry-sol 0.9.5 | parse                           | no
+#   @keystonehq/sol-keyring 0.20.0       | v4, stringify                   | no (v4 random)
+#   @metamask/sdk 0.33.1                 | v4, parse, stringify, validate  | no (v4 random)
+#   @metamask/sdk-communication-layer …  | v4, parse, stringify, validate  | no (v4 random)
+#   @metamask/utils 8.5.0                | v4, parse, stringify            | no (v4 random)
+#   @metamask/utils 9.3.0                | v4, parse, stringify            | no (v4 random)
+#   @metamask/utils 11.9.0               | v4, parse, stringify            | no (v4 random)
+#   @sentry/webpack-plugin 4.7.0         | v4                              | no (v4 random)
+#   @solflare-wallet/metamask-sdk 1.0.3  | v4 (aliased)                    | no (v4 random)
+#   @solflare-wallet/sdk 1.4.2           | v4 (aliased)                    | no (v4 random)
+#   jayson 4.3.0                         | parse, stringify, version       | no
+#   rpc-websockets 7.11.2                | parse, stringify                | no
+#   rpc-websockets 9.3.2                 | v1, parse, stringify            | no (v1 time-based)
+#   uuidv4 6.2.13                        | v4, v5(text, ns), validate, NIL | no (v5 no buf)
+#
+# No consumer calls `v3`, `v6`, or `v5` with a 3rd `buf` argument. The
+# vulnerable code path is unreachable across the entire dep tree.
+#
+# TODO: Re-evaluate at ignoreUntil — re-run the audit after any major
+# lockfile churn (e.g. new wallet SDK, upstream ESM migrations) to confirm
+# no new pre-14 uuid consumer has entered the tree on a vulnerable path.
+ignoreUntil = 2026-08-01T00:00:00Z
+reason = "uuid v3/v5/v6+buf advisory — unreachable (all 16 pre-14 consumers audited; none call v3, v6, or v5 with a buf argument); upgrade blocked by ESM-only uuid@14 vs CJS consumers."


### PR DESCRIPTION
## Summary
Suppresses OSV finding **GHSA-w5hq-g745-h8pq** ("uuid: Missing buffer bounds check in v3/v5/v6 when buf is provided") via `osv-scanner.toml` instead of upgrading, following the repo's existing pattern for unreachable/unfixable advisories (elliptic, protobufjs 6.x, lodash).

## Why not upgrade to uuid@14?

OSV lists 14.0.0 as the fixed version, but uuid@14 is **ESM-only**. Two CJS transitive consumers in the wallet stack still do `require("uuid")` and would throw `ERR_REQUIRE_ESM` at runtime when their wallet is selected:

- **`@keystonehq/sol-keyring`** — under `@solana/wallet-adapter-keystone`, under `@wormhole-foundation/wormhole-connect`. CJS build calls `uuid.v4()` and `uuid.stringify(requestId)`.
- **`uuidv4@6.2.13`** — under `@particle-network/auth` / `@particle-network/crypto`, under `@solana/wallet-adapter-particle`, under wormhole-connect. Calls `v4/validate/version/NIL` and `v5(text, namespace)`.

Both are hit in production wallet-connect flows on `app.mento.org`. (Thanks @cursor for catching this — verified both `require("uuid")` sites in the installed CJS builds, and confirmed `node_modules/uuid/package.json` is `"type": "module"` with no CJS output in `dist-node/`.)

## Why the advisory is unreachable

The vulnerability triggers only in **v3/v5/v6 when a `buf` argument is provided**. Neither consumer hits that path:

- `sol-keyring` uses `v4()` (random, unaffected) and `stringify()` (not the vulnerable function).
- `uuidv4` uses `v4/validate/version/NIL` and `v5(text, namespace)` — `v5` without a `buf` argument.

## Changes
- `osv-scanner.toml` — one new `[[IgnoredVulns]]` entry with full rationale and a time-boxed `ignoreUntil = 2026-08-01`. TODO documented so future cleanup checks whether upstream Keystone / Particle have shipped ESM builds or dropped `uuid`.

## Test plan
- [x] `trunk check --all --filter=osv-scanner` passes
- [x] No lockfile or runtime changes; pre-push hook unblocks
- [ ] Reviewer: confirm the time-boxed ignore duration is acceptable (matches the elliptic/protobufjs precedent's cadence)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Suppresses an OSV vulnerability finding rather than upgrading the affected dependency, which could mask a real exploit if the reachability assumptions change. Risk is limited because it’s time-boxed and documents an explicit audit of transitive consumers and call paths.
> 
> **Overview**
> Adds a new `[[IgnoredVulns]]` entry to `osv-scanner.toml` to ignore `GHSA-w5hq-g745-h8pq` (uuid v3/v5/v6 buffer-bounds issue) until `2026-08-01`.
> 
> The ignore includes detailed rationale: uuid@14 is ESM-only (blocking safe upgrades for CJS transitive consumers) and an audit asserting no dependency calls the vulnerable `buf` code path, plus a TODO to re-audit after major lockfile changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c67f6cc6bc68253fb161a1375c9b1a2bc8f6fec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->