### PR TITLE
test(app): extend connected e2e with swap-pair matrix, slippage, and rejection specs

### DIFF
--- a/apps/app.mento.org/e2e/connected/swap-pairs.spec.ts
+++ b/apps/app.mento.org/e2e/connected/swap-pairs.spec.ts
@@ -1,0 +1,129 @@
+import { expect } from "@playwright/test";
+import { connectedTest as test } from "../fixtures";
+import { erc20BalanceOf, revert, rpc, snapshot } from "./rpc";
+
+// Prerequisite: anvil must be running and seeded before this spec runs —
+//   pnpm fork:mainnet   (anvil --celo --auto-impersonate on 127.0.0.1:8545)
+//   pnpm fork:seed
+// This spec does not start or seed anvil itself.
+//
+// Oracle-staleness caveat: see swap.spec.ts's header comment — re-run
+// `pnpm fork:seed` if quotes start failing.
+//
+// Issue #479 wants a REPRESENTATIVE swap-pair matrix, not the old 169-combo
+// sweep. This file adds 2 pairs beyond the EURm -> USDm pair already covered
+// by swap.spec.ts, chosen among seeded sell tokens (USDm, EURm, USDC — see
+// scripts/fork-seed.mjs) with confirmed oracle + route coverage:
+//   - USDm -> USDC: a direct 1-hop stable/stable route.
+//   - EURm -> GBPm: a 2-hop cross-currency route (both legs re-reported by
+//     fork-seed's RELAYERS map), exercising a different route shape than the
+//     other pairs in this suite.
+// Both pairs were confirmed to quote and swap successfully against a local
+// seeded fork (sdk.routes.findRoute + sdk.quotes.getAmountOut) before being
+// committed here.
+const ACCT0 = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266";
+const USDC = "0xcebA9300f2b948710d2653dD7B07f33A8B32118C";
+const GBPM = "0xCCF663b1fF11028f0b19058d0f7B674004a40746";
+
+const PAIRS = [
+  { from: "USDm", to: "USDC", buyToken: USDC },
+  { from: "EURm", to: "GBPm", buyToken: GBPM },
+] as const;
+
+let snapshotId: string | undefined;
+
+// Preflight: without anvil running, snapshot() in beforeEach dies with an
+// opaque "TypeError: fetch failed" — fail fast with an actionable message.
+test.beforeAll(async () => {
+  try {
+    await rpc<string>("eth_chainId");
+  } catch {
+    throw new Error(
+      "anvil fork not reachable at 127.0.0.1:8545 — start it with `pnpm fork:mainnet` and seed with `pnpm fork:seed` before running test:connected (see spec header comment)",
+    );
+  }
+});
+
+// anvil snapshots are CONSUMED by evm_revert — a fresh snapshot per test.
+test.beforeEach(async () => {
+  snapshotId = await snapshot();
+});
+test.afterEach(async () => {
+  // Guard against beforeEach failing before assignment (e.g. anvil not
+  // running) — reverting an unset snapshotId would throw a second, masking
+  // error on top of the real root cause.
+  if (snapshotId === undefined) return;
+  // Clear before awaiting so a later test never reverts this stale,
+  // already-consumed id.
+  const id = snapshotId;
+  snapshotId = undefined;
+  // anvil returns false (not an error) for an unknown/consumed snapshot id,
+  // so assert the result — a silent no-op here would break fork isolation.
+  expect(await revert(id)).toBe(true);
+});
+
+for (const { from, to, buyToken } of PAIRS) {
+  test(`swaps 1 ${from} for ${to}`, async ({ page }) => {
+    const balanceBefore = await erc20BalanceOf(buyToken, ACCT0);
+
+    await page.goto(`/swap/celo?from=${from}&to=${to}`, {
+      waitUntil: "domcontentloaded",
+    });
+
+    // Eager-connect happens via the fixture's init-script localStorage keys.
+    // The header renders both a mobile (`md:hidden`) and a desktop
+    // (`md:block hidden`) ConnectButton simultaneously — filter to the one
+    // actually visible at this project's viewport instead of `.first()`,
+    // which would resolve to the DOM-first (mobile, hidden here) copy.
+    await expect(
+      page.getByText("0xf39F...2266").filter({ visible: true }),
+    ).toBeVisible({
+      timeout: 20_000,
+    });
+
+    await page.getByTestId("sellAmountInput").fill("1");
+
+    // Button is `approveButton` when the Broker needs a from-token allowance,
+    // else `swapButton`.
+    const submit = page.getByTestId(/^(approveButton|swapButton)$/);
+    await expect(submit).toBeEnabled({ timeout: 30_000 });
+    if ((await submit.getAttribute("data-testid")) === "approveButton") {
+      test.info().annotations.push({
+        type: "flow",
+        description: "approve-then-swap",
+      });
+      await submit.click();
+      await expect(page.getByText("Approve Successful")).toBeVisible({
+        timeout: 60_000,
+      });
+      // Approval success auto-opens the confirm view
+      // (setConfirmView(true) in use-swap-form.tsx) — do not click swapButton
+      // again on the form; it's already gone.
+    } else {
+      test
+        .info()
+        .annotations.push({ type: "flow", description: "direct-swap" });
+      await submit.click();
+    }
+    await expect(page.getByText("Confirm Swap")).toBeVisible({
+      timeout: 30_000,
+    });
+    // swap-page-content.tsx deliberately keeps SwapForm mounted (toggling
+    // only `hidden` via CSS) to avoid a DOM removeChild crash on route
+    // transitions, so the form's own (CSS-hidden) swapButton still matches
+    // this testid alongside the confirm view's — filter to the visible one.
+    const confirmSwapButton = page
+      .getByTestId("swapButton")
+      .filter({ visible: true });
+    await expect(confirmSwapButton).toBeEnabled({
+      timeout: 30_000,
+    });
+    await confirmSwapButton.click();
+    await expect(page.getByText("Swap Successful")).toBeVisible({
+      timeout: 60_000,
+    });
+
+    const balanceAfter = await erc20BalanceOf(buyToken, ACCT0);
+    expect(balanceAfter > balanceBefore).toBe(true);
+  });
+}

