### PR TITLE
refactor(governance): split vote card render sections

### DIFF
--- a/apps/governance.mento.org/app/components/voting/vote-card-actions.tsx
+++ b/apps/governance.mento.org/app/components/voting/vote-card-actions.tsx
@@ -1,0 +1,312 @@
+import { TransactionLink } from "@/components/proposal/components/TransactionLink";
+import {
+  ProposerCancelActionProps,
+  VoteCardCancelActions,
+  WatchdogCancelActionProps,
+} from "@/components/voting/vote-card-cancel-actions";
+import { VoteCardState } from "@/components/voting/derive-vote-card-state";
+import { Proposal, ProposalState } from "@/graphql/subgraph/generated/subgraph";
+import { Button } from "@repo/ui";
+import { ConnectButton } from "@repo/web3";
+import Link from "next/link";
+
+interface VoteCardActionsProps {
+  currentState: VoteCardState;
+  address: string | undefined;
+  proposal: Proposal;
+  proposalState: ProposalState;
+  hasVoted: boolean | undefined;
+  isVotedForApprove: boolean;
+  isVotedForAbstain: boolean;
+  isVotedForReject: boolean;
+  queueEndTime: Date | null;
+  isVetoPeriodOver: boolean;
+  isDeadlinePassed: boolean;
+  isAwaitingUserSignature: boolean;
+  isConfirming: boolean;
+  isAwaitingExecuteSignature: boolean;
+  isExecuteConfirming: boolean;
+  isAwaitingQueueSignature: boolean;
+  isQueueConfirming: boolean;
+  onExecute: () => void;
+  onQueue: () => void;
+  onVote: (support: number) => void;
+  watchdogCancelAction: WatchdogCancelActionProps;
+  proposerCancelAction: ProposerCancelActionProps;
+}
+
+const usedVoteOptionButtonLocator = "usedVoteOptionButton";
+
+export const VoteCardActions = ({
+  currentState,
+  address,
+  proposal,
+  proposalState,
+  hasVoted,
+  isVotedForApprove,
+  isVotedForAbstain,
+  isVotedForReject,
+  queueEndTime,
+  isVetoPeriodOver,
+  isDeadlinePassed,
+  isAwaitingUserSignature,
+  isConfirming,
+  isAwaitingExecuteSignature,
+  isExecuteConfirming,
+  isAwaitingQueueSignature,
+  isQueueConfirming,
+  onExecute,
+  onQueue,
+  onVote,
+  watchdogCancelAction,
+  proposerCancelAction,
+}: VoteCardActionsProps) => {
+  switch (currentState) {
+    case "loading":
+    case "confirming":
+    case "signing":
+      return null;
+
+    case "insufficient-mento":
+      return (
+        <Button variant="default" size="lg" clipped="default" asChild>
+          <Link href="/voting-power">Lock MENTO Tokens</Link>
+        </Button>
+      );
+
+    case "voted":
+    case "defeated":
+    case "expired":
+    case "finished":
+      if (hasVoted) {
+        return (
+          <div className="gap-4 md:grid-cols-3 grid grid-cols-1">
+            {isVotedForApprove && (
+              <Button
+                variant="approve"
+                size="lg"
+                data-testid={usedVoteOptionButtonLocator}
+                disabled
+              >
+                Your vote: YES
+              </Button>
+            )}
+            {isVotedForAbstain && (
+              <Button
+                variant="abstain"
+                size="lg"
+                data-testid={usedVoteOptionButtonLocator}
+                disabled
+              >
+                Your vote: Abstain
+              </Button>
+            )}
+            {isVotedForReject && (
+              <Button
+                variant="reject"
+                size="lg"
+                data-testid={usedVoteOptionButtonLocator}
+                disabled
+              >
+                Your vote: NO
+              </Button>
+            )}
+          </div>
+        );
+      }
+
+      return null;
+
+    case "queued": {
+      const canExecute = queueEndTime && isVetoPeriodOver;
+
+      if (!address) {
+        return (
+          <div className="col-span-full flex justify-center">
+            <ConnectButton
+              size="lg"
+              text={
+                canExecute ? "Connect Wallet to Execute" : "Proposal Queued"
+              }
+              fullWidth
+              disabled={!canExecute}
+            />
+          </div>
+        );
+      }
+
+      if (canExecute) {
+        return (
+          <div className="gap-4 flex flex-col">
+            <Button
+              variant="default"
+              size="lg"
+              clipped="default"
+              onClick={onExecute}
+              disabled={isAwaitingExecuteSignature || isExecuteConfirming}
+              data-testid="executeProposalButton"
+              className="w-full"
+            >
+              {isAwaitingExecuteSignature
+                ? "Confirm in Wallet"
+                : isExecuteConfirming
+                  ? "Executing..."
+                  : "Execute Proposal"}
+            </Button>
+            <VoteCardCancelActions
+              watchdogCancelAction={watchdogCancelAction}
+            />
+          </div>
+        );
+      }
+
+      return (
+        <div className="gap-4 flex flex-col">
+          <Button
+            variant="default"
+            size="lg"
+            clipped="default"
+            disabled
+            className="w-full"
+          >
+            In Veto Period
+          </Button>
+          <VoteCardCancelActions watchdogCancelAction={watchdogCancelAction} />
+        </div>
+      );
+    }
+
+    case "executed": {
+      const executionTxHash = proposal.proposalExecuted?.[0]?.transaction?.id;
+
+      return (
+        <div className="flex justify-center">
+          {executionTxHash ? (
+            <Button variant="outline" size="lg" asChild>
+              <TransactionLink txHash={executionTxHash} className="w-full">
+                View Execution Transaction
+              </TransactionLink>
+            </Button>
+          ) : (
+            <Button variant="default" size="lg" disabled>
+              Proposal Executed
+            </Button>
+          )}
+        </div>
+      );
+    }
+
+    case "succeeded":
+      if (!address) {
+        return (
+          <div className="col-span-full flex justify-center">
+            <ConnectButton size="lg" text="Connect Wallet to Queue" fullWidth />
+          </div>
+        );
+      }
+
+      return (
+        <div className="gap-4 flex flex-col">
+          <Button
+            variant="default"
+            size="lg"
+            clipped="default"
+            onClick={onQueue}
+            disabled={isAwaitingQueueSignature || isQueueConfirming}
+            data-testid="queueProposalButton"
+            className="w-full"
+          >
+            {isAwaitingQueueSignature
+              ? "Confirm in Wallet"
+              : isQueueConfirming
+                ? "Queueing..."
+                : "Queue for Execution"}
+          </Button>
+          <VoteCardCancelActions
+            watchdogCancelAction={watchdogCancelAction}
+            proposerCancelAction={proposerCancelAction}
+          />
+        </div>
+      );
+
+    case "pending":
+      return (
+        <>
+          <div className="gap-4 md:grid-cols-3 grid grid-cols-1">
+            <Button variant="approve" size="lg" disabled>
+              Voting Not Started
+            </Button>
+            <Button variant="abstain" size="lg" disabled>
+              Voting Not Started
+            </Button>
+            <Button variant="reject" size="lg" disabled>
+              Voting Not Started
+            </Button>
+          </div>
+          <VoteCardCancelActions proposerCancelAction={proposerCancelAction} />
+        </>
+      );
+
+    case "ready":
+      if (!address) {
+        return (
+          <div className="col-span-full flex justify-center">
+            <ConnectButton size="lg" text="Connect Wallet to Vote" fullWidth />
+          </div>
+        );
+      }
+
+      return (
+        <>
+          <div className="gap-4 md:grid-cols-3 grid grid-cols-1">
+            <Button
+              variant="approve"
+              size="lg"
+              onClick={() => onVote(1)}
+              disabled={
+                proposalState !== ProposalState.Active ||
+                isDeadlinePassed ||
+                isAwaitingUserSignature ||
+                isConfirming
+              }
+              data-testid="yesProposalButton"
+            >
+              Vote YES
+            </Button>
+            <Button
+              variant="abstain"
+              size="lg"
+              onClick={() => onVote(2)}
+              disabled={
+                proposalState !== ProposalState.Active ||
+                isDeadlinePassed ||
+                isAwaitingUserSignature ||
+                isConfirming
+              }
+              data-testid="abstainProposalButton"
+            >
+              Abstain
+            </Button>
+            <Button
+              variant="reject"
+              size="lg"
+              onClick={() => onVote(0)}
+              disabled={
+                proposalState !== ProposalState.Active ||
+                isDeadlinePassed ||
+                isAwaitingUserSignature ||
+                isConfirming
+              }
+              data-testid="noProposalButton"
+            >
+              Vote NO
+            </Button>
+          </div>
+          <VoteCardCancelActions proposerCancelAction={proposerCancelAction} />
+        </>
+      );
+
+    default:
+      return null;
+  }
+};

