### PR TITLE
feat(reserve): address-label component, collateral grouping, sunburst

### DIFF
--- a/apps/reserve.mento.org/app/components/address-label.tsx
+++ b/apps/reserve.mento.org/app/components/address-label.tsx
@@ -125,7 +125,7 @@ export function AddressLabel({
           type="button"
           onClick={handleCopy}
           aria-label={`Copy address ${displayAddress}`}
-          className="h-3.5 w-3.5 rounded shrink-0 cursor-copy text-muted-foreground opacity-0 transition-opacity group-hover/address:opacity-100 hover:text-foreground focus-visible:opacity-100 focus-visible:outline-2 focus-visible:outline-[var(--ring)]"
+          className="h-3.5 w-3.5 rounded shrink-0 cursor-copy text-muted-foreground opacity-60 transition-opacity hover:opacity-100 hover:text-foreground focus-visible:opacity-100 focus-visible:outline-2 focus-visible:outline-[var(--ring)]"
         >
           {copied ? (
             <Check className="h-3.5 w-3.5 text-green-500" />
@@ -164,7 +164,7 @@ export function AddressLabel({
           type="button"
           onClick={handleCopy}
           aria-label={`Copy address ${displayAddress}`}
-          className="h-4 w-4 rounded shrink-0 cursor-copy text-muted-foreground opacity-0 transition-opacity group-hover/address:opacity-100 hover:text-foreground focus-visible:opacity-100 focus-visible:outline-2 focus-visible:outline-[var(--ring)]"
+          className="h-4 w-4 rounded shrink-0 cursor-copy text-muted-foreground opacity-60 transition-opacity hover:opacity-100 hover:text-foreground focus-visible:opacity-100 focus-visible:outline-2 focus-visible:outline-[var(--ring)]"
         >
           {copied ? (
             <Check className="h-4 w-4 text-green-500" />

--- a/apps/reserve.mento.org/app/components/address-label.tsx
+++ b/apps/reserve.mento.org/app/components/address-label.tsx
@@ -1,0 +1,181 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { Check, ClipboardCopy } from "lucide-react";
+import * as Sentry from "@sentry/nextjs";
+
+type AddressLabelVariant = "default" | "compact";
+
+interface AddressLabelProps {
+  label?: string;
+  address?: string;
+  identifier?: string;
+  chain?: string;
+  variant?: AddressLabelVariant;
+  description?: string;
+  /** Sentry tag for copy-failure breadcrumbs (e.g. "addresses_tab"). */
+  context?: string;
+  className?: string;
+}
+
+const ADDRESS_PATTERN =
+  /^(0x[0-9a-fA-F]{40}|bc1[0-9a-z]{8,90}|[13][a-km-zA-HJ-NP-Z1-9]{25,34})$/;
+
+function looksLikeAddress(value: string): boolean {
+  return ADDRESS_PATTERN.test(value);
+}
+
+function truncateMiddle(address: string): string {
+  if (address.length <= 12) return address;
+  return `${address.slice(0, 6)}\u2026${address.slice(-4)}`;
+}
+
+function explorerUrl(chain: string, address: string): string {
+  if (chain === "bitcoin") {
+    return `https://blockstream.info/address/${address}`;
+  }
+  return `https://debank.com/profile/${address}`;
+}
+
+function explorerTitle(chain: string): string {
+  if (chain === "bitcoin") return "View address on Blockstream";
+  return "View DeFi portfolio and positions on DeBank";
+}
+
+export function AddressLabel({
+  label,
+  address,
+  identifier,
+  chain,
+  variant = "default",
+  description,
+  context,
+  className,
+}: AddressLabelProps) {
+  const rawValue = address ?? identifier;
+  const isAddress = !!rawValue && looksLikeAddress(rawValue);
+  const displayAddress = isAddress ? rawValue : undefined;
+
+  const [copied, setCopied] = useState(false);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    };
+  }, []);
+
+  const handleCopy = async () => {
+    if (!displayAddress) return;
+    try {
+      await navigator.clipboard.writeText(displayAddress);
+      setCopied(true);
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+      timeoutRef.current = setTimeout(() => setCopied(false), 1200);
+    } catch (error) {
+      Sentry.captureException(error, {
+        tags: {
+          feature: "reserve_address_copy",
+          context: context ?? "unknown",
+          chain: chain ?? "unknown",
+        },
+        extra: { address: displayAddress },
+      });
+    }
+  };
+
+  if (!displayAddress) {
+    if (!label && !rawValue) return null;
+    return (
+      <span className={`gap-1 inline-flex items-baseline ${className ?? ""}`}>
+        {label && <span className="font-medium">{label}</span>}
+        {!label && rawValue && <span className="font-medium">{rawValue}</span>}
+      </span>
+    );
+  }
+
+  const truncated = truncateMiddle(displayAddress);
+  const linkHref = chain ? explorerUrl(chain, displayAddress) : undefined;
+  const linkTitle = chain ? explorerTitle(chain) : displayAddress;
+
+  if (variant === "compact") {
+    return (
+      <span
+        className={`group/address gap-2 inline-flex items-center ${className ?? ""}`}
+      >
+        {label && (
+          <span className="text-sm font-medium text-foreground">{label}</span>
+        )}
+        {linkHref ? (
+          <a
+            href={linkHref}
+            target="_blank"
+            rel="noopener noreferrer"
+            title={linkTitle}
+            className="font-mono text-xs text-muted-foreground transition-colors hover:text-[#a855f7]"
+          >
+            {truncated}
+          </a>
+        ) : (
+          <span className="font-mono text-xs text-muted-foreground">
+            {truncated}
+          </span>
+        )}
+        <button
+          type="button"
+          onClick={handleCopy}
+          aria-label={`Copy address ${displayAddress}`}
+          className="h-3.5 w-3.5 rounded shrink-0 cursor-copy text-muted-foreground opacity-0 transition-opacity group-hover/address:opacity-100 hover:text-foreground focus-visible:opacity-100 focus-visible:outline-2 focus-visible:outline-[var(--ring)]"
+        >
+          {copied ? (
+            <Check className="h-3.5 w-3.5 text-green-500" />
+          ) : (
+            <ClipboardCopy className="h-3.5 w-3.5" />
+          )}
+        </button>
+      </span>
+    );
+  }
+
+  return (
+    <div className={`group/address gap-0 flex flex-col ${className ?? ""}`}>
+      {label && (
+        <span className="text-sm font-medium text-muted-foreground">
+          {label}
+        </span>
+      )}
+      <div className="gap-2 flex items-center">
+        {linkHref ? (
+          <a
+            href={linkHref}
+            target="_blank"
+            rel="noopener noreferrer"
+            title={linkTitle}
+            className="font-mono text-sm break-all text-[#8c35fd] underline transition-colors hover:text-[#a855f7]"
+          >
+            {truncated}
+          </a>
+        ) : (
+          <span className="font-mono text-sm break-all text-muted-foreground">
+            {truncated}
+          </span>
+        )}
+        <button
+          type="button"
+          onClick={handleCopy}
+          aria-label={`Copy address ${displayAddress}`}
+          className="h-4 w-4 rounded shrink-0 cursor-copy text-muted-foreground opacity-0 transition-opacity group-hover/address:opacity-100 hover:text-foreground focus-visible:opacity-100 focus-visible:outline-2 focus-visible:outline-[var(--ring)]"
+        >
+          {copied ? (
+            <Check className="h-4 w-4 text-green-500" />
+          ) : (
+            <ClipboardCopy className="h-4 w-4" />
+          )}
+        </button>
+      </div>
+      {description && (
+        <span className="text-xs text-muted-foreground">{description}</span>
+      )}
+    </div>
+  );
+}

--- a/apps/reserve.mento.org/app/components/address-label.tsx
+++ b/apps/reserve.mento.org/app/components/address-label.tsx
@@ -125,7 +125,7 @@ export function AddressLabel({
           type="button"
           onClick={handleCopy}
           aria-label={`Copy address ${displayAddress}`}
-          className="h-3.5 w-3.5 rounded shrink-0 cursor-copy text-muted-foreground opacity-60 transition-opacity hover:opacity-100 hover:text-foreground focus-visible:opacity-100 focus-visible:outline-2 focus-visible:outline-[var(--ring)]"
+          className="h-3.5 w-3.5 rounded shrink-0 cursor-copy text-muted-foreground opacity-60 transition-opacity hover:text-foreground hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-2 focus-visible:outline-[var(--ring)]"
         >
           {copied ? (
             <Check className="h-3.5 w-3.5 text-green-500" />
@@ -164,7 +164,7 @@ export function AddressLabel({
           type="button"
           onClick={handleCopy}
           aria-label={`Copy address ${displayAddress}`}
-          className="h-4 w-4 rounded shrink-0 cursor-copy text-muted-foreground opacity-60 transition-opacity hover:opacity-100 hover:text-foreground focus-visible:opacity-100 focus-visible:outline-2 focus-visible:outline-[var(--ring)]"
+          className="h-4 w-4 rounded shrink-0 cursor-copy text-muted-foreground opacity-60 transition-opacity hover:text-foreground hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-2 focus-visible:outline-[var(--ring)]"
         >
           {copied ? (
             <Check className="h-4 w-4 text-green-500" />

--- a/apps/reserve.mento.org/app/components/sunburst-chart.tsx
+++ b/apps/reserve.mento.org/app/components/sunburst-chart.tsx
@@ -1,0 +1,395 @@
+"use client";
+
+import { useState, useMemo } from "react";
+import { formatUsd, formatPercent } from "@/lib/format";
+
+export type SunburstNode = {
+  id: string;
+  label: string;
+  // Optional override: if not provided, computed as sum of children's values.
+  value: number;
+  // Optional explicit color for ring 0 (inner ring) nodes; child rings
+  // lighten the parent color to keep visual lineage.
+  color?: string;
+  children?: SunburstNode[];
+};
+
+type Slice = {
+  id: string;
+  label: string;
+  value: number;
+  startAngle: number;
+  endAngle: number;
+  innerRadius: number;
+  outerRadius: number;
+  fill: string;
+  depth: number;
+  pathFromRoot: string[];
+};
+
+type SunburstChartProps = {
+  data: SunburstNode[];
+  // Sum used for the percentage in the tooltip / center label.
+  total: number;
+  size?: number;
+  centerLabel?: string;
+  // Controlled hover (sync with sibling components like a table). When
+  // provided, the chart defers hover state to the parent.
+  hoverId?: string | null;
+  onHoverChange?: (id: string | null) => void;
+};
+
+const DEFAULT_PALETTE = [
+  "#66FFB8",
+  "#3D42CD",
+  "#7006FC",
+  "#f59e0b",
+  "#ec4899",
+  "#06b6d4",
+  "#84cc16",
+  "#f43f5e",
+];
+
+// Build flat slice list in a single pass, computing angles per ring.
+function buildSlices(
+  nodes: SunburstNode[],
+  total: number,
+  ringWidth: number,
+  centerHole: number,
+): Slice[] {
+  const slices: Slice[] = [];
+
+  function walk(
+    items: SunburstNode[],
+    startAngle: number,
+    depth: number,
+    parentColor: string | null,
+    parentPath: string[],
+  ): number {
+    let cursor = startAngle;
+    const siblingCount = items.length;
+    items.forEach((node, idx) => {
+      const fraction = total > 0 ? node.value / total : 0;
+      const sweep = fraction * Math.PI * 2;
+      const inner = centerHole + depth * ringWidth;
+      const outer = inner + ringWidth;
+      const fill =
+        node.color ??
+        (parentColor
+          ? deriveChildColor(parentColor, idx, siblingCount, depth)
+          : DEFAULT_PALETTE[idx % DEFAULT_PALETTE.length]!);
+      const path = [...parentPath, node.label];
+      slices.push({
+        id: node.id,
+        label: node.label,
+        value: node.value,
+        startAngle: cursor,
+        endAngle: cursor + sweep,
+        innerRadius: inner,
+        outerRadius: outer,
+        fill,
+        depth,
+        pathFromRoot: path,
+      });
+      if (node.children?.length) {
+        walk(node.children, cursor, depth + 1, fill, path);
+      }
+      cursor += sweep;
+    });
+    return cursor;
+  }
+
+  walk(nodes, -Math.PI / 2, 0, null, []);
+  return slices;
+}
+
+// Spread sibling colors around the parent's hue to keep them visually
+// related but distinguishable. Inner rings drift slightly lighter so
+// outer rings (the actionable leaves) stay vivid.
+function deriveChildColor(
+  parentHex: string,
+  siblingIndex: number,
+  siblingCount: number,
+  depth: number,
+): string {
+  const hsl = hexToHsl(parentHex);
+  if (!hsl) return parentHex;
+  const center = (siblingCount - 1) / 2;
+  const offset = siblingCount > 1 ? siblingIndex - center : 0;
+  const hueSpread = Math.min(48, 18 + siblingCount * 4);
+  const stepDegrees = siblingCount > 1 ? hueSpread / siblingCount : 0;
+  const newHue = (hsl.h + offset * stepDegrees + 360) % 360;
+  const lightnessShift = Math.min(18, depth * 6);
+  const newLightness = Math.max(28, Math.min(72, hsl.l + lightnessShift));
+  const saturation = Math.max(35, hsl.s - depth * 4);
+  return hslToHex({ h: newHue, s: saturation, l: newLightness });
+}
+
+type Hsl = { h: number; s: number; l: number };
+
+function hexToHsl(hex: string): Hsl | null {
+  const cleaned = hex.replace("#", "");
+  if (cleaned.length !== 6) return null;
+  const r = parseInt(cleaned.slice(0, 2), 16) / 255;
+  const g = parseInt(cleaned.slice(2, 4), 16) / 255;
+  const b = parseInt(cleaned.slice(4, 6), 16) / 255;
+  const max = Math.max(r, g, b);
+  const min = Math.min(r, g, b);
+  const l = (max + min) / 2;
+  let h = 0;
+  let s = 0;
+  if (max !== min) {
+    const d = max - min;
+    s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+    switch (max) {
+      case r:
+        h = ((g - b) / d + (g < b ? 6 : 0)) * 60;
+        break;
+      case g:
+        h = ((b - r) / d + 2) * 60;
+        break;
+      default:
+        h = ((r - g) / d + 4) * 60;
+    }
+  }
+  return { h, s: s * 100, l: l * 100 };
+}
+
+function hslToHex({ h, s, l }: Hsl): string {
+  const sNorm = s / 100;
+  const lNorm = l / 100;
+  const c = (1 - Math.abs(2 * lNorm - 1)) * sNorm;
+  const hPrime = h / 60;
+  const x = c * (1 - Math.abs((hPrime % 2) - 1));
+  let r = 0;
+  let g = 0;
+  let b = 0;
+  if (hPrime < 1) [r, g, b] = [c, x, 0];
+  else if (hPrime < 2) [r, g, b] = [x, c, 0];
+  else if (hPrime < 3) [r, g, b] = [0, c, x];
+  else if (hPrime < 4) [r, g, b] = [0, x, c];
+  else if (hPrime < 5) [r, g, b] = [x, 0, c];
+  else [r, g, b] = [c, 0, x];
+  const m = lNorm - c / 2;
+  const toHex = (v: number) =>
+    Math.round((v + m) * 255)
+      .toString(16)
+      .padStart(2, "0");
+  return `#${toHex(r)}${toHex(g)}${toHex(b)}`;
+}
+
+function arcPath(
+  cx: number,
+  cy: number,
+  innerRadius: number,
+  outerRadius: number,
+  startAngle: number,
+  endAngle: number,
+): string {
+  // Guard against full-circle wrap which renders as zero with two arcs.
+  const sweep = endAngle - startAngle;
+  const epsilon = 0.0001;
+  if (sweep < epsilon) return "";
+
+  if (sweep >= Math.PI * 2 - epsilon) {
+    // Render as two half-arcs for a complete ring.
+    const midAngle = startAngle + Math.PI;
+    return [
+      arcPath(cx, cy, innerRadius, outerRadius, startAngle, midAngle - epsilon),
+      arcPath(cx, cy, innerRadius, outerRadius, midAngle, endAngle - epsilon),
+    ].join(" ");
+  }
+
+  const largeArc = sweep > Math.PI ? 1 : 0;
+  const x1 = cx + outerRadius * Math.cos(startAngle);
+  const y1 = cy + outerRadius * Math.sin(startAngle);
+  const x2 = cx + outerRadius * Math.cos(endAngle);
+  const y2 = cy + outerRadius * Math.sin(endAngle);
+  const x3 = cx + innerRadius * Math.cos(endAngle);
+  const y3 = cy + innerRadius * Math.sin(endAngle);
+  const x4 = cx + innerRadius * Math.cos(startAngle);
+  const y4 = cy + innerRadius * Math.sin(startAngle);
+  return [
+    `M ${x1} ${y1}`,
+    `A ${outerRadius} ${outerRadius} 0 ${largeArc} 1 ${x2} ${y2}`,
+    `L ${x3} ${y3}`,
+    `A ${innerRadius} ${innerRadius} 0 ${largeArc} 0 ${x4} ${y4}`,
+    "Z",
+  ].join(" ");
+}
+
+export function SunburstChart({
+  data,
+  total,
+  size = 360,
+  centerLabel,
+  hoverId: controlledHoverId,
+  onHoverChange,
+}: SunburstChartProps) {
+  const [uncontrolledHoverId, setUncontrolledHoverId] = useState<string | null>(
+    null,
+  );
+  const isControlled = controlledHoverId !== undefined;
+  const hoverId = isControlled ? controlledHoverId : uncontrolledHoverId;
+  const setHoverId = (id: string | null) => {
+    if (!isControlled) setUncontrolledHoverId(id);
+    onHoverChange?.(id);
+  };
+
+  const depth = useMemo(() => maxDepth(data), [data]);
+  const center = size / 2;
+  const centerHole = size * 0.12;
+  const ringWidth = (size / 2 - centerHole - 8) / Math.max(depth, 1);
+
+  const slices = useMemo(
+    () => buildSlices(data, total, ringWidth, centerHole),
+    [data, total, ringWidth, centerHole],
+  );
+
+  const hovered = slices.find((s) => s.id === hoverId);
+
+  const isInHoverBranch = (sliceId: string): boolean => {
+    if (!hoverId) return true;
+    if (sliceId === hoverId) return true;
+    if (sliceId.startsWith(`${hoverId}:`)) return true;
+    if (hoverId.startsWith(`${sliceId}:`)) return true;
+    return false;
+  };
+
+  return (
+    <div className="relative inline-block">
+      <svg
+        width={size}
+        height={size}
+        viewBox={`0 0 ${size} ${size}`}
+        role="img"
+        aria-label="Collateral hierarchy sunburst"
+      >
+        {slices.map((s) => {
+          const path = arcPath(
+            center,
+            center,
+            s.innerRadius,
+            s.outerRadius,
+            s.startAngle,
+            s.endAngle,
+          );
+          if (!path) return null;
+          const inBranch = isInHoverBranch(s.id);
+          return (
+            <path
+              key={s.id}
+              d={path}
+              fill={s.fill}
+              stroke="#15111b"
+              strokeWidth={1}
+              opacity={hoverId && !inBranch ? 0.25 : 1}
+              onMouseEnter={() => setHoverId(s.id)}
+              onMouseLeave={() => setHoverId(null)}
+              style={{ cursor: "pointer", transition: "opacity 120ms" }}
+            />
+          );
+        })}
+        {slices.map((s) => {
+          const sweep = s.endAngle - s.startAngle;
+          const ringMid = (s.innerRadius + s.outerRadius) / 2;
+          const ringSpan = s.outerRadius - s.innerRadius;
+          // Only render a label when the arc is wide enough that the
+          // text won't overflow its slice. ~14px glyph * label length
+          // approximates the chord length we have available.
+          const approxChord = sweep * ringMid;
+          const labelText = sliceLabelText(s, approxChord);
+          if (!labelText) return null;
+          const inBranch = isInHoverBranch(s.id);
+          const midAngle = (s.startAngle + s.endAngle) / 2;
+          const x = center + ringMid * Math.cos(midAngle);
+          const y = center + ringMid * Math.sin(midAngle);
+          // Rotate so text follows the arc direction; flip on the
+          // bottom half so it stays right-reading.
+          let rotation = (midAngle * 180) / Math.PI + 90;
+          if (rotation > 90 && rotation < 270) rotation -= 180;
+          const fontSize = Math.min(12, Math.max(9, ringSpan * 0.32));
+          return (
+            <text
+              key={`label:${s.id}`}
+              x={x}
+              y={y}
+              transform={`rotate(${rotation}, ${x}, ${y})`}
+              textAnchor="middle"
+              dominantBaseline="middle"
+              pointerEvents="none"
+              fill={readableTextColor(s.fill)}
+              opacity={hoverId && !inBranch ? 0.2 : 0.95}
+              style={{
+                fontSize,
+                fontWeight: s.depth === 0 ? 600 : 500,
+                transition: "opacity 120ms",
+              }}
+            >
+              {labelText}
+            </text>
+          );
+        })}
+        <text
+          x={center}
+          y={center - 6}
+          textAnchor="middle"
+          className="fill-muted-foreground"
+          style={{ fontSize: 11 }}
+        >
+          {centerLabel ?? "Total"}
+        </text>
+        <text
+          x={center}
+          y={center + 12}
+          textAnchor="middle"
+          className="fill-foreground"
+          style={{ fontSize: 14, fontWeight: 600 }}
+        >
+          {formatUsd(total, true)}
+        </text>
+      </svg>
+      {hovered && (
+        <div
+          role="tooltip"
+          className="px-3 py-2 top-2 rounded text-xs shadow-md pointer-events-none absolute left-1/2 -translate-x-1/2 border border-[var(--border)] bg-popover text-popover-foreground"
+        >
+          <div className="font-medium">{hovered.pathFromRoot.join(" / ")}</div>
+          <div className="text-muted-foreground">
+            {formatUsd(hovered.value)}
+            {total > 0 && ` (${formatPercent((hovered.value / total) * 100)})`}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function maxDepth(nodes: SunburstNode[], current = 1): number {
+  let depth = current;
+  for (const n of nodes) {
+    if (n.children?.length) {
+      depth = Math.max(depth, maxDepth(n.children, current + 1));
+    }
+  }
+  return depth;
+}
+
+function sliceLabelText(slice: Slice, chord: number): string | null {
+  if (chord < 28) return null;
+  // Estimate ~6px per glyph at the resolved font size; trim to fit.
+  const maxChars = Math.max(3, Math.floor(chord / 6));
+  if (slice.label.length <= maxChars) return slice.label;
+  return `${slice.label.slice(0, Math.max(1, maxChars - 1))}\u2026`;
+}
+
+function readableTextColor(hex: string): string {
+  const cleaned = hex.replace("#", "");
+  if (cleaned.length !== 6) return "#0b0a10";
+  const r = parseInt(cleaned.slice(0, 2), 16);
+  const g = parseInt(cleaned.slice(2, 4), 16);
+  const b = parseInt(cleaned.slice(4, 6), 16);
+  // Relative luminance — pick dark text on light fills, light on dark.
+  const lum = (0.299 * r + 0.587 * g + 0.114 * b) / 255;
+  return lum > 0.55 ? "#0b0a10" : "#f7f6fa";
+}

--- a/apps/reserve.mento.org/app/components/tabs/addresses-tab.tsx
+++ b/apps/reserve.mento.org/app/components/tabs/addresses-tab.tsx
@@ -1,76 +1,12 @@
 "use client";
 
-import { useState, useEffect, useRef } from "react";
-import * as Sentry from "@sentry/nextjs";
-import { Check, ClipboardCopy } from "lucide-react";
 import { chainLabel } from "@/lib/chains";
 import { useV2Query } from "@/lib/use-v2-query";
+import { AddressLabel } from "../address-label";
 import { TabSkeleton } from "../tab-skeleton";
-
-function getAddressUrl(chain: string, address: string): string {
-  // DeBank only indexes EVM chains; send native Bitcoin addresses to a
-  // Bitcoin block explorer instead of a dead DeBank profile URL.
-  if (chain === "bitcoin") {
-    return `https://blockstream.info/address/${address}`;
-  }
-  return `https://debank.com/profile/${address}`;
-}
-
-function getAddressLinkTitle(chain: string): string {
-  if (chain === "bitcoin") return "View address on Blockstream";
-  return "View DeFi portfolio and positions on DeBank";
-}
 
 export function AddressesTab() {
   const { data: addresses } = useV2Query("addresses");
-  const [copiedAddresses, setCopiedAddresses] = useState<Set<string>>(
-    new Set(),
-  );
-  const copyTimeoutsRef = useRef<Map<string, NodeJS.Timeout>>(new Map());
-
-  useEffect(() => {
-    const timeouts = copyTimeoutsRef.current;
-    return () => {
-      timeouts.forEach((timeout) => clearTimeout(timeout));
-      timeouts.clear();
-    };
-  }, []);
-
-  const handleCopyAddress = async (
-    address: string,
-    key: string,
-    context: { chain: string; category: string },
-  ) => {
-    try {
-      await navigator.clipboard.writeText(address);
-      setCopiedAddresses((prev) => new Set(prev).add(key));
-
-      const existingTimeout = copyTimeoutsRef.current.get(key);
-      if (existingTimeout) clearTimeout(existingTimeout);
-
-      const timeoutId = setTimeout(() => {
-        setCopiedAddresses((prev) => {
-          const newSet = new Set(prev);
-          newSet.delete(key);
-          return newSet;
-        });
-        copyTimeoutsRef.current.delete(key);
-      }, 500);
-
-      copyTimeoutsRef.current.set(key, timeoutId);
-    } catch (error) {
-      Sentry.captureException(error, {
-        tags: {
-          feature: "reserve_addresses_copy",
-          chain: context.chain,
-        },
-        extra: {
-          address,
-          category: context.category,
-        },
-      });
-    }
-  };
 
   if (!addresses) return <TabSkeleton />;
 
@@ -92,53 +28,16 @@ export function AddressesTab() {
                   {cat.category} on {chainLabel(network.chain)}
                 </h3>
                 <div className="gap-6 flex flex-col">
-                  {cat.addresses.map((addr, addrIndex) => {
-                    const uniqueKey = `${network.chain}-${cat.category}-${addr.address}`;
-                    return (
-                      <div
-                        key={`${addr.address}-${addrIndex}`}
-                        className="gap-0 flex flex-col"
-                      >
-                        {addr.label && (
-                          <span className="text-sm font-medium text-muted-foreground">
-                            {addr.label}
-                          </span>
-                        )}
-                        <div className="gap-3 flex items-center">
-                          <a
-                            href={getAddressUrl(network.chain, addr.address)}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className="text-base leading-relaxed break-all text-[#8c35fd] underline transition-colors hover:text-[#a855f7]"
-                            title={getAddressLinkTitle(network.chain)}
-                          >
-                            {addr.address}
-                          </a>
-                          <button
-                            onClick={() =>
-                              handleCopyAddress(addr.address, uniqueKey, {
-                                chain: network.chain,
-                                category: cat.category,
-                              })
-                            }
-                            aria-label={`Copy address ${addr.address}`}
-                            className="h-4 w-4 shrink-0 cursor-copy opacity-60 hover:opacity-100"
-                          >
-                            {copiedAddresses.has(uniqueKey) ? (
-                              <Check className="h-4 w-4 text-green-500" />
-                            ) : (
-                              <ClipboardCopy className="h-4 w-4" />
-                            )}
-                          </button>
-                        </div>
-                        {addr.description && (
-                          <span className="text-xs text-muted-foreground">
-                            {addr.description}
-                          </span>
-                        )}
-                      </div>
-                    );
-                  })}
+                  {cat.addresses.map((addr, addrIndex) => (
+                    <AddressLabel
+                      key={`${addr.address}-${addrIndex}`}
+                      label={addr.label}
+                      address={addr.address}
+                      chain={network.chain}
+                      description={addr.description}
+                      context={`addresses_tab:${cat.category}`}
+                    />
+                  ))}
                 </div>
               </div>
             ))}

--- a/apps/reserve.mento.org/app/components/tabs/collateral-tab.tsx
+++ b/apps/reserve.mento.org/app/components/tabs/collateral-tab.tsx
@@ -200,7 +200,10 @@ export function CollateralTab() {
           </label>
           <Select
             value={mode}
-            onValueChange={(value) => setMode(value as GroupingMode)}
+            onValueChange={(value) => {
+              setMode(value as GroupingMode);
+              setHoverId(null);
+            }}
           >
             <SelectTrigger id="collateral-grouping" className="md:w-44 w-full">
               <SelectValue />

--- a/apps/reserve.mento.org/app/components/tabs/collateral-tab.tsx
+++ b/apps/reserve.mento.org/app/components/tabs/collateral-tab.tsx
@@ -329,6 +329,11 @@ function buildRows(
   return [...pegRows, totalRow];
 }
 
+function sumSources(records: SourceRecord[] | undefined): number {
+  if (!records) return 0;
+  return records.reduce((s, r) => s + r.source.usd_value, 0);
+}
+
 // Flatten (asset, source) pairs and pro-rate the asset-level balance
 // across sources using the source's USD share.
 function flattenSources(assets: Asset[]): SourceRecord[] {
@@ -356,7 +361,7 @@ function buildRowsByCustody(
   sorted: Asset[],
   totalUsd: number,
   totalPct: number,
-  byCustodian: V2ReserveResponse["collateral"]["by_custodian"],
+  byCustodian: V2ReserveResponse["collateral"]["by_custodian"] | undefined,
 ): TreeRow<CollateralRow>[] {
   const records = flattenSources(sorted);
 
@@ -367,14 +372,20 @@ function buildRowsByCustody(
     byCustody.get(custody)!.push(rec);
   }
 
-  // API-provided totals are authoritative — preferring them over a
-  // sum-of-children avoids drift when the wire format changes (e.g.
-  // sources merged or filtered server-side).
-  const apiTotalsByCustody: Record<CustodyType, number> = {
-    hot: byCustodian.hot_usd,
-    cold: byCustodian.cold_usd,
-    ops: byCustodian.ops_usd,
-  };
+  // Prefer API-provided bucket totals when present so client and server
+  // can't drift; fall back to summing per-source values during rollout
+  // windows where `by_custodian` may not yet be populated.
+  const apiTotalsByCustody: Record<CustodyType, number> = byCustodian
+    ? {
+        hot: byCustodian.hot_usd,
+        cold: byCustodian.cold_usd,
+        ops: byCustodian.ops_usd,
+      }
+    : {
+        hot: sumSources(byCustody.get("hot")),
+        cold: sumSources(byCustody.get("cold")),
+        ops: sumSources(byCustody.get("ops")),
+      };
 
   const custodyRows: TreeRow<CollateralRow>[] = CUSTODY_ORDER.map(
     (custody) => ({
@@ -387,28 +398,34 @@ function buildRowsByCustody(
       const custodyUsd = apiTotalsByCustody[custody];
       const custodyPct = totalUsd > 0 ? (custodyUsd / totalUsd) * 100 : 0;
 
-      // Group by asset symbol; custody buckets cross chains so we
-      // collapse same-symbol records (e.g. USDC on Celo + Ethereum).
-      const bySymbol = new Map<string, SourceRecord[]>();
+      // Group by (chain, symbol) — symbols are not globally unique
+      // across chains (e.g. native BTC vs. wrapped BTC), so a flat
+      // symbol grouping would merge distinct tokens into one row.
+      const byChainSymbol = new Map<string, SourceRecord[]>();
       for (const rec of items) {
-        if (!bySymbol.has(rec.symbol)) bySymbol.set(rec.symbol, []);
-        bySymbol.get(rec.symbol)!.push(rec);
+        const key = `${rec.chain}:${rec.symbol}`;
+        if (!byChainSymbol.has(key)) byChainSymbol.set(key, []);
+        byChainSymbol.get(key)!.push(rec);
       }
 
-      const assetChildren = [...bySymbol.entries()]
-        .map(([symbol, recs]) => ({
-          symbol,
-          recs,
-          assetUsd: recs.reduce((s, r) => s + r.source.usd_value, 0),
-          assetBalance: recs.reduce((s, r) => {
-            const n = parseFloat(r.balance);
-            return Number.isFinite(n) ? s + n : s;
-          }, 0),
-          chain: recs[0]!.chain,
-        }))
+      const assetChildren = [...byChainSymbol.entries()]
+        .map(([key, recs]) => {
+          const first = recs[0]!;
+          return {
+            key,
+            symbol: first.symbol,
+            chain: first.chain,
+            recs,
+            assetUsd: recs.reduce((s, r) => s + r.source.usd_value, 0),
+            assetBalance: recs.reduce((s, r) => {
+              const n = parseFloat(r.balance);
+              return Number.isFinite(n) ? s + n : s;
+            }, 0),
+          };
+        })
         .sort((a, b) => b.assetUsd - a.assetUsd)
         .map<TreeRow<CollateralRow>>((entry) => ({
-          id: `custody:${custody}:asset:${entry.symbol}`,
+          id: `custody:${custody}:chain:${entry.chain}:asset:${entry.symbol}`,
           kind: "asset",
           symbol: entry.symbol,
           chain: entry.chain,
@@ -419,7 +436,7 @@ function buildRowsByCustody(
             .slice()
             .sort((a, b) => b.source.usd_value - a.source.usd_value)
             .map<TreeRow<CollateralRow>>((rec, i) => ({
-              id: `custody:${custody}:asset:${entry.symbol}:source:${rec.source.identifier}:${i}`,
+              id: `custody:${custody}:chain:${entry.chain}:asset:${entry.symbol}:source:${rec.source.identifier}:${i}`,
               kind: "source",
               sourceType: rec.source.type,
               label: rec.source.label,

--- a/apps/reserve.mento.org/app/components/tabs/collateral-tab.tsx
+++ b/apps/reserve.mento.org/app/components/tabs/collateral-tab.tsx
@@ -224,6 +224,7 @@ export function CollateralTab() {
           />
         </div>
         <TreeTable<CollateralRow>
+          key={mode}
           rows={rows}
           columns={columns}
           defaultOpenDepth={defaultOpenDepth}
@@ -231,7 +232,10 @@ export function CollateralTab() {
           rowClassName={(row, depth) =>
             getRowClassNameWithHover(row, depth, hoverId)
           }
-          onRowMouseEnter={(row) => setHoverId(row.id)}
+          onRowMouseEnter={(row) => {
+            if (row.kind === "total") return;
+            setHoverId(row.id);
+          }}
           onRowMouseLeave={() => setHoverId(null)}
           getRowLabel={getCollateralRowLabel}
         />

--- a/apps/reserve.mento.org/app/components/tabs/collateral-tab.tsx
+++ b/apps/reserve.mento.org/app/components/tabs/collateral-tab.tsx
@@ -1,12 +1,23 @@
 "use client";
 
+import { useMemo, useState } from "react";
 import Image from "next/image";
-import type { V2ReserveResponse } from "@/lib/types";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@repo/ui";
+import type { V2ReserveResponse, CollateralSource } from "@/lib/types";
 import { formatUsd, formatNumber, formatPercent } from "@/lib/format";
 import { CHAIN_ICON, chainLabel } from "@/lib/chains";
 import { useV2Query } from "@/lib/use-v2-query";
+import { CUSTODY_META, CUSTODY_ORDER, type CustodyType } from "@/lib/custody";
+import { AddressLabel } from "../address-label";
 import { TreeTable, type Column, type TreeRow } from "../tree-table";
 import { TabSkeleton } from "../tab-skeleton";
+import { SunburstChart, type SunburstNode } from "../sunburst-chart";
 
 const SOURCE_TYPE_LABEL: Record<string, string> = {
   wallet: "Wallet",
@@ -26,13 +37,30 @@ const SOURCE_TYPE_COLOR: Record<string, string> = {
 
 type Peg = "usd" | "eur" | "volatile";
 
-const PEG_META: Record<Peg, { label: string; accent: string }> = {
-  usd: { label: "$USD backed", accent: "border-l-4 border-l-[#66FFB8]" },
-  eur: { label: "€EUR backed", accent: "border-l-4 border-l-[#3D42CD]" },
-  volatile: {
-    label: "Volatile",
-    accent: "border-l-4 border-l-[#7006FC]",
-  },
+const PEG_META: Record<Peg, { label: string; accent: string; color: string }> =
+  {
+    usd: {
+      label: "$USD backed",
+      accent: "border-l-4 border-l-[#66FFB8]",
+      color: "#66FFB8",
+    },
+    eur: {
+      label: "€EUR backed",
+      accent: "border-l-4 border-l-[#3D42CD]",
+      color: "#3D42CD",
+    },
+    volatile: {
+      label: "Volatile",
+      accent: "border-l-4 border-l-[#7006FC]",
+      color: "#7006FC",
+    },
+  };
+
+const CHAIN_COLOR: Record<string, string> = {
+  celo: "#FBCC5C",
+  ethereum: "#627EEA",
+  bitcoin: "#F7931A",
+  monad: "#7006FC",
 };
 
 // Known stablecoins whose ticker doesn't contain "USD"/"EUR" substring.
@@ -56,9 +84,17 @@ function classifyPeg(symbol: string): Peg {
   return "volatile";
 }
 
+type GroupingMode = "asset-type" | "custody" | "network";
+
 type PegRow = {
   kind: "peg";
   peg: Peg;
+  totalUsd: number;
+  percentage: number;
+};
+type CustodyRow = {
+  kind: "custody-type";
+  custody: CustodyType;
   totalUsd: number;
   percentage: number;
 };
@@ -80,6 +116,8 @@ type SourceRow = {
   kind: "source";
   sourceType: string;
   label: string;
+  identifier: string;
+  chain: string;
   balance: string;
   usdValue: number;
 };
@@ -88,34 +126,116 @@ type TotalRow = {
   totalUsd: number;
   percentage: number;
 };
-type CollateralRow = PegRow | NetworkRow | AssetRow | SourceRow | TotalRow;
+type CollateralRow =
+  | PegRow
+  | CustodyRow
+  | NetworkRow
+  | AssetRow
+  | SourceRow
+  | TotalRow;
 
 type Asset = V2ReserveResponse["collateral"]["assets"][number];
 
+// Pre-flattened (asset, source) record for grouping modes that
+// re-aggregate by source rather than by asset.
+type SourceRecord = {
+  source: CollateralSource;
+  symbol: string;
+  chain: string;
+  // Token balance attributed to this source. The API gives usd_value
+  // per source but only an aggregate balance per asset; we pro-rate by
+  // the source's USD share so per-source rows still display amounts.
+  balance: string;
+};
+
 export function CollateralTab() {
   const { data: reserve } = useV2Query("reserve");
-  if (!reserve) return <TabSkeleton />;
-  const { assets } = reserve.collateral;
+  const [mode, setMode] = useState<GroupingMode>("asset-type");
+  const [hoverId, setHoverId] = useState<string | null>(null);
 
-  // Show every asset — no dust filter — so the grand Total row in the table
-  // genuinely reconciles with reserve.collateral.total_usd / 100%.
-  const sorted = [...assets].sort((a, b) => b.usd_value - a.usd_value);
+  const buildContext = useMemo(() => {
+    if (!reserve) return null;
+    const sorted = [...reserve.collateral.assets].sort(
+      (a, b) => b.usd_value - a.usd_value,
+    );
+    return {
+      sorted,
+      totalUsd: reserve.collateral.total_usd,
+      byCustodian: reserve.collateral.by_custodian,
+    };
+  }, [reserve]);
 
-  const rows = buildRows(sorted, reserve.collateral.total_usd, 100);
+  const rows = useMemo<TreeRow<CollateralRow>[]>(() => {
+    if (!buildContext) return [];
+    const { sorted, totalUsd, byCustodian } = buildContext;
+    if (mode === "asset-type") return buildRows(sorted, totalUsd, 100);
+    if (mode === "custody")
+      return buildRowsByCustody(sorted, totalUsd, 100, byCustodian);
+    return buildRowsByNetwork(sorted, totalUsd, 100);
+  }, [buildContext, mode]);
+
+  const sunburstData = useMemo<SunburstNode[]>(
+    () => buildSunburst(rows),
+    [rows],
+  );
+
+  if (!reserve || !buildContext) return <TabSkeleton />;
+
+  // 4-level asset-type benefits from defaultOpenDepth=2 (peg → network).
+  // 3-level modes show second level (asset / custodian) by opening 1 deep.
+  const defaultOpenDepth = mode === "asset-type" ? 2 : 1;
 
   return (
     <div>
-      <h2 className="mb-6 text-2xl font-medium md:block hidden">
-        Reserve Collateral
-      </h2>
-      <TreeTable<CollateralRow>
-        rows={rows}
-        columns={columns}
-        defaultOpenDepth={2}
-        minWidth="600px"
-        rowClassName={getRowClassName}
-        getRowLabel={getCollateralRowLabel}
-      />
+      <div className="md:flex-row md:items-center md:justify-between gap-4 mb-6 flex flex-col">
+        <h2 className="text-2xl font-medium md:block hidden">
+          Reserve Collateral
+        </h2>
+        <div className="md:flex-row md:items-center gap-2 flex flex-col">
+          <label
+            htmlFor="collateral-grouping"
+            className="text-sm text-muted-foreground"
+          >
+            Grouping by:
+          </label>
+          <Select
+            value={mode}
+            onValueChange={(value) => setMode(value as GroupingMode)}
+          >
+            <SelectTrigger id="collateral-grouping" className="md:w-44 w-full">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="asset-type">Asset type</SelectItem>
+              <SelectItem value="custody">Custody</SelectItem>
+              <SelectItem value="network">Network</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+
+      <div className="lg:grid-cols-[auto_1fr] lg:items-start gap-6 grid grid-cols-1">
+        <div className="lg:justify-start flex justify-center">
+          <SunburstChart
+            data={sunburstData}
+            total={reserve.collateral.total_usd}
+            hoverId={hoverId}
+            onHoverChange={setHoverId}
+          />
+        </div>
+        <TreeTable<CollateralRow>
+          rows={rows}
+          columns={columns}
+          defaultOpenDepth={defaultOpenDepth}
+          minWidth="600px"
+          rowClassName={(row, depth) =>
+            getRowClassNameWithHover(row, depth, hoverId)
+          }
+          onRowMouseEnter={(row) => setHoverId(row.id)}
+          onRowMouseLeave={() => setHoverId(null)}
+          getRowLabel={getCollateralRowLabel}
+        />
+      </div>
     </div>
   );
 }
@@ -174,6 +294,8 @@ function buildRows(
               kind: "source",
               sourceType: s.type,
               label: s.label,
+              identifier: s.identifier,
+              chain: asset.chain,
               balance: s.balance,
               usdValue: s.usd_value,
             })),
@@ -200,6 +322,183 @@ function buildRows(
   return [...pegRows, totalRow];
 }
 
+// Flatten (asset, source) pairs and pro-rate the asset-level balance
+// across sources using the source's USD share.
+function flattenSources(assets: Asset[]): SourceRecord[] {
+  const records: SourceRecord[] = [];
+  for (const asset of assets) {
+    const assetTotal = asset.sources.reduce((s, src) => s + src.usd_value, 0);
+    for (const source of asset.sources) {
+      const share = assetTotal > 0 ? source.usd_value / assetTotal : 0;
+      const numericBalance = parseFloat(asset.balance);
+      const proRated = Number.isFinite(numericBalance)
+        ? (numericBalance * share).toString()
+        : asset.balance;
+      records.push({
+        source,
+        symbol: asset.symbol,
+        chain: asset.chain,
+        balance: proRated,
+      });
+    }
+  }
+  return records;
+}
+
+function buildRowsByCustody(
+  sorted: Asset[],
+  totalUsd: number,
+  totalPct: number,
+  byCustodian: V2ReserveResponse["collateral"]["by_custodian"],
+): TreeRow<CollateralRow>[] {
+  const records = flattenSources(sorted);
+
+  const byCustody = new Map<CustodyType, SourceRecord[]>();
+  for (const rec of records) {
+    const custody = rec.source.custodian_type;
+    if (!byCustody.has(custody)) byCustody.set(custody, []);
+    byCustody.get(custody)!.push(rec);
+  }
+
+  // API-provided totals are authoritative — preferring them over a
+  // sum-of-children avoids drift when the wire format changes (e.g.
+  // sources merged or filtered server-side).
+  const apiTotalsByCustody: Record<CustodyType, number> = {
+    hot: byCustodian.hot_usd,
+    cold: byCustodian.cold_usd,
+    ops: byCustodian.ops_usd,
+  };
+
+  const custodyRows: TreeRow<CollateralRow>[] = CUSTODY_ORDER.map(
+    (custody) => ({
+      custody,
+      items: byCustody.get(custody) ?? [],
+    }),
+  )
+    .filter(({ items }) => items.length > 0)
+    .map<TreeRow<CollateralRow>>(({ custody, items }) => {
+      const custodyUsd = apiTotalsByCustody[custody];
+      const custodyPct = totalUsd > 0 ? (custodyUsd / totalUsd) * 100 : 0;
+
+      // Group by asset symbol; custody buckets cross chains so we
+      // collapse same-symbol records (e.g. USDC on Celo + Ethereum).
+      const bySymbol = new Map<string, SourceRecord[]>();
+      for (const rec of items) {
+        if (!bySymbol.has(rec.symbol)) bySymbol.set(rec.symbol, []);
+        bySymbol.get(rec.symbol)!.push(rec);
+      }
+
+      const assetChildren = [...bySymbol.entries()]
+        .map(([symbol, recs]) => ({
+          symbol,
+          recs,
+          assetUsd: recs.reduce((s, r) => s + r.source.usd_value, 0),
+          assetBalance: recs.reduce((s, r) => {
+            const n = parseFloat(r.balance);
+            return Number.isFinite(n) ? s + n : s;
+          }, 0),
+          chain: recs[0]!.chain,
+        }))
+        .sort((a, b) => b.assetUsd - a.assetUsd)
+        .map<TreeRow<CollateralRow>>((entry) => ({
+          id: `custody:${custody}:asset:${entry.symbol}`,
+          kind: "asset",
+          symbol: entry.symbol,
+          chain: entry.chain,
+          balance: entry.assetBalance.toString(),
+          usdValue: entry.assetUsd,
+          percentage: totalUsd > 0 ? (entry.assetUsd / totalUsd) * 100 : 0,
+          children: entry.recs
+            .slice()
+            .sort((a, b) => b.source.usd_value - a.source.usd_value)
+            .map<TreeRow<CollateralRow>>((rec, i) => ({
+              id: `custody:${custody}:asset:${entry.symbol}:source:${rec.source.identifier}:${i}`,
+              kind: "source",
+              sourceType: rec.source.type,
+              label: rec.source.label,
+              identifier: rec.source.identifier,
+              chain: rec.chain,
+              balance: rec.balance,
+              usdValue: rec.source.usd_value,
+            })),
+        }));
+
+      return {
+        id: `custody:${custody}`,
+        kind: "custody-type",
+        custody,
+        totalUsd: custodyUsd,
+        percentage: custodyPct,
+        children: assetChildren,
+      };
+    });
+
+  const totalRow: TreeRow<CollateralRow> = {
+    id: "total",
+    kind: "total",
+    totalUsd,
+    percentage: totalPct,
+  };
+
+  return [...custodyRows, totalRow];
+}
+
+function buildRowsByNetwork(
+  sorted: Asset[],
+  totalUsd: number,
+  totalPct: number,
+): TreeRow<CollateralRow>[] {
+  const byChain = new Map<string, Asset[]>();
+  for (const a of sorted) {
+    if (!byChain.has(a.chain)) byChain.set(a.chain, []);
+    byChain.get(a.chain)!.push(a);
+  }
+
+  const networkRows: TreeRow<CollateralRow>[] = [...byChain.entries()]
+    .map(([chain, chainAssets]) => ({
+      chain,
+      chainAssets,
+      chainUsd: chainAssets.reduce((s, a) => s + a.usd_value, 0),
+      chainPct: chainAssets.reduce((s, a) => s + a.percentage, 0),
+    }))
+    .sort((a, b) => b.chainUsd - a.chainUsd)
+    .map<TreeRow<CollateralRow>>((net) => ({
+      id: `chain:${net.chain}`,
+      kind: "network",
+      chain: net.chain,
+      totalUsd: net.chainUsd,
+      percentage: net.chainPct,
+      children: net.chainAssets.map<TreeRow<CollateralRow>>((asset) => ({
+        id: `chain:${asset.chain}:asset:${asset.symbol}`,
+        kind: "asset",
+        symbol: asset.symbol,
+        chain: asset.chain,
+        balance: asset.balance,
+        usdValue: asset.usd_value,
+        percentage: asset.percentage,
+        children: asset.sources.map<TreeRow<CollateralRow>>((s, i) => ({
+          id: `chain:${asset.chain}:asset:${asset.symbol}:source:${s.identifier}:${i}`,
+          kind: "source",
+          sourceType: s.type,
+          label: s.label,
+          identifier: s.identifier,
+          chain: asset.chain,
+          balance: s.balance,
+          usdValue: s.usd_value,
+        })),
+      })),
+    }));
+
+  const totalRow: TreeRow<CollateralRow> = {
+    id: "total",
+    kind: "total",
+    totalUsd,
+    percentage: totalPct,
+  };
+
+  return [...networkRows, totalRow];
+}
+
 const columns: Column<CollateralRow>[] = [
   {
     key: "asset",
@@ -208,6 +507,11 @@ const columns: Column<CollateralRow>[] = [
     cell: (row) => {
       if (row.kind === "peg") {
         return <span className="font-medium">{PEG_META[row.peg].label}</span>;
+      }
+      if (row.kind === "custody-type") {
+        return (
+          <span className="font-medium">{CUSTODY_META[row.custody].label}</span>
+        );
       }
       if (row.kind === "network") {
         const iconSrc = CHAIN_ICON[row.chain];
@@ -255,7 +559,13 @@ const columns: Column<CollateralRow>[] = [
             >
               {SOURCE_TYPE_LABEL[row.sourceType] ?? row.sourceType}
             </span>
-            <span className="text-sm text-muted-foreground">{row.label}</span>
+            <AddressLabel
+              variant="compact"
+              label={row.label}
+              identifier={row.identifier}
+              chain={row.chain}
+              context={`collateral_tab:${row.sourceType}`}
+            />
           </span>
         );
       }
@@ -285,7 +595,12 @@ const columns: Column<CollateralRow>[] = [
     align: "right",
     width: "25%",
     cell: (row) => {
-      if (row.kind === "peg" || row.kind === "total" || row.kind === "network")
+      if (
+        row.kind === "peg" ||
+        row.kind === "custody-type" ||
+        row.kind === "total" ||
+        row.kind === "network"
+      )
         return <span className="font-medium">{formatUsd(row.totalUsd)}</span>;
       if (row.kind === "asset") return formatUsd(row.usdValue);
       return (
@@ -305,7 +620,10 @@ const columns: Column<CollateralRow>[] = [
       return (
         <span
           className={
-            row.kind === "peg" || row.kind === "total" || row.kind === "network"
+            row.kind === "peg" ||
+            row.kind === "custody-type" ||
+            row.kind === "total" ||
+            row.kind === "network"
               ? "font-medium"
               : undefined
           }
@@ -321,19 +639,95 @@ function getRowClassName(row: TreeRow<CollateralRow>): string {
   if (row.kind === "peg") {
     return `${PEG_META[row.peg].accent} bg-card`;
   }
+  if (row.kind === "custody-type") {
+    return `${CUSTODY_META[row.custody].accent} bg-card`;
+  }
   if (row.kind === "network") return "bg-card/40";
   if (row.kind === "total") return "border-t border-[var(--border)] bg-card";
   if (row.kind === "source") return "bg-[#15111b]/50";
   return "";
 }
 
+function getRowClassNameWithHover(
+  row: TreeRow<CollateralRow>,
+  depth: number,
+  hoverId: string | null,
+): string {
+  const base = getRowClassName(row);
+  if (!hoverId || row.kind === "total") return base;
+  if (row.id === hoverId) return `${base} ring-1 ring-inset ring-[#7006FC]`;
+  // Dim non-matching, non-ancestor rows so the hovered branch stands out.
+  // An ancestor's id is a prefix of the descendant's id (we build ids by
+  // appending segments), so a startsWith check identifies the hovered row's
+  // ancestors and descendants.
+  const isRelated =
+    hoverId.startsWith(`${row.id}:`) || row.id.startsWith(`${hoverId}:`);
+  if (isRelated) return base;
+  return `${base} opacity-50`;
+}
+
 function getCollateralRowLabel(
   row: TreeRow<CollateralRow>,
 ): string | undefined {
   if (row.kind === "peg") return PEG_META[row.peg].label;
+  if (row.kind === "custody-type") return CUSTODY_META[row.custody].label;
   if (row.kind === "network") return chainLabel(row.chain);
   if (row.kind === "asset") return row.symbol;
   if (row.kind === "source") return row.label;
   if (row.kind === "total") return "Total";
+  return undefined;
+}
+
+// Convert the visible TreeRow tree into a SunburstNode tree, dropping
+// the synthetic "total" footer row and assigning a base color to each
+// top-level group so child rings can lighten consistently.
+function buildSunburst(rows: TreeRow<CollateralRow>[]): SunburstNode[] {
+  return rows
+    .filter((r) => r.kind !== "total")
+    .map((r) => toSunburstNode(r, true));
+}
+
+function toSunburstNode(
+  row: TreeRow<CollateralRow>,
+  isRoot: boolean,
+): SunburstNode {
+  const children = row.children
+    ?.filter((c) => c.kind !== "total")
+    .map((c) => toSunburstNode(c, false));
+  return {
+    id: row.id,
+    label: sunburstLabel(row),
+    value: sunburstValue(row),
+    color: isRoot ? rootColor(row) : undefined,
+    children: children?.length ? children : undefined,
+  };
+}
+
+function sunburstLabel(row: TreeRow<CollateralRow>): string {
+  if (row.kind === "peg") return PEG_META[row.peg].label;
+  if (row.kind === "custody-type") return CUSTODY_META[row.custody].label;
+  if (row.kind === "network") return chainLabel(row.chain);
+  if (row.kind === "asset") return row.symbol;
+  if (row.kind === "source") return row.label;
+  return "Total";
+}
+
+function sunburstValue(row: TreeRow<CollateralRow>): number {
+  if (
+    row.kind === "peg" ||
+    row.kind === "custody-type" ||
+    row.kind === "network"
+  )
+    return row.totalUsd;
+  if (row.kind === "asset") return row.usdValue;
+  if (row.kind === "source") return row.usdValue;
+  if (row.kind === "total") return row.totalUsd;
+  return 0;
+}
+
+function rootColor(row: TreeRow<CollateralRow>): string | undefined {
+  if (row.kind === "peg") return PEG_META[row.peg].color;
+  if (row.kind === "custody-type") return CUSTODY_META[row.custody].color;
+  if (row.kind === "network") return CHAIN_COLOR[row.chain];
   return undefined;
 }

--- a/apps/reserve.mento.org/app/components/tabs/positions-tab.tsx
+++ b/apps/reserve.mento.org/app/components/tabs/positions-tab.tsx
@@ -3,9 +3,10 @@
 import Image from "next/image";
 import type { V2ReserveResponse, V2StablecoinsResponse } from "@/lib/types";
 import { formatUsd, formatNumber, formatPercent } from "@/lib/format";
-import { getBlockExplorerUrl, truncateAddress } from "@/lib/format";
+import { getBlockExplorerUrl } from "@/lib/format";
 import { chainLabel } from "@/lib/chains";
 import { useV2Query } from "@/lib/use-v2-query";
+import { AddressLabel } from "../address-label";
 import { InfoTooltip } from "../info-tooltip";
 import { TreeTable, type Column, type TreeRow } from "../tree-table";
 import { TabSkeleton } from "../tab-skeleton";
@@ -356,10 +357,13 @@ const opColumns: Column<OpRow>[] = [
             <span className="rounded px-1.5 py-0.5 font-medium bg-muted text-[10px] text-muted-foreground">
               {chainLabel(row.chain)}
             </span>
-            <span className="text-sm text-muted-foreground">{row.label}</span>
-            <span className="font-mono text-xs text-muted-foreground">
-              {truncateAddress(row.address)}
-            </span>
+            <AddressLabel
+              variant="compact"
+              label={row.label}
+              address={row.address}
+              chain={row.chain}
+              context="positions_tab:operational_holdings"
+            />
           </span>
         );
       }

--- a/apps/reserve.mento.org/app/components/tabs/stablecoins-tab.tsx
+++ b/apps/reserve.mento.org/app/components/tabs/stablecoins-tab.tsx
@@ -1,12 +1,13 @@
 "use client";
 
 import Image from "next/image";
-import type { V2StablecoinsResponse } from "@/lib/types";
+import type { V2AddressesResponse, V2StablecoinsResponse } from "@/lib/types";
 import { formatUsd, formatNumber, formatPercent } from "@/lib/format";
 import { chainLabel } from "@/lib/chains";
 import { useV2Query } from "@/lib/use-v2-query";
 import { IconInfo } from "@repo/ui";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@repo/ui";
+import { AddressLabel } from "../address-label";
 import { TreeTable, type Column, type TreeRow } from "../tree-table";
 import { TabSkeleton } from "../tab-skeleton";
 
@@ -42,6 +43,7 @@ type ChainRow = {
   kind: "chain";
   chain: string;
   address: string;
+  addressLabel?: string;
   debtAmount: string;
   debtUsd: number;
   reserveHeldAmount: string;
@@ -54,8 +56,9 @@ type SupplyRow = CategoryRow | CoinRow | ChainRow;
 
 export function StablecoinsTab() {
   const { data: stablecoins } = useV2Query("stablecoins");
+  const { data: addresses } = useV2Query("addresses");
   if (!stablecoins) return <TabSkeleton />;
-  const rows = buildRows(stablecoins);
+  const rows = buildRows(stablecoins, addresses);
 
   return (
     <div>
@@ -79,7 +82,12 @@ export function StablecoinsTab() {
   );
 }
 
-function buildRows(stablecoins: V2StablecoinsResponse): TreeRow<SupplyRow>[] {
+function buildRows(
+  stablecoins: V2StablecoinsResponse,
+  addresses: V2AddressesResponse | undefined,
+): TreeRow<SupplyRow>[] {
+  const addressLabelLookup = buildAddressLabelLookup(addresses);
+
   const reserveCoins = stablecoins.stablecoins
     .filter((c) => c.backing_type === "reserve")
     .sort((a, b) => b.supply.total_usd - a.supply.total_usd);
@@ -110,6 +118,9 @@ function buildRows(stablecoins: V2StablecoinsResponse): TreeRow<SupplyRow>[] {
       kind: "chain",
       chain: ns.chain,
       address: ns.address,
+      addressLabel: addressLabelLookup.get(
+        `${ns.chain}:${ns.address.toLowerCase()}`,
+      ),
       debtAmount: ns.supply.debt,
       debtUsd: ns.supply.debt_usd,
       reserveHeldAmount: ns.supply.reserve_held,
@@ -201,9 +212,13 @@ const columns: Column<SupplyRow>[] = [
         return (
           <span className="gap-2 inline-flex items-center">
             <NetworkLabel chain={row.chain} />
-            <span className="text-xs font-mono max-w-[120px] truncate text-muted-foreground">
-              {row.address.slice(0, 6)}...{row.address.slice(-4)}
-            </span>
+            <AddressLabel
+              variant="compact"
+              label={row.addressLabel}
+              address={row.address}
+              chain={row.chain}
+              context="stablecoins_tab:network_supply"
+            />
           </span>
         );
       }
@@ -406,4 +421,22 @@ function NetworkLabel({ chain }: { chain: string }) {
       {chainLabel(chain)}
     </span>
   );
+}
+
+function buildAddressLabelLookup(
+  addresses: V2AddressesResponse | undefined,
+): Map<string, string> {
+  const lookup = new Map<string, string>();
+  if (!addresses) return lookup;
+  for (const network of addresses.networks) {
+    for (const cat of network.categories) {
+      for (const addr of cat.addresses) {
+        lookup.set(
+          `${network.chain}:${addr.address.toLowerCase()}`,
+          addr.label,
+        );
+      }
+    }
+  }
+  return lookup;
 }

--- a/apps/reserve.mento.org/app/lib/custody.ts
+++ b/apps/reserve.mento.org/app/lib/custody.ts
@@ -1,0 +1,26 @@
+import type { CustodianType } from "@/lib/types";
+
+export type CustodyType = CustodianType;
+
+export const CUSTODY_META: Record<
+  CustodyType,
+  { label: string; accent: string; color: string }
+> = {
+  cold: {
+    label: "Cold",
+    accent: "border-l-4 border-l-[#3D42CD]",
+    color: "#3D42CD",
+  },
+  ops: {
+    label: "Operational",
+    accent: "border-l-4 border-l-[#66FFB8]",
+    color: "#66FFB8",
+  },
+  hot: {
+    label: "Hot",
+    accent: "border-l-4 border-l-[#7006FC]",
+    color: "#7006FC",
+  },
+};
+
+export const CUSTODY_ORDER: CustodyType[] = ["cold", "ops", "hot"];

--- a/apps/reserve.mento.org/app/lib/format.ts
+++ b/apps/reserve.mento.org/app/lib/format.ts
@@ -16,11 +16,6 @@ export function formatPercent(value: number): string {
   return `${value.toFixed(2)}%`;
 }
 
-export function truncateAddress(address: string): string {
-  if (address.length <= 12) return address;
-  return `${address.slice(0, 6)}...${address.slice(-4)}`;
-}
-
 export function getBlockExplorerUrl(chain: string, address: string): string {
   switch (chain) {
     case "ethereum":

--- a/apps/reserve.mento.org/app/lib/types.ts
+++ b/apps/reserve.mento.org/app/lib/types.ts
@@ -97,18 +97,26 @@ type CollateralSourceType =
   | "fpmm"
   | "stability_pool";
 
+export type CustodianType = "hot" | "cold" | "ops";
+
 export interface CollateralSource {
   type: CollateralSourceType;
   label: string;
   identifier: string;
   balance: string;
   usd_value: number;
+  custodian_type: CustodianType;
 }
 
 // GET /api/v2/reserve
 export interface V2ReserveResponse {
   collateral: {
     total_usd: number;
+    by_custodian: {
+      hot_usd: number;
+      cold_usd: number;
+      ops_usd: number;
+    };
     assets: Array<{
       symbol: string;
       chain: Chain;
@@ -265,6 +273,7 @@ export interface V2AddressesResponse {
         address: string;
         label: string;
         description?: string;
+        custodian_type?: CustodianType;
       }>;
     }>;
   }>;

--- a/apps/reserve.mento.org/app/lib/types.ts
+++ b/apps/reserve.mento.org/app/lib/types.ts
@@ -112,7 +112,7 @@ export interface CollateralSource {
 export interface V2ReserveResponse {
   collateral: {
     total_usd: number;
-    by_custodian: {
+    by_custodian?: {
       hot_usd: number;
       cold_usd: number;
       ops_usd: number;


### PR DESCRIPTION
## Summary

- **Reusable `AddressLabel` component** — single source of truth for label + truncated address + copy-on-hover. Replaces bespoke copy/truncate snippets across the addresses, positions, stablecoins, and collateral tabs.
- **Stablecoins tab labels** — chain rows now cross-reference the addresses dataset so each network supply contract carries its human label instead of just an opaque address.
- **Collateral tab grouping** — new dropdown with three modes: asset-type (existing), custody, network. Custody mode reads the new `source.custodian_type` field and the `collateral.by_custodian.{hot,cold,ops}_usd` totals the API now exposes.
- **Sunburst chart** — hand-rolled SVG (no new deps), inline slice labels where the arc is wide enough, distinct sibling colors via HSL spread, and hover state synced bidirectionally with the table — hovering a slice keeps the whole branch lit and dims unrelated rows; hovering a row highlights the matching slice.

## Test plan

- [ ] `Reserve dashboard` → Addresses tab: copy button reveals on hover, copy works
- [ ] Stablecoins tab: each chain row shows its human label next to the truncated address
- [ ] Collateral tab → switch between Asset type / Custody / Network groupings — totals reconcile in every mode
- [ ] Collateral tab → hover a slice in the sunburst, matching row + ancestor/descendant rows stay lit, others dim
- [ ] Collateral tab → hover a table row, matching slice + branch stays lit in the sunburst

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it adds new collateral aggregation modes (including custody totals sourced from new API fields) and introduces a custom SVG sunburst with synced hover state, which can affect correctness of displayed totals and UI interactions.
> 
> **Overview**
> Adds a reusable `AddressLabel` component (truncate + explorer link + copy-to-clipboard with Sentry error tagging) and replaces bespoke address rendering/copy logic across the Addresses, Positions, Stablecoins, and Collateral tabs.
> 
> Enhances the Collateral tab with a grouping selector (`asset-type`, `custody`, `network`), new custody metadata, and a synced `SunburstChart` visualization that highlights/dims the corresponding table branch on hover.
> 
> Extends API types to include `custodian_type` on collateral sources, optional `collateral.by_custodian` totals, and optional `custodian_type` on address entries; Stablecoins now cross-references `/addresses` to show human labels for per-network supply contract addresses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b4257b05e7d7aeaabbe4f18507d9eb506340b47. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->