### PR TITLE
refactor(app): extract swap form validation hook (3/6)

### DIFF
--- a/apps/app.mento.org/app/components/swap/swap-form/swap-form-validation.test.ts
+++ b/apps/app.mento.org/app/components/swap/swap-form/swap-form-validation.test.ts
@@ -1,5 +1,7 @@
 import type { TokenSymbol } from "@mento-protocol/mento-sdk";
-import { describe, expect, it, vi } from "vitest";
+import { renderHook } from "@testing-library/react";
+import type { ChainId } from "@repo/web3";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const web3Mocks = vi.hoisted(() => {
   const decimal = (value: number) => ({
@@ -19,10 +21,17 @@ const web3Mocks = vi.hoisted(() => {
     parseAmount: vi.fn((value: string) => decimal(Number(value))),
     parseAmountWithDefault: vi.fn((value: string) => decimal(Number(value))),
     toWei: vi.fn((value: { value: number }) => decimal(value.value * 10)),
+    useTradingLimits: vi.fn(),
+    useTradingSuspensionCheck: vi.fn(),
   };
 });
 
+const tradingLimitMocks = vi.hoisted(() => ({
+  checkTradingLimitViolation: vi.fn(),
+}));
+
 vi.mock("@repo/web3", () => web3Mocks);
+vi.mock("./trading-limits", () => tradingLimitMocks);
 
 import {
   getFormattedTokenInBalance,
@@ -31,8 +40,24 @@ import {
   hasSwapAmount,
   validateSwapBalance,
 } from "./swap-form-validation";
+import { useSwapFormValidation } from "./use-swap-form-validation";
 
 const tokenInSymbol = "CELO" as TokenSymbol;
+const tokenOutSymbol = "USDm" as TokenSymbol;
+const chainId = 42220 as ChainId;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  web3Mocks.useTradingLimits.mockReturnValue({
+    data: { tokenToCheck: tokenInSymbol },
+    isLoading: false,
+  });
+  web3Mocks.useTradingSuspensionCheck.mockReturnValue({
+    isLoading: false,
+    isSuspended: false,
+  });
+  tradingLimitMocks.checkTradingLimitViolation.mockReturnValue(null);
+});
 
 describe("swap form balance helpers", () => {
   it("preserves the distinct sell and buy balance formatting paths", () => {
@@ -134,5 +159,58 @@ describe("getTradingSuspensionError", () => {
         tokenOutSymbol: "USDm",
       }),
     ).toBeNull();
+  });
+});
+
+describe("useSwapFormValidation", () => {
+  const renderValidation = () =>
+    renderHook(() =>
+      useSwapFormValidation({
+        allTokenOptions: [{ decimals: 1, symbol: tokenInSymbol }],
+        amount: "1",
+        balances: { [tokenInSymbol]: "20" },
+        chainId,
+        formQuote: "2",
+        hasAmountError: false,
+        selectedTokenInSymbol: tokenInSymbol,
+        selectedTokenOutSymbol: tokenOutSymbol,
+        tokenInSymbol,
+        tokenOutSymbol,
+      }),
+    );
+
+  it("preserves the valid quote and composed amount-validation path", async () => {
+    const { result } = renderValidation();
+
+    expect(result.current.canQuote).toBe(true);
+    expect(result.current.hasAmount).toBe(true);
+    await expect(result.current.validateAmount("1")).resolves.toBe(true);
+    expect(tradingLimitMocks.checkTradingLimitViolation).toHaveBeenCalledWith(
+      expect.objectContaining({ tokenInSymbol, tokenOutSymbol }),
+    );
+  });
+
+  it("surfaces the current trading-limit message through validateAmount", async () => {
+    tradingLimitMocks.checkTradingLimitViolation.mockReturnValue(
+      "Limit reached",
+    );
+    const { result } = renderValidation();
+
+    await expect(result.current.validateAmount("1")).resolves.toBe(
+      "Limit reached",
+    );
+  });
+
+  it("blocks quotes and exposes the pair message while trading is suspended", () => {
+    web3Mocks.useTradingSuspensionCheck.mockReturnValue({
+      isLoading: false,
+      isSuspended: true,
+    });
+    const { result } = renderValidation();
+
+    expect(result.current.canQuote).toBe(false);
+    expect(result.current.tradingSuspensionError).toContain(
+      "Trading temporarily paused for CELO -> USDm",
+    );
   });
 });

--- a/apps/app.mento.org/app/components/swap/swap-form/use-swap-form-effects.test.tsx
+++ b/apps/app.mento.org/app/components/swap/swap-form/use-swap-form-effects.test.tsx
@@ -1,0 +1,185 @@
+import type { TokenSymbol } from "@mento-protocol/mento-sdk";
+import { renderHook } from "@testing-library/react";
+import type { ChainId, SwapFormValues } from "@repo/web3";
+import type { FieldError, UseFormReturn } from "react-hook-form";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { LastChangedToken } from "./route-driven-state";
+import type { FormValues } from "./types";
+
+const web3Mocks = vi.hoisted(() => ({
+  formatWithMaxDecimals: vi.fn(),
+  useTradablePairs: vi.fn(),
+}));
+const toastMocks = vi.hoisted(() => ({ error: vi.fn() }));
+
+vi.mock("@repo/web3", () => web3Mocks);
+vi.mock("sonner", () => ({ toast: toastMocks }));
+
+import {
+  useSwapQuoteFormEffects,
+  useSwapTokenPairEffects,
+} from "./use-swap-form-effects";
+
+const chainId = 42220 as ChainId;
+const celo = "CELO" as TokenSymbol;
+const eurM = "EURm" as TokenSymbol;
+const gbpM = "GBPm" as TokenSymbol;
+const usdM = "USDm" as TokenSymbol;
+
+function createFormHarness() {
+  const reset = vi.fn();
+  const setValue = vi.fn();
+  const form = { reset, setValue } as unknown as UseFormReturn<FormValues>;
+  return { form, reset, setValue };
+}
+
+function createAmountError(message: string): FieldError {
+  return { message, type: "validate" };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  web3Mocks.formatWithMaxDecimals.mockImplementation(
+    (value) => `formatted:${value}`,
+  );
+  web3Mocks.useTradablePairs.mockReturnValue({
+    data: [],
+    isLoading: false,
+  });
+});
+
+describe("useSwapQuoteFormEffects", () => {
+  it("synchronizes formatted quotes and only toasts actionable amount errors", () => {
+    const { form, setValue } = createFormHarness();
+    const props = {
+      amount: "1",
+      amountError: createAmountError("Balance is too low"),
+      form,
+      formQuote: "",
+      hasAmount: true,
+      quote: "2.34567",
+    };
+    const { rerender } = renderHook(
+      (hookProps: Parameters<typeof useSwapQuoteFormEffects>[0]) =>
+        useSwapQuoteFormEffects(hookProps),
+      { initialProps: props },
+    );
+
+    expect(web3Mocks.formatWithMaxDecimals).toHaveBeenCalledWith(
+      "2.34567",
+      4,
+      false,
+    );
+    expect(setValue).toHaveBeenCalledWith("quote", "formatted:2.34567", {
+      shouldValidate: true,
+    });
+    expect(toastMocks.error).toHaveBeenCalledWith("Balance is too low");
+
+    setValue.mockClear();
+    toastMocks.error.mockClear();
+    rerender({
+      ...props,
+      amount: "2",
+      amountError: createAmountError("Invalid input"),
+      formQuote: "formatted:2.34567",
+    });
+    rerender({
+      ...props,
+      amount: "3",
+      amountError: createAmountError("Amount is required"),
+      formQuote: "formatted:2.34567",
+    });
+    rerender({
+      ...props,
+      amount: "4",
+      amountError: createAmountError("Balance is too low"),
+      formQuote: "formatted:2.34567",
+      hasAmount: false,
+    });
+
+    expect(setValue).not.toHaveBeenCalled();
+    expect(toastMocks.error).not.toHaveBeenCalled();
+  });
+});
+
+describe("useSwapTokenPairEffects", () => {
+  it("resets quote and amount after a successful swap while preserving form preferences", () => {
+    const { form, reset } = createFormHarness();
+    const setLastChangedToken = vi.fn();
+    const formValues: SwapFormValues = {
+      amount: "",
+      quote: "2.5",
+      slippage: "0.75",
+      tokenInSymbol: celo,
+      tokenOutSymbol: eurM,
+    };
+
+    renderHook(() =>
+      useSwapTokenPairEffects({
+        chainId,
+        form,
+        formValues,
+        lastChangedTokenRef: { current: null },
+        selectedTokenInSymbol: celo,
+        selectedTokenOutSymbol: eurM,
+        setLastChangedToken,
+      }),
+    );
+
+    expect(web3Mocks.useTradablePairs).toHaveBeenNthCalledWith(
+      1,
+      celo,
+      chainId,
+    );
+    expect(web3Mocks.useTradablePairs).toHaveBeenNthCalledWith(
+      2,
+      eurM,
+      chainId,
+    );
+    expect(setLastChangedToken).toHaveBeenCalledWith(null);
+    expect(reset).toHaveBeenCalledWith({
+      amount: "",
+      quote: "",
+      slippage: "0.75",
+      tokenInSymbol: celo,
+      tokenOutSymbol: eurM,
+    });
+  });
+
+  it.each([
+    ["from", "tokenOutSymbol"],
+    ["to", "tokenInSymbol"],
+  ] as const)(
+    "clears the opposite token when the last-changed %s token creates an invalid pair",
+    (lastChangedToken, fieldToClear) => {
+      web3Mocks.useTradablePairs.mockImplementation((symbol) => ({
+        data: symbol === celo ? [gbpM] : [eurM],
+        isLoading: false,
+      }));
+      const { form, reset, setValue } = createFormHarness();
+      const setLastChangedToken = vi.fn();
+      const lastChangedTokenRef = {
+        current: lastChangedToken as LastChangedToken,
+      };
+
+      renderHook(() =>
+        useSwapTokenPairEffects({
+          chainId,
+          form,
+          formValues: { amount: "1", slippage: "0.3" },
+          lastChangedTokenRef,
+          selectedTokenInSymbol: celo,
+          selectedTokenOutSymbol: usdM,
+          setLastChangedToken,
+        }),
+      );
+
+      expect(reset).not.toHaveBeenCalled();
+      expect(setValue).toHaveBeenCalledWith(fieldToClear, "", {
+        shouldValidate: false,
+      });
+      expect(setLastChangedToken).toHaveBeenCalledWith(null);
+    },
+  );
+});