--- a/apps/governance.mento.org/app/components/voting/vote-card-cancel-actions.tsx
+++ b/apps/governance.mento.org/app/components/voting/vote-card-cancel-actions.tsx
@@ -1,7 +1,7 @@
 import { ProposalCancelButton } from "@/components/voting/proposal-cancel-button";
 import { Button } from "@repo/ui";
 
-interface WatchdogCancelActionProps {
+export interface WatchdogCancelActionProps {
   isWatchdog: boolean;
   hasPendingCancellation: boolean;
   isPendingCancellationStatusUnavailable: boolean;
@@ -15,7 +15,7 @@ interface WatchdogCancelActionProps {
   watchdogAddress: string;
 }
 
-interface ProposerCancelActionProps {
+export interface ProposerCancelActionProps {
   canProposerCancel: boolean;
   onCancel: () => void;
   isAwaitingProposerCancelSignature: boolean;

--- a/apps/governance.mento.org/app/components/voting/vote-card-special-content.tsx
+++ b/apps/governance.mento.org/app/components/voting/vote-card-special-content.tsx
@@ -1,0 +1,126 @@
+import { TransactionLink } from "@/components/proposal/components/TransactionLink";
+import { VoteCardState } from "@/components/voting/derive-vote-card-state";
+import { Button, IconLoading } from "@repo/ui";
+
+interface VoteCardSpecialContentProps {
+  currentState: VoteCardState;
+  isAwaitingExecuteSignature: boolean;
+  isAwaitingQueueSignature: boolean;
+  isExecuteConfirming: boolean;
+  isQueueConfirming: boolean;
+  voteSupport: number | undefined;
+  currentTxHash: string | undefined;
+  hash: string | undefined;
+  executeHash: string | undefined;
+  queueHash: string | undefined;
+}
+
+const getLoadingText = ({
+  currentState,
+  isAwaitingExecuteSignature,
+  isAwaitingQueueSignature,
+  isExecuteConfirming,
+  isQueueConfirming,
+}: Omit<
+  VoteCardSpecialContentProps,
+  "voteSupport" | "currentTxHash" | "hash" | "executeHash" | "queueHash"
+>) => {
+  switch (currentState) {
+    case "loading":
+      return "Loading voting information...";
+    case "signing":
+      if (isAwaitingExecuteSignature) {
+        return "Waiting for execution confirmation...";
+      }
+      if (isAwaitingQueueSignature) {
+        return "Waiting for queue confirmation...";
+      }
+      return "Waiting for confirmation...";
+    case "confirming":
+      if (isExecuteConfirming) {
+        return "Proposal is being executed";
+      }
+      if (isQueueConfirming) {
+        return "Proposal is being queued";
+      }
+      return "Your vote is being processed";
+    default:
+      return "";
+  }
+};
+
+export const VoteCardSpecialContent = ({
+  currentState,
+  isAwaitingExecuteSignature,
+  isAwaitingQueueSignature,
+  isExecuteConfirming,
+  isQueueConfirming,
+  voteSupport,
+  currentTxHash,
+  hash,
+  executeHash,
+  queueHash,
+}: VoteCardSpecialContentProps) => {
+  const loadingStates = ["loading", "signing", "confirming"];
+
+  if (!loadingStates.includes(currentState)) {
+    return null;
+  }
+
+  return (
+    <div className="gap-4 flex flex-col items-center">
+      <IconLoading />
+      <p
+        className="text-muted-foreground"
+        data-testid={
+          currentState === "signing" && "waitingForConfirmationLabel"
+        }
+      >
+        {getLoadingText({
+          currentState,
+          isAwaitingExecuteSignature,
+          isAwaitingQueueSignature,
+          isExecuteConfirming,
+          isQueueConfirming,
+        })}
+      </p>
+      {currentState === "signing" &&
+        !isAwaitingExecuteSignature &&
+        !isAwaitingQueueSignature && (
+          <p
+            className="text-sm text-muted-foreground"
+            data-testid="waitingForConfirmationDescriptionLabel"
+          >
+            You are voting{" "}
+            {voteSupport === 1 ? "YES" : voteSupport === 0 ? "NO" : "ABSTAIN"}{" "}
+            on this proposal
+          </p>
+        )}
+      {currentState === "signing" && isAwaitingExecuteSignature && (
+        <p
+          className="text-sm text-muted-foreground"
+          data-testid="waitingForExecutionDescriptionLabel"
+        >
+          You are executing this proposal
+        </p>
+      )}
+      {currentState === "signing" && isAwaitingQueueSignature && (
+        <p
+          className="text-sm text-muted-foreground"
+          data-testid="waitingForQueueDescriptionLabel"
+        >
+          You are queueing this proposal for execution
+        </p>
+      )}
+      {currentState === "confirming" &&
+        currentTxHash &&
+        (hash || executeHash || queueHash) && (
+          <Button variant="outline" size="sm" asChild className="mt-2">
+            <TransactionLink txHash={currentTxHash}>
+              View on explorer
+            </TransactionLink>
+          </Button>
+        )}
+    </div>
+  );
+};

--- a/apps/governance.mento.org/app/components/voting/vote-card.tsx
+++ b/apps/governance.mento.org/app/components/voting/vote-card.tsx
@@ -3,7 +3,8 @@ import { TransactionLink } from "@/components/proposal/components/TransactionLin
 import { Timer } from "@/components/timer";
 import { deriveVoteCardState } from "@/components/voting/derive-vote-card-state";
 import { getGovernanceTransactionErrorMessage } from "@/components/voting/get-governance-transaction-error-message";
-import { VoteCardCancelActions } from "@/components/voting/vote-card-cancel-actions";
+import { VoteCardActions } from "@/components/voting/vote-card-actions";
+import { VoteCardSpecialContent } from "@/components/voting/vote-card-special-content";
 import { useDelayedVoteCardRefire } from "@/components/voting/use-delayed-vote-card-refire";
 import { getWatchdogMultisigAddress } from "@/config";
 import { useLocksByAccount } from "@/contracts";
@@ -22,19 +23,16 @@ import { getTimelockOperationId } from "@/contracts/governor/utils/get-timelock-
 import { Proposal, ProposalState } from "@/graphql/subgraph/generated/subgraph";
 import { useVeMentoDelegationSummary } from "@/hooks/use-ve-mento-delegation-summary";
 import {
-  Button,
   Card,
   CardContent,
   CardDescription,
   CardHeader,
   CardTitle,
-  IconLoading,
 } from "@repo/ui";
-import { ConnectButton, NumbersService } from "@repo/web3";
+import { NumbersService } from "@repo/web3";
 import { useAccount, useChainId } from "@repo/web3/wagmi";
 import * as Sentry from "@sentry/nextjs";
 import { CheckCircle2, CircleCheck, XCircle, XCircleIcon } from "lucide-react";
-import Link from "next/link";
 import { useEffect, useMemo, useRef, useState } from "react";
 import spacetime from "spacetime";
 import { formatUnits, keccak256, toHex } from "viem";
@@ -690,366 +688,6 @@ export const VoteCard = ({
   const isVotedForAbstain = voteReceipt?.support === 2;
   const isVotedForReject = voteReceipt?.support === 0;
   const hasVoted = voteReceipt?.hasVoted;
-  const usedVoteOptionButtonLocator = "usedVoteOptionButton";
-
-  // Render vote buttons based on state
-  const renderActions = () => {
-    switch (currentState) {
-      case "loading":
-      case "confirming":
-      case "signing":
-        return null;
-
-      case "insufficient-mento":
-        return (
-          <Button variant="default" size="lg" clipped="default" asChild>
-            <Link href="/voting-power">Lock MENTO Tokens</Link>
-          </Button>
-        );
-
-      case "voted":
-      case "defeated":
-      case "expired":
-      case "finished":
-        // Show disabled buttons for finished proposals
-        if (hasVoted) {
-          return (
-            <div className="gap-4 md:grid-cols-3 grid grid-cols-1">
-              {isVotedForApprove && (
-                <Button
-                  variant="approve"
-                  size="lg"
-                  data-testid={usedVoteOptionButtonLocator}
-                  disabled
-                >
-                  Your vote: YES
-                </Button>
-              )}
-              {isVotedForAbstain && (
-                <Button
-                  variant="abstain"
-                  size="lg"
-                  data-testid={usedVoteOptionButtonLocator}
-                  disabled
-                >
-                  Your vote: Abstain
-                </Button>
-              )}
-              {isVotedForReject && (
-                <Button
-                  variant="reject"
-                  size="lg"
-                  data-testid={usedVoteOptionButtonLocator}
-                  disabled
-                >
-                  Your vote: NO
-                </Button>
-              )}
-            </div>
-          );
-        }
-
-        return null;
-
-      case "queued": {
-        // canExecute derives from isVetoPeriodOver (ticks every second) so the
-        // CTA flips in sync with the header countdown when ETA passes.
-        const canExecute = queueEndTime && isVetoPeriodOver;
-
-        if (!address) {
-          return (
-            <div className="col-span-full flex justify-center">
-              <ConnectButton
-                size="lg"
-                text={
-                  canExecute ? "Connect Wallet to Execute" : "Proposal Queued"
-                }
-                fullWidth
-                disabled={!canExecute}
-              />
-            </div>
-          );
-        }
-        if (canExecute) {
-          return (
-            <div className="gap-4 flex flex-col">
-              <Button
-                variant="default"
-                size="lg"
-                clipped="default"
-                onClick={handleExecute}
-                disabled={isAwaitingExecuteSignature || isExecuteConfirming}
-                data-testid="executeProposalButton"
-                className="w-full"
-              >
-                {isAwaitingExecuteSignature
-                  ? "Confirm in Wallet"
-                  : isExecuteConfirming
-                    ? "Executing..."
-                    : "Execute Proposal"}
-              </Button>
-              <VoteCardCancelActions
-                watchdogCancelAction={watchdogCancelAction}
-              />
-            </div>
-          );
-        }
-        // Show disabled button during veto period or cancel button for watchdog
-        return (
-          <div className="gap-4 flex flex-col">
-            <Button
-              variant="default"
-              size="lg"
-              clipped="default"
-              disabled
-              className="w-full"
-            >
-              In Veto Period
-            </Button>
-            <VoteCardCancelActions
-              watchdogCancelAction={watchdogCancelAction}
-            />
-          </div>
-        );
-      }
-
-      case "executed": {
-        // Show link to execution transaction if available
-        const executionTxHash = proposal.proposalExecuted?.[0]?.transaction?.id;
-        return (
-          <div className="flex justify-center">
-            {executionTxHash ? (
-              <Button variant="outline" size="lg" asChild>
-                <TransactionLink txHash={executionTxHash} className="w-full">
-                  View Execution Transaction
-                </TransactionLink>
-              </Button>
-            ) : (
-              <Button variant="default" size="lg" disabled>
-                Proposal Executed
-              </Button>
-            )}
-          </div>
-        );
-      }
-
-      case "succeeded":
-        // Show queue button for succeeded proposals
-        if (!address) {
-          return (
-            <div className="col-span-full flex justify-center">
-              <ConnectButton
-                size="lg"
-                text="Connect Wallet to Queue"
-                fullWidth
-              />
-            </div>
-          );
-        }
-        return (
-          <div className="gap-4 flex flex-col">
-            <Button
-              variant="default"
-              size="lg"
-              clipped="default"
-              onClick={handleQueue}
-              disabled={isAwaitingQueueSignature || isQueueConfirming}
-              data-testid="queueProposalButton"
-              className="w-full"
-            >
-              {isAwaitingQueueSignature
-                ? "Confirm in Wallet"
-                : isQueueConfirming
-                  ? "Queueing..."
-                  : "Queue for Execution"}
-            </Button>
-            <VoteCardCancelActions
-              watchdogCancelAction={watchdogCancelAction}
-              proposerCancelAction={proposerCancelAction}
-            />
-          </div>
-        );
-
-      case "pending":
-        // Show disabled buttons for pending proposals
-        return (
-          <>
-            <div className="gap-4 md:grid-cols-3 grid grid-cols-1">
-              <Button variant="approve" size="lg" disabled>
-                Voting Not Started
-              </Button>
-              <Button variant="abstain" size="lg" disabled>
-                Voting Not Started
-              </Button>
-              <Button variant="reject" size="lg" disabled>
-                Voting Not Started
-              </Button>
-            </div>
-            <VoteCardCancelActions
-              proposerCancelAction={proposerCancelAction}
-            />
-          </>
-        );
-
-      case "ready":
-        if (!address) {
-          return (
-            <div className="col-span-full flex justify-center">
-              <ConnectButton
-                size="lg"
-                text="Connect Wallet to Vote"
-                fullWidth
-              />
-            </div>
-          );
-        }
-        return (
-          <>
-            <div className="gap-4 md:grid-cols-3 grid grid-cols-1">
-              <Button
-                variant="approve"
-                size="lg"
-                onClick={() => handleVote(1)}
-                disabled={
-                  proposalState !== ProposalState.Active ||
-                  isDeadlinePassed ||
-                  isAwaitingUserSignature ||
-                  isConfirming
-                }
-                data-testid="yesProposalButton"
-              >
-                Vote YES
-              </Button>
-              <Button
-                variant="abstain"
-                size="lg"
-                onClick={() => handleVote(2)}
-                disabled={
-                  proposalState !== ProposalState.Active ||
-                  isDeadlinePassed ||
-                  isAwaitingUserSignature ||
-                  isConfirming
-                }
-                data-testid="abstainProposalButton"
-              >
-                Abstain
-              </Button>
-              <Button
-                variant="reject"
-                size="lg"
-                onClick={() => handleVote(0)}
-                disabled={
-                  proposalState !== ProposalState.Active ||
-                  isDeadlinePassed ||
-                  isAwaitingUserSignature ||
-                  isConfirming
-                }
-                data-testid="noProposalButton"
-              >
-                Vote NO
-              </Button>
-            </div>
-            <VoteCardCancelActions
-              proposerCancelAction={proposerCancelAction}
-            />
-          </>
-        );
-
-      default:
-        return null;
-    }
-  };
-
-  // Get loading text based on state
-  const getLoadingText = () => {
-    switch (currentState) {
-      case "loading":
-        return "Loading voting information...";
-      case "signing":
-        if (isAwaitingExecuteSignature) {
-          return "Waiting for execution confirmation...";
-        }
-        if (isAwaitingQueueSignature) {
-          return "Waiting for queue confirmation...";
-        }
-        return "Waiting for confirmation...";
-      case "confirming":
-        if (isExecuteConfirming) {
-          return "Proposal is being executed";
-        }
-        if (isQueueConfirming) {
-          return "Proposal is being queued";
-        }
-        return "Your vote is being processed";
-      default:
-        return "";
-    }
-  };
-
-  // Special content for certain states
-  const renderSpecialContent = () => {
-    const loadingStates = ["loading", "signing", "confirming"];
-
-    if (loadingStates.includes(currentState)) {
-      return (
-        <div className="gap-4 flex flex-col items-center">
-          <IconLoading />
-          <p
-            className="text-muted-foreground"
-            data-testid={
-              currentState === "signing" && "waitingForConfirmationLabel"
-            }
-          >
-            {getLoadingText()}
-          </p>
-          {currentState === "signing" &&
-            !isAwaitingExecuteSignature &&
-            !isAwaitingQueueSignature && (
-              <p
-                className="text-sm text-muted-foreground"
-                data-testid="waitingForConfirmationDescriptionLabel"
-              >
-                You are voting{" "}
-                {variables?.args?.[1] === 1
-                  ? "YES"
-                  : variables?.args?.[1] === 0
-                    ? "NO"
-                    : "ABSTAIN"}{" "}
-                on this proposal
-              </p>
-            )}
-          {currentState === "signing" && isAwaitingExecuteSignature && (
-            <p
-              className="text-sm text-muted-foreground"
-              data-testid="waitingForExecutionDescriptionLabel"
-            >
-              You are executing this proposal
-            </p>
-          )}
-          {currentState === "signing" && isAwaitingQueueSignature && (
-            <p
-              className="text-sm text-muted-foreground"
-              data-testid="waitingForQueueDescriptionLabel"
-            >
-              You are queueing this proposal for execution
-            </p>
-          )}
-          {currentState === "confirming" &&
-            currentTxHash &&
-            (hash || executeHash || queueHash) && (
-              <Button variant="outline" size="sm" asChild className="mt-2">
-                <TransactionLink txHash={currentTxHash}>
-                  View on explorer
-                </TransactionLink>
-              </Button>
-            )}
-        </div>
-      );
-    }
-
-    return null;
-  };
-
   const quorumLabel = useMemo(() => {
     let label = "";
 
@@ -1151,7 +789,18 @@ export const VoteCard = ({
             : "space-y-8 p-4 xl:p-8"
         }
       >
-        {renderSpecialContent()}
+        <VoteCardSpecialContent
+          currentState={currentState}
+          isAwaitingExecuteSignature={isAwaitingExecuteSignature}
+          isAwaitingQueueSignature={isAwaitingQueueSignature}
+          isExecuteConfirming={isExecuteConfirming}
+          isQueueConfirming={isQueueConfirming}
+          voteSupport={variables?.args?.[1] as number | undefined}
+          currentTxHash={currentTxHash}
+          hash={hash}
+          executeHash={executeHash}
+          queueHash={queueHash}
+        />
 
         {!["loading", "confirming", "signing"].includes(currentState) && (
           <>
@@ -1184,7 +833,30 @@ export const VoteCard = ({
                   : "mt-8"
               }
             >
-              {renderActions()}
+              <VoteCardActions
+                currentState={currentState}
+                address={address}
+                proposal={proposal}
+                proposalState={proposalState}
+                hasVoted={hasVoted}
+                isVotedForApprove={isVotedForApprove}
+                isVotedForAbstain={isVotedForAbstain}
+                isVotedForReject={isVotedForReject}
+                queueEndTime={queueEndTime}
+                isVetoPeriodOver={isVetoPeriodOver}
+                isDeadlinePassed={isDeadlinePassed}
+                isAwaitingUserSignature={isAwaitingUserSignature}
+                isConfirming={isConfirming}
+                isAwaitingExecuteSignature={isAwaitingExecuteSignature}
+                isExecuteConfirming={isExecuteConfirming}
+                isAwaitingQueueSignature={isAwaitingQueueSignature}
+                isQueueConfirming={isQueueConfirming}
+                onExecute={handleExecute}
+                onQueue={handleQueue}
+                onVote={handleVote}
+                watchdogCancelAction={watchdogCancelAction}
+                proposerCancelAction={proposerCancelAction}
+              />
             </div>
 
             {activeTransactionErrorMessage &&


### PR DESCRIPTION
## The Problem
- `vote-card.tsx` still contained large inline render branches after phases 1-4 of #413.
- The action switch and loading/special-content JSX made the component harder to scan without changing any behavior.

## The Solution
- extract the action switch into `vote-card-actions.tsx` with explicit props and local imports
- extract the loading/signing/confirming special-content JSX into `vote-card-special-content.tsx`
- export the existing cancel-action prop interfaces from `vote-card-cancel-actions.tsx` so `vote-card.tsx` can pass precomputed action objects through unchanged
- keep the existing vote-card state derivation, transaction error handling, queued execute gating, labels, test ids, and phase-4 error messaging intact

## Validation
- `pnpm --filter governance.mento.org test`
- `pnpm --filter governance.mento.org check-types`
- `trunk check --fix apps/governance.mento.org/app/components/voting/vote-card.tsx apps/governance.mento.org/app/components/voting/vote-card-actions.tsx apps/governance.mento.org/app/components/voting/vote-card-special-content.tsx apps/governance.mento.org/app/components/voting/vote-card-cancel-actions.tsx`
- browser verification via Chrome DevTools MCP on `http://localhost:3002/voting-power` and queued proposal `http://localhost:3002/proposals/112339692544100114229468165282409962931431701913866170915723287810681223839121` with no console errors

## Ship Checklist
- [x] ship skill used
- [x] local review run
- [x] validation run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Structural refactor with logic moved verbatim; state derivation and transaction handling remain in `vote-card.tsx`. Risk is mainly regression in prop wiring, not new governance behavior.
> 
> **Overview**
> **`vote-card.tsx`** is slimmed down by moving two large inline render helpers into dedicated components, without changing governance flows or UI contracts.
> 
> The state-based action switch (vote, queue, execute, connect wallet, cancel actions, test ids) now lives in **`vote-card-actions.tsx`**, driven by explicit props and callbacks from the parent. Loading/signing/confirming UI (spinner copy, vote direction text, explorer link) moves to **`vote-card-special-content.tsx`**, with vote support passed as `voteSupport` instead of reading cast-vote `variables` inside the child.
> 
> **`vote-card-cancel-actions.tsx`** exports **`WatchdogCancelActionProps`** and **`ProposerCancelActionProps`** so the parent can keep building the same precomputed cancel action objects and pass them through **`VoteCardActions`** unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d534bab7e716d67127c35bc63571dffc824ee9b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->