--- a/apps/app.mento.org/e2e/connected/swap-rejection.spec.ts
+++ b/apps/app.mento.org/e2e/connected/swap-rejection.spec.ts
@@ -1,0 +1,176 @@
+import { expect } from "@playwright/test";
+import { createRequire } from "node:module";
+import { encodeFunctionData, parseAbi, type Address } from "viem";
+import { connectedTest as test } from "../fixtures";
+import { revert, rpc, snapshot } from "./rpc";
+
+// Prerequisite: anvil must be running and seeded before this spec runs —
+//   pnpm fork:mainnet   (anvil --celo --auto-impersonate on 127.0.0.1:8545)
+//   pnpm fork:seed
+// This spec does not start or seed anvil itself.
+//
+// See swap-slippage.spec.ts's header comment for why @mento-protocol/mento-sdk
+// is loaded via createRequire in this ESM package.
+const require = createRequire(import.meta.url);
+const { getContractAddress } = require("@mento-protocol/mento-sdk") as {
+  getContractAddress: (chainId: number, name: string) => Address;
+};
+
+const CELO_CHAIN_ID = 42220;
+const ACCT0 = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266";
+const EURM = "0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73";
+const ROUTER_ADDRESS = getContractAddress(CELO_CHAIN_ID, "Router");
+
+const ERC20_APPROVE_ABI = parseAbi([
+  "function approve(address spender, uint256 amount) returns (bool)",
+]);
+
+// ACCT0 is one of anvil's own default unlocked dev accounts (mnemonic
+// "test test ... junk"), so anvil signs for it directly — no
+// anvil_impersonateAccount needed (unlike fork-seed.mjs's whale transfers,
+// which impersonate accounts anvil does NOT hold keys for).
+async function approveRouterMax(token: Address, owner: Address) {
+  const data = encodeFunctionData({
+    abi: ERC20_APPROVE_ABI,
+    functionName: "approve",
+    args: [ROUTER_ADDRESS, 2n ** 256n - 1n],
+  });
+  const hash = await rpc<string>("eth_sendTransaction", [
+    { from: owner, to: token, data },
+  ]);
+  for (let attempt = 0; attempt < 50; attempt++) {
+    const receipt = await rpc<{ status: string } | null>(
+      "eth_getTransactionReceipt",
+      [hash],
+    );
+    if (receipt) {
+      if (receipt.status !== "0x1") {
+        throw new Error(`approve tx ${hash} reverted`);
+      }
+      return;
+    }
+    await new Promise((resolveDelay) => setTimeout(resolveDelay, 100));
+  }
+  throw new Error(`approve tx ${hash} was not mined within 5s`);
+}
+
+let snapshotId: string | undefined;
+
+test.beforeAll(async () => {
+  try {
+    await rpc<string>("eth_chainId");
+  } catch {
+    throw new Error(
+      "anvil fork not reachable at 127.0.0.1:8545 — start it with `pnpm fork:mainnet` and seed with `pnpm fork:seed` before running test:connected (see spec header comment)",
+    );
+  }
+});
+
+test.beforeEach(async () => {
+  snapshotId = await snapshot();
+});
+test.afterEach(async () => {
+  if (snapshotId === undefined) return;
+  const id = snapshotId;
+  snapshotId = undefined;
+  expect(await revert(id)).toBe(true);
+});
+
+test("recovers the form after the wallet rejects the swap transaction", async ({
+  page,
+}) => {
+  // DEVIATION from a literal "reject whatever eth_sendTransaction comes
+  // first": on a freshly seeded/reverted fork the Router has zero EURm
+  // allowance, so the naturally-first eth_sendTransaction is the APPROVE
+  // call, not the swap — rejecting that would test approve-tx rejection
+  // (different error copy: "Approval transaction rejected by user." vs
+  // "Swap transaction rejected by user.", see
+  // packages/web3/src/features/swap/hooks/use-approve-transaction.tsx and
+  // error-handlers.tsx). This spec's target is the swap-tx rejection path
+  // (per #479), so the Router allowance is pre-approved directly via a raw
+  // RPC call (outside the browser, so it doesn't consume the page.route
+  // intercept below) — the UI then renders "swapButton" immediately and the
+  // FIRST eth_sendTransaction the browser actually sends is the swap call.
+  await approveRouterMax(EURM, ACCT0);
+
+  let rejected = false;
+  await page.route(
+    (url) => url.hostname === "localhost" && url.port === "8545",
+    async (route) => {
+      const request = route.request();
+      const postData = request.postData();
+      if (rejected || !postData) {
+        await route.continue();
+        return;
+      }
+
+      let body: { id?: number; method?: string };
+      try {
+        body = JSON.parse(postData);
+      } catch {
+        await route.continue();
+        return;
+      }
+
+      if (body.method === "eth_sendTransaction") {
+        rejected = true;
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            jsonrpc: "2.0",
+            id: body.id,
+            error: { code: 4001, message: "User rejected the request." },
+          }),
+        });
+        return;
+      }
+
+      await route.continue();
+    },
+  );
+
+  await page.goto("/swap/celo?from=EURm&to=USDm", {
+    waitUntil: "domcontentloaded",
+  });
+
+  await expect(
+    page.getByText("0xf39F...2266").filter({ visible: true }),
+  ).toBeVisible({
+    timeout: 20_000,
+  });
+
+  await page.getByTestId("sellAmountInput").fill("1");
+
+  // The Router is pre-approved above, so the form goes straight to
+  // "swapButton" — no approveButton branch to handle here.
+  const submit = page.getByTestId("swapButton");
+  await expect(submit).toBeEnabled({ timeout: 30_000 });
+  await submit.click();
+
+  await expect(page.getByText("Confirm Swap")).toBeVisible({
+    timeout: 30_000,
+  });
+  const confirmSwapButton = page
+    .getByTestId("swapButton")
+    .filter({ visible: true });
+  await expect(confirmSwapButton).toBeEnabled({ timeout: 30_000 });
+  await confirmSwapButton.click();
+
+  // Exact copy from USER_ERROR_MESSAGES.SWAP_REJECTED_BY_USER
+  // (packages/web3/src/features/swap/error-handlers.tsx), surfaced via
+  // getSwapTransactionErrorMessage -> isUserRejection in
+  // use-swap-transaction.tsx's mutation onError handler.
+  await expect(
+    page.getByText("Swap transaction rejected by user."),
+  ).toBeVisible({ timeout: 30_000 });
+
+  // The form recovers to a re-submittable state: use-swap-transaction.tsx's
+  // onError does not call setConfirmView(false), so the confirm view stays
+  // open, and swap-confirm.tsx's button testid/disabled state both key off
+  // isSwapTxLoading/isSwapTxReceiptLoading, which settle back to false once
+  // the mutation errors — the same (CSS-filtered) swapButton should be
+  // enabled again with no further interaction.
+  await expect(confirmSwapButton).toBeEnabled({ timeout: 10_000 });
+  expect(rejected).toBe(true);
+});