--- a/apps/app.mento.org/app/components/swap/swap-form/use-swap-form-effects.ts
+++ b/apps/app.mento.org/app/components/swap/swap-form/use-swap-form-effects.ts
@@ -1,0 +1,130 @@
+import type { TokenSymbol } from "@mento-protocol/mento-sdk";
+import {
+  formatWithMaxDecimals,
+  type ChainId,
+  type SwapFormValues,
+  useTradablePairs,
+} from "@repo/web3";
+import { useEffect, type RefObject } from "react";
+import type { FieldError, UseFormReturn } from "react-hook-form";
+import { toast } from "sonner";
+
+import type { LastChangedToken } from "./route-driven-state";
+import type { FormValues } from "./types";
+
+export function useSwapQuoteFormEffects({
+  amount,
+  amountError,
+  form,
+  formQuote,
+  hasAmount,
+  quote,
+}: {
+  amount: string;
+  amountError?: FieldError;
+  form: UseFormReturn<FormValues>;
+  formQuote: string;
+  hasAmount: boolean;
+  quote?: string;
+}) {
+  useEffect(() => {
+    if (quote !== undefined) {
+      const formattedQuote = formatWithMaxDecimals(quote, 4, false);
+      if (formQuote !== formattedQuote) {
+        form.setValue("quote", formattedQuote, { shouldValidate: true });
+      }
+    }
+  }, [quote, form, formQuote]);
+
+  useEffect(() => {
+    if (
+      amountError?.message &&
+      amountError.message !== "Invalid input" &&
+      amountError.message !== "Amount is required" &&
+      hasAmount
+    ) {
+      toast.error(amountError.message);
+    }
+  }, [amountError, hasAmount, amount]);
+}
+
+export function useSwapTokenPairEffects({
+  chainId,
+  form,
+  formValues,
+  lastChangedTokenRef,
+  selectedTokenInSymbol,
+  selectedTokenOutSymbol,
+  setLastChangedToken,
+}: {
+  chainId: ChainId;
+  form: UseFormReturn<FormValues>;
+  formValues: SwapFormValues | null;
+  lastChangedTokenRef: RefObject<LastChangedToken>;
+  selectedTokenInSymbol?: TokenSymbol;
+  selectedTokenOutSymbol?: TokenSymbol;
+  setLastChangedToken: (value: LastChangedToken) => void;
+}) {
+  const {
+    data: fromTokenTradablePairs,
+    isLoading: isFromTokenTradablePairsLoading,
+  } = useTradablePairs(selectedTokenInSymbol, chainId);
+  const {
+    data: toTokenTradablePairs,
+    isLoading: isToTokenTradablePairsLoading,
+  } = useTradablePairs(selectedTokenOutSymbol, chainId);
+
+  // Reset form fields after a successful swap (formValues.amount is cleared but tokens preserved)
+  useEffect(() => {
+    if (!formValues?.amount && formValues?.tokenInSymbol) {
+      setLastChangedToken(null);
+      form.reset({
+        amount: "",
+        quote: "",
+        tokenInSymbol: formValues.tokenInSymbol,
+        tokenOutSymbol: formValues.tokenOutSymbol || "USDm",
+        slippage: formValues?.slippage || "0.3",
+      });
+    }
+  }, [
+    formValues?.amount,
+    formValues?.tokenInSymbol,
+    formValues?.tokenOutSymbol,
+    formValues?.slippage,
+    form,
+    setLastChangedToken,
+  ]);
+
+  useEffect(() => {
+    const lastChangedToken = lastChangedTokenRef.current;
+
+    if (!selectedTokenInSymbol || !selectedTokenOutSymbol || !lastChangedToken)
+      return;
+    if (isFromTokenTradablePairsLoading || isToTokenTradablePairsLoading)
+      return;
+    if (!fromTokenTradablePairs || !toTokenTradablePairs) return;
+
+    const isValidPair =
+      fromTokenTradablePairs.includes(selectedTokenOutSymbol) ||
+      toTokenTradablePairs.includes(selectedTokenInSymbol);
+
+    if (!isValidPair) {
+      if (lastChangedToken === "from") {
+        form.setValue("tokenOutSymbol", "", { shouldValidate: false });
+      } else if (lastChangedToken === "to") {
+        form.setValue("tokenInSymbol", "", { shouldValidate: false });
+      }
+      setLastChangedToken(null);
+    }
+  }, [
+    selectedTokenInSymbol,
+    selectedTokenOutSymbol,
+    fromTokenTradablePairs,
+    toTokenTradablePairs,
+    isFromTokenTradablePairsLoading,
+    isToTokenTradablePairsLoading,
+    form,
+    lastChangedTokenRef,
+    setLastChangedToken,
+  ]);
+}

