### PR TITLE
chore(ci): skip Vercel builds for unaffected apps via turbo-ignore

### DIFF
--- a/apps/app.mento.org/vercel.json
+++ b/apps/app.mento.org/vercel.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "ignoreCommand": "npx turbo-ignore app.mento.org --fallback=origin/main"
+  "ignoreCommand": "npx turbo-ignore app.mento.org"
 }

--- a/apps/app.mento.org/vercel.json
+++ b/apps/app.mento.org/vercel.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "ignoreCommand": "npx turbo-ignore app.mento.org --fallback=HEAD^1"
+  "ignoreCommand": "npx turbo-ignore app.mento.org --fallback=origin/main"
 }

--- a/apps/app.mento.org/vercel.json
+++ b/apps/app.mento.org/vercel.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "ignoreCommand": "npx turbo-ignore app.mento.org"
+}

--- a/apps/app.mento.org/vercel.json
+++ b/apps/app.mento.org/vercel.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "ignoreCommand": "npx turbo-ignore app.mento.org"
+  "ignoreCommand": "npx turbo-ignore app.mento.org --fallback=HEAD^1"
 }

--- a/apps/governance.mento.org/vercel.json
+++ b/apps/governance.mento.org/vercel.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "ignoreCommand": "npx turbo-ignore governance.mento.org --fallback=origin/main"
+  "ignoreCommand": "npx turbo-ignore governance.mento.org"
 }

--- a/apps/governance.mento.org/vercel.json
+++ b/apps/governance.mento.org/vercel.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "ignoreCommand": "npx turbo-ignore governance.mento.org"
+  "ignoreCommand": "npx turbo-ignore governance.mento.org --fallback=HEAD^1"
 }

--- a/apps/governance.mento.org/vercel.json
+++ b/apps/governance.mento.org/vercel.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "ignoreCommand": "npx turbo-ignore governance.mento.org"
+}

--- a/apps/governance.mento.org/vercel.json
+++ b/apps/governance.mento.org/vercel.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "ignoreCommand": "npx turbo-ignore governance.mento.org --fallback=HEAD^1"
+  "ignoreCommand": "npx turbo-ignore governance.mento.org --fallback=origin/main"
 }

--- a/apps/reserve.mento.org/vercel.json
+++ b/apps/reserve.mento.org/vercel.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "ignoreCommand": "npx turbo-ignore reserve.mento.org"
+}

--- a/apps/reserve.mento.org/vercel.json
+++ b/apps/reserve.mento.org/vercel.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "ignoreCommand": "npx turbo-ignore reserve.mento.org --fallback=HEAD^1"
+  "ignoreCommand": "npx turbo-ignore reserve.mento.org --fallback=origin/main"
 }

--- a/apps/reserve.mento.org/vercel.json
+++ b/apps/reserve.mento.org/vercel.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "ignoreCommand": "npx turbo-ignore reserve.mento.org --fallback=origin/main"
+  "ignoreCommand": "npx turbo-ignore reserve.mento.org"
 }

--- a/apps/reserve.mento.org/vercel.json
+++ b/apps/reserve.mento.org/vercel.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "ignoreCommand": "npx turbo-ignore reserve.mento.org"
+  "ignoreCommand": "npx turbo-ignore reserve.mento.org --fallback=HEAD^1"
 }

--- a/apps/ui.mento.org/vercel.json
+++ b/apps/ui.mento.org/vercel.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "ignoreCommand": "npx turbo-ignore ui.mento.org --fallback=HEAD^1"
+  "ignoreCommand": "npx turbo-ignore ui.mento.org --fallback=origin/main"
 }

--- a/apps/ui.mento.org/vercel.json
+++ b/apps/ui.mento.org/vercel.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "ignoreCommand": "npx turbo-ignore ui.mento.org --fallback=origin/main"
+  "ignoreCommand": "npx turbo-ignore ui.mento.org"
 }

--- a/apps/ui.mento.org/vercel.json
+++ b/apps/ui.mento.org/vercel.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "ignoreCommand": "npx turbo-ignore ui.mento.org"
+}

--- a/apps/ui.mento.org/vercel.json
+++ b/apps/ui.mento.org/vercel.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "ignoreCommand": "npx turbo-ignore ui.mento.org"
+  "ignoreCommand": "npx turbo-ignore ui.mento.org --fallback=HEAD^1"
 }


### PR DESCRIPTION
## Summary

Add a per-app `vercel.json` with `"ignoreCommand": "npx turbo-ignore <workspace>"` so Vercel skips deployments for apps whose workspace (and transitive workspace deps) didn't change since the last deployed commit. Motivated by PR #321, which only modified `osv-scanner.toml` yet still triggered full builds of all 4 Vercel projects.

## Expected skip behavior

Workspace graph: `app.mento.org`, `governance.mento.org`, `reserve.mento.org` each depend on `@repo/ui` + `@repo/web3`; `ui.mento.org` depends on `@repo/ui` only.

| Change | app | gov | reserve | ui |
|---|---|---|---|---|
| `osv-scanner.toml` / `.github/**` / `README.md` only | skip | skip | skip | skip |
| `apps/<name>/**` only | only that app | | | |
| `packages/web3/**` | build | build | build | skip |
| `packages/ui/**` | build | build | build | build |
| `pnpm-lock.yaml` / root `package.json` | build | build | build | build |

## Safety

- `turbo-ignore` exits "proceed with deployment" when it cannot determine a baseline (first deploy, brand-new branch), so an unknown state never causes a false skip.
- On production deploys to `main`, it compares against `VERCEL_GIT_PREVIOUS_SHA` automatically, so a prod deploy only skips if the previous prod build is still a valid ancestor of the current commit.
- Runs before `pnpm install` on Vercel, bootstrapping its own turbo via `npx`.

## Edge case

Root-level files outside every workspace's input set (e.g. `turbo.json` itself, tsconfig bases) can affect builds without turbo seeing them as changes. If such an edit ever needs to rebuild the apps, force a redeploy from the Vercel dashboard.

## Verification

Checked out PR #321's commit (the osv-scanner.toml-only change) locally with a clean working tree and ran `turbo run build --filter=<app>...[HEAD^1] --dry=json` for each app — all four returned 0 affected tasks. Also verified a governance-only commit correctly returned 6 tasks for `governance.mento.org` and 0 for the other three apps.

## Test plan

- [ ] Merge and confirm that a trivial root-only edit (e.g. a README change) produces 4 skipped Vercel deployments on the PR.
- [ ] Confirm that an `apps/governance.mento.org/**`-only change builds only `governance.mento.org` on Vercel and skips the other three.
- [ ] Confirm that a `packages/ui/**` change rebuilds all four apps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Vercel deployment behavior by conditionally skipping builds per app; misconfiguration could cause an app to not redeploy when it should.
> 
> **Overview**
> Adds per-app `vercel.json` files for the four Vercel-deployed workspaces that set `ignoreCommand` to `npx turbo-ignore <workspace>`.
> 
> This makes Vercel automatically skip building/deploying an app when that workspace (or its transitive deps) hasn’t changed since the last deployed commit, reducing unnecessary builds in the monorepo.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63d18e9e52fcbf7f00067bb46e6c0539f812e975. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->