### PR TITLE
test(governance): playwright bootstrap + connected lock-MENTO spec

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,9 +89,14 @@ To test connected-wallet flows (swaps, approvals, locking) locally without a rea
 
 Full runbook — localStorage activation, on-chain verification with `cast`, snapshot/revert discipline, safety rules, troubleshooting: [docs/wallet-testing.md](docs/wallet-testing.md)
 
-## Connected-Wallet E2E (app.mento.org)
+## Connected-Wallet E2E
 
-A functional connected-wallet swap E2E (not VRT) that runs against a seeded local anvil `--celo` fork. Prerequisites, in order: `pnpm fork:mainnet` (anvil fork), `pnpm fork:seed` (seed balances/oracles), and `pnpm exec turbo run build --filter app.mento.org` before the first run — the suite starts `next start` via Playwright's webServer. Then run `pnpm --filter app.mento.org test:connected`. See [docs/wallet-testing.md](docs/wallet-testing.md) for the full runbook.
+Functional connected-wallet Playwright specs (not VRT) that run against a seeded local anvil `--celo` fork. Prerequisites, in order: `pnpm fork:mainnet` (anvil fork), `pnpm fork:seed` (seed balances/oracles).
+
+- **app.mento.org** — a swap E2E. Build with `pnpm exec turbo run build --filter app.mento.org` before the first run — the suite starts `next start` via Playwright's webServer. Then run `pnpm --filter app.mento.org test:connected`.
+- **governance.mento.org** — a create-lock E2E (approve MENTO → lock, two-step, single click). Build with `NEXT_PUBLIC_E2E_TEST=true NEXT_PUBLIC_USE_FORK=true pnpm exec turbo run build --filter governance.mento.org` (copy `apps/governance.mento.org/.env.example` to `.env.local` first — values don't need to be real, but URL-typed vars must be syntactically valid). Then run `pnpm --filter governance.mento.org test:connected`. No vote-casting spec yet (needs an active proposal + subgraph/snapshot orchestration; tracked as future work in #441). Lock/proposal LISTS render from a live subgraph, not the fork, so assertions are on-chain (via the rpc helper) and toast-only, never via the lock list.
+
+See [docs/wallet-testing.md](docs/wallet-testing.md) for the full runbook.
 
 ## Coding Conventions
 

--- a/apps/governance.mento.org/.gitignore
+++ b/apps/governance.mento.org/.gitignore
@@ -13,6 +13,11 @@
 # testing
 /coverage
 
+# playwright (baselines are not applicable here — no visual coverage, see #448)
+/test-results/
+/playwright-report/
+/playwright/.cache/
+
 # next.js
 /.next/
 /out/

--- a/apps/governance.mento.org/e2e/connected/lock.spec.ts
+++ b/apps/governance.mento.org/e2e/connected/lock.spec.ts
@@ -1,0 +1,174 @@
+// Prerequisites (local runbook — see #448 / #441 for the full epic):
+//
+//   # Terminal 1 — anvil fork of Celo mainnet (from #442; runs
+//   # anvil --celo --auto-impersonate on port 8545)
+//   pnpm fork:mainnet
+//
+//   # Terminal 2 — fund anvil accounts 0-2 (CELO + 1,000 MENTO etc.) and
+//   # refresh oracle reports
+//   pnpm fork:seed
+//
+//   # Build the app with the E2E + fork flags inlined (also builds the
+//   # @repo/web3 dependency — note: the governance `dev` script does NOT
+//   # watch @repo/web3, but that is irrelevant here because Playwright's
+//   # webServer runs `next start` against this full turbo build)
+//   NEXT_PUBLIC_E2E_TEST=true NEXT_PUBLIC_USE_FORK=true pnpm exec turbo run build --filter governance.mento.org
+//
+//   # Run the spec
+//   pnpm --filter governance.mento.org test:connected
+//
+// Mixed-state caveat (REQUIRED reading before touching this file): on an
+// anvil fork, the governance app runs in a mixed-state world — everything
+// read through wagmi (useReadContract/useReadContracts -> RPC at
+// http://localhost:8545) reflects the FORK, but everything read through
+// Apollo/the-graph (the proposals list, and the lock cards -
+// useGetLocksQuery in app/contracts/locking/use-locks-by-account.ts)
+// reflects LIVE Celo mainnet, or renders empty because the network policy
+// below blocks the subgraph host. A lock created on the fork will therefore
+// NEVER appear in the lock-card list, and that is not a bug. Assert success
+// ONLY via toasts and on-chain reads (the rpc helper) — never via the lock
+// list UI.
+import { expect, test, type Page } from "@playwright/test";
+import { erc20BalanceOf, mineBlocks, revert, rpc, snapshot } from "./rpc";
+
+const MENTO = "0x7FF62f59e3e89EA34163EA1458EEBCc81177Cfb6";
+const LOCKING = "0x001Bb66636dCd149A1A2bA8C50E408BdDd80279C";
+const ACCT0 = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266";
+const ONE_MENTO = 10n ** 18n;
+
+// Adapted from apps/app.mento.org/e2e/fixtures.ts's connectedNetworkPolicy
+// (#446). Governance has NO sanctions guard and no /api/sanctions route
+// (verified — its only API routes are app/api/contract and
+// app/api/sentry-example-api), so unlike app.mento.org there is nothing to
+// fulfill; same-origin passthrough + external-host block + CDN placeholder
+// are otherwise identical.
+async function connectedNetworkPolicy(page: Page): Promise<void> {
+  const PLACEHOLDER_PNG = Buffer.from(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==",
+    "base64",
+  );
+  const isCdnHost = (h: string): boolean =>
+    h.endsWith(".public.blob.vercel-storage.com");
+
+  await page.route("**/*", (route) => {
+    const url = new URL(route.request().url());
+    const { hostname, pathname } = url;
+    if (hostname === "localhost" || hostname === "127.0.0.1") {
+      if (pathname.startsWith("/api/")) {
+        return route.abort();
+      }
+      if (pathname === "/_next/image") {
+        const target = url.searchParams.get("url") ?? "";
+        const targetHost = URL.canParse(target) ? new URL(target).hostname : "";
+        if (isCdnHost(targetHost)) {
+          return route.fulfill({
+            status: 200,
+            contentType: "image/png",
+            body: PLACEHOLDER_PNG,
+          });
+        }
+      }
+      // Anvil's RPC (127.0.0.1:8545, path "/") and the mock connector's
+      // forwarded eth_sendTransaction calls pass through here unaffected.
+      return route.continue();
+    }
+    if (isCdnHost(hostname)) {
+      return route.fulfill({
+        status: 200,
+        contentType: "image/png",
+        body: PLACEHOLDER_PNG,
+      });
+    }
+    // Kills subgraph, Sentry, analytics — see the mixed-state caveat above.
+    return route.abort();
+  });
+}
+
+// Preflight: without anvil running, snapshot() in beforeEach dies with an
+// opaque "TypeError: fetch failed" — fail fast with an actionable message.
+test.beforeAll(async () => {
+  try {
+    await rpc<string>("eth_chainId");
+  } catch {
+    throw new Error(
+      "anvil fork not reachable at 127.0.0.1:8545 — start it with `pnpm fork:mainnet` and seed with `pnpm fork:seed` before running test:connected (see spec header comment)",
+    );
+  }
+});
+
+let snapshotId: string | undefined;
+
+test.beforeEach(async ({ page }) => {
+  await connectedNetworkPolicy(page);
+  await page.addInitScript(() => {
+    try {
+      window.localStorage.setItem("mento_e2e_wallet", "true");
+      window.localStorage.setItem("mento_e2e_eager_connect", "true");
+      window.localStorage.setItem("mento_use_fork", "true");
+    } catch {
+      /* localStorage may be unavailable before navigation */
+    }
+  });
+  // anvil snapshots are CONSUMED by evm_revert — a fresh snapshot per test.
+  snapshotId = await snapshot();
+});
+
+test.afterEach(async () => {
+  // Guard against beforeEach failing before assignment (e.g. anvil not
+  // running) — reverting an unset snapshotId would throw a second, masking
+  // error on top of the real root cause.
+  if (snapshotId === undefined) return;
+  const id = snapshotId;
+  snapshotId = undefined;
+  expect(await revert(id)).toBe(true);
+});
+
+test("creates a 1 MENTO lock and mints veMENTO", async ({ page }) => {
+  test.setTimeout(180_000);
+
+  const mentoBefore = await erc20BalanceOf(MENTO, ACCT0);
+  const veMentoBefore = await erc20BalanceOf(LOCKING, ACCT0);
+  expect(mentoBefore >= ONE_MENTO).toBe(true); // pnpm fork:seed must have run
+
+  await page.goto("/voting-power", { waitUntil: "domcontentloaded" });
+  await expect(page.getByText("0xf39F...2266")).toBeVisible({
+    timeout: 30_000,
+  }); // eager-connected via the init-script localStorage keys above
+
+  await page.getByTestId("lockAmountInput").fill("1");
+  // Set the unlock date via the Radix slider (keyboard): more robust than
+  // driving the datepickerButton calendar popover. "End" selects the max
+  // valid Wednesday (~2 years out).
+  await page.getByRole("slider").press("End");
+
+  await expect(page.getByTestId("approveMentoButton")).toBeEnabled({
+    timeout: 30_000,
+  });
+
+  // use-approve.ts waits 2 confirmations, use-lock-mento.ts waits 10 —
+  // anvil's default automine only mines a block when a transaction arrives,
+  // so mine empty blocks in the background while the flow is in progress or
+  // the UI would wait for confirmations forever.
+  const miner = setInterval(() => {
+    void rpc("evm_mine", []).catch(() => {});
+  }, 500);
+  try {
+    // A fresh account ALWAYS requires approval (create-lock-provider.tsx), so
+    // the submit button shows "Approve MENTO" / approveMentoButton, and ONE
+    // click drives the whole two-step flow: createLock() sends the ERC-20
+    // approve, waits for confirmation, then automatically sends the `lock`
+    // transaction.
+    await page.getByTestId("approveMentoButton").click();
+    await expect(page.getByText("MENTO locked successfully!")).toBeVisible({
+      timeout: 120_000,
+    });
+  } finally {
+    clearInterval(miner);
+  }
+  await mineBlocks(2); // settle any trailing receipt polls
+
+  const mentoAfter = await erc20BalanceOf(MENTO, ACCT0);
+  const veMentoAfter = await erc20BalanceOf(LOCKING, ACCT0);
+  expect(mentoBefore - mentoAfter).toBe(ONE_MENTO);
+  expect(veMentoAfter > veMentoBefore).toBe(true); // veMENTO minted (amount < 1e18 due to slope weighting)
+});

--- a/apps/governance.mento.org/e2e/connected/lock.spec.ts
+++ b/apps/governance.mento.org/e2e/connected/lock.spec.ts
@@ -124,7 +124,13 @@ test.afterEach(async () => {
 });
 
 test("creates a 1 MENTO lock and mints veMENTO", async ({ page }) => {
-  test.setTimeout(180_000);
+  // Headroom above the sum of this test's own explicit assertion timeouts
+  // (30_000 + 30_000 + 120_000 = 180_000) — that sum alone leaves zero slack
+  // for page.goto, the form interactions, and the trailing mineBlocks(2) +
+  // balance reads, so a merely-slow (not stuck) CI run could otherwise trip
+  // the outer test timeout before the real assertions get a chance to
+  // resolve or fail on their own.
+  test.setTimeout(240_000);
 
   const mentoBefore = await erc20BalanceOf(MENTO, ACCT0);
   const veMentoBefore = await erc20BalanceOf(LOCKING, ACCT0);

--- a/apps/governance.mento.org/e2e/connected/rpc.ts
+++ b/apps/governance.mento.org/e2e/connected/rpc.ts
@@ -1,0 +1,41 @@
+// Copied from apps/app.mento.org/e2e/connected/rpc.ts (#446) rather than
+// extracted into a shared package — see the rationale in issue #448: this is
+// ~50 lines of zero-dep code, and a new workspace package for it adds more
+// surface than it saves.
+const RPC_URL = "http://127.0.0.1:8545";
+
+export async function rpc<T>(
+  method: string,
+  params: unknown[] = [],
+): Promise<T> {
+  const response = await fetch(RPC_URL, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params }),
+  });
+  const json = (await response.json()) as {
+    result?: T;
+    error?: { message: string };
+  };
+  if (json.error) throw new Error(`${method} failed: ${json.error.message}`);
+  return json.result as T;
+}
+
+export const snapshot = () => rpc<string>("evm_snapshot");
+export const revert = (id: string) => rpc<boolean>("evm_revert", [id]);
+
+export async function erc20BalanceOf(
+  token: string,
+  holder: string,
+): Promise<bigint> {
+  const data = `0x70a08231${holder.slice(2).toLowerCase().padStart(64, "0")}`;
+  return BigInt(await rpc<string>("eth_call", [{ to: token, data }, "latest"]));
+}
+
+// NOT present in app.mento.org's copy — governance's write hooks wait for
+// MULTIPLE confirmations (use-approve.ts: 2, use-lock-mento.ts: 10), and
+// anvil's default automine only mines a block when a transaction arrives, so
+// the spec must mine empty blocks in the background while a tx is pending.
+export async function mineBlocks(count: number): Promise<void> {
+  for (let i = 0; i < count; i++) await rpc("evm_mine", []);
+}

