### PR TITLE
ci(e2e): nightly chain-drift run at a freshly resolved fork block

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -8,6 +8,14 @@ on:
       - packages/web3/**
       - scripts/fork-seed.mjs
       - .github/workflows/e2e.yml
+  # Nightly chain-drift check: PR runs only fire when FRONTEND files change,
+  # but the chain can drift under an unchanged frontend (oracle config, pool
+  # liquidity, contract upgrades, RPC behavior). The scheduled run repeats the
+  # suite at a freshly resolved recent block (see "Resolve nightly fork
+  # block") instead of the pinned FORK_BLOCK. Like workflow_dispatch, this
+  # only takes effect once the workflow exists on the default branch.
+  schedule:
+    - cron: "20 4 * * *" # 04:20 UTC nightly (off the top-of-hour cron rush)
   # Only usable once this workflow exists on the default branch.
   workflow_dispatch:
 
@@ -37,6 +45,8 @@ env:
   # EIP-2935 history-contract slot at the fork block (run 29061781044). The
   # "Select fork RPC" step probes keyless public archive endpoints for state
   # at this exact block and fails loudly if none can serve it.
+  # Scheduled (nightly) runs override this with a freshly resolved recent
+  # block — see the "Resolve nightly fork block" step.
   FORK_BLOCK: "71727341"
 
 jobs:
@@ -97,6 +107,38 @@ jobs:
         with:
           version: v1.7.1 # anvil --celo requires foundry >= 1.4; pinned for determinism
           cache: false # we cache ~/.foundry/cache ourselves, keyed on the fork block
+
+      # Nightly runs test CURRENT chain state instead of the pinned block —
+      # resolve head-64 (deep enough that lagging archive-pool backends have
+      # it, recent enough to reflect live oracle/pool/contract state) from the
+      # first candidate that answers, and override FORK_BLOCK for all later
+      # steps (fork-state cache key, archive probe, anvil).
+      - name: Resolve nightly fork block (scheduled runs only)
+        if: github.event_name == 'schedule'
+        shell: bash
+        run: |
+          candidates=(
+            https://celo-rpc.publicnode.com
+            https://celo.api.onfinality.io/public
+            https://1rpc.io/celo
+            https://rpc.ankr.com/celo
+            https://celo.drpc.org
+            https://forno.celo.org
+          )
+          for url in "${candidates[@]}"; do
+            head_hex=$(curl -sf -m 15 -X POST "$url" \
+              -H 'Content-Type: application/json' \
+              --data '{"jsonrpc":"2.0","id":1,"method":"eth_blockNumber","params":[]}' \
+              | sed -n 's/.*"result":"\(0x[0-9a-fA-F]*\)".*/\1/p')
+            if [ -n "$head_hex" ]; then
+              fresh=$(( head_hex - 64 ))
+              echo "FORK_BLOCK=$fresh" >> "$GITHUB_ENV"
+              echo "Nightly run: forking at freshly resolved block $fresh (head $((head_hex)) from $url, minus 64)"
+              exit 0
+            fi
+          done
+          echo "::error::could not resolve a fresh head block from any candidate RPC"
+          exit 1
 
       - name: Cache anvil fork state
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -126,10 +126,13 @@ jobs:
             https://forno.celo.org
           )
           for url in "${candidates[@]}"; do
+            # `|| true`: this step runs under bash -eo pipefail, so a failed
+            # curl in the substitution would otherwise abort the whole step
+            # instead of falling through to the next candidate.
             head_hex=$(curl -sf -m 15 -X POST "$url" \
               -H 'Content-Type: application/json' \
               --data '{"jsonrpc":"2.0","id":1,"method":"eth_blockNumber","params":[]}' \
-              | sed -n 's/.*"result":"\(0x[0-9a-fA-F]*\)".*/\1/p')
+              | sed -n 's/.*"result":"\(0x[0-9a-fA-F]*\)".*/\1/p' || true)
             if [ -n "$head_hex" ]; then
               fresh=$(( head_hex - 64 ))
               echo "FORK_BLOCK=$fresh" >> "$GITHUB_ENV"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -15,7 +15,7 @@ on:
   # block") instead of the pinned FORK_BLOCK. Like workflow_dispatch, this
   # only takes effect once the workflow exists on the default branch.
   schedule:
-    - cron: "20 4 * * *" # 04:20 UTC nightly (off the top-of-hour cron rush)
+    - cron: 20 4 * * * # 04:20 UTC nightly (off the top-of-hour cron rush)
   # Only usable once this workflow exists on the default branch.
   workflow_dispatch:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,7 +98,7 @@ Functional connected-wallet Playwright specs (not VRT) that run against a seeded
 
 See [docs/wallet-testing.md](docs/wallet-testing.md) for the full runbook.
 
-In CI, `.github/workflows/e2e.yml` runs the same suite on PRs touching `apps/app.mento.org/**`, `packages/web3/**`, `scripts/fork-seed.mjs`, or the workflow itself (plus manual `workflow_dispatch`), against an anvil fork pinned to `FORK_BLOCK` (bump roughly monthly). The fork source is a keyless public archive RPC probed at run time — forno cannot serve pinned-block forks because it prunes a block's state within minutes. The workflow is intentionally not a required check yet.
+In CI, `.github/workflows/e2e.yml` runs the same suite on PRs touching `apps/app.mento.org/**`, `packages/web3/**`, `scripts/fork-seed.mjs`, or the workflow itself (plus manual `workflow_dispatch`), against an anvil fork pinned to `FORK_BLOCK` (bump roughly monthly). The fork source is a keyless public archive RPC probed at run time — forno cannot serve pinned-block forks because it prunes a block's state within minutes. A nightly scheduled run (04:20 UTC) repeats the suite at a freshly resolved recent block instead of the pin, to catch chain drift (oracle config, pool, or contract changes) that paths-filtered PR runs never see. The workflow is intentionally not a required check yet.
 
 ## Coding Conventions
 


### PR DESCRIPTION
Adds a nightly `schedule:` trigger (04:20 UTC) to `e2e.yml`. PR-triggered e2e runs only fire when frontend files change, but the chain drifts under an unchanged frontend — oracle config, pool liquidity, contract upgrades, RPC behavior. The nightly repeats the connected swap suite at a **freshly resolved block** (head−64, via a new schedule-only step that overrides `FORK_BLOCK` before the fork-state cache / archive probe / anvil steps) instead of the monthly-bumped pin, so it tests current chain state.

Notes:
- PR runs are unchanged (pinned block, warm fork cache). Nightly gets a cold cache at its fresh block by design — that IS the drift test.
- `schedule:` only takes effect once this workflow exists on the default branch (i.e. after the epic PR #453 merges) — same caveat as the existing `workflow_dispatch`.
- The e2e check on THIS PR validates the PR path; the schedule path can be smoke-tested post-merge via `workflow_dispatch`... note dispatch uses the pinned block — a true schedule-path test happens on the first nightly.
- Failure visibility: nightly failures land in the Actions tab / commit status on main only. Wiring a Discord ping (like the external smoke tests have) is a possible follow-up — this repo has no notify workflow today.

Part of #441.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LPQQFxntvMvndepgAtedEK

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow and docs; PR E2E behavior is unchanged and the nightly path only overrides the fork block on scheduled events.
> 
> **Overview**
> Adds a **nightly scheduled** connected-wallet E2E run (04:20 UTC) so the suite still exercises **current Celo mainnet state** when PR path filters skip workflow runs despite on-chain drift (oracles, pools, contracts, RPC).
> 
> **PR and manual runs are unchanged** — they keep the pinned `FORK_BLOCK`. On `schedule` only, a new step resolves chain head from public RPC candidates, sets `FORK_BLOCK` to **head−64** via `GITHUB_ENV`, and downstream fork cache, archive probe, and anvil steps use that dynamic block (cold cache at a new height is intentional).
> 
> `CLAUDE.md` documents the nightly drift check alongside the existing pinned-block PR CI behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57eb5f044f4967285e449638cc06be100a351f33. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->