### PR TITLE
refactor(governance): split vote card content

### DIFF
--- a/apps/governance.mento.org/app/components/voting/vote-card-content.tsx
+++ b/apps/governance.mento.org/app/components/voting/vote-card-content.tsx
@@ -1,0 +1,520 @@
+import { ProgressBar } from "@/components/progress-bar";
+import { TransactionLink } from "@/components/proposal/components/TransactionLink";
+import { Timer } from "@/components/timer";
+import { VoteCardActions } from "@/components/voting/vote-card-actions";
+import { VoteCardState } from "@/components/voting/derive-vote-card-state";
+import { VoteCardSpecialContent } from "@/components/voting/vote-card-special-content";
+import { Proposal, ProposalState } from "@/graphql/subgraph/generated/subgraph";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@mento-protocol/ui";
+import { CheckCircle2, CircleCheck, XCircle, XCircleIcon } from "lucide-react";
+import { ComponentProps, useMemo } from "react";
+import spacetime from "spacetime";
+
+interface ActiveTransactionError {
+  label: string;
+  message: string;
+}
+
+interface VoteCardContentProps {
+  currentState: VoteCardState;
+  proposal: Proposal;
+  proposalState: ProposalState;
+  votingDeadline: Date | undefined;
+  address: string | undefined;
+  isConnected: boolean;
+  isVotingOpen: boolean;
+  hasQuorum: boolean;
+  forVotes: number;
+  againstVotes: number;
+  abstainVotes: number;
+  quorumNeededFormatted: string;
+  formattedVeMentoBalance: string;
+  formattedTotalVotingPower: string;
+  voteData: ComponentProps<typeof ProgressBar>["data"];
+  hasVoted: boolean | undefined;
+  pendingVoteSupport: number | undefined;
+  recordedVoteSupport: number | undefined;
+  queueEndTime: Date | null;
+  isVetoPeriodOver: boolean;
+  isDeadlinePassed: boolean;
+  isAwaitingUserSignature: boolean;
+  isConfirming: boolean;
+  isAwaitingExecuteSignature: boolean;
+  isExecuteConfirming: boolean;
+  isAwaitingQueueSignature: boolean;
+  isQueueConfirming: boolean;
+  currentTxHash: string | undefined;
+  hash: string | undefined;
+  executeHash: string | undefined;
+  queueHash: string | undefined;
+  onExecute: () => void;
+  onQueue: () => void;
+  onVote: (support: number) => void;
+  isWatchdogSafe: boolean;
+  isWatchdog: boolean;
+  hasPendingCancellation: boolean;
+  isPendingCancellationStatusUnavailable: boolean;
+  onWatchdogCancel: () => void;
+  isAwaitingCancelSignature: boolean;
+  isCancelConfirming: boolean;
+  signaturesCollected: number;
+  signaturesRequired: number;
+  chainId: number;
+  watchdogAddress: string;
+  canProposerCancel: boolean;
+  onProposerCancel: () => void;
+  isAwaitingProposerCancelSignature: boolean;
+  isProposerCancelConfirming: boolean;
+  isProposerCancelConfirmed: boolean;
+  activeTransactionError: ActiveTransactionError | null;
+}
+
+const cardClassName = "w-full pt-0 border-none gap-0 pb-0";
+
+export const VoteCardContent = ({
+  currentState,
+  proposal,
+  proposalState,
+  votingDeadline,
+  address,
+  isConnected,
+  isVotingOpen,
+  hasQuorum,
+  forVotes,
+  againstVotes,
+  abstainVotes,
+  quorumNeededFormatted,
+  formattedVeMentoBalance,
+  formattedTotalVotingPower,
+  voteData,
+  hasVoted,
+  pendingVoteSupport,
+  recordedVoteSupport,
+  queueEndTime,
+  isVetoPeriodOver,
+  isDeadlinePassed,
+  isAwaitingUserSignature,
+  isConfirming,
+  isAwaitingExecuteSignature,
+  isExecuteConfirming,
+  isAwaitingQueueSignature,
+  isQueueConfirming,
+  currentTxHash,
+  hash,
+  executeHash,
+  queueHash,
+  onExecute,
+  onQueue,
+  onVote,
+  isWatchdogSafe,
+  isWatchdog,
+  hasPendingCancellation,
+  isPendingCancellationStatusUnavailable,
+  onWatchdogCancel,
+  isAwaitingCancelSignature,
+  isCancelConfirming,
+  signaturesCollected,
+  signaturesRequired,
+  chainId,
+  watchdogAddress,
+  canProposerCancel,
+  onProposerCancel,
+  isAwaitingProposerCancelSignature,
+  isProposerCancelConfirming,
+  isProposerCancelConfirmed,
+  activeTransactionError,
+}: VoteCardContentProps) => {
+  const isApproved =
+    proposalState === ProposalState.Succeeded ||
+    proposalState === ProposalState.Queued ||
+    proposalState === ProposalState.Executed;
+  const isRejected = proposalState === ProposalState.Defeated;
+  const isCanceled = proposalState === ProposalState.Canceled;
+  const isAbstained =
+    proposalState === ProposalState.Defeated &&
+    abstainVotes > forVotes &&
+    abstainVotes > againstVotes;
+
+  const title = useMemo(() => {
+    switch (currentState) {
+      case "loading":
+        return null;
+      case "confirming":
+        return "Vote Submitted";
+      case "signing":
+        return "Confirm Your Vote";
+      case "insufficient-mento":
+        return "Lock MENTO to Vote";
+      case "executed":
+        return "Proposal Executed";
+      case "queued":
+        return "Proposal Queued";
+      case "succeeded":
+        return "Proposal Succeeded";
+      case "defeated":
+        if (isAbstained) return "Majority Abstained";
+        if (!hasQuorum) return "Quorum Not Met";
+        return "Proposal Defeated";
+      case "canceled":
+        return "Proposal Canceled";
+      case "expired":
+        return "Proposal Expired";
+      case "pending":
+        return "Voting Pending";
+      case "finished":
+        return "Voting Finished";
+      default:
+        if (isVotingOpen) return "Voting is Open";
+        return "Voting Finished";
+    }
+  }, [currentState, isVotingOpen, isAbstained, hasQuorum]);
+
+  const cancelButtonText = useMemo(() => {
+    if (isWatchdogSafe) {
+      // Connected AS the Safe (via WalletConnect) - direct execution
+      if (isAwaitingCancelSignature) return "Confirm in Safe UI";
+      if (isCancelConfirming) return "Cancelling...";
+      return "Cancel Proposal";
+    } else {
+      // Connected as individual watchdog signer - propose in Safe UI
+      return "Propose Cancellation in Safe";
+    }
+  }, [isWatchdogSafe, isAwaitingCancelSignature, isCancelConfirming]);
+  const watchdogCancelAction = {
+    isWatchdog,
+    hasPendingCancellation,
+    isPendingCancellationStatusUnavailable,
+    onCancel: onWatchdogCancel,
+    isAwaitingCancelSignature,
+    isCancelConfirming,
+    cancelButtonText,
+    signaturesCollected,
+    signaturesRequired,
+    chainId,
+    watchdogAddress,
+  };
+  const proposerCancelAction = {
+    canProposerCancel,
+    onCancel: onProposerCancel,
+    isAwaitingProposerCancelSignature,
+    isProposerCancelConfirming,
+    isProposerCancelConfirmed,
+  };
+
+  const description = useMemo(() => {
+    switch (currentState) {
+      case "loading":
+        return null;
+      case "confirming":
+        return null;
+      case "signing":
+        return "Please confirm the transaction in your wallet to cast your vote.";
+      case "insufficient-mento":
+        return "You need to lock your MENTO tokens to participate in governance voting.";
+      case "executed":
+        return (
+          <>
+            This proposal has been successfully executed.
+            <br />
+            The changes outlined in the proposal are now in effect.
+          </>
+        );
+      case "queued":
+        return (
+          <>This proposal has been approved and is queued for execution.</>
+        );
+      case "succeeded":
+        return (
+          <>
+            The community has voted in favor of this proposal.
+            <br />
+            It can now be queued for execution by anyone.
+          </>
+        );
+      case "defeated":
+        if (forVotes > againstVotes) {
+          return (
+            <>
+              The proposal did not reach the required quorum of{" "}
+              {quorumNeededFormatted} votes.
+              <br />
+              It will not move forward.
+            </>
+          );
+        }
+        if (abstainVotes > forVotes && abstainVotes > againstVotes) {
+          return (
+            <>
+              While quorum was met, most voters chose to abstain.
+              <br />
+              As a result, the proposal did not receive enough support to pass.
+            </>
+          );
+        }
+        return (
+          <>
+            The proposal did not receive enough YES votes.
+            <br />
+            It will not move forward.
+          </>
+        );
+      case "expired":
+        return (
+          <>
+            This proposal has expired and can no longer be executed.
+            <br />
+            The execution deadline has passed.
+          </>
+        );
+      case "pending":
+        return (
+          <>
+            Voting for this proposal has not yet started.
+            <br />
+            Please check back when the voting period begins.
+          </>
+        );
+      case "finished":
+        return (
+          <>
+            Voting for this proposal has concluded.
+            <br />
+            The final results are displayed above.
+          </>
+        );
+      case "canceled": {
+        const cancelTxHash = proposal.proposalCanceled?.[0]?.transaction?.id;
+        return (
+          <>
+            This proposal has been canceled. It will not move forward.
+            <br />
+            {cancelTxHash && (
+              <>
+                {" "}
+                <TransactionLink
+                  txHash={cancelTxHash}
+                  className="underline underline-offset-4"
+                >
+                  View cancel transaction &rarr;
+                </TransactionLink>
+              </>
+            )}
+          </>
+        );
+      }
+
+      default:
+        if (isVotingOpen) {
+          return <>Your vote matters - participate in the decision.</>;
+        }
+        return <>Your vote matters - participate in the decision.</>;
+    }
+  }, [
+    currentState,
+    isVotingOpen,
+    forVotes,
+    againstVotes,
+    abstainVotes,
+    quorumNeededFormatted,
+    proposal.proposalCanceled,
+  ]);
+
+  // Show header based on state
+  const showHeader = !["loading", "confirming", "signing"].includes(
+    currentState,
+  );
+  const isVotedForApprove = recordedVoteSupport === 1;
+  const isVotedForAbstain = recordedVoteSupport === 2;
+  const isVotedForReject = recordedVoteSupport === 0;
+  const quorumLabel = useMemo(() => {
+    let label = "";
+
+    if (isVotingOpen) label = hasQuorum ? "Quorum met" : "Quorum not yet met";
+    else label = hasQuorum ? "Quorum met" : "Quorum not met";
+
+    return label;
+  }, [isVotingOpen, hasQuorum]);
+
+  return (
+    <Card className={cardClassName}>
+      {showHeader && (
+        <CardHeader className="mb-0 gap-2 p-4 md:flex-row md:items-center xl:px-8 xl:py-6 flex flex-col items-start justify-between bg-incard">
+          <div className="gap-2 text-sm md:flex-row md:items-center md:gap-8 flex flex-col">
+            {isCanceled && proposal.proposalCanceled?.[0] ? (
+              <div className="gap-2 flex items-center">
+                <div className="gap-1 flex items-center">
+                  <XCircleIcon size={16} />
+                  <span>Cancelled:</span>
+                </div>
+                {proposal.proposalCanceled[0].transaction?.id &&
+                proposal.proposalCanceled[0].timestamp ? (
+                  <TransactionLink
+                    txHash={proposal.proposalCanceled[0].transaction.id}
+                    className="text-muted-foreground underline-offset-4 hover:underline"
+                  >
+                    {spacetime(
+                      new Date(
+                        Number(proposal.proposalCanceled[0].timestamp) * 1000,
+                      ),
+                    ).format("{date-ordinal} {month}, {year}")}
+                  </TransactionLink>
+                ) : proposal.proposalCanceled[0].timestamp ? (
+                  <span className="text-muted-foreground">
+                    {spacetime(
+                      new Date(
+                        Number(proposal.proposalCanceled[0].timestamp) * 1000,
+                      ),
+                    ).format("{date-ordinal} {month}, {year}")}
+                  </span>
+                ) : null}
+              </div>
+            ) : !isCanceled &&
+              !isProposerCancelConfirmed &&
+              currentState === "queued" &&
+              queueEndTime ? (
+              <Timer
+                until={queueEndTime}
+                label="Executable in:"
+                expiredLabel="Executable since"
+              />
+            ) : !isCanceled && !isProposerCancelConfirmed && votingDeadline ? (
+              <Timer until={votingDeadline} />
+            ) : null}
+
+            <div className="gap-2 flex items-center">
+              {!hasQuorum ? (
+                <XCircleIcon size={16} className="text-white" />
+              ) : (
+                <CheckCircle2 size={16} className="text-white" />
+              )}
+              <span>{quorumLabel}</span>
+              <span
+                className="text-sm text-muted-foreground"
+                data-testid="quorumReachedLabel"
+              >
+                Min. {quorumNeededFormatted} veMENTO
+              </span>
+            </div>
+          </div>
+
+          {!hasVoted && currentState === "ready" && isConnected && (
+            <div className="gap-2 text-sm flex items-center">
+              <span>Your Voting Power:</span>
+              <span className="text-muted-foreground">
+                {formattedVeMentoBalance} veMENTO
+              </span>
+            </div>
+          )}
+
+          {hasVoted && currentState !== "ready" && isConnected && (
+            <div className="gap-2 text-sm flex items-center">
+              <span>Total Votes:</span>
+              <span
+                className="text-muted-foreground"
+                data-testid="totalVotesLabel"
+              >
+                {formattedTotalVotingPower} veMENTO
+              </span>
+            </div>
+          )}
+        </CardHeader>
+      )}
+
+      <CardContent
+        className={
+          ["loading", "signing", "confirming"].includes(currentState)
+            ? "py-16 flex items-center justify-center"
+            : "space-y-8 p-4 xl:p-8"
+        }
+      >
+        <VoteCardSpecialContent
+          currentState={currentState}
+          isAwaitingExecuteSignature={isAwaitingExecuteSignature}
+          isAwaitingQueueSignature={isAwaitingQueueSignature}
+          isExecuteConfirming={isExecuteConfirming}
+          isQueueConfirming={isQueueConfirming}
+          voteSupport={pendingVoteSupport}
+          currentTxHash={currentTxHash}
+          hash={hash}
+          executeHash={executeHash}
+          queueHash={queueHash}
+        />
+
+        {!["loading", "confirming", "signing"].includes(currentState) && (
+          <>
+            <div className="space-y-4">
+              <CardTitle
+                className="gap-2 font-medium text-white flex items-center text-3xl"
+                data-testid="voteStatus"
+              >
+                {isApproved && <CircleCheck size={32} />}
+                {isRejected && <XCircle size={32} />}
+                {isCanceled && <XCircle size={32} />}
+                {title}
+              </CardTitle>
+
+              {description && (
+                <CardDescription className="space-y-1 text-lg text-muted-foreground">
+                  {description}
+                </CardDescription>
+              )}
+            </div>
+
+            <div className="py-0">
+              <ProgressBar mode="vote" data={voteData} />
+            </div>
+
+            <div
+              className={
+                currentState === "insufficient-mento"
+                  ? "mt-8 gap-4 flex flex-col"
+                  : "mt-8"
+              }
+            >
+              <VoteCardActions
+                currentState={currentState}
+                address={address}
+                proposal={proposal}
+                proposalState={proposalState}
+                hasVoted={hasVoted}
+                isVotedForApprove={isVotedForApprove}
+                isVotedForAbstain={isVotedForAbstain}
+                isVotedForReject={isVotedForReject}
+                queueEndTime={queueEndTime}
+                isVetoPeriodOver={isVetoPeriodOver}
+                isDeadlinePassed={isDeadlinePassed}
+                isAwaitingUserSignature={isAwaitingUserSignature}
+                isConfirming={isConfirming}
+                isAwaitingExecuteSignature={isAwaitingExecuteSignature}
+                isExecuteConfirming={isExecuteConfirming}
+                isAwaitingQueueSignature={isAwaitingQueueSignature}
+                isQueueConfirming={isQueueConfirming}
+                onExecute={onExecute}
+                onQueue={onQueue}
+                onVote={onVote}
+                watchdogCancelAction={watchdogCancelAction}
+                proposerCancelAction={proposerCancelAction}
+              />
+            </div>
+
+            {activeTransactionError &&
+              (currentState === "ready" ||
+                currentState === "succeeded" ||
+                currentState === "queued") && (
+                <div className="gap-1 text-sm text-red-500 flex w-full flex-col items-center justify-center">
+                  <span>{activeTransactionError.label}</span>
+                  <span>{activeTransactionError.message}</span>
+                </div>
+              )}
+          </>
+        )}
+      </CardContent>
+    </Card>
+  );
+};

