### PR TITLE
test(ui.mento.org): settle popper overlays before VRT snapshot

### DIFF
--- a/apps/ui.mento.org/e2e/fixtures.ts
+++ b/apps/ui.mento.org/e2e/fixtures.ts
@@ -76,6 +76,40 @@ export async function settle(page: Page, theme: Theme): Promise<void> {
   });
 }
 
+// Radix popper overlays (popover/tooltip/dropdown/select/datepicker) mount
+// their content — which is when `getByRole(...).waitFor()` resolves — BEFORE
+// floating-ui commits the final `transform: translate()` on the popper wrapper
+// a frame or two later. Snapshotting in that window catches the panel at a
+// transient position (ghosted/offset text vs a settled baseline). Animations
+// are already zeroed in settle(); this closes the *positional* settle gap by
+// waiting until every open overlay's box stops moving across consecutive frames.
+export async function stabilizeOverlay(page: Page): Promise<void> {
+  await page.evaluate(async () => {
+    const boxes = () =>
+      Array.from(
+        document.querySelectorAll<HTMLElement>(
+          "[data-radix-popper-content-wrapper],[data-slot$='-content'],[role='dialog'],[role='tooltip'],[role='menu']",
+        ),
+      )
+        .map((node) => {
+          const r = node.getBoundingClientRect();
+          return `${r.x},${r.y},${r.width},${r.height}`;
+        })
+        .join("|");
+    const frame = () =>
+      new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+    let previous = boxes();
+    // Stop once positions hold steady for two consecutive frames (cap at 30
+    // frames ~0.5s so a perpetually-animating element can't hang the run).
+    for (let stable = 0, i = 0; stable < 2 && i < 30; i++) {
+      await frame();
+      const next = boxes();
+      stable = next === previous ? stable + 1 : 0;
+      previous = next;
+    }
+  });
+}
+
 export async function snapshotPage(
   page: Page,
   url: string,

--- a/apps/ui.mento.org/e2e/overlays.visual.spec.ts
+++ b/apps/ui.mento.org/e2e/overlays.visual.spec.ts
@@ -1,7 +1,7 @@
 import { argosScreenshot } from "@argos-ci/playwright";
 import { expect, type Page } from "@playwright/test";
 
-import { arm, settle, test, type Theme } from "./fixtures";
+import { arm, settle, stabilizeOverlay, test, type Theme } from "./fixtures";
 
 // Overlay/open states render only after interaction and live in portals, so the
 // full-page showcase snapshots never capture them. Open each one, then snapshot
@@ -90,6 +90,7 @@ for (const overlay of OVERLAYS) {
       await page.goto(overlay.url, { waitUntil: "domcontentloaded" });
       await settle(page, theme);
       await overlay.open(page);
+      await stabilizeOverlay(page);
       await argosScreenshot(
         page,
         `overlay-${overlay.name}-${theme}-${testInfo.project.name}`,


### PR DESCRIPTION
## Problem

The overlay VRT shot `overlay-popover-dark-desktop` flaked on **#358** (Argos [build 38](https://app.argos-ci.com/chapati23/frontend-monorepo/builds/38)) — a PR that never touches the popover. The diff showed ghosted/offset popover text: the panel captured at a transient position vs the settled baseline.

## Root cause

The overlay specs screenshot as soon as `getByRole(...).waitFor()` resolves — which fires the moment the Radix content **mounts**. But floating-ui commits the popper wrapper's final `transform: translate(x,y)` a frame or two **later**. Snapshotting in that window catches the panel mid-position-commit.

Animations were already handled (`settle()` zeroes `animation/transition-duration`; `arm()` emulates `prefers-reduced-motion`), so this was a **positional** settle gap, not a motion one — the reduce-motion lever was already pulled.

## Fix

Add `stabilizeOverlay()`: after opening, poll every open overlay's bounding box and wait until it holds steady for **two consecutive frames** (30-frame ~0.5s cap so nothing can hang). Called after each `overlay.open()` in the spec. Hardens **all** popper overlays — popover, tooltip, dropdown, select, coin-select, datepicker — not just the one that flaked.

## Verification

- `tsc --noEmit -p tsconfig.json` clean; `trunk check` clean.
- Definitive proof is the gate itself: after merge, the `push:main` baseline re-records the popover **settled**, and subsequent logic-only PRs stop diffing it. First post-merge Argos build will show the popover shots as an expected one-time re-baseline (settled vs old flaky frame) — approve once.

## Ship Checklist
- [x] ship skill used
- [x] local review run
- [x] validation run (type-check + lint)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only e2e helper and spec wiring; no production or runtime behavior changes.
> 
> **Overview**
> Fixes flaky Argos overlay screenshots by waiting for **floating-ui** to finish positioning Radix poppers, not just for overlay content to mount.
> 
> Adds **`stabilizeOverlay()`** in e2e fixtures: after open, it polls bounding boxes of popper wrappers, dialogs, tooltips, and menus until positions are unchanged for two consecutive animation frames (30-frame cap). **`overlays.visual.spec.ts`** calls it after each `overlay.open()` and before `argosScreenshot`, covering popover, tooltip, dropdown, select, datepicker, dialog, and sheet.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d549abfe4342a3e11f2441247683bd351af6e84. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->