### PR TITLE
refactor(app): extract max sell amount helper

### DIFF
--- a/apps/app.mento.org/app/components/swap/swap-form/max-sell-amount.test.ts
+++ b/apps/app.mento.org/app/components/swap/swap-form/max-sell-amount.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+
+import { getMaxSellAmount } from "./max-sell-amount";
+
+describe("getMaxSellAmount", () => {
+  it("applies the native gas reserve when the balance exceeds 0.01 CELO", () => {
+    expect(
+      getMaxSellAmount({
+        balanceInWei: "1234567890000000000",
+        decimals: 18,
+        isNativeToken: true,
+      }),
+    ).toBe("1.2245");
+  });
+
+  it("does not subtract the reserve when the native balance is at or below 0.01 CELO", () => {
+    expect(
+      getMaxSellAmount({
+        balanceInWei: "10000000000000000",
+        decimals: 18,
+        isNativeToken: true,
+      }),
+    ).toBe("0.01");
+  });
+
+  it("passes non-native balances through unchanged", () => {
+    expect(
+      getMaxSellAmount({
+        balanceInWei: "1234567890000000000",
+        decimals: 18,
+        isNativeToken: false,
+      }),
+    ).toBe("1.2345");
+  });
+
+  it("truncates to four decimals without thousand separators", () => {
+    expect(
+      getMaxSellAmount({
+        balanceInWei: "123456789123456789123456",
+        decimals: 18,
+        isNativeToken: false,
+      }),
+    ).toBe("123456.7891");
+  });
+});

--- a/apps/app.mento.org/app/components/swap/swap-form/max-sell-amount.test.ts
+++ b/apps/app.mento.org/app/components/swap/swap-form/max-sell-amount.test.ts
@@ -1,8 +1,27 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const formatterMocks = vi.hoisted(() => ({
+  formatBalance: vi.fn(
+    (balanceInWei: string, decimals: number) => `${balanceInWei}:${decimals}`,
+  ),
+  formatWithMaxDecimals: vi.fn(
+    (
+      formattedAmount: string,
+      maxDecimals: number,
+      useThousandSeparators: boolean,
+    ) => `${formattedAmount}:${maxDecimals}:${useThousandSeparators}`,
+  ),
+}));
+
+vi.mock("@repo/web3", () => formatterMocks);
 
 import { getMaxSellAmount } from "./max-sell-amount";
 
 describe("getMaxSellAmount", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it("applies the native gas reserve when the balance exceeds 0.01 CELO", () => {
     expect(
       getMaxSellAmount({
@@ -10,7 +29,11 @@ describe("getMaxSellAmount", () => {
         decimals: 18,
         isNativeToken: true,
       }),
-    ).toBe("1.2245");
+    ).toBe("1224567890000000000:18:4:false");
+    expect(formatterMocks.formatBalance).toHaveBeenCalledWith(
+      "1224567890000000000",
+      18,
+    );
   });
 
   it("does not subtract the reserve when the native balance is at or below 0.01 CELO", () => {
@@ -20,7 +43,25 @@ describe("getMaxSellAmount", () => {
         decimals: 18,
         isNativeToken: true,
       }),
-    ).toBe("0.01");
+    ).toBe("10000000000000000:18:4:false");
+    expect(formatterMocks.formatBalance).toHaveBeenCalledWith(
+      "10000000000000000",
+      18,
+    );
+
+    vi.clearAllMocks();
+
+    expect(
+      getMaxSellAmount({
+        balanceInWei: "9999999999999999",
+        decimals: 18,
+        isNativeToken: true,
+      }),
+    ).toBe("9999999999999999:18:4:false");
+    expect(formatterMocks.formatBalance).toHaveBeenCalledWith(
+      "9999999999999999",
+      18,
+    );
   });
 
   it("passes non-native balances through unchanged", () => {
@@ -30,16 +71,28 @@ describe("getMaxSellAmount", () => {
         decimals: 18,
         isNativeToken: false,
       }),
-    ).toBe("1.2345");
+    ).toBe("1234567890000000000:18:4:false");
+    expect(formatterMocks.formatBalance).toHaveBeenCalledWith(
+      "1234567890000000000",
+      18,
+    );
   });
 