--- a/apps/app.mento.org/app/components/swap/swap-form/use-swap-form-sync.test.tsx
+++ b/apps/app.mento.org/app/components/swap/swap-form/use-swap-form-sync.test.tsx
@@ -1,0 +1,170 @@
+import { renderHook } from "@testing-library/react";
+import type { ChainId, SwapFormValues } from "@repo/web3";
+import type { UseFormReturn } from "react-hook-form";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { RouteDrivenFormState } from "./route-driven-state";
+import type { FormValues } from "./types";
+
+const web3Mocks = vi.hoisted(() => ({
+  getPreferredUsdQuoteTokenSymbol: vi.fn(() => "USDm"),
+  getTokenOptionsByChainId: vi.fn(() => ["CELO", "USDm"]),
+}));
+const syncPlanMocks = vi.hoisted(() => ({
+  getChainChangeSyncPlan: vi.fn(),
+  getRouteDrivenFormStateSyncPlan: vi.fn(),
+}));
+const urlSyncMocks = vi.hoisted(() => ({ useSwapUrlSync: vi.fn() }));
+
+vi.mock("@repo/web3", () => web3Mocks);
+vi.mock("@/hooks/use-swap-url-sync", () => urlSyncMocks);
+vi.mock("./chain-change-sync", () => ({
+  getChainChangeSyncPlan: syncPlanMocks.getChainChangeSyncPlan,
+}));
+vi.mock("./route-driven-state", () => ({
+  getRouteDrivenFormStateSyncPlan:
+    syncPlanMocks.getRouteDrivenFormStateSyncPlan,
+}));
+
+import { useSwapFormSync } from "./use-swap-form-sync";
+
+const celoChainId = 42220 as ChainId;
+const monadChainId = 143 as ChainId;
+const initialRouteState: RouteDrivenFormState = {
+  amount: "1",
+  tokenInSymbol: "CELO",
+  tokenOutSymbol: "USDm",
+};
+
+function createHarness() {
+  const currentValues: FormValues = {
+    amount: "1",
+    quote: "2",
+    slippage: "0.3",
+    tokenInSymbol: "CELO",
+    tokenOutSymbol: "USDm",
+  };
+  const form = {
+    getValues: vi.fn((name?: keyof FormValues) =>
+      name ? currentValues[name] : currentValues,
+    ),
+    reset: vi.fn(),
+    setValue: vi.fn(),
+  } as unknown as UseFormReturn<FormValues>;
+
+  return {
+    form,
+    lastRouteDrivenFormStateRef: {
+      current: null,
+    } as { current: RouteDrivenFormState | null },
+    prevChainIdRef: { current: celoChainId } as { current: number },
+    setConfirmView: vi.fn(),
+    setFormValues: vi.fn(),
+    setLastChangedToken: vi.fn(),
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  syncPlanMocks.getChainChangeSyncPlan.mockReturnValue({
+    kind: "clear-amount-only",
+  });
+  syncPlanMocks.getRouteDrivenFormStateSyncPlan.mockReturnValue({
+    shouldReset: false,
+  });
+});
+
+describe("useSwapFormSync", () => {
+  it("keeps chain sync a mount no-op, then clears amount via functional atom update", () => {
+    const harness = createHarness();
+    const { rerender } = renderHook(
+      ({ formChainId }) =>
+        useSwapFormSync({
+          ...harness,
+          amount: "1",
+          formChainId,
+          formValues: { slippage: "0.3" },
+          isQuoteError: false,
+          routeDrivenFormState: initialRouteState,
+          tokenInSymbol: "CELO",
+          tokenOutSymbol: "USDm",
+        }),
+      { initialProps: { formChainId: celoChainId } },
+    );
+
+    expect(harness.form.setValue).not.toHaveBeenCalled();
+    rerender({ formChainId: monadChainId });
+
+    expect(harness.form.setValue).toHaveBeenNthCalledWith(1, "amount", "");
+    expect(harness.form.setValue).toHaveBeenNthCalledWith(2, "quote", "");
+    const update = harness.setFormValues.mock.calls[0]?.[0] as (
+      previous: SwapFormValues | null,
+    ) => SwapFormValues | null;
+    expect(update(null)).toBeNull();
+    expect(update({ amount: "1", slippage: "0.3" })).toEqual({
+      amount: "",
+      slippage: "0.3",
+    });
+  });
+
+  it("applies route resets and records the route-changed token side", () => {
+    const harness = createHarness();
+    const resetValues: FormValues = {
+      ...initialRouteState,
+      amount: "2",
+      quote: "",
+      slippage: "0.3",
+    };
+    syncPlanMocks.getRouteDrivenFormStateSyncPlan
+      .mockReturnValueOnce({ shouldReset: false })
+      .mockReturnValueOnce({
+        resetValues,
+        routeChangedTokenSide: "from",
+        shouldReset: true,
+      });
+    const { rerender } = renderHook(
+      ({ routeDrivenFormState }) =>
+        useSwapFormSync({
+          ...harness,
+          amount: routeDrivenFormState.amount,
+          formChainId: celoChainId,
+          formValues: { slippage: "0.3" },
+          isQuoteError: false,
+          routeDrivenFormState,
+          tokenInSymbol: "CELO",
+          tokenOutSymbol: "USDm",
+        }),
+      { initialProps: { routeDrivenFormState: initialRouteState } },
+    );
+
+    rerender({
+      routeDrivenFormState: { ...initialRouteState, amount: "2" },
+    });
+    expect(harness.form.reset).toHaveBeenCalledWith(resetValues);
+    expect(harness.setLastChangedToken).toHaveBeenCalledWith("from");
+  });
+
+  it("forwards URL state and exits confirm view on quote errors", () => {
+    const harness = createHarness();
+    renderHook(() =>
+      useSwapFormSync({
+        ...harness,
+        amount: "1",
+        formChainId: celoChainId,
+        formValues: null,
+        isQuoteError: true,
+        routeDrivenFormState: initialRouteState,
+        tokenInSymbol: "CELO",
+        tokenOutSymbol: "USDm",
+      }),
+    );
+
+    expect(urlSyncMocks.useSwapUrlSync).toHaveBeenCalledWith({
+      amount: "1",
+      tokenInSymbol: "CELO",
+      tokenOutSymbol: "USDm",
+      urlChainId: celoChainId,
+    });
+    expect(harness.setConfirmView).toHaveBeenCalledWith(false);
+  });
+});

--- a/apps/app.mento.org/app/components/swap/swap-form/use-swap-form-sync.ts
+++ b/apps/app.mento.org/app/components/swap/swap-form/use-swap-form-sync.ts
@@ -1,0 +1,127 @@
+import { useSwapUrlSync } from "@/hooks/use-swap-url-sync";
+import {
+  getPreferredUsdQuoteTokenSymbol,
+  getTokenOptionsByChainId,
+  type ChainId,
+  type SwapFormValues,
+} from "@repo/web3";
+import {
+  useEffect,
+  type Dispatch,
+  type RefObject,
+  type SetStateAction,
+} from "react";
+import type { UseFormReturn } from "react-hook-form";
+
+import { getChainChangeSyncPlan } from "./chain-change-sync";
+import {
+  getRouteDrivenFormStateSyncPlan,
+  type LastChangedToken,
+  type RouteDrivenFormState,
+} from "./route-driven-state";
+import { getAvailableTokenSymbol } from "./token-selection";
+import type { FormValues } from "./types";
+
+export function useSwapFormSync({
+  amount,
+  form,
+  formChainId,
+  formValues,
+  isQuoteError,
+  lastRouteDrivenFormStateRef,
+  prevChainIdRef,
+  routeDrivenFormState,
+  setConfirmView,
+  setFormValues,
+  setLastChangedToken,
+  tokenInSymbol,
+  tokenOutSymbol,
+}: {
+  amount: string;
+  form: UseFormReturn<FormValues>;
+  formChainId: ChainId;
+  formValues: SwapFormValues | null;
+  isQuoteError: boolean;
+  lastRouteDrivenFormStateRef: RefObject<RouteDrivenFormState | null>;
+  prevChainIdRef: RefObject<number>;
+  routeDrivenFormState: RouteDrivenFormState;
+  setConfirmView: Dispatch<SetStateAction<boolean>>;
+  setFormValues: Dispatch<SetStateAction<SwapFormValues | null>>;
+  setLastChangedToken: (value: LastChangedToken) => void;
+  tokenInSymbol: string;
+  tokenOutSymbol: string;
+}): void {
+  useEffect(() => {
+    if (prevChainIdRef.current === formChainId) return;
+    prevChainIdRef.current = formChainId;
+
+    const availableTokens = getTokenOptionsByChainId(formChainId);
+    const plan = getChainChangeSyncPlan({
+      availableTokens,
+      currentTokenInSymbol: form.getValues("tokenInSymbol"),
+      currentTokenOutSymbol: form.getValues("tokenOutSymbol"),
+      preferredQuoteTokenSymbol: getPreferredUsdQuoteTokenSymbol(formChainId),
+    });
+
+    if (plan.kind === "clear-amount-only") {
+      form.setValue("amount", "");
+      form.setValue("quote", "");
+      setFormValues((prev) => (prev ? { ...prev, amount: "" } : prev));
+      return;
+    }
+
+    form.setValue("tokenInSymbol", plan.tokenInSymbol);
+    form.setValue("tokenOutSymbol", plan.tokenOutSymbol);
+    form.setValue("amount", "");
+    form.setValue("quote", "");
+    setFormValues((prev) =>
+      prev
+        ? {
+            ...prev,
+            tokenInSymbol: getAvailableTokenSymbol(
+              plan.tokenInSymbol,
+              availableTokens,
+            ),
+            tokenOutSymbol: getAvailableTokenSymbol(
+              plan.tokenOutSymbol,
+              availableTokens,
+            ),
+            amount: "",
+          }
+        : prev,
+    );
+    setLastChangedToken(null);
+  }, [form, formChainId, prevChainIdRef, setFormValues, setLastChangedToken]);
+
+  useEffect(() => {
+    const previousRouteState = lastRouteDrivenFormStateRef.current;
+    lastRouteDrivenFormStateRef.current = routeDrivenFormState;
+    const plan = getRouteDrivenFormStateSyncPlan({
+      currentValues: form.getValues(),
+      formValuesSlippage: formValues?.slippage,
+      previousRouteState,
+      routeDrivenFormState,
+    });
+
+    if (!plan.shouldReset) return;
+    form.reset(plan.resetValues);
+    setLastChangedToken(plan.routeChangedTokenSide);
+  }, [
+    form,
+    formValues?.slippage,
+    lastRouteDrivenFormStateRef,
+    routeDrivenFormState,
+    setLastChangedToken,
+  ]);
+
+  useSwapUrlSync({
+    amount,
+    tokenInSymbol,
+    tokenOutSymbol,
+    urlChainId: formChainId,
+  });
+
+  useEffect(() => {
+    if (isQuoteError) setConfirmView(false);
+  }, [isQuoteError, setConfirmView]);
+}

