### PR TITLE
refactor(app): extract swap quote state (5/6)

### DIFF
--- a/apps/app.mento.org/app/components/swap/swap-form/use-swap-form-effects.test.tsx
+++ b/apps/app.mento.org/app/components/swap/swap-form/use-swap-form-effects.test.tsx
@@ -1,0 +1,185 @@
+import type { TokenSymbol } from "@mento-protocol/mento-sdk";
+import { renderHook } from "@testing-library/react";
+import type { ChainId, SwapFormValues } from "@repo/web3";
+import type { FieldError, UseFormReturn } from "react-hook-form";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { LastChangedToken } from "./route-driven-state";
+import type { FormValues } from "./types";
+
+const web3Mocks = vi.hoisted(() => ({
+  formatWithMaxDecimals: vi.fn(),
+  useTradablePairs: vi.fn(),
+}));
+const toastMocks = vi.hoisted(() => ({ error: vi.fn() }));
+
+vi.mock("@repo/web3", () => web3Mocks);
+vi.mock("sonner", () => ({ toast: toastMocks }));
+
+import {
+  useSwapQuoteFormEffects,
+  useSwapTokenPairEffects,
+} from "./use-swap-form-effects";
+
+const chainId = 42220 as ChainId;
+const celo = "CELO" as TokenSymbol;
+const eurM = "EURm" as TokenSymbol;
+const gbpM = "GBPm" as TokenSymbol;
+const usdM = "USDm" as TokenSymbol;
+
+function createFormHarness() {
+  const reset = vi.fn();
+  const setValue = vi.fn();
+  const form = { reset, setValue } as unknown as UseFormReturn<FormValues>;
+  return { form, reset, setValue };
+}
+
+function createAmountError(message: string): FieldError {
+  return { message, type: "validate" };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  web3Mocks.formatWithMaxDecimals.mockImplementation(
+    (value) => `formatted:${value}`,
+  );
+  web3Mocks.useTradablePairs.mockReturnValue({
+    data: [],
+    isLoading: false,
+  });
+});
+
+describe("useSwapQuoteFormEffects", () => {
+  it("synchronizes formatted quotes and only toasts actionable amount errors", () => {
+    const { form, setValue } = createFormHarness();
+    const props = {
+      amount: "1",
+      amountError: createAmountError("Balance is too low"),
+      form,
+      formQuote: "",
+      hasAmount: true,
+      quote: "2.34567",
+    };
+    const { rerender } = renderHook(
+      (hookProps: Parameters<typeof useSwapQuoteFormEffects>[0]) =>
+        useSwapQuoteFormEffects(hookProps),
+      { initialProps: props },
+    );
+
+    expect(web3Mocks.formatWithMaxDecimals).toHaveBeenCalledWith(
+      "2.34567",
+      4,
+      false,
+    );
+    expect(setValue).toHaveBeenCalledWith("quote", "formatted:2.34567", {
+      shouldValidate: true,
+    });
+    expect(toastMocks.error).toHaveBeenCalledWith("Balance is too low");
+
+    setValue.mockClear();
+    toastMocks.error.mockClear();
+    rerender({
+      ...props,
+      amount: "2",
+      amountError: createAmountError("Invalid input"),
+      formQuote: "formatted:2.34567",
+    });
+    rerender({
+      ...props,
+      amount: "3",
+      amountError: createAmountError("Amount is required"),
+      formQuote: "formatted:2.34567",
+    });
+    rerender({
+      ...props,
+      amount: "4",
+      amountError: createAmountError("Balance is too low"),
+      formQuote: "formatted:2.34567",
+      hasAmount: false,
+    });
+
+    expect(setValue).not.toHaveBeenCalled();
+    expect(toastMocks.error).not.toHaveBeenCalled();
+  });
+});
+
+describe("useSwapTokenPairEffects", () => {
+  it("resets quote and amount after a successful swap while preserving form preferences", () => {
+    const { form, reset } = createFormHarness();
+    const setLastChangedToken = vi.fn();
+    const formValues: SwapFormValues = {
+      amount: "",
+      quote: "2.5",
+      slippage: "0.75",
+      tokenInSymbol: celo,
+      tokenOutSymbol: eurM,
+    };
+
+    renderHook(() =>
+      useSwapTokenPairEffects({
+        chainId,
+        form,
+        formValues,
+        lastChangedTokenRef: { current: null },
+        selectedTokenInSymbol: celo,
+        selectedTokenOutSymbol: eurM,
+        setLastChangedToken,
+      }),
+    );
+
+    expect(web3Mocks.useTradablePairs).toHaveBeenNthCalledWith(
+      1,
+      celo,
+      chainId,
+    );
+    expect(web3Mocks.useTradablePairs).toHaveBeenNthCalledWith(
+      2,
+      eurM,
+      chainId,
+    );
+    expect(setLastChangedToken).toHaveBeenCalledWith(null);
+    expect(reset).toHaveBeenCalledWith({
+      amount: "",
+      quote: "",
+      slippage: "0.75",
+      tokenInSymbol: celo,
+      tokenOutSymbol: eurM,
+    });
+  });
+
+  it.each([
+    ["from", "tokenOutSymbol"],
+    ["to", "tokenInSymbol"],
+  ] as const)(
+    "clears the opposite token when the last-changed %s token creates an invalid pair",
+    (lastChangedToken, fieldToClear) => {
+      web3Mocks.useTradablePairs.mockImplementation((symbol) => ({
+        data: symbol === celo ? [gbpM] : [eurM],
+        isLoading: false,
+      }));
+      const { form, reset, setValue } = createFormHarness();
+      const setLastChangedToken = vi.fn();
+      const lastChangedTokenRef = {
+        current: lastChangedToken as LastChangedToken,
+      };
+
+      renderHook(() =>
+        useSwapTokenPairEffects({
+          chainId,
+          form,
+          formValues: { amount: "1", slippage: "0.3" },
+          lastChangedTokenRef,
+          selectedTokenInSymbol: celo,
+          selectedTokenOutSymbol: usdM,
+          setLastChangedToken,
+        }),
+      );
+
+      expect(reset).not.toHaveBeenCalled();
+      expect(setValue).toHaveBeenCalledWith(fieldToClear, "", {
+        shouldValidate: false,
+      });
+      expect(setLastChangedToken).toHaveBeenCalledWith(null);
+    },
+  );
+});