--- a/apps/governance.mento.org/package.json
+++ b/apps/governance.mento.org/package.json
@@ -12,6 +12,7 @@
     "lint": "npx @trunkio/launcher check",
     "start": "next start",
     "test": "vitest run",
+    "test:connected": "playwright test --project=connected",
     "test:watch": "vitest"
   },
   "dependencies": {
@@ -52,6 +53,7 @@
     "@graphql-codegen/typescript-apollo-client-helpers": "^4.0.1",
     "@graphql-codegen/typescript-operations": "^6.0.4",
     "@graphql-codegen/typescript-react-apollo": "^4.4.2",
+    "@playwright/test": "1.61.1",
     "@repo/eslint-config": "workspace:*",
     "@repo/typescript-config": "workspace:*",
     "@repo/vitest-config": "workspace:*",

--- a/apps/governance.mento.org/playwright.config.ts
+++ b/apps/governance.mento.org/playwright.config.ts
@@ -1,0 +1,31 @@
+import { defineConfig } from "@playwright/test";
+
+const PORT = 3002;
+
+export default defineConfig({
+  testDir: "./e2e",
+  // INVARIANT: the connected spec shares ONE anvil fork and isolates via
+  // consumed evm_snapshot/evm_revert ids, so it must never run in parallel
+  // with itself or any future connected spec. Unlike app.mento.org (which has
+  // multiple projects and relies on a load-bearing `--workers=1` CLI flag in
+  // its npm script), governance has only this one project, so `workers: 1`
+  // here is sufficient on its own — always run via
+  // `pnpm --filter governance.mento.org test:connected`.
+  fullyParallel: false,
+  workers: 1,
+  forbidOnly: !!process.env.CI,
+  retries: 0,
+  reporter: [[process.env.CI ? "github" : "list"]],
+  use: { baseURL: `http://localhost:${PORT}` },
+  // A plain "connected/**" glob (as in the issue's initial sketch) also
+  // matches rpc.ts, which the spec imports — Playwright then rejects it as
+  // "should not import test file". Scope to *.spec.ts, matching
+  // app.mento.org's project pattern.
+  projects: [{ name: "connected", testMatch: /connected\/.*\.spec\.ts/ }],
+  webServer: {
+    command: `next start -p ${PORT}`,
+    url: `http://localhost:${PORT}`,
+    reuseExistingServer: !process.env.CI,
+    timeout: 180_000,
+  },
+});

--- a/docs/wallet-testing.md
+++ b/docs/wallet-testing.md
@@ -52,6 +52,15 @@ runs against an anvil fork of Celo mainnet — no real network is ever touched.
 
 5. Drive the UI (e.g. swap 1 CELO -> cUSD), then verify on-chain (next section).
 
+## Automated Playwright specs
+
+Instead of driving the UI by hand, both apps have a `connected` Playwright
+project that does steps 3-5 above automatically against the same seeded fork:
+`pnpm --filter app.mento.org test:connected` (swap) and
+`pnpm --filter governance.mento.org test:connected` (create a MENTO lock). See
+`CLAUDE.md`'s "Connected-Wallet E2E" section for the exact build + run
+commands per app.
+
 ## Activation flags
 
 Two equivalent activation paths. Env vars are read at build/dev-server start;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -359,7 +359,7 @@ importers:
         version: link:../../packages/web3
       '@sentry/nextjs':
         specifier: 'catalog:'
-        version: 10.36.0(@opentelemetry/context-async-hooks@2.5.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(next@15.5.20(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(webpack@5.104.1(postcss@8.5.16))
+        version: 10.36.0(@opentelemetry/context-async-hooks@2.5.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(next@15.5.20(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(webpack@5.104.1(lightningcss@1.32.0)(postcss@8.5.16))
       '@t3-oss/env-nextjs':
         specifier: 'catalog:'
         version: 0.13.11(typescript@5.9.3)(valibot@1.3.0(typescript@5.9.3))(zod@4.4.3)
@@ -448,6 +448,9 @@ importers:
       '@graphql-codegen/typescript-react-apollo':
         specifier: ^4.4.2
         version: 4.4.2(graphql@16.12.0)
+      '@playwright/test':
+        specifier: 1.61.1
+        version: 1.61.1
       '@repo/eslint-config':
         specifier: workspace:*
         version: link:../../packages/eslint-config


### PR DESCRIPTION
# Description

Implements #448 (Part of #441): bootstraps Playwright in `governance.mento.org` (no prior config, no e2e directory — vitest only) and adds ONE connected-wallet spec — create a 1 MENTO lock (approve → lock, two-step, single click) against a seeded local anvil `--celo` fork of Celo mainnet, asserting success via UI toasts AND on-chain MENTO/veMENTO balance reads.

- **`package.json`** — devDependency `@playwright/test@1.61.1` (exact pin, matching app.mento.org / ui.mento.org — no catalog entry) and `"test:connected": "playwright test --project=connected"` (no `--workers=1` flag: unlike app.mento.org, governance has only one Playwright project, so `workers: 1` in the config is sufficient on its own — matches the epic's canonical-names table).
- **`playwright.config.ts`** — port 3002, `next start -p 3002` webServer, single serialized `connected` project with an INVARIANT comment. **Deviation from the issue's literal sketch:** `testMatch: "connected/**"` (a plain glob) also matches `rpc.ts`, which the spec imports — Playwright rejects that with `test file should not import test file`. Scoped to `/connected\/.*\.spec\.ts/`, matching app.mento.org's existing project pattern.
- **`e2e/connected/rpc.ts`** — copied (not shared-package-extracted) from `apps/app.mento.org/e2e/connected/rpc.ts`, per the issue's explicit rationale: it is ~50 lines of zero-dep code, and a new workspace package for it adds more surface than it saves. Adds a `mineBlocks()` helper the app.mento.org copy doesn't need.
- **`e2e/connected/lock.spec.ts`** — the fixture/network-policy logic is copied inline into the spec (adapted from `app.mento.org/e2e/fixtures.ts`'s `connectedNetworkPolicy`) rather than a separate `e2e/fixtures.ts` module, since the issue's file-scope list only names `lock.spec.ts` + `rpc.ts` and there's only one spec to serve. Governance has no `/api/sanctions` route (verified — only `app/api/contract` and `app/api/sentry-example-api`), so unlike app.mento.org there's nothing to fulfill; same localhost-passthrough + external-host-abort + CDN-placeholder policy otherwise. Mines empty blocks in the background during the approve→lock flow (`use-approve.ts` waits 2 confirmations, `use-lock-mento.ts` waits 10 — anvil automine only fires on an incoming tx). Includes the required mixed-state caveat comment (lock lists render from a live-mainnet subgraph, not the fork — asserted on-chain + toast only, never via the lock-card list).
- **`.gitignore`** — added `/test-results/`, `/playwright-report/`, `/playwright/.cache/` (matches app.mento.org).
- **Docs** (docs-drift rule) — #445 landed on `feat/wallet-testing-epic` mid-session, so `docs/wallet-testing.md` is now the canonical runbook home: added a short "Automated Playwright specs" pointer there, and extended `CLAUDE.md`'s "Connected-Wallet E2E (app.mento.org)" section (from #446) into a per-app "Connected-Wallet E2E" section covering governance too.

**Contract addresses — verified against the local `mento-sdk` checkout** (`src/constants/addresses.ts`, `ChainId.CELO` block, commit `64206b4`): MENTO token `0x7FF62f59e3e89EA34163EA1458EEBCc81177Cfb6`, Locking (veMENTO) `0x001Bb66636dCd149A1A2bA8C50E408BdDd80279C` — both match the issue exactly. The local review pass re-confirmed them independently against the governance contract registry.

## Other changes

- `fix: address cleanup review findings` (from the local review pass): `test.setTimeout` bumped 180s → 240s — the old value exactly equaled the sum of the test's three explicit assertion timeouts (30s + 30s + 120s), leaving zero headroom for `page.goto`, form interactions, and the trailing balance reads on a merely-slow run.
- Nothing else. No changes to `packages/web3`, `turbo.json`, `apps/app.mento.org`, `apps/ui.mento.org`, or any Argos/visual workflow.

## Testing

All local, against `pnpm fork:mainnet` (Foundry 1.6.0-nightly) + `pnpm fork:seed`:

- `pnpm --filter governance.mento.org exec playwright --version` → `Version 1.61.1` (matches the pin).
- Build: `NEXT_PUBLIC_E2E_TEST=true NEXT_PUBLIC_USE_FORK=true pnpm exec turbo run build --filter governance.mento.org` → green (only pre-existing React-Compiler/lint warnings, unrelated).
- **Run 1** (`pnpm --filter governance.mento.org test:connected`): `1 passed (9.8s)` — approve tx `0x8952eb3e51bf45d0c320f441342e16986d27c8993cb8c8e0754021fa4aa1407b`, lock tx `0x6582bde47e4723a724df6f3f43ddc430d187108de0e63d65c16c0b7051512c90`.
- Re-seeded (`pnpm fork:seed`) between runs per the issue's guidance.
- **Run 2** (same command, back-to-back, proving snapshot/revert isolation): `1 passed (9.4s)` — approve tx `0xa8be02a01240b77b0864d6b26d04f81f52dcb465defb2e907eb397ca5f729004`, lock tx `0x781f263a980049ed0bea078b9134b0c4f7063e08e3e66882ffd2ef124d066971`.
- **Run 3** (post-review-fix tree, fresh fork at block ~71745587): `1 passed (11.1s)` — approve tx `0x739680a5c890f7592e8c3c6e8e54972c1dfab2752ee4ace33cdaf536d8c2c835`, lock tx `0x6e32ef0f99123ddbf2060492f49c735312b0dffc428e887f3722ae70ba58241a`.
- On-chain evidence via `cast call ... balanceOf`: before each run, acct0 (`0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266`) held `1000000000000000000000` (1000e18) MENTO and `0` veMENTO; after each run (and its `evm_revert`), balances were back to exactly 1000e18 MENTO / 0 veMENTO — confirming the spec's own assertions (`mentoBefore - mentoAfter === 1e18`, `veMentoAfter > veMentoBefore`) AND fork isolation across all runs.
- `pnpm --filter governance.mento.org test` (vitest) → **61 passed (7 files)**, unaffected.
- `pnpm check-types` (all 9 packages) → green. `trunk check --fix` → `No issues`. `pnpm run knip` → 0 findings (knip's built-in Playwright plugin auto-detected the config + dep; no `knip.json` change needed).
- Pre-push hooks (`trunk check --all` on 893 files, `check-types`, `knip`) passed on both pushes.
- **Review:** cleanup pass (1 fix applied, above) + parallel specialist review (verdict: Approve — 0 high/medium findings) + Codex review (PASS_WITH_NOTES — 0 confirmed issues; its one confidence gap, "run the spec against a live fork", is covered by runs 1–3 above).

**Deferred (low-confidence review notes, non-blocking):** background miner's `.catch(() => {})` swallows RPC errors (diagnostics-only concern); governance README has no Connected-Wallet E2E section (outside #448's explicit "touch ONLY these files" scope — natural follow-up when governance gets CI wiring); direction-only veMENTO assertion could add an upper bound; `NEXT_PUBLIC_USE_FORK` not declared in governance `env.mjs` (harmless — `chains.ts` reads `process.env` directly, pre-existing).

## Checklist before requesting a review

- [x] PR title follows the [conventions](https://www.notion.so/Git-Branching-and-Commit-Message-Conventions-18f66f7d06444cfcbac5725ffbc7c04a?pvs=4#9355048863c549ef92fe210a8a1298aa)
- [x] Performed a self-review of my own code changes
- [x] Smoke Test Run/s passed on the CI

## Ship Checklist

- [x] ship skill used
- [x] local review run (cleanup pass + parallel specialist review + codex; 1 fix applied, deferrals above)
- [x] validation run (connected x3 across two fork sessions, vitest x61, types, trunk, knip)

Part of #441. Implements #448.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LPQQFxntvMvndepgAtedEK

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are test tooling and documentation only; no production governance or web3 runtime behavior is modified.
> 
> **Overview**
> Adds **connected-wallet Playwright E2E** to `governance.mento.org`, parallel to the existing `app.mento.org` swap suite: `@playwright/test@1.61.1`, `test:connected`, `playwright.config.ts` (port 3002, `workers: 1`, `connected/*.spec.ts` only), and Playwright output paths in `.gitignore`.
> 
> The new **`lock.spec.ts`** drives approve → lock on `/voting-power` against a seeded anvil fork (E2E wallet via localStorage, inline network policy blocking subgraph/API noise). It uses **`evm_snapshot` / `evm_revert`** per test, background **`evm_mine`** so multi-confirmation hooks complete, and asserts success via toast plus on-chain MENTO / veMENTO balances—not the lock list (subgraph stays live-mainnet). **`rpc.ts`** is copied from the swap app with an extra **`mineBlocks`** helper.
> 
> **`CLAUDE.md`** and **`docs/wallet-testing.md`** now document governance build flags and `pnpm --filter governance.mento.org test:connected` alongside the swap command.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf59518ed7dd49ef4b0bcaec87994eb1b6abf59b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->