### PR TITLE
ci: auto-merge low-risk Dependabot GitHub Actions bumps (Phase 1)

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,99 @@
+name: Dependabot auto-merge
+
+# Phase 1 auto-merge for Dependabot PRs — SCOPED TO GITHUB ACTIONS ONLY.
+#
+# Rationale for starting here: GitHub Action bumps are SHA-pinned, carry a
+# 7-day cooldown (see dependabot.yml), have zero runtime/blast-radius impact
+# on the shipped apps, and are exactly the tier monitoring-monorepo already
+# auto-merges. npm tiers (web3-stack, frontend-core, ui-styling, prod patch)
+# are intentionally NOT handled yet — expand the `ecosystem` gate below once
+# Phase 1 has proven itself.
+#
+# WHY THIS DIFFERS FROM monitoring-monorepo's workflow: this repo's `main`
+# ruleset requires 1 approving review in ADDITION to the `Build and Test`
+# status check. `gh pr merge --auto` waits for required reviews too, so a
+# bot approval is required or nothing ever merges. The github-actions[bot]
+# approval (a different actor than dependabot[bot]) satisfies the rule.
+#
+# The job only runs `gh pr review` / `gh pr merge --auto` — no checkout, no
+# execution against the PR head — so `pull_request` is safe even though
+# Dependabot PRs carry external commits. The merge still waits for every
+# required status check in the branch ruleset.
+#
+# Workflow-injection hygiene: every PR-derived value is passed through env:
+# instead of being interpolated into run: scripts.
+
+# Explicit `types:` drops the default `reopened` event so that a human
+# closing a Dependabot PR (the canonical "do not merge this") stays a
+# durable veto — Dependabot reopening on its next rebase won't re-fire the
+# auto-merge.
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+# checkov (CKV2_GHA_1) requires a top-level read-all. Job-level permissions
+# REPLACE this, so the auto-merge job sets exactly the write scopes it needs.
+permissions: read-all
+
+# Per-PR concurrency so rapid `synchronize` events (Dependabot rebasing on
+# conflict) don't race two merge calls against the same PR. The job is
+# idempotent, so cancelling the stale-head run is safe.
+concurrency:
+  group: dependabot-auto-merge-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  auto-merge:
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    permissions:
+      contents: write # enable auto-merge
+      pull-requests: write # approve + enable auto-merge
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          # alert-lookup is intentionally omitted — it needs a PAT/App token
+          # and would hard-fail this step on every PR with secrets.GITHUB_TOKEN.
+
+      - name: Log classification
+        env:
+          ECOSYSTEM: ${{ steps.meta.outputs.ecosystem }}
+          UPDATE_TYPE: ${{ steps.meta.outputs.update-type }}
+          DEPENDENCY_NAMES: ${{ steps.meta.outputs.dependency-names }}
+          DEPENDENCY_GROUP: ${{ steps.meta.outputs.dependency-group }}
+          MAINTAINER_CHANGES: ${{ steps.meta.outputs.maintainer-changes }}
+        run: |
+          echo "ecosystem:          $ECOSYSTEM"
+          echo "update-type:        $UPDATE_TYPE"
+          echo "dependency-names:   $DEPENDENCY_NAMES"
+          echo "dependency-group:   $DEPENDENCY_GROUP"
+          echo "maintainer-changes: $MAINTAINER_CHANGES"
+
+      - name: Approve and enable auto-merge for low-risk GitHub Actions bumps
+        # Gates, all must hold:
+        #   1. ecosystem == github_actions — Phase 1 scope. npm PRs fall
+        #      through untouched (stay manual).
+        #   2. update-type is explicitly minor or patch. Positive allowlist
+        #      (not `!= major`) so unparsable versions / future classifications
+        #      fail CLOSED. fetch-metadata returns '' when it can't parse.
+        #   3. maintainer-changes not set — supply-chain ownership tripwire.
+        #   4. Not bumping anthropics/* (the claude-code-review reviewer) or
+        #      dependabot/* (fetch-metadata classifies THIS workflow) — both
+        #      are self-loops. Mirrors the exclude-patterns in dependabot.yml.
+        if: |
+          steps.meta.outputs.ecosystem == 'github_actions'
+          && (steps.meta.outputs.update-type == 'version-update:semver-minor'
+              || steps.meta.outputs.update-type == 'version-update:semver-patch')
+          && steps.meta.outputs.maintainer-changes != 'true'
+          && !contains(steps.meta.outputs.dependency-names, 'anthropics/')
+          && !contains(steps.meta.outputs.dependency-names, 'dependabot/')
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          gh pr review --approve "$PR_URL"
+          gh pr merge --auto --squash "$PR_URL"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -48,14 +48,16 @@ concurrency:
 
 jobs:
   metadata:
-    # Author check (it's a Dependabot PR) AND actor check (THIS event was
-    # triggered by Dependabot, not a human pushing an extra commit to the
-    # branch — a `synchronize` from a maintainer keeps user.login as
-    # dependabot[bot], so the actor gate is what blocks approving a
-    # human-modified diff).
+    # Author check (it's a Dependabot PR) AND triggering-actor check (THIS
+    # run/re-run was initiated by Dependabot, not a human — a `synchronize`
+    # from a maintainer keeps user.login as dependabot[bot], so the actor
+    # check is what blocks approving a human-modified diff). We use
+    # `triggering_actor`, not `actor`: on a re-run, `actor` stays sticky to
+    # the original Dependabot trigger, while `triggering_actor` is whoever
+    # initiated the re-run.
     if: >-
       github.event.pull_request.user.login == 'dependabot[bot]'
-      && github.actor == 'dependabot[bot]'
+      && github.triggering_actor == 'dependabot[bot]'
     runs-on: ubuntu-latest
     timeout-minutes: 2
     # READ-ONLY: the third-party action runs here with no write token.
@@ -91,19 +93,26 @@ jobs:
 
   auto-merge:
     needs: metadata
-    # Gates, all must hold (a skipped `metadata` job — failed author/actor
-    # check — skips this job too, so the actor gate protects both):
-    #   1. package-ecosystem == github_actions — Phase 1 scope. npm PRs fall
+    # Gates, all must hold. The author + triggering-actor checks are
+    # RE-ASSERTED here (not just inherited via `needs: metadata`): "re-run
+    # failed jobs" reuses metadata's cached outputs and only re-evaluates
+    # THIS job's `if:`, so without re-checking the initiator, a maintainer
+    # could change the branch and re-run just this job to earn a fresh bot
+    # approval on their diff. `triggering_actor` (not `actor`) is the re-runner.
+    #   1. Author is Dependabot AND this run/re-run was initiated by it.
+    #   2. package-ecosystem == github_actions — Phase 1 scope. npm PRs fall
     #      through untouched (stay manual).
-    #   2. update-type is explicitly minor or patch. Positive allowlist
+    #   3. update-type is explicitly minor or patch. Positive allowlist
     #      (not `!= major`) so unparsable versions / future classifications
     #      fail CLOSED. fetch-metadata returns '' when it can't parse.
-    #   3. maintainer-changes not set — supply-chain ownership tripwire.
-    #   4. Not bumping anthropics/* (the claude-code-review reviewer) or
+    #   4. maintainer-changes not set — supply-chain ownership tripwire.
+    #   5. Not bumping anthropics/* (the claude-code-review reviewer) or
     #      dependabot/* (fetch-metadata classifies THIS workflow) — self-loops.
     #      Mirrors the exclude-patterns in dependabot.yml.
     if: >-
-      needs.metadata.outputs.package-ecosystem == 'github_actions'
+      github.event.pull_request.user.login == 'dependabot[bot]'
+      && github.triggering_actor == 'dependabot[bot]'
+      && needs.metadata.outputs.package-ecosystem == 'github_actions'
       && (needs.metadata.outputs.update-type == 'version-update:semver-minor'
           || needs.metadata.outputs.update-type == 'version-update:semver-patch')
       && needs.metadata.outputs.maintainer-changes != 'true'

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -6,8 +6,8 @@ name: Dependabot auto-merge
 # 7-day cooldown (see dependabot.yml), have zero runtime/blast-radius impact
 # on the shipped apps, and are exactly the tier monitoring-monorepo already
 # auto-merges. npm tiers (web3-stack, frontend-core, ui-styling, prod patch)
-# are intentionally NOT handled yet — expand the `ecosystem` gate below once
-# Phase 1 has proven itself.
+# are intentionally NOT handled yet — widen the package-ecosystem gate below
+# once Phase 1 has proven itself.
 #
 # WHY THIS DIFFERS FROM monitoring-monorepo's workflow: this repo's `main`
 # ruleset requires 1 approving review in ADDITION to the `Build and Test`
@@ -15,10 +15,14 @@ name: Dependabot auto-merge
 # bot approval is required or nothing ever merges. The github-actions[bot]
 # approval (a different actor than dependabot[bot]) satisfies the rule.
 #
