### PR TITLE
test: port cheap unit tests from mento-automation-tests (#479)

### DIFF
--- a/apps/app.mento.org/app/components/swap/swap-form/swap-submit-button.test.tsx
+++ b/apps/app.mento.org/app/components/swap/swap-form/swap-submit-button.test.tsx
@@ -1,0 +1,108 @@
+import React from "react";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { TokenWithBalance } from "@repo/web3";
+
+vi.mock("@mento-protocol/ui", () => ({
+  IconLoading: () => <span>Loading</span>,
+  Button: ({ children, ...props }: React.ComponentProps<"button">) => (
+    <button {...props}>{children}</button>
+  ),
+}));
+
+vi.mock("@repo/web3", () => ({
+  SWAP_INSUFFICIENT_LIQUIDITY_LABEL: "Insufficient liquidity",
+  ConnectButton: () => <button type="button">Connect</button>,
+}));
+
+import { SwapSubmitButton } from "./swap-submit-button";
+
+const allTokenOptions: TokenWithBalance[] = [];
+
+const baseProps = {
+  isConnected: true,
+  hasAmount: true,
+  tokenInSymbol: "USDm",
+  tokenOutSymbol: "CELO",
+  errors: {},
+  isButtonLoading: false,
+  isApproveTxLoading: false,
+  isApprovalProcessing: false,
+  tradingLimitError: null,
+  balanceError: null,
+  isTradingSuspended: false,
+  isSuspensionCheckLoading: false,
+  isError: false,
+  hasInsufficientLiquidityError: false,
+  quoteErrorMessage: null,
+  hasValidQuote: true,
+  shouldApprove: false,
+  allTokenOptions,
+};
+
+describe("SwapSubmitButton", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("disables submit when there is no amount", () => {
+    render(<SwapSubmitButton {...baseProps} hasAmount={false} />);
+
+    expect(
+      (screen.getByTestId("swapButton") as HTMLButtonElement).disabled,
+    ).toBe(true);
+  });
+
+  it("shows the insufficient-balance state and disables submit", () => {
+    render(
+      <SwapSubmitButton {...baseProps} balanceError="Insufficient balance" />,
+    );
+
+    const button = screen.getByTestId(
+      "insufficientBalanceButton",
+    ) as HTMLButtonElement;
+    expect(button.disabled).toBe(true);
+    expect(button.textContent).toBe("Insufficient balance");
+  });
+
+  it("shows the exceeds-trading-limit state and disables submit", () => {
+    render(
+      <SwapSubmitButton
+        {...baseProps}
+        tradingLimitError="Swap exceeds trading limits"
+      />,
+    );
+
+    const button = screen.getByTestId(
+      "swapsExceedsTradingLimitButton",
+    ) as HTMLButtonElement;
+    expect(button.disabled).toBe(true);
+    expect(button.textContent).toBe("Swap exceeds trading limits");
+  });
+
+  it("prefers the trading-limit testid when both errors are present", () => {
+    render(
+      <SwapSubmitButton
+        {...baseProps}
+        balanceError="Insufficient balance"
+        tradingLimitError="Swap exceeds trading limits"
+      />,
+    );
+
+    expect(
+      (
+        screen.getByTestId(
+          "swapsExceedsTradingLimitButton",
+        ) as HTMLButtonElement
+      ).disabled,
+    ).toBe(true);
+  });
+
+  it("enables submit for a valid amount with no errors", () => {
+    render(<SwapSubmitButton {...baseProps} />);
+
+    expect(
+      (screen.getByTestId("swapButton") as HTMLButtonElement).disabled,
+    ).toBe(false);
+  });
+});

--- a/apps/governance.mento.org/app/components/footer.test.tsx
+++ b/apps/governance.mento.org/app/components/footer.test.tsx
@@ -1,0 +1,42 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { Footer } from "@mento-protocol/ui";
+import { afterEach, describe, expect, it } from "vitest";
+
+describe("Governance footer external links", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("links X, Github, and Discord to the expected destinations", () => {
+    render(<Footer type="governance" />);
+
+    expect(
+      (screen.getByTestId("x-link-button") as HTMLAnchorElement).href,
+    ).toBe("https://x.com/MentoLabs");
+    expect(
+      (screen.getByTestId("github-link-button") as HTMLAnchorElement).href,
+    ).toBe("https://github.com/mento-protocol");
+    expect(
+      (screen.getByTestId("discord-link-button") as HTMLAnchorElement).href,
+    ).toBe("http://discord.mento.org/");
+  });
+
+  it("links Mento.org, Reserve, and Privacy Policy to the expected destinations", () => {
+    render(<Footer type="governance" />);
+
+    expect(
+      (screen.getByRole("link", { name: "Mento.org" }) as HTMLAnchorElement)
+        .href,
+    ).toBe("https://mento.org/");
+    expect(
+      (screen.getByRole("link", { name: "Reserve" }) as HTMLAnchorElement).href,
+    ).toBe("https://reserve.mento.org/");
+    expect(
+      (
+        screen.getByRole("link", {
+          name: "Privacy Policy",
+        }) as HTMLAnchorElement
+      ).href,
+    ).toBe("https://mento.org/privacy");
+  });
+});

