### PR TITLE
ci: enforce TypeScript type-checking in every workspace app

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,7 @@ Always use `--filter` to avoid building/running everything unnecessarily.
 
 ## After Making Changes
 
-1. Run `pnpm check-types` — confirm types pass. This also builds upstream workspace package types and generates Next route types for apps that need them; route typegen uses dummy local env values only for config loading.
+1. Run `pnpm check-types` — confirm types pass. This also builds upstream workspace package types and generates Next route types for apps that need them; route typegen uses dummy local env values only for config loading. The `check-types` Turbo task is intentionally uncached so Next route typegen and `tsc` run after local cleans.
 2. Run `trunk check --fix` — confirm linting passes
 3. Verify changes visually on localhost (check the app's package.json `dev` script for the port)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,7 @@ pnpm install                          # Install dependencies
 pnpm exec turbo run dev --filter <app-name>    # Dev server for one app (use package.json name)
 pnpm build                           # Build all
 pnpm exec turbo run build --filter <app-name>  # Build one app
-pnpm check-types                     # TypeScript type checking
+pnpm check-types                     # TypeScript type checking; builds workspace package types first
 trunk check --fix                     # Lint with autofix
 trunk fmt                             # Format
 pnpm test                            # Run tests
@@ -48,7 +48,7 @@ Always use `--filter` to avoid building/running everything unnecessarily.
 
 ## After Making Changes
 
-1. Run `pnpm check-types` — confirm types pass
+1. Run `pnpm check-types` — confirm types pass. This also builds upstream workspace package types and generates Next route types for apps that need them; route typegen uses dummy local env values only for config loading.
 2. Run `trunk check --fix` — confirm linting passes
 3. Verify changes visually on localhost (check the app's package.json `dev` script for the port)
 

--- a/apps/app.mento.org/package.json
+++ b/apps/app.mento.org/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "build": "next build --turbopack",
+    "check-types": "tsc --noEmit",
     "clean": "rm -rf .next && rm -rf .turbo",
     "dev": "concurrently \"pnpm --filter @repo/web3 watch\" \"pnpm --filter @repo/ui watch\" \"next dev --turbopack --port 3000\" --names \"web3,ui,next\" --prefix-colors \"bgBlue,bgGreen,bgMagenta\"",
     "lint": "npx @trunkio/launcher check .",

--- a/apps/app.mento.org/package.json
+++ b/apps/app.mento.org/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "build": "next build --turbopack",
-    "check-types": "tsc --noEmit",
+    "check-types": "NEXT_PUBLIC_STORAGE_URL=https://example.com NEXT_PUBLIC_WALLET_CONNECT_ID=dummy NEXT_PUBLIC_SENTRY_DSN_SWAP= SENTRY_AUTH_TOKEN= next typegen && tsc --noEmit",
     "clean": "rm -rf .next && rm -rf .turbo",
     "dev": "concurrently \"pnpm --filter @repo/web3 watch\" \"pnpm --filter @repo/ui watch\" \"next dev --turbopack --port 3000\" --names \"web3,ui,next\" --prefix-colors \"bgBlue,bgGreen,bgMagenta\"",
     "lint": "npx @trunkio/launcher check .",

--- a/apps/reserve.mento.org/next.config.ts
+++ b/apps/reserve.mento.org/next.config.ts
@@ -68,10 +68,6 @@ const nextConfig: NextConfig = {
       },
     ];
   },
