### PR TITLE
refactor(app): extract remaining swap form effects (6/6)

### DIFF
--- a/apps/app.mento.org/app/components/swap/swap-form/use-swap-form-effects.test.tsx
+++ b/apps/app.mento.org/app/components/swap/swap-form/use-swap-form-effects.test.tsx
@@ -1,0 +1,185 @@
+import type { TokenSymbol } from "@mento-protocol/mento-sdk";
+import { renderHook } from "@testing-library/react";
+import type { ChainId, SwapFormValues } from "@repo/web3";
+import type { FieldError, UseFormReturn } from "react-hook-form";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { LastChangedToken } from "./route-driven-state";
+import type { FormValues } from "./types";
+
+const web3Mocks = vi.hoisted(() => ({
+  formatWithMaxDecimals: vi.fn(),
+  useTradablePairs: vi.fn(),
+}));
+const toastMocks = vi.hoisted(() => ({ error: vi.fn() }));
+
+vi.mock("@repo/web3", () => web3Mocks);
+vi.mock("sonner", () => ({ toast: toastMocks }));
+
+import {
+  useSwapQuoteFormEffects,
+  useSwapTokenPairEffects,
+} from "./use-swap-form-effects";
+
+const chainId = 42220 as ChainId;
+const celo = "CELO" as TokenSymbol;
+const eurM = "EURm" as TokenSymbol;
+const gbpM = "GBPm" as TokenSymbol;
+const usdM = "USDm" as TokenSymbol;
+
+function createFormHarness() {
+  const reset = vi.fn();
+  const setValue = vi.fn();
+  const form = { reset, setValue } as unknown as UseFormReturn<FormValues>;
+  return { form, reset, setValue };
+}
+
+function createAmountError(message: string): FieldError {
+  return { message, type: "validate" };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  web3Mocks.formatWithMaxDecimals.mockImplementation(
+    (value) => `formatted:${value}`,
+  );
+  web3Mocks.useTradablePairs.mockReturnValue({
+    data: [],
+    isLoading: false,
+  });
+});
+
+describe("useSwapQuoteFormEffects", () => {
+  it("synchronizes formatted quotes and only toasts actionable amount errors", () => {
+    const { form, setValue } = createFormHarness();
+    const props = {
+      amount: "1",
+      amountError: createAmountError("Balance is too low"),
+      form,
+      formQuote: "",
+      hasAmount: true,
+      quote: "2.34567",
+    };
+    const { rerender } = renderHook(
+      (hookProps: Parameters<typeof useSwapQuoteFormEffects>[0]) =>
+        useSwapQuoteFormEffects(hookProps),
+      { initialProps: props },
+    );
+
+    expect(web3Mocks.formatWithMaxDecimals).toHaveBeenCalledWith(
+      "2.34567",
+      4,
+      false,
+    );
+    expect(setValue).toHaveBeenCalledWith("quote", "formatted:2.34567", {
+      shouldValidate: true,
+    });
+    expect(toastMocks.error).toHaveBeenCalledWith("Balance is too low");
+
+    setValue.mockClear();
+    toastMocks.error.mockClear();
+    rerender({
+      ...props,
+      amount: "2",
+      amountError: createAmountError("Invalid input"),
+      formQuote: "formatted:2.34567",
+    });
+    rerender({
+      ...props,
+      amount: "3",
+      amountError: createAmountError("Amount is required"),
+      formQuote: "formatted:2.34567",
+    });
+    rerender({
+      ...props,
+      amount: "4",
+      amountError: createAmountError("Balance is too low"),
+      formQuote: "formatted:2.34567",
+      hasAmount: false,
+    });
+
+    expect(setValue).not.toHaveBeenCalled();
+    expect(toastMocks.error).not.toHaveBeenCalled();
+  });
+});
+
+describe("useSwapTokenPairEffects", () => {
+  it("resets quote and amount after a successful swap while preserving form preferences", () => {
+    const { form, reset } = createFormHarness();
+    const setLastChangedToken = vi.fn();
+    const formValues: SwapFormValues = {
+      amount: "",
+      quote: "2.5",
+      slippage: "0.75",
+      tokenInSymbol: celo,
+      tokenOutSymbol: eurM,
+    };
+
+    renderHook(() =>
+      useSwapTokenPairEffects({
+        chainId,
+        form,
+        formValues,
+        lastChangedTokenRef: { current: null },
+        selectedTokenInSymbol: celo,
+        selectedTokenOutSymbol: eurM,
+        setLastChangedToken,
+      }),
+    );
+
+    expect(web3Mocks.useTradablePairs).toHaveBeenNthCalledWith(
+      1,
+      celo,
+      chainId,
+    );
+    expect(web3Mocks.useTradablePairs).toHaveBeenNthCalledWith(
+      2,
+      eurM,
+      chainId,
+    );
+    expect(setLastChangedToken).toHaveBeenCalledWith(null);
+    expect(reset).toHaveBeenCalledWith({
+      amount: "",
+      quote: "",
+      slippage: "0.75",
+      tokenInSymbol: celo,
+      tokenOutSymbol: eurM,
+    });
+  });
+
+  it.each([
+    ["from", "tokenOutSymbol"],
+    ["to", "tokenInSymbol"],
+  ] as const)(
+    "clears the opposite token when the last-changed %s token creates an invalid pair",
+    (lastChangedToken, fieldToClear) => {
+      web3Mocks.useTradablePairs.mockImplementation((symbol) => ({
+        data: symbol === celo ? [gbpM] : [eurM],
+        isLoading: false,
+      }));
+      const { form, reset, setValue } = createFormHarness();
+      const setLastChangedToken = vi.fn();
+      const lastChangedTokenRef = {
+        current: lastChangedToken as LastChangedToken,
+      };
+
+      renderHook(() =>
+        useSwapTokenPairEffects({
+          chainId,
+          form,
+          formValues: { amount: "1", slippage: "0.3" },
+          lastChangedTokenRef,
+          selectedTokenInSymbol: celo,
+          selectedTokenOutSymbol: usdM,
+          setLastChangedToken,
+        }),
+      );
+
+      expect(reset).not.toHaveBeenCalled();
+      expect(setValue).toHaveBeenCalledWith(fieldToClear, "", {
+        shouldValidate: false,
+      });
+      expect(setLastChangedToken).toHaveBeenCalledWith(null);
+    },
+  );
+});

