### PR TITLE
fix(pools): unbreak single-sided zap-in

### DIFF
--- a/apps/app.mento.org/app/components/pools/add-liquidity-form.tsx
+++ b/apps/app.mento.org/app/components/pools/add-liquidity-form.tsx
@@ -39,6 +39,43 @@ import { getContractAddress } from "@mento-protocol/mento-sdk";
 import { useSetAtom } from "jotai";
 import { useQueryClient } from "@tanstack/react-query";
 
+function isSingleTokenLiquidityLimitError(message: string): boolean {
+  return /pool liquidity is insufficient|insufficient liquidity|insufficient reserves|insufficient output amount|bb55fd27/i.test(
+    message,
+  );
+}
+
+function isSingleTokenPoolRatioError(message: string): boolean {
+  return /current pool ratio|cannot be added|insufficient amount[ab]?|insufficient amount[ab] desired|0x8f66ec14|0x34c90624|0xdc6b2ef2|0xacee0513|0x5945ea56/i.test(
+    message,
+  );
+}
+
+function isSingleTokenRouteError(message: string): boolean {
+  return /no viable zap-in route|no viable route|no route|route unavailable|unable to prepare single-token/i.test(
+    message,
+  );
+}
+
+function getSingleTokenLiquidityErrorMessage(
+  message: string,
+  tokenSymbol: string,
+): string {
+  if (isSingleTokenLiquidityLimitError(message)) {
+    return `This pool cannot convert enough ${tokenSymbol} into the other token for this single-token amount. Try a smaller amount or use balanced mode.`;
+  }
+
+  if (isSingleTokenPoolRatioError(message)) {
+    return `This ${tokenSymbol} amount cannot be added at the current pool ratio. Try a smaller amount, higher slippage, or balanced mode.`;
+  }
+
+  if (isSingleTokenRouteError(message)) {
+    return "No single-token route is available for this amount. Try a smaller amount or use balanced mode.";
+  }
+
+  return message.replace(/zap-?in/gi, "single-token liquidity");
+}
+
 function TokenAmountInput({
   token,
   balance,
@@ -376,6 +413,9 @@ export function AddLiquidityForm({
     parsedZap !== null &&
     zapTokenBalance !== undefined &&
     parsedZap > zapTokenBalance;
+  const singleTokenLiquidityError = zapBuildError
+    ? getSingleTokenLiquidityErrorMessage(zapBuildError, zapToken.symbol)
+    : null;
 
   // === Button state ===
 
@@ -390,7 +430,15 @@ export function AddLiquidityForm({
           text: `Insufficient ${zapToken.symbol} balance`,
           disabled: true,
         };
-      if (zapBuildError) return { text: "Unavailable", disabled: true };
+      if (zapBuildError)
+        return {
+          text: isSingleTokenLiquidityLimitError(zapBuildError)
+            ? "Amount too large"
+            : isSingleTokenPoolRatioError(zapBuildError)
+              ? "Adjust amount"
+              : "Unavailable",
+          disabled: true,
+        };
       if (isZapBuilding || isZapQuoting)
         return { text: "Preparing...", disabled: true };
       if (!zapBuildResult) return { text: "Preparing...", disabled: true };
@@ -465,13 +513,13 @@ export function AddLiquidityForm({
 
     try {
       if (mode === "single" && zapBuildResult) {
-        // --- Zap-in flow ---
+        // --- Single-token liquidity flow ---
         const capturedZapAmount = parsedZap;
         const capturedZapTokenIn = zapTokenIn;
         const capturedSlippage = slippage;
 
         if (!capturedZapAmount || capturedZapAmount <= 0n) {
-          throw new Error("Invalid zap amount");
+          throw new Error("Invalid single-token amount");
         }
         if (zapBuildError) {
           throw new Error(zapBuildError);
@@ -509,8 +557,8 @@ export function AddLiquidityForm({
             );
             if (!freshBuild) {
               throw new Error(
-                zapBuildError ||
-                  "No viable zap-in route for this amount. Reduce amount or use balanced mode.",
+                singleTokenLiquidityError ||
+                  "No single-token route is available for this amount. Try a smaller amount or use balanced mode.",
               );
             }
             return freshBuild.zapIn.params;
@@ -614,11 +662,12 @@ export function AddLiquidityForm({
       const msg = err instanceof Error ? err.message : String(err);
       if (!/user\s+rejected/i.test(msg) && !/denied/i.test(msg)) {
         if (
-          /no viable zap-in route/i.test(msg) ||
-          /route unavailable/i.test(msg)
+          isSingleTokenRouteError(msg) ||
+          isSingleTokenLiquidityLimitError(msg) ||
+          isSingleTokenPoolRatioError(msg)
         ) {
           toast.error(
-            "No viable zap-in route for this amount. Reduce amount or use balanced mode.",
+            getSingleTokenLiquidityErrorMessage(msg, zapToken.symbol),
           );
         } else {
           toast.error("Something went wrong. Please try again.");
@@ -957,9 +1006,9 @@ export function AddLiquidityForm({
             >
               {buttonState.text}
             </Button>
-            {mode === "single" && zapBuildError && (
+            {mode === "single" && singleTokenLiquidityError && (
               <p className="text-xs leading-5 text-center text-muted-foreground">
-                {zapBuildError}
+                {singleTokenLiquidityError}
               </p>
             )}
           </>

--- a/apps/app.mento.org/app/components/pools/add-liquidity-form.tsx
+++ b/apps/app.mento.org/app/components/pools/add-liquidity-form.tsx
@@ -52,7 +52,7 @@ function isSingleTokenPoolRatioError(message: string): boolean {
 }
 
 function isSingleTokenRouteError(message: string): boolean {
-  return /no viable zap-in route|no viable route|no route|route unavailable|unable to prepare single-token/i.test(
+  return /no viable zap-in route|no viable route|no route|route unavailable|unable to prepare single-token|no single-token route/i.test(
     message,
   );
 }

--- a/apps/app.mento.org/app/components/pools/add-liquidity-form.tsx
+++ b/apps/app.mento.org/app/components/pools/add-liquidity-form.tsx
@@ -661,10 +661,14 @@ export function AddLiquidityForm({
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       if (!/user\s+rejected/i.test(msg) && !/denied/i.test(msg)) {
+        // The InsufficientAmount* selectors fire in balanced mode too, so the
+        // single-token-specific copy ("…or balanced mode") only makes sense
+        // when the user is actually in single-token mode.
         if (
-          isSingleTokenRouteError(msg) ||
-          isSingleTokenLiquidityLimitError(msg) ||
-          isSingleTokenPoolRatioError(msg)
+          mode === "single" &&
+          (isSingleTokenRouteError(msg) ||
+            isSingleTokenLiquidityLimitError(msg) ||
+            isSingleTokenPoolRatioError(msg))
         ) {
           toast.error(
             getSingleTokenLiquidityErrorMessage(msg, zapToken.symbol),

--- a/apps/app.mento.org/app/components/pools/remove-liquidity-form.tsx
+++ b/apps/app.mento.org/app/components/pools/remove-liquidity-form.tsx
@@ -161,7 +161,7 @@ export function RemoveLiquidityForm({
   const zapOutQuoteErrorMessage = getErrorMessage(zapOutQuoteError);
   const zapOutQuoteUiError = isZapOutQuoteError
     ? isZapOutRouteUnavailableError(zapOutQuoteErrorMessage)
-      ? "No viable zap-out route for this amount. Reduce amount or use balanced mode."
+      ? "No single-token route is available for this amount. Try a smaller amount or use balanced mode."
       : "Unable to quote single-token removal right now."
     : null;
   const zapOutUiError = zapOutBuildError ?? zapOutQuoteUiError;
@@ -338,7 +338,7 @@ export function RemoveLiquidityForm({
         if (!preflightBuild) {
           throw new Error(
             zapOutUiError ||
-              "No viable zap-out route for this amount. Reduce amount or use balanced mode.",
+              "No single-token route is available for this amount. Try a smaller amount or use balanced mode.",
           );
         }
 
@@ -366,7 +366,7 @@ export function RemoveLiquidityForm({
             if (!freshBuild) {
               throw new Error(
                 zapOutBuildError ||
-                  "No viable zap-out route for this amount. Reduce amount or use balanced mode.",
+                  "No single-token route is available for this amount. Try a smaller amount or use balanced mode.",
               );
             }
             return freshBuild.zapOut.params;
@@ -460,7 +460,7 @@ export function RemoveLiquidityForm({
           )
         ) {
           toast.error(
-            "No viable zap-out route for this amount. Reduce amount or use balanced mode.",
+            "No single-token route is available for this amount. Try a smaller amount or use balanced mode.",
           );
         } else {
           toast.error("Something went wrong. Please try again.");

--- a/apps/app.mento.org/app/components/pools/remove-liquidity-form.tsx
+++ b/apps/app.mento.org/app/components/pools/remove-liquidity-form.tsx
@@ -55,7 +55,7 @@ function getErrorMessage(error: unknown): string {
 }
 
 function isZapOutRouteUnavailableError(message: string): boolean {
-  return /no viable zap-out route|route not found|no route for this amount|route unavailable|insufficient liquidity|insufficientliquidity|insufficient reserves|insufficient output amount|bb55fd27|execution reverted|call execution error/i.test(
+  return /no viable zap-out route|route not found|no route for this amount|route unavailable|insufficient liquidity|insufficientliquidity|insufficient reserves|insufficient output amount|bb55fd27|execution reverted|call execution error|no single-token route/i.test(
     message,
   );
 }
@@ -455,7 +455,7 @@ export function RemoveLiquidityForm({
       const msg = err instanceof Error ? err.message : String(err);
       if (!/user\s+rejected/i.test(msg) && !/denied/i.test(msg)) {
         if (
-          /no viable zap-out route|no route for this amount|route unavailable|unable to quote single-token/i.test(
+          /no viable zap-out route|no route for this amount|route unavailable|unable to quote single-token|no single-token route/i.test(
             msg,
           )
         ) {

--- a/packages/web3/src/features/pools/flow-engine.ts
+++ b/packages/web3/src/features/pools/flow-engine.ts
@@ -217,15 +217,20 @@ export async function executeLiquidityFlow(
       // Log full error for debugging, show friendly message to user
       console.error(`[LiquidityFlow] Step "${def.label}" failed:`, error);
 
+      // The InsufficientAmount* / InsufficientLiquidity selectors fire in
+      // both balanced add-liquidity and single-token zap-in. Phrase the copy
+      // so it makes sense regardless of which mode the caller is in — telling
+      // a balanced-mode user to "use balanced mode" is nonsense. The route /
+      // single-token-prepare branch is genuinely zap-only and stays specific.
       const friendlyMessage =
         /pool liquidity is insufficient|insufficient liquidity|insufficientliquidity|insufficient reserves|insufficient output amount|bb55fd27/i.test(
           rawMessage,
         )
-          ? "This pool cannot convert enough of the selected token for this single-token amount. Try a smaller amount or use balanced mode."
+          ? "Pool liquidity is insufficient for this amount. Try a smaller amount."
           : /current pool ratio|cannot be added|insufficient amount[ab]?|insufficient amount[ab] desired|0x8f66ec14|0x34c90624|0xdc6b2ef2|0xacee0513|0x5945ea56/i.test(
                 rawMessage,
               )
-            ? "This single-token amount cannot be added at the current pool ratio. Try a smaller amount, higher slippage, or balanced mode."
+            ? "Pool ratio shifted during the transaction. Try a smaller amount or higher slippage."
             : /no viable zap-(in|out) route|no route for this amount|route unavailable|unable to prepare single-token|unable to quote single-token/i.test(
                   rawMessage,
                 )

--- a/packages/web3/src/features/pools/flow-engine.ts
+++ b/packages/web3/src/features/pools/flow-engine.ts
@@ -87,7 +87,7 @@ function extractFlowErrorString(error: unknown): string {
 function isLikelyDeterministicRevert(error: unknown): boolean {
   const message = extractFlowErrorString(error).toLowerCase();
 
-  return /execution reverted|call execution error|insufficient liquidity|insufficientliquidity|insufficient reserves|insufficient output amount|bb55fd27|always failing transaction|simulation failed|slippage|minimum amount|minimum output|no viable zap-(in|out) route|no route for this amount|route unavailable|unable to prepare single-token|unable to quote single-token/i.test(
+  return /execution reverted|call execution error|insufficient liquidity|insufficientliquidity|insufficient reserves|insufficient output amount|bb55fd27|always failing transaction|simulation failed|slippage|minimum amount|minimum output|no viable zap-(in|out) route|no route for this amount|route unavailable|unable to prepare single-token|unable to quote single-token|no single-token route/i.test(
     message,
   );
 }
@@ -231,7 +231,7 @@ export async function executeLiquidityFlow(
                 rawMessage,
               )
             ? "Pool ratio shifted during the transaction. Try a smaller amount or higher slippage."
-            : /no viable zap-(in|out) route|no route for this amount|route unavailable|unable to prepare single-token|unable to quote single-token/i.test(
+            : /no viable zap-(in|out) route|no route for this amount|route unavailable|unable to prepare single-token|unable to quote single-token|no single-token route/i.test(
                   rawMessage,
                 )
               ? "No single-token route is available for this amount. Try a smaller amount or use balanced mode."

--- a/packages/web3/src/features/pools/flow-engine.ts
+++ b/packages/web3/src/features/pools/flow-engine.ts
@@ -218,17 +218,25 @@ export async function executeLiquidityFlow(
       console.error(`[LiquidityFlow] Step "${def.label}" failed:`, error);
 
       const friendlyMessage =
-        /no viable zap-(in|out) route|no route for this amount|route unavailable|unable to prepare single-token|unable to quote single-token|insufficient liquidity|insufficientliquidity|insufficient reserves|insufficient output amount|bb55fd27/i.test(
+        /pool liquidity is insufficient|insufficient liquidity|insufficientliquidity|insufficient reserves|insufficient output amount|bb55fd27/i.test(
           rawMessage,
         )
-          ? "No viable route for this amount. Reduce amount or use balanced mode."
-          : /reverted/i.test(rawMessage)
-            ? "Transaction was reverted. Please check your inputs and try again."
-            : /insufficient\s+funds/i.test(rawMessage)
-              ? "Insufficient funds to complete this transaction."
-              : /nonce/i.test(rawMessage)
-                ? "Transaction conflict. Please try again."
-                : "Something went wrong. Please try again.";
+          ? "This pool cannot convert enough of the selected token for this single-token amount. Try a smaller amount or use balanced mode."
+          : /current pool ratio|cannot be added|insufficient amount[ab]?|insufficient amount[ab] desired|0x8f66ec14|0x34c90624|0xdc6b2ef2|0xacee0513|0x5945ea56/i.test(
+                rawMessage,
+              )
+            ? "This single-token amount cannot be added at the current pool ratio. Try a smaller amount, higher slippage, or balanced mode."
+            : /no viable zap-(in|out) route|no route for this amount|route unavailable|unable to prepare single-token|unable to quote single-token/i.test(
+                  rawMessage,
+                )
+              ? "No single-token route is available for this amount. Try a smaller amount or use balanced mode."
+              : /reverted/i.test(rawMessage)
+                ? "Transaction was reverted. Please check your inputs and try again."
+                : /insufficient\s+funds/i.test(rawMessage)
+                  ? "Insufficient funds to complete this transaction."
+                  : /nonce/i.test(rawMessage)
+                    ? "Transaction conflict. Please try again."
+                    : "Something went wrong. Please try again.";
 
       // Mark step as error and stop
       setFlowAtom((prev) => {

--- a/packages/web3/src/features/pools/hooks/use-zap-in-transaction.tsx
+++ b/packages/web3/src/features/pools/hooks/use-zap-in-transaction.tsx
@@ -53,6 +53,10 @@ function isSameAddress(addressA: string, addressB: string): boolean {
   return addressA.toLowerCase() === addressB.toLowerCase();
 }
 
+function isAllowanceError(message: string): boolean {
+  return /allowance|insufficient allowance|exceeds allowance/i.test(message);
+}
+
 async function validateZapRouteLiquidity({
   publicClient,
   routerAddress,
@@ -198,54 +202,66 @@ export function useZapInTransaction(pool: PoolDisplay, chainId?: ChainId) {
           options: { slippageTolerance: slippage, deadline },
         });
 
-        if (!result.approval) {
-          try {
-            await publicClient.estimateGas({
-              account: recipient,
-              to: result.zapIn.params.to as Address,
-              data: result.zapIn.params.data as Hex,
-              value: BigInt(result.zapIn.params.value || 0),
-            });
-          } catch (estimateErr) {
-            const estimateMessage =
-              estimateErr instanceof Error
-                ? estimateErr.message
-                : String(estimateErr);
-            let parsedError = getZapInBuildError(estimateMessage);
+        try {
+          await publicClient.estimateGas({
+            account: recipient,
+            to: result.zapIn.params.to as Address,
+            data: result.zapIn.params.data as Hex,
+            value: BigInt(result.zapIn.params.value || 0),
+          });
+        } catch (estimateErr) {
+          const estimateMessage =
+            estimateErr instanceof Error
+              ? estimateErr.message
+              : String(estimateErr);
 
-            if (!parsedError) {
-              try {
-                await Promise.all([
-                  validateZapRouteLiquidity({
-                    publicClient,
-                    routerAddress: result.zapIn.params.to as Address,
-                    routes: result.zapIn.routesA,
-                    amountIn: result.zapIn.amountInA,
-                  }),
-                  validateZapRouteLiquidity({
-                    publicClient,
-                    routerAddress: result.zapIn.params.to as Address,
-                    routes: result.zapIn.routesB,
-                    amountIn: result.zapIn.amountInB,
-                  }),
-                ]);
-              } catch (validationErr) {
-                const validationMessage =
-                  validationErr instanceof Error
-                    ? validationErr.message
-                    : String(validationErr);
-                parsedError =
-                  getZapInBuildError(validationMessage) || validationMessage;
-              }
-            }
-
-            setBuildError(
-              parsedError ||
-                "This single-token amount cannot be simulated right now. Try a smaller amount, higher slippage, or balanced mode.",
-            );
-            setBuildResult(null);
-            return null;
+          // Pre-approval simulations legitimately fail with allowance errors
+          // because the wallet hasn't granted the allowance yet. That doesn't
+          // mean the zap is invalid — let the build through so the approval
+          // step can run; a fresh preflight after approval will catch any
+          // real issues. All other failures (bad route, ratio shift, etc.)
+          // still gate the build to avoid prompting an approval for a zap
+          // we already know will revert.
+          if (result.approval && isAllowanceError(estimateMessage)) {
+            setBuildResult(result);
+            setBuildError(null);
+            return result;
           }
+
+          let parsedError = getZapInBuildError(estimateMessage);
+
+          if (!parsedError) {
+            try {
+              await Promise.all([
+                validateZapRouteLiquidity({
+                  publicClient,
+                  routerAddress: result.zapIn.params.to as Address,
+                  routes: result.zapIn.routesA,
+                  amountIn: result.zapIn.amountInA,
+                }),
+                validateZapRouteLiquidity({
+                  publicClient,
+                  routerAddress: result.zapIn.params.to as Address,
+                  routes: result.zapIn.routesB,
+                  amountIn: result.zapIn.amountInB,
+                }),
+              ]);
+            } catch (validationErr) {
+              const validationMessage =
+                validationErr instanceof Error
+                  ? validationErr.message
+                  : String(validationErr);
+              parsedError =
+                getZapInBuildError(validationMessage) || validationMessage;
+            }
+          }
+
+          setBuildError(
+            parsedError ||
+              "This single-token amount cannot be simulated right now. Try a smaller amount, higher slippage, or balanced mode.",
+          );
+          setBuildResult(null);
+          return null;
         }
 
         setBuildResult(result);

--- a/packages/web3/src/features/pools/hooks/use-zap-in-transaction.tsx
+++ b/packages/web3/src/features/pools/hooks/use-zap-in-transaction.tsx
@@ -22,7 +22,7 @@ const FPMM_FACTORY_POOL_ABI = parseAbi([
 type ZapRoute = ZapInTransaction["zapIn"]["routesA"];
 
 function getZapInBuildError(message: string): string | null {
-  if (/no viable zap-in route/i.test(message)) {
+  if (/no viable zap-in route|no single-token route/i.test(message)) {
     return "No route for this amount. Reduce amount or use balanced mode.";
   }
 

--- a/packages/web3/src/features/pools/hooks/use-zap-in-transaction.tsx
+++ b/packages/web3/src/features/pools/hooks/use-zap-in-transaction.tsx
@@ -2,14 +2,24 @@ import type { ChainId } from "@/config/chains";
 import { getMentoSdk } from "@/features/sdk";
 import { logger } from "@/utils/logger";
 import { toast } from "@repo/ui";
-import type { ZapInTransaction } from "@mento-protocol/mento-sdk";
+import {
+  FPMM_ABI,
+  ROUTER_ABI,
+  type ZapInTransaction,
+} from "@mento-protocol/mento-sdk";
 import { useQueryClient } from "@tanstack/react-query";
 import { useCallback, useEffect, useRef, useState } from "react";
-import type { Address, Hex } from "viem";
+import { parseAbi, type Address, type Hex, type PublicClient } from "viem";
 import { useChainId, usePublicClient, useSendTransaction } from "wagmi";
 import { showLiquiditySuccessToast } from "../liquidity-toast";
 import type { PoolDisplay, SlippageOption } from "../types";
 import { getTransactionErrorMessage } from "../types";
+
+const FPMM_FACTORY_POOL_ABI = parseAbi([
+  "function getPool(address tokenA, address tokenB) view returns (address)",
+]);
+
+type ZapRoute = ZapInTransaction["zapIn"]["routesA"];
 
 function getZapInBuildError(message: string): string | null {
   if (/no viable zap-in route/i.test(message)) {
@@ -17,11 +27,19 @@ function getZapInBuildError(message: string): string | null {
   }
 
   if (
-    /insufficient liquidity|insufficient reserves|insufficient output amount|\bK\b|overflow|underflow/i.test(
+    /insufficient liquidity|insufficient reserves|insufficient output amount|0xbb55fd27|\bK\b|overflow|underflow/i.test(
       message,
     )
   ) {
     return "Pool liquidity is insufficient for this single-token amount.";
+  }
+
+  if (
+    /insufficient amount[ab]?|insufficient amount[ab] desired|0x8f66ec14|0x34c90624|0xdc6b2ef2|0xacee0513|0x5945ea56/i.test(
+      message,
+    )
+  ) {
+    return "This single-token amount cannot be added at the current pool ratio. Try a smaller amount, higher slippage, or balanced mode.";
   }
 
   if (/deadline/i.test(message)) {
@@ -31,8 +49,67 @@ function getZapInBuildError(message: string): string | null {
   return null;
 }
 
-function isAllowanceError(message: string): boolean {
-  return /allowance|insufficient allowance|exceeds allowance/i.test(message);
+function isSameAddress(addressA: string, addressB: string): boolean {
+  return addressA.toLowerCase() === addressB.toLowerCase();
+}
+
+async function validateZapRouteLiquidity({
+  publicClient,
+  routerAddress,
+  routes,
+  amountIn,
+}: {
+  publicClient: PublicClient;
+  routerAddress: Address;
+  routes: ZapRoute;
+  amountIn: bigint;
+}) {
+  if (routes.length === 0 || amountIn === 0n) return;
+
+  const amounts = (await publicClient.readContract({
+    address: routerAddress,
+    abi: ROUTER_ABI,
+    functionName: "getAmountsOut",
+    args: [amountIn, routes],
+  })) as bigint[];
+
+  if (amounts.length !== routes.length + 1) {
+    throw new Error("Unable to validate single-token route liquidity.");
+  }
+
+  await Promise.all(
+    routes.map(async (route, index) => {
+      const poolAddress = (await publicClient.readContract({
+        address: route.factory,
+        abi: FPMM_FACTORY_POOL_ABI,
+        functionName: "getPool",
+        args: [route.from, route.to],
+      })) as Address;
+
+      const [token0, [reserve0, reserve1]] = (await Promise.all([
+        publicClient.readContract({
+          address: poolAddress,
+          abi: FPMM_ABI,
+          functionName: "token0",
+        }),
+        publicClient.readContract({
+          address: poolAddress,
+          abi: FPMM_ABI,
+          functionName: "getReserves",
+        }),
+      ])) as [Address, [bigint, bigint, bigint]];
+
+      const reserveOut = isSameAddress(route.to, token0) ? reserve0 : reserve1;
+      const amountOut = amounts[index + 1];
+
+      // FPMM swaps require output to be strictly below available reserve.
+      if (amountOut == null || amountOut >= reserveOut) {
+        throw new Error(
+          "Pool liquidity is insufficient for this single-token amount.",
+        );
+      }
+    }),
+  );
 }
 
 export function useZapInTransaction(pool: PoolDisplay, chainId?: ChainId) {
@@ -83,7 +160,7 @@ export function useZapInTransaction(pool: PoolDisplay, chainId?: ChainId) {
           queryClient.invalidateQueries({ queryKey: ["readContract"] });
         } else {
           toast.error(
-            "Zap-in transaction reverted on-chain. Try increasing slippage or reducing the amount.",
+            "Single-token liquidity transaction reverted on-chain. Try increasing slippage or reducing the amount.",
           );
           logger.error("Zap-in transaction reverted:", receipt.transactionHash);
         }
@@ -91,7 +168,7 @@ export function useZapInTransaction(pool: PoolDisplay, chainId?: ChainId) {
       .catch((err) => {
         setIsConfirming(false);
         logger.error("Error waiting for zap-in receipt:", err);
-        toast.error("Failed to confirm zap-in transaction.");
+        toast.error("Failed to confirm single-token liquidity transaction.");
       });
   }, [txHash, publicClient, pool, resolvedChainId, queryClient]);
 
@@ -121,24 +198,51 @@ export function useZapInTransaction(pool: PoolDisplay, chainId?: ChainId) {
           options: { slippageTolerance: slippage, deadline },
         });
 
-        try {
-          await publicClient.estimateGas({
-            account: recipient,
-            to: result.zapIn.params.to as Address,
-            data: result.zapIn.params.data as Hex,
-            value: BigInt(result.zapIn.params.value || 0),
-          });
-        } catch (estimateErr) {
-          const estimateMessage =
-            estimateErr instanceof Error
-              ? estimateErr.message
-              : String(estimateErr);
-          const parsedError = getZapInBuildError(estimateMessage);
+        if (!result.approval) {
+          try {
+            await publicClient.estimateGas({
+              account: recipient,
+              to: result.zapIn.params.to as Address,
+              data: result.zapIn.params.data as Hex,
+              value: BigInt(result.zapIn.params.value || 0),
+            });
+          } catch (estimateErr) {
+            const estimateMessage =
+              estimateErr instanceof Error
+                ? estimateErr.message
+                : String(estimateErr);
+            let parsedError = getZapInBuildError(estimateMessage);
 
-          // Allow pre-approval builds to proceed even though the zap call itself
-          // may fail simulation due missing allowance.
-          if (!(result.approval && isAllowanceError(estimateMessage))) {
-            setBuildError(parsedError || "Route unavailable for this amount.");
+            if (!parsedError) {
+              try {
+                await Promise.all([
+                  validateZapRouteLiquidity({
+                    publicClient,
+                    routerAddress: result.zapIn.params.to as Address,
+                    routes: result.zapIn.routesA,
+                    amountIn: result.zapIn.amountInA,
+                  }),
+                  validateZapRouteLiquidity({
+                    publicClient,
+                    routerAddress: result.zapIn.params.to as Address,
+                    routes: result.zapIn.routesB,
+                    amountIn: result.zapIn.amountInB,
+                  }),
+                ]);
+              } catch (validationErr) {
+                const validationMessage =
+                  validationErr instanceof Error
+                    ? validationErr.message
+                    : String(validationErr);
+                parsedError =
+                  getZapInBuildError(validationMessage) || validationMessage;
+              }
+            }
+
+            setBuildError(
+              parsedError ||
+                "This single-token amount cannot be simulated right now. Try a smaller amount, higher slippage, or balanced mode.",
+            );
             setBuildResult(null);
             return null;
           }
@@ -178,7 +282,7 @@ export function useZapInTransaction(pool: PoolDisplay, chainId?: ChainId) {
         toast.error(
           getTransactionErrorMessage(
             err instanceof Error ? err.message : String(err),
-            "Unable to complete zap-in transaction.",
+            "Unable to complete single-token liquidity transaction.",
             "Add liquidity",
           ),
         );

--- a/packages/web3/src/features/pools/hooks/use-zap-out-quote.ts
+++ b/packages/web3/src/features/pools/hooks/use-zap-out-quote.ts
@@ -30,7 +30,7 @@ function getZapOutQuoteRawError(error: unknown): string {
 }
 
 function isDeterministicZapOutRouteError(message: string): boolean {
-  return /no viable zap-out route|route not found|no route|route unavailable|insufficient liquidity|insufficientliquidity|insufficient reserves|insufficient output amount|bb55fd27|execution reverted|call execution error/i.test(
+  return /no viable zap-out route|route not found|no route|route unavailable|insufficient liquidity|insufficientliquidity|insufficient reserves|insufficient output amount|bb55fd27|execution reverted|call execution error|no single-token route/i.test(
     message,
   );
 }

--- a/packages/web3/src/features/pools/hooks/use-zap-out-quote.ts
+++ b/packages/web3/src/features/pools/hooks/use-zap-out-quote.ts
@@ -37,7 +37,7 @@ function isDeterministicZapOutRouteError(message: string): boolean {
 
 function toZapOutQuoteErrorMessage(message: string): string {
   if (isDeterministicZapOutRouteError(message)) {
-    return "No viable zap-out route for this amount. Reduce amount or use balanced mode.";
+    return "No single-token route is available for this amount. Try a smaller amount or use balanced mode.";
   }
 
   return "Unable to quote single-token removal right now.";

--- a/packages/web3/src/features/pools/hooks/use-zap-out-transaction.tsx
+++ b/packages/web3/src/features/pools/hooks/use-zap-out-transaction.tsx
@@ -12,7 +12,11 @@ import type { PoolDisplay, SlippageOption } from "../types";
 import { getTransactionErrorMessage } from "../types";
 
 function getZapOutBuildError(message: string): string {
-  if (/no viable zap-out route|route not found|no route/i.test(message)) {
+  if (
+    /no viable zap-out route|route not found|no route|no single-token route/i.test(
+      message,
+    )
+  ) {
     return "No single-token route is available for this amount. Try a smaller amount or use balanced mode.";
   }
 

--- a/packages/web3/src/features/pools/hooks/use-zap-out-transaction.tsx
+++ b/packages/web3/src/features/pools/hooks/use-zap-out-transaction.tsx
@@ -13,7 +13,7 @@ import { getTransactionErrorMessage } from "../types";
 
 function getZapOutBuildError(message: string): string {
   if (/no viable zap-out route|route not found|no route/i.test(message)) {
-    return "No route for this amount. Reduce amount or use balanced mode.";
+    return "No single-token route is available for this amount. Try a smaller amount or use balanced mode.";
   }
 
   if (
@@ -21,7 +21,7 @@ function getZapOutBuildError(message: string): string {
       message,
     )
   ) {
-    return "No viable zap-out route for this amount. Reduce amount or use balanced mode.";
+    return "No single-token route is available for this amount. Try a smaller amount or use balanced mode.";
   }
 
   return "Unable to prepare single-token removal right now.";
@@ -82,7 +82,7 @@ export function useZapOutTransaction(pool: PoolDisplay, chainId?: ChainId) {
           });
         } else {
           toast.error(
-            "Zap-out transaction reverted on-chain. Try increasing slippage or reducing the amount.",
+            "Single-token removal transaction reverted on-chain. Try increasing slippage or reducing the amount.",
           );
           logger.error(
             "Zap-out transaction reverted:",
@@ -93,7 +93,7 @@ export function useZapOutTransaction(pool: PoolDisplay, chainId?: ChainId) {
       .catch((err) => {
         setIsConfirming(false);
         logger.error("Error waiting for zap-out receipt:", err);
-        toast.error("Failed to confirm zap-out transaction.");
+        toast.error("Failed to confirm single-token removal transaction.");
       });
   }, [txHash, publicClient, pool, resolvedChainId, queryClient]);
 
@@ -153,7 +153,7 @@ export function useZapOutTransaction(pool: PoolDisplay, chainId?: ChainId) {
         toast.error(
           getTransactionErrorMessage(
             err instanceof Error ? err.message : String(err),
-            "Unable to complete zap-out transaction.",
+            "Unable to complete single-token removal transaction.",
             "Remove liquidity",
           ),
         );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,8 +10,8 @@ catalogs:
       specifier: ^9.39.2
       version: 9.39.2
     '@mento-protocol/mento-sdk':
-      specifier: 3.2.6
-      version: 3.2.6
+      specifier: 3.2.7-beta.0
+      version: 3.2.7-beta.0
     '@metamask/jazzicon':
       specifier: github:jmrossy/jazzicon#7a8df28
       version: 2.1.0
@@ -205,7 +205,7 @@ importers:
         version: 5.2.2(react-hook-form@7.71.1(react@19.2.5))
       '@mento-protocol/mento-sdk':
         specifier: 'catalog:'
-        version: 3.2.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)
+        version: 3.2.7-beta.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)
       '@mui/icons-material':
         specifier: ^7.3.2
         version: 7.3.9(@mui/material@7.3.9(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(@types/react@19.2.14)(react@19.2.5)
@@ -244,7 +244,7 @@ importers:
         version: 2.22.1(@tanstack/query-core@5.90.16)(@types/react@19.2.14)(immer@11.1.3)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.44.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5))
       '@wormhole-foundation/wormhole-connect':
         specifier: ^5.1.0
-        version: 5.1.0(7dec88115dc0b6b421bab74122d84d12)
+        version: 5.1.0(duigyiywtgpirgsl4u2ct36rvq)
       jotai:
         specifier: 'catalog:'
         version: 2.16.2(@babel/core@7.29.0)(@babel/template@7.28.6)(@types/react@19.2.14)(react@19.2.5)
@@ -771,7 +771,7 @@ importers:
         version: 4.1.18
       '@turbo/gen':
         specifier: ^2.7.5
-        version: 2.7.5(@types/node@25.5.0)(typescript@5.9.3)
+        version: 2.7.5(@types/node@25.6.0)(typescript@5.9.3)
       '@types/react':
         specifier: 'catalog:'
         version: 19.2.14
@@ -813,7 +813,7 @@ importers:
         version: 5.8.0
       '@mento-protocol/mento-sdk':
         specifier: 'catalog:'
-        version: 3.2.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)
+        version: 3.2.7-beta.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)
       '@metamask/jazzicon':
         specifier: 'catalog:'
         version: https://codeload.github.com/jmrossy/jazzicon/tar.gz/7a8df28
@@ -2937,8 +2937,8 @@ packages:
   '@mayanfinance/swap-sdk@12.2.5':
     resolution: {integrity: sha512-ZPk4QF3eDdh/jv3h+2J7XUNZaT5i5ix9UeH6QX9GkBEG6NqQmdSqRapZx52Z6JZi3BR0ixMBMjsIiGZ1KdjkkA==}
 
-  '@mento-protocol/mento-sdk@3.2.6':
-    resolution: {integrity: sha512-p5/qRTb3wZvoGBUxCCIVciyTAiDITeijubimpv/6AFfG6nJ/fMw0WzUzwooypCiNlh/RhVW8b5pd9QP7iU2N3w==}
+  '@mento-protocol/mento-sdk@3.2.7-beta.0':
+    resolution: {integrity: sha512-hta6T9rf0Orzase1m2G2areMRYADqX16aS2cEqSaq0JD74U3KLHAH2L3w9qZwoNOZJ7QMLr+EujJ8eE8tAWHkQ==}
     engines: {node: '>=18', pnpm: '>=9'}
 
   '@metamask/detect-provider@2.0.0':
@@ -16647,7 +16647,7 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@mento-protocol/mento-sdk@3.2.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)':
+  '@mento-protocol/mento-sdk@3.2.7-beta.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)':
     dependencies:
       viem: 2.44.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)
     transitivePeerDependencies:
@@ -19576,30 +19576,30 @@ snapshots:
       - react-native
       - typescript
 
-  '@solana-program/compute-budget@0.8.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)))':
+  '@solana-program/compute-budget@0.8.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)))':
     dependencies:
-      '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))
+      '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))
 
-  '@solana-program/stake@0.2.1(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)))':
+  '@solana-program/stake@0.2.1(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)))':
     dependencies:
-      '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))
+      '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))
 
   '@solana-program/system@0.10.0(@solana/kit@5.3.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))':
     dependencies:
       '@solana/kit': 5.3.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
 
-  '@solana-program/system@0.7.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)))':
+  '@solana-program/system@0.7.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)))':
     dependencies:
-      '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))
+      '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))
 
-  '@solana-program/token-2022@0.4.2(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)))(@solana/sysvars@5.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))':
+  '@solana-program/token-2022@0.4.2(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)))(@solana/sysvars@5.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))':
     dependencies:
-      '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))
+      '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))
       '@solana/sysvars': 5.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
 
-  '@solana-program/token@0.5.1(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)))':
+  '@solana-program/token@0.5.1(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)))':
     dependencies:
-      '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))
+      '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))
 
   '@solana-program/token@0.9.0(@solana/kit@5.3.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))':
     dependencies:
@@ -19894,7 +19894,7 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))':
+  '@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))':
     dependencies:
       '@solana/accounts': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/addresses': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
@@ -19907,11 +19907,11 @@ snapshots:
       '@solana/rpc': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/rpc-parsed-types': 2.3.0(typescript@5.9.3)
       '@solana/rpc-spec-types': 2.3.0(typescript@5.9.3)
-      '@solana/rpc-subscriptions': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))
+      '@solana/rpc-subscriptions': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))
       '@solana/rpc-types': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/signers': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/sysvars': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
-      '@solana/transaction-confirmation': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))
+      '@solana/transaction-confirmation': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))
       '@solana/transaction-messages': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/transactions': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       typescript: 5.9.3
@@ -20120,14 +20120,14 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/rpc-subscriptions-channel-websocket@2.3.0(typescript@5.9.3)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))':
+  '@solana/rpc-subscriptions-channel-websocket@2.3.0(typescript@5.9.3)(ws@8.18.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))':
     dependencies:
       '@solana/errors': 2.3.0(typescript@5.9.3)
       '@solana/functional': 2.3.0(typescript@5.9.3)
       '@solana/rpc-subscriptions-spec': 2.3.0(typescript@5.9.3)
       '@solana/subscribable': 2.3.0(typescript@5.9.3)
       typescript: 5.9.3
-      ws: 8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+      ws: 8.18.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
 
   '@solana/rpc-subscriptions-channel-websocket@5.3.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)':
     dependencies:
@@ -20157,7 +20157,7 @@ snapshots:
       '@solana/subscribable': 5.3.0(typescript@5.9.3)
       typescript: 5.9.3
 
-  '@solana/rpc-subscriptions@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))':
+  '@solana/rpc-subscriptions@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))':
     dependencies:
       '@solana/errors': 2.3.0(typescript@5.9.3)
       '@solana/fast-stable-stringify': 2.3.0(typescript@5.9.3)
@@ -20165,7 +20165,7 @@ snapshots:
       '@solana/promises': 2.3.0(typescript@5.9.3)
       '@solana/rpc-spec-types': 2.3.0(typescript@5.9.3)
       '@solana/rpc-subscriptions-api': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
-      '@solana/rpc-subscriptions-channel-websocket': 2.3.0(typescript@5.9.3)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))
+      '@solana/rpc-subscriptions-channel-websocket': 2.3.0(typescript@5.9.3)(ws@8.18.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))
       '@solana/rpc-subscriptions-spec': 2.3.0(typescript@5.9.3)
       '@solana/rpc-transformers': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/rpc-types': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
@@ -20393,7 +20393,7 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/transaction-confirmation@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))':
+  '@solana/transaction-confirmation@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))':
     dependencies:
       '@solana/addresses': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/codecs-strings': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
@@ -20401,7 +20401,7 @@ snapshots:
       '@solana/keys': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/promises': 2.3.0(typescript@5.9.3)
       '@solana/rpc': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
-      '@solana/rpc-subscriptions': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))
+      '@solana/rpc-subscriptions': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))
       '@solana/rpc-types': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/transaction-messages': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/transactions': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
@@ -20697,11 +20697,11 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@solana/wallet-adapter-trezor@0.1.6(@solana/sysvars@5.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.84.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@5.0.10))(tslib@2.8.1)(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))':
+  '@solana/wallet-adapter-trezor@0.1.6(@solana/sysvars@5.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.84.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@5.0.10))(tslib@2.8.1)(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@8.18.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))':
     dependencies:
       '@solana/wallet-adapter-base': 0.9.27(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))
       '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
-      '@trezor/connect-web': 9.7.2(@solana/sysvars@5.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.84.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@5.0.10))(tslib@2.8.1)(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))
+      '@trezor/connect-web': 9.7.2(@solana/sysvars@5.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.84.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@5.0.10))(tslib@2.8.1)(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@8.18.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))
       buffer: 6.0.3
     transitivePeerDependencies:
       - '@solana/sysvars'
@@ -20764,7 +20764,7 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@solana/wallet-adapter-wallets@0.19.32(@babel/runtime@7.29.2)(@solana/sysvars@5.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(@types/react@19.2.14)(bs58@6.0.0)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.2.5(react@19.2.5))(react-native@0.84.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@5.0.10))(react@19.2.5)(tslib@2.8.1)(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.5)':
+  '@solana/wallet-adapter-wallets@0.19.32(@babel/runtime@7.29.2)(@solana/sysvars@5.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(@types/react@19.2.14)(bs58@6.0.0)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.2.5(react@19.2.5))(react-native@0.84.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@5.0.10))(react@19.2.5)(tslib@2.8.1)(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@8.18.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.5)':
     dependencies:
       '@solana/wallet-adapter-alpha': 0.1.14(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))
       '@solana/wallet-adapter-avana': 0.1.17(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))
@@ -20797,7 +20797,7 @@ snapshots:
       '@solana/wallet-adapter-tokenary': 0.1.16(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))
       '@solana/wallet-adapter-tokenpocket': 0.4.23(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))
       '@solana/wallet-adapter-torus': 0.11.32(@babel/runtime@7.29.2)(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
-      '@solana/wallet-adapter-trezor': 0.1.6(@solana/sysvars@5.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.84.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@5.0.10))(tslib@2.8.1)(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))
+      '@solana/wallet-adapter-trezor': 0.1.6(@solana/sysvars@5.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.84.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@5.0.10))(tslib@2.8.1)(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@8.18.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))
       '@solana/wallet-adapter-trust': 0.1.17(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))
       '@solana/wallet-adapter-unsafe-burner': 0.1.11(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))
       '@solana/wallet-adapter-walletconnect': 0.1.21(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)
@@ -21497,13 +21497,13 @@ snapshots:
       - react-native
       - utf-8-validate
 
-  '@trezor/blockchain-link@2.6.1(@solana/sysvars@5.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.84.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@5.0.10))(tslib@2.8.1)(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))':
+  '@trezor/blockchain-link@2.6.1(@solana/sysvars@5.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.84.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@5.0.10))(tslib@2.8.1)(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@8.18.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))':
     dependencies:
-      '@solana-program/compute-budget': 0.8.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)))
-      '@solana-program/stake': 0.2.1(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)))
-      '@solana-program/token': 0.5.1(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)))
-      '@solana-program/token-2022': 0.4.2(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)))(@solana/sysvars@5.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))
-      '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))
+      '@solana-program/compute-budget': 0.8.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)))
+      '@solana-program/stake': 0.2.1(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)))
+      '@solana-program/token': 0.5.1(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)))
+      '@solana-program/token-2022': 0.4.2(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)))(@solana/sysvars@5.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))
+      '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))
       '@solana/rpc-types': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@stellar/stellar-sdk': 14.2.0
       '@trezor/blockchain-link-types': 1.5.0(tslib@2.8.1)
@@ -21551,9 +21551,9 @@ snapshots:
       - expo-localization
       - react-native
 
-  '@trezor/connect-web@9.7.2(@solana/sysvars@5.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.84.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@5.0.10))(tslib@2.8.1)(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))':
+  '@trezor/connect-web@9.7.2(@solana/sysvars@5.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.84.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@5.0.10))(tslib@2.8.1)(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@8.18.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))':
     dependencies:
-      '@trezor/connect': 9.7.2(@solana/sysvars@5.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.84.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@5.0.10))(tslib@2.8.1)(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))
+      '@trezor/connect': 9.7.2(@solana/sysvars@5.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.84.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@5.0.10))(tslib@2.8.1)(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@8.18.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))
       '@trezor/connect-common': 0.5.1(react-native@0.84.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@5.0.10))(tslib@2.8.1)
       '@trezor/utils': 9.5.0(tslib@2.8.1)
       '@trezor/websocket-client': 1.3.0(bufferutil@4.1.0)(tslib@2.8.1)(utf-8-validate@5.0.10)