--- a/apps/governance.mento.org/app/components/mento-token-info.test.tsx
+++ b/apps/governance.mento.org/app/components/mento-token-info.test.tsx
@@ -1,0 +1,80 @@
+import React from "react";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const GOVERNOR_ADDRESS = "0x47036d78bB3169b4F5560dD77BF93f4412A59852";
+const MENTO_ADDRESS = "0x7FF62f59e3e89EA34163EA1458EEBCc81177Cfb6";
+const TIMELOCK_ADDRESS = "0x890DB8A597940165901372Dd7DB61C9f246e2147";
+const VE_MENTO_ADDRESS = "0x001Bb66636dCd149A1A2bA8C50E408BdDd80279C";
+const CELO_MAINNET_EXPLORER_URL = "https://celoscan.io";
+
+vi.mock("@mento-protocol/ui", () => ({
+  Accordion: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  AccordionItem: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  AccordionTrigger: ({ children }: { children: React.ReactNode }) => (
+    <button type="button">{children}</button>
+  ),
+  AccordionContent: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  CopyToClipboard: () => <span>Copy</span>,
+}));
+
+vi.mock("@repo/web3", () => ({
+  useContracts: () => ({
+    MentoToken: { address: MENTO_ADDRESS },
+    TimelockController: { address: TIMELOCK_ADDRESS },
+    MentoGovernor: { address: GOVERNOR_ADDRESS },
+    Locking: { address: VE_MENTO_ADDRESS },
+  }),
+  useAccount: () => ({ chain: undefined }),
+  useTokens: () => ({
+    mentoContractData: { totalSupply: 0n, decimals: 18 },
+  }),
+  NumbersService: { parseNumericValue: (value: string) => value },
+  shortenAddress: (address: string) => address,
+}));
+
+vi.mock("@/contracts", () => ({
+  useGovernanceDetails: () => ({
+    proposalThreshold: undefined,
+    quorumNeeded: undefined,
+    votingPeriodFormatted: undefined,
+    timeLockFormatted: undefined,
+  }),
+}));
+
+vi.mock("@/hooks/use-current-chain", () => ({
+  useCurrentChain: () => ({
+    blockExplorers: { default: { url: CELO_MAINNET_EXPLORER_URL } },
+  }),
+}));
+
+import { MentoTokenInfo } from "./mento-token-info";
+
+describe("MentoTokenInfo contract address links", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("links governor/mento/timelock/veMENTO to their mainnet Celoscan pages", () => {
+    render(<MentoTokenInfo />);
+
+    expect(
+      (screen.getByTestId("governor-address-button") as HTMLAnchorElement).href,
+    ).toBe(`${CELO_MAINNET_EXPLORER_URL}/address/${GOVERNOR_ADDRESS}`);
+    expect(
+      (screen.getByTestId("mento-address-button") as HTMLAnchorElement).href,
+    ).toBe(`${CELO_MAINNET_EXPLORER_URL}/address/${MENTO_ADDRESS}`);
+    expect(
+      (screen.getByTestId("timelock-address-button") as HTMLAnchorElement).href,
+    ).toBe(`${CELO_MAINNET_EXPLORER_URL}/address/${TIMELOCK_ADDRESS}`);
+    expect(
+      (screen.getByTestId("veMento-address-button") as HTMLAnchorElement).href,
+    ).toBe(`${CELO_MAINNET_EXPLORER_URL}/address/${VE_MENTO_ADDRESS}`);
+  });
+});

--- a/apps/governance.mento.org/app/components/mento-token-info.test.tsx
+++ b/apps/governance.mento.org/app/components/mento-token-info.test.tsx
@@ -1,12 +1,14 @@
 import React from "react";
 import { cleanup, render, screen } from "@testing-library/react";
