### PR TITLE
chore(ci): fix Claude Code workflow lint issues

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -10,6 +10,8 @@ on:
     #   - "src/**/*.js"
     #   - "src/**/*.jsx"
 
+permissions: read-all
+
 jobs:
   claude-review:
     # Optional: Filter by PR author
@@ -36,9 +38,8 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
-          plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          plugin_marketplaces: https://github.com/anthropics/claude-code.git
+          plugins: code-review@claude-code-plugins
+          prompt: "/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}"
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
-

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -10,6 +10,8 @@ on:
   pull_request_review:
     types: [submitted]
 
+permissions: read-all
+
 jobs:
   claude:
     if: |
@@ -47,4 +49,3 @@ jobs:
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
           # claude_args: '--allowed-tools Bash(gh pr *)'
-

--- a/turbo.json
+++ b/turbo.json
@@ -18,6 +18,7 @@
     "SENTRY_AUTH_TOKEN",
     "CHAINALYSIS_API_KEY"
   ],
+  "globalPassThroughEnv": ["TURBO_REMOTE_CACHE_SIGNATURE_KEY"],
   "tasks": {
     "build": {
       "dependsOn": ["^build"],

--- a/turbo.json
+++ b/turbo.json
@@ -18,7 +18,6 @@
     "SENTRY_AUTH_TOKEN",
     "CHAINALYSIS_API_KEY"
   ],
-  "globalPassThroughEnv": ["TURBO_REMOTE_CACHE_SIGNATURE_KEY"],
   "tasks": {
     "build": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
## Summary

Fix two lint issues in `.github/workflows/claude*.yml` introduced by #325 that were blocking the Trunk pre-push hook for everyone:

- Added `permissions: read-all` at the workflow level (checkov flagged absence of top-level permissions, which defaults the `GITHUB_TOKEN` to write-all). Job-level permissions remain unchanged.
- Removed redundant single-quotes from string values (yamllint).

## What got dropped

This PR originally also added `TURBO_REMOTE_CACHE_SIGNATURE_KEY` to `turbo.json`'s `globalPassThroughEnv` to silence a Vercel build warning, but [review feedback](https://github.com/mento-protocol/frontend-monorepo/pull/326#pullrequestreview-4161633983) (correctly) flagged that as a least-privilege regression — turbo CLI reads `TURBO_*` system env vars natively, so the addition would have forwarded the signing secret to every task subprocess for no functional gain. Reverted in c2ae0115; living with the warning.

## Test plan

- [ ] CI green (Trunk no longer blocks the pre-push hook)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow-only change that tightens default `GITHUB_TOKEN` permissions and adjusts YAML quoting; main risk is inadvertently restricting permissions needed by the Claude action.
> 
> **Overview**
> Adds workflow-level `permissions: read-all` to the Claude GitHub Actions workflows to avoid the implicit write-all default while keeping existing job-level permissions intact.
> 
> Cleans up YAML lint issues by normalizing quoting/formatting for the Claude Code Review action inputs (e.g., `plugin_marketplaces`, `plugins`, and `prompt`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2ae01154bbf20ee67de07c5af6d63af59156f68. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->