@@ -21572,7 +21572,7 @@ snapshots:
       - utf-8-validate
       - ws
 
-  '@trezor/connect@9.7.2(@solana/sysvars@5.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.84.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@5.0.10))(tslib@2.8.1)(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))':
+  '@trezor/connect@9.7.2(@solana/sysvars@5.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.84.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@5.0.10))(tslib@2.8.1)(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@8.18.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))':
     dependencies:
       '@ethereumjs/common': 10.1.1
       '@ethereumjs/tx': 10.1.1
@@ -21580,12 +21580,12 @@ snapshots:
       '@mobily/ts-belt': 3.13.1
       '@noble/hashes': 1.8.0
       '@scure/bip39': 1.6.0
-      '@solana-program/compute-budget': 0.8.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)))
-      '@solana-program/system': 0.7.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)))
-      '@solana-program/token': 0.5.1(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)))
-      '@solana-program/token-2022': 0.4.2(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)))(@solana/sysvars@5.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))
-      '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))
-      '@trezor/blockchain-link': 2.6.1(@solana/sysvars@5.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.84.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@5.0.10))(tslib@2.8.1)(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))
+      '@solana-program/compute-budget': 0.8.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)))
+      '@solana-program/system': 0.7.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)))
+      '@solana-program/token': 0.5.1(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)))
+      '@solana-program/token-2022': 0.4.2(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)))(@solana/sysvars@5.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))
+      '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))
+      '@trezor/blockchain-link': 2.6.1(@solana/sysvars@5.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.84.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@5.0.10))(tslib@2.8.1)(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@8.18.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))
       '@trezor/blockchain-link-types': 1.5.1(tslib@2.8.1)
       '@trezor/blockchain-link-utils': 1.5.2(bufferutil@4.1.0)(react-native@0.84.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@5.0.10))(tslib@2.8.1)(utf-8-validate@5.0.10)
       '@trezor/connect-analytics': 1.4.0(react-native@0.84.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@5.0.10))(tslib@2.8.1)
