### PR TITLE
test(app.mento.org): connected-wallet Playwright fixtures + swap E2E spec

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,9 +77,11 @@ Two layers guard against unintended UI changes:
 
   An intended UI change shows as a diff in the Argos dashboard — approve it there to promote the baseline. Requires the `ARGOS_TOKEN` secret + the Argos GitHub App. `ui.mento.org` needs `NEXT_PUBLIC_STORAGE_URL` (CI uses `vars.STORAGE_URL`; locally use `apps/ui.mento.org/.env.local`). `app.mento.org` needs the env vars from `apps/app.mento.org/.env.example`; for local screenshot renders, `NEXT_PUBLIC_SENTRY_DSN_SWAP` and `SENTRY_AUTH_TOKEN` may be empty strings.
 
-  A third layer, `pnpm --filter app.mento.org test:connected`, runs a connected-wallet swap E2E against a seeded local anvil `--celo` fork (see #445 for the full runbook).
-
   If CI shows all Playwright visual tests passing and then Argos fails with HTTP 402 / Free Plan screenshot capacity, classify it as Argos account quota rather than a visual regression. Report the pass counts and do not disable VRT or change baselines for that failure.
+
+## Connected-Wallet E2E (app.mento.org)
+
+A functional connected-wallet swap E2E (not VRT) that runs against a seeded local anvil `--celo` fork. Prerequisites, in order: `pnpm fork:mainnet` (anvil fork), `pnpm fork:seed` (seed balances/oracles), and `pnpm exec turbo run build --filter app.mento.org` before the first run — the suite starts `next start` via Playwright's webServer. Then run `pnpm --filter app.mento.org test:connected`. See #445 for the full runbook.
 
 ## Coding Conventions
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,8 @@ Two layers guard against unintended UI changes:
 
   An intended UI change shows as a diff in the Argos dashboard — approve it there to promote the baseline. Requires the `ARGOS_TOKEN` secret + the Argos GitHub App. `ui.mento.org` needs `NEXT_PUBLIC_STORAGE_URL` (CI uses `vars.STORAGE_URL`; locally use `apps/ui.mento.org/.env.local`). `app.mento.org` needs the env vars from `apps/app.mento.org/.env.example`; for local screenshot renders, `NEXT_PUBLIC_SENTRY_DSN_SWAP` and `SENTRY_AUTH_TOKEN` may be empty strings.
 
+  A third layer, `pnpm --filter app.mento.org test:connected`, runs a connected-wallet swap E2E against a seeded local anvil `--celo` fork (see #445 for the full runbook).
+
   If CI shows all Playwright visual tests passing and then Argos fails with HTTP 402 / Free Plan screenshot capacity, classify it as Argos account quota rather than a visual regression. Report the pass counts and do not disable VRT or change baselines for that failure.
 
 ## Coding Conventions

--- a/apps/app.mento.org/README.md
+++ b/apps/app.mento.org/README.md
@@ -58,6 +58,16 @@ change, such as `apps/app.mento.org/**`, `packages/ui/**`, `packages/web3/**`,
 root package manager files, `.npmrc`, `turbo.json`,
 `scripts/security-headers.mjs`, or `.github/workflows/visual.yml`.
 
+## Connected-Wallet E2E
+
+The same Playwright setup also hosts a functional connected-wallet swap E2E
+suite (not VRT) that runs against a seeded local anvil `--celo` fork. From the
+repository root, start `pnpm fork:mainnet`, run `pnpm fork:seed`, and build the
+app first (`pnpm exec turbo run build --filter app.mento.org` — the suite
+starts `next start`). Then run `pnpm --filter app.mento.org test:connected`.
+See [#445](https://github.com/mento-protocol/frontend-monorepo/issues/445) for
+the full runbook.
+
 ## Learn More
 
 To learn more about Next.js, take a look at the following resources:

--- a/apps/app.mento.org/e2e/connected/rpc.ts
+++ b/apps/app.mento.org/e2e/connected/rpc.ts
@@ -1,0 +1,29 @@
+const RPC_URL = "http://127.0.0.1:8545";
+
+export async function rpc<T>(
+  method: string,
+  params: unknown[] = [],
+): Promise<T> {
+  const response = await fetch(RPC_URL, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params }),
+  });
+  const json = (await response.json()) as {
+    result?: T;
+    error?: { message: string };
+  };
+  if (json.error) throw new Error(`${method} failed: ${json.error.message}`);
+  return json.result as T;
+}
+
+export const snapshot = () => rpc<string>("evm_snapshot");
+export const revert = (id: string) => rpc<boolean>("evm_revert", [id]);
+
+export async function erc20BalanceOf(
+  token: string,
+  holder: string,
+): Promise<bigint> {
+  const data = `0x70a08231${holder.slice(2).toLowerCase().padStart(64, "0")}`;
+  return BigInt(await rpc<string>("eth_call", [{ to: token, data }, "latest"]));
+}

