### PR TITLE
feat: add CHFm and JPYm bridging between Celo and Monad

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -6,3 +6,7 @@ apps/app.mento.org/app/components/bridge/bridge-config.ts:generic-api-key:58
 apps/app.mento.org/app/components/bridge/bridge-config.ts:generic-api-key:70
 apps/app.mento.org/app/components/bridge/bridge-config.ts:generic-api-key:83
 apps/app.mento.org/app/components/bridge/bridge-config.ts:generic-api-key:95
+apps/app.mento.org/app/components/bridge/bridge-config.ts:generic-api-key:108
+apps/app.mento.org/app/components/bridge/bridge-config.ts:generic-api-key:120
+apps/app.mento.org/app/components/bridge/bridge-config.ts:generic-api-key:133
+apps/app.mento.org/app/components/bridge/bridge-config.ts:generic-api-key:145

--- a/apps/app.mento.org/app/components/bridge/bridge-config.ts
+++ b/apps/app.mento.org/app/components/bridge/bridge-config.ts
@@ -101,13 +101,63 @@ const nttConfig: NttRoute.Config = {
         ],
       },
     ],
+    JPYm: [
+      {
+        chain: "Celo",
+        manager: "0x7431419FE761e7da37587245c55a35E5a356c91B",
+        token: "0xc45eCF20f3CD864B32D9794d6f76814aE8892e20",
+        transceiver: [
+          {
+            address: "0x01C9d280150F932D4a2fe11f40b0d72BFfBCd339",
+            type: "wormhole",
+          },
+        ],
+        eta: 1_200_000, // ~20 min for Celo → Monad
+      },
+      {
+        chain: "Monad",
+        manager: "0x7431419FE761e7da37587245c55a35E5a356c91B",
+        token: "0x22f6A6752800eAB67b84748FeFc3cC658384aF72",
+        transceiver: [
+          {
+            address: "0x01C9d280150F932D4a2fe11f40b0d72BFfBCd339",
+            type: "wormhole",
+          },
+        ],
+      },
+    ],
+    CHFm: [
+      {
+        chain: "Celo",
+        manager: "0xbbFBE2791722E93f27c5cE80e3725c8DD8d09697",
+        token: "0xb55a79F398E759E43C95b979163f30eC87Ee131D",
+        transceiver: [
+          {
+            address: "0x0D05cf3F8d39Dc988E69CC1bF37f972eadBdC093",
+            type: "wormhole",
+          },
+        ],
+        eta: 1_200_000, // ~20 min for Celo → Monad
+      },
+      {
+        chain: "Monad",
+        manager: "0xbbFBE2791722E93f27c5cE80e3725c8DD8d09697",
+        token: "0xF64e91fFEf7ef43aA314F0Bc2AC39f770797990C",
+        transceiver: [
+          {
+            address: "0x0D05cf3F8d39Dc988E69CC1bF37f972eadBdC093",
+            type: "wormhole",
+          },
+        ],
+      },
+    ],
   },
 };
 
 export const bridgeConfig: config.WormholeConnectConfig = {
   network: "Mainnet",
   chains: ["Celo", "Monad"],
-  tokens: ["USDm", "GBPm", "EURm"],
+  tokens: ["USDm", "GBPm", "EURm", "JPYm", "CHFm"],
   tokensConfig: {
     USDm_celo: {
       symbol: "USDm",
@@ -161,6 +211,42 @@ export const bridgeConfig: config.WormholeConnectConfig = {
       tokenId: {
         chain: "Monad",
         address: "0x4D502d735B4C574B487Ed641ae87cEaE884731C7",
+      },
+    },
+    JPYm_celo: {
+      symbol: "JPYm",
+      decimals: 18,
+      icon: "/tokens/JPYm.svg",
+      tokenId: {
+        chain: "Celo",
+        address: "0xc45eCF20f3CD864B32D9794d6f76814aE8892e20",
+      },
+    },
+    JPYm_monad: {
+      symbol: "JPYm",
+      decimals: 18,
+      icon: "/tokens/JPYm.svg",
+      tokenId: {
+        chain: "Monad",
+        address: "0x22f6A6752800eAB67b84748FeFc3cC658384aF72",
+      },
+    },
+    CHFm_celo: {
+      symbol: "CHFm",
+      decimals: 18,
+      icon: "/tokens/CHFm.svg",
+      tokenId: {
+        chain: "Celo",
+        address: "0xb55a79F398E759E43C95b979163f30eC87Ee131D",
+      },
+    },
+    CHFm_monad: {
+      symbol: "CHFm",
+      decimals: 18,
+      icon: "/tokens/CHFm.svg",
+      tokenId: {
+        chain: "Monad",
+        address: "0xF64e91fFEf7ef43aA314F0Bc2AC39f770797990C",
       },
     },
   },


### PR DESCRIPTION
## Summary
- Adds CHFm and JPYm to the Wormhole NTT bridge config
- Configures NTTManager, WormholeTransceiver, and token addresses for each on Celo and Monad
- Registers `CHFm_celo`/`CHFm_monad` and `JPYm_celo`/`JPYm_monad` entries in `tokensConfig`

## Addresses
**JPYm**
- NTTManager: `0x7431419FE761e7da37587245c55a35E5a356c91B`
- WormholeTransceiver: `0x01C9d280150F932D4a2fe11f40b0d72BFfBCd339`
- JPYm on Celo: `0xc45eCF20f3CD864B32D9794d6f76814aE8892e20`
- JPYm on Monad: `0x22f6A6752800eAB67b84748FeFc3cC658384aF72`

**CHFm**
- NTTManager: `0xbbFBE2791722E93f27c5cE80e3725c8DD8d09697`
- WormholeTransceiver: `0x0D05cf3F8d39Dc988E69CC1bF37f972eadBdC093`
- CHFm on Celo: `0xb55a79F398E759E43C95b979163f30eC87Ee131D`
- CHFm on Monad: `0xF64e91fFEf7ef43aA314F0Bc2AC39f770797990C`

## Notes
Stacked on top of #312 (EURm bridge); rebase once that merges.

## Test plan
- [ ] Open bridge UI and confirm CHFm and JPYm appear in the token dropdown for both Celo and Monad
- [ ] Execute a Celo → Monad CHFm transfer on mainnet
- [ ] Execute a Monad → Celo CHFm transfer on mainnet
- [ ] Execute a Celo → Monad JPYm transfer on mainnet
- [ ] Execute a Monad → Celo JPYm transfer on mainnet

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mainnet bridge configuration is extended with new token routes and contract addresses; incorrect addresses/managers/transceivers would directly break bridging or misroute funds.
> 
> **Overview**
> Adds **CHFm** and **JPYm** to the Wormhole NTT bridge configuration for **Celo ↔ Monad**, including new NTT manager/token/transceiver addresses (and ETA for Celo→Monad) and registering new `tokensConfig` entries so they appear in the bridge UI.
> 
> Updates `.gitleaksignore` to allowlist the additional on-chain contract addresses referenced by `bridge-config.ts`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4897e66e8fb76ea55b7e45c5be884479ac5c9c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->