### PR TITLE
chore(sentry): tag environment and zero preview tracesSampleRate

### DIFF
--- a/apps/app.mento.org/instrumentation-client.ts
+++ b/apps/app.mento.org/instrumentation-client.ts
@@ -10,11 +10,15 @@ import {
   sentryIgnoreErrors,
 } from "@repo/web3/sentry-filter";
 
+const vercelEnv = process.env.NEXT_PUBLIC_VERCEL_ENV ?? "development";
+
 Sentry.init({
   dsn: env.NEXT_PUBLIC_SENTRY_DSN_SWAP,
 
   // Disable Sentry in development to avoid localhost errors
   enabled: process.env.NODE_ENV === "production",
+
+  environment: vercelEnv,
 
   // Add optional integrations for additional features
   integrations: [
@@ -35,8 +39,7 @@ Sentry.init({
   denyUrls: sentryDenyUrls,
   beforeSend: filterNoisySentryEvents,
 
-  // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
-  tracesSampleRate: 0.1,
+  tracesSampleRate: vercelEnv === "production" ? 0.1 : 0,
 
   // Define how likely Replay events are sampled.
   // This sets the sample rate to be 1%.

--- a/apps/app.mento.org/instrumentation-client.ts
+++ b/apps/app.mento.org/instrumentation-client.ts
@@ -5,12 +5,18 @@
 import * as Sentry from "@sentry/nextjs";
 import { env } from "@/env.mjs";
 import {
+  createDedupedSentryEventFilter,
   filterNoisySentryEvents,
   sentryDenyUrls,
   sentryIgnoreErrors,
 } from "@repo/web3/sentry-filter";
 
 const vercelEnv = process.env.NEXT_PUBLIC_VERCEL_ENV ?? "development";
+
+const beforeSend =
+  vercelEnv === "preview"
+    ? createDedupedSentryEventFilter()
+    : filterNoisySentryEvents;
 
 Sentry.init({
   dsn: env.NEXT_PUBLIC_SENTRY_DSN_SWAP,
@@ -37,7 +43,7 @@ Sentry.init({
 
   ignoreErrors: sentryIgnoreErrors,
   denyUrls: sentryDenyUrls,
-  beforeSend: filterNoisySentryEvents,
+  beforeSend,
 
   tracesSampleRate: vercelEnv === "production" ? 0.1 : 0,
 

--- a/apps/app.mento.org/sentry.edge.config.ts
+++ b/apps/app.mento.org/sentry.edge.config.ts
@@ -10,17 +10,20 @@ import {
   sentryIgnoreErrors,
 } from "@repo/web3/sentry-filter";
 
+const vercelEnv = process.env.VERCEL_ENV ?? "development";
+
 Sentry.init({
   dsn: env.NEXT_PUBLIC_SENTRY_DSN_SWAP,
 
   // Disable Sentry in development to avoid localhost errors
   enabled: process.env.NODE_ENV === "production",
 
+  environment: vercelEnv,
+
   ignoreErrors: sentryIgnoreErrors,
   beforeSend: filterNoisySentryEvents,
 
-  // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
-  tracesSampleRate: 0.1,
+  tracesSampleRate: vercelEnv === "production" ? 0.1 : 0,
 
   // Setting this option to true will print useful information to the console while you're setting up Sentry.
   debug: false,

--- a/apps/app.mento.org/sentry.server.config.ts
+++ b/apps/app.mento.org/sentry.server.config.ts
@@ -9,17 +9,20 @@ import {
   sentryIgnoreErrors,
 } from "@repo/web3/sentry-filter";
 
+const vercelEnv = process.env.VERCEL_ENV ?? "development";
+
 Sentry.init({
   dsn: env.NEXT_PUBLIC_SENTRY_DSN_SWAP,
 
   // Disable Sentry in development to avoid localhost errors
   enabled: process.env.NODE_ENV === "production",
 
+  environment: vercelEnv,
+
   ignoreErrors: sentryIgnoreErrors,
   beforeSend: filterNoisySentryEvents,
 
-  // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
-  tracesSampleRate: 0.1,
+  tracesSampleRate: vercelEnv === "production" ? 0.1 : 0,
 
   // Setting this option to true will print useful information to the console while you're setting up Sentry.
   debug: false,

--- a/apps/governance.mento.org/instrumentation-client.ts
+++ b/apps/governance.mento.org/instrumentation-client.ts
@@ -5,12 +5,18 @@
 import * as Sentry from "@sentry/nextjs";
 import { env } from "@/env.mjs";
 import {
+  createDedupedSentryEventFilter,
   filterNoisySentryEvents,
   sentryDenyUrls,
   sentryIgnoreErrors,
 } from "@repo/web3/sentry-filter";
 
 const vercelEnv = process.env.NEXT_PUBLIC_VERCEL_ENV ?? "development";
+
+const beforeSend =
+  vercelEnv === "preview"
+    ? createDedupedSentryEventFilter()
+    : filterNoisySentryEvents;
 
 Sentry.init({
   dsn: env.NEXT_PUBLIC_SENTRY_DSN_GOVERNANCE,
@@ -37,7 +43,7 @@ Sentry.init({
 
   ignoreErrors: sentryIgnoreErrors,
   denyUrls: sentryDenyUrls,
-  beforeSend: filterNoisySentryEvents,
+  beforeSend,
 
   tracesSampleRate: vercelEnv === "production" ? 0.1 : 0,
 

--- a/apps/governance.mento.org/instrumentation-client.ts
+++ b/apps/governance.mento.org/instrumentation-client.ts
@@ -10,11 +10,15 @@ import {
   sentryIgnoreErrors,
 } from "@repo/web3/sentry-filter";
 
+const vercelEnv = process.env.NEXT_PUBLIC_VERCEL_ENV ?? "development";
+
 Sentry.init({
   dsn: env.NEXT_PUBLIC_SENTRY_DSN_GOVERNANCE,
 
   // Disable Sentry in development to avoid localhost errors
   enabled: process.env.NODE_ENV === "production",
+
+  environment: vercelEnv,
 
   // Add optional integrations for additional features
   integrations: [
@@ -35,8 +39,7 @@ Sentry.init({
   denyUrls: sentryDenyUrls,
   beforeSend: filterNoisySentryEvents,
 
-  // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
-  tracesSampleRate: 0.1,
+  tracesSampleRate: vercelEnv === "production" ? 0.1 : 0,
 
   // Define how likely Replay events are sampled.
   // This sets the sample rate to be 1%.

--- a/apps/governance.mento.org/sentry.edge.config.ts
+++ b/apps/governance.mento.org/sentry.edge.config.ts
@@ -10,17 +10,20 @@ import {
   sentryIgnoreErrors,
 } from "@repo/web3/sentry-filter";
 
+const vercelEnv = process.env.VERCEL_ENV ?? "development";
+
 Sentry.init({
   dsn: env.NEXT_PUBLIC_SENTRY_DSN_GOVERNANCE,
 
   // Disable Sentry in development to avoid localhost errors
   enabled: process.env.NODE_ENV === "production",
 
+  environment: vercelEnv,
+
   ignoreErrors: sentryIgnoreErrors,
   beforeSend: filterNoisySentryEvents,
 
-  // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
-  tracesSampleRate: 0.1,
+  tracesSampleRate: vercelEnv === "production" ? 0.1 : 0,
 
   // Setting this option to true will print useful information to the console while you're setting up Sentry.
   debug: false,

--- a/apps/governance.mento.org/sentry.server.config.ts
+++ b/apps/governance.mento.org/sentry.server.config.ts
@@ -9,17 +9,20 @@ import {
   sentryIgnoreErrors,
 } from "@repo/web3/sentry-filter";
 
+const vercelEnv = process.env.VERCEL_ENV ?? "development";
+
 Sentry.init({
   dsn: env.NEXT_PUBLIC_SENTRY_DSN_GOVERNANCE,
 
   // Disable Sentry in development to avoid localhost errors
   enabled: process.env.NODE_ENV === "production",
 
+  environment: vercelEnv,
+
   ignoreErrors: sentryIgnoreErrors,
   beforeSend: filterNoisySentryEvents,
 
-  // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
-  tracesSampleRate: 0.1,
+  tracesSampleRate: vercelEnv === "production" ? 0.1 : 0,
 
   // Define how likely Replay events are sampled.
   // This sets the sample rate to be 10%. You may want this to be 100% while

--- a/apps/reserve.mento.org/instrumentation-client.ts
+++ b/apps/reserve.mento.org/instrumentation-client.ts
@@ -10,11 +10,15 @@ import {
   sentryIgnoreErrors,
 } from "@repo/web3/sentry-filter";
 
+const vercelEnv = process.env.NEXT_PUBLIC_VERCEL_ENV ?? "development";
+
 Sentry.init({
   dsn: env.NEXT_PUBLIC_SENTRY_DSN_RESERVE,
 
   // Disable Sentry in development to avoid localhost errors
   enabled: process.env.NODE_ENV === "production",
+
+  environment: vercelEnv,
 
   // Adds request headers and IP for users, for more info visit:
   // https://docs.sentry.io/platforms/javascript/guides/nextjs/configuration/options/#sendDefaultPii
@@ -24,8 +28,7 @@ Sentry.init({
   denyUrls: sentryDenyUrls,
   beforeSend: filterNoisySentryEvents,
 
-  // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
-  tracesSampleRate: 0.1,
+  tracesSampleRate: vercelEnv === "production" ? 0.1 : 0,
 
   // Setting this option to true will print useful information to the console while you're setting up Sentry.
   debug: false,

--- a/apps/reserve.mento.org/instrumentation-client.ts
+++ b/apps/reserve.mento.org/instrumentation-client.ts
@@ -5,12 +5,18 @@
 import * as Sentry from "@sentry/nextjs";
 import { env } from "@/env.mjs";
 import {
+  createDedupedSentryEventFilter,
   filterNoisySentryEvents,
   sentryDenyUrls,
   sentryIgnoreErrors,
 } from "@repo/web3/sentry-filter";
 
 const vercelEnv = process.env.NEXT_PUBLIC_VERCEL_ENV ?? "development";
+
+const beforeSend =
+  vercelEnv === "preview"
+    ? createDedupedSentryEventFilter()
+    : filterNoisySentryEvents;
 
 Sentry.init({
   dsn: env.NEXT_PUBLIC_SENTRY_DSN_RESERVE,
@@ -26,7 +32,7 @@ Sentry.init({
 
   ignoreErrors: sentryIgnoreErrors,
   denyUrls: sentryDenyUrls,
-  beforeSend: filterNoisySentryEvents,
+  beforeSend,
 
   tracesSampleRate: vercelEnv === "production" ? 0.1 : 0,
 

--- a/apps/reserve.mento.org/sentry.edge.config.ts
+++ b/apps/reserve.mento.org/sentry.edge.config.ts
@@ -10,17 +10,20 @@ import {
   sentryIgnoreErrors,
 } from "@repo/web3/sentry-filter";
 
+const vercelEnv = process.env.VERCEL_ENV ?? "development";
+
 Sentry.init({
   dsn: env.NEXT_PUBLIC_SENTRY_DSN_RESERVE,
 
   // Disable Sentry in development to avoid localhost errors
   enabled: process.env.NODE_ENV === "production",
 
+  environment: vercelEnv,
+
   ignoreErrors: sentryIgnoreErrors,
   beforeSend: filterNoisySentryEvents,
 
-  // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
-  tracesSampleRate: 0.1,
+  tracesSampleRate: vercelEnv === "production" ? 0.1 : 0,
 
   // Setting this option to true will print useful information to the console while you're setting up Sentry.
   debug: false,

--- a/apps/reserve.mento.org/sentry.server.config.ts
+++ b/apps/reserve.mento.org/sentry.server.config.ts
@@ -9,17 +9,20 @@ import {
   sentryIgnoreErrors,
 } from "@repo/web3/sentry-filter";
 
+const vercelEnv = process.env.VERCEL_ENV ?? "development";
+
 Sentry.init({
   dsn: env.NEXT_PUBLIC_SENTRY_DSN_RESERVE,
 
   // Disable Sentry in development to avoid localhost errors
   enabled: process.env.NODE_ENV === "production",
 
+  environment: vercelEnv,
+
   ignoreErrors: sentryIgnoreErrors,
   beforeSend: filterNoisySentryEvents,
 
-  // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
-  tracesSampleRate: 0.1,
+  tracesSampleRate: vercelEnv === "production" ? 0.1 : 0,
 
   // Setting this option to true will print useful information to the console while you're setting up Sentry.
   debug: false,

--- a/packages/web3/src/utils/sentry-filter.test.ts
+++ b/packages/web3/src/utils/sentry-filter.test.ts
@@ -1,6 +1,7 @@
 import type { ErrorEvent, EventHint } from "@sentry/nextjs";
 import { describe, expect, it } from "vitest";
 import {
+  createDedupedSentryEventFilter,
   filterNoisySentryEvents,
   sentryDenyUrls,
   sentryIgnoreErrors,
@@ -171,5 +172,78 @@ describe("sentry-filter", () => {
     } as EventHint;
 
     expect(filterNoisySentryEvents(event, hint)).toBeNull();
+  });
+});
+
+describe("createDedupedSentryEventFilter", () => {
+  it("forwards the first occurrence of an event and drops repeats with the same signature", () => {
+    const filter = createDedupedSentryEventFilter();
+    const first = makeEvent({
+      exceptionType: "TypeError",
+      exceptionValue: "Failed to fetch",
+      frames: ["https://reserve.mento.org/_next/static/chunks/app.js"],
+    });
+    const repeat = makeEvent({
+      exceptionType: "TypeError",
+      exceptionValue: "Failed to fetch",
+      frames: ["https://reserve.mento.org/_next/static/chunks/app.js"],
+    });
+
+    expect(filter(first)).toBe(first);
+    expect(filter(repeat)).toBeNull();
+  });
+
+  it("treats events with different messages as distinct signatures", () => {
+    const filter = createDedupedSentryEventFilter();
+    const first = makeEvent({
+      exceptionType: "TypeError",
+      exceptionValue: "Failed to fetch",
+      frames: ["https://reserve.mento.org/_next/static/chunks/app.js"],
+    });
+    const different = makeEvent({
+      exceptionType: "TypeError",
+      exceptionValue: "Load failed",
+      frames: ["https://reserve.mento.org/_next/static/chunks/app.js"],
+    });
+
+    expect(filter(first)).toBe(first);
+    expect(filter(different)).toBe(different);
+  });
+
+  it("still applies the underlying noise filter before deduping", () => {
+    const filter = createDedupedSentryEventFilter();
+    const noisy = makeEvent({ message: "Origin not allowed" });
+
+    expect(filter(noisy)).toBeNull();
+  });
+
+  it("clears its memory once it crosses the configured cap so long-lived tabs don't grow unbounded", () => {
+    const filter = createDedupedSentryEventFilter({ maxSize: 2 });
+    const first = makeEvent({
+      exceptionType: "TypeError",
+      exceptionValue: "Failed to fetch",
+      frames: ["https://reserve.mento.org/_next/static/chunks/a.js"],
+    });
+    const second = makeEvent({
+      exceptionType: "TypeError",
+      exceptionValue: "Load failed",
+      frames: ["https://reserve.mento.org/_next/static/chunks/b.js"],
+    });
+    const third = makeEvent({
+      exceptionType: "TypeError",
+      exceptionValue: "NetworkError",
+      frames: ["https://reserve.mento.org/_next/static/chunks/c.js"],
+    });
+    const repeatOfFirst = makeEvent({
+      exceptionType: "TypeError",
+      exceptionValue: "Failed to fetch",
+      frames: ["https://reserve.mento.org/_next/static/chunks/a.js"],
+    });
+
+    expect(filter(first)).toBe(first);
+    expect(filter(second)).toBe(second);
+    expect(filter(third)).toBe(third);
+    // The cache cleared when `third` arrived, so the original signature is fresh again.
+    expect(filter(repeatOfFirst)).toBe(repeatOfFirst);
   });
 });

--- a/packages/web3/src/utils/sentry-filter.ts
+++ b/packages/web3/src/utils/sentry-filter.ts
@@ -150,3 +150,34 @@ export function filterNoisySentryEvents(
 
   return event;
 }
+
+function eventFingerprint(event: ErrorEvent, hint?: EventHint): string {
+  const message = getEventMessage(event, hint);
+  const eventType = getEventType(event, hint);
+  const firstFrame = getFrameFilenames(event)[0] ?? "";
+  return `${eventType}|${message}|${firstFrame}`;
+}
+
+// Wraps `filterNoisySentryEvents` with an in-memory Set so identical
+// signatures only report once per page load. Intended for noisy
+// environments (Vercel previews) where a single tab can fire the same
+// fetch/CORS error dozens of times via React Query refetches.
+export function createDedupedSentryEventFilter(
+  options: { maxSize?: number } = {},
+): (event: ErrorEvent, hint?: EventHint) => ErrorEvent | null {
+  const maxSize = options.maxSize ?? 200;
+  const seen = new Set<string>();
+
+  return (event, hint) => {
+    const filtered = filterNoisySentryEvents(event, hint);
+    if (!filtered) return null;
+
+    const signature = eventFingerprint(filtered, hint);
+    if (seen.has(signature)) return null;
+
+    if (seen.size >= maxSize) seen.clear();
+    seen.add(signature);
+
+    return filtered;
+  };
+}

--- a/turbo.json
+++ b/turbo.json
@@ -16,7 +16,9 @@
     "NEXT_RUNTIME",
     "CI",
     "SENTRY_AUTH_TOKEN",
-    "CHAINALYSIS_API_KEY"
+    "CHAINALYSIS_API_KEY",
+    "VERCEL_ENV",
+    "NEXT_PUBLIC_VERCEL_ENV"
   ],
   "tasks": {
     "build": {


### PR DESCRIPTION
## Summary

- Sets Sentry `environment` from `VERCEL_ENV` (`NEXT_PUBLIC_VERCEL_ENV` on the client) across all 9 init sites (3 apps × client/edge/server), so production, preview, and development events are distinguishable in the Sentry UI and via alert rules.
- Drops `tracesSampleRate` to `0` outside production, so preview deployments stop contributing performance traces no one looks at. Production stays at `0.1`.
- Errors are still captured on previews — only trace volume is muted. Combined with the API-side CORS fix for preview hostnames, the preview Sentry deluge should subside without losing visibility into real preview regressions.

## Context

Background: after the reserve dashboard v2 redesign (#314), the dashboard moved its analytics fetches from server components to client components (via `useV2Query` + a client-side prefetch sweep in `reserve-tabs.tsx`). On Vercel preview hostnames, those cross-origin requests were blocked by the analytics API's CORS allowlist and flooded Sentry. The CORS allowlist has been fixed on the API side; this PR adds `environment` tagging and tunes traces so previews are quieter going forward.

## Note for deployment

`VERCEL_ENV` is set automatically by Vercel, but Next.js will only ship `NEXT_PUBLIC_VERCEL_ENV` to the client bundle if it is explicitly added as a project env var (Vercel does not auto-promote `VERCEL_ENV` into the public namespace). Each app's Vercel project needs `NEXT_PUBLIC_VERCEL_ENV=$VERCEL_ENV` (or per-environment values) for the client-side `environment` tag to be accurate. Server/edge events get the correct tag without any Vercel config change.

## Test plan

- [ ] Deploy a preview and confirm new Sentry events arrive tagged `environment: preview` (server + client).
- [ ] Confirm production deployment events stay tagged `environment: production` and traces still arrive at the expected ~10% rate.
- [ ] In Sentry, optionally tighten alert rules to `environment:production` so preview noise no longer pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk observability-only change: it adjusts Sentry configuration (environment tagging, sampling, and preview-only deduping) without affecting application behavior, but could reduce Sentry signal in preview/non-prod if misconfigured.
> 
> **Overview**
> Adds Vercel `environment` tagging to Sentry initialization across client/edge/server for the apps, and sets `tracesSampleRate` to `0` outside production to stop collecting non-prod performance traces.
> 
> Introduces `createDedupedSentryEventFilter()` in `packages/web3` and uses it as a preview-only `beforeSend` on clients to drop repeated identical error events per page load (while still applying the existing noise filter). Also updates `turbo.json` to include `VERCEL_ENV` and `NEXT_PUBLIC_VERCEL_ENV` in `globalEnv`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0ea3e7995f98fa91b9b9df5e4f4cc30f0a8cd64. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->