@@ -21732,7 +21732,7 @@ snapshots:
   '@turbo/darwin-arm64@2.9.6':
     optional: true
 
-  '@turbo/gen@2.7.5(@types/node@25.5.0)(typescript@5.9.3)':
+  '@turbo/gen@2.7.5(@types/node@25.6.0)(typescript@5.9.3)':
     dependencies:
       '@turbo/workspaces': 2.7.5
       commander: 10.0.0
@@ -21742,7 +21742,7 @@ snapshots:
       node-plop: 0.26.3
       picocolors: 1.0.1
       proxy-agent: 6.5.0
-      ts-node: 10.9.2(@types/node@25.5.0)(typescript@5.9.3)
+      ts-node: 10.9.2(@types/node@25.6.0)(typescript@5.9.3)
       update-check: 1.5.4
       validate-npm-package-name: 5.0.0
     transitivePeerDependencies:
@@ -22286,7 +22286,7 @@ snapshots:
       - wagmi
       - zod
 
-  '@wagmi/connectors@6.2.0(628704a63c493a56d2ac24cf65ee3715)':
+  '@wagmi/connectors@6.2.0(ap4m3yv4is7p7hbxavtb6wueda)':
     dependencies:
       '@base-org/account': 2.4.0(@types/react@19.2.14)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(immer@11.1.3)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(utf-8-validate@5.0.10)(zod@4.3.5)
       '@coinbase/wallet-sdk': 4.3.6(@types/react@19.2.14)(bufferutil@4.1.0)(immer@11.1.3)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(utf-8-validate@5.0.10)(zod@4.3.5)
