### PR TITLE
refactor(governance): extract delayed vote-card refire

### DIFF
--- a/apps/governance.mento.org/app/components/voting/use-delayed-vote-card-refire.test.ts
+++ b/apps/governance.mento.org/app/components/voting/use-delayed-vote-card-refire.test.ts
@@ -1,0 +1,104 @@
+import { renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useDelayedVoteCardRefire } from "./use-delayed-vote-card-refire";
+
+describe("useDelayedVoteCardRefire", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  it("refires vote receipt and vote confirmation after vote confirmation", () => {
+    const refetchVoteReceipt = vi.fn();
+    const onVoteConfirmed = vi.fn();
+
+    renderHook(() =>
+      useDelayedVoteCardRefire({
+        isVoteConfirmed: true,
+        isQueueConfirmed: false,
+        isProposerCancelConfirmed: false,
+        refetchVoteReceipt,
+        onVoteConfirmed,
+      }),
+    );
+
+    expect(refetchVoteReceipt).toHaveBeenCalledTimes(1);
+    expect(onVoteConfirmed).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(2000);
+    expect(refetchVoteReceipt).toHaveBeenCalledTimes(2);
+    expect(onVoteConfirmed).toHaveBeenCalledTimes(2);
+
+    vi.advanceTimersByTime(3000);
+    expect(refetchVoteReceipt).toHaveBeenCalledTimes(3);
+    expect(onVoteConfirmed).toHaveBeenCalledTimes(3);
+  });
+
+  it.each([
+    {
+      name: "queue confirmation",
+      isQueueConfirmed: true,
+      isProposerCancelConfirmed: false,
+    },
+    {
+      name: "proposer cancel confirmation",
+      isQueueConfirmed: false,
+      isProposerCancelConfirmed: true,
+    },
+  ])(
+    "refires vote confirmation after $name without refetching the vote receipt",
+    ({ isQueueConfirmed, isProposerCancelConfirmed }) => {
+      const refetchVoteReceipt = vi.fn();
+      const onVoteConfirmed = vi.fn();
+
+      renderHook(() =>
+        useDelayedVoteCardRefire({
+          isVoteConfirmed: false,
+          isQueueConfirmed,
+          isProposerCancelConfirmed,
+          refetchVoteReceipt,
+          onVoteConfirmed,
+        }),
+      );
+
+      expect(refetchVoteReceipt).not.toHaveBeenCalled();
+      expect(onVoteConfirmed).toHaveBeenCalledTimes(1);
+
+      vi.advanceTimersByTime(2000);
+      expect(onVoteConfirmed).toHaveBeenCalledTimes(2);
+
+      vi.advanceTimersByTime(3000);
+      expect(onVoteConfirmed).toHaveBeenCalledTimes(3);
+      expect(refetchVoteReceipt).not.toHaveBeenCalled();
+    },
+  );
+
+  it("cleans up pending delayed refires on unmount", () => {
+    const refetchVoteReceipt = vi.fn();
+    const onVoteConfirmed = vi.fn();
+
+    const { unmount } = renderHook(() =>
+      useDelayedVoteCardRefire({
+        isVoteConfirmed: true,
+        isQueueConfirmed: false,
+        isProposerCancelConfirmed: false,
+        refetchVoteReceipt,
+        onVoteConfirmed,
+      }),
+    );
+
+    expect(refetchVoteReceipt).toHaveBeenCalledTimes(1);
+    expect(onVoteConfirmed).toHaveBeenCalledTimes(1);
+
+    unmount();
+    vi.advanceTimersByTime(5000);
+
+    expect(refetchVoteReceipt).toHaveBeenCalledTimes(1);
+    expect(onVoteConfirmed).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/governance.mento.org/app/components/voting/use-delayed-vote-card-refire.ts
+++ b/apps/governance.mento.org/app/components/voting/use-delayed-vote-card-refire.ts
@@ -1,0 +1,60 @@
+import { useEffect } from "react";
+
+interface UseDelayedVoteCardRefireProps {
+  isVoteConfirmed: boolean;
+  isQueueConfirmed: boolean;
+  isProposerCancelConfirmed: boolean;
+  refetchVoteReceipt: () => void;
+  onVoteConfirmed?: () => void;
+}
+
+const scheduleImmediateAndDelayed = (callback: () => void) => {
+  callback();
+
+  const timeoutAfterTwoSeconds = setTimeout(() => {
+    callback();
+  }, 2000);
+
+  const timeoutAfterFiveSeconds = setTimeout(() => {
+    callback();
+  }, 5000);
+
+  return () => {
+    clearTimeout(timeoutAfterTwoSeconds);
+    clearTimeout(timeoutAfterFiveSeconds);
+  };
+};
+
+export const useDelayedVoteCardRefire = ({
+  isVoteConfirmed,
+  isQueueConfirmed,
+  isProposerCancelConfirmed,
+  refetchVoteReceipt,
+  onVoteConfirmed,
+}: UseDelayedVoteCardRefireProps) => {
+  useEffect(() => {
+    if (!isVoteConfirmed) return;
+
+    const cleanups = [scheduleImmediateAndDelayed(refetchVoteReceipt)];
+
+    if (onVoteConfirmed) {
+      cleanups.push(scheduleImmediateAndDelayed(onVoteConfirmed));
+    }
+
+    return () => {
+      cleanups.forEach((cleanup) => cleanup());
+    };
+  }, [isVoteConfirmed, refetchVoteReceipt, onVoteConfirmed]);
+
+  useEffect(() => {
+    if (!isQueueConfirmed || !onVoteConfirmed) return;
+
+    return scheduleImmediateAndDelayed(onVoteConfirmed);
+  }, [isQueueConfirmed, onVoteConfirmed]);
+
+  useEffect(() => {
+    if (!isProposerCancelConfirmed || !onVoteConfirmed) return;
+
+    return scheduleImmediateAndDelayed(onVoteConfirmed);
+  }, [isProposerCancelConfirmed, onVoteConfirmed]);
+};

--- a/apps/governance.mento.org/app/components/voting/vote-card.tsx
+++ b/apps/governance.mento.org/app/components/voting/vote-card.tsx
@@ -3,6 +3,7 @@ import { TransactionLink } from "@/components/proposal/components/TransactionLin
 import { Timer } from "@/components/timer";
 import { deriveVoteCardState } from "@/components/voting/derive-vote-card-state";
 import { VoteCardCancelActions } from "@/components/voting/vote-card-cancel-actions";
+import { useDelayedVoteCardRefire } from "@/components/voting/use-delayed-vote-card-refire";
 import { getWatchdogMultisigAddress } from "@/config";
 import { useLocksByAccount } from "@/contracts";
 import {
@@ -215,83 +216,13 @@ export const VoteCard = ({
     return () => clearInterval(interval);
   }, [votingDeadline, proposal.state]);
 
-  useEffect(() => {
-    if (isConfirmed) {
-      refetchVoteReceipt();
-
-      const voteReceiptTimeout1 = setTimeout(() => {
-        refetchVoteReceipt();
-      }, 2000);
-
-      const voteReceiptTimeout2 = setTimeout(() => {
-        refetchVoteReceipt();
-      }, 5000);
-
-      if (onVoteConfirmed) {
-        onVoteConfirmed();
-
-        const timeout1 = setTimeout(() => {
-          onVoteConfirmed();
-        }, 2000);
-
-        const timeout2 = setTimeout(() => {
-          onVoteConfirmed();
-        }, 5000);
-
-        return () => {
-          clearTimeout(timeout1);
-          clearTimeout(timeout2);
-          clearTimeout(voteReceiptTimeout1);
-          clearTimeout(voteReceiptTimeout2);
-        };
-      }
-
-      return () => {
-        clearTimeout(voteReceiptTimeout1);
-        clearTimeout(voteReceiptTimeout2);
-      };
-    }
-  }, [isConfirmed, refetchVoteReceipt, onVoteConfirmed]);
-
-  // Trigger onVoteConfirmed when queue transaction is confirmed
-  useEffect(() => {
-    if (isQueueConfirmed && onVoteConfirmed) {
-      onVoteConfirmed();
-
-      const timeout1 = setTimeout(() => {
-        onVoteConfirmed();
-      }, 2000);
-
-      const timeout2 = setTimeout(() => {
-        onVoteConfirmed();
-      }, 5000);
-
-      return () => {
-        clearTimeout(timeout1);
-        clearTimeout(timeout2);
-      };
-    }
-  }, [isQueueConfirmed, onVoteConfirmed]);
-
-  // Trigger onVoteConfirmed when proposer cancel transaction is confirmed
-  useEffect(() => {
-    if (isProposerCancelConfirmed && onVoteConfirmed) {
-      onVoteConfirmed();
-
-      const timeout1 = setTimeout(() => {
-        onVoteConfirmed();
-      }, 2000);
-
-      const timeout2 = setTimeout(() => {
-        onVoteConfirmed();
-      }, 5000);
-
-      return () => {
-        clearTimeout(timeout1);
-        clearTimeout(timeout2);
-      };
-    }
-  }, [isProposerCancelConfirmed, onVoteConfirmed]);
+  useDelayedVoteCardRefire({
+    isVoteConfirmed: isConfirmed,
+    isQueueConfirmed,
+    isProposerCancelConfirmed,
+    refetchVoteReceipt,
+    onVoteConfirmed,
+  });
 
   // Calculate total voting power for quorum display
   const totalVotingPower = useMemo(() => {


### PR DESCRIPTION
## The Problem
`vote-card.tsx` repeated the same delayed re-fire timeout sequence in three separate effects for vote confirmation, queue confirmation, and proposer cancel confirmation. That made the confirmation behavior harder to follow and easier to drift.

## The Solution
- extract the repeated immediate/2s/5s timeout scheduling into a focused `useDelayedVoteCardRefire` hook
- keep vote receipt refetching scoped to the vote-confirmed path only
- add focused fake-timer coverage for immediate calls, delayed calls, and cleanup behavior

## Validation
- `pnpm --filter governance.mento.org test`
- `pnpm --filter governance.mento.org check-types`
- `trunk check --fix apps/governance.mento.org/app/components/voting/vote-card.tsx apps/governance.mento.org/app/components/voting/use-delayed-vote-card-refire.ts apps/governance.mento.org/app/components/voting/use-delayed-vote-card-refire.test.ts`
- browser verification on `http://localhost:3002/voting-power`

## Notes
- browser verification used the governance `.env.example` values plus local placeholder values for `NEXT_PUBLIC_WALLET_CONNECT_ID`, `NEXT_PUBLIC_GRAPH_API_KEY`, and `ETHERSCAN_API_KEY` so the page could render in local dev
- the checked-in blank WalletConnect project id causes a runtime crash on `/voting-power` in local dev before that override
- with placeholder values, the page rendered correctly and the remaining console noise was external `400/403` responses from WalletConnect/Web3Modal config endpoints

## Ship Checklist
- [x] ship skill used
- [x] local review run
- [x] validation run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only UI refresh timing with tests locking prior behavior; no auth, chain, or contract logic changes.
> 
> **Overview**
> Moves duplicated **immediate / 2s / 5s** post-confirmation refresh logic out of `vote-card.tsx` into **`useDelayedVoteCardRefire`**, so vote, queue, and proposer-cancel paths share one scheduling helper instead of three copy-pasted `useEffect` blocks.
> 
> **Vote confirmed** still triggers **`refetchVoteReceipt`** and optional **`onVoteConfirmed`** on that schedule; **queue** and **proposer cancel** confirmations only re-fire **`onVoteConfirmed`**, matching prior behavior. **`vote-card.tsx`** wires the hook with the existing confirmation flags and drops ~70 lines of inline timeouts.
> 
> Adds **Vitest** coverage with fake timers for immediate and delayed calls, queue/cancel vs vote receipt scoping, and cleanup on unmount.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7afd852b13a550de2bd6e8d8fa481bb6b516086a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->