### PR TITLE
fix(app): fail-closed sanctions guard + gate localStorage RPC overrides behind debug flag

### DIFF
--- a/apps/app.mento.org/app/components/sanctions-guard.test.tsx
+++ b/apps/app.mento.org/app/components/sanctions-guard.test.tsx
@@ -27,7 +27,11 @@ function renderGuard() {
 
 describe("SanctionsGuard", () => {
   it("renders children when address is clean", () => {
-    useSanctionsCheckMock.mockReturnValue({ isSanctioned: false });
+    useSanctionsCheckMock.mockReturnValue({
+      isSanctioned: false,
+      isChecking: false,
+      checkFailed: false,
+    });
 
     renderGuard();
 
@@ -35,16 +39,26 @@ describe("SanctionsGuard", () => {
     expect(screen.queryByText("Access Restricted")).toBeNull();
   });
 
-  it("renders children while checking", () => {
-    useSanctionsCheckMock.mockReturnValue({ isSanctioned: false });
+  it("renders a neutral loading state while checking, not children", () => {
+    useSanctionsCheckMock.mockReturnValue({
+      isSanctioned: false,
+      isChecking: true,
+      checkFailed: false,
+    });
 
     renderGuard();
 
-    expect(screen.queryByTestId("app-content")).not.toBeNull();
+    expect(screen.queryByTestId("app-content")).toBeNull();
+    expect(screen.queryByText("Access Restricted")).toBeNull();
+    expect(screen.queryByText("Verification unavailable")).toBeNull();
   });
 
   it("renders blocked screen and hides children for sanctioned address", () => {
-    useSanctionsCheckMock.mockReturnValue({ isSanctioned: true });
+    useSanctionsCheckMock.mockReturnValue({
+      isSanctioned: true,
+      isChecking: false,
+      checkFailed: false,
+    });
 
     renderGuard();
 
@@ -52,5 +66,19 @@ describe("SanctionsGuard", () => {
     expect(screen.queryByText("App")).toBeNull();
     expect(screen.queryByText("Access Restricted")).not.toBeNull();
     expect(screen.queryByText(/identified on a sanctions list/)).not.toBeNull();
+  });
+
+  it("renders blocked screen when the check fails, without claiming sanctioned", () => {
+    useSanctionsCheckMock.mockReturnValue({
+      isSanctioned: false,
+      isChecking: false,
+      checkFailed: true,
+    });
+
+    renderGuard();
+
+    expect(screen.queryByTestId("app-content")).toBeNull();
+    expect(screen.queryByText("Verification unavailable")).not.toBeNull();
+    expect(screen.queryByText("Access Restricted")).toBeNull();
   });
 });

--- a/apps/app.mento.org/app/components/sanctions-guard.tsx
+++ b/apps/app.mento.org/app/components/sanctions-guard.tsx
@@ -5,22 +5,31 @@ import { ShieldX } from "lucide-react";
 import type { PropsWithChildren } from "react";
 
 export function SanctionsGuard({ children }: PropsWithChildren) {
-  const { isSanctioned } = useSanctionsCheck();
+  const { isSanctioned, isChecking, checkFailed } = useSanctionsCheck();
 
-  if (isSanctioned) {
+  if (isSanctioned || checkFailed) {
+    const heading = isSanctioned
+      ? "Access Restricted"
+      : "Verification unavailable";
+    const message = isSanctioned
+      ? "This address has been identified on a sanctions list and is unable to access this application. If you believe this is an error, please contact support."
+      : "We couldn't complete the compliance check for this address. Please try again later.";
+
     return (
       <div className="p-8 flex min-h-screen items-center justify-center bg-background">
         <div className="max-w-md gap-6 flex flex-col items-center text-center">
           <ShieldX className="h-16 w-16 text-destructive" />
-          <h1 className="text-2xl font-semibold text-foreground">
-            Access Restricted
-          </h1>
-          <p className="text-muted-foreground">
-            This address has been identified on a sanctions list and is unable
-            to access this application. If you believe this is an error, please
-            contact support.
-          </p>
+          <h1 className="text-2xl font-semibold text-foreground">{heading}</h1>
+          <p className="text-muted-foreground">{message}</p>
         </div>
+      </div>
+    );
+  }
+
+  if (isChecking) {
+    return (
+      <div className="p-8 flex min-h-screen items-center justify-center bg-background">
+        <div className="h-16 w-16 animate-pulse rounded-full bg-muted" />
       </div>
     );
   }

--- a/packages/web3/src/config/chains.ts
+++ b/packages/web3/src/config/chains.ts
@@ -13,6 +13,7 @@ import celoIcon from "./chain-icons/celo.svg";
 import monadIcon from "./chain-icons/monad.svg";
 import polygonIcon from "./chain-icons/polygon.svg";
 import baseIcon from "./chain-icons/base.svg";
+import { readStorageOverride } from "./rpc-overrides";
 
 const useFork = isForkModeEnabled();
 
@@ -262,7 +263,7 @@ function isForkModeEnabled(): boolean {
   }
 
   // In browser, check localStorage first, then environment variable
-  const storedValue = localStorage.getItem("mento_use_fork");
+  const storedValue = readStorageOverride("mento_use_fork");
   if (storedValue !== null) {
     return storedValue === "true";
   }
@@ -277,10 +278,8 @@ function isForkModeEnabled(): boolean {
 }
 
 function getLegacyCustomRpcUrl(): string | undefined {
-  if (typeof window !== "undefined") {
-    const stored = localStorage.getItem("mento_custom_rpc_url");
-    if (stored) return stored;
-  }
+  const stored = readStorageOverride("mento_custom_rpc_url");
+  if (stored) return stored;
   return process.env.NEXT_PUBLIC_RPC_URL || undefined;
 }
 
@@ -289,14 +288,12 @@ function getChainSpecificRpcUrl(
 ): { url: string; source: string } | undefined {
   const config = RPC_OVERRIDE_CONFIG[chainId];
 
-  if (typeof window !== "undefined") {
-    const stored = localStorage.getItem(config.localStorageKey);
-    if (stored) {
-      return {
-        url: stored,
-        source: `custom RPC (${config.localStorageKey})`,
-      };
-    }
+  const stored = readStorageOverride(config.localStorageKey);
+  if (stored) {
+    return {
+      url: stored,
+      source: `custom RPC (${config.localStorageKey})`,
+    };
   }
 
   const envUrl = config.envUrl;

--- a/packages/web3/src/config/rpc-overrides.test.ts
+++ b/packages/web3/src/config/rpc-overrides.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { canUseStorageOverrides, readStorageOverride } from "./rpc-overrides";
+
+describe("canUseStorageOverrides", () => {
+  it("blocks overrides in production without the debug flag", () => {
+    expect(canUseStorageOverrides(true, false)).toBe(false);
+  });
+
+  it("allows overrides in production when the debug flag is set", () => {
+    expect(canUseStorageOverrides(true, true)).toBe(true);
+  });
+
+  it("allows overrides outside production", () => {
+    expect(canUseStorageOverrides(false, false)).toBe(true);
+  });
+});
+
+describe("readStorageOverride", () => {
+  it("returns the stored value when overrides are allowed", () => {
+    const storage = {
+      getItem: vi.fn().mockReturnValue("http://localhost:9999"),
+    };
+
+    const result = readStorageOverride("some-key", storage, false, false);
+
+    expect(result).toBe("http://localhost:9999");
+    expect(storage.getItem).toHaveBeenCalledWith("some-key");
+  });
+
+  it("returns null without reading storage in production with no debug flag", () => {
+    const storage = {
+      getItem: vi.fn().mockReturnValue("http://localhost:9999"),
+    };
+
+    const result = readStorageOverride("some-key", storage, true, false);
+
+    expect(result).toBeNull();
+    expect(storage.getItem).not.toHaveBeenCalled();
+  });
+
+  it("returns null when storage is undefined (SSR)", () => {
+    const result = readStorageOverride("some-key", undefined, false, false);
+
+    expect(result).toBeNull();
+  });
+});

--- a/packages/web3/src/config/rpc-overrides.test.ts
+++ b/packages/web3/src/config/rpc-overrides.test.ts
@@ -39,6 +39,52 @@ describe("readStorageOverride", () => {
     expect(storage.getItem).not.toHaveBeenCalled();
   });
 
+  it("does not touch window localStorage when overrides are blocked", () => {
+    const originalWindow = globalThis.window;
+    const localStorageGetter = vi.fn(() => {
+      throw new Error("localStorage is blocked");
+    });
+
+    Object.defineProperty(globalThis, "window", {
+      configurable: true,
+      value: Object.defineProperty({}, "localStorage", {
+        get: localStorageGetter,
+      }),
+    });
+
+    const result = readStorageOverride("some-key", undefined, true, false);
+
+    expect(result).toBeNull();
+    expect(localStorageGetter).not.toHaveBeenCalled();
+
+    Object.defineProperty(globalThis, "window", {
+      configurable: true,
+      value: originalWindow,
+    });
+  });
+
+  it("returns null when browser storage access is blocked", () => {
+    const originalWindow = globalThis.window;
+
+    Object.defineProperty(globalThis, "window", {
+      configurable: true,
+      value: Object.defineProperty({}, "localStorage", {
+        get() {
+          throw new Error("localStorage is blocked");
+        },
+      }),
+    });
+
+    const result = readStorageOverride("some-key", undefined, false, false);
+
+    expect(result).toBeNull();
+
+    Object.defineProperty(globalThis, "window", {
+      configurable: true,
+      value: originalWindow,
+    });
+  });
+
   it("returns null when storage is undefined (SSR)", () => {
     const result = readStorageOverride("some-key", undefined, false, false);
 

--- a/packages/web3/src/config/rpc-overrides.ts
+++ b/packages/web3/src/config/rpc-overrides.ts
@@ -1,0 +1,25 @@
+import { IS_DEBUG, IS_PROD } from "../utils/environment";
+
+export type StorageLike = Pick<Storage, "getItem">;
+
+/** localStorage RPC/fork overrides are honoured only outside production
+ *  builds, or when the debug flag was baked in at build time. */
+export function canUseStorageOverrides(
+  isProduction: boolean,
+  isDebugEnabled: boolean,
+): boolean {
+  return isDebugEnabled || !isProduction;
+}
+
+export function readStorageOverride(
+  key: string,
+  storage: StorageLike | undefined = typeof window === "undefined"
+    ? undefined
+    : window.localStorage,
+  isProduction: boolean = IS_PROD,
+  isDebugEnabled: boolean = IS_DEBUG,
+): string | null {
+  if (!storage) return null;
+  if (!canUseStorageOverrides(isProduction, isDebugEnabled)) return null;
+  return storage.getItem(key);
+}

--- a/packages/web3/src/config/rpc-overrides.ts
+++ b/packages/web3/src/config/rpc-overrides.ts
@@ -13,13 +13,28 @@ export function canUseStorageOverrides(
 
 export function readStorageOverride(
   key: string,
-  storage: StorageLike | undefined = typeof window === "undefined"
-    ? undefined
-    : window.localStorage,
+  storage?: StorageLike,
   isProduction: boolean = IS_PROD,
   isDebugEnabled: boolean = IS_DEBUG,
 ): string | null {
-  if (!storage) return null;
   if (!canUseStorageOverrides(isProduction, isDebugEnabled)) return null;
-  return storage.getItem(key);
+
+  const storageSource = storage ?? readWindowStorage();
+  if (!storageSource) return null;
+
+  try {
+    return storageSource.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+function readWindowStorage(): StorageLike | undefined {
+  if (typeof window === "undefined") return undefined;
+
+  try {
+    return window.localStorage;
+  } catch {
+    return undefined;
+  }
 }


### PR DESCRIPTION
Closes #397

## What / Why

Two client-side security gaps, fixed together per the issue.

**Part A** — `SanctionsGuard` only blocked on `isSanctioned === true`. A failed or blocked `/api/sanctions` call left `isSanctioned` false, so a failed check let a potentially sanctioned user straight into the app, and `children` rendered while the check was still in flight. The guard now also blocks on `checkFailed` (with distinct "Verification unavailable" copy — a failed check is not a sanctions hit) and shows a neutral loading placeholder (no `children`) while `isChecking` is true.

**Part B** — `packages/web3/src/config/chains.ts` read `localStorage` RPC/fork override keys unconditionally in every environment, so anything that can write `localStorage` (XSS, malicious extension, self-XSS) could persistently repoint mainnet RPC reads and swap quotes. Extracted a small, dependency-injected `packages/web3/src/config/rpc-overrides.ts` (`canUseStorageOverrides` / `readStorageOverride`) that only honours the override when not in production, or when `NEXT_PUBLIC_ENABLE_DEBUG` was baked in at build time. All three `localStorage.getItem` call sites in `chains.ts` now route through it; the `NEXT_PUBLIC_*` env-var override paths (including the `fork:mainnet`/`NEXT_PUBLIC_USE_FORK` workflow) are untouched.

## Verification

```
pnpm --filter @repo/web3 exec tsc --noEmit         # no output — passes
pnpm --filter app.mento.org exec tsc --noEmit      # no output — passes
pnpm --filter @repo/web3 build                     # rebuilt dist (source changed)
pnpm --filter @repo/web3 exec vitest run           # 11 files, 79 tests passed
pnpm --filter app.mento.org exec vitest run        # 19 files, 104 tests passed
grep -n "localStorage.getItem" packages/web3/src/config/chains.ts   # no matches
pnpm --filter app.mento.org exec eslint app/components/sanctions-guard.tsx app/components/sanctions-guard.test.tsx   # clean
pnpm --filter @repo/web3 exec eslint src/config/chains.ts src/config/rpc-overrides.ts src/config/rpc-overrides.test.ts   # clean
pnpm exec prettier --write <changed files>         # formatting fixed, re-ran affected tests, still green
git commit (pre-commit hook ran trunk check --fix on staged files)   # "No issues"
```

Note: `npx @trunkio/launcher fmt` itself failed locally with an `EPERM` on the shared npm cache (root-owned `~/.npm/_cacache`), unrelated to this change — used `prettier --write` + per-package `eslint` directly instead, and the commit's pre-commit hook (which does run trunk) reported no issues.

## Deferred (human step)

The issue's manual runtime checks (browser console `localStorage.setItem` against `turbo dev`, and the `NEXT_PUBLIC_VERCEL_ENV=production turbo build` + `next start` gating check) were not run in this sandboxed session — logic is covered by the new `rpc-overrides.test.ts` unit tests instead.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches compliance access control and mainnet RPC selection—both security-sensitive; behavior changes are intentional fail-closed fixes.
> 
> **Overview**
> **SanctionsGuard** now fails closed: app content stays hidden while `isChecking`, blocks on `checkFailed` with *Verification unavailable* (distinct from a sanctions hit), and only renders children after a clean, completed check.
> 
> **RPC/fork `localStorage` overrides** in `@repo/web3` are routed through new `readStorageOverride` / `canUseStorageOverrides` helpers so production builds ignore those keys unless the debug flag was baked in at build time; env-based RPC/fork paths are unchanged. Unit tests cover the gating and storage edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9db268041552a0e3cc49a81db4be045d620d3509. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->