--- a/apps/app.mento.org/e2e/connected/swap.spec.ts
+++ b/apps/app.mento.org/e2e/connected/swap.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from "@playwright/test";
 import { connectedTest as test } from "../fixtures";
-import { erc20BalanceOf, revert, snapshot } from "./rpc";
+import { erc20BalanceOf, revert, rpc, snapshot } from "./rpc";
 
 // Prerequisite: anvil must be running and seeded before this spec runs —
 //   pnpm fork:mainnet   (anvil --celo --auto-impersonate on 127.0.0.1:8545)
@@ -32,6 +32,18 @@ const ACCT0 = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266";
 const CUSD = "0x765DE816845861e75A25fCA122bb6898B8B1282a";
 
 let snapshotId: string | undefined;
+
+// Preflight: without anvil running, snapshot() in beforeEach dies with an
+// opaque "TypeError: fetch failed" — fail fast with an actionable message.
+test.beforeAll(async () => {
+  try {
+    await rpc<string>("eth_chainId");
+  } catch {
+    throw new Error(
+      "anvil fork not reachable at 127.0.0.1:8545 — start it with `pnpm fork:mainnet` and seed with `pnpm fork:seed` before running test:connected (see spec header comment)",
+    );
+  }
+});
 
 // anvil snapshots are CONSUMED by evm_revert — a fresh snapshot per test.
 test.beforeEach(async () => {

--- a/apps/app.mento.org/e2e/connected/swap.spec.ts
+++ b/apps/app.mento.org/e2e/connected/swap.spec.ts
@@ -1,0 +1,99 @@
+import { expect } from "@playwright/test";
+import { connectedTest as test } from "../fixtures";
+import { erc20BalanceOf, revert, snapshot } from "./rpc";
+
+// Prerequisite: anvil must be running and seeded before this spec runs —
+//   pnpm fork:mainnet   (anvil --celo --auto-impersonate on 127.0.0.1:8545)
+//   pnpm fork:seed
+// This spec does not start or seed anvil itself.
+//
+// Oracle-staleness caveat: Mento quotes depend on SortedOracles median
+// freshness. Right after `pnpm fork:seed` the medians are fresh; they go
+// stale on wall-clock time. If the submit button shows "Rate temporarily
+// unavailable" or a quote error, re-run `pnpm fork:seed` and re-run the suite.
+// Short spec runs immediately after seeding are fine.
+//
+// DEVIATION from the issue's literal "swap 1 CELO for cUSD": the swap form's
+// token selector is populated from getTokenOptionsByChainId(), which is
+// Object.keys(TOKEN_ADDRESSES_BY_CHAIN[chainId]) from the pinned
+// @mento-protocol/mento-sdk@3.3.0-beta.1 (packages/web3/src/config/tokens.ts).
+// That map has no "CELO" entry for Celo mainnet (verified by inspecting the
+// installed SDK at runtime) — the native token is not a selectable sell/buy
+// option anywhere the form validates tokenIn/tokenOut symbols, so `?from=CELO`
+// silently falls back to the default pair instead of erroring. This is a
+// pre-existing SDK/frontend limitation, out of scope for this issue (which may
+// not touch packages/web3 or bump the SDK) — flagged for the team, not fixed
+// here. Using EURm (cEUR) -> USDm (cUSD) instead: both are real
+// SDK-registered tokens, both are seeded by fork-seed.mjs, and the swap still
+// exercises the full approve -> confirm -> swap flow with a real on-chain
+// balance assertion, per the acceptance criteria's "cUSD balance ... increased
+// ON-CHAIN" check.
+const ACCT0 = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266";
+const CUSD = "0x765DE816845861e75A25fCA122bb6898B8B1282a";
+
+let snapshotId: string;
+
+// anvil snapshots are CONSUMED by evm_revert — a fresh snapshot per test.
+test.beforeEach(async () => {
+  snapshotId = await snapshot();
+});
+test.afterEach(async () => {
+  await revert(snapshotId);
+});
+
+test("swaps 1 EURm (cEUR) for USDm (cUSD)", async ({ page }) => {
+  const balanceBefore = await erc20BalanceOf(CUSD, ACCT0);
+
+  await page.goto("/swap/celo?from=EURm&to=USDm", {
+    waitUntil: "domcontentloaded",
+  });
+
+  // Eager-connect happens via the fixture's init-script localStorage keys.
+  // The header renders both a mobile (`md:hidden`) and a desktop
+  // (`md:block hidden`) ConnectButton simultaneously — filter to the one
+  // actually visible at this project's viewport instead of `.first()`,
+  // which would resolve to the DOM-first (mobile, hidden here) copy.
+  await expect(
+    page.getByText("0xf39F...2266").filter({ visible: true }),
+  ).toBeVisible({
+    timeout: 20_000,
+  });
+
+  await page.getByTestId("sellAmountInput").fill("1");
+
+  // Button is `approveButton` when the Broker needs a EURm allowance, else
+  // `swapButton`.
+  const submit = page.getByTestId(/^(approveButton|swapButton)$/);
+  await expect(submit).toBeEnabled({ timeout: 30_000 });
+  if ((await submit.getAttribute("data-testid")) === "approveButton") {
+    await submit.click();
+    await expect(page.getByText("Approve Successful")).toBeVisible({
+      timeout: 60_000,
+    });
+    // Approval success auto-opens the confirm view
+    // (setConfirmView(true) in use-swap-form.tsx) — do not click swapButton
+    // again on the form; it's already gone.
+  } else {
+    await page.getByTestId("swapButton").click();
+  }
+  await expect(page.getByText("Confirm Swap")).toBeVisible({
+    timeout: 30_000,
+  });
+  // swap-page-content.tsx deliberately keeps SwapForm mounted (toggling only
+  // `hidden` via CSS) to avoid a DOM removeChild crash on route transitions,
+  // so the form's own (CSS-hidden) swapButton still matches this testid
+  // alongside the confirm view's — filter to the visible one.
+  const confirmSwapButton = page
+    .getByTestId("swapButton")
+    .filter({ visible: true });
+  await expect(confirmSwapButton).toBeEnabled({
+    timeout: 30_000,
+  });
+  await confirmSwapButton.click();
+  await expect(page.getByText("Swap Successful")).toBeVisible({
+    timeout: 60_000,
+  });
+
+  const balanceAfter = await erc20BalanceOf(CUSD, ACCT0);
+  expect(balanceAfter > balanceBefore).toBe(true);
+});

--- a/apps/app.mento.org/e2e/connected/swap.spec.ts
+++ b/apps/app.mento.org/e2e/connected/swap.spec.ts
@@ -38,7 +38,10 @@ test.beforeEach(async () => {
   snapshotId = await snapshot();
 });
 test.afterEach(async () => {
-  await revert(snapshotId);
+  // Guard against beforeEach failing before assignment (e.g. anvil not
+  // running) — reverting an unset snapshotId would throw a second, masking
+  // error on top of the real root cause.
+  if (snapshotId) await revert(snapshotId);
 });
 
 test("swaps 1 EURm (cEUR) for USDm (cUSD)", async ({ page }) => {

--- a/apps/app.mento.org/e2e/connected/swap.spec.ts
+++ b/apps/app.mento.org/e2e/connected/swap.spec.ts
@@ -31,7 +31,7 @@ import { erc20BalanceOf, revert, snapshot } from "./rpc";
 const ACCT0 = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266";
 const CUSD = "0x765DE816845861e75A25fCA122bb6898B8B1282a";
 
-let snapshotId: string;
+let snapshotId: string | undefined;
 
 // anvil snapshots are CONSUMED by evm_revert — a fresh snapshot per test.
 test.beforeEach(async () => {
@@ -41,7 +41,14 @@ test.afterEach(async () => {
   // Guard against beforeEach failing before assignment (e.g. anvil not
   // running) — reverting an unset snapshotId would throw a second, masking
   // error on top of the real root cause.
-  if (snapshotId) await revert(snapshotId);
+  if (snapshotId === undefined) return;
+  // Clear before awaiting so a later test never reverts this stale,
+  // already-consumed id.
+  const id = snapshotId;
+  snapshotId = undefined;
+  // anvil returns false (not an error) for an unknown/consumed snapshot id,
+  // so assert the result — a silent no-op here would break fork isolation.
+  expect(await revert(id)).toBe(true);
 });
 
 test("swaps 1 EURm (cEUR) for USDm (cUSD)", async ({ page }) => {
@@ -69,6 +76,10 @@ test("swaps 1 EURm (cEUR) for USDm (cUSD)", async ({ page }) => {
   const submit = page.getByTestId(/^(approveButton|swapButton)$/);
   await expect(submit).toBeEnabled({ timeout: 30_000 });
   if ((await submit.getAttribute("data-testid")) === "approveButton") {
+    test.info().annotations.push({
+      type: "flow",
+      description: "approve-then-swap",
+    });
     await submit.click();
     await expect(page.getByText("Approve Successful")).toBeVisible({
       timeout: 60_000,
@@ -77,7 +88,8 @@ test("swaps 1 EURm (cEUR) for USDm (cUSD)", async ({ page }) => {
     // (setConfirmView(true) in use-swap-form.tsx) — do not click swapButton
     // again on the form; it's already gone.
   } else {
-    await page.getByTestId("swapButton").click();
+    test.info().annotations.push({ type: "flow", description: "direct-swap" });
+    await submit.click();
   }
   await expect(page.getByText("Confirm Swap")).toBeVisible({
     timeout: 30_000,

--- a/apps/app.mento.org/e2e/fixtures.ts
+++ b/apps/app.mento.org/e2e/fixtures.ts
@@ -51,6 +51,73 @@ async function blockNetwork(page: Page): Promise<void> {
   });
 }
 
+// Connected-wallet specs need real backend behavior (RPC calls, tx-receipt
+// polling, react-query retries) so they can't freeze time or block localhost.
+// Modeled on blockNetwork above (same CDN-placeholder + localhost passthrough
+// logic), with one addition: fulfill /api/sanctions with the route's clean-check
+// success shape (see app/api/sanctions/route.ts + app/hooks/use-sanctions-check.ts)
+// so the sanctions gate doesn't fail closed without a CHAINALYSIS_API_KEY.
+async function connectedNetworkPolicy(page: Page): Promise<void> {
+  const isCdnHost = (h: string): boolean =>
+    h.endsWith(".public.blob.vercel-storage.com");
+  const placeholder = () =>
+    ({ status: 200, contentType: "image/png", body: PLACEHOLDER_PNG }) as const;
+
+  await page.route("**/*", (route) => {
+    const url = new URL(route.request().url());
+    const { hostname, pathname } = url;
+    if (hostname === "localhost" || hostname === "127.0.0.1") {
+      // Fulfill the sanctions check before the generic /api/* abort below —
+      // Playwright uses the most recently registered matching handler, so this
+      // branch must run first, not as a second competing page.route() call.
+      if (pathname.startsWith("/api/sanctions")) {
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ isSanctioned: false }),
+        });
+      }
+      if (pathname.startsWith("/api/")) {
+        return route.abort();
+      }
+      if (pathname === "/_next/image") {
+        const target = url.searchParams.get("url") ?? "";
+        const targetHost = URL.canParse(target) ? new URL(target).hostname : "";
+        if (isCdnHost(targetHost)) {
+          return route.fulfill(placeholder());
+        }
+      }
+      // Anvil's RPC (127.0.0.1:8545, path "/") and the mock connector's
+      // forwarded eth_sendTransaction calls pass through here unaffected.
+      return route.continue();
+    }
+    if (isCdnHost(hostname)) {
+      return route.fulfill(placeholder());
+    }
+    return route.abort();
+  });
+}
+
+export const connectedTest = base.extend<{ page: Page }>({
+  // Playwright's fixture-provider callback's 2nd param is conventionally named
+  // `use`, but that collides with React's built-in `use` hook and trips
+  // eslint-plugin-react-hooks's rules-of-hooks on this non-component
+  // function — renamed to `runTest` to avoid the false positive.
+  page: async ({ page }, runTest) => {
+    await connectedNetworkPolicy(page);
+    await page.addInitScript(() => {
+      try {
+        window.localStorage.setItem("mento_e2e_wallet", "true");
+        window.localStorage.setItem("mento_e2e_eager_connect", "true");
+        window.localStorage.setItem("mento_use_fork", "true");
+      } catch {
+        /* localStorage may be unavailable before navigation */
+      }
+    });
+    await runTest(page);
+  },
+});
+
 async function arm(page: Page, theme: Theme): Promise<void> {
   await blockNetwork(page);
   await page.clock.setFixedTime(FROZEN_TIME);

--- a/apps/app.mento.org/e2e/fixtures.ts
+++ b/apps/app.mento.org/e2e/fixtures.ts
@@ -10,18 +10,18 @@ const PLACEHOLDER_PNG = Buffer.from(
   "base64",
 );
 
+// Leading dot so only real subdomains of the storage host match
+// (`x.public.blob.vercel-storage.com`), not `evilpublic.blob...`.
+const isCdnHost = (h: string): boolean =>
+  h.endsWith(".public.blob.vercel-storage.com");
+const placeholder = () =>
+  ({ status: 200, contentType: "image/png", body: PLACEHOLDER_PNG }) as const;
+
 // The whole point of the disconnected-shell approach: no wallet, no live data.
 // Block every external request so a logic-only PR can't flake on RPC / subgraph
 // / Merkl / Sentry / analytics / WalletConnect. Same-origin assets pass through;
 // the storage CDN returns a fixed placeholder.
 async function blockNetwork(page: Page): Promise<void> {
-  // Leading dot so only real subdomains of the storage host match
-  // (`x.public.blob.vercel-storage.com`), not `evilpublic.blob...`.
-  const isCdnHost = (h: string): boolean =>
-    h.endsWith(".public.blob.vercel-storage.com");
-  const placeholder = () =>
-    ({ status: 200, contentType: "image/png", body: PLACEHOLDER_PNG }) as const;
-
   await page.route("**/*", (route) => {
     const url = new URL(route.request().url());
     const { hostname, pathname } = url;
@@ -58,11 +58,6 @@ async function blockNetwork(page: Page): Promise<void> {
 // success shape (see app/api/sanctions/route.ts + app/hooks/use-sanctions-check.ts)
 // so the sanctions gate doesn't fail closed without a CHAINALYSIS_API_KEY.
 async function connectedNetworkPolicy(page: Page): Promise<void> {
-  const isCdnHost = (h: string): boolean =>
-    h.endsWith(".public.blob.vercel-storage.com");
-  const placeholder = () =>
-    ({ status: 200, contentType: "image/png", body: PLACEHOLDER_PNG }) as const;
-
   await page.route("**/*", (route) => {
     const url = new URL(route.request().url());
     const { hostname, pathname } = url;

--- a/apps/app.mento.org/package.json
+++ b/apps/app.mento.org/package.json
@@ -10,7 +10,8 @@
     "lint": "npx @trunkio/launcher check .",
     "start": "next start",
     "test": "vitest run",
-    "test:visual": "playwright test",
+    "test:connected": "playwright test --project=connected --workers=1",
+    "test:visual": "playwright test --project=desktop --project=mobile",
     "test:watch": "vitest"
   },
   "dependencies": {

--- a/apps/app.mento.org/playwright.config.ts
+++ b/apps/app.mento.org/playwright.config.ts
@@ -39,6 +39,14 @@ export default defineConfig({
       use: { viewport: { width: 375, height: 812 } },
     },
     {
+      // INVARIANT: all connected specs share ONE anvil fork and isolate via
+      // consumed evm_snapshot/evm_revert ids, so they must never run in
+      // parallel. `fullyParallel: false` only serializes tests WITHIN a spec
+      // file, not across spec files, and Playwright has no per-project
+      // `workers` option — the `--workers=1` flag in the `test:connected`
+      // npm script is load-bearing. Always run this project via
+      // `pnpm --filter app.mento.org test:connected`, never via a bare
+      // `playwright test --project=connected`.
       name: "connected",
       testMatch: /connected\/.*\.spec\.ts/,
       fullyParallel: false,

--- a/apps/app.mento.org/playwright.config.ts
+++ b/apps/app.mento.org/playwright.config.ts
@@ -28,8 +28,23 @@ export default defineConfig({
   reporter,
   use: { baseURL: `http://localhost:${PORT}`, deviceScaleFactor: 1 },
   projects: [
-    { name: "desktop", use: { viewport: { width: 1280, height: 900 } } },
-    { name: "mobile", use: { viewport: { width: 375, height: 812 } } },
+    {
+      name: "desktop",
+      testIgnore: /connected\//,
+      use: { viewport: { width: 1280, height: 900 } },
+    },
+    {
+      name: "mobile",
+      testIgnore: /connected\//,
+      use: { viewport: { width: 375, height: 812 } },
+    },
+    {
+      name: "connected",
+      testMatch: /connected\/.*\.spec\.ts/,
+      fullyParallel: false,
+      timeout: 120_000,
+      use: { viewport: { width: 1280, height: 900 } },
+    },
   ],
   webServer: {
     command: `next start -p ${PORT}`,


### PR DESCRIPTION
# Description

Implements #446 (Part of #441): the first functional connected-wallet Playwright E2E for app.mento.org. A `connected` Playwright project drives a real approve → confirm → swap through the UI against a seeded local anvil `--celo` fork of Celo mainnet, using the #443 E2E mock wallet and #442 fork/seed scripts, and asserts the cUSD balance increase ON-CHAIN — not just success UI.

- **`connectedTest` fixture** (`e2e/fixtures.ts`): fulfills same-origin `/api/sanctions**` with the route's clean-check success shape — HTTP 200, `application/json`, body `{"isSanctioned": false}` (literal boolean, derived from `app/api/sanctions/route.ts` + `use-sanctions-check.ts`) — handled as a branch inside the single `page.route` handler before the generic `/api/*` abort. Keeps CDN placeholders and external-host aborts; no frozen clock, no `Math.random` seed (tx-receipt polling + react-query retries need real timers). Init script sets `mento_e2e_wallet` / `mento_e2e_eager_connect` / `mento_use_fork`. Existing exports (`snapshotPage`, `test`, `Theme`) and visual-fixture behavior unchanged.
- **`e2e/connected/rpc.ts`**: zero-dep fetch-based JSON-RPC helper (`evm_snapshot` / `evm_revert` / `eth_call` `balanceOf`).
- **`e2e/connected/swap.spec.ts`**: fresh snapshot per test, revert asserted (anvil returns `false` for consumed ids), anvil preflight with an actionable error, approve-flow handling per the issue (approval success auto-opens Confirm Swap via `setConfirmView(true)` — no double swapButton click).
- **`playwright.config.ts` / `package.json`**: new serialized `connected` project; `desktop`/`mobile` get `testIgnore: /connected\//`; `test:visual` is now `playwright test --project=desktop --project=mobile` (keeps `.github/workflows/visual.yml` from picking up the connected spec with no anvil); `test:connected` = `playwright test --project=connected --workers=1`.

**⚠️ Deviation needing owner sign-off — swap pair is EURm→USDm, not CELO→cUSD.** The form's token options come from `getTokenOptionsByChainId()` = `Object.keys(TOKEN_ADDRESSES_BY_CHAIN[42220])` in the pinned `@mento-protocol/mento-sdk@3.3.0-beta.1`, which has **no CELO entry** for Celo mainnet (verified at runtime against the installed SDK). Native CELO simply cannot be selected in the swap form today, so `?from=CELO` silently falls back to the default pair. Documented in the spec header; pre-existing SDK/frontend limitation, out of scope here (issue forbids touching `packages/web3` or bumping deps). The spec still exercises the full approve → confirm → swap path with the acceptance criteria's on-chain cUSD balance assertion.

## Other changes

- Docs: CLAUDE.md got a small "Connected-Wallet E2E" section (the issue asked for one line; review flagged that the one-liner contradicted the "Two layers" VRT framing, so it moved to its own 2-sentence section — happy to trim) and `apps/app.mento.org/README.md` gained the equivalent mention (docs-drift rule). #445 owns the full runbook.
- Review-pass hardening commits: snapshot/revert hygiene, `--workers=1` INVARIANT comment on the `connected` project, hoisted shared CDN helpers in `fixtures.ts`.

## Testing

All local, against `pnpm fork:mainnet` + `pnpm fork:seed` (fork of Celo mainnet at block ~71741586):

- `pnpm --filter app.mento.org test:connected` → **1 passed (~10s)** — run twice back-to-back to prove evm_snapshot/evm_revert idempotence (both green).
- On-chain evidence from a passing run: approve tx `0x2f11992ec9d591fc5489aac8c2f36430723a499b054ea8ab630bc63a7c2a510b` (gas 51,758) then swapIn tx `0xc7defe3d6287186bc3df029e6101cbd602b08058ee4aa3dc4c82caa1be737d8a` (gas 300,130) at blocks 71738151/71738152; acct0 cUSD `balanceOf` rose from the seeded 1000e18 and was restored to exactly 1000e18 after `evm_revert`.
- Oracle staleness: did **not** bite when the spec ran within the seed's 360s min-expiry window; runs started >6 min after seeding fail with quote errors as expected — hence "re-seed immediately before running" is documented in the spec header. No new evidence implicating #452 beyond the known 360s legacy-feed window.
- `pnpm --filter app.mento.org test:visual` against a flag-less build → **20 passed** (Argos upload skipped locally without `ARGOS_TOKEN`, as expected).
- `pnpm --filter app.mento.org exec playwright test --list` → connected spec ONLY under `connected`; visual specs ONLY under `desktop`/`mobile` (21 total).
- `tsc --noEmit` (app.mento.org), `pnpm check-types`, `trunk check`, and the pre-push gate (trunk check --all + check-types + knip) all green.

## Checklist before requesting a review

- [x] PR title follows the [conventions](https://www.notion.so/Git-Branching-and-Commit-Message-Conventions-18f66f7d06444cfcbac5725ffbc7c04a?pvs=4#9355048863c549ef92fe210a8a1298aa)
- [x] Performed a self-review of my own code changes
- [x] Smoke Test Run/s passed on the CI

## Ship Checklist

- [x] ship skill used
- [x] local review run (parallel specialist review + codex; 6 findings auto-fixed, deferrals below)
- [x] validation run (connected x2, visual x20, types, trunk, knip)

**Deferred (non-blocking, from review):** `rpc.ts` lacks `response.ok`/`AbortSignal.timeout` hardening; buy-side-only balance assertion (no exact EURm debit check); connected CI wiring is #447 by design (no turbo `test:connected` task on purpose — the build must be flag-baked manually, an automatic `dependsOn: build` would build without `NEXT_PUBLIC_E2E_TEST`/`NEXT_PUBLIC_USE_FORK` and silently test the wrong bundle).

Part of #441. Implements #446.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LPQQFxntvMvndepgAtedEK

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to E2E fixtures, Playwright config, npm scripts, and documentation; production app code and CI visual workflows are unchanged aside from excluding connected specs from VRT.
> 
> **Overview**
> Adds the first **functional connected-wallet** Playwright suite for `app.mento.org`: a serialized `connected` project runs against a seeded local anvil Celo fork while visual VRT stays on `desktop`/`mobile` only.
> 
> A new **`connectedTest` fixture** applies a lighter network policy than disconnected VRT (localhost RPC passthrough, mocked clean `/api/sanctions`, CDN placeholders) and seeds localStorage for the mock wallet and fork mode. **`e2e/connected/rpc.ts`** provides fetch-based JSON-RPC helpers for `evm_snapshot` / `evm_revert` and on-chain `balanceOf` checks.
> 
> **`swap.spec.ts`** drives approve → confirm → swap in the UI and asserts cUSD increased on-chain, with per-test fork isolation via snapshot/revert. The pair is **EURm → USDm** (not CELO → cUSD) because the pinned SDK token map has no selectable native CELO on mainnet—documented in the spec.
> 
> **`test:connected`** runs `playwright test --project=connected --workers=1`; **`test:visual`** is scoped to desktop/mobile so CI VRT does not require anvil. Docs in `CLAUDE.md` and the app README describe prerequisites (`fork:mainnet`, `fork:seed`, build, then `test:connected`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30be5e7d31461a885abb970ee0dbb6ef1c906571. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
