### PR TITLE
docs: document Argos quota failures

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,6 +66,8 @@ Two layers guard against unintended UI changes:
 
   An intended UI change shows as a diff in the Argos dashboard — approve it there to promote the baseline. Requires the `ARGOS_TOKEN` secret + the Argos GitHub App; `NEXT_PUBLIC_STORAGE_URL` must be set (CI uses `vars.STORAGE_URL`; locally use `apps/ui.mento.org/.env.local`).
 
+  If CI shows all Playwright visual tests passing and then Argos fails with HTTP 402 / Free Plan screenshot capacity, classify it as Argos account quota rather than a visual regression. Report the pass counts and do not disable VRT or change baselines for that failure.
+
 ## Coding Conventions
 
 - **Naming:** PascalCase for components, camelCase for variables/functions


### PR DESCRIPTION
## The Problem

Argos visual regression CI can fail with HTTP 402 account quota after all Playwright screenshots pass, and reviewers need a documented way to classify that result.

## The Solution

Document in `CLAUDE.md` that this is Argos account quota, not a visual regression, and that reviewers should report pass counts without disabling VRT or changing baselines.

## Ship Checklist

- [x] ship skill used
- [ ] local review run - skipped per request
- [ ] validation run - skipped per request

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to contributor guidance; no runtime, CI workflow, or test behavior changes.
> 
> **Overview**
> Adds guidance under **Visual Regression Testing** in `CLAUDE.md` for a specific CI failure mode: when Playwright visual tests all pass but Argos then fails with **HTTP 402** / Free Plan screenshot capacity.
> 
> Reviewers should treat that as **Argos account quota**, not a UI regression—report Playwright pass counts and **avoid** disabling VRT or changing baselines in response.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 06c8fd2031b1a065dfabf20b91eaebc41a606100. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->