### PR TITLE
feat(reserve): rework addresses tab around flat API + wire descriptions into positions

### DIFF
--- a/apps/reserve.mento.org/app/components/address-label.tsx
+++ b/apps/reserve.mento.org/app/components/address-label.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef, useState } from "react";
 import { Check, ClipboardCopy } from "lucide-react";
 import * as Sentry from "@sentry/nextjs";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@repo/ui";
 
 type AddressLabelVariant = "default" | "compact";
 
@@ -99,27 +100,52 @@ export function AddressLabel({
   const linkTitle = chain ? explorerTitle(chain) : displayAddress;
 
   if (variant === "compact") {
+    const addressEl = linkHref ? (
+      <a
+        href={linkHref}
+        target="_blank"
+        rel="noopener noreferrer"
+        title={linkTitle}
+        className="font-mono text-xs text-muted-foreground transition-colors hover:text-[#a855f7]"
+      >
+        {truncated}
+      </a>
+    ) : (
+      <span className="font-mono text-xs text-muted-foreground">
+        {truncated}
+      </span>
+    );
+
+    const labelEl = label ? (
+      <span className="text-sm font-medium text-foreground">{label}</span>
+    ) : null;
+
+    // Wrap the label/address with a tooltip when a description is provided
+    // so callers can surface contextual metadata (e.g. the reserve-address
+    // role) without inflating the row height.
+    const triggerContent = (
+      <span className="gap-2 inline-flex cursor-help items-center">
+        {labelEl}
+        {addressEl}
+      </span>
+    );
+
     return (
       <span
         className={`group/address gap-2 inline-flex items-center ${className ?? ""}`}
       >
-        {label && (
-          <span className="text-sm font-medium text-foreground">{label}</span>
-        )}
-        {linkHref ? (
-          <a
-            href={linkHref}
-            target="_blank"
-            rel="noopener noreferrer"
-            title={linkTitle}
-            className="font-mono text-xs text-muted-foreground transition-colors hover:text-[#a855f7]"
-          >
-            {truncated}
-          </a>
+        {description ? (
+          <Tooltip>
+            <TooltipTrigger asChild>{triggerContent}</TooltipTrigger>
+            <TooltipContent className="max-w-xs">
+              <p>{description}</p>
+            </TooltipContent>
+          </Tooltip>
         ) : (
-          <span className="font-mono text-xs text-muted-foreground">
-            {truncated}
-          </span>
+          <>
+            {labelEl}
+            {addressEl}
+          </>
         )}
         <button
           type="button"

--- a/apps/reserve.mento.org/app/components/address-label.tsx
+++ b/apps/reserve.mento.org/app/components/address-label.tsx
@@ -122,9 +122,13 @@ export function AddressLabel({
 
     // Wrap the label/address with a tooltip when a description is provided
     // so callers can surface contextual metadata (e.g. the reserve-address
-    // role) without inflating the row height.
+    // role) without inflating the row height. tabIndex makes the span
+    // keyboard-focusable so the tooltip is reachable without a mouse.
     const triggerContent = (
-      <span className="gap-2 inline-flex cursor-help items-center">
+      <span
+        tabIndex={0}
+        className="gap-2 inline-flex cursor-help items-center rounded-sm focus-visible:outline-2 focus-visible:outline-[var(--ring)]"
+      >
         {labelEl}
         {addressEl}
       </span>

--- a/apps/reserve.mento.org/app/components/tabs/addresses-tab.tsx
+++ b/apps/reserve.mento.org/app/components/tabs/addresses-tab.tsx
@@ -11,6 +11,18 @@ import { TabSkeleton } from "../tab-skeleton";
 const OTHER_KEY = "other" as const;
 type GroupKey = CustodyType | typeof OTHER_KEY;
 
+const KNOWN_CUSTODY_TYPES: ReadonlySet<CustodyType> = new Set(CUSTODY_ORDER);
+
+function groupKeyFor(addr: ReserveAddress): GroupKey {
+  // Route addresses without a custodian_type *or* with an unknown value
+  // (e.g. a future "warm" tier the frontend doesn't know about yet) into
+  // the OTHER bucket so nothing is silently dropped from the UI.
+  if (addr.custodian_type && KNOWN_CUSTODY_TYPES.has(addr.custodian_type)) {
+    return addr.custodian_type;
+  }
+  return OTHER_KEY;
+}
+
 export function AddressesTab() {
   const { data: addresses } = useV2Query("addresses");
 
@@ -18,14 +30,11 @@ export function AddressesTab() {
 
   const byCustody = new Map<GroupKey, ReserveAddress[]>();
   for (const addr of addresses.reserve) {
-    const key: GroupKey = addr.custodian_type ?? OTHER_KEY;
+    const key = groupKeyFor(addr);
     if (!byCustody.has(key)) byCustody.set(key, []);
     byCustody.get(key)!.push(addr);
   }
 
-  // Render known custody types in CUSTODY_ORDER, then anything missing a
-  // custodian_type (defensive — backend may add new categories before the
-  // frontend learns about them).
   const groups: Array<{ key: GroupKey; items: ReserveAddress[] }> = [
     ...CUSTODY_ORDER.map((c) => ({
       key: c as GroupKey,

--- a/apps/reserve.mento.org/app/components/tabs/addresses-tab.tsx
+++ b/apps/reserve.mento.org/app/components/tabs/addresses-tab.tsx
@@ -1,49 +1,152 @@
 "use client";
 
-import { chainLabel } from "@/lib/chains";
+import Image from "next/image";
+import type { Chain, ReserveAddress } from "@/lib/types";
+import { CHAIN_ICON, chainLabel } from "@/lib/chains";
+import { CUSTODY_META, CUSTODY_ORDER, type CustodyType } from "@/lib/custody";
 import { useV2Query } from "@/lib/use-v2-query";
 import { AddressLabel } from "../address-label";
 import { TabSkeleton } from "../tab-skeleton";
+
+const OTHER_KEY = "other" as const;
+type GroupKey = CustodyType | typeof OTHER_KEY;
 
 export function AddressesTab() {
   const { data: addresses } = useV2Query("addresses");
 
   if (!addresses) return <TabSkeleton />;
 
+  const byCustody = new Map<GroupKey, ReserveAddress[]>();
+  for (const addr of addresses.reserve) {
+    const key: GroupKey = addr.custodian_type ?? OTHER_KEY;
+    if (!byCustody.has(key)) byCustody.set(key, []);
+    byCustody.get(key)!.push(addr);
+  }
+
+  // Render known custody types in CUSTODY_ORDER, then anything missing a
+  // custodian_type (defensive — backend may add new categories before the
+  // frontend learns about them).
+  const groups: Array<{ key: GroupKey; items: ReserveAddress[] }> = [
+    ...CUSTODY_ORDER.map((c) => ({
+      key: c as GroupKey,
+      items: byCustody.get(c) ?? [],
+    })),
+    { key: OTHER_KEY, items: byCustody.get(OTHER_KEY) ?? [] },
+  ].filter((g) => g.items.length > 0);
+
   return (
-    <div className="gap-4 md:gap-8 flex h-full flex-col">
+    <div className="gap-8 md:gap-12 flex h-full flex-col">
       <h2 className="text-2xl font-medium md:block hidden">
         Reserve Addresses
       </h2>
 
-      <div className="gap-2 flex flex-col">
-        {addresses.networks.map((network) => (
-          <div key={network.chain} className="gap-2 md:flex-row flex flex-col">
-            {network.categories.map((cat, catIndex) => (
-              <div
-                key={`${network.chain}-${cat.category}-${catIndex}`}
-                className="p-4 md:p-8 flex-1 bg-[#15111b]"
-              >
-                <h3 className="mb-6 text-xl font-medium leading-tight md:mb-8 md:text-2xl text-[#f7f6fa]">
-                  {cat.category} on {chainLabel(network.chain)}
-                </h3>
-                <div className="gap-6 flex flex-col">
-                  {cat.addresses.map((addr, addrIndex) => (
-                    <AddressLabel
-                      key={`${addr.address}-${addrIndex}`}
-                      label={addr.label}
-                      address={addr.address}
-                      chain={network.chain}
-                      description={addr.description}
-                      context={`addresses_tab:${cat.category}`}
-                    />
-                  ))}
-                </div>
-              </div>
-            ))}
-          </div>
+      <div className="gap-8 flex flex-col">
+        {groups.map((group) => (
+          <AddressGroup
+            key={group.key}
+            groupKey={group.key}
+            items={group.items}
+          />
         ))}
       </div>
     </div>
+  );
+}
+
+function AddressGroup({
+  groupKey,
+  items,
+}: {
+  groupKey: GroupKey;
+  items: ReserveAddress[];
+}) {
+  const heading =
+    groupKey === OTHER_KEY
+      ? "Other"
+      : `${CUSTODY_META[groupKey].label} Custody`;
+  const accent = groupKey === OTHER_KEY ? "" : CUSTODY_META[groupKey].accent;
+
+  return (
+    <section className="gap-4 flex flex-col">
+      <h3 className="text-lg font-medium">{heading}</h3>
+      <div className="md:grid-cols-2 xl:grid-cols-3 gap-2 grid grid-cols-1">
+        {items.map((addr) => (
+          <AddressCard key={addr.address} address={addr} accent={accent} />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function AddressCard({
+  address,
+  accent,
+}: {
+  address: ReserveAddress;
+  accent: string;
+}) {
+  return (
+    <div className={`p-4 md:p-6 gap-3 flex flex-col bg-[#15111b] ${accent}`}>
+      <div className="gap-3 flex items-start justify-between">
+        <span className="text-base font-medium leading-tight text-[#f7f6fa]">
+          {address.label}
+        </span>
+        <ChainIconRow chains={address.chains} address={address.address} />
+      </div>
+
+      <AddressLabel
+        variant="compact"
+        address={address.address}
+        context="addresses_tab"
+      />
+
+      {address.description && (
+        <p className="text-sm leading-snug text-muted-foreground">
+          {address.description}
+        </p>
+      )}
+    </div>
+  );
+}
+
+function ChainIconRow({
+  chains,
+  address,
+}: {
+  chains: Chain[];
+  address: string;
+}) {
+  return (
+    <div className="gap-1.5 flex shrink-0 items-center">
+      {chains.map((chain) => (
+        <ChainIconLink key={chain} chain={chain} address={address} />
+      ))}
+    </div>
+  );
+}
+
+function ChainIconLink({ chain, address }: { chain: string; address: string }) {
+  const url =
+    chain === "bitcoin"
+      ? `https://blockstream.info/address/${address}`
+      : `https://debank.com/profile/${address}`;
+  const icon = CHAIN_ICON[chain];
+  if (!icon) return null;
+  return (
+    <a
+      href={url}
+      target="_blank"
+      rel="noopener noreferrer"
+      title={`View on ${chainLabel(chain)}`}
+      className="opacity-70 transition-opacity hover:opacity-100"
+    >
+      <Image
+        src={icon}
+        alt={chainLabel(chain)}
+        width={18}
+        height={18}
+        className="h-[18px] w-[18px]"
+      />
+    </a>
   );
 }

--- a/apps/reserve.mento.org/app/components/tabs/collateral-tab.tsx
+++ b/apps/reserve.mento.org/app/components/tabs/collateral-tab.tsx
@@ -181,9 +181,9 @@ export function CollateralTab() {
 
   if (!reserve || !buildContext) return <TabSkeleton />;
 
-  // 4-level asset-type benefits from defaultOpenDepth=2 (peg → network).
-  // 3-level modes show second level (asset / custodian) by opening 1 deep.
-  const defaultOpenDepth = mode === "asset-type" ? 2 : 1;
+  // 4-level modes (asset-type, custody) open 2 deep so the second
+  // grouping level (network) is visible. 3-level network mode opens 1.
+  const defaultOpenDepth = mode === "network" ? 1 : 2;
 
   return (
     <div>
@@ -398,54 +398,72 @@ function buildRowsByCustody(
       const custodyUsd = apiTotalsByCustody[custody];
       const custodyPct = totalUsd > 0 ? (custodyUsd / totalUsd) * 100 : 0;
 
-      // Group by (chain, symbol) — symbols are not globally unique
-      // across chains (e.g. native BTC vs. wrapped BTC), so a flat
-      // symbol grouping would merge distinct tokens into one row.
-      const byChainSymbol = new Map<string, SourceRecord[]>();
+      const byChain = new Map<string, SourceRecord[]>();
       for (const rec of items) {
-        const key = `${rec.chain}:${rec.symbol}`;
-        if (!byChainSymbol.has(key)) byChainSymbol.set(key, []);
-        byChainSymbol.get(key)!.push(rec);
+        if (!byChain.has(rec.chain)) byChain.set(rec.chain, []);
+        byChain.get(rec.chain)!.push(rec);
       }
 
-      const assetChildren = [...byChainSymbol.entries()]
-        .map(([key, recs]) => {
-          const first = recs[0]!;
+      const networkChildren = [...byChain.entries()]
+        .map(([chain, chainRecs]) => ({
+          chain,
+          chainRecs,
+          chainUsd: chainRecs.reduce((s, r) => s + r.source.usd_value, 0),
+        }))
+        .sort((a, b) => b.chainUsd - a.chainUsd)
+        .map<TreeRow<CollateralRow>>((net) => {
+          // Symbols are not globally unique across chains, but within a
+          // single chain they are — so within each network bucket we can
+          // group by symbol alone.
+          const bySymbol = new Map<string, SourceRecord[]>();
+          for (const rec of net.chainRecs) {
+            if (!bySymbol.has(rec.symbol)) bySymbol.set(rec.symbol, []);
+            bySymbol.get(rec.symbol)!.push(rec);
+          }
+
+          const assetChildren = [...bySymbol.entries()]
+            .map(([symbol, recs]) => ({
+              symbol,
+              recs,
+              assetUsd: recs.reduce((s, r) => s + r.source.usd_value, 0),
+              assetBalance: recs.reduce((s, r) => {
+                const n = parseFloat(r.balance);
+                return Number.isFinite(n) ? s + n : s;
+              }, 0),
+            }))
+            .sort((a, b) => b.assetUsd - a.assetUsd)
+            .map<TreeRow<CollateralRow>>((entry) => ({
+              id: `custody:${custody}:chain:${net.chain}:asset:${entry.symbol}`,
+              kind: "asset",
+              symbol: entry.symbol,
+              chain: net.chain,
+              balance: entry.assetBalance.toString(),
+              usdValue: entry.assetUsd,
+              percentage: totalUsd > 0 ? (entry.assetUsd / totalUsd) * 100 : 0,
+              children: entry.recs
+                .slice()
+                .sort((a, b) => b.source.usd_value - a.source.usd_value)
+                .map<TreeRow<CollateralRow>>((rec, i) => ({
+                  id: `custody:${custody}:chain:${net.chain}:asset:${entry.symbol}:source:${rec.source.identifier}:${i}`,
+                  kind: "source",
+                  sourceType: rec.source.type,
+                  label: rec.source.label,
+                  identifier: rec.source.identifier,
+                  chain: rec.chain,
+                  balance: rec.balance,
+                  usdValue: rec.source.usd_value,
+                })),
+            }));
+
           return {
-            key,
-            symbol: first.symbol,
-            chain: first.chain,
-            recs,
-            assetUsd: recs.reduce((s, r) => s + r.source.usd_value, 0),
-            assetBalance: recs.reduce((s, r) => {
-              const n = parseFloat(r.balance);
-              return Number.isFinite(n) ? s + n : s;
-            }, 0),
+            id: `custody:${custody}:chain:${net.chain}`,
+            kind: "network",
+            chain: net.chain,
+            totalUsd: net.chainUsd,
+            percentage: totalUsd > 0 ? (net.chainUsd / totalUsd) * 100 : 0,
+            children: assetChildren,
           };
-        })
-        .sort((a, b) => b.assetUsd - a.assetUsd)
-        .map<TreeRow<CollateralRow>>((entry) => ({
-          id: `custody:${custody}:chain:${entry.chain}:asset:${entry.symbol}`,
-          kind: "asset",
-          symbol: entry.symbol,
-          chain: entry.chain,
-          balance: entry.assetBalance.toString(),
-          usdValue: entry.assetUsd,
-          percentage: totalUsd > 0 ? (entry.assetUsd / totalUsd) * 100 : 0,
-          children: entry.recs
-            .slice()
-            .sort((a, b) => b.source.usd_value - a.source.usd_value)
-            .map<TreeRow<CollateralRow>>((rec, i) => ({
-              id: `custody:${custody}:chain:${entry.chain}:asset:${entry.symbol}:source:${rec.source.identifier}:${i}`,
-              kind: "source",
-              sourceType: rec.source.type,
-              label: rec.source.label,
-              identifier: rec.source.identifier,
-              chain: rec.chain,
-              balance: rec.balance,
-              usdValue: rec.source.usd_value,
-            })),
-        }));
+        });
 
       return {
         id: `custody:${custody}`,
@@ -453,7 +471,7 @@ function buildRowsByCustody(
         custody,
         totalUsd: custodyUsd,
         percentage: custodyPct,
-        children: assetChildren,
+        children: networkChildren,
       };
     });
 

--- a/apps/reserve.mento.org/app/components/tabs/positions-tab.tsx
+++ b/apps/reserve.mento.org/app/components/tabs/positions-tab.tsx
@@ -1,7 +1,11 @@
 "use client";
 
 import Image from "next/image";
-import type { V2ReserveResponse, V2StablecoinsResponse } from "@/lib/types";
+import type {
+  V2AddressesResponse,
+  V2ReserveResponse,
+  V2StablecoinsResponse,
+} from "@/lib/types";
 import { formatUsd, formatNumber, formatPercent } from "@/lib/format";
 import { getBlockExplorerUrl } from "@/lib/format";
 import { chainLabel } from "@/lib/chains";
@@ -46,27 +50,61 @@ type LiquidityPosition = {
   positionName: string;
   tokens: Token[];
   holder: string;
+  holderAddress: string;
   chain: string;
 };
+
+// Lookup descriptions by address (lowercased — the API returns checksummed
+// addresses but anything we match against may not be).
+type AddressDescriptionMap = Map<string, string>;
+
+function buildAddressDescriptionMap(
+  addresses: V2AddressesResponse | undefined,
+): AddressDescriptionMap {
+  const map = new Map<string, string>();
+  if (!addresses) return map;
+  for (const addr of addresses.reserve) {
+    if (addr.description) map.set(addr.address.toLowerCase(), addr.description);
+  }
+  return map;
+}
+
+function lookupDescription(
+  map: AddressDescriptionMap,
+  address: string | undefined,
+): string | undefined {
+  if (!address) return undefined;
+  return map.get(address.toLowerCase());
+}
 
 export function PositionsTab() {
   const { data: reserve } = useV2Query("reserve");
   const { data: stablecoins } = useV2Query("stablecoins");
+  const { data: addresses } = useV2Query("addresses");
   if (!reserve || !stablecoins) return <TabSkeleton />;
-  return <PositionsTabView reserve={reserve} stablecoins={stablecoins} />;
+  return (
+    <PositionsTabView
+      reserve={reserve}
+      stablecoins={stablecoins}
+      addresses={addresses}
+    />
+  );
 }
 
 function PositionsTabView({
   reserve,
   stablecoins,
+  addresses,
 }: {
   reserve: V2ReserveResponse;
   stablecoins: V2StablecoinsResponse;
+  addresses: V2AddressesResponse | undefined;
 }) {
   const { positions } = reserve;
 
   const priceMap = buildPriceMap(reserve, stablecoins);
   const mentoSymbols = new Set(stablecoins.stablecoins.map((c) => c.symbol));
+  const descriptionMap = buildAddressDescriptionMap(addresses);
 
   // Trust is_mento_stable but fall back to the canonical stablecoin symbol
   // set in case the backend misses the flag for a known Mento stable.
@@ -108,9 +146,15 @@ function PositionsTabView({
         troveOverhead={troveOverheadTotal}
       />
       {stableHoldings.length > 0 && (
-        <OperationalHoldingsSection holdings={stableHoldings} />
+        <OperationalHoldingsSection
+          holdings={stableHoldings}
+          descriptionMap={descriptionMap}
+        />
       )}
-      <LiquidityPositionsSection positions={liquidityPositions} />
+      <LiquidityPositionsSection
+        positions={liquidityPositions}
+        descriptionMap={descriptionMap}
+      />
       <CdpTrovesSection troves={reserve.cdp_troves} />
     </div>
   );
@@ -239,6 +283,7 @@ type OpCustodyRow = {
   chain: string;
   label: string;
   address: string;
+  description?: string;
   balance: string;
   usd: number;
 };
@@ -250,8 +295,10 @@ type OpRow = OpAssetRow | OpCustodyRow | OpTotalRow;
 
 function OperationalHoldingsSection({
   holdings,
+  descriptionMap,
 }: {
   holdings: HoldingEntry[];
+  descriptionMap: AddressDescriptionMap;
 }) {
   const grouped = new Map<
     string,
@@ -297,6 +344,7 @@ function OperationalHoldingsSection({
             chain: c.chain,
             label: c.label,
             address: c.address,
+            description: lookupDescription(descriptionMap, c.address),
             balance: c.balance,
             usd: c.usd_value,
           }))
@@ -362,6 +410,7 @@ const opColumns: Column<OpRow>[] = [
               label={row.label}
               address={row.address}
               chain={row.chain}
+              description={row.description}
               context="positions_tab:operational_holdings"
             />
           </span>
@@ -437,6 +486,8 @@ type PositionRowData = {
   name: string;
   chain: string;
   holder: string;
+  holderAddress: string;
+  holderDescription?: string;
   mentoTokens: Token[];
   collateralTokens: Token[];
 };
@@ -459,8 +510,10 @@ type LiquidityRow =
 
 function LiquidityPositionsSection({
   positions,
+  descriptionMap,
 }: {
   positions: LiquidityPosition[];
+  descriptionMap: AddressDescriptionMap;
 }) {
   const byProtocol = new Map<Protocol, LiquidityPosition[]>();
   for (const p of positions) {
@@ -505,6 +558,11 @@ function LiquidityPositionsSection({
           name: pos.positionName,
           chain: pos.chain,
           holder: pos.holder,
+          holderAddress: pos.holderAddress,
+          holderDescription: lookupDescription(
+            descriptionMap,
+            pos.holderAddress,
+          ),
           mentoTokens: sortTokensBySymbol(
             nonZero.filter((t) => t.isMentoStable),
           ),
@@ -647,7 +705,14 @@ const liquidityColumns: Column<LiquidityRow>[] = [
     cell: (row) => {
       if (row.kind === "position")
         return (
-          <span className="text-sm text-muted-foreground">{row.holder}</span>
+          <AddressLabel
+            variant="compact"
+            label={row.holder}
+            address={row.holderAddress}
+            chain={row.chain}
+            description={row.holderDescription}
+            context="positions_tab:liquidity_holder"
+          />
         );
       return null;
     },
@@ -791,6 +856,7 @@ function normalizePositions(
         },
       ],
       holder: d.label,
+      holderAddress: d.address,
       chain: d.chain,
     });
   }
@@ -816,6 +882,7 @@ function normalizePositions(
         },
       ],
       holder: p.lp_holder_label,
+      holderAddress: p.lp_holder,
       chain: p.chain,
     });
   }
@@ -841,6 +908,7 @@ function normalizePositions(
         },
       ],
       holder: p.owner_label,
+      holderAddress: p.owner,
       chain: p.chain,
     });
   }
@@ -868,6 +936,7 @@ function normalizePositions(
       positionName: d.pool_label,
       tokens,
       holder: d.depositor_label,
+      holderAddress: d.depositor,
       chain: d.chain,
     });
   }

--- a/apps/reserve.mento.org/app/components/tabs/stablecoins-tab.tsx
+++ b/apps/reserve.mento.org/app/components/tabs/stablecoins-tab.tsx
@@ -428,14 +428,12 @@ function buildAddressLabelLookup(
 ): Map<string, string> {
   const lookup = new Map<string, string>();
   if (!addresses) return lookup;
-  for (const network of addresses.networks) {
-    for (const cat of network.categories) {
-      for (const addr of cat.addresses) {
-        lookup.set(
-          `${network.chain}:${addr.address.toLowerCase()}`,
-          addr.label,
-        );
-      }
+  // The new addresses shape gives each address a chains[] list, so emit
+  // one (chain:address)→label entry per chain the address is deployed on.
+  for (const addr of addresses.reserve) {
+    const lower = addr.address.toLowerCase();
+    for (const chain of addr.chains) {
+      lookup.set(`${chain}:${lower}`, addr.label);
     }
   }
   return lookup;

--- a/apps/reserve.mento.org/app/lib/queries.ts
+++ b/apps/reserve.mento.org/app/lib/queries.ts
@@ -61,7 +61,7 @@ export const TAB_ENDPOINTS: Record<TabType, V2Endpoint[]> = {
   [TabType.overview]: ["overview"],
   [TabType.stablecoins]: ["stablecoins"],
   [TabType.collateral]: ["reserve"],
-  [TabType.positions]: ["reserve", "stablecoins"],
+  [TabType.positions]: ["reserve", "stablecoins", "addresses"],
   [TabType.addresses]: ["addresses"],
 };
 

--- a/apps/reserve.mento.org/app/lib/types.ts
+++ b/apps/reserve.mento.org/app/lib/types.ts
@@ -263,19 +263,16 @@ export interface V2ReserveResponse {
   meta?: V2Meta;
 }
 
+export interface ReserveAddress {
+  address: string;
+  chains: Chain[];
+  label: string;
+  custodian_type?: CustodianType;
+  description?: string;
+}
+
 // GET /api/v2/addresses
 export interface V2AddressesResponse {
-  networks: Array<{
-    chain: Chain;
-    categories: Array<{
-      category: string;
-      addresses: Array<{
-        address: string;
-        label: string;
-        description?: string;
-        custodian_type?: CustodianType;
-      }>;
-    }>;
-  }>;
+  reserve: ReserveAddress[];
   meta?: V2Meta;
 }


### PR DESCRIPTION
## Summary

- `/api/v2/addresses` changed shape — it's now a single flat `reserve` list where each address carries `chains[]`, collapsing cross-chain identity. DTO + the stablecoins-tab lookup updated to consume the new shape.
- Addresses tab redesigned around the flat list: cards grouped by custody type (cold / operational / hot), chains shown as a compact icon row with per-chain explorer links, description rendered below.
- `AddressLabel` compact variant now supports description-as-tooltip. The positions tab Holder column (and operational holdings rows) use `AddressLabel`, looking up descriptions by holder address. Plumbed actual addresses through `normalizePositions` and added `addresses` to the positions tab's prefetch list.
- Also rolls in network sub-grouping under custody on the collateral tab (custody → network → asset → source) so it mirrors the asset-type 4-level layout.

## Test plan

- [ ] Addresses tab renders with cold / operational / hot sections; each card shows label, truncated address with copy, chain icons linking to the right explorer per chain, and the description
- [ ] Positions tab Holder column renders the address label + truncated address; hovering shows the description tooltip when the holder appears in `/api/v2/addresses`
- [ ] Operational Holdings rows in the positions tab also surface the description tooltip
- [ ] Stablecoins tab still resolves per-network address labels correctly
- [ ] Collateral tab Custody grouping expands custody → network → asset → source and the default open depth shows networks

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches multiple UI tabs and changes grouping/labeling logic based on a modified API shape; main risk is incorrect grouping or missing labels/descriptions due to address/chain mapping assumptions.
> 
> **Overview**
> Reworks the Reserve app’s `addresses` integration to match a new flat `/api/v2/addresses` response (`reserve: ReserveAddress[]` with `chains[]`), updating DTOs and the stablecoin per-network address-label lookup accordingly.
> 
> Redesigns the Addresses tab into custody-grouped card sections with per-chain explorer icon links and inline descriptions, and upgrades `AddressLabel`’s compact variant to show `description` via an accessible tooltip.
> 
> Enhances the Positions tab by prefetching `addresses`, plumbing through actual holder addresses from normalized positions, and displaying holders/operational wallet rows as `AddressLabel` entries with description tooltips when available; also adjusts Collateral tab custody grouping to add an intermediate network level and updates default tree expansion depth.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e3d9af84a8dd73205d6d61a585d2a2345560a5c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->