--- a/apps/app.mento.org/e2e/connected/swap-slippage.spec.ts
+++ b/apps/app.mento.org/e2e/connected/swap-slippage.spec.ts
@@ -1,0 +1,229 @@
+import { expect } from "@playwright/test";
+import { createRequire } from "node:module";
+import {
+  decodeFunctionData,
+  decodeFunctionResult,
+  encodeFunctionData,
+  type Address,
+  type Hex,
+} from "viem";
+import { connectedTest as test } from "../fixtures";
+import { revert, rpc, snapshot } from "./rpc";
+
+// Prerequisite: anvil must be running and seeded before this spec runs —
+//   pnpm fork:mainnet   (anvil --celo --auto-impersonate on 127.0.0.1:8545)
+//   pnpm fork:seed
+// This spec does not start or seed anvil itself.
+//
+// This package (apps/app.mento.org) is `"type": "module"`, so Playwright
+// loads this spec as native ESM. @mento-protocol/mento-sdk's package.json
+// `exports` map points the ESM ("import") condition at a dist/esm build with
+// broken extensionless relative imports (verified: `node --input-type=module
+// -e "import('@mento-protocol/mento-sdk')"` throws ERR_MODULE_NOT_FOUND on
+// dist/esm/core/constants/chainId). The CJS ("require") condition is fine.
+// `createRequire` forces CJS resolution regardless of this file's own module
+// type, sidestepping the broken ESM build entirely.
+const require = createRequire(import.meta.url);
+const { ROUTER_ABI, getContractAddress } =
+  require("@mento-protocol/mento-sdk") as {
+    ROUTER_ABI: readonly unknown[];
+    getContractAddress: (chainId: number, name: string) => Address;
+  };
+
+const CELO_CHAIN_ID = 42220;
+const ROUTER_ADDRESS = getContractAddress(CELO_CHAIN_ID, "Router");
+const CUSTOM_SLIPPAGE_PERCENT = "15";
+
+// SwapService.calculateMinAmountOut in the pinned mento-sdk
+// (dist/services/swap/SwapService.js): basisPoints = floor(slippage * 100),
+// amountOutMin = expectedAmountOut * (10000 - basisPoints) / 10000n, both
+// integer bigint math with 10000n-scaled basis points.
+const BASIS_POINTS = BigInt(Math.floor(Number(CUSTOM_SLIPPAGE_PERCENT) * 100));
+const SLIPPAGE_MULTIPLIER = 10000n - BASIS_POINTS;
+
+// Route[] struct as decoded from Router ABI's swapExactTokensForTokens.
+type DecodedRoute = { from: Address; to: Address; factory: Address };
+
+let snapshotId: string | undefined;
+let capturedSwapCall:
+  | { amountIn: bigint; amountOutMin: bigint; expectedAmountOut: bigint }
+  | undefined;
+
+test.beforeAll(async () => {
+  try {
+    await rpc<string>("eth_chainId");
+  } catch {
+    throw new Error(
+      "anvil fork not reachable at 127.0.0.1:8545 — start it with `pnpm fork:mainnet` and seed with `pnpm fork:seed` before running test:connected (see spec header comment)",
+    );
+  }
+});
+
+test.beforeEach(async () => {
+  snapshotId = await snapshot();
+  capturedSwapCall = undefined;
+});
+test.afterEach(async () => {
+  if (snapshotId === undefined) return;
+  const id = snapshotId;
+  snapshotId = undefined;
+  expect(await revert(id)).toBe(true);
+});
+
+test("applies custom slippage to the on-chain amountOutMin", async ({
+  page,
+}) => {
+  // Route registered here (inside the test body) runs AFTER the connectedTest
+  // fixture's own page.route("**/*", ...) (registered in the `page` fixture
+  // setup, before this test body executes) — Playwright matches the
+  // LAST-registered handler first, so this intercepts eth_sendTransaction
+  // calls before the fixture's passthrough handler sees them. Every request
+  // that isn't a swap-to-Router call is passed straight through via
+  // route.continue(), preserving the fixture's network policy.
+  await page.route(
+    (url) => url.hostname === "localhost" && url.port === "8545",
+    async (route) => {
+      const request = route.request();
+      const postData = request.postData();
+      if (!postData) {
+        await route.continue();
+        return;
+      }
+
+      let body: {
+        method?: string;
+        params?: [{ to?: string; data?: Hex }];
+      };
+      try {
+        body = JSON.parse(postData);
+      } catch {
+        await route.continue();
+        return;
+      }
+
+      const to = body.params?.[0]?.to;
+      const data = body.params?.[0]?.data;
+      if (
+        body.method === "eth_sendTransaction" &&
+        to?.toLowerCase() === ROUTER_ADDRESS.toLowerCase() &&
+        data
+      ) {
+        const decoded = decodeFunctionData({
+          abi: ROUTER_ABI,
+          data,
+        });
+        if (decoded.functionName === "swapExactTokensForTokens") {
+          const [amountIn, amountOutMin, routes] = decoded.args as [
+            bigint,
+            bigint,
+            DecodedRoute[],
+            Address,
+            bigint,
+          ];
+
+          // Query the router for the current expected output using the EXACT
+          // same amountIn/routes the app just built, BEFORE forwarding this
+          // transaction (i.e. before it mines) — this reads the identical
+          // pre-swap pool state the app's own buildSwapParams() saw when it
+          // computed amountOutMin a moment earlier.
+          const getAmountsOutData = encodeFunctionData({
+            abi: ROUTER_ABI,
+            functionName: "getAmountsOut",
+            args: [amountIn, routes],
+          });
+          const rawResult = await rpc<Hex>("eth_call", [
+            { to: ROUTER_ADDRESS, data: getAmountsOutData },
+            "latest",
+          ]);
+          const amounts = decodeFunctionResult({
+            abi: ROUTER_ABI,
+            functionName: "getAmountsOut",
+            data: rawResult,
+          }) as bigint[];
+          const expectedAmountOut = amounts[amounts.length - 1] as bigint;
+
+          capturedSwapCall = { amountIn, amountOutMin, expectedAmountOut };
+        }
+      }
+
+      await route.continue();
+    },
+  );
+
+  await page.goto("/swap/celo?from=EURm&to=USDm", {
+    waitUntil: "domcontentloaded",
+  });
+
+  await expect(
+    page.getByText("0xf39F...2266").filter({ visible: true }),
+  ).toBeVisible({
+    timeout: 20_000,
+  });
+
+  // Set a distinctive custom slippage before entering the confirm view — the
+  // settings popover unmounts once confirmView is true
+  // (swap-page-content.tsx: `{!confirmView && <SwapSettingsPopover />}`).
+  await page.getByTestId("swapSettingsButton").click();
+  const slippageInput = page.getByTestId("slippageInput");
+  await expect(slippageInput).toBeVisible();
+  await slippageInput.fill(CUSTOM_SLIPPAGE_PERCENT);
+  await expect(slippageInput).toHaveValue(CUSTOM_SLIPPAGE_PERCENT);
+  await page.keyboard.press("Escape");
+
+  await page.getByTestId("sellAmountInput").fill("1");
+
+  const submit = page.getByTestId(/^(approveButton|swapButton)$/);
+  await expect(submit).toBeEnabled({ timeout: 30_000 });
+  if ((await submit.getAttribute("data-testid")) === "approveButton") {
+    await submit.click();
+    await expect(page.getByText("Approve Successful")).toBeVisible({
+      timeout: 60_000,
+    });
+  } else {
+    await submit.click();
+  }
+  await expect(page.getByText("Confirm Swap")).toBeVisible({
+    timeout: 30_000,
+  });
+
+  // Sanity-check the confirm view reflects the custom slippage before
+  // submitting.
+  await expect(page.getByTestId("slippageLabel")).toHaveText(
+    `${CUSTOM_SLIPPAGE_PERCENT}%`,
+  );
+
+  const confirmSwapButton = page
+    .getByTestId("swapButton")
+    .filter({ visible: true });
+  await expect(confirmSwapButton).toBeEnabled({
+    timeout: 30_000,
+  });
+  await confirmSwapButton.click();
+  await expect(page.getByText("Swap Successful")).toBeVisible({
+    timeout: 60_000,
+  });
+
+  if (!capturedSwapCall) {
+    throw new Error(
+      "No swapExactTokensForTokens call to the Router was captured — the route intercept did not see the swap transaction.",
+    );
+  }
+  const { amountIn, amountOutMin, expectedAmountOut } = capturedSwapCall;
+  expect(amountIn > 0n).toBe(true);
+
+  const expectedAmountOutMin =
+    (expectedAmountOut * SLIPPAGE_MULTIPLIER) / 10000n;
+
+  // Compare as a ratio rather than exact equality — a small tolerance
+  // absorbs any block-timing skew between the app's own quote fetch and this
+  // spec's getAmountsOut re-check, both of which happen microseconds apart
+  // on an otherwise-idle fork.
+  const diff =
+    expectedAmountOutMin > amountOutMin
+      ? expectedAmountOutMin - amountOutMin
+      : amountOutMin - expectedAmountOutMin;
+  const toleranceBasisPoints = 50n; // 0.5%
+  expect(diff * 10000n <= expectedAmountOutMin * toleranceBasisPoints).toBe(
+    true,
+  );
+});


