### PR TITLE
ci(vercel): use native skip-unaffected (turbo-ignore fail-opens on shallow clone)

### DIFF
--- a/apps/app.mento.org/_skipverify.txt
+++ b/apps/app.mento.org/_skipverify.txt
@@ -1,0 +1,1 @@
+native-skip verification probe 1781795818

--- a/apps/app.mento.org/_skipverify.txt
+++ b/apps/app.mento.org/_skipverify.txt
@@ -1,1 +1,0 @@
-native-skip verification probe 1781795818

--- a/apps/app.mento.org/vercel.json
+++ b/apps/app.mento.org/vercel.json
@@ -1,4 +1,3 @@
 {
-  "$schema": "https://openapi.vercel.sh/vercel.json",
-  "ignoreCommand": "if [ \"$VERCEL_GIT_COMMIT_REF\" = \"main\" ]; then npx --yes turbo-ignore app.mento.org; else git fetch --quiet origin main:refs/remotes/origin/main 2>/dev/null; npx --yes turbo-ignore app.mento.org --fallback=origin/main; fi"
+  "$schema": "https://openapi.vercel.sh/vercel.json"
 }

--- a/apps/governance.mento.org/vercel.json
+++ b/apps/governance.mento.org/vercel.json
@@ -1,4 +1,3 @@
 {
-  "$schema": "https://openapi.vercel.sh/vercel.json",
-  "ignoreCommand": "if [ \"$VERCEL_GIT_COMMIT_REF\" = \"main\" ]; then npx --yes turbo-ignore governance.mento.org; else git fetch --quiet origin main:refs/remotes/origin/main 2>/dev/null; npx --yes turbo-ignore governance.mento.org --fallback=origin/main; fi"
+  "$schema": "https://openapi.vercel.sh/vercel.json"
 }

--- a/apps/reserve.mento.org/vercel.json
+++ b/apps/reserve.mento.org/vercel.json
@@ -1,4 +1,3 @@
 {
-  "$schema": "https://openapi.vercel.sh/vercel.json",
-  "ignoreCommand": "if [ \"$VERCEL_GIT_COMMIT_REF\" = \"main\" ]; then npx --yes turbo-ignore reserve.mento.org; else git fetch --quiet origin main:refs/remotes/origin/main 2>/dev/null; npx --yes turbo-ignore reserve.mento.org --fallback=origin/main; fi"
+  "$schema": "https://openapi.vercel.sh/vercel.json"
 }

--- a/apps/ui.mento.org/vercel.json
+++ b/apps/ui.mento.org/vercel.json
@@ -1,4 +1,3 @@
 {
-  "$schema": "https://openapi.vercel.sh/vercel.json",
-  "ignoreCommand": "if [ \"$VERCEL_GIT_COMMIT_REF\" = \"main\" ]; then npx --yes turbo-ignore ui.mento.org; else git fetch --quiet origin main:refs/remotes/origin/main 2>/dev/null; npx --yes turbo-ignore ui.mento.org --fallback=origin/main; fi"
+  "$schema": "https://openapi.vercel.sh/vercel.json"
 }


### PR DESCRIPTION
# Description

Reverts the per-app `turbo-ignore` `ignoreCommand`s (added in #382) and relies on Vercel's **native skip-unaffected** step instead.

**Why:** live verification of #382 showed `turbo-ignore` **fail-opens on Vercel's shallow build clone**. Vercel clones the branch at depth 1, so `HEAD`'s parent — and therefore the merge-base with the comparison ref — is the shallow boundary and isn't present. `turbo-ignore` needs that merge-base to compute affected packages, so it logs *"turbo-ignore could not complete … a shallow clone with insufficient history"* and proceeds to build. Re-fetching / unshallowing inside the `ignoreCommand` did not reliably restore the merge-base (reproduced faithfully in a local depth-1 branch clone).

Vercel's **native** skip-unaffected doesn't have this problem — it's computed **server-side with full git history** — and it reliably skips single-app and shared-package changes. It's also Vercel's recommended approach (`turbo-ignore` is deprecated).

**Trade-off:** per Vercel's docs, changes **outside the workspace definition** (root `scripts/`, `.github/`) are treated as global and build all apps. turbo-ignore would skip those *in theory*, but can't in practice on the shallow clone — so native skipping is strictly more effective here.

## Other changes

None — removes the `ignoreCommand` key from the four app `vercel.json` files (back to `$schema` only). All four projects already have `rootDirectory=apps/<app>` and the default Automatic ignored-build-step, so native skipping activates with no project-settings change.

## Testing

- Faithful local repro of Vercel's depth-1 branch clone: `merge-base HEAD origin/main` fails (matches the real build log); `--unshallow` did not reliably fix it.
- **Live verification on this branch ✅:** pushed an `app.mento.org`-only change. Result via the Vercel API: `governance.mento.org` deploy for that commit was **skipped** — CANCELED with **empty build logs** (no build ran), while `app.mento.org` (the changed app) built. Confirms native skipping skips unaffected apps for a single-app change — the behavior turbo-ignore could not deliver on the shallow clone. (Probe commit reverted; the PR is only the four reverts.)

## Checklist before requesting a review

- [x] PR title follows the conventions
- [x] Performed a self-review of my own code changes
- [ ] Smoke Test Run/s passed on the CI
