### PR TITLE
ci: gate Argos visual jobs by app impact

### DIFF
--- a/.github/workflows/visual.yml
+++ b/.github/workflows/visual.yml
@@ -20,21 +20,97 @@ env:
   TURBO_REMOTE_CACHE_SIGNATURE_KEY: ${{ secrets.TURBO_REMOTE_CACHE_SIGNATURE_KEY }}
 
 jobs:
-  visual:
-    name: Visual Regression (${{ matrix.app }})
+  visual-plan:
+    name: Visual Regression Plan
+    runs-on: ubuntu-latest
+    outputs:
+      app: ${{ steps.detect.outputs.app }}
+      ui: ${{ steps.detect.outputs.ui }}
+    steps:
+      - name: Check out code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+
+      - name: Detect visual impact
+        id: detect
+        shell: bash
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          BEFORE_SHA: ${{ github.event.before }}
+          EVENT_NAME: ${{ github.event_name }}
+          HEAD_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          head="$HEAD_SHA"
+          if [[ "$EVENT_NAME" == "pull_request" ]]; then
+            base="${BASE_SHA:?pull_request base SHA is required}"
+          else
+            base="${BEFORE_SHA:-}"
+            if [[ -z "$base" || "$base" =~ ^0+$ ]]; then
+              base="$(git rev-parse "${head}^")"
+            fi
+          fi
+
+          git diff --name-only "$base" "$head" > changed-files.txt
+
+          run_app=false
+          run_ui=false
+
+          while IFS= read -r file; do
+            [[ -z "$file" ]] && continue
+
+            case "$file" in
+              .github/workflows/visual.yml | package.json | pnpm-lock.yaml | pnpm-workspace.yaml | turbo.json | patches/*)
+                run_app=true
+                run_ui=true
+                ;;
+              apps/app.mento.org/*)
+                run_app=true
+                ;;
+              apps/ui.mento.org/*)
+                run_ui=true
+                ;;
+              packages/ui/*)
+                run_app=true
+                run_ui=true
+                ;;
+              packages/web3/*)
+                run_app=true
+                ;;
+            esac
+          done < changed-files.txt
+
+          echo "app=$run_app" >> "$GITHUB_OUTPUT"
+          echo "ui=$run_ui" >> "$GITHUB_OUTPUT"
+
+          {
+            echo "### Visual regression plan"
+            echo
+            echo "- app.mento.org: \`$run_app\`"
+            echo "- ui.mento.org: \`$run_ui\`"
+            echo
+            echo "<details><summary>Changed files</summary>"
+            echo
+            sed 's/^/- `/' changed-files.txt | sed 's/$/`/'
+            echo
+            echo "</details>"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  visual-ui:
+    name: Visual Regression (ui.mento.org)
+    needs: visual-plan
+    if: ${{ always() && (needs.visual-plan.result != 'success' || needs.visual-plan.outputs.ui == 'true') }}
     timeout-minutes: 25
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        app: [ui.mento.org, app.mento.org]
     # Render in the SAME pinned image used to generate baselines — the CI
     # render must equal the baseline render (font subpixel rendering is the #1
     # false-positive source). Tag must match @playwright/test in package.json.
     # NOTE: deliberate divergence from the deployment_status smoke-tests, which
     # run against the live Vercel preview; that render env is not byte-pinnable.
     container:
-      image: mcr.microsoft.com/playwright:v1.61.0-noble
+      image: mcr.microsoft.com/playwright:v1.61.1-noble
 
     env:
       # ui.mento.org needs only STORAGE_URL; app.mento.org additionally needs a
@@ -49,6 +125,12 @@ jobs:
       ARGOS_TOKEN: ${{ secrets.ARGOS_TOKEN }}
 
     steps:
+      - name: Require successful visual plan
+        if: needs.visual-plan.result != 'success'
+        run: |
+          echo "visual-plan did not complete successfully: ${{ needs.visual-plan.result }}"
+          exit 1
+
       - name: Check out code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -65,7 +147,7 @@ jobs:
 
       - name: Get pnpm store directory
         shell: bash
-        run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+        run: echo "STORE_PATH=$(pnpm store path --silent)" >> "$GITHUB_ENV"
 
       - name: Setup pnpm cache
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -79,7 +161,75 @@ jobs:
         run: pnpm install
 
       - name: Build app
-        run: pnpm turbo build --filter=${{ matrix.app }}
+        run: pnpm turbo build --filter=ui.mento.org
 
       - name: Visual regression (Playwright + Argos)
-        run: pnpm --filter ${{ matrix.app }} test:visual
+        run: pnpm --filter ui.mento.org test:visual
+
+  visual-app:
+    name: Visual Regression (app.mento.org)
+    needs: visual-plan
+    if: ${{ always() && (needs.visual-plan.result != 'success' || needs.visual-plan.outputs.app == 'true') }}
+    timeout-minutes: 25
+    runs-on: ubuntu-latest
+    # Render in the SAME pinned image used to generate baselines — the CI
+    # render must equal the baseline render (font subpixel rendering is the #1
+    # false-positive source). Tag must match @playwright/test in package.json.
+    # NOTE: deliberate divergence from the deployment_status smoke-tests, which
+    # run against the live Vercel preview; that render env is not byte-pinnable.
+    container:
+      image: mcr.microsoft.com/playwright:v1.61.1-noble
+
+    env:
+      # ui.mento.org needs only STORAGE_URL; app.mento.org additionally needs a
+      # WalletConnect id + sanctions test-mode, and we disable Sentry entirely
+      # (empty DSN) for a clean, network-free render. Extra vars are harmless to
+      # whichever app doesn't use them. The fixtures block all external network.
+      NEXT_PUBLIC_STORAGE_URL: ${{ vars.STORAGE_URL }}
+      NEXT_PUBLIC_WALLET_CONNECT_ID: ${{ vars.WALLET_CONNECT_ID }}
+      NEXT_PUBLIC_SANCTIONS_TEST_MODE: "true"
+      NEXT_PUBLIC_SENTRY_DSN_SWAP: ""
+      SENTRY_AUTH_TOKEN: ""
+      ARGOS_TOKEN: ${{ secrets.ARGOS_TOKEN }}
+
+    steps:
+      - name: Require successful visual plan
+        if: needs.visual-plan.result != 'success'
+        run: |
+          echo "visual-plan did not complete successfully: ${{ needs.visual-plan.result }}"
+          exit 1
+
+      - name: Check out code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0 # full history so Argos can compute the merge-base baseline
+
+      - name: Setup PNPM
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v4
+
+      - name: Setup Node.js environment
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Get pnpm store directory
+        shell: bash
+        run: echo "STORE_PATH=$(pnpm store path --silent)" >> "$GITHUB_ENV"
+
+      - name: Setup pnpm cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ env.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build app
+        run: pnpm turbo build --filter=app.mento.org
+
+      - name: Visual regression (Playwright + Argos)
+        run: pnpm --filter app.mento.org test:visual

--- a/.github/workflows/visual.yml
+++ b/.github/workflows/visual.yml
@@ -62,7 +62,7 @@ jobs:
             [[ -z "$file" ]] && continue
 
             case "$file" in
-              .github/workflows/visual.yml | package.json | pnpm-lock.yaml | pnpm-workspace.yaml | turbo.json | patches/*)
+              .github/workflows/visual.yml | .npmrc | package.json | pnpm-lock.yaml | pnpm-workspace.yaml | turbo.json | patches/* | scripts/security-headers.mjs)
                 run_app=true
                 run_ui=true
                 ;;

--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ yarn-error.log*
 # Cursor
 .cursor/screenshots/
 .claude/audit-report.md
+.claude/worktrees/
 *.zip
 
 .claude/skills/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,7 +61,8 @@ Two layers guard against unintended UI changes:
   The workflow plans from changed files and only runs the app checks whose
   rendered surfaces can be affected: `apps/ui.mento.org/**` and `packages/ui/**`
   run the showcase; `apps/app.mento.org/**`, `packages/ui/**`, and
-  `packages/web3/**` run the app shells; and root package/workflow changes run
+  `packages/web3/**` run the app shells; and root package, workflow, `.npmrc`,
+  `turbo.json`, `patches/**`, and `scripts/security-headers.mjs` changes run
   both. `apps/reserve.mento.org/**`-only changes skip the current Argos jobs
   because reserve has no pixel VRT suite yet. Run locally:
 
@@ -72,7 +73,7 @@ Two layers guard against unintended UI changes:
   pnpm --filter app.mento.org test:visual
   ```
 
-  An intended UI change shows as a diff in the Argos dashboard — approve it there to promote the baseline. Requires the `ARGOS_TOKEN` secret + the Argos GitHub App; `NEXT_PUBLIC_STORAGE_URL` must be set (CI uses `vars.STORAGE_URL`; locally use `apps/ui.mento.org/.env.local`).
+  An intended UI change shows as a diff in the Argos dashboard — approve it there to promote the baseline. Requires the `ARGOS_TOKEN` secret + the Argos GitHub App. `ui.mento.org` needs `NEXT_PUBLIC_STORAGE_URL` (CI uses `vars.STORAGE_URL`; locally use `apps/ui.mento.org/.env.local`). `app.mento.org` needs the env vars from `apps/app.mento.org/.env.example`; for local screenshot renders, `NEXT_PUBLIC_SENTRY_DSN_SWAP` and `SENTRY_AUTH_TOKEN` may be empty strings.
 
   If CI shows all Playwright visual tests passing and then Argos fails with HTTP 402 / Free Plan screenshot capacity, classify it as Argos account quota rather than a visual regression. Report the pass counts and do not disable VRT or change baselines for that failure.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,11 +57,19 @@ Always use `--filter` to avoid building/running everything unnecessarily.
 Two layers guard against unintended UI changes:
 
 - **DOM/aria snapshots** (`@repo/ui`) — run inside the normal `pnpm test` step. After an _intended_ component change, re-record baselines with `pnpm --filter @repo/ui exec vitest run -u`.
-- **Pixel VRT** (`ui.mento.org` showcase) — Playwright + Argos, in CI via `.github/workflows/visual.yml` (pinned Playwright Docker image; baselines live in Argos, not git). Run locally:
+- **Pixel VRT** (`ui.mento.org` showcase and `app.mento.org` disconnected shells) — Playwright + Argos, in CI via `.github/workflows/visual.yml` (pinned Playwright Docker image; baselines live in Argos, not git).
+  The workflow plans from changed files and only runs the app checks whose
+  rendered surfaces can be affected: `apps/ui.mento.org/**` and `packages/ui/**`
+  run the showcase; `apps/app.mento.org/**`, `packages/ui/**`, and
+  `packages/web3/**` run the app shells; and root package/workflow changes run
+  both. `apps/reserve.mento.org/**`-only changes skip the current Argos jobs
+  because reserve has no pixel VRT suite yet. Run locally:
 
   ```bash
-  pnpm exec turbo run build --filter ui.mento.org  # build the showcase first
-  pnpm --filter ui.mento.org test:visual  # Playwright starts `next start` and captures
+  pnpm exec turbo run build --filter ui.mento.org  # build the showcase
+  pnpm --filter ui.mento.org test:visual
+  pnpm exec turbo run build --filter app.mento.org # build the app shells first
+  pnpm --filter app.mento.org test:visual
   ```
 
   An intended UI change shows as a diff in the Argos dashboard — approve it there to promote the baseline. Requires the `ARGOS_TOKEN` secret + the Argos GitHub App; `NEXT_PUBLIC_STORAGE_URL` must be set (CI uses `vars.STORAGE_URL`; locally use `apps/ui.mento.org/.env.local`).

--- a/apps/app.mento.org/README.md
+++ b/apps/app.mento.org/README.md
@@ -31,6 +31,33 @@ Production builds and local development both use Turbopack.
 
 Tailwind CSS is configured through the v4 CSS-first setup. The app imports Tailwind in `app/globals.css`; shared UI source scanning lives in `packages/ui/src/globals.css`.
 
+## Visual Regression Testing
+
+`app.mento.org` has a Playwright + Argos visual suite for disconnected app
+shells. Create `apps/app.mento.org/.env` from `.env.example` before running it.
+The required visual-run variables are:
+
+- `NEXT_PUBLIC_STORAGE_URL`
+- `NEXT_PUBLIC_WALLET_CONNECT_ID`
+- `NEXT_PUBLIC_SENTRY_DSN_SWAP`
+- `SENTRY_AUTH_TOKEN`
+
+For local screenshot renders, the Sentry DSN and auth token may be empty
+strings.
+
+```bash
+# From the repository root:
+pnpm exec turbo run build --filter app.mento.org
+pnpm --filter app.mento.org test:visual
+```
+
+Diffs are reviewed and baselines are promoted in the Argos dashboard.
+
+The CI workflow runs this suite only when files that can affect the app shells
+change, such as `apps/app.mento.org/**`, `packages/ui/**`, `packages/web3/**`,
+root package manager files, `.npmrc`, `turbo.json`,
+`scripts/security-headers.mjs`, or `.github/workflows/visual.yml`.
+
 ## Learn More
 
 To learn more about Next.js, take a look at the following resources:

--- a/apps/ui.mento.org/README.md
+++ b/apps/ui.mento.org/README.md
@@ -1,6 +1,7 @@
 # ui.mento.org
 
-Component library showcase for `@repo/ui`, and the host app for Argos visual regression testing (VRT) screenshots.
+Component library showcase for `@repo/ui`, and the host app for `@repo/ui`
+Argos visual regression testing (VRT) screenshots.
 
 ## Getting Started
 
@@ -39,6 +40,10 @@ pnpm --filter ui.mento.org test:visual
 ```
 
 Diffs are reviewed and baselines are promoted in the Argos dashboard.
+
+The CI workflow runs this suite only when files that can affect the showcase
+change, such as `apps/ui.mento.org/**`, `packages/ui/**`, root package manager
+files, or `.github/workflows/visual.yml`.
 
 ## Learn More
 

--- a/knip.json
+++ b/knip.json
@@ -4,11 +4,13 @@
   "ignoreWorkspaces": ["packages/typescript-config"],
   "ignore": [
     ".trunk/**",
-    "apps/governance.mento.org/app/graphql/**/generated/**",
     "commitlint.config.mjs",
     "scripts/security-headers.d.mts"
   ],
   "workspaces": {
+    ".": {
+      "ignoreDependencies": ["zod"]
+    },
     "apps/*": {
       "project": "app/**/*.{mjs,tsx,ts}"
     },

