### PR TITLE
ci: concurrency cancellation, honest healthcheck, pinned smoke-test refs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,12 @@ on:
 
 permissions: read-all
 
+# Cancel superseded CI runs on the same ref — rapid pushes shouldn't stack
+# full 15-minute runs.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   TURBO_TEAM: ${{ vars.TURBO_TEAM }}
   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}

--- a/.github/workflows/smoke-test-app-mento.yml
+++ b/.github/workflows/smoke-test-app-mento.yml
@@ -17,7 +17,10 @@ jobs:
   test:
     needs: test-eligibility
     if: needs.test-eligibility.outputs.should_run == 'true'
-    uses: mento-protocol/mento-automation-tests/.github/workflows/app-mento-smoke-test.yml@main
+    # pin: bump deliberately — gh api repos/mento-protocol/mento-automation-tests/commits/main --jq .sha
+    # NOTE: upstream still calls base-test.yml@main internally with CHECKOUT_REF: main,
+    # so this pin covers only the caller layer until upstream plumbs a CHECKOUT_REF input.
+    uses: mento-protocol/mento-automation-tests/.github/workflows/app-mento-smoke-test.yml@af89f97322777f0001ed23b888e8160517591f0a
     with:
       CUSTOM_URL: ${{ github.event.deployment_status.environment_url }}
       IS_MAINNET: false

--- a/.github/workflows/smoke-test-governance.yml
+++ b/.github/workflows/smoke-test-governance.yml
@@ -17,7 +17,10 @@ jobs:
   test:
     needs: test-eligibility
     if: needs.test-eligibility.outputs.should_run == 'true'
-    uses: mento-protocol/mento-automation-tests/.github/workflows/governance-smoke-test.yml@main
+    # pin: bump deliberately — gh api repos/mento-protocol/mento-automation-tests/commits/main --jq .sha
+    # NOTE: upstream still calls base-test.yml@main internally with CHECKOUT_REF: main,
+    # so this pin covers only the caller layer until upstream plumbs a CHECKOUT_REF input.
+    uses: mento-protocol/mento-automation-tests/.github/workflows/governance-smoke-test.yml@af89f97322777f0001ed23b888e8160517591f0a
     with:
       CUSTOM_URL: ${{ github.event.deployment_status.environment_url }}
       IS_MAINNET: false

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "fork:testnet": "anvil --fork-url https://forno.celo-sepolia.celo-testnet.org --port 8545",
     "format": "npx @trunkio/launcher fmt",
     "format:check": "npx @trunkio/launcher check --filter=prettier",
-    "health": "sh ./scripts/healthcheck.sh",
+    "health": "bash ./scripts/healthcheck.sh",
     "knip": "knip",
     "lint": "npx @trunkio/launcher check",
     "lint:fix": "npx @trunkio/launcher check --fix",

--- a/scripts/healthcheck.sh
+++ b/scripts/healthcheck.sh
@@ -1,7 +1,7 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 # Exit immediately if a command exits with a non-zero status.
-# set -euo pipefail
+set -euo pipefail
 
 echo "🚀 Running Health Checks..."
 
@@ -17,9 +17,8 @@ pnpm lint
 printf "\n🧐 Checking types...\n"
 pnpm check-types
 
-# Once we have a test suite, uncomment this.
-# printf "\n🧪 Running tests...\n"
-# pnpm test
+printf "\n🧪 Running tests...\n"
+pnpm test
 
 printf "\n🧱 Building...\n"
 pnpm build


### PR DESCRIPTION
Closes #410

## What

Implements the CODE parts of #410 (parts 1, 2, 4 — part 3, the ruleset edit, is a maintainer action, see below):

1. **`.github/workflows/ci.yml`** — added a `concurrency` block (`group: ci-${{ github.ref }}`, `cancel-in-progress: true`) so rapid pushes cancel superseded 15-minute runs instead of stacking, mirroring the existing pattern in `visual.yml`.
2. **`scripts/healthcheck.sh`** — switched the shebang to `bash` (dash rejects `pipefail`) and uncommented `set -euo pipefail` so a failing step actually stops the script instead of always printing "✅ All Health Checks Passed!"; enabled the previously-disabled `pnpm test` step now that `app.mento.org`, `packages/ui`, and `packages/web3` have test suites. `package.json`'s `health` script now invokes `bash` to match the shebang.
3. **Smoke-test workflows** — pinned `smoke-test-app-mento.yml` and `smoke-test-governance.yml` to the current `mento-protocol/mento-automation-tests` `main` SHA (`af89f97322777f0001ed23b888e8160517591f0a`, fetched via `gh api repos/mento-protocol/mento-automation-tests/commits/main --jq .sha` on 2026-07-06) instead of the mutable `@main` ref, with a `# pin: bump deliberately` comment and a note that upstream still calls `base-test.yml@main` internally until it gets a `CHECKOUT_REF` input.