--- a/apps/app.mento.org/app/components/swap/swap-form/use-swap-form-validation.ts
+++ b/apps/app.mento.org/app/components/swap/swap-form/use-swap-form-validation.ts
@@ -1,0 +1,156 @@
+import type { TokenSymbol } from "@mento-protocol/mento-sdk";
+import {
+  parseAmount,
+  parseAmountWithDefault,
+  useTradingLimits,
+  useTradingSuspensionCheck,
+  type AccountBalances,
+  type ChainId,
+} from "@repo/web3";
+import { useCallback, useMemo } from "react";
+
+import {
+  getFormattedTokenInBalance,
+  getFormattedTokenOutBalance,
+  getTradingSuspensionError,
+  hasSwapAmount,
+  validateSwapBalance,
+} from "./swap-form-validation";
+import { checkTradingLimitViolation } from "./trading-limits";
+
+type TokenOptions = Parameters<
+  typeof validateSwapBalance
+>[0]["allTokenOptions"];
+
+export function useSwapFormValidation({
+  allTokenOptions,
+  amount,
+  balances,
+  chainId,
+  formQuote,
+  hasAmountError,
+  selectedTokenInSymbol,
+  selectedTokenOutSymbol,
+  tokenInSymbol,
+  tokenOutSymbol,
+}: {
+  allTokenOptions: TokenOptions;
+  amount: string;
+  balances: AccountBalances;
+  chainId: ChainId;
+  formQuote: string;
+  hasAmountError: boolean;
+  selectedTokenInSymbol?: TokenSymbol;
+  selectedTokenOutSymbol?: TokenSymbol;
+  tokenInSymbol: string;
+  tokenOutSymbol: string;
+}) {
+  const fromTokenBalance = useMemo(
+    () =>
+      getFormattedTokenInBalance({
+        balances,
+        chainId,
+        tokenSymbol: selectedTokenInSymbol,
+      }),
+    [balances, selectedTokenInSymbol, chainId],
+  );
+  const toTokenBalance = useMemo(
+    () =>
+      getFormattedTokenOutBalance({
+        balances,
+        chainId,
+        tokenSymbol: selectedTokenOutSymbol,
+      }),
+    [balances, selectedTokenOutSymbol, chainId],
+  );
+  const { data: limits, isLoading: limitsLoading } = useTradingLimits(
+    selectedTokenInSymbol,
+    selectedTokenOutSymbol,
+    chainId,
+  );
+  const {
+    isSuspended: isTradingSuspended,
+    isLoading: isSuspensionCheckLoading,
+  } = useTradingSuspensionCheck(
+    selectedTokenInSymbol,
+    selectedTokenOutSymbol,
+    chainId,
+  );
+  const validateBalance = useCallback(
+    (value: string) =>
+      validateSwapBalance({
+        allTokenOptions,
+        balances,
+        tokenInSymbol: selectedTokenInSymbol,
+        value,
+      }),
+    [balances, selectedTokenInSymbol, allTokenOptions],
+  );
+  const validateLimits = useCallback(
+    async (value: string) => {
+      if (!value || limitsLoading || !limits || !limits.tokenToCheck)
+        return true;
+      if (value === "0." || value === "0") return true;
+
+      const parsedAmount = parseAmount(value);
+      if (!parsedAmount) return true;
+
+      const violation = checkTradingLimitViolation({
+        amountIn: parsedAmount,
+        amountOut: parseAmountWithDefault(formQuote, 0),
+        limits,
+        tokenInSymbol,
+        tokenOutSymbol,
+      });
+      return violation || true;
+    },
+    [limitsLoading, limits, tokenInSymbol, tokenOutSymbol, formQuote],
+  );
+  const validateAmount = useCallback(
+    async (value: string) => {
+      const balanceCheck = validateBalance(value);
+      if (balanceCheck !== true) return balanceCheck;
+
+      const limitsCheck = await validateLimits(value);
+      if (limitsCheck !== true) return limitsCheck;
+      return true;
+    },
+    [validateBalance, validateLimits],
+  );
+  const hasAmount = hasSwapAmount(amount);
+  const balanceError = useMemo(() => {
+    if (!hasAmount || !selectedTokenInSymbol) return null;
+    const balanceCheck = validateBalance(amount);
+    return balanceCheck !== true ? balanceCheck : null;
+  }, [amount, hasAmount, selectedTokenInSymbol, validateBalance]);
+  const tradingSuspensionError = useMemo(
+    () =>
+      getTradingSuspensionError({
+        isTradingSuspended,
+        tokenInSymbol,
+        tokenOutSymbol,
+      }),
+    [isTradingSuspended, tokenInSymbol, tokenOutSymbol],
+  );
+  const canQuote =
+    hasAmount &&
+    !hasAmountError &&
+    !limitsLoading &&
+    !isTradingSuspended &&
+    !!selectedTokenInSymbol &&
+    !!selectedTokenOutSymbol;
+
+  return {
+    balanceError,
+    canQuote,
+    fromTokenBalance,
+    hasAmount,
+    isSuspensionCheckLoading,
+    isTradingSuspended,
+    limits,
+    limitsLoading,
+    toTokenBalance,
+    tradingSuspensionError,
+    validateAmount,
+  };
+}

--- a/apps/app.mento.org/app/components/swap/swap-form/use-swap-form.tsx
+++ b/apps/app.mento.org/app/components/swap/swap-form/use-swap-form.tsx
@@ -2,61 +2,38 @@
 
 import { env } from "@/env.mjs";
 import { zodResolver } from "@hookform/resolvers/zod";
-import {
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-  useSyncExternalStore,
-} from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import { useForm, useWatch } from "react-hook-form";
 import { toast } from "sonner";
-import { useSwapUrlSync } from "@/hooks/use-swap-url-sync";
 
 import {
   CELO_EXPLORER,
   ChainId,
   chainIdToChain,
   confirmViewAtom,
-  formatWithMaxDecimals,
   formValuesAtom,
   getNativeTokenSymbol,
   getPreferredUsdQuoteTokenSymbol,
   getTokenDecimals,
   getTokenOptionsByChainId,
   logger,
-  parseAmount,
-  parseAmountWithDefault,
   type SwapFormValues,
-  toWei,
   useAccountBalances,
   useApproveTransaction,
   useOptimizedSwapQuote,
   useSwapAllowance,
   useTokenOptions,
-  useTradablePairs,
 } from "@repo/web3";
 import { useAccount, useChainId } from "@repo/web3/wagmi";
 import { useAtom } from "jotai";
 import { OctagonAlert } from "lucide-react";
 
-import { getChainChangeSyncPlan } from "./chain-change-sync";
+import { getSelectedTokenSymbol } from "./token-selection";
 import {
-  getAvailableTokenSymbol,
-  getSelectedTokenSymbol,
-} from "./token-selection";
-import {
-  getRouteDrivenFormStateSyncPlan,
   type LastChangedToken,
   type RouteDrivenFormState,
 } from "./route-driven-state";
-import {
-  createWaitingForQuoteStore,
-  getTokenPairKey,
-} from "./waiting-for-quote-store";
 import { getMaxSellAmount } from "./max-sell-amount";