--- a/apps/app.mento.org/app/components/swap/swap-form/use-swap-form-effects.ts
+++ b/apps/app.mento.org/app/components/swap/swap-form/use-swap-form-effects.ts
@@ -1,0 +1,130 @@
+import type { TokenSymbol } from "@mento-protocol/mento-sdk";
+import {
+  formatWithMaxDecimals,
+  type ChainId,
+  type SwapFormValues,
+  useTradablePairs,
+} from "@repo/web3";
+import { useEffect, type RefObject } from "react";
+import type { FieldError, UseFormReturn } from "react-hook-form";
+import { toast } from "sonner";
+
+import type { LastChangedToken } from "./route-driven-state";
+import type { FormValues } from "./types";
+
+export function useSwapQuoteFormEffects({
+  amount,
+  amountError,
+  form,
+  formQuote,
+  hasAmount,
+  quote,
+}: {
+  amount: string;
+  amountError?: FieldError;
+  form: UseFormReturn<FormValues>;
+  formQuote: string;
+  hasAmount: boolean;
+  quote?: string;
+}) {
+  useEffect(() => {
+    if (quote !== undefined) {
+      const formattedQuote = formatWithMaxDecimals(quote, 4, false);
+      if (formQuote !== formattedQuote) {
+        form.setValue("quote", formattedQuote, { shouldValidate: true });
+      }
+    }
+  }, [quote, form, formQuote]);
+
+  useEffect(() => {
+    if (
+      amountError?.message &&
+      amountError.message !== "Invalid input" &&
+      amountError.message !== "Amount is required" &&
+      hasAmount
+    ) {
+      toast.error(amountError.message);
+    }
+  }, [amountError, hasAmount, amount]);
+}
+
+export function useSwapTokenPairEffects({
+  chainId,
+  form,
+  formValues,
+  lastChangedTokenRef,
+  selectedTokenInSymbol,
+  selectedTokenOutSymbol,
+  setLastChangedToken,
+}: {
+  chainId: ChainId;
+  form: UseFormReturn<FormValues>;
+  formValues: SwapFormValues | null;
+  lastChangedTokenRef: RefObject<LastChangedToken>;
+  selectedTokenInSymbol?: TokenSymbol;
+  selectedTokenOutSymbol?: TokenSymbol;
+  setLastChangedToken: (value: LastChangedToken) => void;
+}) {
+  const {
+    data: fromTokenTradablePairs,
+    isLoading: isFromTokenTradablePairsLoading,
+  } = useTradablePairs(selectedTokenInSymbol, chainId);
+  const {
+    data: toTokenTradablePairs,
+    isLoading: isToTokenTradablePairsLoading,
+  } = useTradablePairs(selectedTokenOutSymbol, chainId);
+
+  // Reset form fields after a successful swap (formValues.amount is cleared but tokens preserved)
+  useEffect(() => {
+    if (!formValues?.amount && formValues?.tokenInSymbol) {
+      setLastChangedToken(null);
+      form.reset({
+        amount: "",
+        quote: "",
+        tokenInSymbol: formValues.tokenInSymbol,
+        tokenOutSymbol: formValues.tokenOutSymbol || "USDm",
+        slippage: formValues?.slippage || "0.3",
+      });
+    }
+  }, [
+    formValues?.amount,
+    formValues?.tokenInSymbol,
+    formValues?.tokenOutSymbol,
+    formValues?.slippage,
+    form,
+    setLastChangedToken,
+  ]);
+
+  useEffect(() => {
+    const lastChangedToken = lastChangedTokenRef.current;
+
+    if (!selectedTokenInSymbol || !selectedTokenOutSymbol || !lastChangedToken)
+      return;
+    if (isFromTokenTradablePairsLoading || isToTokenTradablePairsLoading)
+      return;
+    if (!fromTokenTradablePairs || !toTokenTradablePairs) return;
+
+    const isValidPair =
+      fromTokenTradablePairs.includes(selectedTokenOutSymbol) ||
+      toTokenTradablePairs.includes(selectedTokenInSymbol);
+
+    if (!isValidPair) {
+      if (lastChangedToken === "from") {
+        form.setValue("tokenOutSymbol", "", { shouldValidate: false });
+      } else if (lastChangedToken === "to") {
+        form.setValue("tokenInSymbol", "", { shouldValidate: false });
+      }
+      setLastChangedToken(null);
+    }
+  }, [
+    selectedTokenInSymbol,
+    selectedTokenOutSymbol,
+    fromTokenTradablePairs,
+    toTokenTradablePairs,
+    isFromTokenTradablePairsLoading,
+    isToTokenTradablePairsLoading,
+    form,
+    lastChangedTokenRef,
+    setLastChangedToken,
+  ]);
+}