@@ -22297,7 +22297,7 @@ snapshots:
       '@wagmi/core': 2.22.1(@tanstack/query-core@5.90.16)(@types/react@19.2.14)(immer@11.1.3)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.44.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5))
       '@walletconnect/ethereum-provider': 2.21.1(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)
       cbw-sdk: '@coinbase/wallet-sdk@3.9.3'
-      porto: 0.2.35(d850088e01e6246b974a17ffa9d2ac02)
+      porto: 0.2.35(rjxzfhi5r7oaafa2zdw4eu5lpq)
       viem: 2.44.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)
     optionalDependencies:
       typescript: 5.9.3
@@ -22339,7 +22339,7 @@ snapshots:
       - wagmi
       - zod
 
-  '@wagmi/connectors@6.2.0(630612136b814801849846a54ef03e3a)':
+  '@wagmi/connectors@6.2.0(jhijuz3c6wu6kvlsnblo2l2tzi)':
     dependencies:
       '@base-org/account': 2.4.0(@types/react@19.2.14)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(immer@11.1.3)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(utf-8-validate@5.0.10)(zod@4.3.5)
       '@coinbase/wallet-sdk': 4.3.6(@types/react@19.2.14)(bufferutil@4.1.0)(immer@11.1.3)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(utf-8-validate@5.0.10)(zod@4.3.5)
