### PR TITLE
refactor(app): extract swap route sync plan

### DIFF
--- a/apps/app.mento.org/app/components/swap/swap-form/chain-change-sync.test.ts
+++ b/apps/app.mento.org/app/components/swap/swap-form/chain-change-sync.test.ts
@@ -1,0 +1,64 @@
+import type { TokenSymbol } from "@mento-protocol/mento-sdk";
+import { describe, expect, it } from "vitest";
+
+import { getChainChangeSyncPlan } from "./chain-change-sync";
+
+describe("getChainChangeSyncPlan", () => {
+  const availableTokens = ["USDm", "cEUR", "cREAL"] as TokenSymbol[];
+
+  it("returns a clear-amount-only plan when both tokens stay valid and distinct", () => {
+    expect(
+      getChainChangeSyncPlan({
+        availableTokens,
+        currentTokenInSymbol: "USDm",
+        currentTokenOutSymbol: "cEUR",
+        preferredQuoteTokenSymbol: "cREAL" as TokenSymbol,
+      }),
+    ).toEqual({ kind: "clear-amount-only" });
+  });
+
+  it("falls back to the preferred quote token when tokenIn is invalid", () => {
+    expect(
+      getChainChangeSyncPlan({
+        availableTokens,
+        currentTokenInSymbol: "invalid",
+        currentTokenOutSymbol: "",
+        preferredQuoteTokenSymbol: "cREAL" as TokenSymbol,
+      }),
+    ).toEqual({
+      kind: "reset-tokens",
+      tokenInSymbol: "cREAL",
+      tokenOutSymbol: "USDm",
+    });
+  });
+
+  it("picks a distinct tokenOut when the resolved pair would be duplicated", () => {
+    expect(
+      getChainChangeSyncPlan({
+        availableTokens,
+        currentTokenInSymbol: "USDm",
+        currentTokenOutSymbol: "USDm",
+        preferredQuoteTokenSymbol: "cREAL" as TokenSymbol,
+      }),
+    ).toEqual({
+      kind: "reset-tokens",
+      tokenInSymbol: "USDm",
+      tokenOutSymbol: "cEUR",
+    });
+  });
+
+  it("handles chains without available tokens", () => {
+    expect(
+      getChainChangeSyncPlan({
+        availableTokens: [],
+        currentTokenInSymbol: "USDm",
+        currentTokenOutSymbol: "cEUR",
+        preferredQuoteTokenSymbol: "cREAL" as TokenSymbol,
+      }),
+    ).toEqual({
+      kind: "reset-tokens",
+      tokenInSymbol: "",
+      tokenOutSymbol: "",
+    });
+  });
+});

--- a/apps/app.mento.org/app/components/swap/swap-form/chain-change-sync.test.ts
+++ b/apps/app.mento.org/app/components/swap/swap-form/chain-change-sync.test.ts
@@ -32,6 +32,21 @@ describe("getChainChangeSyncPlan", () => {
     });
   });
 
