### PR TITLE
chore: preserve clawpatch state in worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,6 @@ yarn-error.log*
 deliverables
 .codex.reviews/
 .codex
+
+# Clawpatch local state and generated review artifacts
+.clawpatch/

--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,0 +1,4 @@
+# Files copied into new agent worktrees (gitignore syntax; only gitignored files are copied).
+# Clawpatch keeps local generated state here; scripts/setup-worktree.sh refreshes
+# checkout-specific project metadata after the copy.
+.clawpatch/

--- a/scripts/setup-worktree.sh
+++ b/scripts/setup-worktree.sh
@@ -36,6 +36,50 @@ print_error() {
 	echo -e "${RED}✗${NC} $1"
 }
 
+copy_clawpatch_state() {
+	print_step "Checking Clawpatch local state..."
+
+	if [[ -d ".clawpatch" ]]; then
+		if command -v clawpatch &>/dev/null; then
+			clawpatch init --force --json >/dev/null
+			print_success "Clawpatch state already present; refreshed local project metadata"
+		else
+			print_success "Clawpatch state already present"
+		fi
+		echo ""
+		return
+	fi
+
+	local worktree_root
+	worktree_root=$(pwd -P)
+	local source_root=""
+	local line
+	while IFS= read -r line; do
+		if [[ ${line} == worktree\ * ]]; then
+			local candidate="${line#worktree }"
+			if [[ ${candidate} != "${worktree_root}" && -d "${candidate}/.clawpatch" ]]; then
+				source_root="${candidate}"
+				break
+			fi
+		fi
+	done < <(git worktree list --porcelain 2>/dev/null || true)
+
+	if [[ -z ${source_root} ]]; then
+		print_warning "No sibling .clawpatch state found; skipping Clawpatch state copy"
+		echo ""
+		return
+	fi
+
+	cp -R "${source_root}/.clawpatch" ".clawpatch"
+	if command -v clawpatch &>/dev/null; then
+		clawpatch init --force --json >/dev/null
+		print_success "Copied Clawpatch state from ${source_root} and refreshed local project metadata"
+	else
+		print_warning "Copied Clawpatch state from ${source_root}; install clawpatch and run 'clawpatch init --force' before using it"
+	fi
+	echo ""
+}
+
 # Check if we're in the right directory
 if [[ ! -f "package.json" ]]; then
 	print_error "Error: package.json not found. Please run this script from the root of the frontend-monorepo."
@@ -44,6 +88,8 @@ fi
 
 print_step "Setting up worktree environment..."
 echo ""
+
+copy_clawpatch_state
 
 # Check Node version
 print_step "Checking Node.js version..."

--- a/scripts/setup-worktree.sh
+++ b/scripts/setup-worktree.sh
@@ -36,47 +36,62 @@ print_error() {
 	echo -e "${RED}✗${NC} $1"
 }
 
