### PR TITLE
chore(ci): enable signed Turborepo remote caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,7 +348,13 @@ The signing key is provisioned in:
 - GitHub Actions, as the `TURBO_REMOTE_CACHE_SIGNATURE_KEY` Repository Secret.
 - Each Vercel project (`app.mento.org`, `governance.mento.org`, `reserve.mento.org`, `ui.mento.org`) for production, preview, and development environments.
 
-If you need to _write_ to the cache locally (most contributors don't — reads work without the key), export `TURBO_REMOTE_CACHE_SIGNATURE_KEY` in your shell with the same value. Ask a maintainer for the value; never commit it.
+**Local development:** With signing enabled, both reads and writes require the key — a Turbo client without `TURBO_REMOTE_CACHE_SIGNATURE_KEY` cannot verify signatures on downloaded artifacts and treats every task as a remote-cache miss (it then runs the task locally and uses local cache normally). To get remote-cache hits locally, export the key in your shell with the same value used in CI:
+
+```bash
+export TURBO_REMOTE_CACHE_SIGNATURE_KEY="<value from a maintainer>"
+```
+
+Never commit the key. If you don't set it, nothing breaks — you just lose the remote-cache speedup.
 
 **Rotating the key:** generate a new value (`openssl rand -hex 64`), then update all 13 locations in lockstep (1 GitHub secret + 4 projects × 3 envs). After rotation, the cache is effectively wiped — first build per task repopulates it.
 

--- a/README.md
+++ b/README.md
@@ -341,11 +341,16 @@ The `.github/workflows/ci.yml` workflow is configured to automatically leverage 
 
 #### Signed Remote Caching
 
-This repository has Signed Remote Caching enabled (`"signature": true` in `turbo.json`) for enhanced security. This prevents cache poisoning by ensuring only trusted sources can write to the cache.
+Signed Remote Caching is **enabled** (`"signature": true` in `turbo.json`). Artifacts are HMAC-signed with `TURBO_REMOTE_CACHE_SIGNATURE_KEY` before upload, and signatures are verified on download. This prevents cache poisoning: an attacker who steals `TURBO_TOKEN` (read/write API access) but not the signing key cannot inject malicious build artifacts.
 
-- **How it works:** Artifacts uploaded to the cache are signed using a secret key. Artifacts downloaded are verified against this signature.
-- **CI Requirement:** The signing key must be provided to the CI environment via the `TURBO_REMOTE_CACHE_SIGNATURE_KEY` environment variable. This should be configured as a Repository Secret in GitHub Actions settings.
-- **Local Requirement:** If you need to _write_ to the cache locally (i.e., upload artifacts that weren't already there) with signing enabled, you would also need to set the `TURBO_REMOTE_CACHE_SIGNATURE_KEY` environment variable in your local shell. Reading from the cache generally doesn't require the key.
+The signing key is provisioned in:
+
+- GitHub Actions, as the `TURBO_REMOTE_CACHE_SIGNATURE_KEY` Repository Secret.
+- Each Vercel project (`app.mento.org`, `governance.mento.org`, `reserve.mento.org`, `ui.mento.org`) for production, preview, and development environments.
+
+If you need to _write_ to the cache locally (most contributors don't — reads work without the key), export `TURBO_REMOTE_CACHE_SIGNATURE_KEY` in your shell with the same value. Ask a maintainer for the value; never commit it.
+
+**Rotating the key:** generate a new value (`openssl rand -hex 64`), then update all 13 locations in lockstep (1 GitHub secret + 4 projects × 3 envs). After rotation, the cache is effectively wiped — first build per task repopulates it.
 
 ## Potential Future Improvements
 

--- a/turbo.json
+++ b/turbo.json
@@ -52,6 +52,6 @@
     }
   },
   "remoteCache": {
-    "signature": false
+    "signature": true
   }
 }


### PR DESCRIPTION
## Summary

Enable HMAC signing on the Turborepo remote cache so artifacts are verified on download. Closes a poisoning vector: an attacker with `TURBO_TOKEN` alone (e.g. from a leaked log or transcript) can no longer inject malicious cached build outputs that downstream CI/Vercel builds would blindly execute.

## What changed

- `turbo.json` — `remoteCache.signature: false → true`.
- `README.md` — updated the Signed Remote Caching section to describe the live state, where the signing key is provisioned, and how to rotate it.

## Pre-merge plumbing (already done)

- **GitHub Secret** `TURBO_REMOTE_CACHE_SIGNATURE_KEY` rotated to a fresh `openssl rand -hex 64` value.
- **Vercel env vars** `TURBO_REMOTE_CACHE_SIGNATURE_KEY` set on all 4 projects (`app.mento.org`, `governance.mento.org`, `reserve.mento.org`, `ui.mento.org`) for production, preview, and development — same value as the GitHub secret. Verified via `vercel env ls` (12/12 ✅).

So at merge time, every environment that writes to or reads from the cache already has the key.

## Threat model

- **Defends:** stolen `TURBO_TOKEN`, compromised cache storage, supply-chain via cache poisoning.
- **Doesn't defend:** an attacker with both the token *and* the signing key (e.g. a fully compromised CI runner with all env vars exfiltrated).
- **Out of scope:** malicious code in actual source — signing only protects the cache layer.

## Cost

- One-time cache repopulation post-merge: every task is a cache miss on its first run on each runner. Subsequent runs hit the new signed cache normally.
- Build time is unchanged (HMAC adds microseconds).

## Test plan

- [ ] First merge to `main` triggers a CI build; confirm logs show no `Insufficient permissions` warnings and no signature errors.
- [ ] Subsequent CI run on a no-op PR shows remote cache hits (replays logs from cache instead of rebuilding).
- [ ] Trigger a Vercel preview deploy on each of the 4 apps; confirm builds succeed and don't error on signature mismatch.

## Rotation runbook

`README.md` documents the procedure: regenerate `openssl rand -hex 64`, then update all 13 locations in lockstep (1 GitHub secret + 4 projects × 3 envs). After rotation the cache effectively wipes and repopulates.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Enables signed remote caching, which can cause widespread cache misses or build failures if `TURBO_REMOTE_CACHE_SIGNATURE_KEY` is misconfigured across CI/Vercel/local environments. No application/runtime logic changes, but it affects the build/deploy pipeline.
> 
> **Overview**
> **Enables Signed Turborepo Remote Caching** by switching `turbo.json` `remoteCache.signature` from `false` to `true`, so cached artifacts are HMAC-signed and verified using `TURBO_REMOTE_CACHE_SIGNATURE_KEY`.
> 
> Updates `README.md` to reflect the new signed-cache behavior, including where the signing key must be configured (GitHub Actions + Vercel projects), local development implications, and a key-rotation runbook.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e19ead89a6e6b2e98f24355d6d7fa24306ce64a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->