-  // TODO: Remove once stable
-  typescript: {
-    ignoreBuildErrors: true,
-  },
   images: {
     remotePatterns: [
       {

--- a/apps/reserve.mento.org/package.json
+++ b/apps/reserve.mento.org/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "build": "next build --turbopack",
+    "check-types": "tsc --noEmit",
     "clean": "rm -rf .next && rm -rf .turbo",
     "dev": "next dev --turbopack --port 3001",
     "lint": "npx @trunkio/launcher check",

--- a/apps/reserve.mento.org/package.json
+++ b/apps/reserve.mento.org/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "build": "next build --turbopack",
-    "check-types": "tsc --noEmit",
+    "check-types": "NEXT_PUBLIC_STORAGE_URL=https://example.com NEXT_PUBLIC_SENTRY_DSN_RESERVE= SENTRY_AUTH_TOKEN= next typegen && tsc --noEmit",
     "clean": "rm -rf .next && rm -rf .turbo",
     "dev": "next dev --turbopack --port 3001",
     "lint": "npx @trunkio/launcher check",

--- a/docs/archive/borrow-v3/prd-phase-1-read-path.md
+++ b/docs/archive/borrow-v3/prd-phase-1-read-path.md
@@ -345,7 +345,7 @@ Check what the SDK exposes and use the simplest working approach.
 
 ## Success Metrics
 
-- All typechecks pass (`pnpm check-types` + `tsc --noEmit` in app)
+- All typechecks pass (`pnpm check-types`)
 - `tsup` build succeeds for `packages/web3`
 - Dashboard renders with empty state for wallets with no positions
 - Dashboard renders position cards for wallets with open troves (testable on Celo mainnet/fork)

--- a/turbo.json
+++ b/turbo.json
@@ -29,6 +29,7 @@
     },
     "lint": {},
     "check-types": {
+      "dependsOn": ["^build"],
       "outputs": [".tsbuildinfo", "tsconfig.tsbuildinfo"],
       "cache": true
     },

--- a/turbo.json
+++ b/turbo.json
@@ -30,8 +30,7 @@
     "lint": {},
     "check-types": {
       "dependsOn": ["^build"],
-      "outputs": [".tsbuildinfo", "tsconfig.tsbuildinfo"],
-      "cache": true
+      "cache": false
     },
     "test": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
## The Problem

GitHub issue #393 asks CI to enforce TypeScript type-checking across every workspace app. `app.mento.org` and `reserve.mento.org` were the two app packages still missing a local `check-types` task, and `reserve.mento.org` was still bypassing build-time TypeScript failures with `ignoreBuildErrors`.

Closes #393.

## The Solution

- add `"check-types": "tsc --noEmit"` to `apps/app.mento.org/package.json` and `apps/reserve.mento.org/package.json`
- remove the `typescript.ignoreBuildErrors` block from `apps/reserve.mento.org/next.config.ts`
- build `@repo/ui` and `@repo/web3` before validating the app typechecks
- verify the affected Next apps still build with placeholder env values

## Validation

- `CI=true pnpm install --frozen-lockfile`
- `pnpm --filter @repo/ui build`
- `pnpm --filter @repo/web3 build`
- `pnpm exec turbo run check-types` (6 successful tasks; repeated twice manually and once again in pre-push, with the existing 4 shared tasks replayed from cache while the 2 new app tasks executed under the shared worktree cache)
- `pnpm exec turbo run test`
- `trunk check --fix`
- `NEXT_PUBLIC_STORAGE_URL=https://example.com NEXT_PUBLIC_SENTRY_DSN_RESERVE="" SENTRY_AUTH_TOKEN="" pnpm --filter reserve.mento.org exec next build`
- `NEXT_PUBLIC_STORAGE_URL=https://example.com NEXT_PUBLIC_WALLET_CONNECT_ID=test-walletconnect-id NEXT_PUBLIC_SENTRY_DSN_SWAP="" SENTRY_AUTH_TOKEN="" pnpm --filter app.mento.org exec next build`
- `rg -n '"check-types"': '"tsc --noEmit"' apps/*/package.json`
- `rg -n '"ignoreBuildErrors"' apps/` (no matches)
- `git diff --unified=0 -- apps/app.mento.org/package.json apps/reserve.mento.org/package.json apps/reserve.mento.org/next.config.ts | rg -n '"^\\+.*(\\bany\\b|@ts-ignore|@ts-expect-error|ignoreBuildErrors)"'` (no matches)

Browser verification was not applicable because this change only affects scripts/config and did not alter UI behavior.

## Ship Checklist
- [x] ship skill used
- [x] local review run
- [x] validation run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tooling and config only; no runtime product logic, though reserve builds now fail on TypeScript errors that were previously ignored.
> 
> **Overview**
> **Enforces TypeScript across the two apps that were still missing local type-checks**, aligning `app.mento.org` and `reserve.mento.org` with the rest of the monorepo so `pnpm check-types` (already run in CI) actually validates them.
> 
> Each app gets a **`check-types` script** that runs **`next typegen`** with placeholder public env vars, then **`tsc --noEmit`**. **`reserve.mento.org`** drops **`typescript.ignoreBuildErrors`** from `next.config.ts`, so production builds can no longer ship with type errors.
> 
> **Turbo** changes the **`check-types` task** to **`dependsOn: ["^build"]`** (so `@repo/ui` / `@repo/web3` dist types exist first) and sets **`cache: false`** so route typegen and `tsc` rerun reliably after cleans. **CLAUDE.md** and an archived borrow doc are updated to describe the new workflow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3293959899ce4da6423a43dbdd688519376de1ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->