### PR TITLE
refactor(governance): extract vote card state derivation

### DIFF
--- a/apps/governance.mento.org/app/components/voting/derive-vote-card-state.test.ts
+++ b/apps/governance.mento.org/app/components/voting/derive-vote-card-state.test.ts
@@ -1,0 +1,219 @@
+import { ProposalState } from "@/graphql/subgraph/generated/subgraph";
+import { describe, expect, it } from "vitest";
+import {
+  deriveVoteCardState,
+  type VoteCardStateInputs,
+} from "./derive-vote-card-state";
+
+function makeInputs(
+  overrides: Partial<VoteCardStateInputs> = {},
+): VoteCardStateInputs {
+  return {
+    isInitializing: false,
+    isConfirmed: false,
+    isConfirming: false,
+    isExecuteConfirming: false,
+    isQueueConfirming: false,
+    isQueueConfirmed: false,
+    isQueueTransactionPending: false,
+    isAwaitingUserSignature: false,
+    isAwaitingExecuteSignature: false,
+    isAwaitingQueueSignature: false,
+    hasVoted: false,
+    hasEnoughLockedMentoToVote: true,
+    isConnected: true,
+    isVotingOpen: true,
+    proposalState: ProposalState.Active,
+    isDeadlinePassed: false,
+    ...overrides,
+  };
+}
+
+describe("deriveVoteCardState", () => {
+  it("returns loading when initialization is in progress", () => {
+    expect(
+      deriveVoteCardState(
+        makeInputs({
+          isInitializing: true,
+          isConfirming: true,
+          proposalState: ProposalState.Executed,
+          isVotingOpen: false,
+        }),
+      ),
+    ).toBe("loading");
+  });
+
+  it("returns confirming while a vote transaction is confirming", () => {
+    expect(deriveVoteCardState(makeInputs({ isConfirming: true }))).toBe(
+      "confirming",
+    );
+  });
+
+  it("returns signing while awaiting a wallet signature", () => {
+    expect(
+      deriveVoteCardState(
+        makeInputs({
+          isAwaitingUserSignature: true,
+          proposalState: ProposalState.Canceled,
+          isVotingOpen: false,
+        }),
+      ),
+    ).toBe("signing");
+  });
+
+  it("returns succeeded after a succeeded proposal queue confirmation", () => {
+    expect(
+      deriveVoteCardState(
+        makeInputs({
+          proposalState: ProposalState.Succeeded,
+          isVotingOpen: false,
+          isQueueConfirmed: true,
+        }),
+      ),
+    ).toBe("succeeded");
+  });
+
+  it("returns voted for an active proposal after the voter has voted", () => {
+    expect(deriveVoteCardState(makeInputs({ hasVoted: true }))).toBe("voted");
+  });
+
+  it("returns voted after a vote confirmation even before receipt refresh", () => {
+    expect(deriveVoteCardState(makeInputs({ isConfirmed: true }))).toBe(
+      "voted",
+    );
+  });
+
+  it("returns finished when active voting has passed its deadline", () => {
+    expect(
+      deriveVoteCardState(
+        makeInputs({
+          isVotingOpen: false,
+          isDeadlinePassed: true,
+        }),
+      ),
+    ).toBe("finished");
+  });
+
+  it("returns executed for executed proposals", () => {
+    expect(
+      deriveVoteCardState(
+        makeInputs({
+          proposalState: ProposalState.Executed,
+          isVotingOpen: false,
+        }),
+      ),
+    ).toBe("executed");
+  });
+
+  it("returns queued for queued proposals", () => {
+    expect(
+      deriveVoteCardState(
+        makeInputs({
+          proposalState: ProposalState.Queued,
+          isVotingOpen: false,
+        }),
+      ),
+    ).toBe("queued");
+  });
+
+  it("returns defeated for defeated proposals", () => {
+    expect(
+      deriveVoteCardState(
+        makeInputs({
+          proposalState: ProposalState.Defeated,
+          isVotingOpen: false,
+        }),
+      ),
+    ).toBe("defeated");
+  });
+
+  it("returns canceled for canceled proposals", () => {
+    expect(
+      deriveVoteCardState(
+        makeInputs({
+          proposalState: ProposalState.Canceled,
+          isVotingOpen: false,
+        }),
+      ),
+    ).toBe("canceled");
+  });
+
+  it("returns expired for expired proposals", () => {
+    expect(
+      deriveVoteCardState(
+        makeInputs({
+          proposalState: ProposalState.Expired,
+          isVotingOpen: false,
+        }),
+      ),
+    ).toBe("expired");
+  });
+
+  it("returns pending for pending proposals", () => {
+    expect(
+      deriveVoteCardState(
+        makeInputs({
+          proposalState: ProposalState.Pending,
+          isVotingOpen: false,
+        }),
+      ),
+    ).toBe("pending");
+  });
+
+  it("returns insufficient-mento for connected voters without voting power", () => {
+    expect(
+      deriveVoteCardState(
+        makeInputs({
+          hasEnoughLockedMentoToVote: false,
+        }),
+      ),
+    ).toBe("insufficient-mento");
+  });
+
+  it("returns ready for a disconnected voter while voting is open", () => {
+    expect(
+      deriveVoteCardState(
+        makeInputs({
+          hasEnoughLockedMentoToVote: false,
+          isConnected: false,
+        }),
+      ),
+    ).toBe("ready");
+  });
+
+  it("keeps confirming precedence over terminal states", () => {
+    expect(
+      deriveVoteCardState(
+        makeInputs({
+          isExecuteConfirming: true,
+          proposalState: ProposalState.Executed,
+          isVotingOpen: false,
+        }),
+      ),
+    ).toBe("confirming");
+  });
+
+  it("keeps signing precedence over terminal states", () => {
+    expect(
+      deriveVoteCardState(
+        makeInputs({
+          isAwaitingQueueSignature: true,
+          proposalState: ProposalState.Queued,
+          isVotingOpen: false,
+        }),
+      ),
+    ).toBe("signing");
+  });
+
+  it("returns confirming for a succeeded proposal while the queue transaction is pending", () => {
+    expect(
+      deriveVoteCardState(
+        makeInputs({
+          proposalState: ProposalState.Succeeded,
+          isVotingOpen: false,
+          isQueueTransactionPending: true,
+        }),
+      ),
+    ).toBe("confirming");
+  });
+});

