### PR TITLE
chore(knip): ignore .claude/worktrees/** in unused-files scan

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -2,6 +2,7 @@
   "$schema": "https://unpkg.com/knip@5/schema.json",
   "ignoreBinaries": ["anvil"],
   "ignore": [
+    ".claude/worktrees/**",
     ".trunk/**",
     "apps/governance.mento.org/app/graphql/**/generated/**",
     "commitlint.config.mjs"


### PR DESCRIPTION
## Summary
Add \`.claude/worktrees/**\` to knip's \`ignore\` list so transient agent-created git worktrees don't pollute the unused-files scan.

## Why
\`.claude/worktrees/\` holds ephemeral git worktrees spawned by agents (e.g. \`isolation: worktree\` mode). Their contents are mirrors of other branches — not workspace sources — but knip was traversing them and flagging every file as "unused" (786 entries from a single stale worktree was enough to fail the pre-push \`check-knip-pre-push\` hook on unrelated branches).

Matches the intent of \`.trunk/**\` already being on the ignore list: tooling scratch space shouldn't be in the monorepo's knip scope.

## Test plan
- [x] \`pnpm run knip\` passes locally with no stale worktrees
- [x] \`pnpm run knip\` passes locally with a stale worktree present under \`.claude/worktrees/\`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that just excludes transient `.claude/worktrees/**` directories from Knip analysis; no runtime code paths are affected.
> 
> **Overview**
> Updates `knip.json` to ignore `.claude/worktrees/**`, preventing agent-created git worktrees from being traversed and reported as unused files during Knip scans.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 606205a30a48cabe81744b954f2b7459ef1a4a14. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->