@@ -22350,7 +22350,7 @@ snapshots:
       '@wagmi/core': 2.22.1(@tanstack/query-core@5.90.16)(@types/react@19.2.14)(immer@11.1.3)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.44.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5))
       '@walletconnect/ethereum-provider': 2.21.1(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)
       cbw-sdk: '@coinbase/wallet-sdk@3.9.3'
-      porto: 0.2.35(e3dd7ea3947bb655c3ce9468d1cee882)
+      porto: 0.2.35(fyexqdiytlnymj6uxu23okcvua)
       viem: 2.44.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)
     optionalDependencies:
       typescript: 5.9.3
@@ -22392,7 +22392,7 @@ snapshots:
       - wagmi
       - zod
 
-  '@wagmi/connectors@6.2.0(fdca11b92d1d17d07535caa51eff5117)':
+  '@wagmi/connectors@6.2.0(p7eg4dwmbuejywsjmjd24uoalu)':
     dependencies:
       '@base-org/account': 2.4.0(@types/react@19.2.14)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(immer@11.1.3)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(utf-8-validate@5.0.10)(zod@4.3.5)
       '@coinbase/wallet-sdk': 4.3.6(@types/react@19.2.14)(bufferutil@4.1.0)(immer@11.1.3)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(utf-8-validate@5.0.10)(zod@4.3.5)