--- a/apps/governance.mento.org/app/components/voting/derive-vote-card-state.ts
+++ b/apps/governance.mento.org/app/components/voting/derive-vote-card-state.ts
@@ -1,0 +1,109 @@
+import { ProposalState } from "@/graphql/subgraph/generated/subgraph";
+
+export type VoteCardState =
+  | "loading"
+  | "confirming"
+  | "signing"
+  | "succeeded"
+  | "voted"
+  | "finished"
+  | "executed"
+  | "queued"
+  | "defeated"
+  | "canceled"
+  | "expired"
+  | "pending"
+  | "insufficient-mento"
+  | "ready";
+
+export interface VoteCardStateInputs {
+  isInitializing: boolean;
+  isConfirmed: boolean;
+  isConfirming: boolean;
+  isExecuteConfirming: boolean;
+  isQueueConfirming: boolean;
+  isQueueConfirmed: boolean;
+  isQueueTransactionPending: boolean;
+  isAwaitingUserSignature: boolean;
+  isAwaitingExecuteSignature: boolean;
+  isAwaitingQueueSignature: boolean;
+  hasVoted: boolean;
+  hasEnoughLockedMentoToVote: boolean;
+  isConnected: boolean;
+  isVotingOpen: boolean;
+  proposalState: ProposalState;
+  isDeadlinePassed: boolean;
+}
+
+export function deriveVoteCardState({
+  isInitializing,
+  isConfirmed,
+  isConfirming,
+  isExecuteConfirming,
+  isQueueConfirming,
+  isQueueConfirmed,
+  isQueueTransactionPending,
+  isAwaitingUserSignature,
+  isAwaitingExecuteSignature,
+  isAwaitingQueueSignature,
+  hasVoted,
+  hasEnoughLockedMentoToVote,
+  isConnected,
+  isVotingOpen,
+  proposalState,
+  isDeadlinePassed,
+}: VoteCardStateInputs): VoteCardState {
+  if (isInitializing) return "loading";
+
+  if (isConfirming || isExecuteConfirming || isQueueConfirming) {
+    return "confirming";
+  }
+
+  if (
+    isAwaitingUserSignature ||
+    isAwaitingExecuteSignature ||
+    isAwaitingQueueSignature
+  ) {
+    return "signing";
+  }
+
+  if (proposalState === ProposalState.Succeeded && isQueueConfirmed) {
+    return "succeeded";
+  }
+
+  if ((proposalState === ProposalState.Active && hasVoted) || isConfirmed) {
+    return "voted";
+  }
+
+  if (!isVotingOpen) {
+    if (proposalState === ProposalState.Active && isDeadlinePassed) {
+      return "finished";
+    }
+
+    switch (proposalState) {
+      case ProposalState.Executed:
+        return "executed";
+      case ProposalState.Queued:
+        return "queued";
+      case ProposalState.Succeeded:
+        if (isQueueTransactionPending) return "confirming";
+        return "succeeded";
+      case ProposalState.Defeated:
+        return "defeated";
+      case ProposalState.Canceled:
+        return "canceled";
+      case ProposalState.Expired:
+        return "expired";
+      case ProposalState.Pending:
+        return "pending";
+      default:
+        return "finished";
+    }
+  }
+
+  if (!hasEnoughLockedMentoToVote && isConnected) {
+    return "insufficient-mento";
+  }
+
+  return "ready";
+}

