### PR TITLE
fix: post-merge review follow-ups for the wallet-testing epic (docs + connected-spec timeout)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,7 +85,7 @@ To test connected-wallet flows (swaps, approvals, locking) locally without a rea
 
 1. `pnpm fork:mainnet` — anvil fork of Celo mainnet on port 8545 (Foundry >= 1.4)
 2. `pnpm fork:seed` — fund test accounts + refresh oracle rates (re-run after `evm_revert` or when quotes stall)
-3. `NEXT_PUBLIC_E2E_TEST=true NEXT_PUBLIC_USE_FORK=true pnpm exec turbo run dev --filter app.mento.org`, then connect the "E2E Test Wallet" (requires `CHAINALYSIS_API_KEY` in `apps/app.mento.org/.env.local`)
+3. `NEXT_PUBLIC_E2E_TEST=true NEXT_PUBLIC_USE_FORK=true pnpm exec turbo run dev --filter app.mento.org`, then connect the "E2E Test Wallet" (first run: copy `apps/app.mento.org/.env.example` to `.env.local` and fill it — the env schema fails startup otherwise; `CHAINALYSIS_API_KEY` needs a real key, the Sentry vars may stay empty — see the runbook's prerequisites). For governance flows (lock/voting power), start `governance.mento.org` (port 3002) the same way.
 
 Full runbook — localStorage activation, on-chain verification with `cast`, snapshot/revert discipline, safety rules, troubleshooting: [docs/wallet-testing.md](docs/wallet-testing.md)
 

--- a/apps/app.mento.org/playwright.config.ts
+++ b/apps/app.mento.org/playwright.config.ts
@@ -50,7 +50,11 @@ export default defineConfig({
       name: "connected",
       testMatch: /connected\/.*\.spec\.ts/,
       fullyParallel: false,
-      timeout: 120_000,
+      // Headroom above the sum of the swap spec's chained assertion budgets
+      // (20s connect + 30s enable + 60s approve + 30s confirm + 30s enable +
+      // 60s swap ≈ 230s worst case on the approve path) — same rationale as
+      // the governance connected project's 240s budget.
+      timeout: 240_000,
       use: { viewport: { width: 1280, height: 900 } },
     },
   ],

--- a/docs/wallet-testing.md
+++ b/docs/wallet-testing.md
@@ -46,11 +46,26 @@ runs against an anvil fork of Celo mainnet — no real network is ever touched.
    NEXT_PUBLIC_E2E_TEST=true NEXT_PUBLIC_USE_FORK=true pnpm exec turbo run dev --filter app.mento.org
    ```
 
+   For governance flows (lock MENTO / voting power — the lock UI lives in
+   `governance.mento.org`, not `app.mento.org`), start that app instead and use
+   [http://localhost:3002/voting-power](http://localhost:3002/voting-power):
+
+   ```bash
+   NEXT_PUBLIC_E2E_TEST=true NEXT_PUBLIC_USE_FORK=true pnpm exec turbo run dev --filter governance.mento.org
+   ```
+
+   Note: governance's `dev` script does not watch `@repo/web3` — after changing
+   that package, run `pnpm exec turbo run build --filter @repo/web3` first (see
+   Troubleshooting).
+
 4. Open [http://localhost:3000](http://localhost:3000), click Connect — the modal shows only
    "E2E Test Wallet". Click it. You are connected as
    `0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266` (anvil junk account 0).
 
-5. Drive the UI (e.g. swap 1 CELO -> cUSD), then verify on-chain (next section).
+5. Drive the UI (e.g. swap 1 EURm -> USDm — native CELO is not a selectable
+   swap token: the pinned mento-sdk's token map has no CELO entry for Celo
+   mainnet, so `?from=CELO` silently falls back to the default pair), then
+   verify on-chain (next section).
 
 ## Automated Playwright specs
 

--- a/docs/wallet-testing.md
+++ b/docs/wallet-testing.md
@@ -54,9 +54,13 @@ runs against an anvil fork of Celo mainnet — no real network is ever touched.
    NEXT_PUBLIC_E2E_TEST=true NEXT_PUBLIC_USE_FORK=true pnpm exec turbo run dev --filter governance.mento.org
    ```
 
-   Note: governance's `dev` script does not watch `@repo/web3` — after changing
-   that package, run `pnpm exec turbo run build --filter @repo/web3` first (see
-   Troubleshooting).
+   First run: copy `apps/governance.mento.org/.env.example` to
+   `apps/governance.mento.org/.env.local` — governance validates its own env
+   schema at startup. The example's prefilled URLs work as-is and the empty
+   values (`NEXT_PUBLIC_GRAPH_API_KEY`, Sentry DSN) may stay empty for local
+   E2E use; there is no sanctions gate here. Note: governance's `dev` script
+   does not watch `@repo/web3` — after changing that package, run
+   `pnpm exec turbo run build --filter @repo/web3` first (see Troubleshooting).
 
 4. Open [http://localhost:3000](http://localhost:3000), click Connect — the modal shows only
    "E2E Test Wallet". Click it. You are connected as


### PR DESCRIPTION
Addresses the post-merge Codex review on PR #454 (review 4667782646, landed 5 minutes after that PR merged, so its babysit loop had already ended):

1. **CLAUDE.md quick-start env prereqs complete** — step 3 now says to copy `apps/app.mento.org/.env.example` to `.env.local` first (the env schema fails startup otherwise), with `CHAINALYSIS_API_KEY` as the one var needing a real value.
2. **Governance startup for lock flows** — the runbook quick-start now includes starting `governance.mento.org` (port 3002, `/voting-power`) for lock/voting-power testing, with the `@repo/web3` build caveat.
3. **Selectable swap pair in the example** — `swap 1 CELO -> cUSD` → `swap 1 EURm -> USDm`, with the reason (no CELO entry in the pinned SDK token map).

Part of #441.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LPQQFxntvMvndepgAtedEK

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only changes to developer runbooks; no application or infrastructure code.
> 
> **Overview**
> **Documentation-only** follow-up to post-merge review on wallet-connected local testing (`CLAUDE.md` and `docs/wallet-testing.md`).
> 
> The **app.mento.org** quick-start step now tells readers to copy `.env.example` to `.env.local` before first run (env schema blocks startup otherwise), which vars need real values vs. may be empty, and to start **governance.mento.org** on port 3002 for lock/voting-power flows. The runbook adds the same governance dev command, `/voting-power` URL, and a note that governance `dev` does not watch `@repo/web3` (rebuild that package after changes).
> 
> The manual swap example changes from **CELO → cUSD** to **EURm → USDm**, with a short explanation that native CELO is not in the pinned mento-sdk swap token map on Celo mainnet, so `?from=CELO` falls back to the default pair.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1569026d3116513c67d3b3cff13832e52a9a00da. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->