+  it("preserves an unavailable preferred quote token before falling back to the first available token", () => {
+    expect(
+      getChainChangeSyncPlan({
+        availableTokens,
+        currentTokenInSymbol: "invalid",
+        currentTokenOutSymbol: "",
+        preferredQuoteTokenSymbol: "cUSD" as TokenSymbol,
+      }),
+    ).toEqual({
+      kind: "reset-tokens",
+      tokenInSymbol: "cUSD",
+      tokenOutSymbol: "USDm",
+    });
+  });
+
   it("picks a distinct tokenOut when the resolved pair would be duplicated", () => {
     expect(
       getChainChangeSyncPlan({
@@ -47,13 +62,28 @@ describe("getChainChangeSyncPlan", () => {
     });
   });
 
-  it("handles chains without available tokens", () => {
+  it("keeps the preferred quote when no tokens are available", () => {
     expect(
       getChainChangeSyncPlan({
         availableTokens: [],
         currentTokenInSymbol: "USDm",
         currentTokenOutSymbol: "cEUR",
         preferredQuoteTokenSymbol: "cREAL" as TokenSymbol,
+      }),
+    ).toEqual({
+      kind: "reset-tokens",
+      tokenInSymbol: "cREAL",
+      tokenOutSymbol: "",
+    });
+  });
+
+  it("handles chains without available tokens or a preferred quote", () => {
+    expect(
+      getChainChangeSyncPlan({
+        availableTokens: [],
+        currentTokenInSymbol: "USDm",
+        currentTokenOutSymbol: "cEUR",
+        preferredQuoteTokenSymbol: null,
       }),
     ).toEqual({
       kind: "reset-tokens",

--- a/apps/app.mento.org/app/components/swap/swap-form/chain-change-sync.ts
+++ b/apps/app.mento.org/app/components/swap/swap-form/chain-change-sync.ts
@@ -1,0 +1,71 @@
+import type { TokenSymbol } from "@mento-protocol/mento-sdk";
+
+import {
+  getAvailableTokenSymbol,
+  getDefaultTokenInSymbol,
+} from "./token-selection";
+
+type ClearAmountOnlyPlan = {
+  kind: "clear-amount-only";
+};
+
+type ResetTokensPlan = {
+  kind: "reset-tokens";
+  tokenInSymbol: TokenSymbol | "";
+  tokenOutSymbol: TokenSymbol | "";
+};
+
+export type ChainChangeSyncPlan = ClearAmountOnlyPlan | ResetTokensPlan;
+
+interface GetChainChangeSyncPlanOptions {
+  availableTokens: TokenSymbol[];
+  currentTokenInSymbol: string | undefined;
+  currentTokenOutSymbol: string | undefined;
+  preferredQuoteTokenSymbol: TokenSymbol | null | undefined;
+}
+
+export function getChainChangeSyncPlan({
+  availableTokens,
+  currentTokenInSymbol,
+  currentTokenOutSymbol,
+  preferredQuoteTokenSymbol,
+}: GetChainChangeSyncPlanOptions): ChainChangeSyncPlan {
+  const resolvedTokenIn = getAvailableTokenSymbol(
+    currentTokenInSymbol,
+    availableTokens,
+  );
+  const resolvedTokenOut = getAvailableTokenSymbol(
+    currentTokenOutSymbol,
+    availableTokens,
+  );
+
+  if (
+    resolvedTokenIn &&
+    resolvedTokenOut &&
+    resolvedTokenIn !== resolvedTokenOut
+  ) {
+    return { kind: "clear-amount-only" };
+  }
+
+  const tokenInSymbol =
+    resolvedTokenIn ??
+    getDefaultTokenInSymbol(preferredQuoteTokenSymbol, availableTokens) ??
+    "";
+
+  let tokenOutSymbol: TokenSymbol | "" = resolvedTokenOut ?? "";
+  if (tokenInSymbol && tokenOutSymbol && tokenInSymbol === tokenOutSymbol) {
+    tokenOutSymbol = "";
+  }
+
+  if (!tokenOutSymbol && availableTokens.length > 1) {
+    const fallbackTokenOut =
+      availableTokens.find((token) => token !== tokenInSymbol) ?? "";
+    tokenOutSymbol = fallbackTokenOut;
+  }
+
+  return {
+    kind: "reset-tokens",
+    tokenInSymbol,
+    tokenOutSymbol,
+  };
+}

--- a/apps/app.mento.org/app/components/swap/swap-form/chain-change-sync.ts
+++ b/apps/app.mento.org/app/components/swap/swap-form/chain-change-sync.ts
@@ -1,9 +1,6 @@
 import type { TokenSymbol } from "@mento-protocol/mento-sdk";
 
-import {
-  getAvailableTokenSymbol,
-  getDefaultTokenInSymbol,
-} from "./token-selection";
+import { getAvailableTokenSymbol } from "./token-selection";
 
 type ClearAmountOnlyPlan = {
   kind: "clear-amount-only";
@@ -48,9 +45,7 @@ export function getChainChangeSyncPlan({
   }
 
   const tokenInSymbol =
-    resolvedTokenIn ??
-    getDefaultTokenInSymbol(preferredQuoteTokenSymbol, availableTokens) ??
-    "";
+    resolvedTokenIn ?? preferredQuoteTokenSymbol ?? availableTokens[0] ?? "";
 
   let tokenOutSymbol: TokenSymbol | "" = resolvedTokenOut ?? "";
   if (tokenInSymbol && tokenOutSymbol && tokenInSymbol === tokenOutSymbol) {

--- a/apps/app.mento.org/app/components/swap/swap-form/route-driven-state.test.ts
+++ b/apps/app.mento.org/app/components/swap/swap-form/route-driven-state.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  getRouteDrivenFormStateSyncPlan,
   getRouteChangedTokenSide,
   hasRouteDrivenFormStateChanged,
   type RouteDrivenFormState,
@@ -23,6 +24,136 @@ describe("route-driven swap form state", () => {
     );
   });
 
+  it("returns no reset plan when the route state is unchanged", () => {
+    expect(
+      getRouteDrivenFormStateSyncPlan({
+        currentValues: {
+          amount: "2",
+          quote: "123",
+          tokenInSymbol: "CELO",
+          tokenOutSymbol: "cUSD",
+          slippage: "0.5",
+        },
+        formValuesSlippage: "0.4",
+        previousRouteState: fullRouteState,
+        routeDrivenFormState: fullRouteState,
+      }),
+    ).toEqual({ shouldReset: false });
+  });
+
+  it("returns no reset plan when the form already matches the route state", () => {
+    expect(
+      getRouteDrivenFormStateSyncPlan({
+        currentValues: {
+          amount: "1",
+          quote: "123",
+          tokenInSymbol: "USDm",
+          tokenOutSymbol: "GBPm",
+          slippage: "0.5",
+        },
+        formValuesSlippage: "0.4",
+        previousRouteState: {
+          amount: "2",
+          tokenInSymbol: "CELO",
+          tokenOutSymbol: "cUSD",
+        },
+        routeDrivenFormState: fullRouteState,
+      }),
+    ).toEqual({ shouldReset: false });
+  });
+
+  it("builds a reset payload from the route state and current form values", () => {
+    expect(
+      getRouteDrivenFormStateSyncPlan({
+        currentValues: {
+          amount: "2",
+          quote: "123",
+          tokenInSymbol: "CELO",
+          tokenOutSymbol: "cUSD",
+          slippage: "0.5",
+        },
+        formValuesSlippage: "0.4",
+        previousRouteState: {
+          amount: "2",
+          tokenInSymbol: "CELO",
+          tokenOutSymbol: "cUSD",
+        },
+        routeDrivenFormState: fullRouteState,
+      }),
+    ).toEqual({
+      shouldReset: true,
+      resetValues: {
+        amount: "1",
+        quote: "",
+        tokenInSymbol: "USDm",
+        tokenOutSymbol: "GBPm",
+        slippage: "0.5",
+      },
+      routeChangedTokenSide: "from",
+    });
+  });
+
+  it("falls back to stored slippage when the current form has none", () => {
+    expect(
+      getRouteDrivenFormStateSyncPlan({
+        currentValues: {
+          amount: "2",
+          quote: "123",
+          tokenInSymbol: "CELO",
+          tokenOutSymbol: "cUSD",
+          slippage: "",
+        },
+        formValuesSlippage: "0.4",
+        previousRouteState: {
+          amount: "2",
+          tokenInSymbol: "CELO",
+          tokenOutSymbol: "cUSD",
+        },
+        routeDrivenFormState: fullRouteState,
+      }),
+    ).toEqual({
+      shouldReset: true,
+      resetValues: {
+        amount: "1",
+        quote: "",
+        tokenInSymbol: "USDm",
+        tokenOutSymbol: "GBPm",
+        slippage: "0.4",
+      },
+      routeChangedTokenSide: "from",
+    });
+  });
+
+  it('falls back to "0.3" slippage when neither source has a value', () => {
+    expect(
+      getRouteDrivenFormStateSyncPlan({
+        currentValues: {
+          amount: "2",
+          quote: "123",
+          tokenInSymbol: "CELO",
+          tokenOutSymbol: "cUSD",
+          slippage: "",
+        },
+        previousRouteState: {
+          amount: "2",
+          tokenInSymbol: "CELO",
+          tokenOutSymbol: "cUSD",
+        },
+        routeDrivenFormState: fullRouteState,
+      }),
+    ).toEqual({
+      shouldReset: true,
+      resetValues: {
+        amount: "1",
+        quote: "",
+        tokenInSymbol: "USDm",
+        tokenOutSymbol: "GBPm",
+        slippage: "0.3",
+      },
+      routeChangedTokenSide: "from",
+    });
+  });
+
   it("marks a one-sided from route as a from-side change", () => {
     expect(
       getRouteChangedTokenSide(null, {
@@ -41,5 +172,31 @@ describe("route-driven swap form state", () => {
         tokenOutSymbol: "GBPm",
       }),
     ).toBe("to");
+  });
+
+  it("marks a changed to token as a to-side change", () => {
+    expect(
+      getRouteChangedTokenSide(
+        {
+          amount: "1",
+          tokenInSymbol: "USDm",
+          tokenOutSymbol: "cEUR",
+        },
+        fullRouteState,
+      ),
+    ).toBe("to");
+  });
+
+  it("marks a changed amount with both route tokens present as a from-side change", () => {
+    expect(
+      getRouteChangedTokenSide(
+        {
+          amount: "2",
+          tokenInSymbol: "USDm",
+          tokenOutSymbol: "GBPm",
+        },
+        fullRouteState,
+      ),
+    ).toBe("from");
   });
 });

--- a/apps/app.mento.org/app/components/swap/swap-form/route-driven-state.ts
+++ b/apps/app.mento.org/app/components/swap/swap-form/route-driven-state.ts
@@ -6,6 +6,22 @@ export type RouteDrivenFormState = {
 
 export type LastChangedToken = "from" | "to" | null;
 
+type RouteDrivenFormValues = {
+  amount: string;
+  quote: string;
+  tokenInSymbol: string;
+  tokenOutSymbol: string;
+  slippage?: string;
+};
+
+export type RouteDrivenFormStateSyncPlan =
+  | { shouldReset: false }
+  | {
+      shouldReset: true;
+      resetValues: RouteDrivenFormValues;
+      routeChangedTokenSide: LastChangedToken;
+    };
+
 export function hasRouteDrivenFormStateChanged(
   previousRouteState: RouteDrivenFormState | null,
   routeDrivenFormState: RouteDrivenFormState,
@@ -42,4 +58,50 @@ export function getRouteChangedTokenSide(
     routeDrivenFormState.tokenOutSymbol
     ? "from"
     : null;
+}
+
+export function getRouteDrivenFormStateSyncPlan({
+  currentValues,
+  formValuesSlippage,
+  previousRouteState,
+  routeDrivenFormState,
+}: {
+  currentValues: RouteDrivenFormValues;
+  formValuesSlippage?: string;
+  previousRouteState: RouteDrivenFormState | null;
+  routeDrivenFormState: RouteDrivenFormState;
+}): RouteDrivenFormStateSyncPlan {
+  const routeStateChanged = hasRouteDrivenFormStateChanged(
+    previousRouteState,
+    routeDrivenFormState,
+  );
+
+  if (!routeStateChanged) {
+    return { shouldReset: false };
+  }
+
+  const formAlreadyMatchesRoute =
+    currentValues.amount === routeDrivenFormState.amount &&
+    currentValues.tokenInSymbol === routeDrivenFormState.tokenInSymbol &&
+    currentValues.tokenOutSymbol === routeDrivenFormState.tokenOutSymbol;
+
+  if (formAlreadyMatchesRoute) {
+    return { shouldReset: false };
+  }
+
+  return {
+    shouldReset: true,
+    resetValues: {
+      ...currentValues,
+      amount: routeDrivenFormState.amount,
+      quote: "",
+      tokenInSymbol: routeDrivenFormState.tokenInSymbol,
+      tokenOutSymbol: routeDrivenFormState.tokenOutSymbol,
+      slippage: currentValues.slippage || formValuesSlippage || "0.3",
+    },
+    routeChangedTokenSide: getRouteChangedTokenSide(
+      previousRouteState,
+      routeDrivenFormState,
+    ),
+  };
 }

--- a/apps/app.mento.org/app/components/swap/swap-form/use-swap-form.tsx
+++ b/apps/app.mento.org/app/components/swap/swap-form/use-swap-form.tsx
@@ -55,8 +55,7 @@ import {
   getSelectedTokenSymbol,
 } from "./token-selection";
 import {
-  getRouteChangedTokenSide,
-  hasRouteDrivenFormStateChanged,
+  getRouteDrivenFormStateSyncPlan,
   type LastChangedToken,
   type RouteDrivenFormState,
 } from "./route-driven-state";
@@ -493,37 +492,20 @@ export function useSwapForm(opts?: UseSwapFormOptions) {
 
   useEffect(() => {
     const previousRouteState = lastRouteDrivenFormStateRef.current;
-    const routeStateChanged = hasRouteDrivenFormStateChanged(
-      previousRouteState,
-      routeDrivenFormState,
-    );
 
     lastRouteDrivenFormStateRef.current = routeDrivenFormState;
 
-    if (!routeStateChanged) return;
-
-    const currentValues = form.getValues();
-    const formAlreadyMatchesRoute =
-      currentValues.amount === routeDrivenFormState.amount &&
-      currentValues.tokenInSymbol === routeDrivenFormState.tokenInSymbol &&
-      currentValues.tokenOutSymbol === routeDrivenFormState.tokenOutSymbol;
-
-    if (formAlreadyMatchesRoute) return;
-
-    const routeChangedTokenSide = getRouteChangedTokenSide(
+    const plan = getRouteDrivenFormStateSyncPlan({
+      currentValues: form.getValues(),
+      formValuesSlippage: formValues?.slippage,
       previousRouteState,
       routeDrivenFormState,
-    );
-
-    form.reset({
-      ...currentValues,
-      amount: routeDrivenFormState.amount,
-      quote: "",
-      tokenInSymbol: routeDrivenFormState.tokenInSymbol,
-      tokenOutSymbol: routeDrivenFormState.tokenOutSymbol,
-      slippage: currentValues.slippage || formValues?.slippage || "0.3",
     });
-    setLastChangedToken(routeChangedTokenSide);
+
+    if (!plan.shouldReset) return;
+
+    form.reset(plan.resetValues);
+    setLastChangedToken(plan.routeChangedTokenSide);
   }, [form, formValues?.slippage, routeDrivenFormState, setLastChangedToken]);
 
   useSwapUrlSync({

--- a/apps/app.mento.org/app/components/swap/swap-form/use-swap-form.tsx
+++ b/apps/app.mento.org/app/components/swap/swap-form/use-swap-form.tsx
@@ -48,6 +48,7 @@ import { useAccount, useChainId } from "@repo/web3/wagmi";
 import { useAtom } from "jotai";
 import { OctagonAlert } from "lucide-react";
 
+import { getChainChangeSyncPlan } from "./chain-change-sync";
 import {
   getAvailableTokenSymbol,
   getDefaultTokenInSymbol,
@@ -452,52 +453,22 @@ export function useSwapForm(opts?: UseSwapFormOptions) {
     prevChainIdRef.current = formChainId;
 
     const availableTokens = getTokenOptionsByChainId(formChainId);
-
-    const currentTokenIn = getAvailableTokenSymbol(
-      form.getValues("tokenInSymbol"),
+    const plan = getChainChangeSyncPlan({
       availableTokens,
-    );
-    const currentTokenOut = getAvailableTokenSymbol(
-      form.getValues("tokenOutSymbol"),
-      availableTokens,
-    );
+      currentTokenInSymbol: form.getValues("tokenInSymbol"),
+      currentTokenOutSymbol: form.getValues("tokenOutSymbol"),
+      preferredQuoteTokenSymbol: getPreferredUsdQuoteTokenSymbol(formChainId),
+    });
 
-    const tokenInValid = Boolean(currentTokenIn);
-    const tokenOutValid = Boolean(currentTokenOut);
-
-    // If both tokens are valid on the new chain, just clear amount/quote
-    if (
-      currentTokenIn &&
-      currentTokenOut &&
-      currentTokenIn !== currentTokenOut
-    ) {
+    if (plan.kind === "clear-amount-only") {
       form.setValue("amount", "");
       form.setValue("quote", "");
       setFormValues((prev) => (prev ? { ...prev, amount: "" } : prev));
       return;
     }
 
-    const preferredQuote = getPreferredUsdQuoteTokenSymbol(formChainId);
-
-    const newTokenIn: string =
-      tokenInValid && currentTokenIn
-        ? currentTokenIn
-        : preferredQuote || availableTokens[0] || "";
-    let newTokenOut: string =
-      tokenOutValid && currentTokenOut ? currentTokenOut : "";
-
-    // Ensure tokenIn !== tokenOut
-    if (newTokenIn && newTokenOut && newTokenIn === newTokenOut) {
-      newTokenOut = "";
-    }
-
-    // Pick a default tokenOut if needed
-    if (!newTokenOut && availableTokens.length > 1) {
-      newTokenOut = availableTokens.find((t) => t !== newTokenIn) || "";
-    }
-
-    form.setValue("tokenInSymbol", newTokenIn);
-    form.setValue("tokenOutSymbol", newTokenOut);
+    form.setValue("tokenInSymbol", plan.tokenInSymbol);
+    form.setValue("tokenOutSymbol", plan.tokenOutSymbol);
     form.setValue("amount", "");
     form.setValue("quote", "");
 
@@ -505,11 +476,8 @@ export function useSwapForm(opts?: UseSwapFormOptions) {
       prev
         ? {
             ...prev,
-            tokenInSymbol: getAvailableTokenSymbol(newTokenIn, availableTokens),
-            tokenOutSymbol: getAvailableTokenSymbol(
-              newTokenOut,
-              availableTokens,
-            ),
+            tokenInSymbol: plan.tokenInSymbol || undefined,
+            tokenOutSymbol: plan.tokenOutSymbol || undefined,
             amount: "",
           }
         : prev,

--- a/apps/app.mento.org/app/components/swap/swap-form/use-swap-form.tsx
+++ b/apps/app.mento.org/app/components/swap/swap-form/use-swap-form.tsx
@@ -476,8 +476,14 @@ export function useSwapForm(opts?: UseSwapFormOptions) {
       prev
         ? {
             ...prev,
-            tokenInSymbol: plan.tokenInSymbol || undefined,
-            tokenOutSymbol: plan.tokenOutSymbol || undefined,
+            tokenInSymbol: getAvailableTokenSymbol(
+              plan.tokenInSymbol,
+              availableTokens,
+            ),
+            tokenOutSymbol: getAvailableTokenSymbol(
+              plan.tokenOutSymbol,
+              availableTokens,
+            ),
             amount: "",
           }
         : prev,


### PR DESCRIPTION
## The Problem
- the swap form still keeps one route-driven sync effect inline in use-swap-form.tsx
- that effect owns change detection, form-match short-circuiting, reset payload construction, and last-changed-token derivation
- issue #404 phase e needs the remaining route-sync behavior moved into the route-driven-state module without changing behavior

## The Solution
- added a pure getRouteDrivenFormStateSyncPlan helper in route-driven-state.ts to decide whether route changes should reset the form and to build the exact reset payload
- kept the effect shell in use-swap-form.tsx minimal: it still updates lastRouteDrivenFormStateRef before any early return, then applies form.reset and setLastChangedToken from the helper plan
- extended route-driven-state tests to cover unchanged route state, already-matching form state, reset payload/slippage fallback ordering, and changed-token-side outcomes

## Validation
- pnpm --filter app.mento.org exec vitest run app/components/swap/swap-form/route-driven-state.test.ts
- pnpm --filter app.mento.org test
- pnpm --filter app.mento.org exec tsc --noEmit
- trunk check --fix apps/app.mento.org/app/components/swap/swap-form/use-swap-form.tsx apps/app.mento.org/app/components/swap/swap-form/route-driven-state.ts apps/app.mento.org/app/components/swap/swap-form/route-driven-state.test.ts
- built @repo/ui and @repo/web3 once so the app-local tsc command could resolve workspace dist types in this fresh worktree
- browser verification in chrome-devtools on http://127.0.0.1:3000/swap/celo?from=USDm&to=GBPm&amount=2.5 confirmed the route-driven amount/token state applied and updated correctly; console/network still showed expected env-related 403/400s from the dummy storage URL and WalletConnect project id used only for local verification

## Ship Checklist
- [x] ship skill used
- [x] local review run
- [x] validation run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving refactor with logic moved to a tested pure function; swap UX risk is limited if tests match prior inline behavior.
> 
> **Overview**
> Moves **route-driven swap form sync** out of `use-swap-form.tsx` into a pure **`getRouteDrivenFormStateSyncPlan`** helper in `route-driven-state.ts`. The helper decides whether URL/route changes should reset the form, builds the reset payload (amount, tokens, cleared quote, slippage fallbacks), and derives **`routeChangedTokenSide`** for quote direction.
> 
> The hook effect is reduced to updating the route ref, calling the planner, and applying **`form.reset`** / **`setLastChangedToken`** when **`shouldReset`** is true. **`route-driven-state.test.ts`** adds coverage for no-op paths, reset payloads, slippage ordering (`current` → stored → `"0.3"`), and extra **`getRouteChangedTokenSide`** cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f1a0b7c4ef7db494af2946ada0add22525631a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->