### PR TITLE
refactor(app): extract swap chain change sync plan

### DIFF
--- a/apps/app.mento.org/app/components/swap/swap-form/chain-change-sync.test.ts
+++ b/apps/app.mento.org/app/components/swap/swap-form/chain-change-sync.test.ts
@@ -1,0 +1,64 @@
+import type { TokenSymbol } from "@mento-protocol/mento-sdk";
+import { describe, expect, it } from "vitest";
+
+import { getChainChangeSyncPlan } from "./chain-change-sync";
+
+describe("getChainChangeSyncPlan", () => {
+  const availableTokens = ["USDm", "cEUR", "cREAL"] as TokenSymbol[];
+
+  it("returns a clear-amount-only plan when both tokens stay valid and distinct", () => {
+    expect(
+      getChainChangeSyncPlan({
+        availableTokens,
+        currentTokenInSymbol: "USDm",
+        currentTokenOutSymbol: "cEUR",
+        preferredQuoteTokenSymbol: "cREAL" as TokenSymbol,
+      }),
+    ).toEqual({ kind: "clear-amount-only" });
+  });
+
+  it("falls back to the preferred quote token when tokenIn is invalid", () => {
+    expect(
+      getChainChangeSyncPlan({
+        availableTokens,
+        currentTokenInSymbol: "invalid",
+        currentTokenOutSymbol: "",
+        preferredQuoteTokenSymbol: "cREAL" as TokenSymbol,
+      }),
+    ).toEqual({
+      kind: "reset-tokens",
+      tokenInSymbol: "cREAL",
+      tokenOutSymbol: "USDm",
+    });
+  });
+
+  it("picks a distinct tokenOut when the resolved pair would be duplicated", () => {
+    expect(
+      getChainChangeSyncPlan({
+        availableTokens,
+        currentTokenInSymbol: "USDm",
+        currentTokenOutSymbol: "USDm",
+        preferredQuoteTokenSymbol: "cREAL" as TokenSymbol,
+      }),
+    ).toEqual({
+      kind: "reset-tokens",
+      tokenInSymbol: "USDm",
+      tokenOutSymbol: "cEUR",
+    });
+  });
+
+  it("handles chains without available tokens", () => {
+    expect(
+      getChainChangeSyncPlan({
+        availableTokens: [],
+        currentTokenInSymbol: "USDm",
+        currentTokenOutSymbol: "cEUR",
+        preferredQuoteTokenSymbol: "cREAL" as TokenSymbol,
+      }),
+    ).toEqual({
+      kind: "reset-tokens",
+      tokenInSymbol: "",
+      tokenOutSymbol: "",
+    });
+  });
+});

--- a/apps/app.mento.org/app/components/swap/swap-form/chain-change-sync.test.ts
+++ b/apps/app.mento.org/app/components/swap/swap-form/chain-change-sync.test.ts
@@ -32,6 +32,21 @@ describe("getChainChangeSyncPlan", () => {
     });
   });
 