--- a/apps/app.mento.org/app/components/swap/swap-form/use-swap-form-effects.ts
+++ b/apps/app.mento.org/app/components/swap/swap-form/use-swap-form-effects.ts
@@ -1,0 +1,130 @@
+import type { TokenSymbol } from "@mento-protocol/mento-sdk";
+import {
+  formatWithMaxDecimals,
+  type ChainId,
+  type SwapFormValues,
+  useTradablePairs,
+} from "@repo/web3";
+import { useEffect, type RefObject } from "react";
+import type { FieldError, UseFormReturn } from "react-hook-form";
+import { toast } from "sonner";
+
+import type { LastChangedToken } from "./route-driven-state";
+import type { FormValues } from "./types";
+
+export function useSwapQuoteFormEffects({
+  amount,
+  amountError,
+  form,
+  formQuote,
+  hasAmount,
+  quote,
+}: {
+  amount: string;
+  amountError?: FieldError;
+  form: UseFormReturn<FormValues>;
+  formQuote: string;
+  hasAmount: boolean;
+  quote?: string;
+}) {
+  useEffect(() => {
+    if (quote !== undefined) {
+      const formattedQuote = formatWithMaxDecimals(quote, 4, false);
+      if (formQuote !== formattedQuote) {
+        form.setValue("quote", formattedQuote, { shouldValidate: true });
+      }
+    }
+  }, [quote, form, formQuote]);
+
+  useEffect(() => {
+    if (
+      amountError?.message &&
+      amountError.message !== "Invalid input" &&
+      amountError.message !== "Amount is required" &&
+      hasAmount
+    ) {
+      toast.error(amountError.message);
+    }
+  }, [amountError, hasAmount, amount]);
+}
+
+export function useSwapTokenPairEffects({
+  chainId,
+  form,
+  formValues,
+  lastChangedTokenRef,
+  selectedTokenInSymbol,
+  selectedTokenOutSymbol,
+  setLastChangedToken,
+}: {
+  chainId: ChainId;
+  form: UseFormReturn<FormValues>;
+  formValues: SwapFormValues | null;
+  lastChangedTokenRef: RefObject<LastChangedToken>;
+  selectedTokenInSymbol?: TokenSymbol;
+  selectedTokenOutSymbol?: TokenSymbol;
+  setLastChangedToken: (value: LastChangedToken) => void;
+}) {
+  const {
+    data: fromTokenTradablePairs,
+    isLoading: isFromTokenTradablePairsLoading,
+  } = useTradablePairs(selectedTokenInSymbol, chainId);
+  const {
+    data: toTokenTradablePairs,
+    isLoading: isToTokenTradablePairsLoading,
+  } = useTradablePairs(selectedTokenOutSymbol, chainId);
+
+  // Reset form fields after a successful swap (formValues.amount is cleared but tokens preserved)
+  useEffect(() => {
+    if (!formValues?.amount && formValues?.tokenInSymbol) {
+      setLastChangedToken(null);
+      form.reset({
+        amount: "",
+        quote: "",
+        tokenInSymbol: formValues.tokenInSymbol,
+        tokenOutSymbol: formValues.tokenOutSymbol || "USDm",
+        slippage: formValues?.slippage || "0.3",
+      });
+    }
+  }, [
+    formValues?.amount,
+    formValues?.tokenInSymbol,
+    formValues?.tokenOutSymbol,
+    formValues?.slippage,
+    form,
+    setLastChangedToken,
+  ]);
+
+  useEffect(() => {
+    const lastChangedToken = lastChangedTokenRef.current;
+
+    if (!selectedTokenInSymbol || !selectedTokenOutSymbol || !lastChangedToken)
+      return;
+    if (isFromTokenTradablePairsLoading || isToTokenTradablePairsLoading)
+      return;
+    if (!fromTokenTradablePairs || !toTokenTradablePairs) return;
+
+    const isValidPair =
+      fromTokenTradablePairs.includes(selectedTokenOutSymbol) ||
+      toTokenTradablePairs.includes(selectedTokenInSymbol);
+
+    if (!isValidPair) {
+      if (lastChangedToken === "from") {
+        form.setValue("tokenOutSymbol", "", { shouldValidate: false });
+      } else if (lastChangedToken === "to") {
+        form.setValue("tokenInSymbol", "", { shouldValidate: false });
+      }
+      setLastChangedToken(null);
+    }
+  }, [
+    selectedTokenInSymbol,
+    selectedTokenOutSymbol,
+    fromTokenTradablePairs,
+    toTokenTradablePairs,
+    isFromTokenTradablePairsLoading,
+    isToTokenTradablePairsLoading,
+    form,
+    lastChangedTokenRef,
+    setLastChangedToken,
+  ]);
+}

