### PR TITLE
test(web3): characterize transaction flow engines

### DIFF
--- a/packages/web3/src/features/borrow/tx-flows/engine.test.ts
+++ b/packages/web3/src/features/borrow/tx-flows/engine.test.ts
@@ -1,0 +1,453 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { BorrowFlowState } from "../atoms/flow-atoms";
+
+vi.mock("./send-tx", () => ({
+  sendSdkTransaction: vi.fn(),
+  waitForTx: vi.fn(),
+}));
+
+const { executeFlow } = await import("./engine");
+const sendTxModule = await import("./send-tx");
+
+const sendSdkTransactionMock = vi.mocked(sendTxModule.sendSdkTransaction);
+const waitForTxMock = vi.mocked(sendTxModule.waitForTx);
+
+function createFlowRecorder() {
+  let state: BorrowFlowState | null = null;
+  const snapshots: Array<BorrowFlowState | null> = [];
+
+  const setFlowAtom = (
+    update:
+      | BorrowFlowState
+      | null
+      | ((prev: BorrowFlowState | null) => BorrowFlowState | null),
+  ) => {
+    state = typeof update === "function" ? update(state) : update;
+    snapshots.push(state === null ? null : structuredClone(state));
+  };
+
+  return {
+    setFlowAtom,
+    snapshots,
+    getState: () => state,
+  };
+}
+
+describe("executeFlow", () => {
+  const wagmiConfig = {} as never;
+  const account = "0x00000000000000000000000000000000000000aa";
+  const firstHash =
+    "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+  const secondHash =
+    "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("runs a two-step happy path and preserves the borrow flow shape", async () => {
+    const recorder = createFlowRecorder();
+    const approveBuildTx = vi.fn().mockResolvedValue({
+      to: "0x0000000000000000000000000000000000000011",
+      data: "0x11",
+      value: 1n,
+    });
+    const openBuildTx = vi.fn().mockResolvedValue({
+      to: "0x0000000000000000000000000000000000000012",
+      data: "0x12",
+      value: 2n,
+    });
+
+    sendSdkTransactionMock
+      .mockResolvedValueOnce(firstHash as never)
+      .mockResolvedValueOnce(secondHash as never);
+    waitForTxMock
+      .mockResolvedValueOnce({ status: "success" } as never)
+      .mockResolvedValueOnce({ status: "success" } as never);
+
+    const result = await executeFlow(
+      wagmiConfig,
+      recorder.setFlowAtom,
+      "open-trove",
+      "Open Trove",
+      account,
+      [
+        { id: "approve", label: "Approve", buildTx: approveBuildTx },
+        { id: "open", label: "Open", buildTx: openBuildTx },
+      ],
+      { successHref: "/borrow/manage/1?token=GBPm" },
+    );
+
+    expect(result).toEqual({
+      success: true,
+      txHashes: [firstHash, secondHash],
+    });
+    expect(sendSdkTransactionMock).toHaveBeenNthCalledWith(
+      1,
+      wagmiConfig,
+      {
+        to: "0x0000000000000000000000000000000000000011",
+        data: "0x11",
+        value: 1n,
+      },
+      undefined,
+      account,
+    );
+    expect(sendSdkTransactionMock).toHaveBeenNthCalledWith(
+      2,
+      wagmiConfig,
+      {
+        to: "0x0000000000000000000000000000000000000012",
+        data: "0x12",
+        value: 2n,
+      },
+      undefined,
+      account,
+    );
+    expect(recorder.snapshots).toEqual([
+      {
+        flowId: "open-trove",
+        operation: "Open Trove",
+        currentStepIndex: 0,
+        account,
+        successHref: "/borrow/manage/1?token=GBPm",
+        steps: [
+          { id: "approve", label: "Approve", status: "idle" },
+          { id: "open", label: "Open", status: "idle" },
+        ],
+      },
+      {
+        flowId: "open-trove",
+        operation: "Open Trove",
+        currentStepIndex: 0,
+        account,
+        successHref: "/borrow/manage/1?token=GBPm",
+        steps: [
+          { id: "approve", label: "Approve", status: "pending" },
+          { id: "open", label: "Open", status: "idle" },
+        ],
+      },
+      {
+        flowId: "open-trove",
+        operation: "Open Trove",
+        currentStepIndex: 0,
+        account,
+        successHref: "/borrow/manage/1?token=GBPm",
+        steps: [
+          {
+            id: "approve",
+            label: "Approve",
+            status: "confirming",
+            txHash: firstHash,
+          },
+          { id: "open", label: "Open", status: "idle" },
+        ],
+      },
+      {
+        flowId: "open-trove",
+        operation: "Open Trove",
+        currentStepIndex: 1,
+        account,
+        successHref: "/borrow/manage/1?token=GBPm",
+        steps: [
+          {
+            id: "approve",
+            label: "Approve",
+            status: "confirmed",
+            txHash: firstHash,
+          },
+          { id: "open", label: "Open", status: "idle" },
+        ],
+      },
+      {
+        flowId: "open-trove",
+        operation: "Open Trove",
+        currentStepIndex: 1,
+        account,
+        successHref: "/borrow/manage/1?token=GBPm",
+        steps: [
+          {
+            id: "approve",
+            label: "Approve",
+            status: "confirmed",
+            txHash: firstHash,
+          },
+          { id: "open", label: "Open", status: "pending" },
+        ],
+      },
+      {
+        flowId: "open-trove",
+        operation: "Open Trove",
+        currentStepIndex: 1,
+        account,
+        successHref: "/borrow/manage/1?token=GBPm",
+        steps: [
+          {
+            id: "approve",
+            label: "Approve",
+            status: "confirmed",
+            txHash: firstHash,
+          },
+          {
+            id: "open",
+            label: "Open",
+            status: "confirming",
+            txHash: secondHash,
+          },
+        ],
+      },
+      {
+        flowId: "open-trove",
+        operation: "Open Trove",
+        currentStepIndex: 2,
+        account,
+        successHref: "/borrow/manage/1?token=GBPm",
+        steps: [
+          {
+            id: "approve",
+            label: "Approve",
+            status: "confirmed",
+            txHash: firstHash,
+          },
+          {
+            id: "open",
+            label: "Open",
+            status: "confirmed",
+            txHash: secondHash,
+          },
+        ],
+      },
+    ]);
+    expect(recorder.getState()).toEqual({
+      flowId: "open-trove",
+      operation: "Open Trove",
+      currentStepIndex: 2,
+      account,
+      successHref: "/borrow/manage/1?token=GBPm",
+      steps: [
+        {
+          id: "approve",
+          label: "Approve",
+          status: "confirmed",
+          txHash: firstHash,
+        },
+        {
+          id: "open",
+          label: "Open",
+          status: "confirmed",
+          txHash: secondHash,
+        },
+      ],
+    });
+  });
+
+  it("marks skipped steps as confirmed with an exact skipped label", async () => {
+    const recorder = createFlowRecorder();
+
+    sendSdkTransactionMock.mockResolvedValueOnce(firstHash as never);
+    waitForTxMock.mockResolvedValueOnce({ status: "success" } as never);
+
+    const result = await executeFlow(
+      wagmiConfig,
+      recorder.setFlowAtom,
+      "close-trove",
+      "Close Trove",
+      account,
+      [
+        {
+          id: "approve",
+          label: "Approve",
+          buildTx: vi.fn().mockResolvedValue(null),
+        },
+        {
+          id: "close",
+          label: "Close",
+          buildTx: vi.fn().mockResolvedValue({
+            to: "0x0000000000000000000000000000000000000013",
+            data: "0x13",
+            value: 0n,
+          }),
+        },
+      ],
+    );
+
+    expect(result).toEqual({ success: true, txHashes: [firstHash] });
+    expect(sendSdkTransactionMock).toHaveBeenCalledTimes(1);
+    expect(recorder.snapshots[1]).toEqual({
+      flowId: "close-trove",
+      operation: "Close Trove",
+      currentStepIndex: 1,
+      account,
+      successHref: undefined,
+      steps: [
+        {
+          id: "approve",
+          label: "Approve — Skipped",
+          status: "confirmed",
+        },
+        { id: "close", label: "Close", status: "idle" },
+      ],
+    });
+  });
+
+  it("marks the failing step as error, aborts, and does not build later steps", async () => {
+    const recorder = createFlowRecorder();
+    const stepThreeBuildTx = vi.fn();
+
+    sendSdkTransactionMock
+      .mockResolvedValueOnce(firstHash as never)
+      .mockRejectedValueOnce(new Error("rpc exploded"));
+    waitForTxMock.mockResolvedValueOnce({ status: "success" } as never);
+
+    const result = await executeFlow(
+      wagmiConfig,
+      recorder.setFlowAtom,
+      "adjust-trove",
+      "Adjust Trove",
+      account,
+      [
+        {
+          id: "approve",
+          label: "Approve",
+          buildTx: vi.fn().mockResolvedValue({
+            to: "0x0000000000000000000000000000000000000014",
+            data: "0x14",
+            value: 1n,
+          }),
+        },
+        {
+          id: "adjust",
+          label: "Adjust",
+          buildTx: vi.fn().mockResolvedValue({
+            to: "0x0000000000000000000000000000000000000015",
+            data: "0x15",
+            value: 2n,
+          }),
+        },
+        {
+          id: "stake",
+          label: "Stake",
+          buildTx: stepThreeBuildTx,
+        },
+      ],
+    );
+
+    expect(result).toEqual({ success: false, txHashes: [firstHash] });
+    expect(stepThreeBuildTx).not.toHaveBeenCalled();
+    expect(recorder.getState()).toEqual({
+      flowId: "adjust-trove",
+      operation: "Adjust Trove",
+      currentStepIndex: 1,
+      account,
+      successHref: undefined,
+      steps: [
+        {
+          id: "approve",
+          label: "Approve",
+          status: "confirmed",
+          txHash: firstHash,
+        },
+        {
+          id: "adjust",
+          label: "Adjust",
+          status: "error",
+          error: { name: "Error", message: "rpc exploded" },
+        },
+        { id: "stake", label: "Stake", status: "idle" },
+      ],
+    });
+  });
+
+  it("stores the raw reverted receipt message on the failing borrow step", async () => {
+    const recorder = createFlowRecorder();
+
+    sendSdkTransactionMock.mockResolvedValueOnce(firstHash as never);
+    waitForTxMock.mockResolvedValueOnce({ status: "reverted" } as never);
+
+    const result = await executeFlow(
+      wagmiConfig,
+      recorder.setFlowAtom,
+      "withdraw-sp",
+      "Withdraw SP",
+      account,
+      [
+        {
+          id: "withdraw",
+          label: "Withdraw",
+          buildTx: vi.fn().mockResolvedValue({
+            to: "0x0000000000000000000000000000000000000016",
+            data: "0x16",
+            value: 0n,
+          }),
+        },
+      ],
+    );
+
+    expect(result).toEqual({ success: false, txHashes: [] });
+    expect(recorder.getState()).toEqual({
+      flowId: "withdraw-sp",
+      operation: "Withdraw SP",
+      currentStepIndex: 0,
+      account,
+      successHref: undefined,
+      steps: [
+        {
+          id: "withdraw",
+          label: "Withdraw",
+          status: "error",
+          txHash: firstHash,
+          error: { name: "Error", message: "Transaction reverted on-chain" },
+        },
+      ],
+    });
+  });
+
+  it("keeps the flow state and marks the step as error on user rejection", async () => {
+    const recorder = createFlowRecorder();
+
+    sendSdkTransactionMock.mockRejectedValueOnce(
+      new Error("Transaction rejected by user"),
+    );
+
+    const result = await executeFlow(
+      wagmiConfig,
+      recorder.setFlowAtom,
+      "claim-rewards",
+      "Claim Rewards",
+      account,
+      [
+        {
+          id: "claim",
+          label: "Claim",
+          buildTx: vi.fn().mockResolvedValue({
+            to: "0x0000000000000000000000000000000000000017",
+            data: "0x17",
+            value: 0n,
+          }),
+        },
+      ],
+      { successHref: "/borrow/manage/claim" },
+    );
+
+    expect(result).toEqual({ success: false, txHashes: [] });
+    expect(recorder.getState()).toEqual({
+      flowId: "claim-rewards",
+      operation: "Claim Rewards",
+      currentStepIndex: 0,
+      account,
+      successHref: "/borrow/manage/claim",
+      steps: [
+        {
+          id: "claim",
+          label: "Claim",
+          status: "error",
+          error: {
+            name: "Error",
+            message: "Transaction rejected by user",
+          },
+        },
+      ],
+    });
+    expect(recorder.snapshots.at(-1)).not.toBeNull();
+  });
+});

