### PR TITLE
perf(ui): make @repo/ui tree-shakeable — externalize heavy deps, enable code-splitting

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -2,6 +2,9 @@
   "name": "@repo/ui",
   "version": "0.0.0",
   "private": true,
+  "sideEffects": [
+    "**/*.css"
+  ],
   "type": "module",
   "exports": {
     ".": {

--- a/packages/ui/tsup.config.ts
+++ b/packages/ui/tsup.config.ts
@@ -5,11 +5,11 @@ export default defineConfig({
   entry: ["src/index.ts"],
   format: ["esm", "cjs"],
   dts: true,
-  splitting: false, // keeps everything in one JS file
-  minify: true,
+  splitting: true,
+  minify: false,
   sourcemap: true,
   target: "esnext",
-  external: ["react", "react-dom"],
+  skipNodeModulesBundle: true,
   publicDir: "src/assets",
   esbuildOptions(options) {
     // ✅ give the plugin the metafile


### PR DESCRIPTION
Closes #405

## What

`packages/ui/tsup.config.ts`: `splitting: true`, `minify: false`, add `skipNodeModulesBundle: true`, drop the redundant `external: ["react", "react-dom"]`. `packages/ui/package.json`: add `"sideEffects": ["**/*.css"]` (array form — preserves the CSS import side-effect while allowing consumers to tree-shake unused exports). `esbuildOptions` (metafile + dataurl loaders) and `preserveDirectivesPlugin` unchanged. No exports-map change, no app changes.

## Why / honest finding

The issue's premise — "every runtime dep is inlined into one minified blob" — **does not hold on the current tsup version (8.5.1)**. tsup externalizes everything in `dependencies`/`peerDependencies` by default, so on `main` `recharts`, `@tiptap/*`, and all Radix packages are **already bare `import ... from "recharts"` specifiers** in `dist/index.js`, not inlined (recharts/tiptap internals like `CartesianGrid`/`ProseMirror` are absent from main's dist). Adding `skipNodeModulesBundle: true` makes that externalization explicit/robust rather than reliant on the `dependencies` list.

Consequently the changes are **correct config hardening** (explicit externalization, code-splitting enabled, unminified so consumers minify once via `transpilePackages`, and an explicit `sideEffects` declaration) but they do **not** produce the dramatic First-Load-JS drop the issue predicted — that reduction was already in effect. See measurement below.

## First Load JS — before/after (`app.mento.org`, full `next build`)

Identical before (main config) and after (this branch). Representative routes:

| Route | Before (main) | After (branch) |
|---|---|---|
| `/` | 893 kB | 893 kB |
| `/swap` | 893 kB | 893 kB |
| `/borrow` | 905 kB | 905 kB |
| `/earn` | 907 kB | 907 kB |
| `/pools` | 913 kB | 913 kB |
| shared by all | 261 kB | 261 kB |

Next.js 15's webpack already tree-shakes the `@repo/ui` barrel and never pulled `recharts`/`tiptap` into `app.mento.org`'s bundle — the `sideEffects` field does not change this here, but it is the correct, defensive declaration to keep that behavior guaranteed and to avoid webpack ever pruning the CSS import.

`governance.mento.org` (branch, tiptap consumer) builds cleanly with no "Module not found" — tiptap resolves through the workspace symlink:

```
┌ ƒ /                     10.1 kB   956 kB
├ ƒ /create-proposal      11.4 kB   996 kB   (RichTextEditor / tiptap)
├ ƒ /proposals/[id]       37.3 kB  1.05 MB
└ ƒ /voting-power         23.5 kB   985 kB
+ First Load JS shared      —       252 kB
```

## Verification

- `pnpm --filter @repo/ui build` → success. `dist/` has `index.js`, `index.cjs`, `globals.css`. Single entry with no dynamic imports → one JS chunk (splitting only forks chunks when there are multiple entry/dynamic-import points; not a regression).
- Externalized, not inlined: `grep -rl '"@tiptap/react"' packages/ui/dist --include="*.js"` and `grep -rl '"recharts"' packages/ui/dist --include="*.js"` both match `dist/index.js` (bare specifiers survive). `recharts` appears only 4× (import statements), no library internals.
- Client boundary: `head -1 packages/ui/dist/index.js` → `"use client";`
- `grep -n '"sideEffects"' packages/ui/package.json` → present, array form `["**/*.css"]`.
- DOM snapshots: `pnpm --filter @repo/ui exec vitest run` → 28 passed; `git status --porcelain packages/ui/src` → empty (no snapshot churn).
- Typecheck: `pnpm --filter @repo/ui exec tsc --noEmit`, `... app.mento.org ...`, `... governance.mento.org ...` → all pass.
- App builds: `app.mento.org` and `governance.mento.org` both `next build` successfully against the new `@repo/ui` (governance Sentry 401s are dummy-token sourcemap-upload noise, non-fatal).
- `trunk fmt` + `trunk check --fix` on both changed files → No issues. (trunk reordered `sideEffects` above `type` in package.json — its formatter's choice.)

### Dist size note (analyze)
`pnpm --filter @repo/ui analyze` total: main **1.17 MB** vs branch **1.32 MB**. The branch dist is slightly *larger* raw because `minify: false` — not an order-of-magnitude shrink, because deps were never inlined to begin with (see finding). App First-Load-JS is unaffected since consumers minify `@repo/ui` via `transpilePackages`.

## Deferred (human step)

- Pixel VRT (`ui.mento.org` Argos) and the dev-server eyeball check (governance fully styled at :3002) require secrets/interactive session — could not run here. The `sideEffects: ["**/*.css"]` array form is specifically chosen to keep `import "@repo/ui/globals.css"` from being pruned; please confirm Argos shows zero diffs and the page is styled before merge.
- Full 4-app build matrix (`reserve.mento.org`, `ui.mento.org`) not run in this env; `app.mento.org` + `governance.mento.org` verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-only changes to the shared UI package with verified app builds; no runtime logic or API surface changes.
> 
> **Overview**
> Hardens **`@repo/ui`** build and package metadata so consumers can tree-shake unused exports while keeping global CSS imports safe.
> 
> **`tsup.config.ts`** turns on **code splitting**, disables **library minification** (apps minify via `transpilePackages`), and sets **`skipNodeModulesBundle: true`** so heavy deps stay as bare imports instead of being bundled. The redundant **`external: ["react", "react-dom"]`** line is removed because tsup already externalizes `dependencies`/`peerDependencies`.
> 
> **`package.json`** adds **`sideEffects: ["**/*.css"]`** so bundlers may drop unused JS from the barrel but still treat **`globals.css`** as a side effect.
> 
> No export map or app changes. Per author measurements, **First Load JS** on main routes is unchanged; raw **`dist`** may be slightly larger unminified.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1dd9bb2d75d2c4ea42f3f406768bc0b4ae5b58de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->