-import { checkTradingLimitViolation } from "./trading-limits";
 import {
   getSwapFormInitialState,
   type SwapFormRouteOptions,
@@ -64,7 +41,13 @@ import {
 } from "./swap-form-initial-state";
 import { getTokenBalanceValue } from "./swap-form-validation";
 import { defaultEmptyBalances, formSchema, type FormValues } from "./types";
+import {
+  useSwapQuoteFormEffects,
+  useSwapTokenPairEffects,
+} from "./use-swap-form-effects";
 import { useSwapFormValidation } from "./use-swap-form-validation";
+import { useSwapQuoteState } from "./use-swap-quote-state";
+import { useSwapFormSync } from "./use-swap-form-sync";
 
 export function useSwapForm(opts?: SwapFormRouteOptions) {
   const { address, isConnected } = useAccount();
@@ -232,209 +215,51 @@ export function useSwapForm(opts?: SwapFormRouteOptions) {
     lastChangedTokenRef.current = value;
   }, []);
 
-  // ── Side effects ────────────────────────────────────────────────────
-
-  // Reset token selections when chain changes
-  useEffect(() => {
-    if (prevChainIdRef.current === formChainId) return;
-    prevChainIdRef.current = formChainId;
-
-    const availableTokens = getTokenOptionsByChainId(formChainId);
-    const plan = getChainChangeSyncPlan({
-      availableTokens,
-      currentTokenInSymbol: form.getValues("tokenInSymbol"),
-      currentTokenOutSymbol: form.getValues("tokenOutSymbol"),
-      preferredQuoteTokenSymbol: getPreferredUsdQuoteTokenSymbol(formChainId),
-    });
-
-    if (plan.kind === "clear-amount-only") {
-      form.setValue("amount", "");
-      form.setValue("quote", "");
-      setFormValues((prev) => (prev ? { ...prev, amount: "" } : prev));
-      return;
-    }
-
-    form.setValue("tokenInSymbol", plan.tokenInSymbol);
-    form.setValue("tokenOutSymbol", plan.tokenOutSymbol);
-    form.setValue("amount", "");
-    form.setValue("quote", "");
-
-    setFormValues((prev) =>
-      prev
-        ? {
-            ...prev,
-            tokenInSymbol: getAvailableTokenSymbol(
-              plan.tokenInSymbol,
-              availableTokens,
-            ),
-            tokenOutSymbol: getAvailableTokenSymbol(
-              plan.tokenOutSymbol,
-              availableTokens,
-            ),
-            amount: "",
-          }
-        : prev,
-    );
-    setLastChangedToken(null);
-  }, [form, formChainId, setFormValues, setLastChangedToken]);
-
-  useEffect(() => {
-    const previousRouteState = lastRouteDrivenFormStateRef.current;
-
-    lastRouteDrivenFormStateRef.current = routeDrivenFormState;
-
-    const plan = getRouteDrivenFormStateSyncPlan({
-      currentValues: form.getValues(),
-      formValuesSlippage: formValues?.slippage,
-      previousRouteState,
-      routeDrivenFormState,
-    });
-
-    if (!plan.shouldReset) return;
-
-    form.reset(plan.resetValues);
-    setLastChangedToken(plan.routeChangedTokenSide);
-  }, [form, formValues?.slippage, routeDrivenFormState, setLastChangedToken]);
-
-  useSwapUrlSync({
+  useSwapFormSync({
     amount,
+    form,
+    formChainId,
+    formValues,
+    isQuoteError: isError,
+    lastRouteDrivenFormStateRef,
+    prevChainIdRef,
+    routeDrivenFormState,
+    setConfirmView,
+    setFormValues,
+    setLastChangedToken,
     tokenInSymbol,
     tokenOutSymbol,
-    urlChainId: formChainId,
   });
 
-  useEffect(() => {
-    if (isError) {
-      setConfirmView(false);
-    }
-  }, [isError, setConfirmView]);
-
-  const tradingLimitError = useMemo(() => {
-    if (!hasAmount || !limits || limitsLoading) return null;
-
-    return checkTradingLimitViolation({
-      amountIn: parseAmountWithDefault(amount, 0),
-      amountOut: parseAmountWithDefault(quote, 0),
-      limits,
-      tokenInSymbol,
-      tokenOutSymbol,
-    });
-  }, [
+  const {
+    amountInWei,
+    buyUSDValue,
+    isButtonLoading,
+    isLoading,
+    sellUSDValue,
+    tradingLimitError,
+  } = useSwapQuoteState({
     amount,
-    quote,
+    canQuote,
+    chainId: formChainId,
+    formQuote,
+    fromTokenUSDValue,
+    hasAmount,
+    isQuoteError: isError,
+    isTradingSuspended,
     limits,
     limitsLoading,
-    tokenInSymbol,
-    tokenOutSymbol,
-    hasAmount,
-  ]);
-
-  useEffect(() => {
-    if (tradingLimitError) {
-      toast.error(tradingLimitError, { duration: 20000 });
-    }
-  }, [tradingLimitError]);
-
-  useEffect(() => {
-    const prevError = prevTradingSuspensionErrorRef.current;
-    const hasError = tradingSuspensionError !== null;
-    const errorChanged = prevError !== tradingSuspensionError;
-
-    if (hasError && errorChanged) {
-      if (suspensionToastIdRef.current) {
-        toast.dismiss(suspensionToastIdRef.current);
-      }
-      suspensionToastIdRef.current = toast.error(tradingSuspensionError, {
-        duration: 20000,
-      });
-    } else if (prevError !== null && !hasError) {
-      if (suspensionToastIdRef.current) {
-        toast.dismiss(suspensionToastIdRef.current);
-        suspensionToastIdRef.current = null;
-      }
-    }
-
-    prevTradingSuspensionErrorRef.current = tradingSuspensionError;
-  }, [tradingSuspensionError]);
-
-  const isLoading =
-    quoteFetching && canQuote && !tradingLimitError && !limitsLoading;
-
-  const waitingForQuotePairStore = useMemo(
-    () => createWaitingForQuoteStore(),
-    [],
-  );
-  const waitingForQuotePair = useSyncExternalStore(
-    waitingForQuotePairStore.subscribe,
-    waitingForQuotePairStore.getSnapshot,
-    waitingForQuotePairStore.getSnapshot,
-  );
-  const tokenPairKey = getTokenPairKey({
-    tokenInSymbol: selectedTokenInSymbol,
-    tokenOutSymbol: selectedTokenOutSymbol,
-  });
-
-  useEffect(() => {
-    waitingForQuotePairStore.update({
-      hasAmount,
-      isTradingSuspended,
-      quote,
-      quoteFetching,
-      tokenInSymbol: selectedTokenInSymbol,
-      tokenOutSymbol: selectedTokenOutSymbol,
-    });
-  }, [
-    hasAmount,
-    isTradingSuspended,
+    prevTradingSuspensionErrorRef,
     quote,
     quoteFetching,
     selectedTokenInSymbol,
     selectedTokenOutSymbol,
-    waitingForQuotePairStore,
-  ]);
-
-  const isWaitingForQuote =
-    tokenPairKey !== null && waitingForQuotePair === tokenPairKey;
-
-  const isButtonLoading = useMemo(
-    () =>
-      !isTradingSuspended &&
-      !isError &&
-      (quoteFetching || isWaitingForQuote) &&
-      hasAmount &&
-      !!selectedTokenInSymbol &&
-      !!selectedTokenOutSymbol,
-    [
-      quoteFetching,
-      isWaitingForQuote,
-      hasAmount,
-      selectedTokenInSymbol,
-      selectedTokenOutSymbol,
-      isTradingSuspended,
-      isError,
-    ],
-  );
-
-  const sellUSDValue = useMemo(() => {
-    return tokenInSymbol === "USDm" ? amount || "0" : fromTokenUSDValue || "0";
-  }, [tokenInSymbol, amount, fromTokenUSDValue]);
-
-  const buyUSDValue = useMemo(() => {
-    return tokenOutSymbol === "USDm"
-      ? formQuote || "0"
-      : toTokenUSDValue || "0";
-  }, [tokenOutSymbol, formQuote, toTokenUSDValue]);
-
-  const amountInWei = useMemo(() => {
-    if (!selectedTokenInSymbol) return "0";
-    const parsedAmount = parseAmount(amount);
-    if (!parsedAmount || !parsedAmount.gt(0)) return "0";
-
-    return toWei(
-      parsedAmount,
-      getTokenDecimals(selectedTokenInSymbol, formChainId),
-    ).toFixed(0);
-  }, [amount, selectedTokenInSymbol, formChainId]);
+    suspensionToastIdRef,
+    toTokenUSDValue,
+    tokenInSymbol,
+    tokenOutSymbol,
+    tradingSuspensionError,
+  });
 
   // ── Allowance & approval ────────────────────────────────────────────
 
@@ -507,25 +332,14 @@ export function useSwapForm(opts?: SwapFormRouteOptions) {
     },
   });
 
-  useEffect(() => {
-    if (quote !== undefined) {
-      const formattedQuote = formatWithMaxDecimals(quote, 4, false);
-      if (formQuote !== formattedQuote) {
-        form.setValue("quote", formattedQuote, { shouldValidate: true });
-      }
-    }
-  }, [quote, form, formQuote]);
-
-  useEffect(() => {
-    if (
-      errors.amount?.message &&
-      errors.amount.message !== "Invalid input" &&
-      errors.amount.message !== "Amount is required" &&
-      hasAmount
-    ) {
-      toast.error(errors.amount.message);
-    }
-  }, [errors.amount, hasAmount, amount]);
+  useSwapQuoteFormEffects({
+    amount,
+    amountError: errors.amount,
+    form,
+    formQuote,
+    hasAmount,
+    quote,
+  });
 
   // ── Submit ──────────────────────────────────────────────────────────
 
@@ -570,67 +384,15 @@ export function useSwapForm(opts?: SwapFormRouteOptions) {
 
   // ── Token pair validation ───────────────────────────────────────────
 
-  const {
-    data: fromTokenTradablePairs,
-    isLoading: isFromTokenTradablePairsLoading,
-  } = useTradablePairs(selectedTokenInSymbol, formChainId);
-  const {
-    data: toTokenTradablePairs,
-    isLoading: isToTokenTradablePairsLoading,
-  } = useTradablePairs(selectedTokenOutSymbol, formChainId);
-
-  // Reset form fields after a successful swap (formValues.amount is cleared but tokens preserved)
-  useEffect(() => {
-    if (!formValues?.amount && formValues?.tokenInSymbol) {
-      setLastChangedToken(null);
-      form.reset({
-        amount: "",
-        quote: "",
-        tokenInSymbol: formValues.tokenInSymbol,
-        tokenOutSymbol: formValues.tokenOutSymbol || "USDm",
-        slippage: formValues?.slippage || "0.3",
-      });
-    }
-  }, [
-    formValues?.amount,
-    formValues?.tokenInSymbol,
-    formValues?.tokenOutSymbol,
-    formValues?.slippage,
+  useSwapTokenPairEffects({
+    chainId: formChainId,
     form,
-    setLastChangedToken,
-  ]);
-
-  useEffect(() => {
-    const lastChangedToken = lastChangedTokenRef.current;
-
-    if (!selectedTokenInSymbol || !selectedTokenOutSymbol || !lastChangedToken)
-      return;
-    if (isFromTokenTradablePairsLoading || isToTokenTradablePairsLoading)
-      return;
-    if (!fromTokenTradablePairs || !toTokenTradablePairs) return;
-
-    const isValidPair =
-      fromTokenTradablePairs.includes(selectedTokenOutSymbol) ||
-      toTokenTradablePairs.includes(selectedTokenInSymbol);
-
-    if (!isValidPair) {
-      if (lastChangedToken === "from") {
-        form.setValue("tokenOutSymbol", "", { shouldValidate: false });
-      } else if (lastChangedToken === "to") {
-        form.setValue("tokenInSymbol", "", { shouldValidate: false });
-      }
-      setLastChangedToken(null);
-    }
-  }, [
+    formValues,
+    lastChangedTokenRef,
     selectedTokenInSymbol,
     selectedTokenOutSymbol,
-    fromTokenTradablePairs,
-    toTokenTradablePairs,
-    isFromTokenTradablePairsLoading,
-    isToTokenTradablePairsLoading,
-    form,
     setLastChangedToken,
-  ]);
+  });
 
   // ── Return ──────────────────────────────────────────────────────────
 

--- a/apps/app.mento.org/app/components/swap/swap-form/use-swap-form.tsx
+++ b/apps/app.mento.org/app/components/swap/swap-form/use-swap-form.tsx
@@ -36,8 +36,6 @@ import {
   useSwapAllowance,
   useTokenOptions,
   useTradablePairs,
-  useTradingLimits,
-  useTradingSuspensionCheck,
 } from "@repo/web3";
 import { useAccount, useChainId } from "@repo/web3/wagmi";
 import { useAtom } from "jotai";
@@ -64,15 +62,9 @@ import {
   type SwapFormRouteOptions,
   useStableRouteDrivenFormState,
 } from "./swap-form-initial-state";
-import {
-  getFormattedTokenInBalance,
-  getFormattedTokenOutBalance,
-  getTokenBalanceValue,
-  getTradingSuspensionError,
-  hasSwapAmount,
-  validateSwapBalance,
-} from "./swap-form-validation";
+import { getTokenBalanceValue } from "./swap-form-validation";
 import { defaultEmptyBalances, formSchema, type FormValues } from "./types";
+import { useSwapFormValidation } from "./use-swap-form-validation";
 
 export function useSwapForm(opts?: SwapFormRouteOptions) {
   const { address, isConnected } = useAccount();
@@ -151,91 +143,31 @@ export function useSwapForm(opts?: SwapFormRouteOptions) {
   const amount = useWatch({ control: form.control, name: "amount" });
   const formQuote = useWatch({ control: form.control, name: "quote" });
 
-  // Token balances
-  const fromTokenBalance = useMemo(
-    () =>
-      getFormattedTokenInBalance({
-        balances,
-        chainId: formChainId,
-        tokenSymbol: selectedTokenInSymbol,
-      }),
-    [balances, selectedTokenInSymbol, formChainId],
-  );
-
-  const toTokenBalance = useMemo(
-    () =>
-      getFormattedTokenOutBalance({
-        balances,
-        chainId: formChainId,
-        tokenSymbol: selectedTokenOutSymbol,
-      }),
-    [balances, selectedTokenOutSymbol, formChainId],
-  );
-
-  // Trading limits
-  const { data: limits, isLoading: limitsLoading } = useTradingLimits(
-    selectedTokenInSymbol,
-    selectedTokenOutSymbol,
-    formChainId,
-  );
-
-  // Trading suspension
+  const { errors } = form.formState;
   const {
-    isSuspended: isTradingSuspended,
-    isLoading: isSuspensionCheckLoading,
-  } = useTradingSuspensionCheck(
+    balanceError,
+    canQuote,
+    fromTokenBalance,
+    hasAmount,
+    isSuspensionCheckLoading,
+    isTradingSuspended,
+    limits,
+    limitsLoading,
+    toTokenBalance,
+    tradingSuspensionError,
+    validateAmount,
+  } = useSwapFormValidation({
+    allTokenOptions,
+    amount,
+    balances,
+    chainId: formChainId,
+    formQuote,
+    hasAmountError: Boolean(errors.amount),
     selectedTokenInSymbol,
     selectedTokenOutSymbol,
-    formChainId,
-  );
-
-  // ── Validation ──────────────────────────────────────────────────────
-
-  const validateBalance = useCallback(
-    (value: string) =>
-      validateSwapBalance({
-        allTokenOptions,
-        balances,
-        tokenInSymbol: selectedTokenInSymbol,
-        value,
-      }),
-    [balances, selectedTokenInSymbol, allTokenOptions],
-  );
-
-  const validateLimits = useCallback(
-    async (value: string) => {
-      if (!value || limitsLoading || !limits || !limits.tokenToCheck)
-        return true;
-      if (value === "0." || value === "0") return true;
-
-      const parsedAmount = parseAmount(value);
-      if (!parsedAmount) return true;
-
-      const violation = checkTradingLimitViolation({
-        amountIn: parsedAmount,
-        amountOut: parseAmountWithDefault(formQuote, 0),
-        limits,
-        tokenInSymbol,
-        tokenOutSymbol,
-      });
-
-      return violation || true;
-    },
-    [limitsLoading, limits, tokenInSymbol, tokenOutSymbol, formQuote],
-  );
-
-  const validateAmount = useCallback(
-    async (value: string) => {
-      const balanceCheck = validateBalance(value);
-      if (balanceCheck !== true) return balanceCheck;
-
-      const limitsCheck = await validateLimits(value);
-      if (limitsCheck !== true) return limitsCheck;
-
-      return true;
-    },
-    [validateBalance, validateLimits],
-  );
+    tokenInSymbol,
+    tokenOutSymbol,
+  });
 
   // ── Handlers ────────────────────────────────────────────────────────
 
@@ -273,36 +205,6 @@ export function useSwapForm(opts?: SwapFormRouteOptions) {
       });
     }
   };
