### PR TITLE
ci(e2e): deep-history archive probe + fail-fast seed (first-nightly failure)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -307,6 +307,16 @@ jobs:
           # repeatedly with varied params across the account methods anvil
           # actually issues, and require every request to pass.
           block_hex=$(printf '0x%x' "$FORK_BLOCK")
+          # A fresh (nightly) FORK_BLOCK sits only ~64 blocks behind head, so
+          # a NON-archive node passes every probe at it — and then, at one
+          # Celo block per second, the fork block slides out of that node's
+          # retention window minutes into the run. Exactly this killed the
+          # first nightly (run 29311411018): publicnode answered 15/15 probes,
+          # then started returning 403 "Archive requests require a personal
+          # token" mid-seed and anvil panicked. Only true archive nodes can
+          # also answer ~28h (100k blocks) below the fork block, so require
+          # that as well.
+          deep_hex=$(printf '0x%x' $((FORK_BLOCK - 100000)))
           candidates=(
             https://celo-rpc.publicnode.com
             https://celo.api.onfinality.io/public
@@ -327,12 +337,13 @@ jobs:
               call "$url" eth_getBalance '["0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266","'"$block_hex"'"]' || return 1
               call "$url" eth_getTransactionCount '["0x70997970C51812dc3A010C7d01b50e0d17dc79C8","'"$block_hex"'"]' || return 1
               call "$url" eth_getStorageAt '["0x765DE816845861e75A25fCA122bb6898B8B1282a","0x'"$i"'","'"$block_hex"'"]' || return 1
+              call "$url" eth_getBalance '["0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266","'"$deep_hex"'"]' || return 1
             done
           }
           for url in "${candidates[@]}"; do
             if probe "$url"; then
               echo "FORK_URL=$url" >> "$GITHUB_ENV"
-              echo "Selected $url (15/15 archive-state probes at block $FORK_BLOCK passed)"
+              echo "Selected $url (20/20 archive-state probes passed at block $FORK_BLOCK and 100k below)"
               exit 0
             fi
             echo "$url failed an archive-state probe at block $FORK_BLOCK - skipping"
@@ -600,6 +611,16 @@ jobs:
           # repeatedly with varied params across the account methods anvil
           # actually issues, and require every request to pass.
           block_hex=$(printf '0x%x' "$FORK_BLOCK")
+          # A fresh (nightly) FORK_BLOCK sits only ~64 blocks behind head, so
+          # a NON-archive node passes every probe at it — and then, at one
+          # Celo block per second, the fork block slides out of that node's
+          # retention window minutes into the run. Exactly this killed the
+          # first nightly (run 29311411018): publicnode answered 15/15 probes,
+          # then started returning 403 "Archive requests require a personal
+          # token" mid-seed and anvil panicked. Only true archive nodes can
+          # also answer ~28h (100k blocks) below the fork block, so require
+          # that as well.
+          deep_hex=$(printf '0x%x' $((FORK_BLOCK - 100000)))
           candidates=(
             https://celo-rpc.publicnode.com
             https://celo.api.onfinality.io/public
@@ -620,12 +641,13 @@ jobs:
               call "$url" eth_getBalance '["0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266","'"$block_hex"'"]' || return 1
               call "$url" eth_getTransactionCount '["0x70997970C51812dc3A010C7d01b50e0d17dc79C8","'"$block_hex"'"]' || return 1
               call "$url" eth_getStorageAt '["0x765DE816845861e75A25fCA122bb6898B8B1282a","0x'"$i"'","'"$block_hex"'"]' || return 1
+              call "$url" eth_getBalance '["0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266","'"$deep_hex"'"]' || return 1
             done
           }
           for url in "${candidates[@]}"; do
             if probe "$url"; then
               echo "FORK_URL=$url" >> "$GITHUB_ENV"
-              echo "Selected $url (15/15 archive-state probes at block $FORK_BLOCK passed)"
+              echo "Selected $url (20/20 archive-state probes passed at block $FORK_BLOCK and 100k below)"
               exit 0
             fi
             echo "$url failed an archive-state probe at block $FORK_BLOCK - skipping"

--- a/scripts/fork-seed.mjs
+++ b/scripts/fork-seed.mjs
@@ -243,16 +243,38 @@ export function decodeAddressArray(data) {
 
 let requestId = 0;
 
+// Armed by assertMainnetFork() once anvil has answered. Before that, a
+// connection failure falls through to the preflight's friendlier "start the
+// fork first" handling; after it, losing the connection mid-seed means anvil
+// crashed (e.g. run 29311411018: a mid-run upstream-RPC 403 panicked anvil),
+// and every remaining step would fail the same way — so abort immediately
+// instead of drowning the real error in per-item warnings and exiting 0.
+let anvilConfirmedReachable = false;
+
 /**
  * @param {string} method
  * @param {unknown[]} [params]
  */
 async function rpc(method, params = []) {
-  const response = await fetch(RPC_URL, {
-    method: "POST",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify({ jsonrpc: "2.0", id: ++requestId, method, params }),
-  });
+  /** @type {Response} */
+  let response;
+  try {
+    response = await fetch(RPC_URL, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ jsonrpc: "2.0", id: ++requestId, method, params }),
+    });
+  } catch (/** @type {unknown} */ error) {
+    if (anvilConfirmedReachable) {
+      const message = error instanceof Error ? error.message : String(error);
+      fail(
+        `Lost connection to anvil at ${RPC_URL} mid-seed (${method}: ${message}).`,
+      );
+      fail("The fork process has likely crashed — check its log for a panic.");
+      process.exit(1);
+    }
+    throw error;
+  }
   const json = await response.json();
   if (json.error) throw new Error(`${method}: ${json.error.message}`);
   return json.result;
