### PR TITLE
test(ui.mento.org): complete VRT coverage — charts, sheet, coin-select, datepicker

### DIFF
--- a/apps/ui.mento.org/app/form-components/page.tsx
+++ b/apps/ui.mento.org/app/form-components/page.tsx
@@ -20,6 +20,12 @@ import {
   Slider,
   Calendar,
   CoinInput,
+  CoinSelect,
+  CoinSelectContent,
+  CoinSelectItem,
+  CoinSelectTrigger,
+  CoinSelectValue,
+  Datepicker,
 } from "@repo/ui";
 import { useState } from "react";
 
@@ -29,6 +35,7 @@ export default function FormComponentsPage() {
   const [radioValue, setRadioValue] = useState("option1");
   const [selectValue, setSelectValue] = useState("");
   const [date, setDate] = useState<Date | undefined>(new Date());
+  const [coin, setCoin] = useState("CELO");
 
   return (
     <div className="gap-8 p-6 flex w-full flex-col">
@@ -146,6 +153,43 @@ export default function FormComponentsPage() {
           </CardHeader>
           <CardContent>
             <CoinInput defaultValue="123.456" />
+          </CardContent>
+        </Card>
+
+        {/* Coin Select */}
+        <Card>
+          <CardHeader>
+            <CardTitle>Coin Select</CardTitle>
+            <CardDescription>Token selector dropdown</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <CoinSelect value={coin} onValueChange={setCoin}>
+              <CoinSelectTrigger>
+                <CoinSelectValue />
+              </CoinSelectTrigger>
+              <CoinSelectContent>
+                <CoinSelectItem value="CELO">CELO</CoinSelectItem>
+                <CoinSelectItem value="USDC">USDC</CoinSelectItem>
+                <CoinSelectItem value="USDm">USDm</CoinSelectItem>
+              </CoinSelectContent>
+            </CoinSelect>
+          </CardContent>
+        </Card>
+
+        {/* Datepicker */}
+        <Card>
+          <CardHeader>
+            <CardTitle>Datepicker</CardTitle>
+            <CardDescription>
+              Date selector with calendar popover
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <Datepicker
+              value={new Date(2026, 0, 15)}
+              onChange={() => {}}
+              formatter={(d) => d.toLocaleDateString("en-US")}
+            />
           </CardContent>
         </Card>
       </div>

--- a/apps/ui.mento.org/app/form-components/page.tsx
+++ b/apps/ui.mento.org/app/form-components/page.tsx
@@ -29,6 +29,10 @@ import {
 } from "@repo/ui";
 import { useState } from "react";
 
+// Stable reference — inlining `new Date(...)` would make a fresh object every
+// render and re-trigger Datepicker's value-sync effect.
+const DATEPICKER_DEFAULT_DATE = new Date(2026, 0, 15);
+
 export default function FormComponentsPage() {
   const [sliderValue, setSliderValue] = useState([50]);
   const [checkboxChecked, setCheckboxChecked] = useState(false);
@@ -186,7 +190,7 @@ export default function FormComponentsPage() {
           </CardHeader>
           <CardContent>
             <Datepicker
-              value={new Date(2026, 0, 15)}
+              value={DATEPICKER_DEFAULT_DATE}
               onChange={() => {}}
               formatter={(d) => d.toLocaleDateString("en-US")}
             />

--- a/apps/ui.mento.org/app/interactive-components/page.tsx
+++ b/apps/ui.mento.org/app/interactive-components/page.tsx
@@ -26,9 +26,17 @@ import {
   DropdownMenuLabel,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
 } from "@repo/ui";
+import { useState } from "react";
 
 export default function InteractiveComponentsPage() {
+  const [sheetOpen, setSheetOpen] = useState(false);
+
   return (
     <div className="gap-8 p-6 flex w-full flex-col">
       <div className="space-y-2">
@@ -123,6 +131,27 @@ export default function InteractiveComponentsPage() {
                 <DropdownMenuItem>Delete</DropdownMenuItem>
               </DropdownMenuContent>
             </DropdownMenu>
+          </CardContent>
+        </Card>
+
+        {/* Sheet */}
+        <Card>
+          <CardHeader>
+            <CardTitle>Sheet</CardTitle>
+            <CardDescription>Slide-over panels</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <Button variant="outline" onClick={() => setSheetOpen(true)}>
+              Open Sheet
+            </Button>
+            <Sheet open={sheetOpen} onOpenChange={setSheetOpen}>
+              <SheetContent>
+                <SheetHeader>
+                  <SheetTitle>Sheet Title</SheetTitle>
+                  <SheetDescription>A slide-over panel.</SheetDescription>
+                </SheetHeader>
+              </SheetContent>
+            </Sheet>
           </CardContent>
         </Card>
       </div>

--- a/apps/ui.mento.org/app/specialized-components/page.tsx
+++ b/apps/ui.mento.org/app/specialized-components/page.tsx
@@ -25,6 +25,8 @@ import {
   ProposalListItem,
   ProposalListItemBody,
   ProposalListItemIndex,
+  BalanceGauge,
+  ReserveChart,
 } from "@repo/ui";
 import Image from "next/image";
 
@@ -126,6 +128,37 @@ export default function SpecializedComponentsPage() {
                 <ProposalListItemBody>Second proposal</ProposalListItemBody>
               </ProposalListItem>
             </ProposalList>
+          </CardContent>
+        </Card>
+        {/* Charts */}
+        <Card>
+          <CardHeader>
+            <CardTitle>Charts</CardTitle>
+            <CardDescription>
+              Reserve and balance visualizations
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="gap-6 flex flex-wrap items-center justify-around">
+            <BalanceGauge
+              token0Percent={33.3}
+              token1Percent={66.7}
+              token0Reserves="333K"
+              token1Reserves="667K"
+              token0Symbol="GBPm"
+              token1Symbol="USDm"
+              exchangeRate="1.33"
+              inputSymbol="GBPm"
+              outputSymbol="USDm"
+            />
+            <div className="h-40 w-40">
+              <ReserveChart
+                data={[
+                  { name: "USDC", value: 40, color: "#3b82f6" },
+                  { name: "CELO", value: 35, color: "#f59e0b" },
+                  { name: "ETH", value: 25, color: "#10b981" },
+                ]}
+              />
+            </div>
           </CardContent>
         </Card>
       </div>

--- a/apps/ui.mento.org/e2e/overlays.visual.spec.ts
+++ b/apps/ui.mento.org/e2e/overlays.visual.spec.ts
@@ -1,5 +1,5 @@
 import { argosScreenshot } from "@argos-ci/playwright";
-import { type Page } from "@playwright/test";
+import { expect, type Page } from "@playwright/test";
 
 import { arm, settle, test, type Theme } from "./fixtures";
 
@@ -51,6 +51,32 @@ const OVERLAYS: Overlay[] = [
     open: async (page) => {
       await page.getByRole("combobox").first().click();
       await page.getByRole("option", { name: "Option 1" }).waitFor();
+    },
+  },
+  {
+    name: "coin-select",
+    url: "/form-components",
+    open: async (page) => {
+      await page.getByRole("combobox").filter({ hasText: "CELO" }).click();
+      await page.getByRole("option", { name: "USDC" }).waitFor();
+    },
+  },
+  {
+    name: "datepicker",
+    url: "/form-components",
+    open: async (page) => {
+      await page.getByRole("button", { name: "1/15/2026" }).click();
+      // The page also has a standalone Calendar grid; wait for the popover's
+      // calendar to bring the count to 2 (unambiguous, vs strict-mode on one).
+      await expect(page.getByRole("grid")).toHaveCount(2);
+    },
+  },
+  {
+    name: "sheet",
+    url: "/interactive-components",
+    open: async (page) => {
+      await page.getByRole("button", { name: "Open Sheet" }).click();
+      await page.getByRole("dialog").waitFor();
     },
   },
 ];


### PR DESCRIPTION
## What

Completes the visual-regression coverage expansion — the determinism-sensitive remainder split out of #367. **Closes #370.**

## Charts (the part that needed care)

Mounts **BalanceGauge** and **ReserveChart** (recharts) on the specialized page. They animate on mount and the `@repo/ui` wrappers don't expose `isAnimationActive` — but **Argos's stabilization waits out the finite mount animation**, so they capture **deterministically with no production change**. Verified byte-identical across two runs.

## New overlay open-states

Added to `e2e/overlays.visual.spec.ts`: **sheet, coin-select, datepicker** — joining dialog/popover/tooltip/dropdown/select from #371. (Caught one strict-mode collision: the form page already has a standalone `Calendar` grid, so the datepicker waits for *two* grids.)

## Newly-mounted components

**CoinSelect** + **Datepicker** (form), **Sheet** (interactive, controlled-open since it has no exported trigger).

## Validation

- **56/56** specs pass; all desktop shots **byte-identical across two clean runs**.
- `check-types` / `knip` / prettier clean.

## Argos baselines

Adds new overlay/chart screenshots and changes a few page baselines (new components appended). Since `argos/ui.mento.org` is **required**, the check will block until you approve the new baselines in the dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Demo-only pages and e2e visual tests; no production app or shared library behavior changes.
> 
> **Overview**
> Extends the **ui.mento.org** component showcase and **Argos** overlay visual tests so the remaining high-risk UI (charts and portal overlays) is covered.
> 
> **Showcase pages** now mount **CoinSelect** and **Datepicker** on the form page (with a module-level default date so the datepicker does not re-sync every render), a controlled **Sheet** on the interactive page, and **BalanceGauge** / **ReserveChart** with sample data on the specialized page.
> 
> **`overlays.visual.spec.ts`** adds open-state snapshots for **coin-select**, **datepicker** (waits for two calendar grids to avoid clashing with the standalone **Calendar**), and **sheet**, alongside the existing overlay tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b238f3c476ad94c6ad74a0178d54dc0dd076b4d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->