-
-  // ── Derived state ───────────────────────────────────────────────────
-
-  const { errors } = form.formState;
-  const hasAmount = hasSwapAmount(amount);
-
-  const balanceError = useMemo(() => {
-    if (!hasAmount || !selectedTokenInSymbol) return null;
-
-    const balanceCheck = validateBalance(amount);
-    return balanceCheck !== true ? balanceCheck : null;
-  }, [amount, hasAmount, selectedTokenInSymbol, validateBalance]);
-
-  const tradingSuspensionError = useMemo(
-    () =>
-      getTradingSuspensionError({
-        isTradingSuspended,
-        tokenInSymbol,
-        tokenOutSymbol,
-      }),
-    [isTradingSuspended, tokenInSymbol, tokenOutSymbol],
-  );
-
-  const canQuote =
-    !!hasAmount &&
-    !errors.amount &&
-    !limitsLoading &&
-    !isTradingSuspended &&
-    !!selectedTokenInSymbol &&
-    !!selectedTokenOutSymbol;
 
   // ── Quote ───────────────────────────────────────────────────────────
 

--- a/apps/app.mento.org/app/components/swap/swap-form/use-swap-quote-state.test.tsx
+++ b/apps/app.mento.org/app/components/swap/swap-form/use-swap-quote-state.test.tsx
@@ -1,0 +1,169 @@
+import type { TokenSymbol } from "@mento-protocol/mento-sdk";
+import { renderHook } from "@testing-library/react";
+import type { ChainId } from "@repo/web3";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { SwapTradingLimits } from "./trading-limits";
+
+const web3Mocks = vi.hoisted(() => ({
+  getTokenDecimals: vi.fn(() => 18),
+  parseAmount: vi.fn(),
+  parseAmountWithDefault: vi.fn((value) => ({ value })),
+  toWei: vi.fn(),
+}));
+const toastMocks = vi.hoisted(() => ({
+  dismiss: vi.fn(),
+  error: vi.fn(),
+}));
+const tradingLimitMocks = vi.hoisted(() => ({
+  checkTradingLimitViolation: vi.fn(),
+}));
+
+vi.mock("@repo/web3", () => web3Mocks);
+vi.mock("sonner", () => ({ toast: toastMocks }));
+vi.mock("./trading-limits", () => tradingLimitMocks);
+
+import { useSwapQuoteState } from "./use-swap-quote-state";
+
+const chainId = 42220 as ChainId;
+const celo = "CELO" as TokenSymbol;
+const usdM = "USDm" as TokenSymbol;
+const noLimits: SwapTradingLimits = {
+  L0: null,
+  L1: null,
+  LG: null,
+  tokenToCheck: null,
+};
+type QuoteStateProps = Parameters<typeof useSwapQuoteState>[0];
+
+function createProps(
+  overrides: Partial<QuoteStateProps> = {},
+): QuoteStateProps {
+  return {
+    amount: "1.25",
+    canQuote: true,
+    chainId,
+    formQuote: "2.5",
+    fromTokenUSDValue: "4.5",
+    hasAmount: true,
+    isQuoteError: false,
+    isTradingSuspended: false,
+    limits: null,
+    limitsLoading: false,
+    prevTradingSuspensionErrorRef: { current: null },
+    quote: "2.5",
+    quoteFetching: true,
+    selectedTokenInSymbol: celo,
+    selectedTokenOutSymbol: usdM,
+    suspensionToastIdRef: { current: null },
+    toTokenUSDValue: "2.5",
+    tokenInSymbol: "CELO",
+    tokenOutSymbol: "USDm",
+    tradingSuspensionError: null,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  const parsedAmount = { gt: vi.fn(() => true) };
+  web3Mocks.parseAmount.mockReturnValue(parsedAmount);
+  web3Mocks.toWei.mockReturnValue({
+    toFixed: vi.fn(() => "1250000000000000000"),
+  });
+  tradingLimitMocks.checkTradingLimitViolation.mockReturnValue(null);
+});
+
+describe("useSwapQuoteState", () => {
+  it("derives loading, USD values, and the positive input amount in wei", () => {
+    const props = createProps();
+    const { result, rerender } = renderHook(
+      (hookProps: QuoteStateProps) => useSwapQuoteState(hookProps),
+      { initialProps: props },
+    );
+
+    expect(result.current).toEqual({
+      amountInWei: "1250000000000000000",
+      buyUSDValue: "2.5",
+      isButtonLoading: true,
+      isLoading: true,
+      sellUSDValue: "4.5",
+      tradingLimitError: null,
+    });
+    expect(web3Mocks.parseAmount).toHaveBeenCalledWith("1.25");
+    expect(web3Mocks.getTokenDecimals).toHaveBeenCalledWith(celo, chainId);
+    expect(web3Mocks.toWei).toHaveBeenCalledWith(
+      web3Mocks.parseAmount.mock.results[0]?.value,
+      18,
+    );
+
+    rerender({
+      ...props,
+      amount: "3",
+      fromTokenUSDValue: "ignored",
+      toTokenUSDValue: "6.75",
+      tokenInSymbol: "USDm",
+      tokenOutSymbol: "CELO",
+    });
+    expect(result.current.sellUSDValue).toBe("3");
+    expect(result.current.buyUSDValue).toBe("6.75");
+  });
+
+  it("surfaces a trading-limit violation, blocks loading, and shows its toast", () => {
+    tradingLimitMocks.checkTradingLimitViolation.mockReturnValue(
+      "Trading limit exceeded",
+    );
+
+    const { result } = renderHook(() =>
+      useSwapQuoteState(createProps({ limits: noLimits })),
+    );
+
+    expect(result.current.tradingLimitError).toBe("Trading limit exceeded");
+    expect(result.current.isLoading).toBe(false);
+    expect(tradingLimitMocks.checkTradingLimitViolation).toHaveBeenCalledWith({
+      amountIn: { value: "1.25" },
+      amountOut: { value: "2.5" },
+      limits: noLimits,
+      tokenInSymbol: "CELO",
+      tokenOutSymbol: "USDm",
+    });
+    expect(toastMocks.error).toHaveBeenCalledWith("Trading limit exceeded", {
+      duration: 20000,
+    });
+  });
+
+  it("replaces a changed suspension toast and dismisses it when the error clears", () => {
+    toastMocks.error.mockReturnValueOnce(101).mockReturnValueOnce(102);
+    const prevErrorRef = { current: null as string | null };
+    const toastIdRef = { current: null as string | number | null };
+    const props = createProps({
+      prevTradingSuspensionErrorRef: prevErrorRef,
+      quoteFetching: false,
+      suspensionToastIdRef: toastIdRef,
+    });
+    const { rerender } = renderHook(
+      (hookProps: QuoteStateProps) => useSwapQuoteState(hookProps),
+      { initialProps: props },
+    );
+
+    rerender({ ...props, tradingSuspensionError: "Suspended" });
+    expect(toastMocks.error).toHaveBeenLastCalledWith("Suspended", {
+      duration: 20000,
+    });
+    expect(prevErrorRef.current).toBe("Suspended");
+    expect(toastIdRef.current).toBe(101);
+
+    rerender({ ...props, tradingSuspensionError: "Still suspended" });
+    expect(toastMocks.dismiss).toHaveBeenCalledWith(101);
+    expect(toastMocks.error).toHaveBeenLastCalledWith("Still suspended", {
+      duration: 20000,
+    });
+    expect(prevErrorRef.current).toBe("Still suspended");
+    expect(toastIdRef.current).toBe(102);
+
+    rerender({ ...props, tradingSuspensionError: null });
+    expect(toastMocks.dismiss).toHaveBeenLastCalledWith(102);
+    expect(prevErrorRef.current).toBeNull();
+    expect(toastIdRef.current).toBeNull();
+  });
+});

