### PR TITLE
fix(web3): close-trove approves maxUint256 — use a 0.1% debt buffer; fix exact-balance gate

### DIFF
--- a/apps/app.mento.org/app/components/borrow/manage-trove/close-form.tsx
+++ b/apps/app.mento.org/app/components/borrow/manage-trove/close-form.tsx
@@ -4,6 +4,7 @@ import { useMemo } from "react";
 import { Button } from "@repo/ui";
 import {
   useCloseTrove,
+  computeBufferedDebt,
   formatCollateralAmount,
   formatDebtTokenAmount,
   type DebtTokenConfig,
@@ -40,6 +41,8 @@ export function CloseForm({
 
   // Total debt to repay (debt includes accrued interest from SDK)
   const totalDebt = troveData.debt;
+  // Buffered debt accounts for interest accrual between quote and execution
+  const bufferedDebt = computeBufferedDebt(totalDebt);
   const collateralToReceive = troveData.collateral;
 
   // Debt token wallet balance
@@ -59,7 +62,7 @@ export function CloseForm({
   const insufficientBalance =
     debtTokenBalance !== undefined &&
     totalDebt > 0n &&
-    debtTokenBalance < totalDebt;
+    debtTokenBalance < bufferedDebt;
 
   const buttonDisabledReason = useMemo(() => {
     if (!isConnected) return "Connect wallet";
@@ -138,8 +141,9 @@ export function CloseForm({
       {insufficientBalance && (
         <p className="text-sm text-destructive">
           Your {debtToken.symbol} balance is insufficient to repay the full
-          debt. You need {formatDebtTokenAmount(totalDebt, debtToken)} but only
-          have {formatDebtTokenAmount(debtTokenBalance ?? 0n, debtToken)}.
+          debt. You need {formatDebtTokenAmount(bufferedDebt, debtToken)}{" "}
+          (includes a small buffer for interest accrual) but only have{" "}
+          {formatDebtTokenAmount(debtTokenBalance ?? 0n, debtToken)}.
         </p>
       )}
 

--- a/packages/web3/src/features/borrow/hooks/close-trove-approval.test.ts
+++ b/packages/web3/src/features/borrow/hooks/close-trove-approval.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  buildCloseTroveApprovalCall,
+  computeBufferedDebt,
+} from "./close-trove-approval";
+
+describe("computeBufferedDebt", () => {
+  it("applies a 0.1% buffer", () => {
+    expect(computeBufferedDebt(1000n)).toBe(1001n);
+  });
+});
+
+describe("buildCloseTroveApprovalCall", () => {
+  it("builds an approval for the buffered amount when allowance is insufficient", async () => {
+    const approvalCall = { to: "0x1", data: "0x", value: 0n } as const;
+    const getDebtAllowance = vi.fn().mockResolvedValue(0n);
+    const buildDebtApprovalParams = vi.fn().mockResolvedValue(approvalCall);
+
+    const result = await buildCloseTroveApprovalCall(
+      { getDebtAllowance, buildDebtApprovalParams } as never,
+      "GBPm",
+      "0xaccount",
+      "0xborrowerOps",
+      1000n,
+    );
+
+    expect(buildDebtApprovalParams).toHaveBeenCalledWith(
+      "GBPm",
+      "0xborrowerOps",
+      1001n,
+    );
+    expect(result).toBe(approvalCall);
+  });
+
+  it("resolves null when allowance already covers the buffered debt", async () => {
+    const getDebtAllowance = vi.fn().mockResolvedValue(2000n);
+    const buildDebtApprovalParams = vi.fn();
+
+    const result = await buildCloseTroveApprovalCall(
+      { getDebtAllowance, buildDebtApprovalParams } as never,
+      "GBPm",
+      "0xaccount",
+      "0xborrowerOps",
+      1000n,
+    );
+
+    expect(buildDebtApprovalParams).not.toHaveBeenCalled();
+    expect(result).toBeNull();
+  });
+
+  it("resolves null when allowance exactly equals the buffered debt", async () => {
+    const getDebtAllowance = vi.fn().mockResolvedValue(1001n);
+    const buildDebtApprovalParams = vi.fn();
+
+    const result = await buildCloseTroveApprovalCall(
+      { getDebtAllowance, buildDebtApprovalParams } as never,
+      "GBPm",
+      "0xaccount",
+      "0xborrowerOps",
+      1000n,
+    );
+
+    expect(buildDebtApprovalParams).not.toHaveBeenCalled();
+    expect(result).toBeNull();
+  });
+});

--- a/packages/web3/src/features/borrow/hooks/close-trove-approval.ts
+++ b/packages/web3/src/features/borrow/hooks/close-trove-approval.ts
@@ -1,0 +1,31 @@
+import type { BorrowService } from "@mento-protocol/mento-sdk";
+import type { CallParams } from "../types";
+
+type CloseTroveApprovalSdk = Pick<
+  BorrowService,
+  "getDebtAllowance" | "buildDebtApprovalParams"
+>;
+
+// closeTrove pulls entireDebt at execution time and interest accrues per
+// second, so an exact-amount approval can revert between quote and
+// confirmation. +0.1% covers ~7 days of accrual at 5% APR.
+export function computeBufferedDebt(debt: bigint): bigint {
+  return (debt * 1001n) / 1000n;
+}
+
+export async function buildCloseTroveApprovalCall(
+  sdk: CloseTroveApprovalSdk,
+  symbol: string,
+  account: string,
+  borrowerOperations: string,
+  debt: bigint,
+): Promise<CallParams | null> {
+  const bufferedDebt = computeBufferedDebt(debt);
+  const allowance = await sdk.getDebtAllowance(
+    symbol,
+    account,
+    borrowerOperations,
+  );
+  if (allowance >= bufferedDebt) return null;
+  return sdk.buildDebtApprovalParams(symbol, borrowerOperations, bufferedDebt);
+}

--- a/packages/web3/src/features/borrow/hooks/index.ts
+++ b/packages/web3/src/features/borrow/hooks/index.ts
@@ -2,6 +2,7 @@ export { useAdjustInterestRate } from "./use-adjust-interest-rate";
 export { useAdjustTrove } from "./use-adjust-trove";
 export { useBorrowAllowance } from "./use-borrow-allowance";
 export { useClaimCollateral } from "./use-claim-collateral";
+export { computeBufferedDebt } from "./close-trove-approval";
 export { useCloseTrove } from "./use-close-trove";
 export { useBorrowService } from "./use-borrow-service";
 export { useBranchStats } from "./use-branch-stats";

--- a/packages/web3/src/features/borrow/hooks/use-close-trove.ts
+++ b/packages/web3/src/features/borrow/hooks/use-close-trove.ts
@@ -1,7 +1,6 @@
 import { toast } from "@repo/ui";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useSetAtom } from "jotai";
-import { maxUint256 } from "viem";
 import type { Config } from "wagmi";
 import { getChainId, getPublicClient } from "wagmi/actions";
 import { getBorrowRegistry } from "@mento-protocol/mento-sdk";
@@ -9,6 +8,7 @@ import { resolveAddressesFromRegistry } from "@mento-protocol/mento-sdk";
 import { borrowFlowAtom } from "../atoms/flow-atoms";
 import type { CallParams } from "../types";
 import { executeFlow } from "../tx-flows/engine";
+import { buildCloseTroveApprovalCall } from "./close-trove-approval";
 import { useBorrowService } from "./use-borrow-service";
 
 interface CloseTroveMutationParams {
@@ -58,19 +58,14 @@ export function useCloseTrove() {
           {
             id: "approve-debt",
             label: "Approve Debt Token",
-            buildTx: async (): Promise<CallParams | null> => {
-              const allowance = await sdk.getDebtAllowance(
+            buildTx: async (): Promise<CallParams | null> =>
+              buildCloseTroveApprovalCall(
+                sdk,
                 symbol,
                 account,
                 borrowerOps,
-              );
-              if (allowance >= debt) return null;
-              return sdk.buildDebtApprovalParams(
-                symbol,
-                borrowerOps,
-                maxUint256,
-              );
-            },
+                debt,
+              ),
           },
           {
             id: "close-trove",


### PR DESCRIPTION
Closes #401

## What
- Replaced the unlimited `maxUint256` debt-token approval in `useCloseTrove` with a buffered amount (`debt * 1001n / 1000n`, +0.1%), extracted into a new pure/testable helper `close-trove-approval.ts` (`computeBufferedDebt`, `buildCloseTroveApprovalCall`), matching the `adjust-trove-transaction.ts` pattern.
- The buffered value is used for both the allowance-sufficiency check (`allowance >= bufferedDebt`) and the `buildDebtApprovalParams` amount.
- `computeBufferedDebt` is exported from `@repo/web3` via `hooks/index.ts`.
- `close-form.tsx` now computes `bufferedDebt` and uses it for the insufficient-balance gate and the "you need X" copy (now clarified with "includes a small buffer for interest accrual"). The "Debt to repay" / "You will repay" displays and `closeTrove.mutate({ debt: totalDebt, ... })` still use the exact debt, per spec (no double-buffering).

## Why
closeTrove pulls `entireDebt` at execution time, and interest accrues per second in this Liquity-v2-style system, so an exact-amount approval can revert between quote and confirmation. An unlimited (`maxUint256`) allowance avoided that but unnecessarily enlarged the attack surface. A 0.1% buffer covers realistic quote-to-confirmation windows (~7 days at 5% APR) without granting a standing unlimited allowance. The UI balance gate is updated to match so users don't pass the check with exactly the exact debt and then hit a revert.

## Verification

```
pnpm --filter @repo/web3 exec tsc --noEmit          # pass, no output
pnpm --filter @repo/web3 build                       # pass (rebuilt dist so app resolves new export)
pnpm --filter @repo/web3 exec vitest run src/features/borrow/hooks/close-trove-approval.test.ts
  # 4 passed (allowance below buffer -> approval w/ buffered amount; allowance >= buffer -> null;
  #           allowance == buffer -> null; computeBufferedDebt(1000n) === 1001n)
pnpm --filter @repo/web3 exec vitest run src/features/borrow
  # 6 files, 25 tests passed (no regressions)
pnpm --filter app.mento.org exec tsc --noEmit        # pass, no output
pnpm --filter @repo/web3 exec eslint src/features/borrow/hooks/{close-trove-approval.ts,close-trove-approval.test.ts,use-close-trove.ts,index.ts}   # clean
pnpm --filter app.mento.org exec eslint app/components/borrow/manage-trove/close-form.tsx   # clean
npx @trunkio/launcher check --fix <changed files>    # Checked 5 files, No issues
grep -rn "maxUint256" packages/web3/src/features/borrow/    # no matches
```

## Deferred (human step)
- Manual browser smoke test (wallet with balance below buffered debt showing the updated warning copy) was not run in this sandboxed session — no wallet/dev server available here. Recommend a quick manual check on `/borrow` before merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches debt-token approvals and close-trove transaction flow; changes are scoped and tested but affect real fund movement on close.
> 
> **Overview**
> Close-trove debt-token approval no longer grants **unlimited** allowance. It now approves only a **0.1% buffered** amount (`debt * 1001n / 1000n`) so execution can cover interest that accrues between quote and confirmation, without leaving a standing max approval.
> 
> Logic lives in new **`close-trove-approval.ts`** (`computeBufferedDebt`, `buildCloseTroveApprovalCall`), wired from **`useCloseTrove`**; **`computeBufferedDebt`** is re-exported from `@repo/web3`. Vitest covers buffer math and allowance skip/approve paths.
> 
> **`close-form.tsx`** uses buffered debt for the insufficient-balance gate and warning copy (with a note about the interest buffer). Displayed repay amounts and the mutation still pass **exact** debt so the buffer is not applied twice.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 316560a991d14d6a00397ad6eabc2ccc3ddc61ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->