-# The job only runs `gh pr review` / `gh pr merge --auto` — no checkout, no
-# execution against the PR head — so `pull_request` is safe even though
-# Dependabot PRs carry external commits. The merge still waits for every
-# required status check in the branch ruleset.
+# TWO-JOB SPLIT (supply-chain hardening): the third-party fetch-metadata
+# action runs in a READ-ONLY `metadata` job. Under `pull_request`, a
+# Dependabot PR that bumps dependabot/fetch-metadata's own pin would run the
+# PR's bumped action — so we never give that step a write token. The
+# `auto-merge` job that approves/merges holds the write scopes but contains
+# NO third-party `uses:` (only `gh`), so a compromised action pin and the
+# write token never coexist. (The dependabot/* exclusion below still keeps
+# such self-bumps manual; the cooldown buys detection time.)
 #
 # Workflow-injection hygiene: every PR-derived value is passed through env:
 # instead of being interpolated into run: scripts.
@@ -32,7 +36,7 @@ on:
     types: [opened, synchronize]
 
 # checkov (CKV2_GHA_1) requires a top-level read-all. Job-level permissions
-# REPLACE this, so the auto-merge job sets exactly the write scopes it needs.
+# REPLACE this, so each job sets exactly the scopes it needs.
 permissions: read-all
 
 # Per-PR concurrency so rapid `synchronize` events (Dependabot rebasing on
@@ -43,13 +47,25 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  auto-merge:
-    if: github.event.pull_request.user.login == 'dependabot[bot]'
+  metadata:
+    # Author check (it's a Dependabot PR) AND actor check (THIS event was
+    # triggered by Dependabot, not a human pushing an extra commit to the
+    # branch — a `synchronize` from a maintainer keeps user.login as
+    # dependabot[bot], so the actor gate is what blocks approving a
+    # human-modified diff).
+    if: >-
+      github.event.pull_request.user.login == 'dependabot[bot]'
+      && github.actor == 'dependabot[bot]'
     runs-on: ubuntu-latest
     timeout-minutes: 2
+    # READ-ONLY: the third-party action runs here with no write token.
     permissions:
-      contents: write # enable auto-merge
-      pull-requests: write # approve + enable auto-merge
+      pull-requests: read
+    outputs:
+      package-ecosystem: ${{ steps.meta.outputs.package-ecosystem }}
+      update-type: ${{ steps.meta.outputs.update-type }}
+      dependency-names: ${{ steps.meta.outputs.dependency-names }}
+      maintainer-changes: ${{ steps.meta.outputs.maintainer-changes }}
     steps:
       - name: Fetch Dependabot metadata
         id: meta
@@ -61,36 +77,46 @@ jobs:
 
       - name: Log classification
         env:
-          ECOSYSTEM: ${{ steps.meta.outputs.ecosystem }}
+          PACKAGE_ECOSYSTEM: ${{ steps.meta.outputs.package-ecosystem }}
           UPDATE_TYPE: ${{ steps.meta.outputs.update-type }}
           DEPENDENCY_NAMES: ${{ steps.meta.outputs.dependency-names }}
           DEPENDENCY_GROUP: ${{ steps.meta.outputs.dependency-group }}
           MAINTAINER_CHANGES: ${{ steps.meta.outputs.maintainer-changes }}
         run: |
-          echo "ecosystem:          $ECOSYSTEM"
+          echo "package-ecosystem:  $PACKAGE_ECOSYSTEM"
           echo "update-type:        $UPDATE_TYPE"
           echo "dependency-names:   $DEPENDENCY_NAMES"
           echo "dependency-group:   $DEPENDENCY_GROUP"
           echo "maintainer-changes: $MAINTAINER_CHANGES"
 
