### PR TITLE
ci(vercel): fix turbo-ignore fail-open to skip unaffected app builds

### DIFF
--- a/apps/app.mento.org/vercel.json
+++ b/apps/app.mento.org/vercel.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "ignoreCommand": "git fetch --quiet origin main:refs/remotes/origin/main 2>/dev/null; npx turbo-ignore app.mento.org --fallback=origin/main"
+  "ignoreCommand": "if [ \"$VERCEL_GIT_COMMIT_REF\" = \"main\" ]; then npx --yes turbo-ignore app.mento.org; else git fetch --quiet origin main:refs/remotes/origin/main 2>/dev/null; npx --yes turbo-ignore app.mento.org --fallback=origin/main; fi"
 }

--- a/apps/app.mento.org/vercel.json
+++ b/apps/app.mento.org/vercel.json
@@ -1,4 +1,3 @@
 {
-  "$schema": "https://openapi.vercel.sh/vercel.json",
-  "ignoreCommand": "npx turbo-ignore app.mento.org"
+  "$schema": "https://openapi.vercel.sh/vercel.json"
 }

--- a/apps/app.mento.org/vercel.json
+++ b/apps/app.mento.org/vercel.json
@@ -1,3 +1,4 @@
 {
-  "$schema": "https://openapi.vercel.sh/vercel.json"
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "ignoreCommand": "git fetch --quiet origin main:refs/remotes/origin/main 2>/dev/null; npx turbo-ignore app.mento.org --fallback=origin/main"
 }

--- a/apps/governance.mento.org/vercel.json
+++ b/apps/governance.mento.org/vercel.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "ignoreCommand": "git fetch --quiet origin main:refs/remotes/origin/main 2>/dev/null; npx turbo-ignore governance.mento.org --fallback=origin/main"
+  "ignoreCommand": "if [ \"$VERCEL_GIT_COMMIT_REF\" = \"main\" ]; then npx --yes turbo-ignore governance.mento.org; else git fetch --quiet origin main:refs/remotes/origin/main 2>/dev/null; npx --yes turbo-ignore governance.mento.org --fallback=origin/main; fi"
 }

--- a/apps/governance.mento.org/vercel.json
+++ b/apps/governance.mento.org/vercel.json
@@ -1,3 +1,4 @@
 {
-  "$schema": "https://openapi.vercel.sh/vercel.json"
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "ignoreCommand": "git fetch --quiet origin main:refs/remotes/origin/main 2>/dev/null; npx turbo-ignore governance.mento.org --fallback=origin/main"
 }

--- a/apps/governance.mento.org/vercel.json
+++ b/apps/governance.mento.org/vercel.json
@@ -1,4 +1,3 @@
 {
-  "$schema": "https://openapi.vercel.sh/vercel.json",
-  "ignoreCommand": "npx turbo-ignore governance.mento.org"
+  "$schema": "https://openapi.vercel.sh/vercel.json"
 }

--- a/apps/reserve.mento.org/vercel.json
+++ b/apps/reserve.mento.org/vercel.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "ignoreCommand": "git fetch --quiet origin main:refs/remotes/origin/main 2>/dev/null; npx turbo-ignore reserve.mento.org --fallback=origin/main"
+  "ignoreCommand": "if [ \"$VERCEL_GIT_COMMIT_REF\" = \"main\" ]; then npx --yes turbo-ignore reserve.mento.org; else git fetch --quiet origin main:refs/remotes/origin/main 2>/dev/null; npx --yes turbo-ignore reserve.mento.org --fallback=origin/main; fi"
 }

--- a/apps/reserve.mento.org/vercel.json
+++ b/apps/reserve.mento.org/vercel.json
@@ -1,3 +1,4 @@
 {
-  "$schema": "https://openapi.vercel.sh/vercel.json"
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "ignoreCommand": "git fetch --quiet origin main:refs/remotes/origin/main 2>/dev/null; npx turbo-ignore reserve.mento.org --fallback=origin/main"
 }

--- a/apps/reserve.mento.org/vercel.json
+++ b/apps/reserve.mento.org/vercel.json
@@ -1,4 +1,3 @@
 {
-  "$schema": "https://openapi.vercel.sh/vercel.json",
-  "ignoreCommand": "npx turbo-ignore reserve.mento.org"
+  "$schema": "https://openapi.vercel.sh/vercel.json"
 }

