### PR TITLE
chore(ci): skip Claude code review for dependabot PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -14,11 +14,7 @@ permissions: read-all
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    if: github.event.pull_request.user.login != 'dependabot[bot]'
 
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Summary
- Adds `if: github.event.pull_request.user.login != 'dependabot[bot]'` condition to skip the Claude review job on Dependabot PRs
- Dependabot PRs are automated version bumps — Claude reviews add noise and burn API credits without value

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a simple CI workflow condition change that only affects whether an automated review job runs and does not touch runtime code or data.
> 
> **Overview**
> Prevents the `Claude Code Review` workflow from running on Dependabot PRs by adding a job-level `if` guard (`github.event.pull_request.user.login != 'dependabot[bot]'`).
> 
> This reduces CI noise and avoids spending review credits on automated dependency bump pull requests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf791920f366942755e00a5efd312d932efeb43a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->