--- a/apps/app.mento.org/app/components/swap/swap-form/use-swap-quote-state.ts
+++ b/apps/app.mento.org/app/components/swap/swap-form/use-swap-quote-state.ts
@@ -1,0 +1,201 @@
+import type { TokenSymbol } from "@mento-protocol/mento-sdk";
+import {
+  getTokenDecimals,
+  parseAmount,
+  parseAmountWithDefault,
+  toWei,
+  type ChainId,
+} from "@repo/web3";
+import {
+  useEffect,
+  useMemo,
+  useSyncExternalStore,
+  type RefObject,
+} from "react";
+import { toast } from "sonner";
+
+import { checkTradingLimitViolation } from "./trading-limits";
+import {
+  createWaitingForQuoteStore,
+  getTokenPairKey,
+} from "./waiting-for-quote-store";
+
+type TradingLimits = Parameters<typeof checkTradingLimitViolation>[0]["limits"];
+
+export function useSwapQuoteState({
+  amount,
+  canQuote,
+  chainId,
+  formQuote,
+  fromTokenUSDValue,
+  hasAmount,
+  isQuoteError,
+  isTradingSuspended,
+  limits,
+  limitsLoading,
+  prevTradingSuspensionErrorRef,
+  quote,
+  quoteFetching,
+  selectedTokenInSymbol,
+  selectedTokenOutSymbol,
+  suspensionToastIdRef,
+  toTokenUSDValue,
+  tokenInSymbol,
+  tokenOutSymbol,
+  tradingSuspensionError,
+}: {
+  amount: string;
+  canQuote: boolean;
+  chainId: ChainId;
+  formQuote: string;
+  fromTokenUSDValue?: string;
+  hasAmount: boolean;
+  isQuoteError: boolean;
+  isTradingSuspended: boolean;
+  limits?: TradingLimits | null;
+  limitsLoading: boolean;
+  prevTradingSuspensionErrorRef: RefObject<string | null>;
+  quote?: string;
+  quoteFetching: boolean;
+  selectedTokenInSymbol?: TokenSymbol;
+  selectedTokenOutSymbol?: TokenSymbol;
+  suspensionToastIdRef: RefObject<string | number | null>;
+  toTokenUSDValue?: string;
+  tokenInSymbol: string;
+  tokenOutSymbol: string;
+  tradingSuspensionError: string | null;
+}) {
+  const tradingLimitError = useMemo(() => {
+    if (!hasAmount || !limits || limitsLoading) return null;
+    return checkTradingLimitViolation({
+      amountIn: parseAmountWithDefault(amount, 0),
+      amountOut: parseAmountWithDefault(quote, 0),
+      limits,
+      tokenInSymbol,
+      tokenOutSymbol,
+    });
+  }, [
+    amount,
+    quote,
+    limits,
+    limitsLoading,
+    tokenInSymbol,
+    tokenOutSymbol,
+    hasAmount,
+  ]);
+
+  useEffect(() => {
+    if (tradingLimitError) {
+      toast.error(tradingLimitError, { duration: 20000 });
+    }
+  }, [tradingLimitError]);
+
+  useEffect(() => {
+    const prevError = prevTradingSuspensionErrorRef.current;
+    const hasError = tradingSuspensionError !== null;
+    const errorChanged = prevError !== tradingSuspensionError;
+
+    if (hasError && errorChanged) {
+      if (suspensionToastIdRef.current) {
+        toast.dismiss(suspensionToastIdRef.current);
+      }
+      suspensionToastIdRef.current = toast.error(tradingSuspensionError, {
+        duration: 20000,
+      });
+    } else if (prevError !== null && !hasError) {
+      if (suspensionToastIdRef.current) {
+        toast.dismiss(suspensionToastIdRef.current);
+        suspensionToastIdRef.current = null;
+      }
+    }
+
+    prevTradingSuspensionErrorRef.current = tradingSuspensionError;
+  }, [
+    prevTradingSuspensionErrorRef,
+    suspensionToastIdRef,
+    tradingSuspensionError,
+  ]);
+
+  const isLoading =
+    quoteFetching && canQuote && !tradingLimitError && !limitsLoading;
+  const waitingForQuotePairStore = useMemo(
+    () => createWaitingForQuoteStore(),
+    [],
+  );
+  const waitingForQuotePair = useSyncExternalStore(
+    waitingForQuotePairStore.subscribe,
+    waitingForQuotePairStore.getSnapshot,
+    waitingForQuotePairStore.getSnapshot,
+  );
+  const tokenPairKey = getTokenPairKey({
+    tokenInSymbol: selectedTokenInSymbol,
+    tokenOutSymbol: selectedTokenOutSymbol,
+  });
+
+  useEffect(() => {
+    waitingForQuotePairStore.update({
+      hasAmount,
+      isTradingSuspended,
+      quote,
+      quoteFetching,
+      tokenInSymbol: selectedTokenInSymbol,
+      tokenOutSymbol: selectedTokenOutSymbol,
+    });
+  }, [
+    hasAmount,
+    isTradingSuspended,
+    quote,
+    quoteFetching,
+    selectedTokenInSymbol,
+    selectedTokenOutSymbol,
+    waitingForQuotePairStore,
+  ]);
+
+  const isWaitingForQuote =
+    tokenPairKey !== null && waitingForQuotePair === tokenPairKey;
+  const isButtonLoading = useMemo(
+    () =>
+      !isTradingSuspended &&
+      !isQuoteError &&
+      (quoteFetching || isWaitingForQuote) &&
+      hasAmount &&
+      !!selectedTokenInSymbol &&
+      !!selectedTokenOutSymbol,
+    [
+      quoteFetching,
+      isWaitingForQuote,
+      hasAmount,
+      selectedTokenInSymbol,
+      selectedTokenOutSymbol,
+      isTradingSuspended,
+      isQuoteError,
+    ],
+  );
+  const sellUSDValue = useMemo(
+    () => (tokenInSymbol === "USDm" ? amount || "0" : fromTokenUSDValue || "0"),
+    [tokenInSymbol, amount, fromTokenUSDValue],
+  );
+  const buyUSDValue = useMemo(
+    () =>
+      tokenOutSymbol === "USDm" ? formQuote || "0" : toTokenUSDValue || "0",
+    [tokenOutSymbol, formQuote, toTokenUSDValue],
+  );
+  const amountInWei = useMemo(() => {
+    if (!selectedTokenInSymbol) return "0";
+    const parsedAmount = parseAmount(amount);
+    if (!parsedAmount || !parsedAmount.gt(0)) return "0";
+    return toWei(
+      parsedAmount,
+      getTokenDecimals(selectedTokenInSymbol, chainId),
+    ).toFixed(0);
+  }, [amount, selectedTokenInSymbol, chainId]);
+
+  return {
+    amountInWei,
+    buyUSDValue,
+    isButtonLoading,
+    isLoading,
+    sellUSDValue,
+    tradingLimitError,
+  };
+}