--- a/apps/governance.mento.org/app/components/voting/vote-card.tsx
+++ b/apps/governance.mento.org/app/components/voting/vote-card.tsx
@@ -1,6 +1,7 @@
 import { ProgressBar } from "@/components/progress-bar";
 import { TransactionLink } from "@/components/proposal/components/TransactionLink";
 import { Timer } from "@/components/timer";
+import { deriveVoteCardState } from "@/components/voting/derive-vote-card-state";
 import { ProposalCancelButton } from "@/components/voting/proposal-cancel-button";
 import { getWatchdogMultisigAddress } from "@/config";
 import { useLocksByAccount } from "@/contracts";
@@ -498,57 +499,24 @@ export const VoteCard = ({
   const hasQuorum = totalVotingPower >= (quorumNeeded || BigInt(0));
 
   const currentState = useMemo(() => {
-    if (isInitializing) return "loading";
-
-    // Show normal loading states during queue transaction
-    if (isConfirming || isExecuteConfirming || isQueueConfirming)
-      return "confirming";
-    if (
-      isAwaitingUserSignature ||
-      isAwaitingExecuteSignature ||
-      isAwaitingQueueSignature
-    )
-      return "signing";
-
-    // Only show queued state after queue transaction is confirmed
-    if (proposalState === ProposalState.Succeeded && isQueueConfirmed) {
-      return "succeeded";
-    }
-    if (
-      (proposalState === ProposalState.Active && voteReceipt?.hasVoted) ||
-      isConfirmed
-    )
-      return "voted";
-
-    if (!isVotingOpen) {
-      if (proposalState === ProposalState.Active && isDeadlinePassed) {
-        return "finished";
-      }
-
-      switch (proposalState) {
-        case ProposalState.Executed:
-          return "executed";
-        case ProposalState.Queued:
-          return "queued";
-        case ProposalState.Succeeded:
-          // Keep showing the queueing state if the queue transaction is pending
-          if (isQueueTransactionPending) return "confirming";
-          return "succeeded";
-        case ProposalState.Defeated:
-          return "defeated";
-        case ProposalState.Canceled:
-          return "canceled";
-        case ProposalState.Expired:
-          return "expired";
-        case ProposalState.Pending:
-          return "pending";
-        default:
-          return "finished";
-      }
-    }
-
-    if (!hasEnoughLockedMentoToVote && isConnected) return "insufficient-mento";
-    return "ready";
+    return deriveVoteCardState({
+      isInitializing,
+      isConfirmed,
+      isConfirming,
+      isExecuteConfirming,
+      isQueueConfirming,
+      isQueueConfirmed,
+      isQueueTransactionPending: Boolean(isQueueTransactionPending),
+      isAwaitingUserSignature,
+      isAwaitingExecuteSignature,
+      isAwaitingQueueSignature,
+      hasVoted: Boolean(voteReceipt?.hasVoted),
+      hasEnoughLockedMentoToVote,
+      isConnected,
+      isVotingOpen,
+      proposalState,
+      isDeadlinePassed,
+    });
   }, [
     isInitializing,
     isConfirmed,


### PR DESCRIPTION
## The Problem
Issue #413 asks us to break up the `vote-card.tsx` state machine. Phase 1 is to extract the inline vote-card state derivation into a pure function without changing behavior, and lock its precedence down with focused tests.

## The Solution
- Extracted the `currentState` derivation into `app/components/voting/derive-vote-card-state.ts` as a pure helper with typed inputs and outputs.
- Kept `vote-card.tsx` on `useMemo`, preserved the existing dependency list, and routed the same inputs through `deriveVoteCardState`, normalizing `isQueueTransactionPending` with `Boolean(...)` at the call site.
- Added exhaustive unit coverage in `derive-vote-card-state.test.ts`, including every returned state plus the precedence edges called out in issue #413.
- This is Phase 1 only, stacked on PR #464 (`perf/412-governance-polling-errors`).

## Validation
- `trunk check --fix apps/governance.mento.org/app/components/voting/derive-vote-card-state.ts apps/governance.mento.org/app/components/voting/derive-vote-card-state.test.ts apps/governance.mento.org/app/components/voting/vote-card.tsx`
- `pnpm exec turbo run build --filter "./packages/*"`
- `pnpm --filter governance.mento.org test`
- `pnpm exec turbo run check-types --filter governance.mento.org`
- `pnpm exec turbo run build --filter governance.mento.org` (blocked locally: governance env validation fails because required vars like `ETHERSCAN_API_KEY`, `NEXT_PUBLIC_SUBGRAPH_URL`, and `NEXT_PUBLIC_WALLET_CONNECT_ID` are unset in this worktree)

## Browser Verification
- Started `governance.mento.org` locally on `http://127.0.0.1:3002` and verified `/voting-power` renders with the new extraction in place.
- Confirmed the page content loads (`Your voting power`) after providing a non-empty local WalletConnect placeholder for dev-only verification.
- Remaining console errors were external-resource failures from placeholder local env/auth setup (HTTP 403 and 400), not from the vote-card refactor.

## Ship Checklist
- [x] ship skill used
- [x] local review run
- [x] validation run

Refs #413

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only with unit tests locking precedence; risk is accidental UI state regression if inputs diverge from the old inline logic.
> 
> **Overview**
> Moves the vote card’s inline `currentState` logic out of `vote-card.tsx` into a pure **`deriveVoteCardState`** helper with typed **`VoteCardState`** / **`VoteCardStateInputs`**.
> 
> The component still computes `currentState` via **`useMemo`** with the same dependency list; it now passes wallet, transaction, receipt, and proposal inputs into the helper (including **`Boolean(...)`** for queue-pending and **`hasVoted`**). **`derive-vote-card-state.test.ts`** adds Vitest coverage for every returned state and precedence rules (loading/confirming/signing over terminal states, queue-pending on succeeded proposals).
> 
> Phase 1 refactor only—intended behavior parity for governance voting UI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4df7668e4e2790265600ba6d8554a2cdbff583e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->