--- a/apps/governance.mento.org/app/components/voting/vote-card.test.tsx
+++ b/apps/governance.mento.org/app/components/voting/vote-card.test.tsx
@@ -1,0 +1,189 @@
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Proposal, ProposalState } from "@/graphql/subgraph/generated/subgraph";
+
+const mocks = vi.hoisted(() => ({
+  captureException: vi.fn(),
+  castVote: vi.fn(),
+  castVoteError: undefined as unknown,
+  castVoteVariables: { args: [1n, 2] },
+  executeProposal: vi.fn(),
+  queueProposal: vi.fn(),
+  cancelProposal: vi.fn(),
+  cancelProposalAsProposer: vi.fn(),
+  refetchVoteReceipt: vi.fn(),
+  voteCardContent: vi.fn<(props: Record<string, unknown>) => null>(() => null),
+  voteReceiptData: { hasVoted: true, support: 1 },
+}));
+
+vi.mock("@/components/voting/vote-card-content", () => ({
+  VoteCardContent: mocks.voteCardContent,
+}));
+
+vi.mock("@/components/voting/use-delayed-vote-card-refire", () => ({
+  useDelayedVoteCardRefire: vi.fn(),
+}));
+
+vi.mock("@/config", () => ({
+  getWatchdogMultisigAddress: () =>
+    "0x1111111111111111111111111111111111111111",
+}));
+
+vi.mock("@/contracts", () => ({
+  useLocksByAccount: () => ({ locks: [] }),
+}));
+
+vi.mock("@/contracts/governor", () => ({
+  useCancelProposalAsProposer: () => ({
+    cancelProposalAsProposer: mocks.cancelProposalAsProposer,
+    isAwaitingUserSignature: false,
+    isConfirming: false,
+    isConfirmed: false,
+  }),
+  useCancelProposalAsWatchdog: () => ({
+    hash: undefined,
+    cancelProposal: mocks.cancelProposal,
+    isAwaitingUserSignature: false,
+    isConfirming: false,
+    error: undefined,
+  }),
+  useCastVote: () => ({
+    hash: undefined,
+    castVote: mocks.castVote,
+    variables: mocks.castVoteVariables,
+    isAwaitingUserSignature: false,
+    isConfirming: false,
+    isConfirmed: false,
+    error: mocks.castVoteError,
+  }),
+  useExecuteProposal: () => ({
+    hash: undefined,
+    executeProposal: mocks.executeProposal,
+    isAwaitingUserSignature: false,
+    isConfirming: false,
+    error: undefined,
+  }),
+  useIsWatchdog: () => ({
+    isWatchdog: false,
+    isWatchdogSafe: false,
+  }),
+  usePendingMultisigCancellation: () => ({
+    hasPendingCancellation: false,
+    isStatusUnavailable: false,
+    signaturesCollected: 0,
+    signaturesRequired: 0,
+  }),
+  useQueueProposal: () => ({
+    hash: undefined,
+    queueProposal: mocks.queueProposal,
+    isAwaitingUserSignature: false,
+    isConfirming: false,
+    isConfirmed: false,
+    error: undefined,
+  }),
+  useQuorum: () => ({ quorumNeeded: 0n }),
+  useVoteReceipt: () => ({
+    data: mocks.voteReceiptData,
+    isLoading: false,
+    refetch: mocks.refetchVoteReceipt,
+  }),
+}));
+
+vi.mock("@/contracts/governor/utils/get-timelock-operation-id", () => ({
+  getTimelockOperationId: () =>
+    "0x2222222222222222222222222222222222222222222222222222222222222222",
+}));
+
+vi.mock("@/hooks/use-ve-mento-delegation-summary", () => ({
+  useVeMentoDelegationSummary: () => ({ ownVe: 0, receivedVe: 0 }),
+}));
+
+vi.mock("@repo/web3", () => ({
+  NumbersService: {
+    parseNumericValue: (value: string) => value,
+  },
+}));
+
+vi.mock("@repo/web3/wagmi", () => ({
+  useAccount: () => ({
+    address: undefined,
+    isConnecting: false,
+    isConnected: false,
+  }),
+  useChainId: () => 42220,
+}));
+
+vi.mock("@sentry/nextjs", () => ({
+  captureException: mocks.captureException,
+}));
+
+const { VoteCard } = await import("./vote-card");
+
+const proposal = {
+  calls: [],
+  description: "",
+  proposalCanceled: [],
+  proposalExecuted: [],
+  proposalId: 1n,
+  proposalQueued: [],
+  proposer: { id: "0x3333333333333333333333333333333333333333" },
+  startBlock: 1n,
+  state: ProposalState.Executed,
+  votes: undefined,
+} as unknown as Proposal;
+
+beforeEach(() => {
+  mocks.castVoteError = undefined;
+  mocks.castVoteVariables = { args: [1n, 2] };
+  mocks.voteReceiptData = { hasVoted: true, support: 1 };
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("VoteCard", () => {
+  it("passes pending and recorded vote support to the extracted content separately", () => {
+    render(<VoteCard proposal={proposal} votingDeadline={undefined} />);
+
+    const contentProps = mocks.voteCardContent.mock.calls.at(-1)?.[0] as
+      | {
+          pendingVoteSupport: number | undefined;
+          recordedVoteSupport: number | undefined;
+        }
+      | undefined;
+
+    expect(contentProps).toMatchObject({
+      pendingVoteSupport: 2,
+      recordedVoteSupport: 1,
+    });
+  });
+
+  it("captures a cast-vote hook error only once per error object", () => {
+    const voteError = new Error("execution reverted");
+    mocks.castVoteError = voteError;
+
+    const { rerender } = render(
+      <VoteCard proposal={proposal} votingDeadline={undefined} />,
+    );
+
+    expect(mocks.captureException).toHaveBeenCalledOnce();
+    expect(mocks.captureException).toHaveBeenCalledWith(voteError);
+
+    mocks.castVoteError = undefined;
+    rerender(<VoteCard proposal={proposal} votingDeadline={undefined} />);
+    mocks.castVoteError = voteError;
+    rerender(<VoteCard proposal={proposal} votingDeadline={undefined} />);
+
+    expect(mocks.captureException).toHaveBeenCalledOnce();
+  });
+
+  it("does not capture a rejected cast-vote request", () => {
+    mocks.castVoteError = new Error("User rejected request");
+
+    render(<VoteCard proposal={proposal} votingDeadline={undefined} />);
+
+    expect(mocks.captureException).not.toHaveBeenCalled();
+  });
+});

--- a/apps/governance.mento.org/app/components/voting/vote-card.tsx
+++ b/apps/governance.mento.org/app/components/voting/vote-card.tsx
@@ -1,5 +1,6 @@
 import { deriveVoteCardState } from "@/components/voting/derive-vote-card-state";
 import { getActiveGovernanceTransactionError } from "@/components/voting/get-active-governance-transaction-error";
+import { getGovernanceTransactionErrorMessage } from "@/components/voting/get-governance-transaction-error-message";
 import { VoteCardContent } from "@/components/voting/vote-card-content";
 import { useDelayedVoteCardRefire } from "@/components/voting/use-delayed-vote-card-refire";
 import { getWatchdogMultisigAddress } from "@/config";
@@ -21,7 +22,7 @@ import { useVeMentoDelegationSummary } from "@/hooks/use-ve-mento-delegation-sum
 import { NumbersService } from "@repo/web3";
 import { useAccount, useChainId } from "@repo/web3/wagmi";
 import * as Sentry from "@sentry/nextjs";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { formatUnits, keccak256, toHex } from "viem";
 
 interface VoteCardProps {
@@ -408,6 +409,22 @@ export const VoteCard = ({
     { kind: "cancel", error: cancelError },
     { kind: "vote", error },
   ]);
+  const capturedVoteErrorsRef = useRef<Set<unknown>>(new Set());
+
+  // Execute, queue, and cancel errors are captured by their callbacks or hooks.
+  // Cast-vote does not receive an onError callback, so capture its hook state here.
+  useEffect(() => {
+    if (
+      !error ||
+      getGovernanceTransactionErrorMessage(error) === null ||
+      capturedVoteErrorsRef.current.has(error)
+    ) {
+      return;
+    }
+
+    Sentry.captureException(error);
+    capturedVoteErrorsRef.current.add(error);
+  }, [error]);
 
   const currentState = useMemo(() => {
     return deriveVoteCardState({

--- a/apps/governance.mento.org/app/components/voting/vote-card.tsx
+++ b/apps/governance.mento.org/app/components/voting/vote-card.tsx
@@ -1,10 +1,6 @@
-import { ProgressBar } from "@/components/progress-bar";
-import { TransactionLink } from "@/components/proposal/components/TransactionLink";
-import { Timer } from "@/components/timer";
 import { deriveVoteCardState } from "@/components/voting/derive-vote-card-state";
 import { getActiveGovernanceTransactionError } from "@/components/voting/get-active-governance-transaction-error";
-import { VoteCardActions } from "@/components/voting/vote-card-actions";
-import { VoteCardSpecialContent } from "@/components/voting/vote-card-special-content";
+import { VoteCardContent } from "@/components/voting/vote-card-content";
 import { useDelayedVoteCardRefire } from "@/components/voting/use-delayed-vote-card-refire";
 import { getWatchdogMultisigAddress } from "@/config";
 import { useLocksByAccount } from "@/contracts";
@@ -22,19 +18,10 @@ import {
 import { getTimelockOperationId } from "@/contracts/governor/utils/get-timelock-operation-id";
 import { Proposal, ProposalState } from "@/graphql/subgraph/generated/subgraph";
 import { useVeMentoDelegationSummary } from "@/hooks/use-ve-mento-delegation-summary";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@mento-protocol/ui";
 import { NumbersService } from "@repo/web3";
 import { useAccount, useChainId } from "@repo/web3/wagmi";
 import * as Sentry from "@sentry/nextjs";
-import { CheckCircle2, CircleCheck, XCircle, XCircleIcon } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
-import spacetime from "spacetime";
 import { formatUnits, keccak256, toHex } from "viem";
 
 interface VoteCardProps {
@@ -42,8 +29,6 @@ interface VoteCardProps {
   votingDeadline: Date | undefined;
   onVoteConfirmed?: () => void;
 }
-
-const cardClassName = "w-full pt-0 border-none gap-0 pb-0";
 
 export const VoteCard = ({
   proposal,
@@ -416,16 +401,6 @@ export const VoteCard = ({
 
   const isVotingOpen =
     proposalState === ProposalState.Active && !isDeadlinePassed;
-  const isApproved =
-    proposalState === ProposalState.Succeeded ||
-    proposalState === ProposalState.Queued ||
-    proposalState === ProposalState.Executed;
-  const isRejected = proposalState === ProposalState.Defeated;
-  const isCanceled = proposalState === ProposalState.Canceled;
-  const isAbstained =
-    proposalState === ProposalState.Defeated &&
-    abstainVotes > forVotes &&
-    abstainVotes > againstVotes;
   const hasQuorum = totalVotingPower >= (quorumNeeded || BigInt(0));
   const activeTransactionError = getActiveGovernanceTransactionError([
     { kind: "execute", error: executeError },
@@ -472,381 +447,61 @@ export const VoteCard = ({
     isDeadlinePassed,
   ]);
 
-  const title = useMemo(() => {
-    switch (currentState) {
-      case "loading":
-        return null;
-      case "confirming":
-        return "Vote Submitted";
-      case "signing":
-        return "Confirm Your Vote";
-      case "insufficient-mento":
-        return "Lock MENTO to Vote";
-      case "executed":
-        return "Proposal Executed";
-      case "queued":
-        return "Proposal Queued";
-      case "succeeded":
-        return "Proposal Succeeded";
-      case "defeated":
-        if (isAbstained) return "Majority Abstained";
-        if (!hasQuorum) return "Quorum Not Met";
-        return "Proposal Defeated";
-      case "canceled":
-        return "Proposal Canceled";
-      case "expired":
-        return "Proposal Expired";
-      case "pending":
-        return "Voting Pending";
-      case "finished":
-        return "Voting Finished";
-      default:
-        if (isVotingOpen) return "Voting is Open";
-        return "Voting Finished";
-    }
-  }, [currentState, isVotingOpen, isAbstained, hasQuorum]);
-
-  const cancelButtonText = useMemo(() => {
-    if (isWatchdogSafe) {
-      // Connected AS the Safe (via WalletConnect) - direct execution
-      if (isAwaitingCancelSignature) return "Confirm in Safe UI";
-      if (isCancelConfirming) return "Cancelling...";
-      return "Cancel Proposal";
-    } else {
-      // Connected as individual watchdog signer - propose in Safe UI
-      return "Propose Cancellation in Safe";
-    }
-  }, [isWatchdogSafe, isAwaitingCancelSignature, isCancelConfirming]);
-  const watchdogCancelAction = {
-    isWatchdog,
-    hasPendingCancellation,
-    isPendingCancellationStatusUnavailable,
-    onCancel: handleCancelByWatchdog,
-    isAwaitingCancelSignature,
-    isCancelConfirming,
-    cancelButtonText,
-    signaturesCollected,
-    signaturesRequired,
-    chainId,
-    watchdogAddress,
-  };
-  const proposerCancelAction = {
-    canProposerCancel,
-    onCancel: handleCancelByProposer,
-    isAwaitingProposerCancelSignature,
-    isProposerCancelConfirming,
-    isProposerCancelConfirmed,
-  };
-
-  const description = useMemo(() => {
-    switch (currentState) {
-      case "loading":
-        return null;
-      case "confirming":
-        return null;
-      case "signing":
-        return "Please confirm the transaction in your wallet to cast your vote.";
-      case "insufficient-mento":
-        return "You need to lock your MENTO tokens to participate in governance voting.";
-      case "executed":
-        return (
-          <>
-            This proposal has been successfully executed.
-            <br />
-            The changes outlined in the proposal are now in effect.
-          </>
-        );
-      case "queued":
-        return (
-          <>This proposal has been approved and is queued for execution.</>
-        );
-      case "succeeded":
-        return (
-          <>
-            The community has voted in favor of this proposal.
-            <br />
-            It can now be queued for execution by anyone.
-          </>
-        );
-      case "defeated":
-        if (forVotes > againstVotes) {
-          return (
-            <>
-              The proposal did not reach the required quorum of{" "}
-              {quorumNeededFormatted} votes.
-              <br />
-              It will not move forward.
-            </>
-          );
-        }
-        if (abstainVotes > forVotes && abstainVotes > againstVotes) {
-          return (
-            <>
-              While quorum was met, most voters chose to abstain.
-              <br />
-              As a result, the proposal did not receive enough support to pass.
-            </>
-          );
-        }
-        return (
-          <>
-            The proposal did not receive enough YES votes.
-            <br />
-            It will not move forward.
-          </>
-        );
-      case "expired":
-        return (
-          <>
-            This proposal has expired and can no longer be executed.
-            <br />
-            The execution deadline has passed.
-          </>
-        );
-      case "pending":
-        return (
-          <>
-            Voting for this proposal has not yet started.
-            <br />
-            Please check back when the voting period begins.
-          </>
-        );
-      case "finished":
-        return (
-          <>
-            Voting for this proposal has concluded.
-            <br />
-            The final results are displayed above.
-          </>
-        );
-      case "canceled": {
-        const cancelTxHash = proposal.proposalCanceled?.[0]?.transaction?.id;
-        return (
-          <>
-            This proposal has been canceled. It will not move forward.
-            <br />
-            {cancelTxHash && (
-              <>
-                {" "}
-                <TransactionLink
-                  txHash={cancelTxHash}
-                  className="underline underline-offset-4"
-                >
-                  View cancel transaction &rarr;
-                </TransactionLink>
-              </>
-            )}
-          </>
-        );
-      }
-
-      default:
-        if (isVotingOpen) {
-          return <>Your vote matters - participate in the decision.</>;
-        }
-        return <>Your vote matters - participate in the decision.</>;
-    }
-  }, [
-    currentState,
-    isVotingOpen,
-    forVotes,
-    againstVotes,
-    abstainVotes,
-    quorumNeededFormatted,
-    proposal.proposalCanceled,
-  ]);
-
-  // Show header based on state
-  const showHeader = !["loading", "confirming", "signing"].includes(
-    currentState,
-  );
-  const isVotedForApprove = voteReceipt?.support === 1;
-  const isVotedForAbstain = voteReceipt?.support === 2;
-  const isVotedForReject = voteReceipt?.support === 0;
-  const hasVoted = voteReceipt?.hasVoted;
-  const quorumLabel = useMemo(() => {
-    let label = "";
-
-    if (isVotingOpen) label = hasQuorum ? "Quorum met" : "Quorum not yet met";
-    else label = hasQuorum ? "Quorum met" : "Quorum not met";
-
-    return label;
-  }, [isVotingOpen, hasQuorum]);
-
   return (
-    <Card className={cardClassName}>
-      {showHeader && (
-        <CardHeader className="mb-0 gap-2 p-4 md:flex-row md:items-center xl:px-8 xl:py-6 flex flex-col items-start justify-between bg-incard">
-          <div className="gap-2 text-sm md:flex-row md:items-center md:gap-8 flex flex-col">
-            {isCanceled && proposal.proposalCanceled?.[0] ? (
-              <div className="gap-2 flex items-center">
-                <div className="gap-1 flex items-center">
-                  <XCircleIcon size={16} />
-                  <span>Cancelled:</span>
-                </div>
-                {proposal.proposalCanceled[0].transaction?.id &&
-                proposal.proposalCanceled[0].timestamp ? (
-                  <TransactionLink
-                    txHash={proposal.proposalCanceled[0].transaction.id}
-                    className="text-muted-foreground underline-offset-4 hover:underline"
-                  >
-                    {spacetime(
-                      new Date(
-                        Number(proposal.proposalCanceled[0].timestamp) * 1000,
-                      ),
-                    ).format("{date-ordinal} {month}, {year}")}
-                  </TransactionLink>
-                ) : proposal.proposalCanceled[0].timestamp ? (
-                  <span className="text-muted-foreground">
-                    {spacetime(
-                      new Date(
-                        Number(proposal.proposalCanceled[0].timestamp) * 1000,
-                      ),
-                    ).format("{date-ordinal} {month}, {year}")}
-                  </span>
-                ) : null}
-              </div>
-            ) : !isCanceled &&
-              !isProposerCancelConfirmed &&
-              currentState === "queued" &&
-              queueEndTime ? (
-              <Timer
-                until={queueEndTime}
-                label="Executable in:"
-                expiredLabel="Executable since"
-              />
-            ) : !isCanceled && !isProposerCancelConfirmed && votingDeadline ? (
-              <Timer until={votingDeadline} />
-            ) : null}
-
-            <div className="gap-2 flex items-center">
-              {!hasQuorum ? (
-                <XCircleIcon size={16} className="text-white" />
-              ) : (
-                <CheckCircle2 size={16} className="text-white" />
-              )}
-              <span>{quorumLabel}</span>
-              <span
-                className="text-sm text-muted-foreground"
-                data-testid="quorumReachedLabel"
-              >
-                Min. {quorumNeededFormatted} veMENTO
-              </span>
-            </div>
-          </div>
-
-          {!hasVoted && currentState === "ready" && isConnected && (
-            <div className="gap-2 text-sm flex items-center">
-              <span>Your Voting Power:</span>
-              <span className="text-muted-foreground">
-                {formattedVeMentoBalance} veMENTO
-              </span>
-            </div>
-          )}
-
-          {hasVoted && currentState !== "ready" && isConnected && (
-            <div className="gap-2 text-sm flex items-center">
-              <span>Total Votes:</span>
-              <span
-                className="text-muted-foreground"
-                data-testid="totalVotesLabel"
-              >
-                {formattedTotalVotingPower} veMENTO
-              </span>
-            </div>
-          )}
-        </CardHeader>
-      )}
-
-      <CardContent
-        className={
-          ["loading", "signing", "confirming"].includes(currentState)
-            ? "py-16 flex items-center justify-center"
-            : "space-y-8 p-4 xl:p-8"
-        }
-      >
-        <VoteCardSpecialContent
-          currentState={currentState}
-          isAwaitingExecuteSignature={isAwaitingExecuteSignature}
-          isAwaitingQueueSignature={isAwaitingQueueSignature}
-          isExecuteConfirming={isExecuteConfirming}
-          isQueueConfirming={isQueueConfirming}
-          voteSupport={variables?.args?.[1] as number | undefined}
-          currentTxHash={currentTxHash}
-          hash={hash}
-          executeHash={executeHash}
-          queueHash={queueHash}
-        />
-
-        {!["loading", "confirming", "signing"].includes(currentState) && (
-          <>
-            <div className="space-y-4">
-              <CardTitle
-                className="gap-2 font-medium text-white flex items-center text-3xl"
-                data-testid="voteStatus"
-              >
-                {isApproved && <CircleCheck size={32} />}
-                {isRejected && <XCircle size={32} />}
-                {isCanceled && <XCircle size={32} />}
-                {title}
-              </CardTitle>
-
-              {description && (
-                <CardDescription className="space-y-1 text-lg text-muted-foreground">
-                  {description}
-                </CardDescription>
-              )}
-            </div>
-
-            <div className="py-0">
-              <ProgressBar mode="vote" data={voteData} />
-            </div>
-
-            <div
-              className={
-                currentState === "insufficient-mento"
-                  ? "mt-8 gap-4 flex flex-col"
-                  : "mt-8"
-              }
-            >
-              <VoteCardActions
-                currentState={currentState}
-                address={address}
-                proposal={proposal}
-                proposalState={proposalState}
-                hasVoted={hasVoted}
-                isVotedForApprove={isVotedForApprove}
-                isVotedForAbstain={isVotedForAbstain}
-                isVotedForReject={isVotedForReject}
-                queueEndTime={queueEndTime}
-                isVetoPeriodOver={isVetoPeriodOver}
-                isDeadlinePassed={isDeadlinePassed}
-                isAwaitingUserSignature={isAwaitingUserSignature}
-                isConfirming={isConfirming}
-                isAwaitingExecuteSignature={isAwaitingExecuteSignature}
-                isExecuteConfirming={isExecuteConfirming}
-                isAwaitingQueueSignature={isAwaitingQueueSignature}
-                isQueueConfirming={isQueueConfirming}
-                onExecute={handleExecute}
-                onQueue={handleQueue}
-                onVote={handleVote}
-                watchdogCancelAction={watchdogCancelAction}
-                proposerCancelAction={proposerCancelAction}
-              />
-            </div>
-
-            {activeTransactionError &&
-              (currentState === "ready" ||
-                currentState === "succeeded" ||
-                currentState === "queued") && (
-                <div className="gap-1 text-sm text-red-500 flex w-full flex-col items-center justify-center">
-                  <span>{activeTransactionError.label}</span>
-                  <span>{activeTransactionError.message}</span>
-                </div>
-              )}
-          </>
-        )}
-      </CardContent>
-    </Card>
+    <VoteCardContent
+      currentState={currentState}
+      proposal={proposal}
+      proposalState={proposalState}
+      votingDeadline={votingDeadline}
+      address={address}
+      isConnected={isConnected}
+      isVotingOpen={isVotingOpen}
+      hasQuorum={hasQuorum}
+      forVotes={forVotes}
+      againstVotes={againstVotes}
+      abstainVotes={abstainVotes}
+      quorumNeededFormatted={quorumNeededFormatted}
+      formattedVeMentoBalance={formattedVeMentoBalance}
+      formattedTotalVotingPower={formattedTotalVotingPower}
+      voteData={voteData}
+      hasVoted={voteReceipt?.hasVoted}
+      pendingVoteSupport={variables?.args?.[1] as number | undefined}
+      recordedVoteSupport={voteReceipt?.support}
+      queueEndTime={queueEndTime}
+      isVetoPeriodOver={isVetoPeriodOver}
+      isDeadlinePassed={isDeadlinePassed}
+      isAwaitingUserSignature={isAwaitingUserSignature}
+      isConfirming={isConfirming}
+      isAwaitingExecuteSignature={isAwaitingExecuteSignature}
+      isExecuteConfirming={isExecuteConfirming}
+      isAwaitingQueueSignature={isAwaitingQueueSignature}
+      isQueueConfirming={isQueueConfirming}
+      currentTxHash={currentTxHash}
+      hash={hash}
+      executeHash={executeHash}
+      queueHash={queueHash}
+      onExecute={handleExecute}
+      onQueue={handleQueue}
+      onVote={handleVote}
+      isWatchdogSafe={isWatchdogSafe}
+      isWatchdog={isWatchdog}
+      hasPendingCancellation={hasPendingCancellation}
+      isPendingCancellationStatusUnavailable={
+        isPendingCancellationStatusUnavailable
+      }
+      onWatchdogCancel={handleCancelByWatchdog}
+      isAwaitingCancelSignature={isAwaitingCancelSignature}
+      isCancelConfirming={isCancelConfirming}
+      signaturesCollected={signaturesCollected}
+      signaturesRequired={signaturesRequired}
+      chainId={chainId}
+      watchdogAddress={watchdogAddress}
+      canProposerCancel={canProposerCancel}
+      onProposerCancel={handleCancelByProposer}
+      isAwaitingProposerCancelSignature={isAwaitingProposerCancelSignature}
+      isProposerCancelConfirming={isProposerCancelConfirming}
+      isProposerCancelConfirmed={isProposerCancelConfirmed}
+      activeTransactionError={activeTransactionError}
+    />
   );
 };


### PR DESCRIPTION
## The Problem

Issue #413's first four phases and the initial phase-5 extractions are already on `main`, but `vote-card.tsx` was still 852 lines. That left the issue's `<= 600`-line acceptance criterion unmet and kept the remaining render tree mixed with transaction orchestration.

The current cast-vote hook also exposed asynchronous errors only through hook state. Unlike execute, queue, and cancellation flows, it has no error callback or internal Sentry capture, so those failures were visible in the card but absent from telemetry.

Part of #413.

## The Solution

- Extract the remaining presentational render tree into `vote-card-content.tsx`, leaving `VoteCard` responsible for hooks, derived values, timers, transaction callbacks, and state orchestration.
- Keep pending cast support and the recorded receipt support as separate props so signing/confirming UI and completed-vote UI preserve their original data sources.
- Capture non-rejection cast-vote hook errors once per error identity. Execute, queue, and cancellation hook-state errors remain intentionally excluded because their callbacks or hooks already capture them; this avoids the duplicate events identified in the [PR #473 review thread](https://github.com/mento-protocol/frontend-monorepo/pull/473#discussion_r3570700004).
- Add focused component tests for pending-versus-recorded support wiring, hook-error deduplication, and rejected-request filtering.

Final source sizes:

- `vote-card.tsx`: 524 lines
- `vote-card-content.tsx`: 520 lines

Validation:

- `pnpm exec turbo run test --filter governance.mento.org` — 13 files, 94 tests passed
- `pnpm check-types` — 8/8 tasks passed across the workspace
- `trunk check --fix apps/governance.mento.org/app/components/voting/vote-card.tsx apps/governance.mento.org/app/components/voting/vote-card-content.tsx apps/governance.mento.org/app/components/voting/vote-card.test.tsx` — clean
- `pnpm exec turbo run build --filter governance.mento.org` — passed with local example environment values
- Fresh-context semantic review and deterministic branch review — clean

Browser verification with the linked `governance.mento.org` Vercel development environment:

- Live mainnet data reached `defeated` (proposal `7158410…4118277`), `executed` (`4773762…6118898`), and `queued` (`1123396…3839121`). Their status copy, vote totals, execution content, CTAs, and the queued wallet-connect interaction matched `main`.
- The other 11 state-machine members were not reachable from current live proposal/account data in this run and are verified by the exhaustive pure-function suite: `loading`, `confirming`, `signing`, `succeeded`, `voted`, `finished`, `canceled`, `expired`, `pending`, `insufficient-mento`, and `ready`.
- Console: no application errors. The defeated/executed navigations logged only the pre-existing blocked WalletConnect telemetry request (`pulse.walletconnect.org`, `net::ERR_CONNECTION_CLOSED`); the queued route and interaction were clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly a structural refactor with behavior-preserving UI; added telemetry only filters rejections and dedupes cast-vote errors.
> 
> **Overview**
> Moves the governance **vote card** UI into a new `VoteCardContent` component so `VoteCard` only wires hooks, derived state, and transaction handlers—bringing `vote-card.tsx` under the issue’s size target without changing visible behavior.
> 
> **Vote support** is passed as two props: `pendingVoteSupport` (in-flight cast from hook variables) for signing/confirming UI, and `recordedVoteSupport` (receipt) for completed-vote labels and actions.
> 
> Adds **Sentry** reporting for `useCastVote` hook errors that lack an `onError` path: skips user-rejection messages via `getGovernanceTransactionErrorMessage`, and deduplicates by error object identity. Execute/queue/cancel hook errors are not double-reported.
> 
> New **`vote-card.test.tsx`** covers the pending vs recorded props and cast-vote error capture behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e0e849502ec7d439a7f4e3a7b18d2d8e3b43a9b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->