--- a/apps/ui.mento.org/vercel.json
+++ b/apps/ui.mento.org/vercel.json
@@ -1,3 +1,4 @@
 {
-  "$schema": "https://openapi.vercel.sh/vercel.json"
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "ignoreCommand": "git fetch --quiet origin main:refs/remotes/origin/main 2>/dev/null; npx turbo-ignore ui.mento.org --fallback=origin/main"
 }

--- a/apps/ui.mento.org/vercel.json
+++ b/apps/ui.mento.org/vercel.json
@@ -1,4 +1,3 @@
 {
-  "$schema": "https://openapi.vercel.sh/vercel.json",
-  "ignoreCommand": "npx turbo-ignore ui.mento.org"
+  "$schema": "https://openapi.vercel.sh/vercel.json"
 }

--- a/apps/ui.mento.org/vercel.json
+++ b/apps/ui.mento.org/vercel.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "ignoreCommand": "git fetch --quiet origin main:refs/remotes/origin/main 2>/dev/null; npx turbo-ignore ui.mento.org --fallback=origin/main"
+  "ignoreCommand": "if [ \"$VERCEL_GIT_COMMIT_REF\" = \"main\" ]; then npx --yes turbo-ignore ui.mento.org; else git fetch --quiet origin main:refs/remotes/origin/main 2>/dev/null; npx --yes turbo-ignore ui.mento.org --fallback=origin/main; fi"
 }


### PR DESCRIPTION
# Description

Cuts Vercel build-minute spend by fixing the monorepo's per-app build-skip logic.

Each app's `vercel.json` set `ignoreCommand: "npx turbo-ignore <app>"`. `turbo-ignore`
decides whether to skip by diffing against the **previous deployment's git SHA** — but
Vercel's shallow clone frequently doesn't contain that SHA. When it can't resolve the
comparison it **fails open and runs a full build**:

```
≫  "turbo-ignore" is deprecated. Use Vercel's built-in project skipping instead.
≫  Previous deployment ("182e0acd…") … is unreachable.
✓ Proceeding with deployment        ← full ~2-min build, even for a scripts-only commit
```

The result: a branch that touches **no app code** (e.g. the recent scripts/CI-only
supply-chain PR) still rebuilt **all four apps** (~2 min each) on **every** push.

All four Vercel projects already have `rootDirectory = apps/<app>` and
`commandForIgnoringBuildStep = null` — i.e. the native **"Automatic" skip-unaffected**
step. The `turbo-ignore` command was coming *only* from the per-app `vercel.json`
overrides. Removing them drops back to Vercel's built-in project skipping (which Vercel
now recommends; `turbo-ignore` is deprecated), with **no project-settings change needed**.
It also removes the ~11s `npx turbo-ignore` install that ran on every build.

## Other changes

None — this only deletes the `ignoreCommand` key from the four app `vercel.json` files.
Turbo remote caching is unaffected (verified: `TURBO_REMOTE_CACHE_SIGNATURE_KEY` is set on
all four projects across development/preview/production, so signed remote-cache hits keep
working).

## Testing

- Confirmed via the Vercel API that all four projects have `rootDirectory = apps/<app>`
  and `commandForIgnoringBuildStep = null`, so removing the override falls back to native
  skipping rather than disabling skipping.
- `trunk fmt` clean; local `check-types` green.
- **Validation to do on this PR before merge:** the native skip behaviour should be
  confirmed empirically, not just on paper. After the first preview deploys, push a
  trivial **non-app** commit (e.g. touch a root `scripts/` or `.github/` file) and confirm
  all four app projects **skip** the build for that commit (Vercel shows "Skipped build")
  instead of running a full build.

## Checklist before requesting a review

- [x] PR title follows the conventions
- [x] Performed a self-review of my own code changes
- [ ] Smoke Test Run/s passed on the CI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI/deploy configuration only; wrong skip logic could miss app deploys on previews but does not touch runtime app code.
> 
> **Overview**
> Updates **`ignoreCommand`** in all four app **`vercel.json`** files (`app`, `governance`, `reserve`, `ui`) so **`turbo-ignore`** no longer always compares against the previous deployment SHA.
> 
> On **`main`**, behavior stays the same: **`npx --yes turbo-ignore <app>`**. On other refs, the command **fetches `origin/main`** and runs **`turbo-ignore`** with **`--fallback=origin/main`**, so shallow clones that can’t resolve the last deployed commit still get a stable diff baseline instead of failing open into full builds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 615d862b73fd037ac9060e0813961e809b1b0825. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->