-copy_clawpatch_state() {
-	print_step "Checking Clawpatch local state..."
-
-	if [[ -d ".clawpatch" ]]; then
-		if command -v clawpatch &>/dev/null; then
-			clawpatch init --force --json >/dev/null
-			print_success "Clawpatch state already present; refreshed local project metadata"
-		else
-			print_success "Clawpatch state already present"
-		fi
-		echo ""
-		return
-	fi
-
+find_clawpatch_source_root() {
+	local result_var="$1"
 	local worktree_root
 	worktree_root=$(pwd -P)
-	local source_root=""
 	local line
 	while IFS= read -r line; do
 		if [[ ${line} == worktree\ * ]]; then
 			local candidate="${line#worktree }"
 			if [[ ${candidate} != "${worktree_root}" && -d "${candidate}/.clawpatch" ]]; then
-				source_root="${candidate}"
-				break
+				printf -v "${result_var}" "%s" "${candidate}"
+				return
 			fi
 		fi
 	done < <(git worktree list --porcelain 2>/dev/null || true)
+}
 
-	if [[ -z ${source_root} ]]; then
-		print_warning "No sibling .clawpatch state found; skipping Clawpatch state copy"
+refresh_clawpatch_metadata() {
+	local state_message="$1"
+	if command -v clawpatch &>/dev/null; then
+		if clawpatch init --force --json >/dev/null; then
+			print_success "${state_message}; refreshed local project metadata"
+		else
+			print_warning "${state_message}; 'clawpatch init --force' failed, continuing setup"
+		fi
+	else
+		print_warning "${state_message}; install clawpatch and run 'clawpatch init --force' before using it"
+	fi
+}
+
+copy_clawpatch_state() {
+	print_step "Checking Clawpatch local state..."
+
+	if [[ -f ".clawpatch/project.json" ]]; then
+		refresh_clawpatch_metadata "Clawpatch state already present"
 		echo ""
 		return
 	fi
 
-	cp -R "${source_root}/.clawpatch" ".clawpatch"
-	if command -v clawpatch &>/dev/null; then
-		clawpatch init --force --json >/dev/null
-		print_success "Copied Clawpatch state from ${source_root} and refreshed local project metadata"
-	else
-		print_warning "Copied Clawpatch state from ${source_root}; install clawpatch and run 'clawpatch init --force' before using it"
+	local source_root
+	source_root=""
+	find_clawpatch_source_root source_root
+
+	if [[ -n ${source_root} ]]; then
+		mkdir -p ".clawpatch"
+		cp -R "${source_root}/.clawpatch/." ".clawpatch"
+		refresh_clawpatch_metadata "Copied Clawpatch state from ${source_root}"
+		echo ""
+		return
 	fi
+
+	if [[ -d ".clawpatch" ]]; then
+		refresh_clawpatch_metadata "Existing Clawpatch state is incomplete and no sibling state was found"
+	else
+		print_warning "No sibling .clawpatch state found; skipping Clawpatch state copy"
+	fi
+
 	echo ""
 }
 


### PR DESCRIPTION
## Summary
- ignore generated Clawpatch project state so it stays local to each checkout
- add .worktreeinclude so agent worktree creation can copy .clawpatch/ when the worktree runner supports ignored-file includes
- refresh or copy sibling Clawpatch state from scripts/setup-worktree.sh, then rerun clawpatch init so project metadata points at the new checkout

## Validation
- autoreview local guardrail: clean
- reviewer subagent: no issues found
- bash -n scripts/setup-worktree.sh
- git diff --check
- git check-ignore -v .clawpatch/project.json .clawpatch/features/feat_ui-flow_a291fb6739.json
- trunk fmt .gitignore .worktreeinclude scripts/setup-worktree.sh
- trunk check .gitignore .worktreeinclude scripts/setup-worktree.sh
- committed-branch throwaway worktree test: .worktreeinclude present, .clawpatch/ ignored, setup function copied from /Users/chapati/code/mento/frontend-monorepo, clawpatch init rewrote rootPath to the temp worktree
- pnpm --filter ui.mento.org check-types
- git push pre-push hook: Trunk, Turbo check-types, knip

Browser verification not run: this is repo workflow/local tooling only; no UI surface changed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Developer workflow and local tooling only; no app runtime, auth, or production paths change.
> 
> **Overview**
> Keeps **Clawpatch** local state out of git and makes new **agent worktrees** reuse it without manual setup.
> 
> **`.gitignore`** now ignores `.clawpatch/` so generated project metadata and review artifacts stay checkout-local. **`.worktreeinclude`** lists that path so worktree creation can copy ignored Clawpatch files when the runner supports include lists.
> 
> **`scripts/setup-worktree.sh`** runs early in setup: if `.clawpatch/project.json` is missing, it finds another linked worktree with `.clawpatch/`, copies that tree in, then runs **`clawpatch init --force`** (when the CLI is installed) so `rootPath` and project metadata match the new checkout. Existing or partial state gets a refresh or a clear warning instead of failing the rest of setup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e04c291f81cc30303c044128e4deae39bda9677b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->