+  it("preserves an unavailable preferred quote token before falling back to the first available token", () => {
+    expect(
+      getChainChangeSyncPlan({
+        availableTokens,
+        currentTokenInSymbol: "invalid",
+        currentTokenOutSymbol: "",
+        preferredQuoteTokenSymbol: "cUSD" as TokenSymbol,
+      }),
+    ).toEqual({
+      kind: "reset-tokens",
+      tokenInSymbol: "cUSD",
+      tokenOutSymbol: "USDm",
+    });
+  });
+
   it("picks a distinct tokenOut when the resolved pair would be duplicated", () => {
     expect(
       getChainChangeSyncPlan({
@@ -47,13 +62,28 @@ describe("getChainChangeSyncPlan", () => {
     });
   });
 
-  it("handles chains without available tokens", () => {
+  it("keeps the preferred quote when no tokens are available", () => {
     expect(
       getChainChangeSyncPlan({
         availableTokens: [],
         currentTokenInSymbol: "USDm",
         currentTokenOutSymbol: "cEUR",
         preferredQuoteTokenSymbol: "cREAL" as TokenSymbol,
+      }),
+    ).toEqual({
+      kind: "reset-tokens",
+      tokenInSymbol: "cREAL",
+      tokenOutSymbol: "",
+    });
+  });
+
+  it("handles chains without available tokens or a preferred quote", () => {
+    expect(
+      getChainChangeSyncPlan({
+        availableTokens: [],
+        currentTokenInSymbol: "USDm",
+        currentTokenOutSymbol: "cEUR",
+        preferredQuoteTokenSymbol: null,
       }),
     ).toEqual({
       kind: "reset-tokens",

--- a/apps/app.mento.org/app/components/swap/swap-form/chain-change-sync.ts
+++ b/apps/app.mento.org/app/components/swap/swap-form/chain-change-sync.ts
@@ -1,0 +1,71 @@
+import type { TokenSymbol } from "@mento-protocol/mento-sdk";
+
+import {
+  getAvailableTokenSymbol,
+  getDefaultTokenInSymbol,
+} from "./token-selection";
+
+type ClearAmountOnlyPlan = {
+  kind: "clear-amount-only";
+};
+
+type ResetTokensPlan = {
+  kind: "reset-tokens";
+  tokenInSymbol: TokenSymbol | "";
+  tokenOutSymbol: TokenSymbol | "";
+};
+
+export type ChainChangeSyncPlan = ClearAmountOnlyPlan | ResetTokensPlan;
+
+interface GetChainChangeSyncPlanOptions {
+  availableTokens: TokenSymbol[];
+  currentTokenInSymbol: string | undefined;
+  currentTokenOutSymbol: string | undefined;
+  preferredQuoteTokenSymbol: TokenSymbol | null | undefined;
+}
+
+export function getChainChangeSyncPlan({
+  availableTokens,
+  currentTokenInSymbol,
+  currentTokenOutSymbol,
+  preferredQuoteTokenSymbol,
+}: GetChainChangeSyncPlanOptions): ChainChangeSyncPlan {
+  const resolvedTokenIn = getAvailableTokenSymbol(
+    currentTokenInSymbol,
+    availableTokens,
+  );
+  const resolvedTokenOut = getAvailableTokenSymbol(
+    currentTokenOutSymbol,
+    availableTokens,
+  );
+
+  if (
+    resolvedTokenIn &&
+    resolvedTokenOut &&
+    resolvedTokenIn !== resolvedTokenOut
+  ) {
+    return { kind: "clear-amount-only" };
+  }
+
+  const tokenInSymbol =
+    resolvedTokenIn ??
+    getDefaultTokenInSymbol(preferredQuoteTokenSymbol, availableTokens) ??
+    "";
+
+  let tokenOutSymbol: TokenSymbol | "" = resolvedTokenOut ?? "";
+  if (tokenInSymbol && tokenOutSymbol && tokenInSymbol === tokenOutSymbol) {
+    tokenOutSymbol = "";
+  }
+
+  if (!tokenOutSymbol && availableTokens.length > 1) {
+    const fallbackTokenOut =
+      availableTokens.find((token) => token !== tokenInSymbol) ?? "";
+    tokenOutSymbol = fallbackTokenOut;
+  }
+
+  return {
+    kind: "reset-tokens",
+    tokenInSymbol,
+    tokenOutSymbol,
+  };
+}

--- a/apps/app.mento.org/app/components/swap/swap-form/chain-change-sync.ts
+++ b/apps/app.mento.org/app/components/swap/swap-form/chain-change-sync.ts
@@ -1,9 +1,6 @@
 import type { TokenSymbol } from "@mento-protocol/mento-sdk";
 
-import {
-  getAvailableTokenSymbol,
-  getDefaultTokenInSymbol,
-} from "./token-selection";
+import { getAvailableTokenSymbol } from "./token-selection";
 
 type ClearAmountOnlyPlan = {
   kind: "clear-amount-only";
@@ -48,9 +45,7 @@ export function getChainChangeSyncPlan({
   }
 
   const tokenInSymbol =
-    resolvedTokenIn ??
-    getDefaultTokenInSymbol(preferredQuoteTokenSymbol, availableTokens) ??
-    "";
+    resolvedTokenIn ?? preferredQuoteTokenSymbol ?? availableTokens[0] ?? "";
 
   let tokenOutSymbol: TokenSymbol | "" = resolvedTokenOut ?? "";
   if (tokenInSymbol && tokenOutSymbol && tokenInSymbol === tokenOutSymbol) {

--- a/apps/app.mento.org/app/components/swap/swap-form/use-swap-form.tsx
+++ b/apps/app.mento.org/app/components/swap/swap-form/use-swap-form.tsx
@@ -48,6 +48,7 @@ import { useAccount, useChainId } from "@repo/web3/wagmi";
 import { useAtom } from "jotai";
 import { OctagonAlert } from "lucide-react";
 
+import { getChainChangeSyncPlan } from "./chain-change-sync";
 import {
   getAvailableTokenSymbol,
   getDefaultTokenInSymbol,
@@ -452,52 +453,22 @@ export function useSwapForm(opts?: UseSwapFormOptions) {
     prevChainIdRef.current = formChainId;
 
     const availableTokens = getTokenOptionsByChainId(formChainId);
-
-    const currentTokenIn = getAvailableTokenSymbol(
-      form.getValues("tokenInSymbol"),
+    const plan = getChainChangeSyncPlan({
       availableTokens,
-    );
-    const currentTokenOut = getAvailableTokenSymbol(
-      form.getValues("tokenOutSymbol"),
-      availableTokens,
-    );
+      currentTokenInSymbol: form.getValues("tokenInSymbol"),
+      currentTokenOutSymbol: form.getValues("tokenOutSymbol"),
+      preferredQuoteTokenSymbol: getPreferredUsdQuoteTokenSymbol(formChainId),
+    });
 
-    const tokenInValid = Boolean(currentTokenIn);
-    const tokenOutValid = Boolean(currentTokenOut);
-
-    // If both tokens are valid on the new chain, just clear amount/quote
-    if (
-      currentTokenIn &&
-      currentTokenOut &&
-      currentTokenIn !== currentTokenOut
-    ) {
+    if (plan.kind === "clear-amount-only") {
       form.setValue("amount", "");
       form.setValue("quote", "");
       setFormValues((prev) => (prev ? { ...prev, amount: "" } : prev));
       return;
     }
 
-    const preferredQuote = getPreferredUsdQuoteTokenSymbol(formChainId);
-
-    const newTokenIn: string =
-      tokenInValid && currentTokenIn
-        ? currentTokenIn
-        : preferredQuote || availableTokens[0] || "";
-    let newTokenOut: string =
-      tokenOutValid && currentTokenOut ? currentTokenOut : "";
-
-    // Ensure tokenIn !== tokenOut
-    if (newTokenIn && newTokenOut && newTokenIn === newTokenOut) {
-      newTokenOut = "";
-    }
-
-    // Pick a default tokenOut if needed
-    if (!newTokenOut && availableTokens.length > 1) {
-      newTokenOut = availableTokens.find((t) => t !== newTokenIn) || "";
-    }
-
-    form.setValue("tokenInSymbol", newTokenIn);
-    form.setValue("tokenOutSymbol", newTokenOut);
+    form.setValue("tokenInSymbol", plan.tokenInSymbol);
+    form.setValue("tokenOutSymbol", plan.tokenOutSymbol);
     form.setValue("amount", "");
     form.setValue("quote", "");
 
@@ -505,11 +476,8 @@ export function useSwapForm(opts?: UseSwapFormOptions) {
       prev
         ? {
             ...prev,
-            tokenInSymbol: getAvailableTokenSymbol(newTokenIn, availableTokens),
-            tokenOutSymbol: getAvailableTokenSymbol(
-              newTokenOut,
-              availableTokens,
-            ),
+            tokenInSymbol: plan.tokenInSymbol || undefined,
+            tokenOutSymbol: plan.tokenOutSymbol || undefined,
             amount: "",
           }
         : prev,

--- a/apps/app.mento.org/app/components/swap/swap-form/use-swap-form.tsx
+++ b/apps/app.mento.org/app/components/swap/swap-form/use-swap-form.tsx
@@ -476,8 +476,14 @@ export function useSwapForm(opts?: UseSwapFormOptions) {
       prev
         ? {
             ...prev,
-            tokenInSymbol: plan.tokenInSymbol || undefined,
-            tokenOutSymbol: plan.tokenOutSymbol || undefined,
+            tokenInSymbol: getAvailableTokenSymbol(
+              plan.tokenInSymbol,
+              availableTokens,
+            ),
+            tokenOutSymbol: getAvailableTokenSymbol(
+              plan.tokenOutSymbol,
+              availableTokens,
+            ),
             amount: "",
           }
         : prev,


### PR DESCRIPTION
## The Problem
- issue #404 phase d still kept the chain-change token reset logic inline in `use-swap-form.tsx`.
- the effect mixed chain-change detection, token resolution, fallback selection, and form/atom mutations in one block.
- that made the chain-sync behavior harder to reason about and harder to cover directly with tests.

## The Solution
- extract a pure `getChainChangeSyncPlan(...)` helper for the chain-change decision logic.
- keep the `useSwapForm` effect focused on detecting the chain change, getting the plan, and applying the existing side effects.
- add focused unit coverage for the clear-amount-only path, invalid tokenIn fallback, duplicate token pairs, and no-available-token handling.

## Validation
- `pnpm --filter app.mento.org exec vitest run app/components/swap/swap-form/chain-change-sync.test.ts`
- `pnpm --filter app.mento.org test`
- `pnpm --filter app.mento.org exec tsc --noEmit`
- `trunk check --fix apps/app.mento.org/app/components/swap/swap-form/use-swap-form.tsx apps/app.mento.org/app/components/swap/swap-form/chain-change-sync.ts apps/app.mento.org/app/components/swap/swap-form/chain-change-sync.test.ts`

## Browser Verification
- verified `http://localhost:3000/swap/celo` in chrome-devtools.
- enabled testnet mode on `/swap/celo-sepolia` and confirmed the swap form rendered with the expected token pair after the route-level chain change.
- console errors were limited to expected local-placeholder env effects: background image 404 from `NEXT_PUBLIC_STORAGE_URL=https://example.com`, plus WalletConnect 403/400 responses from `NEXT_PUBLIC_WALLET_CONNECT_ID=dummy`.

## Ship Checklist
- [x] ship skill used
- [x] local review run
- [x] validation run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving refactor with new unit tests; only swap form state on chain change is affected, with no auth or transaction-path changes.
> 
> **Overview**
> Chain-change handling in the swap form is refactored by moving token resolution and fallback rules into a pure **`getChainChangeSyncPlan`** helper that returns either **`clear-amount-only`** (both tokens still valid and distinct on the new chain) or **`reset-tokens`** with resolved `tokenIn`/`tokenOut` symbols.
> 
> **`useSwapForm`**’s chain-change effect now only detects the switch, builds the plan from available tokens and the preferred USD quote, then applies the same form/atom updates as before. Unit tests cover clear-amount-only, invalid inputs, duplicate pairs, preferred quote when it is not on the chain’s list, and empty token lists.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3a161cdf2ab3d41a56e39e4b75fe7696ea988d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->