### PR TITLE
fix(borrow): add missing lucide-react icons to manage-trove-view test mock

### DIFF
--- a/apps/app.mento.org/app/components/borrow/manage-trove/manage-trove-view.test.tsx
+++ b/apps/app.mento.org/app/components/borrow/manage-trove/manage-trove-view.test.tsx
@@ -109,9 +109,19 @@ vi.mock("../shared/trove-status-badge", () => ({
 }));
 
 vi.mock("lucide-react", () => ({
+  AlertOctagon: () => <span />,
+  ArrowDownToLine: () => <span />,
   Check: () => <span>✓</span>,
   ChevronLeft: () => <span>‹</span>,
+  Clock: () => <span />,
   Copy: () => <span>⎘</span>,
+  ExternalLink: () => <span />,
+  Filter: () => <span />,
+  MinusCircle: () => <span />,
+  Percent: () => <span />,
+  PlusCircle: () => <span />,
+  TrendingDown: () => <span />,
+  TrendingUp: () => <span />,
 }));
 
 import { ManageTroveView } from "./manage-trove-view";


### PR DESCRIPTION
## Summary

- The `ManageTroveView` test file hand-rolls a `lucide-react` mock that only enumerates the icons used by the file when the test was written (`Check`, `ChevronLeft`, `Copy`).
- PR #346 added [`TroveActivityPanel`](apps/app.mento.org/app/components/borrow/manage-trove/trove-activity-panel.tsx#L14-L25), which `ManageTroveView` now renders. The panel imports 10 additional `lucide-react` icons; the first one accessed at module load (`ArrowDownToLine`) throws on the mock, taking out the whole test file.
- This change adds the 10 missing icons (`AlertOctagon`, `ArrowDownToLine`, `Clock`, `ExternalLink`, `Filter`, `MinusCircle`, `Percent`, `PlusCircle`, `TrendingDown`, `TrendingUp`) to the mock — same pattern the sibling [`trove-activity-panel.test.tsx`](apps/app.mento.org/app/components/borrow/manage-trove/trove-activity-panel.test.tsx#L102-L113) already uses.

A more durable fix (`Proxy`-based mock, or extracting the validation logic into a pure function as discussed) is worth a follow-up — flagged as a separate refactor PR.

## Test plan

- [x] `pnpm vitest run app/components/borrow/manage-trove/manage-trove-view.test.tsx` — 6 tests pass locally
- [ ] CI `Build and Test` job passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only mock update with no runtime or security impact.
> 
> **Overview**
> Extends the hand-rolled `lucide-react` mock in `manage-trove-view.test.tsx` so it includes the icons imported by **`TroveActivityPanel`**, which `ManageTroveView` now renders. Without these stubs, the test suite fails when the panel loads and accesses icons such as `ArrowDownToLine` that were not on the mock.
> 
> The change adds ten icon components (`AlertOctagon`, `ArrowDownToLine`, `Clock`, `ExternalLink`, `Filter`, `MinusCircle`, `Percent`, `PlusCircle`, `TrendingDown`, `TrendingUp`) using the same empty `<span />` pattern already used in `trove-activity-panel.test.tsx`. Production behavior is unchanged; this only restores the manage-trove view tests after the activity panel was wired in.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f538cb838af34a19d7bc45a677dfde64e7b7837. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->