### PR TITLE
test(ui.mento.org): expand VRT coverage — overlay open-states + more components

### DIFF
--- a/apps/ui.mento.org/app/form-components/page.tsx
+++ b/apps/ui.mento.org/app/form-components/page.tsx
@@ -19,6 +19,7 @@ import {
   SelectValue,
   Slider,
   Calendar,
+  CoinInput,
 } from "@repo/ui";
 import { useState } from "react";
 
@@ -134,6 +135,17 @@ export default function FormComponentsPage() {
               onSelect={setDate}
               className="rounded-md border"
             />
+          </CardContent>
+        </Card>
+
+        {/* Coin Input */}
+        <Card>
+          <CardHeader>
+            <CardTitle>Coin Input</CardTitle>
+            <CardDescription>Numeric token amount input</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <CoinInput defaultValue="123.456" />
           </CardContent>
         </Card>
       </div>

--- a/apps/ui.mento.org/app/interactive-components/page.tsx
+++ b/apps/ui.mento.org/app/interactive-components/page.tsx
@@ -20,6 +20,12 @@ import {
   TooltipProvider,
   TooltipTrigger,
   Button,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
 } from "@repo/ui";
 
 export default function InteractiveComponentsPage() {
@@ -95,6 +101,28 @@ export default function InteractiveComponentsPage() {
                 </TooltipContent>
               </Tooltip>
             </TooltipProvider>
+          </CardContent>
+        </Card>
+
+        {/* Dropdown Menu */}
+        <Card>
+          <CardHeader>
+            <CardTitle>Dropdown Menu</CardTitle>
+            <CardDescription>Action menus</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button variant="outline">Open Menu</Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent>
+                <DropdownMenuLabel>Actions</DropdownMenuLabel>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem>Edit</DropdownMenuItem>
+                <DropdownMenuItem>Duplicate</DropdownMenuItem>
+                <DropdownMenuItem>Delete</DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
           </CardContent>
         </Card>
       </div>

--- a/apps/ui.mento.org/app/specialized-components/page.tsx
+++ b/apps/ui.mento.org/app/specialized-components/page.tsx
@@ -16,6 +16,15 @@ import {
   CoinCardSymbol,
   CommunityCard,
   ProposalStatus,
+  Skeleton,
+  ProposalCard,
+  ProposalCardBody,
+  ProposalCardFooter,
+  ProposalCardHeader,
+  ProposalList,
+  ProposalListItem,
+  ProposalListItemBody,
+  ProposalListItemIndex,
 } from "@repo/ui";
 import Image from "next/image";
 
@@ -69,6 +78,54 @@ export default function SpecializedComponentsPage() {
               <ProposalStatus variant="executed">Executed</ProposalStatus>
               <ProposalStatus variant="canceled">Canceled</ProposalStatus>
             </div>
+          </CardContent>
+        </Card>
+
+        {/* Skeleton */}
+        <Card>
+          <CardHeader>
+            <CardTitle>Skeleton</CardTitle>
+            <CardDescription>Loading placeholders</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            <Skeleton className="h-12 w-12 rounded-full" />
+            <Skeleton className="h-4 w-3/4" />
+            <Skeleton className="h-4 w-1/2" />
+          </CardContent>
+        </Card>
+
+        {/* Proposal Card */}
+        <ProposalCard>
+          <ProposalCardHeader>
+            <span className="font-medium">Proposal #42</span>
+          </ProposalCardHeader>
+          <ProposalCardBody>
+            <p className="text-sm text-muted-foreground">
+              Increase the stability pool cap to 10M.
+            </p>
+          </ProposalCardBody>
+          <ProposalCardFooter>
+            <ProposalStatus variant="active">Active</ProposalStatus>
+          </ProposalCardFooter>
+        </ProposalCard>
+
+        {/* Proposal List */}
+        <Card>
+          <CardHeader>
+            <CardTitle>Proposal List</CardTitle>
+            <CardDescription>Compact proposal rows</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <ProposalList>
+              <ProposalListItem>
+                <ProposalListItemIndex index="1" />
+                <ProposalListItemBody>First proposal</ProposalListItemBody>
+              </ProposalListItem>
+              <ProposalListItem>
+                <ProposalListItemIndex index="2" />
+                <ProposalListItemBody>Second proposal</ProposalListItemBody>
+              </ProposalListItem>
+            </ProposalList>
           </CardContent>
         </Card>
       </div>

--- a/apps/ui.mento.org/e2e/fixtures.ts
+++ b/apps/ui.mento.org/e2e/fixtures.ts
@@ -28,7 +28,7 @@ const animatedRegions = (page: Page): Locator[] => [
 ];
 
 // Applied before navigation — order matters (all before app scripts run).
-async function arm(page: Page, theme: Theme): Promise<void> {
+export async function arm(page: Page, theme: Theme): Promise<void> {
   // Fix displayed time (calendar default month, any relative timestamps)
   // WITHOUT faking timers — clock.install() would stall React hydration;
   // setFixedTime only pins Date/Date.now.
@@ -58,7 +58,7 @@ async function arm(page: Page, theme: Theme): Promise<void> {
   }, theme);
 }
 
-async function settle(page: Page, theme: Theme): Promise<void> {
+export async function settle(page: Page, theme: Theme): Promise<void> {
   await page.waitForLoadState("networkidle");
   // The resolved theme must be on <html> before capture (next-themes is
   // two-phase; the SidebarProvider also shifts one frame post-hydration).
@@ -67,8 +67,13 @@ async function settle(page: Page, theme: Theme): Promise<void> {
   );
   // Vendored Inter must be ready so text never snapshots in a fallback face.
   await page.evaluate(() => document.fonts.ready);
-  // Stable scrollbar gutter — Linux/Docker scrollbars shift layout vs macOS.
-  await page.addStyleTag({ content: "html{scrollbar-gutter:stable}" });
+  // Stable scrollbar gutter (Linux/Docker scrollbars shift layout vs macOS) +
+  // kill animations/transitions so opened overlays (Radix dialogs/menus/
+  // popovers) snap to their final state instead of being caught mid-animation.
+  await page.addStyleTag({
+    content:
+      "html{scrollbar-gutter:stable}*,*::before,*::after{animation-duration:0s!important;animation-delay:0s!important;transition-duration:0s!important;transition-delay:0s!important}",
+  });
 }
 
 export async function snapshotPage(

--- a/apps/ui.mento.org/e2e/overlays.visual.spec.ts
+++ b/apps/ui.mento.org/e2e/overlays.visual.spec.ts
@@ -1,0 +1,73 @@
+import { argosScreenshot } from "@argos-ci/playwright";
+import { type Page } from "@playwright/test";
+
+import { arm, settle, test, type Theme } from "./fixtures";
+
+// Overlay/open states render only after interaction and live in portals, so the
+// full-page showcase snapshots never capture them. Open each one, then snapshot
+// — a visual change to these panels would otherwise produce no Argos diff.
+type Overlay = {
+  name: string;
+  url: string;
+  open: (page: Page) => Promise<void>;
+};
+
+const OVERLAYS: Overlay[] = [
+  {
+    name: "dialog",
+    url: "/interactive-components",
+    open: async (page) => {
+      await page.getByRole("button", { name: "Open Dialog" }).click();
+      await page.getByRole("dialog").waitFor();
+    },
+  },
+  {
+    name: "popover",
+    url: "/interactive-components",
+    open: async (page) => {
+      await page.getByRole("button", { name: "Open Popover" }).click();
+      await page.getByRole("heading", { name: "Popover Content" }).waitFor();
+    },
+  },
+  {
+    name: "tooltip",
+    url: "/interactive-components",
+    open: async (page) => {
+      await page.getByRole("button", { name: "Hover me" }).hover();
+      await page.getByRole("tooltip").waitFor();
+    },
+  },
+  {
+    name: "dropdown-menu",
+    url: "/interactive-components",
+    open: async (page) => {
+      await page.getByRole("button", { name: "Open Menu" }).click();
+      await page.getByRole("menu").waitFor();
+    },
+  },
+  {
+    name: "select",
+    url: "/form-components",
+    open: async (page) => {
+      await page.getByRole("combobox").first().click();
+      await page.getByRole("option", { name: "Option 1" }).waitFor();
+    },
+  },
+];
+
+const THEMES: Theme[] = ["light", "dark"];
+
+for (const overlay of OVERLAYS) {
+  for (const theme of THEMES) {
+    test(`${overlay.name} open (${theme})`, async ({ page }, testInfo) => {
+      await arm(page, theme);
+      await page.goto(overlay.url, { waitUntil: "domcontentloaded" });
+      await settle(page, theme);
+      await overlay.open(page);
+      await argosScreenshot(
+        page,
+        `overlay-${overlay.name}-${theme}-${testInfo.project.name}`,
+      );
+    });
+  }
+}


### PR DESCRIPTION
## What

Expands the visual-regression gate's coverage (follow-up to #364's pilot). **Closes #367**; the determinism-sensitive remainder is tracked in **#370**.

## Overlay open-states (the key gap)

New `e2e/overlays.visual.spec.ts` opens each portal overlay *before* snapshotting — **dialog, popover, tooltip, dropdown-menu, select**. These panels render only after interaction and live in portals, so the resting full-page snapshots never captured them; a visual regression in an open dialog would previously produce **no Argos diff**.

## Newly-mounted components

Added to the showcase so they're covered by the full-page snapshots: **CoinInput** (form), **Skeleton, ProposalCard, ProposalList** (specialized), **DropdownMenu** (interactive).

## Determinism

- `settle()` now also zeroes all animation/transition durations, so Radix overlays snap to their final open state instead of being caught mid-animation.
- Verified: **44/44 specs pass**, and all desktop shots are **byte-identical across two clean runs**.

## Deferred → #370 (to keep the gate flake-free)

Split out the determinism-sensitive pieces: recharts charts (`BalanceGauge` / `ReserveChart` / `ChartContainer` — finite mount animations, no `isAnimationActive` prop exposed on the `@repo/ui` wrappers), `Sheet` (no exported trigger / full-viewport), and CoinSelect/Datepicker open-states.

## Note on Argos baselines

This adds ~20 new overlay screenshots and changes 3 page baselines (new components appended). Since `argos/ui.mento.org` is now **required**, the check will block until the **new baselines are approved** in the Argos dashboard — expected, and a nice exercise of the approval flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to the UI showcase app and Playwright/Argos tests; no production routing, auth, or data paths.
> 
> **Overview**
> Expands the **ui.mento.org** visual-regression gate so more `@repo/ui` pieces are exercised and portal overlays are captured in their **open** state.
> 
> The component showcase adds demos for **CoinInput**, **DropdownMenu**, **Skeleton**, **ProposalCard**, and **ProposalList**, so existing full-page Argos shots include them. A new **`e2e/overlays.visual.spec.ts`** drives interaction (click/hover), then snapshots **dialog**, **popover**, **tooltip**, **dropdown-menu**, and **select** in light and dark—states that resting page shots miss because they render in portals after user action.
> 
> **`settle()`** in fixtures now forces zero animation/transition duration so Radix overlays land in a stable frame, and **`arm` / `settle`** are exported for reuse by the overlay spec.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5481b913b1001666e8fc6f187b7adc47890d8391. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->