--- a/packages/web3/src/features/pools/flow-engine.test.ts
+++ b/packages/web3/src/features/pools/flow-engine.test.ts
@@ -1,0 +1,514 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { LiquidityFlowState } from "./flow-atoms";
+
+vi.mock("wagmi/actions", () => ({
+  estimateGas: vi.fn(),
+  sendTransaction: vi.fn(),
+  waitForTransactionReceipt: vi.fn(),
+}));
+
+vi.mock("@/utils/transaction-fees", () => ({
+  getTransactionFeeOverrides: vi.fn(),
+}));
+
+const { executeLiquidityFlow } = await import("./flow-engine");
+const wagmiActions = await import("wagmi/actions");
+const transactionFees = await import("@/utils/transaction-fees");
+
+const estimateGasMock = vi.mocked(wagmiActions.estimateGas);
+const sendTransactionMock = vi.mocked(wagmiActions.sendTransaction);
+const waitForTransactionReceiptMock = vi.mocked(
+  wagmiActions.waitForTransactionReceipt,
+);
+const getTransactionFeeOverridesMock = vi.mocked(
+  transactionFees.getTransactionFeeOverrides,
+);
+
+function createFlowRecorder() {
+  let state: LiquidityFlowState | null = null;
+  const snapshots: Array<LiquidityFlowState | null> = [];
+
+  const setFlowAtom = (
+    update:
+      | LiquidityFlowState
+      | null
+      | ((prev: LiquidityFlowState | null) => LiquidityFlowState | null),
+  ) => {
+    state = typeof update === "function" ? update(state) : update;
+    snapshots.push(state === null ? null : structuredClone(state));
+  };
+
+  return {
+    setFlowAtom,
+    snapshots,
+    getState: () => state,
+  };
+}
+
+describe("executeLiquidityFlow", () => {
+  const wagmiConfig = {} as never;
+  const firstHash =
+    "0x1111111111111111111111111111111111111111111111111111111111111111";
+  const secondHash =
+    "0x2222222222222222222222222222222222222222222222222222222222222222";
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getTransactionFeeOverridesMock.mockResolvedValue({});
+    consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  it("runs a two-step happy path and records every state transition", async () => {
+    const recorder = createFlowRecorder();
+    const stepOneBuildTx = vi.fn().mockResolvedValue({
+      to: "0x0000000000000000000000000000000000000001",
+      data: "0x01",
+      value: 1n,
+    });
+    const stepTwoBuildTx = vi.fn().mockResolvedValue({
+      to: "0x0000000000000000000000000000000000000002",
+      data: "0x02",
+      value: 2n,
+    });
+
+    estimateGasMock.mockResolvedValueOnce(100n).mockResolvedValueOnce(200n);
+    sendTransactionMock
+      .mockResolvedValueOnce(firstHash as never)
+      .mockResolvedValueOnce(secondHash as never);
+    waitForTransactionReceiptMock
+      .mockResolvedValueOnce({ status: "success" } as never)
+      .mockResolvedValueOnce({ status: "success" } as never);
+
+    const result = await executeLiquidityFlow(
+      wagmiConfig,
+      recorder.setFlowAtom,
+      "Add liquidity",
+      [
+        { id: "approve", label: "Approve", buildTx: stepOneBuildTx },
+        { id: "deposit", label: "Deposit", buildTx: stepTwoBuildTx },
+      ],
+      42220,
+    );
+
+    expect(result).toEqual({
+      success: true,
+      txHashes: [firstHash, secondHash],
+    });
+    expect(stepOneBuildTx).toHaveBeenCalledTimes(1);
+    expect(stepTwoBuildTx).toHaveBeenCalledTimes(1);
+    expect(sendTransactionMock).toHaveBeenNthCalledWith(1, wagmiConfig, {
+      to: "0x0000000000000000000000000000000000000001",
+      data: "0x01",
+      value: 1n,
+      chainId: 42220,
+      gas: 125n,
+    });
+    expect(sendTransactionMock).toHaveBeenNthCalledWith(2, wagmiConfig, {
+      to: "0x0000000000000000000000000000000000000002",
+      data: "0x02",
+      value: 2n,
+      chainId: 42220,
+      gas: 250n,
+    });
+    expect(recorder.snapshots).toEqual([
+      {
+        operation: "Add liquidity",
+        currentStepIndex: 0,
+        chainId: 42220,
+        steps: [
+          { id: "approve", label: "Approve", status: "idle" },
+          { id: "deposit", label: "Deposit", status: "idle" },
+        ],
+      },
+      {
+        operation: "Add liquidity",
+        currentStepIndex: 0,
+        chainId: 42220,
+        steps: [
+          { id: "approve", label: "Approve", status: "pending" },
+          { id: "deposit", label: "Deposit", status: "idle" },
+        ],
+      },
+      {
+        operation: "Add liquidity",
+        currentStepIndex: 0,
+        chainId: 42220,
+        steps: [
+          {
+            id: "approve",
+            label: "Approve",
+            status: "confirming",
+            txHash: firstHash,
+          },
+          { id: "deposit", label: "Deposit", status: "idle" },
+        ],
+      },
+      {
+        operation: "Add liquidity",
+        currentStepIndex: 1,
+        chainId: 42220,
+        steps: [
+          {
+            id: "approve",
+            label: "Approve",
+            status: "confirmed",
+            txHash: firstHash,
+          },
+          { id: "deposit", label: "Deposit", status: "idle" },
+        ],
+      },
+      {
+        operation: "Add liquidity",
+        currentStepIndex: 1,
+        chainId: 42220,
+        steps: [
+          {
+            id: "approve",
+            label: "Approve",
+            status: "confirmed",
+            txHash: firstHash,
+          },
+          { id: "deposit", label: "Deposit", status: "pending" },
+        ],
+      },
+      {
+        operation: "Add liquidity",
+        currentStepIndex: 1,
+        chainId: 42220,
+        steps: [
+          {
+            id: "approve",
+            label: "Approve",
+            status: "confirmed",
+            txHash: firstHash,
+          },
+          {
+            id: "deposit",
+            label: "Deposit",
+            status: "confirming",
+            txHash: secondHash,
+          },
+        ],
+      },
+      {
+        operation: "Add liquidity",
+        currentStepIndex: 2,
+        chainId: 42220,
+        steps: [
+          {
+            id: "approve",
+            label: "Approve",
+            status: "confirmed",
+            txHash: firstHash,
+          },
+          {
+            id: "deposit",
+            label: "Deposit",
+            status: "confirmed",
+            txHash: secondHash,
+          },
+        ],
+      },
+    ]);
+    expect(recorder.getState()).toEqual({
+      operation: "Add liquidity",
+      currentStepIndex: 2,
+      chainId: 42220,
+      steps: [
+        {
+          id: "approve",
+          label: "Approve",
+          status: "confirmed",
+          txHash: firstHash,
+        },
+        {
+          id: "deposit",
+          label: "Deposit",
+          status: "confirmed",
+          txHash: secondHash,
+        },
+      ],
+    });
+  });
+
+  it("marks skipped steps as confirmed with an exact skipped label", async () => {
+    const recorder = createFlowRecorder();
+
+    estimateGasMock.mockResolvedValueOnce(80n);
+    sendTransactionMock.mockResolvedValueOnce(firstHash as never);
+    waitForTransactionReceiptMock.mockResolvedValueOnce({
+      status: "success",
+    } as never);
+
+    const result = await executeLiquidityFlow(
+      wagmiConfig,
+      recorder.setFlowAtom,
+      "Rebalance",
+      [
+        {
+          id: "approve",
+          label: "Approve",
+          buildTx: vi.fn().mockResolvedValue(null),
+        },
+        {
+          id: "rebalance",
+          label: "Rebalance",
+          buildTx: vi.fn().mockResolvedValue({
+            to: "0x0000000000000000000000000000000000000003",
+            data: "0x03",
+            value: 0n,
+          }),
+        },
+      ],
+      42220,
+    );
+
+    expect(result).toEqual({ success: true, txHashes: [firstHash] });
+    expect(sendTransactionMock).toHaveBeenCalledTimes(1);
+    expect(recorder.snapshots[1]).toEqual({
+      operation: "Rebalance",
+      currentStepIndex: 1,
+      chainId: 42220,
+      steps: [
+        {
+          id: "approve",
+          label: "Approve — Skipped",
+          status: "confirmed",
+        },
+        { id: "rebalance", label: "Rebalance", status: "idle" },
+      ],
+    });
+  });
+
+  it("marks the failing step as error, aborts, and does not build later steps", async () => {
+    const recorder = createFlowRecorder();
+    const stepThreeBuildTx = vi.fn();
+
+    estimateGasMock.mockResolvedValueOnce(100n);
+    sendTransactionMock
+      .mockResolvedValueOnce(firstHash as never)
+      .mockRejectedValueOnce(new Error("rpc exploded"));
+    waitForTransactionReceiptMock.mockResolvedValueOnce({
+      status: "success",
+    } as never);
+
+    const result = await executeLiquidityFlow(
+      wagmiConfig,
+      recorder.setFlowAtom,
+      "Add liquidity",
+      [
+        {
+          id: "approve",
+          label: "Approve",
+          buildTx: vi.fn().mockResolvedValue({
+            to: "0x0000000000000000000000000000000000000001",
+            data: "0x01",
+            value: 1n,
+          }),
+        },
+        {
+          id: "deposit",
+          label: "Deposit",
+          buildTx: vi.fn().mockResolvedValue({
+            to: "0x0000000000000000000000000000000000000002",
+            data: "0x02",
+            value: 2n,
+          }),
+        },
+        {
+          id: "stake",
+          label: "Stake",
+          buildTx: stepThreeBuildTx,
+        },
+      ],
+    );
+
+    expect(result).toEqual({ success: false, txHashes: [firstHash] });
+    expect(stepThreeBuildTx).not.toHaveBeenCalled();
+    expect(recorder.getState()).toEqual({
+      operation: "Add liquidity",
+      currentStepIndex: 1,
+      steps: [
+        {
+          id: "approve",
+          label: "Approve",
+          status: "confirmed",
+          txHash: firstHash,
+        },
+        {
+          id: "deposit",
+          label: "Deposit",
+          status: "error",
+          error: { message: "Something went wrong. Please try again." },
+        },
+        { id: "stake", label: "Stake", status: "idle" },
+      ],
+    });
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      '[LiquidityFlow] Step "Deposit" failed:',
+      expect.any(Error),
+    );
+  });
+
+  it("surfaces reverted receipts while preserving the pools-friendly error copy", async () => {
+    const recorder = createFlowRecorder();
+
+    estimateGasMock.mockResolvedValueOnce(100n);
+    sendTransactionMock.mockResolvedValueOnce(firstHash as never);
+    waitForTransactionReceiptMock.mockResolvedValueOnce({
+      status: "reverted",
+    } as never);
+
+    const result = await executeLiquidityFlow(
+      wagmiConfig,
+      recorder.setFlowAtom,
+      "Remove liquidity",
+      [
+        {
+          id: "remove",
+          label: "Remove",
+          buildTx: vi.fn().mockResolvedValue({
+            to: "0x0000000000000000000000000000000000000004",
+            data: "0x04",
+            value: 0n,
+          }),
+        },
+      ],
+    );
+
+    expect(result).toEqual({ success: false, txHashes: [] });
+    expect(recorder.getState()).toEqual({
+      operation: "Remove liquidity",
+      currentStepIndex: 0,
+      steps: [
+        {
+          id: "remove",
+          label: "Remove",
+          status: "error",
+          error: {
+            message:
+              "Transaction was reverted. Please check your inputs and try again.",
+          },
+          txHash: firstHash,
+        },
+      ],
+    });
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      '[LiquidityFlow] Step "Remove" failed:',
+      expect.objectContaining({ message: "Transaction reverted on-chain" }),
+    );
+  });
+
+  it("clears the flow entirely on user rejection", async () => {
+    const recorder = createFlowRecorder();
+
+    estimateGasMock.mockResolvedValueOnce(100n);
+    sendTransactionMock.mockRejectedValueOnce(new Error("User rejected"));
+
+    const result = await executeLiquidityFlow(
+      wagmiConfig,
+      recorder.setFlowAtom,
+      "Add liquidity",
+      [
+        {
+          id: "approve",
+          label: "Approve",
+          buildTx: vi.fn().mockResolvedValue({
+            to: "0x0000000000000000000000000000000000000005",
+            data: "0x05",
+            value: 0n,
+          }),
+        },
+      ],
+    );
+
+    expect(result).toEqual({ success: false, txHashes: [] });
+    expect(recorder.snapshots.at(-1)).toBeNull();
+    expect(recorder.getState()).toBeNull();
+  });
+
+  it("falls back to wallet gas estimation and still spreads fee overrides", async () => {
+    const recorder = createFlowRecorder();
+
+    estimateGasMock.mockRejectedValueOnce(new Error("rpc timeout"));
+    getTransactionFeeOverridesMock.mockResolvedValueOnce({
+      maxFeePerGas: 50n,
+      maxPriorityFeePerGas: 5n,
+    });
+    sendTransactionMock.mockResolvedValueOnce(firstHash as never);
+    waitForTransactionReceiptMock.mockResolvedValueOnce({
+      status: "success",
+    } as never);
+
+    const result = await executeLiquidityFlow(
+      wagmiConfig,
+      recorder.setFlowAtom,
+      "Rebalance",
+      [
+        {
+          id: "rebalance",
+          label: "Rebalance",
+          buildTx: vi.fn().mockResolvedValue({
+            to: "0x0000000000000000000000000000000000000006",
+            data: "0x06",
+            value: 3n,
+          }),
+        },
+      ],
+      80002,
+    );
+
+    expect(result).toEqual({ success: true, txHashes: [firstHash] });
+    expect(sendTransactionMock).toHaveBeenCalledWith(wagmiConfig, {
+      to: "0x0000000000000000000000000000000000000006",
+      data: "0x06",
+      value: 3n,
+      chainId: 80002,
+      maxFeePerGas: 50n,
+      maxPriorityFeePerGas: 5n,
+    });
+    expect(sendTransactionMock.mock.calls[0]?.[1]).not.toHaveProperty("gas");
+  });
+
+  it("aborts on deterministic estimate reverts without sending the transaction", async () => {
+    const recorder = createFlowRecorder();
+
+    estimateGasMock.mockRejectedValueOnce(new Error("execution reverted"));
+
+    const result = await executeLiquidityFlow(
+      wagmiConfig,
+      recorder.setFlowAtom,
+      "Rebalance",
+      [
+        {
+          id: "rebalance",
+          label: "Rebalance",
+          buildTx: vi.fn().mockResolvedValue({
+            to: "0x0000000000000000000000000000000000000007",
+            data: "0x07",
+            value: 0n,
+          }),
+        },
+      ],
+    );
+
+    expect(result).toEqual({ success: false, txHashes: [] });
+    expect(sendTransactionMock).not.toHaveBeenCalled();
+    expect(recorder.getState()).toEqual({
+      operation: "Rebalance",
+      currentStepIndex: 0,
+      steps: [
+        {
+          id: "rebalance",
+          label: "Rebalance",
+          status: "error",
+          error: {
+            message:
+              "Transaction was reverted. Please check your inputs and try again.",
+          },
+        },
+      ],
+    });
+  });
+});