--- a/apps/app.mento.org/app/components/swap/swap-form/use-swap-form.tsx
+++ b/apps/app.mento.org/app/components/swap/swap-form/use-swap-form.tsx
@@ -2,7 +2,7 @@
 
 import { env } from "@/env.mjs";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import { useForm, useWatch } from "react-hook-form";
 import { toast } from "sonner";
 
@@ -11,7 +11,6 @@ import {
   ChainId,
   chainIdToChain,
   confirmViewAtom,
-  formatWithMaxDecimals,
   formValuesAtom,
   getNativeTokenSymbol,
   getPreferredUsdQuoteTokenSymbol,
@@ -24,7 +23,6 @@ import {
   useOptimizedSwapQuote,
   useSwapAllowance,
   useTokenOptions,
-  useTradablePairs,
 } from "@repo/web3";
 import { useAccount, useChainId } from "@repo/web3/wagmi";
 import { useAtom } from "jotai";
@@ -43,6 +41,10 @@ import {
 } from "./swap-form-initial-state";
 import { getTokenBalanceValue } from "./swap-form-validation";
 import { defaultEmptyBalances, formSchema, type FormValues } from "./types";
+import {
+  useSwapQuoteFormEffects,
+  useSwapTokenPairEffects,
+} from "./use-swap-form-effects";
 import { useSwapFormValidation } from "./use-swap-form-validation";
 import { useSwapQuoteState } from "./use-swap-quote-state";
 import { useSwapFormSync } from "./use-swap-form-sync";
@@ -330,25 +332,14 @@ export function useSwapForm(opts?: SwapFormRouteOptions) {
     },
   });
 
-  useEffect(() => {
-    if (quote !== undefined) {
-      const formattedQuote = formatWithMaxDecimals(quote, 4, false);
-      if (formQuote !== formattedQuote) {
-        form.setValue("quote", formattedQuote, { shouldValidate: true });
-      }
-    }
-  }, [quote, form, formQuote]);
-
-  useEffect(() => {
-    if (
-      errors.amount?.message &&
-      errors.amount.message !== "Invalid input" &&
-      errors.amount.message !== "Amount is required" &&
-      hasAmount
-    ) {
-      toast.error(errors.amount.message);
-    }
-  }, [errors.amount, hasAmount, amount]);
+  useSwapQuoteFormEffects({
+    amount,
+    amountError: errors.amount,
+    form,
+    formQuote,
+    hasAmount,
+    quote,
+  });
 
   // ── Submit ──────────────────────────────────────────────────────────
 