### PR DESCRIPTION
## What

Adds three new connected-wallet Playwright specs under `apps/app.mento.org/e2e/connected/`, following `swap.spec.ts`'s established pattern (snapshot/revert per test, mock-connector eager-connect, approve-or-swap branching). Addresses the swap-pair matrix, custom-slippage, and tx-rejection items of #479 (part of epic #441). Does not close #479 — other coverage items remain open.

- **`swap-pairs.spec.ts`** — 2 additional seeded pairs beyond the existing EURm→USDm spec: `USDm→USDC` (direct 1-hop stable/stable route) and `EURm→GBPm` (2-hop cross-currency route). Each asserts a strict on-chain balance increase of the buy token.
- **`swap-slippage.spec.ts`** — sets a distinctive 15% slippage via the settings popover (`swapSettingsButton` → `slippageInput`), captures the `Router.swapExactTokensForTokens` calldata sent to the mock connector's RPC via a `page.route` intercept, and asserts the decoded `amountOutMin` matches the SDK's `calculateMinAmountOut` formula (`expectedAmountOut * (10000 - basisPoints) / 10000n`) against an independently-queried `getAmountsOut` call made against the same pre-swap pool state.
- **`swap-rejection.spec.ts`** — simulates a wallet rejection at the route layer (EIP-1193 code 4001 JSON-RPC error) for the swap transaction specifically, and asserts both the exact rejection toast copy ("Swap transaction rejected by user.") and that the confirm button recovers to an enabled, re-submittable state.