## Why

Prevents CI resource waste from stacked runs, makes `pnpm health` an honest signal (it currently always exits 0), and removes a mutable ref from a repo with an otherwise SHA-pinning posture.

## Verification

```
grep -A2 'concurrency:' .github/workflows/ci.yml
# concurrency:
#   group: ci-${{ github.ref }}
#   cancel-in-progress: true

grep -n 'set -euo pipefail\|pnpm test\|env bash' scripts/healthcheck.sh
# 1:#!/usr/bin/env bash
# 4:set -euo pipefail
# 21:pnpm test

grep -rn 'mento-automation-tests.*@main' .github/workflows/
# (no output — both files now reference the pinned SHA)
```

Injected-failure test (per acceptance criteria), then reverted:
```
printf 'export const  probe = 1\n' > packages/ui/src/healthcheck-probe.ts && pnpm health; echo "exit=$?"
# ... formatting autofix runs first (pre-existing trunk behavior, unrelated to this change),
# then the build step fails because this sandbox lacks the app env vars (SENTRY_AUTH_TOKEN,
# NEXT_PUBLIC_* etc.) that CI provides as secrets — a real failure surfaces correctly:
# exit=1, and "All Health Checks Passed" is NOT printed (confirmed via grep -c on full output = 0).
rm packages/ui/src/healthcheck-probe.ts
```

`npx @trunkio/launcher fmt` and `npx @trunkio/launcher check --fix` on the changed files: `✔ No issues`.

Not run in this environment: `pnpm health` on a clean tree exiting 0 end-to-end — the sandbox is missing several apps' runtime env vars (Sentry, WalletConnect, storage URL) needed for `turbo run build`, so `pnpm build` fails here independent of this change. CI has those secrets configured, so this should pass there; flagging it for a human to confirm once CI runs.

## Deferred (human step)

**Part 3 of #410 — add 4 checks to ruleset 4913327 (requires repo admin):**

```bash
gh api repos/mento-protocol/frontend-monorepo/rulesets/4913327 > /tmp/ruleset.json

jq '.rules |= map(
      if .type == "required_status_checks" then
        .parameters.required_status_checks += [
          {"context": "Visual Regression (app.mento.org)", "integration_id": 15368},
          {"context": "lockfile integrity + registry",     "integration_id": 15368},
          {"context": "catalog version-skew",              "integration_id": 15368},
          {"context": "dependency-review",                 "integration_id": 15368}
        ]
      else . end
    )
    | {name, target, enforcement, bypass_actors, conditions, rules}' \
  /tmp/ruleset.json > /tmp/ruleset-updated.json

gh api -X PUT repos/mento-protocol/frontend-monorepo/rulesets/4913327 \
  --input /tmp/ruleset-updated.json
```

Verify afterward with:
```bash
gh api repos/mento-protocol/frontend-monorepo/rulesets/4913327 --jq '[.rules[] | select(.type == "required_status_checks") | .parameters.required_status_checks[].context]'
```
should list 7 contexts total.

**Upstream PR to `mento-protocol/mento-automation-tests`** adding a `CHECKOUT_REF` input to `app-mento-smoke-test.yml` / `governance-smoke-test.yml` (threaded through to `base-test.yml`) is a separate PR in that repo, not attempted here — not something this agent has push access to do without explicit instruction.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow and local-dev script changes only; no application runtime or auth logic. Slightly stricter local/CI behavior from enabled tests and fail-fast healthcheck.
> 
> **Overview**
> **CI** now uses a `concurrency` group on `github.ref` with `cancel-in-progress: true`, so newer pushes on the same branch/PR cancel in-flight **Build and Test** runs instead of stacking ~15-minute jobs (same idea as `visual.yml`).
> 
> **`pnpm health`** is meant to be a real gate: `healthcheck.sh` runs under **bash** with **`set -euo pipefail`**, and **`pnpm test`** is back in the sequence (format → lint → types → test → build). The root **`health`** script invokes **`bash`** explicitly so failures stop the script and it no longer always prints success.
> 
> **Deployment smoke tests** for app and governance no longer call **`mento-automation-tests` workflows at `@main`**; they’re pinned to commit **`af89f973…`** with comments on how to bump. The pin only covers the reusable workflow reference—upstream may still use `@main` internally until a `CHECKOUT_REF` input exists.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 640dbee848e624eb3246a74ce8bf87a00fd3fd52. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->