@@ -369,6 +391,7 @@ async function assertMainnetFork() {
     process.exit(1);
   }
   ok(`Connected to Celo mainnet fork at ${RPC_URL}`);
+  anvilConfirmedReachable = true;
 }
 
 /**


### PR DESCRIPTION
## What

The first-ever nightly e2e run ([29311411018](https://github.com/mento-protocol/frontend-monorepo/actions/runs/29311411018), 2026-07-14 06:27 UTC) failed. This fixes both the root cause and the misleading failure mode.

## Root cause

The nightly forks at a **freshly resolved head−64 block** — which is *recent* state, servable by non-archive nodes. `celo-rpc.publicnode.com` therefore passed all 15 archive probes at that block. But Celo mints a block per second: minutes into the run, the fork block slid out of publicnode's free retention window, the upstream began returning **403 "Archive requests require a personal token"**, and anvil **panicked** (`do_mine_block` unwrap on the storage fetch — a foundry bug that it panics rather than errors; from `anvil.log` in the run artifact):

```
Message: pre-execution changes failed: Internal(Other(Database(GetStorage(0x0000f908..., 4388,
HTTP error 403 with body: {"error":{"message":"Archive requests require a personal token..."}}
Location: crates/anvil/src/eth/backend/mem/mod.rs:1324
```

PR runs never hit this: the pinned block is old enough that non-archive nodes already fail the probe at selection time. The probe's blind spot is exclusive to the nightly's fresh block.

The failure then surfaced in the worst possible place: the crashed anvil made `fork-seed.mjs` print 30+ per-feed `⚠ fetch failed` warnings and **exit 0**, so the job only died two steps later at the re-seed with "anvil is no longer reachable" — no pointer to the panic.

## Fixes

1. **Deep-history probe** (both fork jobs): each candidate must now also answer `eth_getBalance` at `FORK_BLOCK − 100000` (~28h of 1-second blocks) in every probe round — 20/20 total. Only true archive nodes pass, so retention-window nodes are filtered out before anvil forks through them. No behavior change for PR runs beyond 5 extra probe calls (a node serving the pinned block serves 100k below it too).
2. **Fail-fast seed**: `fork-seed.mjs` now aborts with exit 1 the moment a JSON-RPC call fails at the connection layer *after* the preflight confirmed anvil was up ("Lost connection to anvil … the fork process has likely crashed — check its log for a panic"). The preflight's friendly "start the fork first" path is unchanged, as is the skip-with-warning policy for per-feed/whale data issues.

## Verification

- `node scripts/fork-seed.test.mjs` — 15/15 pass (encoders untouched)
- YAML parses; `trunk check` clean on both files
- This PR touches `e2e.yml` + `fork-seed.mjs`, so both fork jobs run at the pinned block — proving the hardened probe still selects a working RPC on the PR path
- The nightly path itself can only be proven by the next scheduled run (~04:20 UTC); if it selects a different RPC and goes green, the #487 nightly streak starts counting from there

Relates to #487 (the required-check promotion criterion needs 7 consecutive green nightlies — this failure was documented there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YMrH8V7c3btnC1LZQXcN4b

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI probe and seed-script error handling only; no production app or auth paths. Slight extra RPC load during fork selection on PR runs.
> 
> **Overview**
> Hardens **nightly E2E** fork RPC selection and makes **fork seeding** fail loudly when anvil dies mid-run.
> 
> In **both** `e2e-connected` and `e2e-governance` jobs, the **Select fork RPC** step now requires each candidate to pass **20/20** probes (was 15/15): every probe round adds `eth_getBalance` at **`FORK_BLOCK − 100000`** so pruned/free-tier endpoints that only serve recent state cannot be chosen when the nightly fork block is ~64 blocks behind head.
> 
> **`fork-seed.mjs`** sets `anvilConfirmedReachable` after the mainnet preflight; if a later JSON-RPC `fetch` fails at the connection layer, it **exits 1** with a message to check anvil’s log instead of emitting many per-feed warnings and exiting 0. Preflight “start the fork first” behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7057261479353aebe87c8bc5cf830b2ffb50a4f5. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->