+import { addresses, ChainId } from "@mento-protocol/mento-sdk";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-const GOVERNOR_ADDRESS = "0x47036d78bB3169b4F5560dD77BF93f4412A59852";
-const MENTO_ADDRESS = "0x7FF62f59e3e89EA34163EA1458EEBCc81177Cfb6";
-const TIMELOCK_ADDRESS = "0x890DB8A597940165901372Dd7DB61C9f246e2147";
-const VE_MENTO_ADDRESS = "0x001Bb66636dCd149A1A2bA8C50E408BdDd80279C";
 const CELO_MAINNET_EXPLORER_URL = "https://celoscan.io";
+// The real Celo mainnet contract addresses, straight from the SDK's own
+// mapping. Using these (instead of hardcoded copies) both for the mock and
+// the assertions means a change to the SDK's addresses, or a regression in
+// how the component wires them up, actually fails this test.
+const celoAddresses = addresses[ChainId.CELO];
 
 vi.mock("@mento-protocol/ui", () => ({
   Accordion: ({ children }: { children: React.ReactNode }) => (
@@ -24,12 +26,20 @@ vi.mock("@mento-protocol/ui", () => ({
   CopyToClipboard: () => <span>Copy</span>,
 }));
 
+// useContracts stays mocked: unmocking it means importing @repo/web3's real
+// barrel, which transitively pulls in RainbowKit's CSS. Vitest's CSS
+// pipeline then runs the app's postcss.config.mjs (a Next.js-style config,
+// string plugin names) and fails ("Invalid PostCSS Plugin") — an unrelated
+// build-pipeline problem, not something this test should have to fix. So the
+// mock stays, but its addresses come straight from the SDK instead of being
+// copy-pasted, so a change to the SDK's mapping (or a wiring bug that swaps
+// which contract goes where) still fails this test.
 vi.mock("@repo/web3", () => ({
   useContracts: () => ({
-    MentoToken: { address: MENTO_ADDRESS },
-    TimelockController: { address: TIMELOCK_ADDRESS },
-    MentoGovernor: { address: GOVERNOR_ADDRESS },
-    Locking: { address: VE_MENTO_ADDRESS },
+    MentoToken: { address: celoAddresses.MentoToken },
+    TimelockController: { address: celoAddresses.TimelockController },
+    MentoGovernor: { address: celoAddresses.MentoGovernor },
+    Locking: { address: celoAddresses.Locking },
   }),
   useAccount: () => ({ chain: undefined }),
   useTokens: () => ({
@@ -66,15 +76,19 @@ describe("MentoTokenInfo contract address links", () => {
 
     expect(
       (screen.getByTestId("governor-address-button") as HTMLAnchorElement).href,
-    ).toBe(`${CELO_MAINNET_EXPLORER_URL}/address/${GOVERNOR_ADDRESS}`);
+    ).toBe(
+      `${CELO_MAINNET_EXPLORER_URL}/address/${celoAddresses.MentoGovernor}`,
+    );
     expect(
       (screen.getByTestId("mento-address-button") as HTMLAnchorElement).href,
-    ).toBe(`${CELO_MAINNET_EXPLORER_URL}/address/${MENTO_ADDRESS}`);
+    ).toBe(`${CELO_MAINNET_EXPLORER_URL}/address/${celoAddresses.MentoToken}`);
     expect(
       (screen.getByTestId("timelock-address-button") as HTMLAnchorElement).href,
-    ).toBe(`${CELO_MAINNET_EXPLORER_URL}/address/${TIMELOCK_ADDRESS}`);
+    ).toBe(
+      `${CELO_MAINNET_EXPLORER_URL}/address/${celoAddresses.TimelockController}`,
+    );
     expect(
       (screen.getByTestId("veMento-address-button") as HTMLAnchorElement).href,
-    ).toBe(`${CELO_MAINNET_EXPLORER_URL}/address/${VE_MENTO_ADDRESS}`);
+    ).toBe(`${CELO_MAINNET_EXPLORER_URL}/address/${celoAddresses.Locking}`);
   });
 });

--- a/apps/governance.mento.org/app/components/mento-token-info.test.tsx
+++ b/apps/governance.mento.org/app/components/mento-token-info.test.tsx
@@ -10,6 +10,12 @@ const CELO_MAINNET_EXPLORER_URL = "https://celoscan.io";
 // how the component wires them up, actually fails this test.
 const celoAddresses = addresses[ChainId.CELO];
 
+// Hoisting constraint: vi.mock factories run while the (hoisted) component
+// import resolves — BEFORE the consts above are initialized. Referencing them
+// is only safe inside the arrow functions a factory returns (accessed at
+// render time), as done below. Dereferencing them directly in a factory body
+// would throw a TDZ ReferenceError.
+
 vi.mock("@mento-protocol/ui", () => ({
   Accordion: ({ children }: { children: React.ReactNode }) => (
     <div>{children}</div>

--- a/apps/governance.mento.org/app/components/nav/header.test.tsx
+++ b/apps/governance.mento.org/app/components/nav/header.test.tsx
@@ -1,0 +1,52 @@
+import React from "react";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@mento-protocol/ui", () => ({
+  cn: (...classes: unknown[]) =>
+    classes.filter((value) => typeof value === "string" && value).join(" "),
+  Logo: () => <span>Logo</span>,
+  NavigationMenu: ({ children }: { children: React.ReactNode }) => (
+    <nav>{children}</nav>
+  ),
+  NavigationMenuItem: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+  NavigationMenuLink: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+  NavigationMenuList: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+}));
+
+vi.mock("@repo/web3", () => ({
+  Celo: {},
+  CeloSepolia: {},
+  ChainButton: () => <span>Chain</span>,
+  ConnectButton: () => <span>Connect</span>,
+}));
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/",
+}));
+
+import { Header } from "./header";
+
+describe("Header external links", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("links the Governance Forum item to the Mento forum", () => {
+    render(<Header />);
+
+    expect(
+      (
+        screen.getByRole("link", {
+          name: "Governance Forum",
+        }) as HTMLAnchorElement | null
+      )?.href,
+    ).toBe("https://forum.mento.org/");
+  });
+});

