### PR TITLE
fix(ui): correct aria-invalid border utility on Input

### DIFF
--- a/packages/ui/src/components/ui/__snapshots__/input.test.tsx.snap
+++ b/packages/ui/src/components/ui/__snapshots__/input.test.tsx.snap
@@ -2,14 +2,14 @@
 
 exports[`Input > renders the 'default' state unchanged 1`] = `
 <input
-  class="shadow-xs h-9 min-w-0 px-3 py-1 text-base file:h-7 file:text-sm file:font-medium md:text-sm flex w-full rounded-none border border-input bg-transparent transition-[color,box-shadow] outline-none selection:bg-primary selection:text-primary-foreground file:inline-flex file:border-0 file:bg-transparent file:text-foreground placeholder:text-muted-foreground disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 dark:bg-input/30 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 aria-invalid:border-destructivem focus-within:border-primary focus:border-primary aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40"
+  class="shadow-xs h-9 min-w-0 px-3 py-1 text-base file:h-7 file:text-sm file:font-medium md:text-sm flex w-full rounded-none border border-input bg-transparent transition-[color,box-shadow] outline-none selection:bg-primary selection:text-primary-foreground file:inline-flex file:border-0 file:bg-transparent file:text-foreground placeholder:text-muted-foreground disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 dark:bg-input/30 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-within:border-primary focus:border-primary aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40"
   data-slot="input"
 />
 `;
 
 exports[`Input > renders the 'disabled' state unchanged 1`] = `
 <input
-  class="shadow-xs h-9 min-w-0 px-3 py-1 text-base file:h-7 file:text-sm file:font-medium md:text-sm flex w-full rounded-none border border-input bg-transparent transition-[color,box-shadow] outline-none selection:bg-primary selection:text-primary-foreground file:inline-flex file:border-0 file:bg-transparent file:text-foreground placeholder:text-muted-foreground disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 dark:bg-input/30 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 aria-invalid:border-destructivem focus-within:border-primary focus:border-primary aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40"
+  class="shadow-xs h-9 min-w-0 px-3 py-1 text-base file:h-7 file:text-sm file:font-medium md:text-sm flex w-full rounded-none border border-input bg-transparent transition-[color,box-shadow] outline-none selection:bg-primary selection:text-primary-foreground file:inline-flex file:border-0 file:bg-transparent file:text-foreground placeholder:text-muted-foreground disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 dark:bg-input/30 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-within:border-primary focus:border-primary aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40"
   data-slot="input"
   disabled=""
 />
@@ -18,14 +18,14 @@ exports[`Input > renders the 'disabled' state unchanged 1`] = `
 exports[`Input > renders the 'invalid' state unchanged 1`] = `
 <input
   aria-invalid="true"
-  class="shadow-xs h-9 min-w-0 px-3 py-1 text-base file:h-7 file:text-sm file:font-medium md:text-sm flex w-full rounded-none border border-input bg-transparent transition-[color,box-shadow] outline-none selection:bg-primary selection:text-primary-foreground file:inline-flex file:border-0 file:bg-transparent file:text-foreground placeholder:text-muted-foreground disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 dark:bg-input/30 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 aria-invalid:border-destructivem focus-within:border-primary focus:border-primary aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40"
+  class="shadow-xs h-9 min-w-0 px-3 py-1 text-base file:h-7 file:text-sm file:font-medium md:text-sm flex w-full rounded-none border border-input bg-transparent transition-[color,box-shadow] outline-none selection:bg-primary selection:text-primary-foreground file:inline-flex file:border-0 file:bg-transparent file:text-foreground placeholder:text-muted-foreground disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 dark:bg-input/30 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-within:border-primary focus:border-primary aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40"
   data-slot="input"
 />
 `;
 
 exports[`Input > renders the 'text' state unchanged 1`] = `
 <input
-  class="shadow-xs h-9 min-w-0 px-3 py-1 text-base file:h-7 file:text-sm file:font-medium md:text-sm flex w-full rounded-none border border-input bg-transparent transition-[color,box-shadow] outline-none selection:bg-primary selection:text-primary-foreground file:inline-flex file:border-0 file:bg-transparent file:text-foreground placeholder:text-muted-foreground disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 dark:bg-input/30 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 aria-invalid:border-destructivem focus-within:border-primary focus:border-primary aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40"
+  class="shadow-xs h-9 min-w-0 px-3 py-1 text-base file:h-7 file:text-sm file:font-medium md:text-sm flex w-full rounded-none border border-input bg-transparent transition-[color,box-shadow] outline-none selection:bg-primary selection:text-primary-foreground file:inline-flex file:border-0 file:bg-transparent file:text-foreground placeholder:text-muted-foreground disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 dark:bg-input/30 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-within:border-primary focus:border-primary aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40"
   data-slot="input"
   placeholder="Search"
   type="text"

--- a/packages/ui/src/components/ui/input.tsx
+++ b/packages/ui/src/components/ui/input.tsx
@@ -10,7 +10,7 @@ function Input({ className, type, ...props }: React.ComponentProps<"input">) {
       className={cn(
         "shadow-xs h-9 min-w-0 px-3 py-1 text-base file:h-7 file:text-sm file:font-medium md:text-sm flex w-full rounded-none border border-input bg-transparent transition-[color,box-shadow] outline-none selection:bg-primary selection:text-primary-foreground file:inline-flex file:border-0 file:bg-transparent file:text-foreground placeholder:text-muted-foreground disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 dark:bg-input/30",
         "focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50",
-        "aria-invalid:border-destructivem focus-within:border-primary focus:border-primary aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40",
+        "focus-within:border-primary focus:border-primary aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40",
         className,
       )}
       {...props}


### PR DESCRIPTION
## What

Fixes the `aria-invalid:border-destructivem` typo (trailing `m`) in `Input` → `aria-invalid:border-destructive`. The invalid utility meant `aria-invalid` inputs never received the destructive border (dead CSS).

Closes #365 (deferred from #364, where the new VRT baseline recorded the pre-existing bug).

## How the gate behaved — a clean demonstration of the two layers

- The **`@repo/ui` DOM snapshot** caught the `className` change immediately — 4 `input` snapshots failed; I re-baselined them.
- `prettier-plugin-tailwindcss` then re-sorted the now-*recognized* class into canonical order, so the source line reorders too (and the snapshot was re-recorded against the formatted source).
- The **Argos pixel layer** will show **no diff**: the showcase renders no `aria-invalid` input, so the destructive border isn't visible on screen. That's exactly why both layers exist — a structural/class change invisible to pixels is still caught by the DOM snapshot.

## Validation

- `@repo/ui` suite **28/28** green; `check-types` / `knip` / prettier clean.
- Surgical: only `input.tsx` + its snapshot changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-component CSS class typo fix with snapshot-only test updates; no logic or API changes.
> 
> **Overview**
> Fixes a typo in the shared **`Input`** Tailwind classes: `aria-invalid:border-destructivem` → `aria-invalid:border-destructive`. The stray `m` meant the invalid-state border utility never compiled, so inputs with `aria-invalid` did not show the destructive border.
> 
> The invalid/aria utility string is also reordered (Prettier/Tailwind class sort) alongside the fix. **`input.test.tsx.snap`** is re-baselined for all four Input snapshot cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3039185d47f1aa8166d3bd71443c3500bf742239. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->