### PR TITLE
test(app.mento.org): wait for bridge widget mount before VRT snapshot

### DIFF
--- a/apps/app.mento.org/e2e/disconnected.visual.spec.ts
+++ b/apps/app.mento.org/e2e/disconnected.visual.spec.ts
@@ -1,18 +1,36 @@
+import type { Page } from "@playwright/test";
+
 import { snapshotPage, test, type Theme } from "./fixtures";
+
+// The bridge form is the Wormhole widget, dynamically imported (ssr:false) with
+// a loading-dot fallback. It mounts client-side after `networkidle` (its blocked
+// external calls abort instantly), so wait for its disconnected "Connect source
+// wallet" CTA to render — otherwise the snapshot races the skeleton vs the form.
+const waitForBridgeWidget = async (page: Page): Promise<void> => {
+  await page
+    .locator(".bridge-widget")
+    .getByText(/connect source wallet/i)
+    .first()
+    .waitFor();
+};
 
 // Disconnected (no-wallet) default states — live data fetching is gated on a
 // connected account, so these shells are deterministic with the network blocked.
-const PAGES = [
+const PAGES: {
+  url: string;
+  name: string;
+  ready?: (page: Page) => Promise<void>;
+}[] = [
   { url: "/swap/celo", name: "swap-celo" },
   { url: "/borrow/open", name: "borrow-open" },
   { url: "/earn", name: "earn" },
   { url: "/pools", name: "pools" },
-  { url: "/bridge", name: "bridge" },
+  { url: "/bridge", name: "bridge", ready: waitForBridgeWidget },
 ];
 
 const THEMES: Theme[] = ["dark", "light"];
 
-for (const { url, name } of PAGES) {
+for (const { url, name, ready } of PAGES) {
   for (const theme of THEMES) {
     test(`${name} disconnected (${theme})`, async ({ page }, testInfo) => {
       await snapshotPage(
@@ -20,6 +38,7 @@ for (const { url, name } of PAGES) {
         url,
         `${name}-disconnected-${theme}-${testInfo.project.name}`,
         theme,
+        ready,
       );
     });
   }

--- a/apps/app.mento.org/e2e/fixtures.ts
+++ b/apps/app.mento.org/e2e/fixtures.ts
@@ -86,10 +86,20 @@ export async function snapshotPage(
   url: string,
   name: string,
   theme: Theme,
+  // Pages with async client-mounted content (e.g. the bridge's dynamically
+  // imported Wormhole widget) must wait for it to render before capture —
+  // networkidle returns early because the widget's external calls are blocked,
+  // so the snapshot otherwise races the mount (loading skeleton vs full form).
+  ready?: (page: Page) => Promise<void>,
 ): Promise<void> {
   await arm(page, theme);
   await page.goto(url, { waitUntil: "domcontentloaded" });
   await settle(page, theme);
+  if (ready) {
+    await ready(page);
+    // The just-mounted content may pull its own webfonts/icons in.
+    await page.evaluate(() => document.fonts.ready);
+  }
   await argosScreenshot(page, name);
 }
 


### PR DESCRIPTION
## Problem

`bridge-disconnected-*` flaked on **#358** (a PR that never touches the bridge). The baseline captured the bridge **loading skeleton** (pulse dot); a re-run captured the **full Wormhole form** (From/To + "Connect source wallet"). Pure load-race — same shot, different mount timing.

## Root cause

The `/bridge` form is `@wormhole-foundation/wormhole-connect`, dynamically imported (`ssr:false`) with a loading-dot fallback. It mounts **client-side after `networkidle`**: the widget's external calls are blocked by the disconnected-shell fixture and abort instantly, so `networkidle` returns before the dynamic chunk resolves and the form paints. The snapshot then races the mount.

## Fix

Add an optional `ready(page)` gate to `snapshotPage` and, for the bridge page, wait for the widget's disconnected **"Connect source wallet"** CTA before capture (verified: Wormhole renders `Connect ${side} wallet`). The loaded form is now always snapshotted. All other pages pass no `ready` callback and are unchanged.

## Verification

- Confirmed the exact CTA string against `wormhole-connect@5.1.0` source (`Connect ${e.side} wallet`), so the selector can't silently time out on a wording guess.
- `tsc --noEmit -p tsconfig.json` clean; `trunk check` clean.
- Definitive proof is the gate: after merge the `push:main` baseline re-records the bridge shots as the **loaded form** (one-time expected re-baseline vs the old skeleton frame), then logic-only PRs stop diffing them.

## Ship Checklist
- [x] ship skill used
- [x] local review run
- [x] validation run (type-check + lint)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> E2E/visual-test harness only; no production app logic. Expect a one-time bridge baseline update to the loaded form instead of the loading skeleton.
> 
> **Overview**
> Fixes flaky **`bridge-disconnected-*`** visual regression tests by gating screenshots until the dynamically imported Wormhole bridge UI has finished mounting.
> 
> **`snapshotPage`** in `fixtures.ts` now accepts an optional **`ready(page)`** hook that runs after the usual arm/goto/settle flow; when provided, it also waits on **`document.fonts.ready`** again so fonts from the newly mounted widget are settled before Argos capture.
> 
> **`disconnected.visual.spec.ts`** wires **`waitForBridgeWidget`** only for **`/bridge`**, waiting inside **`.bridge-widget`** for the disconnected **"Connect source wallet"** CTA. Other disconnected pages are unchanged (no `ready` callback).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a530b0529d1c3209ef0d37a85c8e79bf98c25248. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->