-      - name: Approve and enable auto-merge for low-risk GitHub Actions bumps
-        # Gates, all must hold:
-        #   1. ecosystem == github_actions — Phase 1 scope. npm PRs fall
-        #      through untouched (stay manual).
-        #   2. update-type is explicitly minor or patch. Positive allowlist
-        #      (not `!= major`) so unparsable versions / future classifications
-        #      fail CLOSED. fetch-metadata returns '' when it can't parse.
-        #   3. maintainer-changes not set — supply-chain ownership tripwire.
-        #   4. Not bumping anthropics/* (the claude-code-review reviewer) or
-        #      dependabot/* (fetch-metadata classifies THIS workflow) — both
-        #      are self-loops. Mirrors the exclude-patterns in dependabot.yml.
-        if: |
-          steps.meta.outputs.ecosystem == 'github_actions'
-          && (steps.meta.outputs.update-type == 'version-update:semver-minor'
-              || steps.meta.outputs.update-type == 'version-update:semver-patch')
-          && steps.meta.outputs.maintainer-changes != 'true'
-          && !contains(steps.meta.outputs.dependency-names, 'anthropics/')
-          && !contains(steps.meta.outputs.dependency-names, 'dependabot/')
+  auto-merge:
+    needs: metadata
+    # Gates, all must hold (a skipped `metadata` job — failed author/actor
+    # check — skips this job too, so the actor gate protects both):
+    #   1. package-ecosystem == github_actions — Phase 1 scope. npm PRs fall
+    #      through untouched (stay manual).
+    #   2. update-type is explicitly minor or patch. Positive allowlist
+    #      (not `!= major`) so unparsable versions / future classifications
+    #      fail CLOSED. fetch-metadata returns '' when it can't parse.
+    #   3. maintainer-changes not set — supply-chain ownership tripwire.
+    #   4. Not bumping anthropics/* (the claude-code-review reviewer) or
+    #      dependabot/* (fetch-metadata classifies THIS workflow) — self-loops.
+    #      Mirrors the exclude-patterns in dependabot.yml.
+    if: >-
+      needs.metadata.outputs.package-ecosystem == 'github_actions'
+      && (needs.metadata.outputs.update-type == 'version-update:semver-minor'
+          || needs.metadata.outputs.update-type == 'version-update:semver-patch')
+      && needs.metadata.outputs.maintainer-changes != 'true'
+      && !contains(needs.metadata.outputs.dependency-names, 'anthropics/')
+      && !contains(needs.metadata.outputs.dependency-names, 'dependabot/')
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    # WRITE scopes live here — but this job runs no third-party `uses:`.
+    permissions:
+      contents: write # enable auto-merge
+      pull-requests: write # approve + enable auto-merge
+    steps:
+      - name: Approve and enable auto-merge
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_URL: ${{ github.event.pull_request.html_url }}


### PR DESCRIPTION
## What

Adds `.github/workflows/dependabot-auto-merge.yml`, **scoped to the `github-actions` ecosystem only** (Phase 1). It approves and enables `--auto --squash` for **minor/patch** action bumps once the required `Build and Test` check passes.

## Why

Dependabot PRs were piling up unattended. GitHub Action bumps are the safest tier to start auto-merging: SHA-pinned, 7-day cooldown (see `dependabot.yml`), zero runtime blast radius — exactly the tier `monitoring-monorepo` already auto-merges.

## Safety gates (all must hold)

- `ecosystem == github_actions` — **npm PRs fall through untouched / stay manual**
- update-type is **minor or patch** (positive allowlist → major/unparsable fail closed)
- `maintainer-changes \!= 'true'` — supply-chain ownership tripwire
- excludes `anthropics/*` (the claude-code-review reviewer) and `dependabot/*` (self-loops)
- merge still waits for the `Build and Test` required status check

## Frontend-specific vs monitoring-monorepo's version

- Adds a `gh pr review --approve` step — this repo's `main` ruleset requires **1 approval** on top of CI; `--auto` waits on it. The `github-actions[bot]` approval (≠ `dependabot[bot]`) satisfies it. *(Org policy "Allow GitHub Actions to create and approve pull requests" was enabled to permit this.)*
- Gated on `ecosystem` rather than the group name so scope is unambiguous.

## Rollout

This workflow only acts after it lands on `main` (`pull_request` runs from the base branch). First PR it will pick up is **#361** (grouped github-actions bump). The 6 open npm Dependabot PRs remain manual by design — future phases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Grants GITHUB_TOKEN PR approve/merge on a narrow Dependabot subset, but scope is limited to github_actions minor/patch with multiple fail-closed gates; npm and risky bumps stay manual.
> 
> **Overview**
> Adds **`dependabot-auto-merge.yml`**, a Phase 1 workflow that **approves and enables squash auto-merge** for Dependabot PRs that only bump **GitHub Actions** at **minor/patch**, after existing required checks (including **Build and Test**) pass.
> 
> Unlike a simpler auto-merge setup, it **bot-approves** PRs because `main` requires a human review in addition to CI. It splits work into a **read-only `metadata` job** (third-party `dependabot/fetch-metadata`) and a **write `auto-merge` job** that only runs `gh`—so write tokens never run alongside third-party actions. **npm Dependabot PRs are unchanged** (manual); gates also block major/unparsed bumps, `maintainer-changes`, `anthropics/*`, and `dependabot/*`, and ignore `reopened` so a closed PR stays vetoed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18be4db71ba922e7e6ccf66787c5089bfa0b0a91. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->