@@ -22403,7 +22403,7 @@ snapshots:
       '@wagmi/core': 2.22.1(@tanstack/query-core@5.90.16)(@types/react@19.2.14)(immer@11.1.3)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.44.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5))
       '@walletconnect/ethereum-provider': 2.21.1(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)
       cbw-sdk: '@coinbase/wallet-sdk@3.9.3'
-      porto: 0.2.35(d36d9fce83bdc2480adabee29628b432)
+      porto: 0.2.35(ssbn2rsf6yhbasf5nocjgozndq)
       viem: 2.44.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)
     optionalDependencies:
       typescript: 5.9.3
@@ -24029,7 +24029,7 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@wormhole-foundation/wormhole-connect@5.1.0(7dec88115dc0b6b421bab74122d84d12)':
+  '@wormhole-foundation/wormhole-connect@5.1.0(duigyiywtgpirgsl4u2ct36rvq)':
     dependencies:
       '@aptos-labs/ts-sdk': 2.0.0(got@11.8.6)
       '@aptos-labs/wallet-adapter-core': 5.5.0(@aptos-labs/ts-sdk@2.0.0(got@11.8.6))(@mizuwallet-sdk/protocol@0.0.2)(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.1.1)(aptos@1.22.1(got@11.8.6))(axios@1.15.0)(got@11.8.6)
@@ -24055,7 +24055,7 @@ snapshots:
       '@reduxjs/toolkit': 2.9.0(react-redux@9.2.0(@types/react@19.2.14)(react@19.2.5)(redux@5.0.1))(react@19.2.5)
       '@solana-mobile/wallet-standard-mobile': 0.4.1(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.84.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@5.0.10))(typescript@5.9.3)
       '@solana/spl-token': 0.4.0(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
-      '@solana/wallet-adapter-wallets': 0.19.32(@babel/runtime@7.29.2)(@solana/sysvars@5.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(@types/react@19.2.14)(bs58@6.0.0)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.2.5(react@19.2.5))(react-native@0.84.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@5.0.10))(react@19.2.5)(tslib@2.8.1)(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.5)
+      '@solana/wallet-adapter-wallets': 0.19.32(@babel/runtime@7.29.2)(@solana/sysvars@5.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(@types/react@19.2.14)(bs58@6.0.0)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.2.5(react@19.2.5))(react-native@0.84.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@5.0.10))(react@19.2.5)(tslib@2.8.1)(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@8.18.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.5)
       '@testnet-mayan/swap-sdk': 1.2.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@wormhole-foundation/sdk': 4.9.1(bufferutil@4.1.0)(google-protobuf@3.21.4)(got@11.8.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)
       '@wormhole-foundation/sdk-aptos': 4.9.1(got@11.8.6)
@@ -29146,28 +29146,7 @@ snapshots:
       - immer
       - use-sync-external-store
 
-  porto@0.2.35(d36d9fce83bdc2480adabee29628b432):
-    dependencies:
-      '@wagmi/core': 2.22.1(@tanstack/query-core@5.90.16)(@types/react@19.2.14)(immer@11.1.3)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.44.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5))
-      hono: 4.12.14
-      idb-keyval: 6.2.2
-      mipd: 0.0.7(typescript@5.9.3)
-      ox: 0.9.17(typescript@5.9.3)(zod@4.3.5)
-      viem: 2.44.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)
-      zod: 4.3.5
-      zustand: 5.0.9(@types/react@19.2.14)(immer@11.1.3)(react@19.2.5)(use-sync-external-store@1.4.0(react@19.2.5))
-    optionalDependencies:
-      '@tanstack/react-query': 5.90.16(react@19.2.5)
-      react: 19.2.5
-      react-native: 0.84.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@5.0.10)
-      typescript: 5.9.3
-      wagmi: 2.19.5(@tanstack/query-core@5.90.16)(@tanstack/react-query@5.90.16(react@19.2.5))(@types/react@19.2.14)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(immer@11.1.3)(react-native@0.84.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@5.0.10))(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.44.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5))(zod@4.3.5)
-    transitivePeerDependencies:
-      - '@types/react'
-      - immer
-      - use-sync-external-store
-
-  porto@0.2.35(d850088e01e6246b974a17ffa9d2ac02):
+  porto@0.2.35(fyexqdiytlnymj6uxu23okcvua):
     dependencies:
       '@wagmi/core': 2.22.1(@tanstack/query-core@5.90.16)(@types/react@19.2.14)(immer@11.1.3)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.44.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5))
       hono: 4.12.14