--- a/apps/app.mento.org/app/components/swap/swap-form/use-swap-form.tsx
+++ b/apps/app.mento.org/app/components/swap/swap-form/use-swap-form.tsx
@@ -2,14 +2,7 @@
 
 import { env } from "@/env.mjs";
 import { zodResolver } from "@hookform/resolvers/zod";
-import {
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-  useSyncExternalStore,
-} from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useForm, useWatch } from "react-hook-form";
 import { toast } from "sonner";
 
@@ -25,10 +18,7 @@ import {
   getTokenDecimals,
   getTokenOptionsByChainId,
   logger,
-  parseAmount,
-  parseAmountWithDefault,
   type SwapFormValues,
-  toWei,
   useAccountBalances,
   useApproveTransaction,
   useOptimizedSwapQuote,
@@ -45,12 +35,7 @@ import {
   type LastChangedToken,
   type RouteDrivenFormState,
 } from "./route-driven-state";
-import {
-  createWaitingForQuoteStore,
-  getTokenPairKey,
-} from "./waiting-for-quote-store";
 import { getMaxSellAmount } from "./max-sell-amount";
-import { checkTradingLimitViolation } from "./trading-limits";
 import {
   getSwapFormInitialState,
   type SwapFormRouteOptions,
@@ -59,6 +44,7 @@ import {
 import { getTokenBalanceValue } from "./swap-form-validation";
 import { defaultEmptyBalances, formSchema, type FormValues } from "./types";
 import { useSwapFormValidation } from "./use-swap-form-validation";
+import { useSwapQuoteState } from "./use-swap-quote-state";
 import { useSwapFormSync } from "./use-swap-form-sync";
 
 export function useSwapForm(opts?: SwapFormRouteOptions) {
@@ -243,132 +229,35 @@ export function useSwapForm(opts?: SwapFormRouteOptions) {
     tokenOutSymbol,
   });
 
-  const tradingLimitError = useMemo(() => {
-    if (!hasAmount || !limits || limitsLoading) return null;
-
-    return checkTradingLimitViolation({
-      amountIn: parseAmountWithDefault(amount, 0),
-      amountOut: parseAmountWithDefault(quote, 0),
-      limits,
-      tokenInSymbol,
-      tokenOutSymbol,
-    });
-  }, [
+  const {
+    amountInWei,
+    buyUSDValue,
+    isButtonLoading,
+    isLoading,
+    sellUSDValue,
+    tradingLimitError,
+  } = useSwapQuoteState({
     amount,
-    quote,
+    canQuote,
+    chainId: formChainId,
+    formQuote,
+    fromTokenUSDValue,
+    hasAmount,
+    isQuoteError: isError,
+    isTradingSuspended,
     limits,
     limitsLoading,
-    tokenInSymbol,
-    tokenOutSymbol,
-    hasAmount,
-  ]);
-
-  useEffect(() => {
-    if (tradingLimitError) {
-      toast.error(tradingLimitError, { duration: 20000 });
-    }
-  }, [tradingLimitError]);
-
-  useEffect(() => {
-    const prevError = prevTradingSuspensionErrorRef.current;
-    const hasError = tradingSuspensionError !== null;
-    const errorChanged = prevError !== tradingSuspensionError;
-
-    if (hasError && errorChanged) {
-      if (suspensionToastIdRef.current) {
-        toast.dismiss(suspensionToastIdRef.current);
-      }
-      suspensionToastIdRef.current = toast.error(tradingSuspensionError, {
-        duration: 20000,
-      });
-    } else if (prevError !== null && !hasError) {
-      if (suspensionToastIdRef.current) {
-        toast.dismiss(suspensionToastIdRef.current);
-        suspensionToastIdRef.current = null;
-      }
-    }
-
-    prevTradingSuspensionErrorRef.current = tradingSuspensionError;
-  }, [tradingSuspensionError]);
-
-  const isLoading =
-    quoteFetching && canQuote && !tradingLimitError && !limitsLoading;
-
-  const waitingForQuotePairStore = useMemo(
-    () => createWaitingForQuoteStore(),
-    [],
-  );
-  const waitingForQuotePair = useSyncExternalStore(
-    waitingForQuotePairStore.subscribe,
-    waitingForQuotePairStore.getSnapshot,
-    waitingForQuotePairStore.getSnapshot,
-  );
-  const tokenPairKey = getTokenPairKey({
-    tokenInSymbol: selectedTokenInSymbol,
-    tokenOutSymbol: selectedTokenOutSymbol,
-  });
-
-  useEffect(() => {
-    waitingForQuotePairStore.update({
-      hasAmount,
-      isTradingSuspended,
-      quote,
-      quoteFetching,
-      tokenInSymbol: selectedTokenInSymbol,
-      tokenOutSymbol: selectedTokenOutSymbol,
-    });
-  }, [
-    hasAmount,
-    isTradingSuspended,
+    prevTradingSuspensionErrorRef,
     quote,
     quoteFetching,
     selectedTokenInSymbol,
     selectedTokenOutSymbol,
-    waitingForQuotePairStore,
-  ]);
-
-  const isWaitingForQuote =
-    tokenPairKey !== null && waitingForQuotePair === tokenPairKey;
-
-  const isButtonLoading = useMemo(
-    () =>
-      !isTradingSuspended &&
-      !isError &&
-      (quoteFetching || isWaitingForQuote) &&
-      hasAmount &&
-      !!selectedTokenInSymbol &&
-      !!selectedTokenOutSymbol,
-    [
-      quoteFetching,
-      isWaitingForQuote,
-      hasAmount,
-      selectedTokenInSymbol,
-      selectedTokenOutSymbol,
-      isTradingSuspended,
-      isError,
-    ],
-  );
-
-  const sellUSDValue = useMemo(() => {
-    return tokenInSymbol === "USDm" ? amount || "0" : fromTokenUSDValue || "0";
-  }, [tokenInSymbol, amount, fromTokenUSDValue]);
-
-  const buyUSDValue = useMemo(() => {
-    return tokenOutSymbol === "USDm"
-      ? formQuote || "0"
-      : toTokenUSDValue || "0";
-  }, [tokenOutSymbol, formQuote, toTokenUSDValue]);
-
-  const amountInWei = useMemo(() => {
-    if (!selectedTokenInSymbol) return "0";
-    const parsedAmount = parseAmount(amount);
-    if (!parsedAmount || !parsedAmount.gt(0)) return "0";
-
-    return toWei(
-      parsedAmount,
-      getTokenDecimals(selectedTokenInSymbol, formChainId),
-    ).toFixed(0);
-  }, [amount, selectedTokenInSymbol, formChainId]);
+    suspensionToastIdRef,
+    toTokenUSDValue,
+    tokenInSymbol,
+    tokenOutSymbol,
+    tradingSuspensionError,
+  });
 
   // ── Allowance & approval ────────────────────────────────────────────
 

--- a/apps/app.mento.org/app/components/swap/swap-form/use-swap-form.tsx
+++ b/apps/app.mento.org/app/components/swap/swap-form/use-swap-form.tsx
@@ -2,7 +2,7 @@
 
 import { env } from "@/env.mjs";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import { useForm, useWatch } from "react-hook-form";
 import { toast } from "sonner";
 
@@ -11,7 +11,6 @@ import {
   ChainId,
   chainIdToChain,
   confirmViewAtom,
-  formatWithMaxDecimals,
   formValuesAtom,
   getNativeTokenSymbol,
   getPreferredUsdQuoteTokenSymbol,
@@ -24,7 +23,6 @@ import {
   useOptimizedSwapQuote,
   useSwapAllowance,
   useTokenOptions,
-  useTradablePairs,
 } from "@repo/web3";
 import { useAccount, useChainId } from "@repo/web3/wagmi";
 import { useAtom } from "jotai";
@@ -43,6 +41,10 @@ import {
 } from "./swap-form-initial-state";
 import { getTokenBalanceValue } from "./swap-form-validation";
 import { defaultEmptyBalances, formSchema, type FormValues } from "./types";
+import {
+  useSwapQuoteFormEffects,
+  useSwapTokenPairEffects,
+} from "./use-swap-form-effects";
 import { useSwapFormValidation } from "./use-swap-form-validation";
 import { useSwapQuoteState } from "./use-swap-quote-state";
 import { useSwapFormSync } from "./use-swap-form-sync";
@@ -330,25 +332,14 @@ export function useSwapForm(opts?: SwapFormRouteOptions) {
     },
   });
 
-  useEffect(() => {
-    if (quote !== undefined) {
-      const formattedQuote = formatWithMaxDecimals(quote, 4, false);
-      if (formQuote !== formattedQuote) {
-        form.setValue("quote", formattedQuote, { shouldValidate: true });
-      }
-    }
-  }, [quote, form, formQuote]);
-
-  useEffect(() => {
-    if (
-      errors.amount?.message &&
-      errors.amount.message !== "Invalid input" &&
-      errors.amount.message !== "Amount is required" &&
-      hasAmount
-    ) {
-      toast.error(errors.amount.message);
-    }
-  }, [errors.amount, hasAmount, amount]);
+  useSwapQuoteFormEffects({
+    amount,
+    amountError: errors.amount,
+    form,
+    formQuote,
+    hasAmount,
+    quote,
+  });
 
   // ── Submit ──────────────────────────────────────────────────────────
 
@@ -393,67 +384,15 @@ export function useSwapForm(opts?: SwapFormRouteOptions) {
 
   // ── Token pair validation ───────────────────────────────────────────
 
-  const {
-    data: fromTokenTradablePairs,
-    isLoading: isFromTokenTradablePairsLoading,
-  } = useTradablePairs(selectedTokenInSymbol, formChainId);
-  const {
-    data: toTokenTradablePairs,
-    isLoading: isToTokenTradablePairsLoading,
-  } = useTradablePairs(selectedTokenOutSymbol, formChainId);
-
-  // Reset form fields after a successful swap (formValues.amount is cleared but tokens preserved)
-  useEffect(() => {
-    if (!formValues?.amount && formValues?.tokenInSymbol) {
-      setLastChangedToken(null);
-      form.reset({
-        amount: "",
-        quote: "",
-        tokenInSymbol: formValues.tokenInSymbol,
-        tokenOutSymbol: formValues.tokenOutSymbol || "USDm",
-        slippage: formValues?.slippage || "0.3",
-      });
-    }
-  }, [
-    formValues?.amount,
-    formValues?.tokenInSymbol,
-    formValues?.tokenOutSymbol,
-    formValues?.slippage,
+  useSwapTokenPairEffects({
+    chainId: formChainId,
     form,
-    setLastChangedToken,
-  ]);
-
-  useEffect(() => {
-    const lastChangedToken = lastChangedTokenRef.current;
-
-    if (!selectedTokenInSymbol || !selectedTokenOutSymbol || !lastChangedToken)
-      return;
-    if (isFromTokenTradablePairsLoading || isToTokenTradablePairsLoading)
-      return;
-    if (!fromTokenTradablePairs || !toTokenTradablePairs) return;
-
-    const isValidPair =
-      fromTokenTradablePairs.includes(selectedTokenOutSymbol) ||
-      toTokenTradablePairs.includes(selectedTokenInSymbol);
-
-    if (!isValidPair) {
-      if (lastChangedToken === "from") {
-        form.setValue("tokenOutSymbol", "", { shouldValidate: false });
-      } else if (lastChangedToken === "to") {
-        form.setValue("tokenInSymbol", "", { shouldValidate: false });
-      }
-      setLastChangedToken(null);
-    }
-  }, [
+    formValues,
+    lastChangedTokenRef,
     selectedTokenInSymbol,
     selectedTokenOutSymbol,
-    fromTokenTradablePairs,
-    toTokenTradablePairs,
-    isFromTokenTradablePairsLoading,
-    isToTokenTradablePairsLoading,
-    form,
     setLastChangedToken,
-  ]);
+  });
 
   // ── Return ──────────────────────────────────────────────────────────
 

--- a/apps/app.mento.org/app/components/swap/swap-form/use-swap-quote-state.test.tsx
+++ b/apps/app.mento.org/app/components/swap/swap-form/use-swap-quote-state.test.tsx
@@ -1,0 +1,169 @@
+import type { TokenSymbol } from "@mento-protocol/mento-sdk";
+import { renderHook } from "@testing-library/react";
+import type { ChainId } from "@repo/web3";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { SwapTradingLimits } from "./trading-limits";
+
+const web3Mocks = vi.hoisted(() => ({
+  getTokenDecimals: vi.fn(() => 18),
+  parseAmount: vi.fn(),
+  parseAmountWithDefault: vi.fn((value) => ({ value })),
+  toWei: vi.fn(),
+}));
+const toastMocks = vi.hoisted(() => ({
+  dismiss: vi.fn(),
+  error: vi.fn(),
+}));
+const tradingLimitMocks = vi.hoisted(() => ({
+  checkTradingLimitViolation: vi.fn(),
+}));
+
+vi.mock("@repo/web3", () => web3Mocks);
+vi.mock("sonner", () => ({ toast: toastMocks }));
+vi.mock("./trading-limits", () => tradingLimitMocks);
+
+import { useSwapQuoteState } from "./use-swap-quote-state";
+
+const chainId = 42220 as ChainId;
+const celo = "CELO" as TokenSymbol;
+const usdM = "USDm" as TokenSymbol;
+const noLimits: SwapTradingLimits = {
+  L0: null,
+  L1: null,
+  LG: null,
+  tokenToCheck: null,
+};
+type QuoteStateProps = Parameters<typeof useSwapQuoteState>[0];
+
+function createProps(
+  overrides: Partial<QuoteStateProps> = {},
+): QuoteStateProps {
+  return {
+    amount: "1.25",
+    canQuote: true,
+    chainId,
+    formQuote: "2.5",
+    fromTokenUSDValue: "4.5",
+    hasAmount: true,
+    isQuoteError: false,
+    isTradingSuspended: false,
+    limits: null,
+    limitsLoading: false,
+    prevTradingSuspensionErrorRef: { current: null },
+    quote: "2.5",
+    quoteFetching: true,
+    selectedTokenInSymbol: celo,
+    selectedTokenOutSymbol: usdM,
+    suspensionToastIdRef: { current: null },
+    toTokenUSDValue: "2.5",
+    tokenInSymbol: "CELO",
+    tokenOutSymbol: "USDm",
+    tradingSuspensionError: null,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  const parsedAmount = { gt: vi.fn(() => true) };
+  web3Mocks.parseAmount.mockReturnValue(parsedAmount);
+  web3Mocks.toWei.mockReturnValue({
+    toFixed: vi.fn(() => "1250000000000000000"),
+  });
+  tradingLimitMocks.checkTradingLimitViolation.mockReturnValue(null);
+});
+
+describe("useSwapQuoteState", () => {
+  it("derives loading, USD values, and the positive input amount in wei", () => {
+    const props = createProps();
+    const { result, rerender } = renderHook(
+      (hookProps: QuoteStateProps) => useSwapQuoteState(hookProps),
+      { initialProps: props },
+    );
+
+    expect(result.current).toEqual({
+      amountInWei: "1250000000000000000",
+      buyUSDValue: "2.5",
+      isButtonLoading: true,
+      isLoading: true,
+      sellUSDValue: "4.5",
+      tradingLimitError: null,
+    });
+    expect(web3Mocks.parseAmount).toHaveBeenCalledWith("1.25");
+    expect(web3Mocks.getTokenDecimals).toHaveBeenCalledWith(celo, chainId);
+    expect(web3Mocks.toWei).toHaveBeenCalledWith(
+      web3Mocks.parseAmount.mock.results[0]?.value,
+      18,
+    );
+
+    rerender({
+      ...props,
+      amount: "3",
+      fromTokenUSDValue: "ignored",
+      toTokenUSDValue: "6.75",
+      tokenInSymbol: "USDm",
+      tokenOutSymbol: "CELO",
+    });
+    expect(result.current.sellUSDValue).toBe("3");
+    expect(result.current.buyUSDValue).toBe("6.75");
+  });
+
+  it("surfaces a trading-limit violation, blocks loading, and shows its toast", () => {
+    tradingLimitMocks.checkTradingLimitViolation.mockReturnValue(
+      "Trading limit exceeded",
+    );
+
+    const { result } = renderHook(() =>
+      useSwapQuoteState(createProps({ limits: noLimits })),
+    );
+
+    expect(result.current.tradingLimitError).toBe("Trading limit exceeded");
+    expect(result.current.isLoading).toBe(false);
+    expect(tradingLimitMocks.checkTradingLimitViolation).toHaveBeenCalledWith({
+      amountIn: { value: "1.25" },
+      amountOut: { value: "2.5" },
+      limits: noLimits,
+      tokenInSymbol: "CELO",
+      tokenOutSymbol: "USDm",
+    });
+    expect(toastMocks.error).toHaveBeenCalledWith("Trading limit exceeded", {
+      duration: 20000,
+    });
+  });
+
+  it("replaces a changed suspension toast and dismisses it when the error clears", () => {
+    toastMocks.error.mockReturnValueOnce(101).mockReturnValueOnce(102);
+    const prevErrorRef = { current: null as string | null };
+    const toastIdRef = { current: null as string | number | null };
+    const props = createProps({
+      prevTradingSuspensionErrorRef: prevErrorRef,
+      quoteFetching: false,
+      suspensionToastIdRef: toastIdRef,
+    });
+    const { rerender } = renderHook(
+      (hookProps: QuoteStateProps) => useSwapQuoteState(hookProps),
+      { initialProps: props },
+    );
+
+    rerender({ ...props, tradingSuspensionError: "Suspended" });
+    expect(toastMocks.error).toHaveBeenLastCalledWith("Suspended", {
+      duration: 20000,
+    });
+    expect(prevErrorRef.current).toBe("Suspended");
+    expect(toastIdRef.current).toBe(101);
+
+    rerender({ ...props, tradingSuspensionError: "Still suspended" });
+    expect(toastMocks.dismiss).toHaveBeenCalledWith(101);
+    expect(toastMocks.error).toHaveBeenLastCalledWith("Still suspended", {
+      duration: 20000,
+    });
+    expect(prevErrorRef.current).toBe("Still suspended");
+    expect(toastIdRef.current).toBe(102);
+
+    rerender({ ...props, tradingSuspensionError: null });
+    expect(toastMocks.dismiss).toHaveBeenLastCalledWith(102);
+    expect(prevErrorRef.current).toBeNull();
+    expect(toastIdRef.current).toBeNull();
+  });
+});

--- a/apps/app.mento.org/app/components/swap/swap-form/use-swap-quote-state.ts
+++ b/apps/app.mento.org/app/components/swap/swap-form/use-swap-quote-state.ts
@@ -1,0 +1,201 @@
+import type { TokenSymbol } from "@mento-protocol/mento-sdk";
+import {
+  getTokenDecimals,
+  parseAmount,
+  parseAmountWithDefault,
+  toWei,
+  type ChainId,
+} from "@repo/web3";
+import {
+  useEffect,
+  useMemo,
+  useSyncExternalStore,
+  type RefObject,
+} from "react";
+import { toast } from "sonner";
+
+import { checkTradingLimitViolation } from "./trading-limits";
+import {
+  createWaitingForQuoteStore,
+  getTokenPairKey,
+} from "./waiting-for-quote-store";
+
+type TradingLimits = Parameters<typeof checkTradingLimitViolation>[0]["limits"];
+
+export function useSwapQuoteState({
+  amount,
+  canQuote,
+  chainId,
+  formQuote,
+  fromTokenUSDValue,
+  hasAmount,
+  isQuoteError,
+  isTradingSuspended,
+  limits,
+  limitsLoading,
+  prevTradingSuspensionErrorRef,
+  quote,
+  quoteFetching,
+  selectedTokenInSymbol,
+  selectedTokenOutSymbol,
+  suspensionToastIdRef,
+  toTokenUSDValue,
+  tokenInSymbol,
+  tokenOutSymbol,
+  tradingSuspensionError,
+}: {
+  amount: string;
+  canQuote: boolean;
+  chainId: ChainId;
+  formQuote: string;
+  fromTokenUSDValue?: string;
+  hasAmount: boolean;
+  isQuoteError: boolean;
+  isTradingSuspended: boolean;
+  limits?: TradingLimits | null;
+  limitsLoading: boolean;
+  prevTradingSuspensionErrorRef: RefObject<string | null>;
+  quote?: string;
+  quoteFetching: boolean;
+  selectedTokenInSymbol?: TokenSymbol;
+  selectedTokenOutSymbol?: TokenSymbol;
+  suspensionToastIdRef: RefObject<string | number | null>;
+  toTokenUSDValue?: string;
+  tokenInSymbol: string;
+  tokenOutSymbol: string;
+  tradingSuspensionError: string | null;
+}) {
+  const tradingLimitError = useMemo(() => {
+    if (!hasAmount || !limits || limitsLoading) return null;
+    return checkTradingLimitViolation({
+      amountIn: parseAmountWithDefault(amount, 0),
+      amountOut: parseAmountWithDefault(quote, 0),
+      limits,
+      tokenInSymbol,
+      tokenOutSymbol,
+    });
+  }, [
+    amount,
+    quote,
+    limits,
+    limitsLoading,
+    tokenInSymbol,
+    tokenOutSymbol,
+    hasAmount,
+  ]);
+
+  useEffect(() => {
+    if (tradingLimitError) {
+      toast.error(tradingLimitError, { duration: 20000 });
+    }
+  }, [tradingLimitError]);
+
+  useEffect(() => {
+    const prevError = prevTradingSuspensionErrorRef.current;
+    const hasError = tradingSuspensionError !== null;
+    const errorChanged = prevError !== tradingSuspensionError;
+
+    if (hasError && errorChanged) {
+      if (suspensionToastIdRef.current) {
+        toast.dismiss(suspensionToastIdRef.current);
+      }
+      suspensionToastIdRef.current = toast.error(tradingSuspensionError, {
+        duration: 20000,
+      });
+    } else if (prevError !== null && !hasError) {
+      if (suspensionToastIdRef.current) {
+        toast.dismiss(suspensionToastIdRef.current);
+        suspensionToastIdRef.current = null;
+      }
+    }
+
+    prevTradingSuspensionErrorRef.current = tradingSuspensionError;
+  }, [
+    prevTradingSuspensionErrorRef,
+    suspensionToastIdRef,
+    tradingSuspensionError,
+  ]);
+
+  const isLoading =
+    quoteFetching && canQuote && !tradingLimitError && !limitsLoading;
+  const waitingForQuotePairStore = useMemo(
+    () => createWaitingForQuoteStore(),
+    [],
+  );
+  const waitingForQuotePair = useSyncExternalStore(
+    waitingForQuotePairStore.subscribe,
+    waitingForQuotePairStore.getSnapshot,
+    waitingForQuotePairStore.getSnapshot,
+  );
+  const tokenPairKey = getTokenPairKey({
+    tokenInSymbol: selectedTokenInSymbol,
+    tokenOutSymbol: selectedTokenOutSymbol,
+  });
+
+  useEffect(() => {
+    waitingForQuotePairStore.update({
+      hasAmount,
+      isTradingSuspended,
+      quote,
+      quoteFetching,
+      tokenInSymbol: selectedTokenInSymbol,
+      tokenOutSymbol: selectedTokenOutSymbol,
+    });
+  }, [
+    hasAmount,
+    isTradingSuspended,
+    quote,
+    quoteFetching,
+    selectedTokenInSymbol,
+    selectedTokenOutSymbol,
+    waitingForQuotePairStore,
+  ]);
+
+  const isWaitingForQuote =
+    tokenPairKey !== null && waitingForQuotePair === tokenPairKey;
+  const isButtonLoading = useMemo(
+    () =>
+      !isTradingSuspended &&
+      !isQuoteError &&
+      (quoteFetching || isWaitingForQuote) &&
+      hasAmount &&
+      !!selectedTokenInSymbol &&
+      !!selectedTokenOutSymbol,
+    [
+      quoteFetching,
+      isWaitingForQuote,
+      hasAmount,
+      selectedTokenInSymbol,
+      selectedTokenOutSymbol,
+      isTradingSuspended,
+      isQuoteError,
+    ],
+  );
+  const sellUSDValue = useMemo(
+    () => (tokenInSymbol === "USDm" ? amount || "0" : fromTokenUSDValue || "0"),
+    [tokenInSymbol, amount, fromTokenUSDValue],
+  );
+  const buyUSDValue = useMemo(
+    () =>
+      tokenOutSymbol === "USDm" ? formQuote || "0" : toTokenUSDValue || "0",
+    [tokenOutSymbol, formQuote, toTokenUSDValue],
+  );
+  const amountInWei = useMemo(() => {
+    if (!selectedTokenInSymbol) return "0";
+    const parsedAmount = parseAmount(amount);
+    if (!parsedAmount || !parsedAmount.gt(0)) return "0";
+    return toWei(
+      parsedAmount,
+      getTokenDecimals(selectedTokenInSymbol, chainId),
+    ).toFixed(0);
+  }, [amount, selectedTokenInSymbol, chainId]);
+
+  return {
+    amountInWei,
+    buyUSDValue,
+    isButtonLoading,
+    isLoading,
+    sellUSDValue,
+    tradingLimitError,
+  };
+}


### PR DESCRIPTION
## The Problem

Quote-derived loading, trading-limit feedback, suspension toasts, waiting-for-quote state, USD values, and wei conversion still form a large inline block in `useSwapForm`.

## The Solution

Extract that block into `useSwapQuoteState` at the same hook position. Preserve toast transitions, local external-store behavior, loading precedence, USD fallbacks, and amount conversion, with focused hook characterization tests.

## Validation

- `pnpm exec turbo run test --filter app.mento.org`
- `pnpm --filter app.mento.org check-types`
- `trunk check --fix` on changed files
- Production app build

## Stack

5 of 6. Base: #495. Next: #497.

Part of #404; this PR intentionally does not close the issue.

## Ship Checklist

- [x] Waiting-for-quote and toast transition semantics preserved
- [x] Loading and USD-value precedence unchanged
- [x] No dependency changes
- [x] Existing public hook return shape preserved

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving refactor of swap form quote UX; no new dependencies and the hook API surface is unchanged, though regressions would affect trading limits, loading, and approval amounts.
> 
> **Overview**
> Moves quote-derived UI state out of **`useSwapForm`** into a new **`useSwapQuoteState`** hook, called in the same place in the form lifecycle so **`useSwapForm`’s public return shape stays the same**.
> 
> The new hook owns trading-limit checks and toasts, trading-suspension toast dismiss/replace behavior, the waiting-for-quote external store, quote/button loading flags, sell/buy USD fallbacks (including **USDm**), and **`amountInWei`** for approvals. **`use-swap-quote-state.test.tsx`** adds focused tests for those derivations and toast transitions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ad0a67e9e1b1f93ea610a71c9c25178293d2b1b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->