--- a/package.json
+++ b/package.json
@@ -39,8 +39,7 @@
     "prettier-plugin-tailwindcss": "^0.8.0",
     "turbo": "^2.10.0",
     "typescript": "catalog:",
-    "typescript-eslint": "catalog:",
-    "zod": "catalog:"
+    "typescript-eslint": "catalog:"
   },
   "packageManager": "pnpm@10.24.0",
   "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -197,9 +197,6 @@ importers:
       typescript-eslint:
         specifier: 'catalog:'
         version: 8.53.1(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3)
-      zod:
-        specifier: ^4.4.3
-        version: 4.4.3
 
   apps/app.mento.org:
     dependencies:


### PR DESCRIPTION
## Description

- Adds a Visual Regression Plan job that detects which Argos suites can be affected by changed files.
- Splits the old always-on matrix into explicit `ui.mento.org` and `app.mento.org` jobs gated by that plan, so reserve-only changes skip current Argos uploads.
- Aligns the Playwright Docker image with `@playwright/test` 1.61.1 and updates VRT docs.

## Other changes

- Adds a planner-failure guard so app-specific visual checks fail if planning fails instead of silently passing as skipped.

## Testing

- `actionlint .github/workflows/visual.yml`
- `pnpm exec prettier --check .github/workflows/visual.yml CLAUDE.md apps/app.mento.org/README.md apps/ui.mento.org/README.md knip.json package.json`
- `git diff --check`
- `trunk check .gitignore .github/workflows/visual.yml CLAUDE.md apps/app.mento.org/README.md knip.json package.json`
- planner shell smoke test: reserve-only skipped both jobs; app-only ran app; ui-only ran ui; shared UI/workflow/lockfile ran both; `.npmrc` and `scripts/security-headers.mjs` ran both
- `pnpm exec turbo run test:visual --filter=ui.mento.org --dry-run=json | jq -r .tasks[].taskId`
- `pnpm exec turbo run test:visual --filter=app.mento.org --dry-run=json | jq -r .tasks[].taskId`
- `~/.agents/skills/autoreview/scripts/autoreview --engine local --mode local`
- fresh-context semantic autoreview pass: accepted one planner-failure skipped-job finding, fixed it, reran review clean
- `pnpm knip --no-progress`
- `env CI=true pnpm knip`
- `pnpm install --frozen-lockfile --lockfile-only`
- `pnpm supply-chain:lockfile-lint`
- `pnpm supply-chain:version-skew`
- `trunk check package.json`
- `trunk check knip.json`
- normal pre-push hook passed on `37fd730`