### PR DESCRIPTION
## The Problem

The parent swap hook still coordinates balances, trading limits, trading suspension, validators, and quote eligibility inline, leaving too many validation concerns in one render path.

## The Solution

Extract the existing validation hook sequence into `useSwapFormValidation`. Preserve hook order, callback dependencies, validation precedence, derived error state, and quote eligibility without changing the submit or approval flow.

## Validation

- `pnpm exec turbo run test --filter app.mento.org`
- `pnpm --filter app.mento.org check-types`
- `trunk check --fix` on changed files
- Production app build

## Stack

3 of 6. Base: #493. Next: #495.

Part of #404; this PR intentionally does not close the issue.

## Ship Checklist

- [x] Existing hook order and dependencies preserved
- [x] No dependency changes
- [x] Validation precedence unchanged
- [x] Existing public hook return shape preserved

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving refactor with targeted hook tests; swap validation rules and public `useSwapForm` API stay the same.
> 
> **Overview**
> Moves swap-form validation out of `useSwapForm` into a dedicated **`useSwapFormValidation`** hook so balances, trading limits, suspension checks, amount validation, and quote eligibility live in one place.
> 
> `useSwapForm` now calls that hook and drops the inlined `useTradingLimits` / `useTradingSuspensionCheck` wiring and local `validateBalance` / `validateLimits` / `validateAmount` logic; its return shape and submit/approval flow are unchanged. **`swap-form-validation.test.ts`** adds hook tests (mocked web3 + trading limits) for `canQuote`, `validateAmount`, trading-limit messages, and suspension blocking.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c214152e7b52591b697898ecb30d01536b50d656. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->