-  it("truncates to four decimals without thousand separators", () => {
-    expect(
-      getMaxSellAmount({
-        balanceInWei: "123456789123456789123456",
-        decimals: 18,
-        isNativeToken: false,
-      }),
-    ).toBe("123456.7891");
+  it("formats the balance with four decimals and no thousand separators", () => {
+    formatterMocks.formatBalance.mockReturnValueOnce("123456.78912345");
+    formatterMocks.formatWithMaxDecimals.mockReturnValueOnce("123456.7891");
+
+    const result = getMaxSellAmount({
+      balanceInWei: "123456789123456789123456",
+      decimals: 18,
+      isNativeToken: false,
+    });
+
+    expect(result).toBe("123456.7891");
+    expect(formatterMocks.formatWithMaxDecimals).toHaveBeenCalledWith(
+      "123456.78912345",
+      4,
+      false,
+    );
   });
 });

--- a/apps/app.mento.org/app/components/swap/swap-form/max-sell-amount.ts
+++ b/apps/app.mento.org/app/components/swap/swap-form/max-sell-amount.ts
@@ -1,4 +1,4 @@
-import { formatUnits } from "viem";
+import { formatBalance, formatWithMaxDecimals } from "@repo/web3";
 
 const NATIVE_TOKEN_GAS_RESERVE_WEI = BigInt("10000000000000000"); // 0.01 CELO
 
@@ -23,26 +23,5 @@ export function getMaxSellAmount({
   }
 
   const formattedAmount = formatBalance(maxAmountInWei, decimals);
-  return formatWithMaxDecimals(formattedAmount);
-}
-
-function formatBalance(value: string, decimals: number): string {
-  try {
-    const formatted = formatUnits(BigInt(value), decimals);
-    const decimalPoint = formatted.indexOf(".");
-    if (decimalPoint === -1) return formatted;
-    return formatted.slice(0, decimalPoint + 5);
-  } catch {
-    return "0";
-  }
-}
-
-function formatWithMaxDecimals(value: string): string {
-  if (!value || value === "0") return "0";
-
-  const [wholePart = "", decimalPart = ""] = value.split(".");
-  const trimmedDecimals = decimalPart.replace(/0+$/, "");
-
-  if (!trimmedDecimals) return wholePart;
-  return `${wholePart}.${trimmedDecimals}`;
+  return formatWithMaxDecimals(formattedAmount, 4, false);
 }

--- a/apps/app.mento.org/app/components/swap/swap-form/max-sell-amount.ts
+++ b/apps/app.mento.org/app/components/swap/swap-form/max-sell-amount.ts
@@ -1,0 +1,48 @@
+import { formatUnits } from "viem";
+
+const NATIVE_TOKEN_GAS_RESERVE_WEI = BigInt("10000000000000000"); // 0.01 CELO
+
+interface GetMaxSellAmountParams {
+  balanceInWei: string;
+  decimals: number;
+  isNativeToken: boolean;
+}
+
+export function getMaxSellAmount({
+  balanceInWei,
+  decimals,
+  isNativeToken,
+}: GetMaxSellAmountParams): string {
+  let maxAmountInWei = balanceInWei;
+
+  if (isNativeToken) {
+    const balance = BigInt(balanceInWei);
+    if (balance > NATIVE_TOKEN_GAS_RESERVE_WEI) {
+      maxAmountInWei = (balance - NATIVE_TOKEN_GAS_RESERVE_WEI).toString();
+    }
+  }
+
+  const formattedAmount = formatBalance(maxAmountInWei, decimals);
+  return formatWithMaxDecimals(formattedAmount);
+}
+
+function formatBalance(value: string, decimals: number): string {
+  try {
+    const formatted = formatUnits(BigInt(value), decimals);
+    const decimalPoint = formatted.indexOf(".");
+    if (decimalPoint === -1) return formatted;
+    return formatted.slice(0, decimalPoint + 5);
+  } catch {
+    return "0";
+  }
+}
+
+function formatWithMaxDecimals(value: string): string {
+  if (!value || value === "0") return "0";
+
+  const [wholePart = "", decimalPart = ""] = value.split(".");
+  const trimmedDecimals = decimalPart.replace(/0+$/, "");
+
+  if (!trimmedDecimals) return wholePart;
+  return `${wholePart}.${trimmedDecimals}`;
+}

