### PR TITLE
docs(security): document Wormhole dependency risk

### DIFF
--- a/docs/dependency-overrides.md
+++ b/docs/dependency-overrides.md
@@ -14,6 +14,36 @@ sync is a requirement, not a suggestion — a catalog bump for an overridden
 package is silently defeated otherwise (this happened to `zod`; see the table
 below).
 
+## Wormhole Connect (`@wormhole-foundation/wormhole-connect`)
+
+`app.mento.org` uses Wormhole Connect only for the `/bridge` route. The widget
+UI is lazy-loaded in `apps/app.mento.org/app/components/bridge/bridge-view.tsx`
+with `next/dynamic` and `ssr: false`, so the UI package should not enter the
+shared application bundle. The route config in
+`apps/app.mento.org/app/components/bridge/bridge-config.ts` also imports the
+`@wormhole-foundation/wormhole-connect/ntt` subpath; that value import belongs
+to the bridge route chunk.
+
+The app declares `@mui/icons-material`, `@mui/material`,
+`@mui/styled-engine`, `@mui/system`, `@emotion/react`, and `@emotion/styled`
+only to satisfy Wormhole Connect peer ranges. There are no direct TypeScript,
+TSX, or app config imports of those packages in `apps/app.mento.org`. Do not
+remove them independently, and do not start using them directly in Mento UI
+code.
+
+As of the 2026-07-10 check for issue #418, `osv-scanner.toml` has 74 ignored
+vulnerability blocks, and 15 blocks mention the Wormhole Connect dependency
+chain in the reason or surrounding comments. That cluster is currently axios
+(3 blocks), protobufjs including `@protobufjs/utf8` (11 blocks), and uuid (1
+block). Do not attribute the elliptic or bn.js suppressions to Wormhole; their
+documented chains are separate.
+
+Removing Wormhole Connect is intentionally out of scope for this document. At
+the next quarterly dependency review, check `/bridge` traffic in Vercel
+Analytics for the `app.mento.org` project. Record the review date and traffic
+figure on the tracking issue; if traffic is near zero, open a dedicated removal
+proposal before changing dependencies.
+
 ## Range-scoped entries need no row here
 
 Most entries in `pnpm.overrides` are range-scoped CVE floors, e.g.:


### PR DESCRIPTION
## The Problem

Issue #418 tracks three security-operations follow-ups. The repo-local piece was missing durable documentation for the Wormhole Connect dependency-risk cluster, including its peer-only MUI/emotion packages and the related vulnerability suppressions.

Refs #418.

## The Solution

- Added a Wormhole Connect section to `docs/dependency-overrides.md`.
- Documented that the widget UI is lazy-loaded on `/bridge`, while the `/ntt` route config is a value import for the bridge route chunk.
- Documented the peer-only `@mui/*` and `@emotion/*` dependencies so future cleanup does not remove them independently or start using them in Mento UI code.
- Recorded the current suppression context: 74 ignored vulnerability blocks total, with 15 mentioning the Wormhole Connect chain; elliptic and bn.js are explicitly called out as separate chains.
- Left the Graph Studio key restriction and upstream mento-sdk release/tag work as owner/upstream actions outside this docs-only PR.

## Validation

- `trunk fmt docs/dependency-overrides.md` -> passed
- `trunk check --fix docs/dependency-overrides.md` -> passed
- `pnpm knip` -> passed
- `pnpm exec turbo run check-types` -> passed
- pre-push typecheck + Knip hook -> passed

## Ship Checklist

- [x] ship skill used
- [x] local review run
- [x] validation run
- [x] browser verification not applicable for docs-only change

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime, dependency, or security-config modifications.
> 
> **Overview**
> Adds a **Wormhole Connect** section to `docs/dependency-overrides.md` for issue #418, so the bridge-only dependency cluster is documented alongside unconditional override rows.
> 
> The new text explains `/bridge` lazy-loading via `bridge-view.tsx`, the `/ntt` config import in `bridge-config.ts`, and that **MUI/emotion** packages exist only as Wormhole peers (not for direct Mento UI use). It also records **osv-scanner** context (74 ignores, 15 tied to Wormhole’s axios/protobufjs/uuid chain vs separate elliptic/bn.js chains) and a **quarterly review** process using Vercel `/bridge` traffic before any removal proposal.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5bfe8d8329ec798a74feab8af02cc07d8fa4f4d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->