@@ -29188,7 +29167,7 @@ snapshots:
       - immer
       - use-sync-external-store
 
-  porto@0.2.35(e3dd7ea3947bb655c3ce9468d1cee882):
+  porto@0.2.35(rjxzfhi5r7oaafa2zdw4eu5lpq):
     dependencies:
       '@wagmi/core': 2.22.1(@tanstack/query-core@5.90.16)(@types/react@19.2.14)(immer@11.1.3)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.44.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5))
       hono: 4.12.14
@@ -29204,6 +29183,27 @@ snapshots:
       react-native: 0.84.1(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@5.0.10)
       typescript: 5.9.3
       wagmi: 2.19.5(@tanstack/query-core@5.90.16)(@tanstack/react-query@5.90.16(react@19.2.5))(@types/react@19.2.14)(bufferutil@4.1.0)(immer@11.1.3)(react-native@0.84.1(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@5.0.10))(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.44.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5))(zod@4.3.5)
+    transitivePeerDependencies:
+      - '@types/react'
+      - immer
+      - use-sync-external-store
+
+  porto@0.2.35(ssbn2rsf6yhbasf5nocjgozndq):
+    dependencies:
+      '@wagmi/core': 2.22.1(@tanstack/query-core@5.90.16)(@types/react@19.2.14)(immer@11.1.3)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.44.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5))
+      hono: 4.12.14
+      idb-keyval: 6.2.2
+      mipd: 0.0.7(typescript@5.9.3)
+      ox: 0.9.17(typescript@5.9.3)(zod@4.3.5)
+      viem: 2.44.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)
+      zod: 4.3.5
+      zustand: 5.0.9(@types/react@19.2.14)(immer@11.1.3)(react@19.2.5)(use-sync-external-store@1.4.0(react@19.2.5))
+    optionalDependencies:
+      '@tanstack/react-query': 5.90.16(react@19.2.5)
+      react: 19.2.5
+      react-native: 0.84.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@5.0.10)
+      typescript: 5.9.3
+      wagmi: 2.19.5(@tanstack/query-core@5.90.16)(@tanstack/react-query@5.90.16(react@19.2.5))(@types/react@19.2.14)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(immer@11.1.3)(react-native@0.84.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@5.0.10))(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.44.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5))(zod@4.3.5)
     transitivePeerDependencies:
       - '@types/react'
       - immer
@@ -30773,14 +30773,14 @@ snapshots:
 
   ts-mixer@6.0.4: {}
 
-  ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3):
+  ts-node@10.9.2(@types/node@25.6.0)(typescript@5.9.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.12
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
-      '@types/node': 25.5.0
+      '@types/node': 25.6.0
       acorn: 8.15.0
       acorn-walk: 8.3.4
       arg: 4.1.3
@@ -31432,7 +31432,7 @@ snapshots:
   wagmi@2.19.5(@tanstack/query-core@5.90.16)(@tanstack/react-query@5.90.16(react@19.2.5))(@types/react@19.2.14)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(immer@11.1.3)(react-native@0.84.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@5.0.10))(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.44.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5))(zod@4.3.5):
     dependencies:
       '@tanstack/react-query': 5.90.16(react@19.2.5)
-      '@wagmi/connectors': 6.2.0(fdca11b92d1d17d07535caa51eff5117)
+      '@wagmi/connectors': 6.2.0(p7eg4dwmbuejywsjmjd24uoalu)
       '@wagmi/core': 2.22.1(@tanstack/query-core@5.90.16)(@types/react@19.2.14)(immer@11.1.3)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.44.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5))
       react: 19.2.5
       use-sync-external-store: 1.4.0(react@19.2.5)
@@ -31477,7 +31477,7 @@ snapshots:
   wagmi@2.19.5(@tanstack/query-core@5.90.16)(@tanstack/react-query@5.90.16(react@19.2.5))(@types/react@19.2.14)(bufferutil@4.1.0)(immer@11.1.3)(react-native@0.84.1(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@5.0.10))(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.44.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5))(zod@4.3.5):
     dependencies:
       '@tanstack/react-query': 5.90.16(react@19.2.5)
-      '@wagmi/connectors': 6.2.0(630612136b814801849846a54ef03e3a)
+      '@wagmi/connectors': 6.2.0(ap4m3yv4is7p7hbxavtb6wueda)
       '@wagmi/core': 2.22.1(@tanstack/query-core@5.90.16)(@types/react@19.2.14)(immer@11.1.3)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.44.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5))
       react: 19.2.5
       use-sync-external-store: 1.4.0(react@19.2.5)
@@ -31522,7 +31522,7 @@ snapshots:
   wagmi@2.19.5(@tanstack/query-core@5.90.16)(@tanstack/react-query@5.90.16(react@19.2.5))(@types/react@19.2.14)(bufferutil@4.1.0)(immer@11.1.3)(react-native@0.84.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@5.0.10))(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.44.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5))(zod@4.3.5):
     dependencies:
       '@tanstack/react-query': 5.90.16(react@19.2.5)
-      '@wagmi/connectors': 6.2.0(628704a63c493a56d2ac24cf65ee3715)
+      '@wagmi/connectors': 6.2.0(jhijuz3c6wu6kvlsnblo2l2tzi)
       '@wagmi/core': 2.22.1(@tanstack/query-core@5.90.16)(@types/react@19.2.14)(immer@11.1.3)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.44.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5))
       react: 19.2.5
       use-sync-external-store: 1.4.0(react@19.2.5)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,8 +10,8 @@ catalogs:
       specifier: ^9.39.2
       version: 9.39.2
     '@mento-protocol/mento-sdk':
-      specifier: 3.2.7-beta.0
-      version: 3.2.7-beta.0
+      specifier: 3.2.8
+      version: 3.2.8
     '@metamask/jazzicon':
       specifier: github:jmrossy/jazzicon#7a8df28
       version: 2.1.0
@@ -205,7 +205,7 @@ importers:
         version: 5.2.2(react-hook-form@7.71.1(react@19.2.5))
       '@mento-protocol/mento-sdk':
         specifier: 'catalog:'
