### PR TITLE
perf(governance): polling diet + surface subgraph errors

### DIFF
--- a/apps/governance.mento.org/app/components/lock-list.tsx
+++ b/apps/governance.mento.org/app/components/lock-list.tsx
@@ -3,6 +3,7 @@ import { useLockedAmount, useLocksByAccount } from "@/contracts";
 import { LockWithExpiration } from "@/contracts/types";
 import { useLockAmountsFromWithdrawals } from "@/hooks/use-lock-amounts-from-withdrawals";
 import {
+  Button,
   CopyToClipboard,
   LockCard,
   LockCardActions,
@@ -37,8 +38,8 @@ import { UpdateLockDialog } from "./update-lock-dialog";
 
 export const LockList = () => {
   const { address } = useAccount();
-  const { locks, loading, refetch } = useLocksByAccount({
-    account: address as string,
+  const { locks, loading, error, refetch } = useLocksByAccount({
+    account: address,
   });
   const { refetch: refetchLockedAmount } = useLockedAmount();
 
@@ -152,7 +153,18 @@ export const LockList = () => {
     setIsUpdateDialogOpen(false);
   };
 
-  if (!locks || locks.length === 0) {
+  if (error && locks.length === 0) {
+    return (
+      <div className="mt-20 gap-3 flex flex-col items-start">
+        <p className="text-sm text-white">Could not load your locks.</p>
+        <Button type="button" onClick={() => void refetch()}>
+          Retry
+        </Button>
+      </div>
+    );
+  }
+
+  if (locks.length === 0) {
     return <></>;
   }
 

--- a/apps/governance.mento.org/app/components/lock-list.tsx
+++ b/apps/governance.mento.org/app/components/lock-list.tsx
@@ -153,7 +153,7 @@ export const LockList = () => {
     setIsUpdateDialogOpen(false);
   };
 
-  if (error && locks.length === 0) {
+  if (address && error && locks.length === 0) {
     return (
       <div className="mt-20 gap-3 flex flex-col items-start">
         <p className="text-sm text-white">Could not load your locks.</p>

--- a/apps/governance.mento.org/app/components/proposal-list.tsx
+++ b/apps/governance.mento.org/app/components/proposal-list.tsx
@@ -81,7 +81,7 @@ const usePagination = ({
 };
 
 export const ProposalList = () => {
-  const { proposals, isLoading } = useProposals();
+  const { proposals, isLoading, error, refetchProposals } = useProposals();
   const { veMentoBalance, isBalanceLoading } = useTokens();
   const { proposalThreshold, isLoadingProposalThreshold } =
     useProposalThreshold();
@@ -181,6 +181,15 @@ export const ProposalList = () => {
         {isLoading ? (
           <div className="gap-4 absolute top-1/2 left-1/2 flex -translate-x-1/2 -translate-y-1/2 flex-col items-center">
             <IconLoading />
+          </div>
+        ) : error && filteredProposals.length === 0 ? (
+          <div className="gap-3 max-w-xs px-6 absolute top-1/2 left-1/2 flex w-full -translate-x-1/2 -translate-y-1/2 flex-col items-center text-center">
+            <span className="font-medium text-white">
+              Could not load proposals.
+            </span>
+            <Button type="button" onClick={() => void refetchProposals()}>
+              Retry
+            </Button>
           </div>
         ) : filteredProposals.length === 0 ? (
           <div className="gap-2 text-sm text-white/70 absolute top-1/2 left-1/2 flex -translate-x-1/2 -translate-y-1/2 flex-col items-center text-center">

--- a/apps/governance.mento.org/app/components/proposal-list.tsx
+++ b/apps/governance.mento.org/app/components/proposal-list.tsx
@@ -182,7 +182,7 @@ export const ProposalList = () => {
           <div className="gap-4 absolute top-1/2 left-1/2 flex -translate-x-1/2 -translate-y-1/2 flex-col items-center">
             <IconLoading />
           </div>
-        ) : error && filteredProposals.length === 0 ? (
+        ) : error && proposals.length === 0 ? (
           <div className="gap-3 max-w-xs px-6 absolute top-1/2 left-1/2 flex w-full -translate-x-1/2 -translate-y-1/2 flex-col items-center text-center">
             <span className="font-medium text-white">
               Could not load proposals.

--- a/apps/governance.mento.org/app/components/proposal/content.tsx
+++ b/apps/governance.mento.org/app/components/proposal/content.tsx
@@ -29,7 +29,7 @@ export const ProposalContent = () => {
     chainId: ensureChainId(chainId),
     query: {
       enabled: proposal !== undefined,
-      refetchInterval: CELO_BLOCK_TIME,
+      refetchInterval: 30_000,
     },
   });
 

--- a/apps/governance.mento.org/app/components/voting-power-card.tsx
+++ b/apps/governance.mento.org/app/components/voting-power-card.tsx
@@ -12,12 +12,11 @@ import { useAccount } from "@repo/web3/wagmi";
 export const VotingPowerCard = () => {
   const { isConnected, address } = useAccount();
   const { mentoBalance } = useTokens();
-  const account = useAccount();
-  const { lock, hasLock, activeLocks } = useLockInfo(account.address);
+  const { lock, hasLock, activeLocks } = useLockInfo(address);
 
   // Get locks for delegation calculation
   const { locks } = useLocksByAccount({
-    account: address as string,
+    account: address,
   });
 
   // Calculate total voting power including received delegations

--- a/apps/governance.mento.org/app/components/voting-power-form.tsx
+++ b/apps/governance.mento.org/app/components/voting-power-form.tsx
@@ -38,7 +38,7 @@ export default function VotingPowerForm() {
 
   const { mentoBalance, veMentoBalance, refetchBalances } = useTokens();
   const { locks, refetch: refetchLocks } = useLocksByAccount({
-    account: address!,
+    account: address,
   });
 
   // Get on-chain withdrawable principal

--- a/apps/governance.mento.org/app/components/voting/derive-vote-card-state.test.ts
+++ b/apps/governance.mento.org/app/components/voting/derive-vote-card-state.test.ts
@@ -1,0 +1,219 @@
+import { ProposalState } from "@/graphql/subgraph/generated/subgraph";
+import { describe, expect, it } from "vitest";
+import {
+  deriveVoteCardState,
+  type VoteCardStateInputs,
+} from "./derive-vote-card-state";
+
+function makeInputs(
+  overrides: Partial<VoteCardStateInputs> = {},
+): VoteCardStateInputs {
+  return {
+    isInitializing: false,
+    isConfirmed: false,
+    isConfirming: false,
+    isExecuteConfirming: false,
+    isQueueConfirming: false,
+    isQueueConfirmed: false,
+    isQueueTransactionPending: false,
+    isAwaitingUserSignature: false,
+    isAwaitingExecuteSignature: false,
+    isAwaitingQueueSignature: false,
+    hasVoted: false,
+    hasEnoughLockedMentoToVote: true,
+    isConnected: true,
+    isVotingOpen: true,
+    proposalState: ProposalState.Active,
+    isDeadlinePassed: false,
+    ...overrides,
+  };
+}
+
+describe("deriveVoteCardState", () => {
+  it("returns loading when initialization is in progress", () => {
+    expect(
+      deriveVoteCardState(
+        makeInputs({
+          isInitializing: true,
+          isConfirming: true,
+          proposalState: ProposalState.Executed,
+          isVotingOpen: false,
+        }),
+      ),
+    ).toBe("loading");
+  });
+
+  it("returns confirming while a vote transaction is confirming", () => {
+    expect(deriveVoteCardState(makeInputs({ isConfirming: true }))).toBe(
+      "confirming",
+    );
+  });
+
+  it("returns signing while awaiting a wallet signature", () => {
+    expect(
+      deriveVoteCardState(
+        makeInputs({
+          isAwaitingUserSignature: true,
+          proposalState: ProposalState.Canceled,
+          isVotingOpen: false,
+        }),
+      ),
+    ).toBe("signing");
+  });
+
+  it("returns succeeded after a succeeded proposal queue confirmation", () => {
+    expect(
+      deriveVoteCardState(
+        makeInputs({
+          proposalState: ProposalState.Succeeded,
+          isVotingOpen: false,
+          isQueueConfirmed: true,
+        }),
+      ),
+    ).toBe("succeeded");
+  });
+
+  it("returns voted for an active proposal after the voter has voted", () => {
+    expect(deriveVoteCardState(makeInputs({ hasVoted: true }))).toBe("voted");
+  });
+
+  it("returns voted after a vote confirmation even before receipt refresh", () => {
+    expect(deriveVoteCardState(makeInputs({ isConfirmed: true }))).toBe(
+      "voted",
+    );
+  });
+
+  it("returns finished when active voting has passed its deadline", () => {
+    expect(
+      deriveVoteCardState(
+        makeInputs({
+          isVotingOpen: false,
+          isDeadlinePassed: true,
+        }),
+      ),
+    ).toBe("finished");
+  });
+
+  it("returns executed for executed proposals", () => {
+    expect(
+      deriveVoteCardState(
+        makeInputs({
+          proposalState: ProposalState.Executed,
+          isVotingOpen: false,
+        }),
+      ),
+    ).toBe("executed");
+  });
+
+  it("returns queued for queued proposals", () => {
+    expect(
+      deriveVoteCardState(
+        makeInputs({
+          proposalState: ProposalState.Queued,
+          isVotingOpen: false,
+        }),
+      ),
+    ).toBe("queued");
+  });
+
+  it("returns defeated for defeated proposals", () => {
+    expect(
+      deriveVoteCardState(
+        makeInputs({
+          proposalState: ProposalState.Defeated,
+          isVotingOpen: false,
+        }),
+      ),
+    ).toBe("defeated");
+  });
+
+  it("returns canceled for canceled proposals", () => {
+    expect(
+      deriveVoteCardState(
+        makeInputs({
+          proposalState: ProposalState.Canceled,
+          isVotingOpen: false,
+        }),
+      ),
+    ).toBe("canceled");
+  });
+
+  it("returns expired for expired proposals", () => {
+    expect(
+      deriveVoteCardState(
+        makeInputs({
+          proposalState: ProposalState.Expired,
+          isVotingOpen: false,
+        }),
+      ),
+    ).toBe("expired");
+  });
+
+  it("returns pending for pending proposals", () => {
+    expect(
+      deriveVoteCardState(
+        makeInputs({
+          proposalState: ProposalState.Pending,
+          isVotingOpen: false,
+        }),
+      ),
+    ).toBe("pending");
+  });
+
+  it("returns insufficient-mento for connected voters without voting power", () => {
+    expect(
+      deriveVoteCardState(
+        makeInputs({
+          hasEnoughLockedMentoToVote: false,
+        }),
+      ),
+    ).toBe("insufficient-mento");
+  });
+
+  it("returns ready for a disconnected voter while voting is open", () => {
+    expect(
+      deriveVoteCardState(
+        makeInputs({
+          hasEnoughLockedMentoToVote: false,
+          isConnected: false,
+        }),
+      ),
+    ).toBe("ready");
+  });
+
+  it("keeps confirming precedence over terminal states", () => {
+    expect(
+      deriveVoteCardState(
+        makeInputs({
+          isExecuteConfirming: true,
+          proposalState: ProposalState.Executed,
+          isVotingOpen: false,
+        }),
+      ),
+    ).toBe("confirming");
+  });
+
+  it("keeps signing precedence over terminal states", () => {
+    expect(
+      deriveVoteCardState(
+        makeInputs({
+          isAwaitingQueueSignature: true,
+          proposalState: ProposalState.Queued,
+          isVotingOpen: false,
+        }),
+      ),
+    ).toBe("signing");
+  });
+
+  it("returns confirming for a succeeded proposal while the queue transaction is pending", () => {
+    expect(
+      deriveVoteCardState(
+        makeInputs({
+          proposalState: ProposalState.Succeeded,
+          isVotingOpen: false,
+          isQueueTransactionPending: true,
+        }),
+      ),
+    ).toBe("confirming");
+  });
+});

--- a/apps/governance.mento.org/app/components/voting/derive-vote-card-state.ts
+++ b/apps/governance.mento.org/app/components/voting/derive-vote-card-state.ts
@@ -1,0 +1,109 @@
+import { ProposalState } from "@/graphql/subgraph/generated/subgraph";
+
+export type VoteCardState =
+  | "loading"
+  | "confirming"
+  | "signing"
+  | "succeeded"
+  | "voted"
+  | "finished"
+  | "executed"
+  | "queued"
+  | "defeated"
+  | "canceled"
+  | "expired"
+  | "pending"
+  | "insufficient-mento"
+  | "ready";
+
+export interface VoteCardStateInputs {
+  isInitializing: boolean;
+  isConfirmed: boolean;
+  isConfirming: boolean;
+  isExecuteConfirming: boolean;
+  isQueueConfirming: boolean;
+  isQueueConfirmed: boolean;
+  isQueueTransactionPending: boolean;
+  isAwaitingUserSignature: boolean;
+  isAwaitingExecuteSignature: boolean;
+  isAwaitingQueueSignature: boolean;
+  hasVoted: boolean;
+  hasEnoughLockedMentoToVote: boolean;
+  isConnected: boolean;
+  isVotingOpen: boolean;
+  proposalState: ProposalState;
+  isDeadlinePassed: boolean;
+}
+
+export function deriveVoteCardState({
+  isInitializing,
+  isConfirmed,
+  isConfirming,
+  isExecuteConfirming,
+  isQueueConfirming,
+  isQueueConfirmed,
+  isQueueTransactionPending,
+  isAwaitingUserSignature,
+  isAwaitingExecuteSignature,
+  isAwaitingQueueSignature,
+  hasVoted,
+  hasEnoughLockedMentoToVote,
+  isConnected,
+  isVotingOpen,
+  proposalState,
+  isDeadlinePassed,
+}: VoteCardStateInputs): VoteCardState {
+  if (isInitializing) return "loading";
+
+  if (isConfirming || isExecuteConfirming || isQueueConfirming) {
+    return "confirming";
+  }
+
+  if (
+    isAwaitingUserSignature ||
+    isAwaitingExecuteSignature ||
+    isAwaitingQueueSignature
+  ) {
+    return "signing";
+  }
+
+  if (proposalState === ProposalState.Succeeded && isQueueConfirmed) {
+    return "succeeded";
+  }
+
+  if ((proposalState === ProposalState.Active && hasVoted) || isConfirmed) {
+    return "voted";
+  }
+
+  if (!isVotingOpen) {
+    if (proposalState === ProposalState.Active && isDeadlinePassed) {
+      return "finished";
+    }
+
+    switch (proposalState) {
+      case ProposalState.Executed:
+        return "executed";
+      case ProposalState.Queued:
+        return "queued";
+      case ProposalState.Succeeded:
+        if (isQueueTransactionPending) return "confirming";
+        return "succeeded";
+      case ProposalState.Defeated:
+        return "defeated";
+      case ProposalState.Canceled:
+        return "canceled";
+      case ProposalState.Expired:
+        return "expired";
+      case ProposalState.Pending:
+        return "pending";
+      default:
+        return "finished";
+    }
+  }
+
+  if (!hasEnoughLockedMentoToVote && isConnected) {
+    return "insufficient-mento";
+  }
+
+  return "ready";
+}

--- a/apps/governance.mento.org/app/components/voting/vote-card.tsx
+++ b/apps/governance.mento.org/app/components/voting/vote-card.tsx
@@ -53,7 +53,7 @@ export const VoteCard = ({
 
   // Get locks for delegation calculation
   const { locks } = useLocksByAccount({
-    account: address as string,
+    account: address,
   });
 
   // Calculate total voting power including received delegations

--- a/apps/governance.mento.org/app/components/voting/vote-card.tsx
+++ b/apps/governance.mento.org/app/components/voting/vote-card.tsx
@@ -1,6 +1,7 @@
 import { ProgressBar } from "@/components/progress-bar";
 import { TransactionLink } from "@/components/proposal/components/TransactionLink";
 import { Timer } from "@/components/timer";
+import { deriveVoteCardState } from "@/components/voting/derive-vote-card-state";
 import { ProposalCancelButton } from "@/components/voting/proposal-cancel-button";
 import { getWatchdogMultisigAddress } from "@/config";
 import { useLocksByAccount } from "@/contracts";
@@ -498,57 +499,24 @@ export const VoteCard = ({
   const hasQuorum = totalVotingPower >= (quorumNeeded || BigInt(0));
 
   const currentState = useMemo(() => {
-    if (isInitializing) return "loading";
-
-    // Show normal loading states during queue transaction
-    if (isConfirming || isExecuteConfirming || isQueueConfirming)
-      return "confirming";
-    if (
-      isAwaitingUserSignature ||
-      isAwaitingExecuteSignature ||
-      isAwaitingQueueSignature
-    )
-      return "signing";
-
-    // Only show queued state after queue transaction is confirmed
-    if (proposalState === ProposalState.Succeeded && isQueueConfirmed) {
-      return "succeeded";
-    }
-    if (
-      (proposalState === ProposalState.Active && voteReceipt?.hasVoted) ||
-      isConfirmed
-    )
-      return "voted";
-
-    if (!isVotingOpen) {
-      if (proposalState === ProposalState.Active && isDeadlinePassed) {
-        return "finished";
-      }
-
-      switch (proposalState) {
-        case ProposalState.Executed:
-          return "executed";
-        case ProposalState.Queued:
-          return "queued";
-        case ProposalState.Succeeded:
-          // Keep showing the queueing state if the queue transaction is pending
-          if (isQueueTransactionPending) return "confirming";
-          return "succeeded";
-        case ProposalState.Defeated:
-          return "defeated";
-        case ProposalState.Canceled:
-          return "canceled";
-        case ProposalState.Expired:
-          return "expired";
-        case ProposalState.Pending:
-          return "pending";
-        default:
-          return "finished";
-      }
-    }
-
-    if (!hasEnoughLockedMentoToVote && isConnected) return "insufficient-mento";
-    return "ready";
+    return deriveVoteCardState({
+      isInitializing,
+      isConfirmed,
+      isConfirming,
+      isExecuteConfirming,
+      isQueueConfirming,
+      isQueueConfirmed,
+      isQueueTransactionPending: Boolean(isQueueTransactionPending),
+      isAwaitingUserSignature,
+      isAwaitingExecuteSignature,
+      isAwaitingQueueSignature,
+      hasVoted: Boolean(voteReceipt?.hasVoted),
+      hasEnoughLockedMentoToVote,
+      isConnected,
+      isVotingOpen,
+      proposalState,
+      isDeadlinePassed,
+    });
   }, [
     isInitializing,
     isConfirmed,

--- a/apps/governance.mento.org/app/components/voting/vote-title.tsx
+++ b/apps/governance.mento.org/app/components/voting/vote-title.tsx
@@ -10,7 +10,7 @@ export const VoteTitle = () => {
 
   // Get locks for delegation calculation
   const { locks } = useLocksByAccount({
-    account: address as string,
+    account: address,
   });
 
   // Calculate total voting power including received delegations

--- a/apps/governance.mento.org/app/contracts/governor/use-pending-multisig-cancel.ts
+++ b/apps/governance.mento.org/app/contracts/governor/use-pending-multisig-cancel.ts
@@ -176,8 +176,8 @@ export const usePendingMultisigCancellation = (
         throw normalizedError;
       }
     },
-    // Refetch every 3 seconds to keep signatures count updated
-    refetchInterval: 3000,
+    // Poll conservatively; this status is useful but does not need near-real-time churn.
+    refetchInterval: 15_000,
     // Keep previous data while refetching
     placeholderData: (previousData) => previousData,
   });

--- a/apps/governance.mento.org/app/contracts/governor/use-proposal.ts
+++ b/apps/governance.mento.org/app/contracts/governor/use-proposal.ts
@@ -1,5 +1,4 @@
 import { getSubgraphApiName } from "@/config";
-import { CELO_BLOCK_TIME } from "@repo/web3";
 import { GovernorABI } from "@repo/web3";
 import {
   STATE_FROM_NUMBER,
@@ -47,7 +46,7 @@ export const useProposal = (proposalId: bigint) => {
     args: [proposalId],
     chainId: ensuredChainId,
     query: {
-      refetchInterval: CELO_BLOCK_TIME * 10,
+      refetchInterval: 30_000,
       enabled: graphProposals.length > 0,
     },
   });

--- a/apps/governance.mento.org/app/contracts/governor/use-proposals.ts
+++ b/apps/governance.mento.org/app/contracts/governor/use-proposals.ts
@@ -9,8 +9,9 @@ import {
   Proposal,
   useGetProposalsQuery,
 } from "@/graphql/subgraph/generated/subgraph";
+import { reportSubgraphError } from "@/utils/report-subgraph-error";
 
-import { useCallback, useMemo } from "react";
+import { useCallback, useEffect, useMemo } from "react";
 import { useReadContracts } from "@repo/web3/wagmi";
 
 export const useProposals = () => {
@@ -19,6 +20,7 @@ export const useProposals = () => {
 
   const {
     data: graphData,
+    error,
     refetch,
     loading,
   } = useGetProposalsQuery({
@@ -28,8 +30,8 @@ export const useProposals = () => {
     initialFetchPolicy: "network-only",
     nextFetchPolicy: "cache-and-network",
     refetchWritePolicy: "merge",
-    errorPolicy: "ignore",
-    pollInterval: 5000,
+    errorPolicy: "all",
+    pollInterval: 60_000,
   });
 
   const { data: chainData, isLoading } = useReadContracts({
@@ -46,10 +48,32 @@ export const useProposals = () => {
         )
       : [],
     query: {
-      refetchInterval: 5000,
+      refetchInterval: 60_000,
+      refetchOnWindowFocus: true,
       enabled: graphData && graphData.proposals.length > 0,
     },
   });
+
+  useEffect(() => {
+    if (!error) {
+      return;
+    }
+
+    reportSubgraphError(error, "GetProposals");
+  }, [error]);
+
+  useEffect(() => {
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === "visible") {
+        void refetch();
+      }
+    };
+
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    return () => {
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+    };
+  }, [refetch]);
 
   const proposals: Proposal[] = useMemo<Proposal[]>(() => {
     if (chainData === undefined) return [];
@@ -86,6 +110,7 @@ export const useProposals = () => {
   );
 
   return {
+    error,
     isLoading: isLoading || loading,
     proposals,
     proposalExists,

--- a/apps/governance.mento.org/app/contracts/locking/use-lock-info.ts
+++ b/apps/governance.mento.org/app/contracts/locking/use-lock-info.ts
@@ -10,7 +10,7 @@ const formatNumber = (value: bigint | undefined, decimals: number): string =>
   Number(formatUnits(value ?? BigInt(0), decimals)).toFixed(3);
 
 export const useLockInfo = (address: string | undefined) => {
-  const { locks, refetch } = useLocksByAccount({ account: address! });
+  const { locks, refetch } = useLocksByAccount({ account: address });
 
   const { data: unlockedMento, isLoading: isUnlockedMentoLoading } =
     useUnlockedMento();

--- a/apps/governance.mento.org/app/contracts/locking/use-locks-by-account.test.ts
+++ b/apps/governance.mento.org/app/contracts/locking/use-locks-by-account.test.ts
@@ -1,0 +1,69 @@
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+const useGetLocksQueryMock = vi.fn();
+const reportSubgraphErrorMock = vi.fn();
+
+vi.mock("@/config", () => ({
+  getSubgraphApiName: () => "governance",
+}));
+
+vi.mock("@/graphql/subgraph/generated/subgraph", () => ({
+  useGetLocksQuery: useGetLocksQueryMock,
+}));
+
+vi.mock("@/utils/report-subgraph-error", () => ({
+  reportSubgraphError: reportSubgraphErrorMock,
+}));
+
+vi.mock("@repo/web3", () => ({
+  useEnsureChainId: () => 42220,
+}));
+
+vi.mock("./use-locking-week", () => ({
+  useLockingWeek: () => ({ currentWeek: 1 }),
+}));
+
+const { useLocksByAccount } = await import("./use-locks-by-account");
+
+describe("useLocksByAccount", () => {
+  it("ignores stale cached locks and errors while the account query is skipped", () => {
+    const staleError = new Error("stale error");
+    useGetLocksQueryMock.mockReturnValue({
+      data: {
+        locks: [
+          {
+            amount: "100",
+            cliff: 0,
+            delegate: { id: "0xabc" },
+            lockCreate: [],
+            lockId: "1",
+            owner: { id: "0xabc" },
+            relocked: false,
+            replacedBy: null,
+            replaces: null,
+            slope: 1,
+            time: "1",
+          },
+        ],
+      },
+      error: staleError,
+      loading: false,
+      refetch: vi.fn(),
+    });
+
+    const { result } = renderHook(() =>
+      useLocksByAccount({ account: undefined }),
+    );
+
+    expect(useGetLocksQueryMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        skip: true,
+        variables: { address: "" },
+      }),
+    );
+    expect(result.current.locks).toEqual([]);
+    expect(result.current.error).toBeUndefined();
+    expect(reportSubgraphErrorMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/governance.mento.org/app/contracts/locking/use-locks-by-account.ts
+++ b/apps/governance.mento.org/app/contracts/locking/use-locks-by-account.ts
@@ -35,17 +35,18 @@ export const useLocksByAccount = ({
     },
     ssr: false,
   });
+  const activeError = account ? error : undefined;
 
   useEffect(() => {
-    if (!error) {
+    if (!activeError) {
       return;
     }
 
-    reportSubgraphError(error, "GetLocks");
-  }, [error]);
+    reportSubgraphError(activeError, "GetLocks");
+  }, [activeError]);
 
   const locks = useMemo(() => {
-    if (!data) {
+    if (!account || !data) {
       return [] as LockWithExpiration[];
     }
 
@@ -78,11 +79,11 @@ export const useLocksByAccount = ({
     mapped.sort((a, b) => Number(b.lockId) - Number(a.lockId));
 
     return mapped;
-  }, [data, currentLockingWeek]) as LockWithExpiration[];
+  }, [account, data, currentLockingWeek]) as LockWithExpiration[];
 
   return {
     locks,
-    error,
+    error: activeError,
     ...rest,
   };
 };

--- a/apps/governance.mento.org/app/contracts/locking/use-locks-by-account.ts
+++ b/apps/governance.mento.org/app/contracts/locking/use-locks-by-account.ts
@@ -4,13 +4,14 @@ import {
   GetLocksQueryResult,
   useGetLocksQuery,
 } from "@/graphql/subgraph/generated/subgraph";
+import { reportSubgraphError } from "@/utils/report-subgraph-error";
 import { useEnsureChainId } from "@repo/web3";
-import { useMemo } from "react";
+import { useEffect, useMemo } from "react";
 import LockingHelper from "./locking-helper";
 import { useLockingWeek } from "./use-locking-week";
 
 interface UseLocksProps {
-  account: string;
+  account: string | undefined;
 }
 
 export const useLocksByAccount = ({
@@ -21,18 +22,27 @@ export const useLocksByAccount = ({
   const { currentWeek: currentLockingWeek } = useLockingWeek();
   const ensuredChainId = useEnsureChainId();
 
-  const { data, ...rest } = useGetLocksQuery({
+  const { data, error, ...rest } = useGetLocksQuery({
     refetchWritePolicy: "overwrite",
     fetchPolicy: "network-only",
-    errorPolicy: "ignore",
+    errorPolicy: "all",
+    skip: !account,
     variables: {
-      address: account,
+      address: account ?? "",
     },
     context: {
       apiName: getSubgraphApiName(ensuredChainId),
     },
     ssr: false,
   });
+
+  useEffect(() => {
+    if (!error) {
+      return;
+    }
+
+    reportSubgraphError(error, "GetLocks");
+  }, [error]);
 
   const locks = useMemo(() => {
     if (!data) {
@@ -72,6 +82,7 @@ export const useLocksByAccount = ({
 
   return {
     locks,
+    error,
     ...rest,
   };
 };

--- a/apps/governance.mento.org/app/hooks/use-lock-amounts-from-withdrawals.ts
+++ b/apps/governance.mento.org/app/hooks/use-lock-amounts-from-withdrawals.ts
@@ -2,9 +2,10 @@ import { getSubgraphApiName } from "@/config";
 import { LockWithExpiration } from "@/contracts/types";
 import { useGetWithdrawalsQuery } from "@/graphql/subgraph/generated/subgraph";
 import { LockAmounts } from "@/types/lock-amounts";
+import { reportSubgraphError } from "@/utils/report-subgraph-error";
 import { calculateLockAmountsFromWithdrawals } from "@/utils/calculate-lock-amounts-from-withdrawals";
 import { useEnsureChainId } from "@repo/web3";
-import { useMemo } from "react";
+import { useEffect, useMemo } from "react";
 
 interface UseLockAmountsFromWithdrawalsParams {
   locks: LockWithExpiration[] | undefined;
@@ -42,15 +43,23 @@ export function useLockAmountsFromWithdrawals({
   const { data, loading, error } = useGetWithdrawalsQuery({
     skip: !address,
     fetchPolicy: "network-only",
-    errorPolicy: "ignore",
+    errorPolicy: "all",
     variables: {
-      address: address as `0x${string}`,
+      address: address ?? "",
     },
     context: {
       apiName: getSubgraphApiName(ensuredChainId),
     },
     ssr: false,
   });
+
+  useEffect(() => {
+    if (!error) {
+      return;
+    }
+
+    reportSubgraphError(error, "GetWithdrawals");
+  }, [error]);
 
   // Calculate lock amounts using withdrawal events
   const lockAmounts = useMemo(() => {
@@ -74,6 +83,6 @@ export function useLockAmountsFromWithdrawals({
     lockAmounts,
     lockAmountsMap,
     loading,
-    error: error as Error | undefined,
+    error: error ?? undefined,
   };
 }

--- a/apps/governance.mento.org/app/utils/report-subgraph-error.ts
+++ b/apps/governance.mento.org/app/utils/report-subgraph-error.ts
@@ -1,0 +1,40 @@
+import * as Sentry from "@sentry/nextjs";
+
+const REPORT_DEDUPE_MS = 5 * 60 * 1000;
+const lastReportedAtByKey = new Map<string, number>();
+
+function normalizeError(error: unknown): Error {
+  if (error instanceof Error) {
+    return error;
+  }
+
+  if (typeof error === "string") {
+    return new Error(error);
+  }
+
+  return new Error("Unknown governance subgraph error");
+}
+
+export function reportSubgraphError(error: unknown, queryName: string): void {
+  const normalizedError = normalizeError(error);
+  const reportKey = [
+    queryName,
+    normalizedError.name,
+    normalizedError.message,
+  ].join(":");
+  const now = Date.now();
+  const lastReportedAt = lastReportedAtByKey.get(reportKey) ?? 0;
+
+  if (now - lastReportedAt < REPORT_DEDUPE_MS) {
+    return;
+  }
+
+  lastReportedAtByKey.set(reportKey, now);
+
+  Sentry.captureException(normalizedError, {
+    tags: {
+      context: "governance-subgraph",
+      queryName,
+    },
+  });
+}


### PR DESCRIPTION
## The Problem
- governance.mento.org was polling subgraph and on-chain state far more aggressively than needed
- subgraph failures were being flattened into empty states, especially for proposals and account locks
- account lock hooks relied on address casts/non-null assertions that hid the disconnected path and made `skip` handling brittle

## The Solution
- slow proposal, proposal-detail, block, watchdog-cancel, and proposal-state polling to the requested intervals
- add a shared governance subgraph Sentry reporter with 5 minute dedupe and wire it into the proposals, locks, and withdrawals hooks
- switch the affected GraphQL hooks to `errorPolicy: "all"`, surface retryable error UI for proposals and locks, and refetch proposals on `visibilitychange`
- remove the lock-account address casts/non-null assertions from the targeted governance components and hooks so disconnected users cleanly skip `GetLocks`

## Validation
- `pnpm exec turbo run check-types --filter governance.mento.org`
- `trunk check --fix`
- `pnpm --filter governance.mento.org test`
- `set -a; source apps/governance.mento.org/.env.example; set +a; pnpm exec turbo run build --filter governance.mento.org`
  - advanced into `Creating an optimized production build ...` and then produced no further output for roughly 40 seconds locally, so I interrupted it and am leaving the final production build verdict to CI

## Browser Evidence
- started the governance dev server from this worktree on `http://127.0.0.1:3002`
- used local placeholder env values `NEXT_PUBLIC_WALLET_CONNECT_ID=local-dev` and `NEXT_PUBLIC_GRAPH_API_KEY=local-dev` to force the governance subgraph into a failing auth path without changing committed code
- homepage verification:
  - `/` rendered `Could not load proposals.` with a `Retry` button
  - clicking `Retry` issued a fresh `getProposals` request and the browser showed the same subgraph failure instead of a silent empty state
  - captured failing response body from The Graph gateway: `{"errors":[{"message":"auth error: malformed API key"}]}`
- disconnected voting-power verification:
  - `/voting-power` rendered the disconnected shell
  - network inspection showed zero `GetLocks` subgraph requests while disconnected, which confirms the new `skip: !account` path
- remaining gap:
  - I could not fully exercise the connected-wallet `Could not load your locks.` browser state because no local wallet connector was available to attach an address in DevTools

## Ship Checklist
- [x] ship skill used
- [x] local review run
- [x] validation run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly fetch intervals, error visibility, and optional-address typing; no on-chain or auth logic changes.
> 
> **Overview**
> **Reduces aggressive polling** across proposals, proposal detail, block numbers, governor state, and watchdog cancel status (e.g. 5s → 60s for proposals, 3s → 15s for multisig cancel).
> 
> **Subgraph failures are no longer swallowed:** GraphQL hooks use `errorPolicy: "all"`, a shared **`reportSubgraphError`** utility reports to Sentry with 5‑minute dedupe, and **proposal** and **lock** lists show retry UI when loads fail with no data.
> 
> **Lock fetching** accepts `address | undefined`, skips `GetLocks` when disconnected, and drops address casts in voting/locking UI. **`useProposals`** refetches on tab visibility; a unit test covers skipped lock queries ignoring stale cache/errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 809b4f48ddaa760bd9b4deb0c7811ea575bc45f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## Post-Merge Acceptance Closeout (2026-07-14)

Verified on current `origin/main` `8e7f2e66143ca69f8423efb9eace346c0f8dde8a`, which contains squash merge `01377359426e54ff71882e5aaabd61077be793dc`.

- Current-main static acceptance passes: no `errorPolicy: "ignore"`, old 1/3/5-second polling expressions, or `address as string`; `skip: !account` is present and the shared reporter remains wired into all three hooks.
- Local gates pass: 98/98 governance Vitest tests, focused Turbo typecheck, and a production governance build. The build retains pre-existing React Compiler warnings but completes successfully.
- Chrome request budget, disconnected on an executed production proposal:
  - before #464: at least 60 `eth_blockNumber` requests per 60 seconds from the former one-second interval
  - after #464: 4 total RPC + subgraph requests across 73.2 seconds (two at ~29.5s and two at ~59.6s; zero subgraph requests), within the <=6/60s budget
- Disconnected `/` and `/voting-power`: zero `getLocks` operations.
- Fault-injected production-mode build:
  - proposal failure renders `Could not load proposals.`; Retry issues one fresh `getProposals`
  - connected E2E Test Wallet renders `Could not load your locks.`; Retry increments `getLocks` from 2 to 3
  - the reporter invoked one Sentry `captureException` and produced one `event` envelope in 1.65s for a client configured to the `/monitoring` tunnel; transport was intercepted locally before external egress
- Chrome visibility transition: hidden emitted no fetch, then visible emitted exactly one fresh `getProposals` (1 -> 2) before the 60-second poll.
- Chrome console error sweep was clean on the verified production and local fault-state pages.
- Temporary diagnostics were reverted; the worktree is clean and the production-only Sentry guard remains intact.
