### PR TITLE
test(web3): money-math safety net — unit tests + coverage gates for swap/borrow math

### DIFF
--- a/packages/vitest-config/vitest.shared.js
+++ b/packages/vitest-config/vitest.shared.js
@@ -30,7 +30,7 @@ export default defineConfig({
       "**/.trunk/**",
     ],
     globals: false,
-    passWithNoTests: true,
+    passWithNoTests: false,
     coverage: {
       provider: "v8",
       reporter: ["text", "json", "html"],

--- a/packages/web3/package.json
+++ b/packages/web3/package.json
@@ -46,7 +46,7 @@
     "dev:js": "tsup --watch",
     "generate:component": "turbo gen react-component",
     "lint": "eslint . --max-warnings 100",
-    "test": "vitest run",
+    "test": "vitest run --coverage",
     "test:coverage": "vitest run --coverage",
     "test:watch": "vitest",
     "watch": "pnpm dev:js"

--- a/packages/web3/src/features/borrow/leverage/math.test.ts
+++ b/packages/web3/src/features/borrow/leverage/math.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+import {
+  getCloseFlashLoanAmount,
+  getLeverDownTroveParams,
+  getLeverUpTroveParams,
+  getOpenLeveragedTroveParams,
+} from "./math";
+
+const WAD = 10n ** 18n;
+
+describe("getOpenLeveragedTroveParams", () => {
+  it("computes flash loan, expected debt, and max net debt with 5% slippage", () => {
+    const result = getOpenLeveragedTroveParams(10n * WAD, 2.0, 2n * WAD);
+    expect(result.flashLoanAmount).toBe(10n * WAD);
+    expect(result.expectedBoldAmount).toBe(20n * WAD);
+    // 105/100 slippage applied to the expected debt.
+    expect(result.maxNetDebt).toBe(21n * WAD);
+  });
+
+  it("returns a zero flash loan when leverage factor is 1.0", () => {
+    const result = getOpenLeveragedTroveParams(10n * WAD, 1.0, 2n * WAD);
+    expect(result.flashLoanAmount).toBe(0n);
+  });
+
+  it("quantises leverage factors to 1/1000 steps (Math.round × 1000)", () => {
+    // 2.0 and 2.0004 round to the same ×1000 integer (2000).
+    const a = getOpenLeveragedTroveParams(10n * WAD, 2.0, 2n * WAD);
+    const b = getOpenLeveragedTroveParams(10n * WAD, 2.0004, 2n * WAD);
+    expect(b.flashLoanAmount).toBe(a.flashLoanAmount);
+    expect(b.expectedBoldAmount).toBe(a.expectedBoldAmount);
+    expect(b.maxNetDebt).toBe(a.maxNetDebt);
+  });
+
+  it("quantises 1.0005 up (Math.round of 1000.5 → 1001), producing a non-zero flash loan", () => {
+    const result = getOpenLeveragedTroveParams(10n * WAD, 1.0005, 2n * WAD);
+    // leverageRatio = 1001/1000 * WAD, so flashLoan = coll * (1/1000)
+    expect(result.flashLoanAmount).toBe((10n * WAD) / 1000n);
+  });
+
+  it("handles a 1-wei collateral without overflow", () => {
+    const result = getOpenLeveragedTroveParams(1n, 2.0, 2n * WAD);
+    expect(result.flashLoanAmount).toBe(1n);
+  });
+
+  it("handles huge collateral values without overflow and stays monotonic", () => {
+    const low = getOpenLeveragedTroveParams(10n ** 36n, 2.0, 2n * WAD);
+    const high = getOpenLeveragedTroveParams(10n ** 36n, 3.0, 2n * WAD);
+    expect(high.flashLoanAmount > low.flashLoanAmount).toBe(true);
+    expect(low.flashLoanAmount).toBe(10n ** 36n);
+  });
+});
+
+describe("getCloseFlashLoanAmount", () => {
+  it("applies the default 5% slippage", () => {
+    // 100e18 debt / 2e18 price = 50 collateral, × 1.05 = 52.5e18.
+    expect(getCloseFlashLoanAmount(100n * WAD, 2n * WAD)).toBe(
+      525n * 10n ** 17n,
+    );
+  });
+
+  it("applies an explicit 0% slippage", () => {
+    expect(getCloseFlashLoanAmount(100n * WAD, 2n * WAD, 0n)).toBe(50n * WAD);
+  });
+});
+
+describe("getLeverUpTroveParams", () => {
+  it("computes an increasing flash loan for a higher target leverage", () => {
+    // currentCR 2.0 → currentLR 2.0; target 3.0 > 2.0 is valid.
+    const currentCR = 2n * WAD;
+    const result = getLeverUpTroveParams(10n * WAD, currentCR, 3.0, 2n * WAD);
+    expect(result.flashLoanAmount > 0n).toBe(true);
+    expect(result.effectiveBoldAmount > 0n).toBe(true);
+  });
+
+  it("throws when the target leverage is not higher than current", () => {
+    const currentCR = 2n * WAD; // currentLR = 2.0
+    expect(() =>
+      getLeverUpTroveParams(10n * WAD, currentCR, 2.0, 2n * WAD),
+    ).toThrow(/must increase/);
+  });
+});
+
+describe("getLeverDownTroveParams", () => {
+  it("computes a flash loan and minimum debt for a lower target leverage", () => {
+    const currentCR = 15n * 10n ** 17n; // 1.5 → currentLR = 3.0
+    const result = getLeverDownTroveParams(10n * WAD, currentCR, 2.0, 2n * WAD);
+    expect(result.flashLoanAmount > 0n).toBe(true);
+    expect(result.minBoldAmount > 0n).toBe(true);
+  });
+
+  it("throws when the target leverage is not lower than current", () => {
+    const currentCR = 15n * 10n ** 17n; // 1.5 → currentLR = 3.0
+    expect(() =>
+      getLeverDownTroveParams(10n * WAD, currentCR, 3.0, 2n * WAD),
+    ).toThrow(/must decrease/);
+  });
+});
+
+describe("collateral-ratio boundary", () => {
+  it("throws RangeError: Division by zero when currentCR equals 1.0", () => {
+    // collateralRatioToLeverageRatio divides by (cr - 1e18); cr === 1e18 → /0.
+    expect(() => getLeverUpTroveParams(10n * WAD, WAD, 3.0, 2n * WAD)).toThrow(
+      RangeError,
+    );
+  });
+});

--- a/packages/web3/src/features/swap/hooks/use-swap-quote.ts
+++ b/packages/web3/src/features/swap/hooks/use-swap-quote.ts
@@ -1,7 +1,7 @@
 import { toast } from "@repo/ui";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useCallback, useEffect, useMemo, useRef } from "react";
-import { type Address, type ReadContractReturnType } from "viem";
+import { type Address } from "viem";
 import { useChainId, usePublicClient } from "wagmi";
 
 import { SWAP_QUOTE_REFETCH_INTERVAL } from "@/config/constants";
@@ -12,11 +12,11 @@ import {
 } from "@/config/usd-quote-tokens";
 import { getMentoSdk, getTradablePairForTokens } from "@/features/sdk";
 import { buildSwapRoute } from "@/features/swap/build-swap-route";
+import { validateRouteLiquidity } from "@/features/swap/route-liquidity";
 import {
   extractFullErrorString,
   getToastErrorMessage,
   isInsufficientLiquidityError,
-  SWAP_INSUFFICIENT_LIQUIDITY_LABEL,
   shouldRetrySwapError,
 } from "@/features/swap/error-handlers";
 import {
@@ -30,11 +30,9 @@ import { logger } from "@/utils/logger";
 import {
   ROUTER_ABI,
   TokenSymbol,
-  type Route,
   encodeRoutePath,
   getContractAddress,
   getTokenAddress,
-  type Mento,
 } from "@mento-protocol/mento-sdk";
 
 const TOAST_THROTTLE_MS = 10_000;
@@ -56,77 +54,6 @@ interface UseSwapQuoteOptions {
   validatePoolLiquidity?: boolean;
   insufficientLiquidityFallbackUrl?: string;
   chainId?: number;
-}
-
-function isSameAddress(addressA: string, addressB: string): boolean {
-  return addressA.toLowerCase() === addressB.toLowerCase();
-}
-
-async function validateRouteLiquidity(params: {
-  mento: Mento;
-  route: Route;
-  amounts: ReadContractReturnType<typeof ROUTER_ABI, "getAmountsOut">;
-  routerRoutes: ReturnType<typeof encodeRoutePath>;
-}) {
-  const { mento, route, amounts, routerRoutes } = params;
-
-  if (routerRoutes.length === 0) return;
-  if (amounts.length !== routerRoutes.length + 1) {
-    throw new Error("Unable to validate swap liquidity.");
-  }
-
-  const poolDetailsByAddr = new Map(
-    await Promise.all(
-      route.path.map(
-        async (pool) =>
-          [
-            pool.poolAddr.toLowerCase(),
-            await mento.pools.getPoolDetails(pool.poolAddr),
-          ] as const,
-      ),
-    ),
-  );
-
-  // routerRoutes is the authoritative, direction-aware order of hops; route.path
-  // is only consulted to resolve (factory, {from,to}) → poolAddr.
-  const remainingPools = [...route.path];
-
-  for (const [hopIndex, hop] of routerRoutes.entries()) {
-    const poolIdx = remainingPools.findIndex(
-      (p) =>
-        isSameAddress(p.factoryAddr, hop.factory) &&
-        ((isSameAddress(p.token0, hop.from) &&
-          isSameAddress(p.token1, hop.to)) ||
-          (isSameAddress(p.token1, hop.from) &&
-            isSameAddress(p.token0, hop.to))),
-    );
-    const pool = poolIdx === -1 ? undefined : remainingPools[poolIdx];
-    if (!pool) {
-      throw new Error("Unable to validate swap liquidity.");
-    }
-    remainingPools.splice(poolIdx, 1);
-
-    const details = poolDetailsByAddr.get(pool.poolAddr.toLowerCase());
-    const hopAmountOut = amounts[hopIndex + 1];
-    if (!details || hopAmountOut == null) {
-      throw new Error("Unable to validate swap liquidity.");
-    }
-
-    const reserveOut = isSameAddress(hop.to, pool.token0)
-      ? details.reserve0
-      : isSameAddress(hop.to, pool.token1)
-        ? details.reserve1
-        : null;
-
-    if (reserveOut == null) {
-      throw new Error("Unable to validate swap liquidity.");
-    }
-
-    // Router swaps require output strictly below available reserve.
-    if (hopAmountOut >= reserveOut) {
-      throw new Error(SWAP_INSUFFICIENT_LIQUIDITY_LABEL);
-    }
-  }
 }
 
 /**

--- a/packages/web3/src/features/swap/hooks/use-swap-transaction.test.ts
+++ b/packages/web3/src/features/swap/hooks/use-swap-transaction.test.ts
@@ -15,6 +15,9 @@ import {
 } from "@/features/swap/error-handlers";
 import { getSwapTransactionErrorMessage } from "./swap-transaction-error";
 
+// Dynamic import after the vi.mock declaration above, mirroring use-open-trove.test.ts.
+const { parseDeadlineMinutes } = await import("./use-swap-transaction");
+
 describe("getSwapTransactionErrorMessage", () => {
   const testCases: Array<{
     name: string;
@@ -161,5 +164,27 @@ describe("getSwapTransactionErrorMessage", () => {
       const result = getSwapTransactionErrorMessage(input as Error);
       expect(result).toBe(expected);
     });
+  });
+});
+
+describe("parseDeadlineMinutes", () => {
+  const fallbackCases: Array<{ name: string; input: string | undefined }> = [
+    { name: "undefined", input: undefined },
+    { name: "empty string", input: "" },
+    { name: "non-numeric", input: "abc" },
+    { name: "zero", input: "0" },
+    { name: "negative", input: "-3" },
+  ];
+
+  it.each(fallbackCases)("returns 5 for $name", ({ input }) => {
+    expect(parseDeadlineMinutes(input)).toBe(5);
+  });
+
+  it("returns the parsed value for a valid positive integer string", () => {
+    expect(parseDeadlineMinutes("20")).toBe(20);
+  });
+
+  it("truncates a decimal string via parseInt", () => {
+    expect(parseDeadlineMinutes("2.9")).toBe(2);
   });
 });

--- a/packages/web3/src/features/swap/hooks/use-swap-transaction.tsx
+++ b/packages/web3/src/features/swap/hooks/use-swap-transaction.tsx
@@ -24,7 +24,7 @@ import {
 import { getSwapTransactionErrorMessage } from "./swap-transaction-error";
 import { confirmViewAtom, formValuesAtom } from "../swap-atoms";
 
-function parseDeadlineMinutes(deadlineMinutes?: string): number {
+export function parseDeadlineMinutes(deadlineMinutes?: string): number {
   const parsed = Number.parseInt(deadlineMinutes ?? "", 10);
 
   if (!Number.isFinite(parsed) || parsed <= 0) {

--- a/packages/web3/src/features/swap/route-liquidity.test.ts
+++ b/packages/web3/src/features/swap/route-liquidity.test.ts
@@ -1,0 +1,315 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  type Mento,
+  type Route,
+  encodeRoutePath,
+} from "@mento-protocol/mento-sdk";
+import { SWAP_INSUFFICIENT_LIQUIDITY_LABEL } from "@/features/swap/error-handlers";
+import { validateRouteLiquidity } from "./route-liquidity";
+
+const FACTORY = "0xffffffffffffffffffffffffffffffffffffffff";
+const TOKEN_A = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+const TOKEN_B = "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+const TOKEN_C = "0xcccccccccccccccccccccccccccccccccccccccc";
+const POOL_1 = "0x1111111111111111111111111111111111111111";
+const POOL_2 = "0x2222222222222222222222222222222222222222";
+
+interface PoolStub {
+  poolAddr: string;
+  factoryAddr: string;
+  token0: string;
+  token1: string;
+}
+
+interface HopStub {
+  factory: string;
+  from: string;
+  to: string;
+}
+
+type Reserves = { reserve0: bigint; reserve1: bigint };
+
+function makeRoute(pools: PoolStub[]): Route {
+  return { path: pools } as unknown as Route;
+}
+
+function makeRouterRoutes(hops: HopStub[]): ReturnType<typeof encodeRoutePath> {
+  return hops as unknown as ReturnType<typeof encodeRoutePath>;
+}
+
+function makeAmounts(
+  values: bigint[],
+): Parameters<typeof validateRouteLiquidity>[0]["amounts"] {
+  return values as unknown as Parameters<
+    typeof validateRouteLiquidity
+  >[0]["amounts"];
+}
+
+function makeMento(reservesByPool: Record<string, Reserves>): {
+  mento: Mento;
+  getPoolDetails: ReturnType<typeof vi.fn>;
+} {
+  const getPoolDetails = vi.fn((poolAddr: string) => {
+    const reserves = reservesByPool[poolAddr.toLowerCase()];
+    return Promise.resolve(reserves);
+  });
+  const mento = { pools: { getPoolDetails } } as unknown as Mento;
+  return { mento, getPoolDetails };
+}
+
+describe("validateRouteLiquidity", () => {
+  it("resolves without querying pool details for an empty route", async () => {
+    const { mento, getPoolDetails } = makeMento({});
+    await expect(
+      validateRouteLiquidity({
+        mento,
+        route: makeRoute([]),
+        amounts: makeAmounts([100n]),
+        routerRoutes: makeRouterRoutes([]),
+      }),
+    ).resolves.toBeUndefined();
+    expect(getPoolDetails).not.toHaveBeenCalled();
+  });
+
+  it("rejects when amounts length does not equal hops + 1", async () => {
+    const { mento } = makeMento({});
+    await expect(
+      validateRouteLiquidity({
+        mento,
+        route: makeRoute([
+          {
+            poolAddr: POOL_1,
+            factoryAddr: FACTORY,
+            token0: TOKEN_A,
+            token1: TOKEN_B,
+          },
+        ]),
+        amounts: makeAmounts([100n]),
+        routerRoutes: makeRouterRoutes([
+          { factory: FACTORY, from: TOKEN_A, to: TOKEN_B },
+        ]),
+      }),
+    ).rejects.toThrow("Unable to validate swap liquidity.");
+  });
+
+  it("resolves when the hop output is strictly below the reserve", async () => {
+    const { mento } = makeMento({
+      [POOL_1.toLowerCase()]: { reserve0: 0n, reserve1: 1000n },
+    });
+    await expect(
+      validateRouteLiquidity({
+        mento,
+        route: makeRoute([
+          {
+            poolAddr: POOL_1,
+            factoryAddr: FACTORY,
+            token0: TOKEN_A,
+            token1: TOKEN_B,
+          },
+        ]),
+        amounts: makeAmounts([100n, 999n]),
+        routerRoutes: makeRouterRoutes([
+          { factory: FACTORY, from: TOKEN_A, to: TOKEN_B },
+        ]),
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("rejects with the insufficient-liquidity label when output equals the reserve", async () => {
+    const { mento } = makeMento({
+      [POOL_1.toLowerCase()]: { reserve0: 0n, reserve1: 1000n },
+    });
+    await expect(
+      validateRouteLiquidity({
+        mento,
+        route: makeRoute([
+          {
+            poolAddr: POOL_1,
+            factoryAddr: FACTORY,
+            token0: TOKEN_A,
+            token1: TOKEN_B,
+          },
+        ]),
+        amounts: makeAmounts([100n, 1000n]),
+        routerRoutes: makeRouterRoutes([
+          { factory: FACTORY, from: TOKEN_A, to: TOKEN_B },
+        ]),
+      }),
+    ).rejects.toThrow(SWAP_INSUFFICIENT_LIQUIDITY_LABEL);
+  });
+
+  it("rejects with the insufficient-liquidity label when output exceeds the reserve", async () => {
+    const { mento } = makeMento({
+      [POOL_1.toLowerCase()]: { reserve0: 0n, reserve1: 1000n },
+    });
+    await expect(
+      validateRouteLiquidity({
+        mento,
+        route: makeRoute([
+          {
+            poolAddr: POOL_1,
+            factoryAddr: FACTORY,
+            token0: TOKEN_A,
+            token1: TOKEN_B,
+          },
+        ]),
+        amounts: makeAmounts([100n, 1001n]),
+        routerRoutes: makeRouterRoutes([
+          { factory: FACTORY, from: TOKEN_A, to: TOKEN_B },
+        ]),
+      }),
+    ).rejects.toThrow(SWAP_INSUFFICIENT_LIQUIDITY_LABEL);
+  });
+
+  it("selects reserve1 when the hop output token is token1", async () => {
+    // hop.to === token1 → reserve1 is the constraint (reserve0 is irrelevant).
+    const { mento } = makeMento({
+      [POOL_1.toLowerCase()]: { reserve0: 1n, reserve1: 1000n },
+    });
+    await expect(
+      validateRouteLiquidity({
+        mento,
+        route: makeRoute([
+          {
+            poolAddr: POOL_1,
+            factoryAddr: FACTORY,
+            token0: TOKEN_A,
+            token1: TOKEN_B,
+          },
+        ]),
+        amounts: makeAmounts([100n, 999n]),
+        routerRoutes: makeRouterRoutes([
+          { factory: FACTORY, from: TOKEN_A, to: TOKEN_B },
+        ]),
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("selects reserve0 when the hop output token is token0 (reversed direction)", async () => {
+    // hop.to === token0 → reserve0 is the constraint; low reserve0 forces rejection.
+    const { mento } = makeMento({
+      [POOL_1.toLowerCase()]: { reserve0: 500n, reserve1: 100000n },
+    });
+    await expect(
+      validateRouteLiquidity({
+        mento,
+        route: makeRoute([
+          {
+            poolAddr: POOL_1,
+            factoryAddr: FACTORY,
+            token0: TOKEN_A,
+            token1: TOKEN_B,
+          },
+        ]),
+        amounts: makeAmounts([100n, 600n]),
+        routerRoutes: makeRouterRoutes([
+          { factory: FACTORY, from: TOKEN_B, to: TOKEN_A },
+        ]),
+      }),
+    ).rejects.toThrow(SWAP_INSUFFICIENT_LIQUIDITY_LABEL);
+  });
+
+  it("matches pool and token addresses case-insensitively", async () => {
+    const { mento } = makeMento({
+      [POOL_1.toLowerCase()]: { reserve0: 0n, reserve1: 1000n },
+    });
+    await expect(
+      validateRouteLiquidity({
+        mento,
+        route: makeRoute([
+          {
+            poolAddr: POOL_1.toUpperCase().replace("0X", "0x"),
+            factoryAddr: FACTORY.toUpperCase().replace("0X", "0x"),
+            token0: TOKEN_A.toUpperCase().replace("0X", "0x"),
+            token1: TOKEN_B,
+          },
+        ]),
+        amounts: makeAmounts([100n, 999n]),
+        routerRoutes: makeRouterRoutes([
+          { factory: FACTORY, from: TOKEN_A, to: TOKEN_B },
+        ]),
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("rejects when no pool matches a hop", async () => {
+    const { mento } = makeMento({
+      [POOL_1.toLowerCase()]: { reserve0: 0n, reserve1: 1000n },
+    });
+    await expect(
+      validateRouteLiquidity({
+        mento,
+        route: makeRoute([
+          {
+            poolAddr: POOL_1,
+            factoryAddr: FACTORY,
+            token0: TOKEN_A,
+            token1: TOKEN_B,
+          },
+        ]),
+        amounts: makeAmounts([100n, 999n]),
+        // hop references TOKEN_C which no pool contains.
+        routerRoutes: makeRouterRoutes([
+          { factory: FACTORY, from: TOKEN_A, to: TOKEN_C },
+        ]),
+      }),
+    ).rejects.toThrow("Unable to validate swap liquidity.");
+  });
+
+  it("rejects when pool details are missing for a matched pool", async () => {
+    // getPoolDetails resolves undefined → the `!details` guard trips.
+    const { mento } = makeMento({});
+    await expect(
+      validateRouteLiquidity({
+        mento,
+        route: makeRoute([
+          {
+            poolAddr: POOL_1,
+            factoryAddr: FACTORY,
+            token0: TOKEN_A,
+            token1: TOKEN_B,
+          },
+        ]),
+        amounts: makeAmounts([100n, 999n]),
+        routerRoutes: makeRouterRoutes([
+          { factory: FACTORY, from: TOKEN_A, to: TOKEN_B },
+        ]),
+      }),
+    ).rejects.toThrow("Unable to validate swap liquidity.");
+  });
+
+  it("validates a multi-hop route across two pools with the same token pair", async () => {
+    // Both pools trade the A/B pair; the splice ensures each hop consumes a
+    // distinct pool rather than re-matching the first.
+    const { mento, getPoolDetails } = makeMento({
+      [POOL_1.toLowerCase()]: { reserve0: 0n, reserve1: 1000n },
+      [POOL_2.toLowerCase()]: { reserve0: 2000n, reserve1: 0n },
+    });
+    await expect(
+      validateRouteLiquidity({
+        mento,
+        route: makeRoute([
+          {
+            poolAddr: POOL_1,
+            factoryAddr: FACTORY,
+            token0: TOKEN_A,
+            token1: TOKEN_B,
+          },
+          {
+            poolAddr: POOL_2,
+            factoryAddr: FACTORY,
+            token0: TOKEN_A,
+            token1: TOKEN_B,
+          },
+        ]),
+        // hop 1: A→B uses POOL_1.reserve1 (1000); hop 2: B→A uses POOL_2.reserve0 (2000).
+        amounts: makeAmounts([100n, 900n, 1900n]),
+        routerRoutes: makeRouterRoutes([
+          { factory: FACTORY, from: TOKEN_A, to: TOKEN_B },
+          { factory: FACTORY, from: TOKEN_B, to: TOKEN_A },
+        ]),
+      }),
+    ).resolves.toBeUndefined();
+    expect(getPoolDetails).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/web3/src/features/swap/route-liquidity.ts
+++ b/packages/web3/src/features/swap/route-liquidity.ts
@@ -1,0 +1,79 @@
+import { SWAP_INSUFFICIENT_LIQUIDITY_LABEL } from "@/features/swap/error-handlers";
+import { type ReadContractReturnType } from "viem";
+import {
+  ROUTER_ABI,
+  type Route,
+  encodeRoutePath,
+  type Mento,
+} from "@mento-protocol/mento-sdk";
+
+function isSameAddress(addressA: string, addressB: string): boolean {
+  return addressA.toLowerCase() === addressB.toLowerCase();
+}
+
+export async function validateRouteLiquidity(params: {
+  mento: Mento;
+  route: Route;
+  amounts: ReadContractReturnType<typeof ROUTER_ABI, "getAmountsOut">;
+  routerRoutes: ReturnType<typeof encodeRoutePath>;
+}) {
+  const { mento, route, amounts, routerRoutes } = params;
+
+  if (routerRoutes.length === 0) return;
+  if (amounts.length !== routerRoutes.length + 1) {
+    throw new Error("Unable to validate swap liquidity.");
+  }
+
+  const poolDetailsByAddr = new Map(
+    await Promise.all(
+      route.path.map(
+        async (pool) =>
+          [
+            pool.poolAddr.toLowerCase(),
+            await mento.pools.getPoolDetails(pool.poolAddr),
+          ] as const,
+      ),
+    ),
+  );
+
+  // routerRoutes is the authoritative, direction-aware order of hops; route.path
+  // is only consulted to resolve (factory, {from,to}) → poolAddr.
+  const remainingPools = [...route.path];
+
+  for (const [hopIndex, hop] of routerRoutes.entries()) {
+    const poolIdx = remainingPools.findIndex(
+      (p) =>
+        isSameAddress(p.factoryAddr, hop.factory) &&
+        ((isSameAddress(p.token0, hop.from) &&
+          isSameAddress(p.token1, hop.to)) ||
+          (isSameAddress(p.token1, hop.from) &&
+            isSameAddress(p.token0, hop.to))),
+    );
+    const pool = poolIdx === -1 ? undefined : remainingPools[poolIdx];
+    if (!pool) {
+      throw new Error("Unable to validate swap liquidity.");
+    }
+    remainingPools.splice(poolIdx, 1);
+
+    const details = poolDetailsByAddr.get(pool.poolAddr.toLowerCase());
+    const hopAmountOut = amounts[hopIndex + 1];
+    if (!details || hopAmountOut == null) {
+      throw new Error("Unable to validate swap liquidity.");
+    }
+
+    const reserveOut = isSameAddress(hop.to, pool.token0)
+      ? details.reserve0
+      : isSameAddress(hop.to, pool.token1)
+        ? details.reserve1
+        : null;
+
+    if (reserveOut == null) {
+      throw new Error("Unable to validate swap liquidity.");
+    }
+
+    // Router swaps require output strictly below available reserve.
+    if (hopAmountOut >= reserveOut) {
+      throw new Error(SWAP_INSUFFICIENT_LIQUIDITY_LABEL);
+    }
+  }
+}

--- a/packages/web3/src/features/swap/utils.test.ts
+++ b/packages/web3/src/features/swap/utils.test.ts
@@ -1,0 +1,172 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { TokenSymbol } from "@mento-protocol/mento-sdk";
+import {
+  calcExchangeRate,
+  formatBalance,
+  formatWithMaxDecimals,
+  invertExchangeRate,
+  isValidTokenPair,
+  parseInputExchangeAmount,
+} from "./utils";
+
+type TokenArg = Parameters<typeof isValidTokenPair>[2];
+
+function makeToken(symbol: string): TokenArg {
+  return { symbol } as unknown as TokenArg;
+}
+
+const CELO_CHAIN_ID = 42220;
+
+describe("calcExchangeRate", () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it("rates a 6-decimal token against an 18-decimal token", () => {
+    expect(calcExchangeRate("1000000", 6, "2000000000000000000", 18)).toBe(
+      "0.5000",
+    );
+  });
+
+  it("rates two 18-decimal tokens", () => {
+    expect(
+      calcExchangeRate("1000000000000000000", 18, "2000000000000000000", 18),
+    ).toBe("0.5000");
+  });
+
+  it("rounds down to four decimals", () => {
+    expect(
+      calcExchangeRate("1000000000000000000", 18, "3000000000000000000", 18),
+    ).toBe("0.3333");
+  });
+
+  it("returns '0' when the destination amount is zero (Infinity path)", () => {
+    expect(calcExchangeRate("1000000000000000000", 18, "0", 18)).toBe("0");
+  });
+
+  it("returns '0' and warns on unparseable input (catch path)", () => {
+    expect(calcExchangeRate("garbage", 18, "1", 18)).toBe("0");
+    expect(warnSpy).toHaveBeenCalled();
+  });
+});
+
+describe("invertExchangeRate", () => {
+  it("inverts a normal rate", () => {
+    expect(invertExchangeRate("2")).toBe("0.5000");
+  });
+
+  it("returns '0' for a zero rate", () => {
+    expect(invertExchangeRate("0")).toBe("0");
+  });
+
+  it("returns '0' for unparseable input", () => {
+    expect(invertExchangeRate("garbage")).toBe("0");
+  });
+});
+
+describe("parseInputExchangeAmount", () => {
+  it("returns '0' for null", () => {
+    expect(
+      parseInputExchangeAmount(null, TokenSymbol.USDm, CELO_CHAIN_ID),
+    ).toBe("0");
+  });
+
+  it("clamps negative amounts to '0'", () => {
+    expect(
+      parseInputExchangeAmount("-5", TokenSymbol.USDm, CELO_CHAIN_ID),
+    ).toBe("0");
+  });
+
+  it("converts a decimal amount to 18-decimal wei", () => {
+    expect(
+      parseInputExchangeAmount("1.5", TokenSymbol.USDm, CELO_CHAIN_ID),
+    ).toBe("1500000000000000000");
+  });
+
+  it("passes a wei value through unchanged when isWei is true", () => {
+    expect(
+      parseInputExchangeAmount(
+        "1500000000000000000",
+        TokenSymbol.USDm,
+        CELO_CHAIN_ID,
+        true,
+      ),
+    ).toBe("1500000000000000000");
+  });
+});
+
+describe("formatWithMaxDecimals", () => {
+  it("truncates to four decimals with thousand separators", () => {
+    expect(formatWithMaxDecimals("1234.56789")).toBe("1,234.5678");
+  });
+
+  it("strips trailing zeros without separators (form input branch)", () => {
+    expect(formatWithMaxDecimals("0.30000", 4, false)).toBe("0.3");
+  });
+
+  it("returns '0' for empty, '0', and NaN inputs", () => {
+    expect(formatWithMaxDecimals("")).toBe("0");
+    expect(formatWithMaxDecimals("0")).toBe("0");
+    expect(formatWithMaxDecimals("abc")).toBe("0");
+  });
+
+  // test.fails: documents the current float bug — flips to a normal test when "fix(web3): float math in max-balance & trading-limit paths + NaN slippage guard" lands.
+  it.fails(
+    "preserves >15-significant-digit integers (currently loses precision)",
+    () => {
+      expect(formatWithMaxDecimals("999999999999999999")).toBe(
+        "999,999,999,999,999,999",
+      );
+    },
+  );
+
+  // test.fails: documents the current float bug — flips to a normal test when "fix(web3): float math in max-balance & trading-limit paths + NaN slippage guard" lands.
+  it.fails(
+    "does not round 4.35 down to 4.34 via Math.floor float error",
+    () => {
+      expect(formatWithMaxDecimals("4.35", 2)).toBe("4.35");
+    },
+  );
+});
+
+describe("formatBalance", () => {
+  it("keeps up to four decimal places", () => {
+    expect(formatBalance("1234567890000000000", 18)).toBe("1.2345");
+  });
+
+  it("formats a value with fewer than four decimals unchanged", () => {
+    expect(formatBalance("1500000000000000000", 18)).toBe("1.5");
+  });
+
+  it("returns '0' for unparseable input", () => {
+    expect(formatBalance("garbage", 18)).toBe("0");
+  });
+});
+
+describe("isValidTokenPair", () => {
+  const usdc = makeToken("USDC");
+  const usdm = makeToken("USDm");
+
+  it("returns true for two distinct tokens", () => {
+    expect(isValidTokenPair("USDC", "USDm", usdc, usdm)).toBe(true);
+  });
+
+  it("returns false when the symbols are identical", () => {
+    expect(isValidTokenPair("USDC", "USDC", usdc, usdc)).toBe(false);
+  });
+
+  it("returns false when a token object is missing", () => {
+    expect(isValidTokenPair("USDC", "USDm", null, usdm)).toBe(false);
+    expect(isValidTokenPair("USDC", "USDm", usdc, null)).toBe(false);
+  });
+
+  it("returns false when a symbol is undefined", () => {
+    expect(isValidTokenPair(undefined, "USDm", usdc, usdm)).toBe(false);
+  });
+});

--- a/packages/web3/vitest.config.ts
+++ b/packages/web3/vitest.config.ts
@@ -8,4 +8,25 @@ export default mergeConfig(sharedConfig, {
       "@": resolve(__dirname, "./src"),
     },
   },
+  test: {
+    // The SDK ships an ESM build with extensionless relative imports that Node's
+    // native resolver rejects; inlining lets Vite transform and resolve it.
+    server: {
+      deps: {
+        inline: [/@mento-protocol\/mento-sdk/],
+      },
+    },
+    coverage: {
+      all: true, // untested included files count as 0% — keeps the gate deletion-proof
+      include: [
+        "src/features/borrow/leverage/math.ts",
+        "src/features/swap/utils.ts",
+        "src/features/swap/route-liquidity.ts",
+      ],
+      thresholds: {
+        lines: 90,
+        branches: 90,
+      },
+    },
+  },
 });


### PR DESCRIPTION
Closes #392

## What / Why

The pure bigint money math in `packages/web3` (leverage math, swap exchange-rate/amount formatting, the per-hop route-liquidity guard) had zero unit tests, and CI would still pass if every test in the repo were deleted. This adds behaviour tests for those modules and turns on coverage gates so they cannot rot.

- Extracted the route-liquidity guard verbatim into `packages/web3/src/features/swap/route-liquidity.ts` (exported `validateRouteLiquidity`, `isSameAddress` stays private, not barrel-exported) and imported it back into `use-swap-quote.ts`.
- Exported `parseDeadlineMinutes` from `use-swap-transaction.tsx` (one-word change) for testing.
- New tests: `borrow/leverage/math.test.ts`, `swap/utils.test.ts`, `swap/route-liquidity.test.ts`, plus a `parseDeadlineMinutes` block in the existing `use-swap-transaction.test.ts`.
- `utils.test.ts` documents the current `formatWithMaxDecimals` float bugs via two `it.fails` cases (precision loss on >15-sig-digit inputs; `Math.floor` artifact on `4.35`), to be flipped to passing when the float-math fix lands.
- Flipped `passWithNoTests: false` in `vitest.shared.js`; added a scoped v8 coverage gate (`all: true`, include math.ts/utils.ts/route-liquidity.ts, thresholds lines/branches 90) in `packages/web3/vitest.config.ts`; changed the web3 `test` script to `vitest run --coverage`.
- Added `server.deps.inline` for `@mento-protocol/mento-sdk` in the web3 vitest config: the SDK's ESM build uses extensionless relative imports that Node's native resolver rejects; inlining lets Vite transform and resolve it so the real `getTokenDecimals`/SDK types load in tests.

## Verification

```
$ pnpm --filter @repo/web3 test
Test Files  13 passed (13)
     Tests  128 passed (128)
Coverage (included files): math.ts 100%, route-liquidity.ts 94.5% lines / 92.3% branch, utils.ts 96.5% lines / 92.6% branch
All files 97.32% lines / 93.44% branch  (>= 90 thresholds)  → exit 0

$ # gate is real:
$ mv .../math.test.ts $TMPDIR/ && pnpm --filter @repo/web3 test  # exit 1 (coverage threshold)
$ mv $TMPDIR/math.test.ts .../                                    # restored

$ pnpm --filter @repo/web3 exec tsc --noEmit   # exit 0
$ pnpm knip                                     # exit 0 (no new unused-export findings)
$ trunk check --fix <changed files>            # No issues
```

Both `it.fails` cases are reported as passing (expected failures).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Covers swap liquidity checks and borrow leverage math (user-funds paths) and flips monorepo-wide `passWithNoTests` to false, which can break packages that lack tests.
> 
> **Overview**
> Adds a **safety net** around pure bigint swap/borrow math in `@repo/web3`: new Vitest suites for leverage math, swap `utils`, and per-hop route liquidity, plus **90% line/branch coverage gates** on those three modules so CI fails if tests are removed or coverage drops.
> 
> **Refactors for testability (behavior unchanged):** `validateRouteLiquidity` moves from `use-swap-quote.ts` into `route-liquidity.ts`; `parseDeadlineMinutes` is exported from `use-swap-transaction.tsx` for direct tests. `utils.test.ts` uses two `it.fails` cases to lock in known `formatWithMaxDecimals` float bugs until a follow-up fix.
> 
> **CI/tooling:** Shared Vitest sets `passWithNoTests: false`; web3 `test` runs with `--coverage`, scoped `coverage.include` + `all: true`, and `server.deps.inline` for `@mento-protocol/mento-sdk` so tests can load the SDK under Node.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b0b8c4e35b38992173f3d444b523c9d4433dd2f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->