-        version: 3.2.7-beta.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)
+        version: 3.2.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)
       '@mui/icons-material':
         specifier: ^7.3.2
         version: 7.3.9(@mui/material@7.3.9(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(@types/react@19.2.14)(react@19.2.5)
@@ -353,7 +353,7 @@ importers:
         version: link:../../packages/web3
       '@sentry/nextjs':
         specifier: 'catalog:'
-        version: 10.36.0(@opentelemetry/context-async-hooks@2.5.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.5.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(next@15.5.15(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(webpack@5.104.1)
+        version: 10.36.0(@opentelemetry/context-async-hooks@2.5.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.5.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(next@15.5.15(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(babel-plugin-macros@3.1.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(webpack@5.104.1)
       '@t3-oss/env-nextjs':
         specifier: 'catalog:'
         version: 0.13.11(typescript@5.9.3)(valibot@1.3.0(typescript@5.9.3))(zod@4.3.5)
@@ -368,7 +368,7 @@ importers:
         version: 5.0.6
       '@vercel/analytics':
         specifier: 'catalog:'
-        version: 1.6.1(next@15.5.15(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)
+        version: 1.6.1(next@15.5.15(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(babel-plugin-macros@3.1.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)
       date-fns:
         specifier: ^4.1.0
         version: 4.1.0
@@ -480,7 +480,7 @@ importers:
         version: link:../../packages/web3
       '@sentry/nextjs':
         specifier: 'catalog:'
-        version: 10.36.0(@opentelemetry/context-async-hooks@2.5.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.5.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(next@15.5.15(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(webpack@5.104.1)
+        version: 10.36.0(@opentelemetry/context-async-hooks@2.5.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.5.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(next@15.5.15(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(babel-plugin-macros@3.1.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(webpack@5.104.1)
       '@t3-oss/env-nextjs':
         specifier: 'catalog:'
         version: 0.13.11(typescript@5.9.3)(valibot@1.3.0(typescript@5.9.3))(zod@4.3.5)
@@ -489,7 +489,7 @@ importers:
         version: 5.90.16(react@19.2.5)
       '@vercel/analytics':
         specifier: 'catalog:'
-        version: 1.6.1(next@15.5.15(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)
+        version: 1.6.1(next@15.5.15(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(babel-plugin-macros@3.1.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)
       lucide-react:
         specifier: 'catalog:'
         version: 0.562.0(react@19.2.5)
@@ -813,7 +813,7 @@ importers:
         version: 5.8.0
       '@mento-protocol/mento-sdk':
         specifier: 'catalog:'
-        version: 3.2.7-beta.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)
+        version: 3.2.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)
       '@metamask/jazzicon':
         specifier: 'catalog:'
         version: https://codeload.github.com/jmrossy/jazzicon/tar.gz/7a8df28
@@ -2937,8 +2937,8 @@ packages:
   '@mayanfinance/swap-sdk@12.2.5':
     resolution: {integrity: sha512-ZPk4QF3eDdh/jv3h+2J7XUNZaT5i5ix9UeH6QX9GkBEG6NqQmdSqRapZx52Z6JZi3BR0ixMBMjsIiGZ1KdjkkA==}
 
-  '@mento-protocol/mento-sdk@3.2.7-beta.0':
-    resolution: {integrity: sha512-hta6T9rf0Orzase1m2G2areMRYADqX16aS2cEqSaq0JD74U3KLHAH2L3w9qZwoNOZJ7QMLr+EujJ8eE8tAWHkQ==}
+  '@mento-protocol/mento-sdk@3.2.8':
+    resolution: {integrity: sha512-hn112o5j4/dvsW3L+aa3d5vl7E4LoWAMjMvmoQg11pNFRSejDWPgwyu5U23fEHuAaOHD7sIUx+BhmLr/pKwYHw==}
     engines: {node: '>=18', pnpm: '>=9'}
 
   '@metamask/detect-provider@2.0.0':
@@ -16647,7 +16647,7 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@mento-protocol/mento-sdk@3.2.7-beta.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)':
+  '@mento-protocol/mento-sdk@3.2.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)':
     dependencies:
       viem: 2.44.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5)
     transitivePeerDependencies:
@@ -19361,6 +19361,31 @@ snapshots:
 
   '@sentry/core@10.36.0': {}
 
+  '@sentry/nextjs@10.36.0(@opentelemetry/context-async-hooks@2.5.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.5.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(next@15.5.15(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(babel-plugin-macros@3.1.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(webpack@5.104.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/semantic-conventions': 1.38.0
+      '@rollup/plugin-commonjs': 28.0.1(rollup@4.59.0)
+      '@sentry-internal/browser-utils': 10.36.0
+      '@sentry/bundler-plugin-core': 4.7.0
+      '@sentry/core': 10.36.0
+      '@sentry/node': 10.36.0
+      '@sentry/opentelemetry': 10.36.0(@opentelemetry/api@1.9.0)(@opentelemetry/context-async-hooks@2.5.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.5.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.38.0)
+      '@sentry/react': 10.36.0(react@19.2.5)
+      '@sentry/vercel-edge': 10.36.0
+      '@sentry/webpack-plugin': 4.7.0(webpack@5.104.1)
+      next: 15.5.15(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(babel-plugin-macros@3.1.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      rollup: 4.59.0
+      stacktrace-parser: 0.1.11
+    transitivePeerDependencies:
+      - '@opentelemetry/context-async-hooks'
+      - '@opentelemetry/core'
+      - '@opentelemetry/sdk-trace-base'
+      - encoding
+      - react
+      - supports-color
+      - webpack
+
   '@sentry/nextjs@10.36.0(@opentelemetry/context-async-hooks@2.5.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.5.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(next@15.5.15(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-macros@3.1.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(webpack@5.104.1(esbuild@0.27.2))':
     dependencies:
       '@opentelemetry/api': 1.9.0
@@ -19400,31 +19425,6 @@ snapshots:
       '@sentry/vercel-edge': 10.36.0
       '@sentry/webpack-plugin': 4.7.0(webpack@5.104.1)
       next: 15.5.15(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-macros@3.1.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      rollup: 4.59.0
-      stacktrace-parser: 0.1.11
-    transitivePeerDependencies:
-      - '@opentelemetry/context-async-hooks'
-      - '@opentelemetry/core'
-      - '@opentelemetry/sdk-trace-base'
-      - encoding
-      - react
-      - supports-color
-      - webpack
-
-  '@sentry/nextjs@10.36.0(@opentelemetry/context-async-hooks@2.5.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.5.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(next@15.5.15(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(webpack@5.104.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/semantic-conventions': 1.38.0
-      '@rollup/plugin-commonjs': 28.0.1(rollup@4.59.0)
-      '@sentry-internal/browser-utils': 10.36.0
-      '@sentry/bundler-plugin-core': 4.7.0
-      '@sentry/core': 10.36.0
-      '@sentry/node': 10.36.0
-      '@sentry/opentelemetry': 10.36.0(@opentelemetry/api@1.9.0)(@opentelemetry/context-async-hooks@2.5.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.5.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.38.0)
-      '@sentry/react': 10.36.0(react@19.2.5)
-      '@sentry/vercel-edge': 10.36.0
-      '@sentry/webpack-plugin': 4.7.0(webpack@5.104.1)
-      next: 15.5.15(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(babel-plugin-macros@3.1.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       rollup: 4.59.0
       stacktrace-parser: 0.1.11
     transitivePeerDependencies:
@@ -22160,14 +22160,14 @@ snapshots:
     dependencies:
       '@vanilla-extract/css': 1.17.3(babel-plugin-macros@3.1.0)
 
+  '@vercel/analytics@1.6.1(next@15.5.15(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(babel-plugin-macros@3.1.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)':
+    optionalDependencies:
+      next: 15.5.15(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(babel-plugin-macros@3.1.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react: 19.2.5
+
   '@vercel/analytics@1.6.1(next@15.5.15(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-macros@3.1.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)':
     optionalDependencies:
       next: 15.5.15(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-macros@3.1.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      react: 19.2.5
-
-  '@vercel/analytics@1.6.1(next@15.5.15(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)':
-    optionalDependencies:
-      next: 15.5.15(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(babel-plugin-macros@3.1.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       react: 19.2.5
 
   '@vitest/coverage-v8@3.2.4(vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.5.0)(jiti@2.6.1)(jsdom@26.1.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.32.0)(terser@5.46.2)(yaml@2.8.3))':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,7 +5,7 @@ packages:
 catalog:
   "@wagmi/core": ^2.22.1
   "@eslint/js": ^9.39.2
-  "@mento-protocol/mento-sdk": 3.2.6
+  "@mento-protocol/mento-sdk": 3.2.7-beta.0
   "@metamask/jazzicon": github:jmrossy/jazzicon#7a8df28
   "@rainbow-me/rainbowkit": ^2.2.10
   "@sentry/nextjs": ^10.35.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,7 +5,7 @@ packages:
 catalog:
   "@wagmi/core": ^2.22.1
   "@eslint/js": ^9.39.2
-  "@mento-protocol/mento-sdk": 3.2.7-beta.0
+  "@mento-protocol/mento-sdk": 3.2.8
   "@metamask/jazzicon": github:jmrossy/jazzicon#7a8df28
   "@rainbow-me/rainbowkit": ^2.2.10
   "@sentry/nextjs": ^10.35.0


### PR DESCRIPTION
## Summary

- Bumps `@mento-protocol/mento-sdk` to **3.2.8** ([mento-protocol/mento-sdk#169](https://github.com/mento-protocol/mento-sdk/pull/169)), which fixes single-sided zap-in reverting on-chain at any non-trivial amount regardless of slippage.
- Improves frontend error reporting around the zap reverts: parses the new `InsufficientAmount*` selectors, splits the disabled-button copy into "Amount too large" vs "Adjust amount" so the user knows whether to shrink the amount or widen slippage, and renames "zap" to "single-token liquidity" in user-facing surfaces.

### Why the SDK bump matters

`Router.generateZapInParams` was producing `amountAMin` / `amountBMin` against pre-swap reserves, but on-chain `_quoteZapLiquidity` runs *after* the zap's internal swap on the same pool. The deterministic price impact of the swap consumed the entire user slippage budget, so any zap exceeding ~2% of pool reserves (at 1% slippage) reverted with `InsufficientAmountB` / `InsufficientAmountA`. SDK 3.2.8 re-quotes the minimums against projected post-swap reserves so user slippage only buffers real drift.

Verified end-to-end against `3.2.7-beta.0` before publishing the stable release.

### Files

- `pnpm-workspace.yaml`, `pnpm-lock.yaml` — SDK pin
- `apps/app.mento.org/app/components/pools/add-liquidity-form.tsx` — selector-aware error copy + button states
- `apps/app.mento.org/app/components/pools/remove-liquidity-form.tsx` — error message rename
- `packages/web3/src/features/pools/flow-engine.ts` — error-message dispatcher updates
- `packages/web3/src/features/pools/hooks/use-zap-in-transaction.tsx` — selector parsing, post-revert route validation fallback
- `packages/web3/src/features/pools/hooks/use-zap-out-quote.ts`, `use-zap-out-transaction.tsx` — error message rename

## Test plan

- [x] CI green
- [x] Single-sided zap-in with `tokenIn == token0` at 1% slippage, varying amounts (small / medium / large fraction of pool reserves)
- [x] Single-sided zap-in with `tokenIn == token1` (mirror)
- [x] Balanced add-liquidity still works (no regression)
- [x] Single-sided zap-out still works (unchanged in this PR but shares some helpers)
- [x] Error states surface the right copy: "Amount too large" for liquidity-bound failures, "Adjust amount" for ratio failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches transaction-building/simulation and error handling for liquidity flows; while mostly UX and validation logic, misclassification could incorrectly block transactions or show misleading guidance.
> 
> **Overview**
> Fixes single-token add-liquidity reliability by bumping `@mento-protocol/mento-sdk` to `3.2.8` and updating zap-in build/simulation handling to better tolerate pre-approval allowance failures while adding an on-chain reserve/route liquidity validation fallback.
> 
> Improves UX around single-token add/remove by standardizing copy from “zap” to **single-token liquidity/removal**, recognizing new deterministic revert selectors (liquidity-limit vs pool-ratio vs route-unavailable), and surfacing more actionable disabled-button + toast messages; the flow engine’s friendly error mapping is also updated to avoid mode-specific wording in balanced flows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29b91ea7f8b1a6053ced4cceba0433865f657816. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->