### PR TITLE
ci: have Claude review Dependabot npm PRs (skip auto-merged actions tier)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -14,7 +14,20 @@ permissions: read-all
 
 jobs:
   claude-review:
-    if: github.event.pull_request.user.login != 'dependabot[bot]'
+    # Review human PRs (as before) AND Dependabot PRs — EXCEPT the
+    # github-actions tier. That tier is auto-merged (see
+    # dependabot-auto-merge.yml), and `gh pr merge --auto` waits only on the
+    # required checks, so this advisory review would land on an
+    # already-merged PR — decorative cost/noise. The npm tiers stay manual,
+    # so AI review there gives a human something to read before merging.
+    #
+    # REQUIRES `CLAUDE_CODE_OAUTH_TOKEN` in the *Dependabot* secrets store
+    # (Settings → Secrets and variables → Dependabot): Dependabot-triggered
+    # runs do NOT receive Actions secrets, so without it the action runs with
+    # an empty token and fails.
+    if: >-
+      github.event.pull_request.user.login != 'dependabot[bot]'
+      || !startsWith(github.head_ref, 'dependabot/github_actions/')
 
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -50,5 +50,10 @@ jobs:
           plugin_marketplaces: https://github.com/anthropics/claude-code.git
           plugins: code-review@claude-code-plugins
           prompt: "/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}"
+          # Dependabot is a bot actor; with a `prompt` set the action runs in
+          # agent mode, whose checkHumanActor rejects bot-authored events
+          # unless the bot is allow-listed here. Scoped to dependabot[bot] so
+          # other bots still can't trigger a review.
+          allowed_bots: dependabot[bot]
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options


### PR DESCRIPTION
## What

Removes the blanket `dependabot[bot]` exclusion on `claude-code-review.yml` so Claude reviews **Dependabot npm PRs**, while still skipping the **github-actions tier** (gated on the `dependabot/github_actions/` branch prefix).

## Why

Pairs with the Phase 1 auto-merge work (#369):

- **npm tiers** (web3-stack, frontend-core, ui-styling, security-runtime, …) stay **manual-merge** → an AI pre-read gives a human something to act on before merging (breaking changes hiding in a "minor" bump, suspicious lockfile/postinstall changes, mis-grouped majors).
- **github-actions tier** is **auto-merged**, and `gh pr merge --auto` waits only on the required checks (`Build and Test` + `Visual Regression`). An optional review there would land on an already-merged PR — decorative cost/noise. So it stays excluded.

## ⚠️ Required before this works

`CLAUDE_CODE_OAUTH_TOKEN` currently lives in the **Actions** secrets store. Dependabot-triggered runs do **not** receive Actions secrets — only the **Dependabot** secrets store. Without copying the token there, the action runs on Dependabot PRs with an empty token and fails.

```
gh secret set CLAUDE_CODE_OAUTH_TOKEN --app dependabot --repo mento-protocol/frontend-monorepo
```

(or Settings → Secrets and variables → Dependabot → New repository secret)

## Safety note

The review job is read-only (`contents: read`, `pull-requests: read`) and the workflow never installs or builds the bumped dependency, so untrusted bump code is never executed — the token isn't exposed to arbitrary code execution.

## Codex

Codex is the external GitHub-App connector, not a repo workflow — its Dependabot coverage is toggled in the Codex cloud settings, not here. See PR comment for steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI workflow condition and bot allow-list only; no app runtime or dependency install changes, though misconfiguration of Dependabot secrets would cause failed review jobs on Dependabot PRs.
> 
> **Overview**
> **Claude Code Review** no longer skips every Dependabot PR. The job still runs for human authors as before, and now also runs for Dependabot when the head branch is **not** under `dependabot/github_actions/` (npm/manual tiers get a review; auto-merged Actions bumps stay excluded).
> 
> The workflow documents that **`CLAUDE_CODE_OAUTH_TOKEN` must live in Dependabot secrets**, not only Actions secrets, or Dependabot-triggered runs fail with an empty token.
> 
> The **`anthropics/claude-code-action`** step sets **`allowed_bots: dependabot[bot]`** so agent mode accepts Dependabot as the PR author without opening reviews to other bots.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 85a2d1319b4a1152e674852343937cc596dfd919. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->