@@ -393,67 +384,15 @@ export function useSwapForm(opts?: SwapFormRouteOptions) {
 
   // ── Token pair validation ───────────────────────────────────────────
 
-  const {
-    data: fromTokenTradablePairs,
-    isLoading: isFromTokenTradablePairsLoading,
-  } = useTradablePairs(selectedTokenInSymbol, formChainId);
-  const {
-    data: toTokenTradablePairs,
-    isLoading: isToTokenTradablePairsLoading,
-  } = useTradablePairs(selectedTokenOutSymbol, formChainId);
-
-  // Reset form fields after a successful swap (formValues.amount is cleared but tokens preserved)
-  useEffect(() => {
-    if (!formValues?.amount && formValues?.tokenInSymbol) {
-      setLastChangedToken(null);
-      form.reset({
-        amount: "",
-        quote: "",
-        tokenInSymbol: formValues.tokenInSymbol,
-        tokenOutSymbol: formValues.tokenOutSymbol || "USDm",
-        slippage: formValues?.slippage || "0.3",
-      });
-    }
-  }, [
-    formValues?.amount,
-    formValues?.tokenInSymbol,
-    formValues?.tokenOutSymbol,
-    formValues?.slippage,
+  useSwapTokenPairEffects({
+    chainId: formChainId,
     form,
-    setLastChangedToken,
-  ]);
-
-  useEffect(() => {
-    const lastChangedToken = lastChangedTokenRef.current;
-
-    if (!selectedTokenInSymbol || !selectedTokenOutSymbol || !lastChangedToken)
-      return;
-    if (isFromTokenTradablePairsLoading || isToTokenTradablePairsLoading)
-      return;
-    if (!fromTokenTradablePairs || !toTokenTradablePairs) return;
-
-    const isValidPair =
-      fromTokenTradablePairs.includes(selectedTokenOutSymbol) ||
-      toTokenTradablePairs.includes(selectedTokenInSymbol);
-
-    if (!isValidPair) {
-      if (lastChangedToken === "from") {
-        form.setValue("tokenOutSymbol", "", { shouldValidate: false });
-      } else if (lastChangedToken === "to") {
-        form.setValue("tokenInSymbol", "", { shouldValidate: false });
-      }
-      setLastChangedToken(null);
-    }
-  }, [
+    formValues,
+    lastChangedTokenRef,
     selectedTokenInSymbol,
     selectedTokenOutSymbol,
-    fromTokenTradablePairs,
-    toTokenTradablePairs,
-    isFromTokenTradablePairsLoading,
-    isToTokenTradablePairsLoading,
-    form,
     setLastChangedToken,
-  ]);
+  });
 
   // ── Return ──────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## The Problem

The last inline quote/form and post-swap token-pair effects keep `useSwapForm` above the issue's 500-line target.

## The Solution

Extract those effects into `use-swap-form-effects.ts` at their original call sites. The parent hook is now 461 lines (down from 911 on `origin/main`), while its return block remains byte-for-byte identical. Approval and submit logic remain in place and unchanged.

## Validation

- App tests: 29 files, 173 tests passed
- Workspace typecheck: 8 tasks passed
- Production `app.mento.org` build passed
- Trunk checks passed on every changed file
- Playwright disconnected visual suite: 20/20 passed on desktop and mobile; `ARGOS_TOKEN` was absent, so screenshots were not uploaded or compared
- Fresh-context semantic autoreview plus deterministic guardrail

Browser verification on the six-PR stack tip with the linked `app.mento.org` Vercel development environment:

- Default `/swap/celo` preserved USDm → GBPm, an editable Sell field, disabled Buy field, and disconnected Connect state.
- Entering `1` updated the USD value to `~$1` and retained the disabled output state while disconnected.
- Reversing the pair preserved the amount and synchronized the route to `?from=GBPm&to=USDm&amount=1`; the live quote resolved to `1.3308` USDm with the displayed rate.
- An invalid same-token route (`USDm` → `USDm`) self-corrected to USDm → GBPm and cleared the invalid amount.
- Selecting EURm updated both the buy asset and route; browser back restored the prior GBPm → USDm amount and quote.
- Console remained free of errors throughout.

## Stack

6 of 6. Base: #496.

Part of #404; this PR intentionally does not close the issue.

## Ship Checklist

- [x] `use-swap-form.tsx` is below 500 lines
- [x] Return block is byte-for-byte unchanged
- [x] Effect ordering and state precedence preserved
- [x] No dependency changes
- [x] Submit and approval flow unchanged

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical refactor with behavior-preserving effect moves and new unit tests; no changes to submit, approval, or swap execution paths.
> 
> **Overview**
> Finishes shrinking **`useSwapForm`** by moving the last inline `useEffect` blocks into **`use-swap-form-effects.ts`**, wired at the same points in the parent hook so effect order stays the same.
> 
> **`useSwapQuoteFormEffects`** keeps quote display in sync via `formatWithMaxDecimals` and shows **sonner** toasts for actionable amount errors (skipping “Invalid input”, “Amount is required”, and empty-amount cases). **`useSwapTokenPairEffects`** owns tradable-pair lookups, the post-swap form reset when `formValues.amount` is cleared, and clearing the opposite token when the user picks an invalid pair.
> 
> **`use-swap-form.tsx`** drops the duplicated logic and unused imports; submit, approval, and the public return shape are unchanged. New Vitest coverage exercises quote sync, toast filtering, post-swap reset, and invalid-pair cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d32f1cbe5aa6e7e4488fe781b59639f3c9ff9ef6. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->