### PR DESCRIPTION
## The Problem

Issue #403 needs the existing pools and borrow transaction-flow engines characterized before the shared-engine refactor. Without these tests, the refactor can silently change step sequencing, skip behavior, error handling, tx hash accumulation, or the intentionally divergent user-rejection behavior.

Refs #403.

## The Solution

Add Phase 1 characterization tests for both old engines:

- pools `executeLiquidityFlow`: happy path, skipped steps, abort/error path, reverted receipts, user rejection clearing, tx hash ordering/state shape, gas headroom, fee overrides, and gas-estimate fallback behavior.
- borrow `executeFlow`: happy path, skipped steps, abort/error path, reverted receipts, user rejection retaining the flow, and tx hash ordering/state shape.

No production code changes are included. Phase 2, the unified engine and caller migration, remains open.

## Validation

- `pnpm --filter @repo/web3 test` — 20 files, 176 tests passed; coverage thresholds green.
- `trunk check --fix packages/web3/src/features/pools/flow-engine.test.ts packages/web3/src/features/borrow/tx-flows/engine.test.ts` — no issues.
- `pnpm exec turbo run check-types` — passed.
- pre-push hook — passed full trunk check, typecheck, and knip.

## Ship Checklist

- [x] ship skill used
- [x] local review run
- [x] validation run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only additions with mocked I/O; no runtime or contract behavior changes.
> 
> **Overview**
> Adds **Phase 1 characterization tests** only—no production changes—for the borrow `executeFlow` and pools `executeLiquidityFlow` engines ahead of a shared-engine refactor (#403).
> 
> **Borrow** (`engine.test.ts`): mocks `send-tx`; asserts multi-step success (state snapshots, `txHashes`, SDK send args), steps skipped when `buildTx` returns `null` (`Approve — Skipped`), abort on mid-flow failure without later `buildTx`, on-chain revert message on the step, and **user rejection leaving flow state** with an error on the step.
> 
> **Pools** (`flow-engine.test.ts`): mocks wagmi actions and fee overrides; covers the same sequencing/skip/abort patterns plus **gas headroom** on sends, **fee overrides** when estimate fails, **estimate-revert** without sending, user-friendly revert copy, and **user rejection clearing** flow state to `null` (contrasts with borrow).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 006edbedfafa37f1700d5f836fb6e283b394fb6c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->