## Why

Issue #479 wants broader connected-swap coverage than the single EURm→USDm happy path: a representative pair matrix, slippage correctness verified on-chain (not just UI display), and wallet-rejection recovery.

## Notable deviations from the task's literal assumptions (documented in spec comments)

- The swap transaction is `Router.swapExactTokensForTokens(uint256 amountIn, uint256 amountOutMin, Route[] routes, address to, uint256 deadline)`, **not** `Broker.swapIn(...)`. `amountOutMin` is the calldata's second 32-byte word (right after `amountIn`), not the final word — the `Route[]` array is dynamic and encoded via an offset, but only affects data *after* the two leading `uint256` args.
- `apps/app.mento.org` is `"type": "module"`, and `@mento-protocol/mento-sdk`'s `exports` map points the ESM condition at a build with broken extensionless relative imports (verified directly with plain Node). `swap-slippage.spec.ts` and `swap-rejection.spec.ts` use `createRequire(import.meta.url)` to force CJS resolution for `ROUTER_ABI`/`getContractAddress`, sidestepping this.
- `swap-rejection.spec.ts` pre-approves the Router allowance via a raw RPC call (anvil's dev accounts are self-signing, no `anvil_impersonateAccount` needed) so the intercepted "first" `eth_sendTransaction` is genuinely the swap call, not an incidental approve — otherwise a fresh/reverted fork's zero allowance would make the first transaction the approve, testing the wrong rejection path.

## How verified

- Ran a full local anvil `--celo` fork (`pnpm fork:mainnet` + `pnpm fork:seed`), built `app.mento.org` with `NEXT_PUBLIC_E2E_TEST=true NEXT_PUBLIC_USE_FORK=true`, and ran `pnpm --filter app.mento.org test:connected` — all 5 connected specs (the existing swap spec + these 3 new files, 5 tests total) passed in ~36s wall-clock, well under the ~10 min budget.
- Before committing to the swap-pairs, independently confirmed each candidate pair quotes and routes via the SDK directly against the seeded fork (`sdk.routes.findRoute` + `sdk.quotes.getAmountOut`) — `USDm→USDC` (1 hop), `EURm→GBPm` (2 hops), and two other candidates that also worked but weren't needed.
- `pnpm exec turbo run check-types --filter app.mento.org` — passes.
- `trunk check --fix` on the 3 new files — passes (auto-formatted, no lint issues).
- Docs drift check: grepped `AGENTS.md`, `CLAUDE.md`, `README.md`, `docs/wallet-testing.md` for references to the old slippage-preset testids or a connected-spec inventory — none found, so no doc updates were needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YMrH8V7c3btnC1LZQXcN4b

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only additions under `e2e/connected/`; no production swap, wallet, or routing code is modified.
> 
> **Overview**
> Adds **three connected-wallet Playwright specs** on the seeded Celo anvil fork, following the existing `swap.spec.ts` pattern (anvil preflight, per-test snapshot/revert, eager mock wallet, approve-or-swap flow).
> 
> **`swap-pairs.spec.ts`** runs end-to-end swaps for **USDm→USDC** (1-hop) and **EURm→GBPm** (2-hop) and asserts the buy-token ERC-20 balance increases on-chain.
> 
> **`swap-slippage.spec.ts`** sets **15%** custom slippage in the UI, intercepts `Router.swapExactTokensForTokens` via `page.route`, and checks decoded **`amountOutMin`** against the SDK slippage formula using an independent `getAmountsOut` read (with small tolerance).
> 
> **`swap-rejection.spec.ts`** pre-approves the router off-browser so the first wallet `eth_sendTransaction` is the swap, returns **EIP-1193 4001**, and asserts the **swap rejection** copy plus that the confirm **swap** button is enabled again.
> 
> Slippage/rejection specs load **`@mento-protocol/mento-sdk`** via **`createRequire`** because the package’s ESM build breaks under this app’s native ESM Playwright setup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b6c6c3590f7194f796bd65730de5f906915e138. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->