## Checklist before requesting a review

- [x] PR title follows the conventions
- [x] Performed a self-review of my own code changes
- [ ] Smoke Test Run/s passed on the CI

## Ship Checklist

- [x] ship skill used
- [x] local review run
- [x] validation run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI gating for visual regression—incorrect path rules could skip needed Argos runs or waste quota—but planner-failure guards reduce silent false greens; no production app runtime impact.
> 
> **Overview**
> Replaces the always-on two-app matrix in **`.github/workflows/visual.yml`** with a **`visual-plan`** job that diffs changed files against the PR/base commit and sets whether **`ui.mento.org`** and **`app.mento.org`** Argos suites should run. Separate **`visual-ui`** and **`visual-app`** jobs only execute when their flag is true (e.g. reserve-only changes skip both), and each job **fails if planning did not succeed** instead of appearing as a benign skip.
> 
> The pinned Playwright Docker image moves from **v1.61.0** to **v1.61.1** to match **`@playwright/test`**. **CLAUDE.md** and app READMEs document the gating rules and local **`test:visual`** commands for both apps. Minor housekeeping: ignore **`.claude/worktrees/`**, drop unused root **`zod`** from **`package.json`** / lockfile, and adjust **`knip.json`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37fd7305d03d2c8629cff82da8ad151132f53b9c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

