### PR TITLE
fix(web3): block storage rpc overrides on public domains

### DIFF
--- a/packages/web3/src/config/rpc-overrides.test.ts
+++ b/packages/web3/src/config/rpc-overrides.test.ts
@@ -11,8 +11,20 @@ describe("canUseStorageOverrides", () => {
     expect(canUseStorageOverrides(true, true)).toBe(true);
   });
 
-  it("allows overrides outside production", () => {
+  it("allows overrides outside production on non-public hosts", () => {
     expect(canUseStorageOverrides(false, false)).toBe(true);
+    expect(canUseStorageOverrides(false, false, "preview.vercel.app")).toBe(
+      true,
+    );
+  });
+
+  it("blocks overrides on public Mento hosts without the debug flag", () => {
+    expect(canUseStorageOverrides(false, false, "app.mento.org")).toBe(false);
+    expect(canUseStorageOverrides(false, false, "mento.org")).toBe(false);
+  });
+
+  it("allows overrides on public Mento hosts when the debug flag is set", () => {
+    expect(canUseStorageOverrides(false, true, "app.mento.org")).toBe(true);
   });
 });
 
@@ -34,6 +46,23 @@ describe("readStorageOverride", () => {
     };
 
     const result = readStorageOverride("some-key", storage, true, false);
+
+    expect(result).toBeNull();
+    expect(storage.getItem).not.toHaveBeenCalled();
+  });
+
+  it("returns null without reading storage on public Mento hosts", () => {
+    const storage = {
+      getItem: vi.fn().mockReturnValue("http://localhost:9999"),
+    };
+
+    const result = readStorageOverride(
+      "some-key",
+      storage,
+      false,
+      false,
+      "app.mento.org",
+    );
 
     expect(result).toBeNull();
     expect(storage.getItem).not.toHaveBeenCalled();

--- a/packages/web3/src/config/rpc-overrides.ts
+++ b/packages/web3/src/config/rpc-overrides.ts
@@ -2,13 +2,16 @@ import { IS_DEBUG, IS_PROD } from "../utils/environment";
 
 export type StorageLike = Pick<Storage, "getItem">;
 
-/** localStorage RPC/fork overrides are honoured only outside production
+/** localStorage RPC/fork overrides are honoured only outside production-public
  *  builds, or when the debug flag was baked in at build time. */
 export function canUseStorageOverrides(
   isProduction: boolean,
   isDebugEnabled: boolean,
+  hostname?: string,
 ): boolean {
-  return isDebugEnabled || !isProduction;
+  if (isDebugEnabled) return true;
+  if (isProduction) return false;
+  return !isPublicMentoHostname(hostname ?? readWindowHostname());
 }
 
 export function readStorageOverride(
@@ -16,8 +19,11 @@ export function readStorageOverride(
   storage?: StorageLike,
   isProduction: boolean = IS_PROD,
   isDebugEnabled: boolean = IS_DEBUG,
+  hostname?: string,
 ): string | null {
-  if (!canUseStorageOverrides(isProduction, isDebugEnabled)) return null;
+  if (!canUseStorageOverrides(isProduction, isDebugEnabled, hostname)) {
+    return null;
+  }
 
   const storageSource = storage ?? readWindowStorage();
   if (!storageSource) return null;
@@ -27,6 +33,17 @@ export function readStorageOverride(
   } catch {
     return null;
   }
+}
+
+function isPublicMentoHostname(hostname: string | undefined): boolean {
+  if (!hostname) return false;
+  const normalized = hostname.toLowerCase();
+  return normalized === "mento.org" || normalized.endsWith(".mento.org");
+}
+
+function readWindowHostname(): string | undefined {
+  if (typeof window === "undefined") return undefined;
+  return window.location?.hostname;
 }
 
 function readWindowStorage(): StorageLike | undefined {


### PR DESCRIPTION
## The Problem

Post-merge production verification showed that app.mento.org still honored stale localStorage RPC overrides when Vercel labels the deployment as a non-production/custom environment. That leaves the public domain able to route through a user-planted RPC URL.

## The Solution

Treat mento.org and *.mento.org browser hosts as production-public for storage override gating unless NEXT_PUBLIC_ENABLE_DEBUG is explicitly enabled. Keep non-production preview hosts able to use overrides, and add tests covering the public-host block.

## Verification

- pnpm --filter @repo/web3 exec vitest run src/config/rpc-overrides.test.ts
- pnpm --filter @repo/web3 check-types
- trunk fmt packages/web3/src/config/rpc-overrides.ts packages/web3/src/config/rpc-overrides.test.ts
- trunk check --fix packages/web3/src/config/rpc-overrides.ts packages/web3/src/config/rpc-overrides.test.ts

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Web3 RPC routing gating on public domains; misclassified hostnames could block legitimate debug flows or briefly leave overrides enabled.
> 
> **Overview**
> **Closes a gap where `app.mento.org` could still apply stale `localStorage` RPC/fork URLs** when the deployment is not flagged as production (e.g. Vercel custom environments).
> 
> `canUseStorageOverrides` and `readStorageOverride` now take an optional **hostname** and treat `mento.org` and `*.mento.org` as **production-public**: overrides are denied unless `NEXT_PUBLIC_ENABLE_DEBUG` is on. Non-production preview hosts (e.g. `preview.vercel.app`) can still use overrides. When hostname is omitted, the browser’s `window.location.hostname` is used.
> 
> Tests cover public-host blocking, debug bypass, and that `readStorageOverride` does not read storage on public Mento hosts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b78c5e5bb756285a5a36971f6a07b0aaee167948. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->