--- a/apps/app.mento.org/app/components/swap/swap-form/use-swap-form.tsx
+++ b/apps/app.mento.org/app/components/swap/swap-form/use-swap-form.tsx
@@ -63,6 +63,7 @@ import {
   createWaitingForQuoteStore,
   getTokenPairKey,
 } from "./waiting-for-quote-store";
+import { getMaxSellAmount } from "./max-sell-amount";
 import { defaultEmptyBalances, formSchema, type FormValues } from "./types";
 
 interface UseSwapFormOptions {
@@ -470,25 +471,14 @@ export function useSwapForm(opts?: UseSwapFormOptions) {
   const handleUseMaxBalance = () => {
     if (!selectedTokenInSymbol) return;
 
-    let maxAmountInWei: string = String(
+    const balanceInWei = String(
       getTokenBalanceValue(balances, selectedTokenInSymbol) || "0",
     );
-    const decimals = getTokenDecimals(selectedTokenInSymbol, formChainId);
-
-    if (selectedTokenInSymbol === nativeTokenSymbol) {
-      const gasReserveWei = BigInt("10000000000000000"); // 0.01 CELO
-      const balance = BigInt(maxAmountInWei);
-      if (balance > gasReserveWei) {
-        maxAmountInWei = (balance - gasReserveWei).toString();
-      }
-    }
-
-    const formattedAmount = formatBalance(maxAmountInWei, decimals);
-    const formattedAmountWithMaxDecimals = formatWithMaxDecimals(
-      formattedAmount,
-      4,
-      false,
-    );
+    const formattedAmountWithMaxDecimals = getMaxSellAmount({
+      balanceInWei,
+      decimals: getTokenDecimals(selectedTokenInSymbol, formChainId),
+      isNativeToken: selectedTokenInSymbol === nativeTokenSymbol,
+    });
     form.setValue("amount", formattedAmountWithMaxDecimals);
 
     if (selectedTokenInSymbol === nativeTokenSymbol) {


### PR DESCRIPTION
## The Problem
Issue #404 Phase (b) needs the swap form max-balance computation extracted from `use-swap-form.tsx` into a tested pure helper without pulling in the later decomposition phases.

## The Solution
- Extract the max sell amount computation into `max-sell-amount.ts`.
- Keep the toast side effects and `form.setValue` inside `use-swap-form.tsx`.
- Preserve the original formatting path by composing the existing `formatBalance` and `formatWithMaxDecimals(formattedAmount, 4, false)` helpers.
- Add co-located tests for native reserve application, reserve no-op at and below the reserve, non-native passthrough, and four-decimal/no-thousands formatting.
- Keep this Phase (b) PR stacked on PR #465 / `refactor/404-waiting-for-quote-store`.

Refs #404

## Validation
- `pnpm --filter app.mento.org exec vitest run app/components/swap/swap-form/max-sell-amount.test.ts`
- `pnpm --filter app.mento.org test`
- `pnpm --filter app.mento.org exec tsc --noEmit`
- `trunk check --fix apps/app.mento.org/app/components/swap/swap-form/use-swap-form.tsx apps/app.mento.org/app/components/swap/swap-form/max-sell-amount.ts apps/app.mento.org/app/components/swap/swap-form/max-sell-amount.test.ts`
- `git diff --check`
- Pre-push hook passed after d110228a (`trunk`, turbo `check-types`, `knip`)

## Browser Verification
- Started `app.mento.org` locally at `http://127.0.0.1:3000/swap/celo`.
- Verified the disconnected swap shell renders on `/swap/celo`.
- Clicked `MAX`; with zero balance, the sell input updated to `0` without surfacing a new runtime exception.
- Console errors observed during local verification were environment-specific: dummy WalletConnect `projectId` returned `403/400`, and placeholder `NEXT_PUBLIC_STORAGE_URL=https://example.com` produced a background image `404`.

## Ship Checklist
- [x] ship skill used
- [x] local review run
- [x] validation run