### PR TITLE
fix(ui): disable recharts mount animation under prefers-reduced-motion

### DIFF
--- a/packages/ui/src/components/ui/balance-gauge.tsx
+++ b/packages/ui/src/components/ui/balance-gauge.tsx
@@ -2,7 +2,7 @@
 
 import { Cell, Pie, PieChart } from "recharts";
 import { type ChartConfig, ChartContainer } from "./chart.js";
-import { useMediaQuery } from "../../hooks/use-media-query.js";
+import { usePrefersReducedMotion } from "../../hooks/use-prefers-reduced-motion.js";
 
 /** Needle rendered as a custom SVG element inside the PieChart */
 function GaugeNeedle({
@@ -88,7 +88,7 @@ export function BalanceGauge({
   // Disable the recharts mount animation for users who prefer reduced motion —
   // also makes the chart deterministic under visual-regression tests, which
   // emulate prefers-reduced-motion.
-  const reducedMotion = useMediaQuery("(prefers-reduced-motion: reduce)");
+  const reducedMotion = usePrefersReducedMotion();
   const gaugeData = [
     { name: "token0", value: token0Percent },
     { name: "token1", value: token1Percent },

--- a/packages/ui/src/components/ui/balance-gauge.tsx
+++ b/packages/ui/src/components/ui/balance-gauge.tsx
@@ -2,6 +2,7 @@
 
 import { Cell, Pie, PieChart } from "recharts";
 import { type ChartConfig, ChartContainer } from "./chart.js";
+import { useMediaQuery } from "../../hooks/use-media-query.js";
 
 /** Needle rendered as a custom SVG element inside the PieChart */
 function GaugeNeedle({
@@ -84,6 +85,10 @@ export function BalanceGauge({
   primaryColor = "var(--primary)",
   secondaryColor = "var(--primary-border)",
 }: BalanceGaugeProps) {
+  // Disable the recharts mount animation for users who prefer reduced motion —
+  // also makes the chart deterministic under visual-regression tests, which
+  // emulate prefers-reduced-motion.
+  const reducedMotion = useMediaQuery("(prefers-reduced-motion: reduce)");
   const gaugeData = [
     { name: "token0", value: token0Percent },
     { name: "token1", value: token1Percent },
@@ -114,6 +119,7 @@ export function BalanceGauge({
               data={gaugeData}
               dataKey="value"
               nameKey="name"
+              isAnimationActive={!reducedMotion}
               cx="50%"
               cy="100%"
               startAngle={180}

--- a/packages/ui/src/components/ui/reserve-chart.tsx
+++ b/packages/ui/src/components/ui/reserve-chart.tsx
@@ -4,6 +4,7 @@ import { Pie, PieChart, Cell, Sector } from "recharts";
 import { type ChartConfig, ChartContainer } from "./chart.js";
 import { useEffect, useState } from "react";
 import { PieSectorDataItem } from "recharts/types/polar/Pie.js";
+import { useMediaQuery } from "../../hooks/use-media-query.js";
 
 export interface ChartSegment {
   name: string;
@@ -53,6 +54,7 @@ export function ReserveChart({
   activeSegment,
   onActiveChanged,
 }: ReserveChartProps) {
+  const reducedMotion = useMediaQuery("(prefers-reduced-motion: reduce)");
   const [activeSegmentInternal, setActiveSegmentInternal] = useState<
     string | undefined
   >(activeSegment);
@@ -112,6 +114,7 @@ export function ReserveChart({
             data={data}
             dataKey="value"
             nameKey="name"
+            isAnimationActive={!reducedMotion}
             innerRadius="60%" // Adjusted for inner ring space
             outerRadius="90%"
             strokeWidth={0} // stroke="var(--background)"
@@ -154,6 +157,7 @@ export function ReserveChart({
             data={data}
             dataKey="value"
             nameKey="name"
+            isAnimationActive={!reducedMotion}
             innerRadius="55%"
             outerRadius="60%" // Ends where the outer ring begins
             strokeWidth={0}

--- a/packages/ui/src/components/ui/reserve-chart.tsx
+++ b/packages/ui/src/components/ui/reserve-chart.tsx
@@ -4,7 +4,7 @@ import { Pie, PieChart, Cell, Sector } from "recharts";
 import { type ChartConfig, ChartContainer } from "./chart.js";
 import { useEffect, useState } from "react";
 import { PieSectorDataItem } from "recharts/types/polar/Pie.js";
-import { useMediaQuery } from "../../hooks/use-media-query.js";
+import { usePrefersReducedMotion } from "../../hooks/use-prefers-reduced-motion.js";
 
 export interface ChartSegment {
   name: string;
@@ -54,7 +54,7 @@ export function ReserveChart({
   activeSegment,
   onActiveChanged,
 }: ReserveChartProps) {
-  const reducedMotion = useMediaQuery("(prefers-reduced-motion: reduce)");
+  const reducedMotion = usePrefersReducedMotion();
   const [activeSegmentInternal, setActiveSegmentInternal] = useState<
     string | undefined
   >(activeSegment);

--- a/packages/ui/src/hooks/use-prefers-reduced-motion.ts
+++ b/packages/ui/src/hooks/use-prefers-reduced-motion.ts
@@ -1,0 +1,27 @@
+import { useEffect, useState } from "react";
+
+const QUERY = "(prefers-reduced-motion: reduce)";
+
+// @public comment suppresses the invalid knip unused-export warning
+// https://knip.dev/reference/jsdoc-tsdoc-tags#public
+/** @public */
+export function usePrefersReducedMotion(): boolean {
+  // Lazy initializer reads the real value on the FIRST client render, so
+  // animation-gated props (e.g. recharts `isAnimationActive`) are never forced
+  // on for a frame under reduced motion. SSR yields `false`, but chart content
+  // is client-only (recharts needs measured dimensions), so there's no
+  // meaningful hydration mismatch.
+  const [reduced, setReduced] = useState(
+    () => typeof window !== "undefined" && window.matchMedia(QUERY).matches,
+  );
+
+  useEffect(() => {
+    const media = window.matchMedia(QUERY);
+    const onChange = () => setReduced(media.matches);
+    onChange();
+    media.addEventListener("change", onChange);
+    return () => media.removeEventListener("change", onChange);
+  }, []);
+
+  return reduced;
+}


### PR DESCRIPTION
## What

`BalanceGauge` and `ReserveChart` run recharts' finite mount animation. That makes them **non-deterministic in CI visual regression** — Argos's stabilization catches a slightly different animation frame each run, so the **required `ui.mento.org` argos check flakes on every PR** (e.g. "4 changed" one run, "5 changed" the next; surfaced on #375).

## Fix

Pass `isAnimationActive={\!reducedMotion}` (via the existing `useMediaQuery` hook) to the recharts `<Pie>` elements, so the charts **skip the mount animation when `prefers-reduced-motion` is set** — which the VRT fixtures emulate.

- **Deterministic** in tests (no animation frame to vary).
- **Accessibility win** — real users keep the animation unless they opt out of motion.
- Charts still render their full final state (verified — gauge + dual-ring pie both correct).

## Baselines

This changes the `ui.mento.org` specialized/charts shots (they now render the settled final frame deterministically). Approve them **once** to establish a stable baseline — after which the charts stop flaking the gate.

Follow-up to #372 (which added the charts). Unblocks #375.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI-only change to chart animation props with no auth, data, or API impact; baseline snapshots for chart pages may need a one-time update.
> 
> **Overview**
> Adds **`usePrefersReducedMotion`**, which listens to `prefers-reduced-motion: reduce` (lazy read on first client render plus `matchMedia` updates), and wires **`isAnimationActive={!reducedMotion}`** on the recharts `<Pie>` elements in **`BalanceGauge`** and **`ReserveChart`** (outer and inner rings).
> 
> Recharts mount animations are **skipped when reduced motion is preferred**, so charts render their final frame immediately. That makes **Argos / visual-regression** shots stable when fixtures emulate reduced motion, while users who do not opt out still get the mount animation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a1121cd5879ead0c97cfcc6d513b9e31f1b89fe5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->