--- a/apps/governance.mento.org/package.json
+++ b/apps/governance.mento.org/package.json
@@ -53,6 +53,7 @@
     "@graphql-codegen/typescript-apollo-client-helpers": "^4.0.1",
     "@graphql-codegen/typescript-operations": "^6.0.4",
     "@graphql-codegen/typescript-react-apollo": "^4.4.2",
+    "@mento-protocol/mento-sdk": "catalog:",
     "@playwright/test": "1.61.1",
     "@repo/eslint-config": "workspace:*",
     "@repo/typescript-config": "workspace:*",

--- a/apps/governance.mento.org/vitest.config.ts
+++ b/apps/governance.mento.org/vitest.config.ts
@@ -2,6 +2,8 @@ import { resolve } from "path";
 import { mergeConfig } from "vitest/config";
 import sharedConfig from "@repo/vitest-config/shared";
 
+const uiSrcDir = resolve(__dirname, "../../packages/ui/src");
+
 export default mergeConfig(sharedConfig, {
   esbuild: {
     jsx: "automatic",
@@ -9,6 +11,19 @@ export default mergeConfig(sharedConfig, {
   },
   resolve: {
     alias: {
+      // @mento-protocol/ui's package.json only exposes dist/ (tsup output), so a
+      // standalone `pnpm --filter governance.mento.org test` fails to resolve it
+      // without a prior turbo build. footer.test.tsx renders the real Footer, so
+      // we alias straight to its source instead of mocking it away. We can't
+      // alias the package's full barrel (src/index.ts): that pulls in the whole
+      // component library (e.g. mode-toggle.tsx), whose own internal "@/..."
+      // imports collide with governance's own "@" alias below (same alias
+      // string, different roots). Footer's own dependency surface is tiny
+      // (two "@/..." imports plus relative icon imports), so we alias directly
+      // to its file and resolve those two imports explicitly.
+      "@/lib/links.js": resolve(uiSrcDir, "lib/links.ts"),
+      "@/lib/utils.js": resolve(uiSrcDir, "lib/utils.ts"),
+      "@mento-protocol/ui": resolve(uiSrcDir, "components/footer.tsx"),
       // Mirror the tsconfig path alias used by the app
       "@": resolve(__dirname, "./app"),
     },
@@ -16,5 +31,13 @@ export default mergeConfig(sharedConfig, {
   test: {
     environment: "jsdom",
     include: ["app/**/*.test.ts", "app/**/*.test.tsx"],
+    // The SDK ships an ESM build with extensionless relative imports that Node's
+    // native resolver rejects; inlining lets Vite transform and resolve it.
+    // (Mirrors packages/web3/vitest.config.ts, which hit the same issue.)
+    server: {
+      deps: {
+        inline: [/@mento-protocol\/mento-sdk/],
+      },
+    },
   },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -448,6 +448,9 @@ importers:
       '@graphql-codegen/typescript-react-apollo':
         specifier: ^4.4.2
         version: 4.4.2(graphql@16.12.0)
+      '@mento-protocol/mento-sdk':
+        specifier: 'catalog:'
+        version: 3.3.0-beta.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
       '@playwright/test':
         specifier: 1.61.1
         version: 1.61.1


### PR DESCRIPTION
## What

Part of #479 (\"port the old suite's cheap, wallet-free assertions as vitest unit/component tests\"). Does not close #479 — other sub-cases remain.

Adds 4 new vitest test files, all running inside the existing `pnpm --filter app.mento.org test` / `pnpm --filter governance.mento.org test` (turbo) pipelines — no Playwright, no new CI wiring:

- `apps/app.mento.org/.../swap-form/swap-submit-button.test.tsx` — sell-amount validation states: no-amount → disabled `swapButton`; `balanceError` → disabled `insufficientBalanceButton`; `tradingLimitError` → disabled `swapsExceedsTradingLimitButton`; trading-limit takes priority when both errors are set; valid amount → enabled.
- `apps/governance.mento.org/.../mento-token-info.test.tsx` — governor/mento/timelock/veMENTO contract-address links resolve to the expected mainnet Celoscan URLs (`https://celoscan.io/address/<addr>`), addresses cross-checked against `@mento-protocol/mento-sdk`'s `addresses[42220]`.
- `apps/governance.mento.org/.../nav/header.test.tsx` — the "Governance Forum" nav link points at `https://forum.mento.org/`.
- `apps/governance.mento.org/.../footer.test.tsx` — X/Github/Discord/Mento.org/Reserve/Privacy-Policy footer links (rendered with `type="governance"`) match the hrefs actually in `packages/ui/src/components/footer.tsx` / `packages/ui/src/lib/links.ts`.

## Why these, and what's deliberately left to the E2E layer

- **Amounts/decimals formatting** (old `amounts.spec.ts` / `decimals.spec.ts`): the swap form's sell/buy USD labels reuse `formatWithMaxDecimals` / `formatBalance` from `@repo/web3`, which are already exhaustively unit-tested in `packages/web3/src/features/swap/utils.test.ts` (4-decimal truncation, `4.35` not rounding to `4.34`, thousand separators, etc.) — no new test needed to avoid duplicating coverage.
- **Token selection** (old `token-selections.spec.ts`): `getAvailableTokenSymbol` / `getDefaultTokenInSymbol` / `getSelectedTokenSymbol` (valid pair, invalid/unknown symbol fallback) are already covered by `token-selection.test.ts`. Left to E2E/leftovers: the swap-direction flip (`swapInputsButton` → `handleReverseTokens`) and the `?from=&to=` deep-link token derivation (including same-token collision avoidance) both live as unexported inline logic inside the ~900-line `use-swap-form.tsx` hook, entangled with balances/quotes/trading-limits/wagmi state. Testing them in isolation would require either extracting pure functions (a refactor out of scope for a "port tests" task) or standing up the full hook's dependency graph — the kind of heavy, quote/wallet-adjacent harness this task explicitly says to skip. These stay covered by the connected E2E suite.
- **Governance contract links / header-footer links**: implemented as component tests against the real `MentoTokenInfo`, `Header`, and `Footer` components (mocking only the wagmi/jotai/data-hook boundary), per "whichever matches how the code is factored." Note the Discord href in code (`http://discord.mento.org`, a redirect) differs from the old spec's raw invite URL (`https://discord.com/invite/...`) — the test asserts what's actually in the codebase today.

## How verified

- `pnpm --filter app.mento.org test` — 25 files / 144 tests passed (includes the new file, 5 tests).
- `pnpm --filter governance.mento.org test` — 15 files / 95 tests passed (includes the 3 new files, 4 tests).
- `pnpm exec turbo run check-types --filter app.mento.org --filter governance.mento.org` — passed.
- `trunk check --fix` on the 4 new files — no issues, auto-formatted.
- Pre-push hook (`trunk check --all` equivalent) ran clean on push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YMrH8V7c3btnC1LZQXcN4b

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only additions with no runtime, auth, or deployment behavior changes.
> 
> **Overview**
> Adds **four new Vitest component tests** (no production or CI changes) as part of porting wallet-free assertions from the old automation suite into existing `app.mento.org` and `governance.mento.org` test pipelines.
> 
> **Swap app:** `swap-submit-button.test.tsx` exercises `SwapSubmitButton` with mocked UI/web3 deps—disabled submit when there is no amount, insufficient-balance and trading-limit error buttons (labels + disabled state), trading-limit UI when both errors are set, and an enabled `swapButton` on a valid happy path.
> 
> **Governance app:** Three files assert external `href`s on real components (with boundary mocks where needed): `MentoTokenInfo` contract links to mainnet Celoscan URLs; `Header` “Governance Forum” → `https://forum.mento.org/`; `Footer` (`type="governance"`) social and site links (including Discord as `http://discord.mento.org/` per current UI).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6578adfbf262efd2a8a81394d369d76a7ba239df. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->