### PR TITLE
ci: enforce immutable GitHub Action pins

### DIFF
--- a/.github/workflows/action-pins-source.yml
+++ b/.github/workflows/action-pins-source.yml
@@ -35,6 +35,6 @@ jobs:
       - name: Install proposed policy dependencies
         run: pnpm install --frozen-lockfile --ignore-scripts --filter .
       - name: Test proposed action-pin policy
-        run: node scripts/check-github-action-pins.test.mjs
+        run: pnpm ci:action-pins:test
       - name: Scan proposed action pins
         run: node scripts/check-github-action-pins.mjs

--- a/.github/workflows/action-pins-source.yml
+++ b/.github/workflows/action-pins-source.yml
@@ -1,0 +1,40 @@
+name: GitHub Actions Policy Source
+
+# Validate proposed checker changes from the pull request itself. This job is
+# deliberately separate from the trusted pull_request_target enforcement job:
+# it receives no secrets and cannot report the required Action Pin Policy name.
+on:
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  policy-source:
+    name: Action Pin Policy Source
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Check out proposed policy
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - name: Setup PNPM
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v4
+        with:
+          version: 10.24.0
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+      - name: Install proposed policy dependencies
+        run: pnpm install --frozen-lockfile --ignore-scripts --filter .
+      - name: Test proposed action-pin policy
+        run: node scripts/check-github-action-pins.test.mjs
+      - name: Scan proposed action pins
+        run: node scripts/check-github-action-pins.mjs

--- a/.github/workflows/action-pins.yml
+++ b/.github/workflows/action-pins.yml
@@ -1,0 +1,31 @@
+name: GitHub Actions Policy
+
+# This workflow intentionally has no path filter: once `Action Pin Policy` is
+# required, every PR must report the context instead of being left pending.
+on:
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  action-pins:
+    name: Action Pin Policy
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Check out code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+      - name: Test action-pin policy
+        run: node scripts/check-github-action-pins.test.mjs
+      - name: Enforce immutable action pins
+        run: node scripts/check-github-action-pins.mjs

--- a/.github/workflows/action-pins.yml
+++ b/.github/workflows/action-pins.yml
@@ -34,11 +34,23 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           path: pr-head
           persist-credentials: false
+          # checkout v7 requires this for fork heads. Safe here because PR files
+          # are input to the trusted-base checker and are never executed.
+          allow-unsafe-pr-checkout: true
+      - name: Setup PNPM
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v4
+        with:
+          version: 10.24.0
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
+      - name: Install trusted policy dependencies
+        working-directory: trusted-base
+        run: pnpm install --frozen-lockfile --ignore-scripts --filter .
       - name: Test action-pin policy
+        # Proposed policy changes run separately in the credential-free
+        # pull_request workflow defined by action-pins-source.yml.
         working-directory: trusted-base
         run: node scripts/check-github-action-pins.test.mjs
       - name: Enforce immutable action pins

--- a/.github/workflows/action-pins.yml
+++ b/.github/workflows/action-pins.yml
@@ -9,7 +9,7 @@ on:
     branches: [main]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/action-pins.yml
+++ b/.github/workflows/action-pins.yml
@@ -3,7 +3,9 @@ name: GitHub Actions Policy
 # This workflow intentionally has no path filter: once `Action Pin Policy` is
 # required, every PR must report the context instead of being left pending.
 on:
-  pull_request:
+  # Run the workflow definition from the trusted base branch. The job never
+  # executes code from the pull request; it only scans its YAML files.
+  pull_request_target:
     branches: [main]
 
 concurrency:
@@ -19,13 +21,28 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - name: Check out code
+      - name: Check out trusted policy
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          path: trusted-base
+          persist-credentials: false
+      - name: Check out pull request
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.sha }}
+          path: pr-head
+          persist-credentials: false
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
       - name: Test action-pin policy
+        working-directory: trusted-base
         run: node scripts/check-github-action-pins.test.mjs
       - name: Enforce immutable action pins
+        working-directory: trusted-base
+        env:
+          GITHUB_ACTION_PINS_ROOT: ${{ github.workspace }}/pr-head
         run: node scripts/check-github-action-pins.mjs

--- a/.github/workflows/action-pins.yml
+++ b/.github/workflows/action-pins.yml
@@ -4,7 +4,8 @@ name: GitHub Actions Policy
 # required, every PR must report the context instead of being left pending.
 on:
   # Run the workflow definition from the trusted base branch. The job never
-  # executes code from the pull request; it only scans its YAML files.
+  # executes or checks out code from the pull request. Trusted code fetches
+  # only the exact head commit's Actions YAML through GitHub's Git API.
   pull_request_target:
     branches: [main]
 
@@ -27,16 +28,6 @@ jobs:
           ref: ${{ github.event.pull_request.base.sha }}
           path: trusted-base
           persist-credentials: false
-      - name: Check out pull request
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-          ref: ${{ github.event.pull_request.head.sha }}
-          path: pr-head
-          persist-credentials: false
-          # checkout v7 requires this for fork heads. Safe here because PR files
-          # are input to the trusted-base checker and are never executed.
-          allow-unsafe-pr-checkout: true
       - name: Setup PNPM
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v4
         with:
@@ -52,9 +43,17 @@ jobs:
         # Proposed policy changes run separately in the credential-free
         # pull_request workflow defined by action-pins-source.yml.
         working-directory: trusted-base
-        run: node scripts/check-github-action-pins.test.mjs
+        run: pnpm ci:action-pins:test
+      - name: Fetch pull request Actions YAML
+        working-directory: trusted-base
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          PR_HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          ACTION_PIN_OUTPUT_DIR: ${{ runner.temp }}/action-pin-pr-head
+        run: node scripts/fetch-action-pin-yaml.mjs
       - name: Enforce immutable action pins
         working-directory: trusted-base
         env:
-          GITHUB_ACTION_PINS_ROOT: ${{ github.workspace }}/pr-head
+          GITHUB_ACTION_PINS_ROOT: ${{ runner.temp }}/action-pin-pr-head
         run: node scripts/check-github-action-pins.mjs

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -14,22 +14,27 @@ permissions: read-all
 
 jobs:
   claude-review:
-    # Review human PRs (as before) AND Dependabot PRs — EXCEPT the
+    # Review same-repository human PRs AND Dependabot PRs — EXCEPT the
     # github-actions tier. That tier is auto-merged (see
     # dependabot-auto-merge.yml), and `gh pr merge --auto` waits only on the
     # required checks, so this advisory review would land on an
     # already-merged PR — decorative cost/noise. The npm tiers stay manual,
-    # so AI review there gives a human something to read before merging.
+    # so AI review there gives a human something to read before merging. Fork
+    # PRs cannot access the required OAuth secret and are skipped explicitly.
     #
     # REQUIRES `CLAUDE_CODE_OAUTH_TOKEN` in the *Dependabot* secrets store
     # (Settings → Secrets and variables → Dependabot): Dependabot-triggered
     # runs do NOT receive Actions secrets, so without it the action runs with
     # an empty token and fails.
     if: >-
-      github.event.pull_request.user.login != 'dependabot[bot]'
-      || !startsWith(github.head_ref, 'dependabot/github_actions/')
+      github.event.pull_request.head.repo.full_name == github.repository
+      && (
+        github.event.pull_request.user.login != 'dependabot[bot]'
+        || !startsWith(github.head_ref, 'dependabot/github_actions/')
+      )
 
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       contents: read
       pull-requests: read
@@ -38,13 +43,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 1
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@v1.0.166
+        uses: anthropics/claude-code-action@f87768c6d25f92ae6efa7175e223ef77d4cbf97f # v1.0.166
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: https://github.com/anthropics/claude-code.git

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -14,8 +14,8 @@ permissions: read-all
 
 jobs:
   claude:
-    # Only trusted repository members may turn a comment, review, or issue into
-    # an authenticated Claude invocation.
+    # Only trusted repository members may invoke Claude directly. An assignment
+    # by a maintainer is also a trusted activation for an existing issue.
     if: |
       (
         github.event_name == 'issue_comment' &&
@@ -35,7 +35,10 @@ jobs:
       (
         github.event_name == 'issues' &&
         (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) &&
-        contains(fromJSON('["OWNER","MEMBER"]'), github.event.issue.author_association)
+        (
+          github.event.action == 'assigned' ||
+          contains(fromJSON('["OWNER","MEMBER"]'), github.event.issue.author_association)
+        )
       )
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -14,12 +14,31 @@ permissions: read-all
 
 jobs:
   claude:
+    # Only trusted repository members may turn a comment, review, or issue into
+    # an authenticated Claude invocation.
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      (
+        github.event_name == 'issue_comment' &&
+        contains(github.event.comment.body, '@claude') &&
+        contains(fromJSON('["OWNER","MEMBER"]'), github.event.comment.author_association)
+      ) ||
+      (
+        github.event_name == 'pull_request_review_comment' &&
+        contains(github.event.comment.body, '@claude') &&
+        contains(fromJSON('["OWNER","MEMBER"]'), github.event.comment.author_association)
+      ) ||
+      (
+        github.event_name == 'pull_request_review' &&
+        contains(github.event.review.body, '@claude') &&
+        contains(fromJSON('["OWNER","MEMBER"]'), github.event.review.author_association)
+      ) ||
+      (
+        github.event_name == 'issues' &&
+        (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) &&
+        contains(fromJSON('["OWNER","MEMBER"]'), github.event.issue.author_association)
+      )
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read
       pull-requests: read
@@ -28,13 +47,13 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 1
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1.0.166
+        uses: anthropics/claude-code-action@f87768c6d25f92ae6efa7175e223ef77d4cbf97f # v1.0.166
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,7 @@ pnpm exec turbo run dev --filter <app-name>    # Dev server for one app (use pac
 pnpm build                           # Build all
 pnpm exec turbo run build --filter <app-name>  # Build one app
 pnpm check-types                     # TypeScript type checking; builds workspace package types first
+pnpm ci:action-pins                  # Verify third-party GitHub Actions use documented SHA pins
 trunk check --fix                     # Lint with autofix
 trunk fmt                             # Format
 pnpm test                            # Run tests

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,7 @@ pnpm build                           # Build all
 pnpm exec turbo run build --filter <app-name>  # Build one app
 pnpm check-types                     # TypeScript type checking; builds workspace package types first
 pnpm ci:action-pins                  # Verify third-party GitHub Actions use documented SHA pins
+pnpm ci:action-pins:test             # Test the action-pin scanner and REST materializer
 trunk check --fix                     # Lint with autofix
 trunk fmt                             # Format
 pnpm test                            # Run tests

--- a/README.md
+++ b/README.md
@@ -125,12 +125,17 @@ pnpm format:check
 
 # Verify every third-party GitHub Action uses an immutable SHA + version comment
 pnpm ci:action-pins
+
+# Run the action-pin scanner and REST materializer fixture suites
+pnpm ci:action-pins:test
 ```
 
 Two always-run checks protect the policy on every pull request:
-`GitHub Actions Policy` runs the trusted base-branch checker against the PR,
-while `GitHub Actions Policy Source` runs the proposed checker and fixtures in
-a credential-free `pull_request` workflow. After these workflows merge, branch
+`GitHub Actions Policy` runs the trusted base-branch checker against only the
+PR head's Actions YAML, fetched as inert blobs from its exact commit through the
+GitHub Git API. It never checks out or executes pull-request files. `GitHub
+Actions Policy Source` runs the proposed checker, REST materializer, and fixtures
+in a credential-free `pull_request` workflow. After these workflows merge, branch
 protection must require both `Action Pin Policy` and `Action Pin Policy Source`
 so neither trusted enforcement nor proposed-policy validation can be skipped.
 Because the source lane necessarily runs pull-request-controlled policy code,

--- a/README.md
+++ b/README.md
@@ -127,10 +127,23 @@ pnpm format:check
 pnpm ci:action-pins
 ```
 
-The always-run `GitHub Actions Policy` workflow executes the policy's fixture
-tests and the repository scan on every pull request. When adding or updating a
-third-party action, pin its full 40-character commit SHA and retain the release
-tag as an inline comment (for example, `uses: org/action@<sha> # v1.2.3`).
+Two always-run checks protect the policy on every pull request:
+`GitHub Actions Policy` runs the trusted base-branch checker against the PR,
+while `GitHub Actions Policy Source` runs the proposed checker and fixtures in
+a credential-free `pull_request` workflow. After these workflows merge, branch
+protection must require both `Action Pin Policy` and `Action Pin Policy Source`
+so neither trusted enforcement nor proposed-policy validation can be skipped.
+Because the source lane necessarily runs pull-request-controlled policy code,
+changes to either policy workflow, checker, or fixture suite must also require
+protected human/code-owner review or an organization required-workflow rule;
+the two status contexts alone are not a tamper-proof approval boundary.
+Canonical structure changes such as pnpm/Node versions, commands, or triggers
+intentionally require a protected two-PR transition: first teach the trusted
+checker to allow the transition while retaining the old workflow, then change
+the workflow and tighten the checker. Immutable action SHA bumps are normalized
+by the checker and can remain a single PR. When adding or updating a third-party
+action, pin its full 40-character commit SHA and retain the release tag as an
+inline comment (for example, `uses: org/action@<sha> # v1.2.3`).
 
 #### App-Specific Linting
 

--- a/README.md
+++ b/README.md
@@ -122,7 +122,15 @@ pnpm format
 
 # Check formatting without making changes
 pnpm format:check
+
+# Verify every third-party GitHub Action uses an immutable SHA + version comment
+pnpm ci:action-pins
 ```
+
+The always-run `GitHub Actions Policy` workflow executes the policy's fixture
+tests and the repository scan on every pull request. When adding or updating a
+third-party action, pin its full 40-character commit SHA and retain the release
+tag as an inline comment (for example, `uses: org/action@<sha> # v1.2.3`).
 
 #### App-Specific Linting
 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
     "blockexplorer:stop": "docker stop otterscan && docker rm otterscan",
     "build": "turbo run build",
     "check-types": "turbo run check-types",
+    "ci:action-pins": "node scripts/check-github-action-pins.mjs",
+    "ci:action-pins:test": "node scripts/check-github-action-pins.test.mjs",
     "clean": "rm -rf .turbo && turbo run clean",
     "dev": "turbo run dev",
     "dev:app.mento.org": "turbo run dev --filter=app.mento.org",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "turbo run build",
     "check-types": "turbo run check-types",
     "ci:action-pins": "node scripts/check-github-action-pins.mjs",
-    "ci:action-pins:test": "node scripts/check-github-action-pins.test.mjs",
+    "ci:action-pins:test": "node scripts/check-github-action-pins.test.mjs && node scripts/fetch-action-pin-yaml.test.mjs",
     "clean": "rm -rf .turbo && turbo run clean",
     "dev": "turbo run dev",
     "dev:app.mento.org": "turbo run dev --filter=app.mento.org",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "prettier-plugin-tailwindcss": "^0.8.0",
     "turbo": "^2.10.0",
     "typescript": "catalog:",
-    "typescript-eslint": "catalog:"
+    "typescript-eslint": "catalog:",
+    "yaml": "2.9.0"
   },
   "packageManager": "pnpm@10.24.0",
   "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -197,6 +197,9 @@ importers:
       typescript-eslint:
         specifier: 'catalog:'
         version: 8.53.1(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3)
+      yaml:
+        specifier: 2.9.0
+        version: 2.9.0
 
   apps/app.mento.org:
     dependencies:

--- a/scripts/check-github-action-pins.mjs
+++ b/scripts/check-github-action-pins.mjs
@@ -70,21 +70,138 @@ function normalizeUsesValue(raw) {
   return value;
 }
 
+/** @param {string} raw */
+function stripLeadingAnchor(raw) {
+  return raw.replace(/^(?:&[^\s[\]{},]+\s+)*/, "");
+}
+
+/** @param {string} raw @param {string} delimiter */
+function findTopLevelDelimiter(raw, delimiter) {
+  let quote = "";
+  let depth = 0;
+
+  for (let index = 0; index < raw.length; index++) {
+    const character = raw[index];
+
+    if (quote === '"') {
+      if (character === "\\") index++;
+      else if (character === '"') quote = "";
+      continue;
+    }
+
+    if (quote === "'") {
+      if (character === "'" && raw[index + 1] === "'") index++;
+      else if (character === "'") quote = "";
+      continue;
+    }
+
+    if (character === '"' || character === "'") {
+      quote = character;
+    } else if (character === "{" || character === "[") {
+      depth++;
+    } else if (character === "}" || character === "]") {
+      depth--;
+    } else if (character === delimiter && depth === 0) {
+      return index;
+    }
+  }
+
+  return -1;
+}
+
+/** @param {string} body */
+function splitFlowFields(body) {
+  const fields = [];
+  let rest = body;
+
+  while (rest.length > 0) {
+    const commaIndex = findTopLevelDelimiter(rest, ",");
+    if (commaIndex === -1) {
+      fields.push(rest);
+      break;
+    }
+
+    fields.push(rest.slice(0, commaIndex));
+    rest = rest.slice(commaIndex + 1);
+  }
+
+  return fields;
+}
+
 /** @param {string} line */
-function extractUsesRawValue(line) {
+function extractFlowMappingBody(line) {
+  let candidate = line.trim();
+  const sequencePrefix = candidate.match(/^-\s+/)?.[0];
+  if (!sequencePrefix) return null;
+
+  candidate = candidate.slice(sequencePrefix.length);
+  candidate = stripLeadingAnchor(candidate).trimStart();
+  if (!candidate.startsWith("{") || !candidate.endsWith("}")) return null;
+  return candidate.slice(1, -1);
+}
+
+/** @param {string} raw */
+function normalizeFlowKey(raw) {
+  let key = raw.trim();
+  if (/^\?\s+/.test(key)) key = key.replace(/^\?\s+/, "");
+  return stripLeadingAnchor(key);
+}
+
+/** @param {string} line */
+function extractUsesRawValues(line) {
   const plain = line.match(
-    /^\s*(?:-\s*)?(?:"uses"|'uses'|uses)\s*:\s*(.*?)\s*$/,
+    /^\s*(?:-\s+)?(?:&[^\s[\]{},]+\s+)*(?:"uses"|'uses'|uses)\s*:\s*(.*?)\s*$/,
   );
-  if (plain) return plain[1] ?? "";
+  if (plain) return [plain[1] ?? ""];
 
   const { value: lineWithoutComment, comment } = splitInlineComment(line);
-  const flow = lineWithoutComment.match(
-    /^\s*-\s*\{.*(?:"uses"|'uses'|uses)\s*:\s*([^,}]+).*}\s*$/,
-  );
-  if (!flow) return null;
+  const body = extractFlowMappingBody(lineWithoutComment);
+  if (body == null) return [];
 
-  const value = flow[1] ?? "";
-  return comment ? `${value} # ${comment}` : value;
+  return splitFlowFields(body).flatMap((field) => {
+    const colonIndex = findTopLevelDelimiter(field, ":");
+    if (colonIndex === -1) return [];
+
+    const key = normalizeFlowKey(field.slice(0, colonIndex));
+    if (key !== "uses" && key !== '"uses"' && key !== "'uses'") return [];
+
+    const value = field.slice(colonIndex + 1).trim();
+    return [comment ? `${value} # ${comment}` : value];
+  });
+}
+
+/** @param {string} line */
+function blockScalarState(line) {
+  const { value } = splitInlineComment(line);
+  const indicator = value.match(/:\s*([>|](?:[+-][1-9]?|[1-9][+-]?)?)\s*$/);
+  if (!indicator) return null;
+
+  const leadingIndent = value.match(/^\s*/)?.[0].length ?? 0;
+  const sequencePrefix = value.slice(leadingIndent).match(/^-\s+/)?.[0] ?? "";
+  const parentIndent = leadingIndent + sequencePrefix.length;
+  const explicitIndent = indicator[1]?.match(/[1-9]/)?.[0];
+
+  return {
+    parentIndent,
+    contentIndent: explicitIndent
+      ? parentIndent + Number(explicitIndent)
+      : null,
+  };
+}
+
+/**
+ * @param {string} line
+ * @param {{ parentIndent: number, contentIndent: number | null }} state
+ */
+function isBlockScalarContent(line, state) {
+  if (/^\s*(?:#.*)?$/.test(line)) return true;
+
+  const indent = line.match(/^\s*/)?.[0].length ?? 0;
+  if (state.contentIndent != null) return indent >= state.contentIndent;
+  if (indent <= state.parentIndent) return false;
+
+  state.contentIndent = indent;
+  return true;
 }
 
 /** @param {string} value */
@@ -135,29 +252,34 @@ const queuedFiles = new Set(files);
 for (let fileIndex = 0; fileIndex < files.length; fileIndex++) {
   const file = files[fileIndex];
   const lines = readFileSync(file, "utf8").split(/\r?\n/);
+  let blockScalar = null;
 
   lines.forEach((line, lineIndex) => {
-    const rawValue = extractUsesRawValue(line);
-    if (rawValue == null) return;
+    if (blockScalar && isBlockScalarContent(line, blockScalar)) return;
+    blockScalar = blockScalarState(line);
 
-    const value = normalizeUsesValue(rawValue);
-    if (isLocalAction(value)) {
-      for (const manifest of localActionManifestPaths(file, value)) {
-        if (!queuedFiles.has(manifest)) {
-          queuedFiles.add(manifest);
-          files.push(manifest);
+    for (const rawValue of extractUsesRawValues(line)) {
+      const value = normalizeUsesValue(rawValue);
+      if (isLocalAction(value)) {
+        for (const manifest of localActionManifestPaths(file, value)) {
+          if (!queuedFiles.has(manifest)) {
+            queuedFiles.add(manifest);
+            files.push(manifest);
+          }
         }
+        continue;
       }
-      return;
+
+      if (isPinnedExternalAction(value) && hasReleaseTagComment(rawValue)) {
+        continue;
+      }
+
+      failures.push({
+        file: relative(ROOT, file),
+        line: lineIndex + 1,
+        value,
+      });
     }
-
-    if (isPinnedExternalAction(value) && hasReleaseTagComment(rawValue)) return;
-
-    failures.push({
-      file: relative(ROOT, file),
-      line: lineIndex + 1,
-      value,
-    });
   });
 }
 

--- a/scripts/check-github-action-pins.mjs
+++ b/scripts/check-github-action-pins.mjs
@@ -5,24 +5,168 @@
  * followed recursively so actions outside `.github/actions` are covered too.
  */
 
-import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { lstatSync, readdirSync, readFileSync, realpathSync } from "node:fs";
 import { dirname, join, relative, resolve } from "node:path";
 import process from "node:process";
+import { isDeepStrictEqual } from "node:util";
+import {
+  LineCounter,
+  isAlias,
+  isMap,
+  isScalar,
+  isSeq,
+  parseDocument,
+} from "yaml";
 
 // Script-local fixture knob, not an input to the Turbo task graph.
 // eslint-disable-next-line turbo/no-undeclared-env-vars
 const ROOT = resolve(process.env["GITHUB_ACTION_PINS_ROOT"] ?? process.cwd());
+const REAL_ROOT = realpathSync(ROOT);
 const PINNED_REF = /^[0-9a-f]{40}$/i;
+const RELEASE_TAG = /^v\d+(?:[.\w-].*)?$/;
 const SCAN_DIRS = [".github/workflows", ".github/actions"];
+const REQUIRED_POLICY_FILES = [
+  ".github/workflows/action-pins.yml",
+  ".github/workflows/action-pins-source.yml",
+];
+const NORMALIZED_POLICY_WORKFLOWS = new Map([
+  [
+    ".github/workflows/action-pins.yml",
+    {
+      name: "GitHub Actions Policy",
+      on: { pull_request_target: { branches: ["main"] } },
+      concurrency: {
+        group: "${{ github.workflow }}-${{ github.event.pull_request.number }}",
+        "cancel-in-progress": true,
+      },
+      permissions: { contents: "read" },
+      jobs: {
+        "action-pins": {
+          name: "Action Pin Policy",
+          "runs-on": "ubuntu-latest",
+          "timeout-minutes": 5,
+          steps: [
+            {
+              name: "Check out trusted policy",
+              uses: "actions/checkout@<sha>",
+              with: {
+                ref: "${{ github.event.pull_request.base.sha }}",
+                path: "trusted-base",
+                "persist-credentials": false,
+              },
+            },
+            {
+              name: "Check out pull request",
+              uses: "actions/checkout@<sha>",
+              with: {
+                repository:
+                  "${{ github.event.pull_request.head.repo.full_name }}",
+                ref: "${{ github.event.pull_request.head.sha }}",
+                path: "pr-head",
+                "persist-credentials": false,
+                "allow-unsafe-pr-checkout": true,
+              },
+            },
+            {
+              name: "Setup PNPM",
+              uses: "pnpm/action-setup@<sha>",
+              with: { version: "10.24.0" },
+            },
+            {
+              name: "Set up Node.js",
+              uses: "actions/setup-node@<sha>",
+              with: { "node-version": 22 },
+            },
+            {
+              name: "Install trusted policy dependencies",
+              "working-directory": "trusted-base",
+              run: "pnpm install --frozen-lockfile --ignore-scripts --filter .",
+            },
+            {
+              name: "Test action-pin policy",
+              "working-directory": "trusted-base",
+              run: "node scripts/check-github-action-pins.test.mjs",
+            },
+            {
+              name: "Enforce immutable action pins",
+              "working-directory": "trusted-base",
+              env: {
+                GITHUB_ACTION_PINS_ROOT: "${{ github.workspace }}/pr-head",
+              },
+              run: "node scripts/check-github-action-pins.mjs",
+            },
+          ],
+        },
+      },
+    },
+  ],
+  [
+    ".github/workflows/action-pins-source.yml",
+    {
+      name: "GitHub Actions Policy Source",
+      on: { pull_request: { branches: ["main"] } },
+      concurrency: {
+        group: "${{ github.workflow }}-${{ github.event.pull_request.number }}",
+        "cancel-in-progress": true,
+      },
+      permissions: { contents: "read" },
+      jobs: {
+        "policy-source": {
+          name: "Action Pin Policy Source",
+          "runs-on": "ubuntu-latest",
+          "timeout-minutes": 5,
+          steps: [
+            {
+              name: "Check out proposed policy",
+              uses: "actions/checkout@<sha>",
+              with: { "persist-credentials": false },
+            },
+            {
+              name: "Setup PNPM",
+              uses: "pnpm/action-setup@<sha>",
+              with: { version: "10.24.0" },
+            },
+            {
+              name: "Set up Node.js",
+              uses: "actions/setup-node@<sha>",
+              with: { "node-version": 22 },
+            },
+            {
+              name: "Install proposed policy dependencies",
+              run: "pnpm install --frozen-lockfile --ignore-scripts --filter .",
+            },
+            {
+              name: "Test proposed action-pin policy",
+              run: "node scripts/check-github-action-pins.test.mjs",
+            },
+            {
+              name: "Scan proposed action pins",
+              run: "node scripts/check-github-action-pins.mjs",
+            },
+          ],
+        },
+      },
+    },
+  ],
+]);
 
 /** @param {string} path */
 function isYaml(path) {
   return path.endsWith(".yml") || path.endsWith(".yaml");
 }
 
+/** @param {string} path */
+function isRegularFile(path) {
+  try {
+    return lstatSync(path).isFile();
+  } catch {
+    return false;
+  }
+}
+
 /** @param {string} directory */
 function* walkYaml(directory) {
-  if (!existsSync(directory)) return;
+  if (!isDirectory(directory)) return;
 
   for (const entry of readdirSync(directory, { withFileTypes: true })) {
     const path = join(directory, entry.name);
@@ -31,6 +175,15 @@ function* walkYaml(directory) {
     } else if (entry.isFile() && isYaml(path)) {
       yield path;
     }
+  }
+}
+
+/** @param {string} path */
+function isDirectory(path) {
+  try {
+    return lstatSync(path).isDirectory();
+  } catch {
+    return false;
   }
 }
 
@@ -58,150 +211,210 @@ function splitInlineComment(raw) {
   return { value: raw.trim(), comment: "" };
 }
 
-/** @param {string} raw */
-function normalizeUsesValue(raw) {
-  const { value } = splitInlineComment(raw);
-  if (
-    (value.startsWith('"') && value.endsWith('"')) ||
-    (value.startsWith("'") && value.endsWith("'"))
-  ) {
-    return value.slice(1, -1).trim();
-  }
-  return value;
-}
+/** @param {unknown} node @param {import("yaml").Document} document */
+function resolveAliases(node, document) {
+  const aliases = new Set();
+  let resolved = node;
 
-/** @param {string} raw */
-function stripLeadingAnchor(raw) {
-  return raw.replace(/^(?:&[^\s[\]{},]+\s+)*/, "");
-}
-
-/** @param {string} raw @param {string} delimiter */
-function findTopLevelDelimiter(raw, delimiter) {
-  let quote = "";
-  let depth = 0;
-
-  for (let index = 0; index < raw.length; index++) {
-    const character = raw[index];
-
-    if (quote === '"') {
-      if (character === "\\") index++;
-      else if (character === '"') quote = "";
-      continue;
+  while (isAlias(resolved)) {
+    if (aliases.has(resolved)) throw new Error("cyclic YAML alias");
+    aliases.add(resolved);
+    const target = resolved.resolve(document);
+    if (target == null) {
+      throw new Error(`unresolved YAML alias \`*${resolved.source}\``);
     }
-
-    if (quote === "'") {
-      if (character === "'" && raw[index + 1] === "'") index++;
-      else if (character === "'") quote = "";
-      continue;
-    }
-
-    if (character === '"' || character === "'") {
-      quote = character;
-    } else if (character === "{" || character === "[") {
-      depth++;
-    } else if (character === "}" || character === "]") {
-      depth--;
-    } else if (character === delimiter && depth === 0) {
-      return index;
-    }
+    resolved = target;
   }
 
-  return -1;
+  return resolved;
 }
 
-/** @param {string} body */
-function splitFlowFields(body) {
-  const fields = [];
-  let rest = body;
-
-  while (rest.length > 0) {
-    const commaIndex = findTopLevelDelimiter(rest, ",");
-    if (commaIndex === -1) {
-      fields.push(rest);
-      break;
-    }
-
-    fields.push(rest.slice(0, commaIndex));
-    rest = rest.slice(commaIndex + 1);
-  }
-
-  return fields;
-}
-
-/** @param {string} line */
-function extractFlowMappingBody(line) {
-  let candidate = line.trim();
-  const sequencePrefix = candidate.match(/^-\s+/)?.[0];
-  if (!sequencePrefix) return null;
-
-  candidate = candidate.slice(sequencePrefix.length);
-  candidate = stripLeadingAnchor(candidate).trimStart();
-  if (!candidate.startsWith("{") || !candidate.endsWith("}")) return null;
-  return candidate.slice(1, -1);
-}
-
-/** @param {string} raw */
-function normalizeFlowKey(raw) {
-  let key = raw.trim();
-  if (/^\?\s+/.test(key)) key = key.replace(/^\?\s+/, "");
-  return stripLeadingAnchor(key);
-}
-
-/** @param {string} line */
-function extractUsesRawValues(line) {
-  const plain = line.match(
-    /^\s*(?:-\s+)?(?:&[^\s[\]{},]+\s+)*(?:"uses"|'uses'|uses)\s*:\s*(.*?)\s*$/,
-  );
-  if (plain) return [plain[1] ?? ""];
-
-  const { value: lineWithoutComment, comment } = splitInlineComment(line);
-  const body = extractFlowMappingBody(lineWithoutComment);
-  if (body == null) return [];
-
-  return splitFlowFields(body).flatMap((field) => {
-    const colonIndex = findTopLevelDelimiter(field, ":");
-    if (colonIndex === -1) return [];
-
-    const key = normalizeFlowKey(field.slice(0, colonIndex));
-    if (key !== "uses" && key !== '"uses"' && key !== "'uses'") return [];
-
-    const value = field.slice(colonIndex + 1).trim();
-    return [comment ? `${value} # ${comment}` : value];
-  });
-}
-
-/** @param {string} line */
-function blockScalarState(line) {
-  const { value } = splitInlineComment(line);
-  const indicator = value.match(/:\s*([>|](?:[+-][1-9]?|[1-9][+-]?)?)\s*$/);
-  if (!indicator) return null;
-
-  const leadingIndent = value.match(/^\s*/)?.[0].length ?? 0;
-  const sequencePrefix = value.slice(leadingIndent).match(/^-\s+/)?.[0] ?? "";
-  const parentIndent = leadingIndent + sequencePrefix.length;
-  const explicitIndent = indicator[1]?.match(/[1-9]/)?.[0];
-
-  return {
-    parentIndent,
-    contentIndent: explicitIndent
-      ? parentIndent + Number(explicitIndent)
-      : null,
-  };
+/** @param {unknown} node @param {import("yaml").Document} document */
+function scalarValue(node, document) {
+  const resolved = resolveAliases(node, document);
+  return isScalar(resolved) && typeof resolved.value === "string"
+    ? resolved.value
+    : null;
 }
 
 /**
- * @param {string} line
- * @param {{ parentIndent: number, contentIndent: number | null }} state
+ * Match mapping keys by their YAML value, including quoted, tagged, explicit,
+ * and alias keys. `YAMLMap#get()` intentionally does not resolve alias keys.
+ * @param {unknown} node
+ * @param {string} key
+ * @param {import("yaml").Document} document
  */
-function isBlockScalarContent(line, state) {
-  if (/^\s*(?:#.*)?$/.test(line)) return true;
+function findPair(node, key, document) {
+  const mapping = resolveAliases(node, document);
+  if (!isMap(mapping)) return null;
+  const matches = mapping.items.filter(
+    (pair) => scalarValue(pair.key, document) === key,
+  );
+  if (matches.length > 1) {
+    throw new Error(`duplicate semantic \`${key}\` keys`);
+  }
+  return matches[0] ?? null;
+}
 
-  const indent = line.match(/^\s*/)?.[0].length ?? 0;
-  if (state.contentIndent != null) return indent >= state.contentIndent;
-  if (indent <= state.parentIndent) return false;
+/**
+ * Reject duplicate semantic keys even when YAML aliases hide them from the
+ * parser's ordinary duplicate-key check. This also makes `toJS()` safe for
+ * trust-boundary comparisons below.
+ * @param {unknown} node
+ * @param {import("yaml").Document} document
+ * @param {WeakSet<object>} [visited]
+ */
+function assertUniqueSemanticMappings(node, document, visited = new WeakSet()) {
+  const resolved = resolveAliases(node, document);
+  if (!isMap(resolved) && !isSeq(resolved)) return;
+  if (visited.has(resolved)) return;
+  visited.add(resolved);
 
-  state.contentIndent = indent;
-  return true;
+  if (isSeq(resolved)) {
+    for (const item of resolved.items) {
+      assertUniqueSemanticMappings(item, document, visited);
+    }
+    return;
+  }
+
+  const keys = new Set();
+  for (const pair of resolved.items) {
+    const key = scalarValue(pair.key, document);
+    if (key == null) throw new Error("non-string YAML mapping key");
+    if (keys.has(key)) throw new Error(`duplicate semantic \`${key}\` keys`);
+    keys.add(key);
+    assertUniqueSemanticMappings(pair.value, document, visited);
+  }
+}
+
+/** @param {unknown} value */
+function normalizePolicyWorkflow(value) {
+  if (Array.isArray(value)) return value.map(normalizePolicyWorkflow);
+  if (value != null && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, nested]) => [
+        key,
+        normalizePolicyWorkflow(nested),
+      ]),
+    );
+  }
+  if (typeof value !== "string") return value;
+
+  for (const action of [
+    "actions/checkout",
+    "actions/setup-node",
+    "pnpm/action-setup",
+  ]) {
+    const prefix = `${action}@`;
+    if (
+      value.startsWith(prefix) &&
+      PINNED_REF.test(value.slice(prefix.length))
+    ) {
+      return `${prefix}<sha>`;
+    }
+  }
+
+  return value;
+}
+
+/**
+ * These workflows form the policy's trust boundary. The target workflow runs
+ * only base-branch code; the source workflow exercises proposed checker code
+ * without credentials. Validate their complete executable structure from the
+ * trusted checker so a PR cannot replace either required check with a no-op.
+ * Action SHAs are normalized; other canonical changes intentionally use the
+ * protected two-PR transition documented in README.md.
+ * @param {string} path
+ * @param {import("yaml").Document} document
+ */
+function assertPolicyWorkflowStructure(path, document) {
+  const expected = NORMALIZED_POLICY_WORKFLOWS.get(path);
+  if (!expected) return;
+
+  assertUniqueSemanticMappings(document.contents, document);
+  const actual = normalizePolicyWorkflow(document.toJS({ maxAliasCount: 100 }));
+  if (!isDeepStrictEqual(actual, expected)) {
+    throw new Error("does not match the trusted action-pin workflow structure");
+  }
+}
+
+/** @param {unknown} node @param {string} source */
+function sourceLine(node, source) {
+  const offset = Array.isArray(node?.range) ? node.range[0] : 0;
+  const start = source.lastIndexOf("\n", Math.max(0, offset - 1)) + 1;
+  const end = source.indexOf("\n", offset);
+  return source.slice(start, end === -1 ? source.length : end);
+}
+
+/** @param {unknown} node @param {string} source */
+function hasReleaseTagComment(node, source) {
+  return RELEASE_TAG.test(splitInlineComment(sourceLine(node, source)).comment);
+}
+
+/** @param {unknown} node @param {LineCounter} lineCounter */
+function lineNumber(node, lineCounter) {
+  const offset = Array.isArray(node?.range) ? node.range[0] : 0;
+  return lineCounter.linePos(offset).line;
+}
+
+/**
+ * Collect only executable `uses` fields: a reusable-workflow job's direct
+ * field or a direct item in a workflow/composite action's `steps` sequence.
+ * Nested inputs such as `with.uses` are ordinary data and are ignored.
+ * @param {unknown} root
+ * @param {import("yaml").Document} document
+ */
+function collectUses(root, document) {
+  const references = [];
+
+  /** @param {unknown} executable */
+  const addDirectUses = (executable) => {
+    const uses = findPair(executable, "uses", document);
+    if (!uses) return;
+
+    const reference = {
+      keyNode: uses.key,
+      valueNode: uses.value,
+      // If the executable mapping is itself an alias, the version comment
+      // belongs at that use site. Otherwise preserve the original value node
+      // so a value alias cannot borrow a comment from its anchor definition.
+      commentNode: isAlias(executable) ? executable : (uses.value ?? uses.key),
+    };
+    if (
+      references.some(
+        (existing) =>
+          existing.keyNode === reference.keyNode &&
+          existing.valueNode === reference.valueNode &&
+          existing.commentNode === reference.commentNode,
+      )
+    ) {
+      return;
+    }
+    references.push(reference);
+  };
+
+  /** @param {unknown} stepsNode */
+  const addSteps = (stepsNode) => {
+    const steps = resolveAliases(stepsNode, document);
+    if (!isSeq(steps)) return;
+    for (const step of steps.items) addDirectUses(step);
+  };
+
+  const jobsPair = findPair(root, "jobs", document);
+  const jobs = resolveAliases(jobsPair?.value, document);
+  if (isMap(jobs)) {
+    for (const jobPair of jobs.items) {
+      const job = jobPair.value;
+      addDirectUses(job);
+      addSteps(findPair(job, "steps", document)?.value);
+    }
+  }
+
+  const runsPair = findPair(root, "runs", document);
+  const runs = resolveAliases(runsPair?.value, document);
+  if (isMap(runs)) addSteps(findPair(runs, "steps", document)?.value);
+
+  return references;
 }
 
 /** @param {string} value */
@@ -213,12 +426,6 @@ function isLocalAction(value) {
 function isPinnedExternalAction(value) {
   const atIndex = value.lastIndexOf("@");
   return atIndex !== -1 && PINNED_REF.test(value.slice(atIndex + 1));
-}
-
-/** @param {string} raw */
-function hasReleaseTagComment(raw) {
-  const { comment } = splitInlineComment(raw);
-  return /^v\d+(?:[.\w-].*)?$/.test(comment);
 }
 
 /** @param {string} root @param {string} path */
@@ -238,9 +445,36 @@ function localActionManifestPaths(fromFile, value) {
 
   if (!isInsideRoot(ROOT, actionDirectory)) return [];
 
-  return ["action.yml", "action.yaml"]
-    .map((name) => join(actionDirectory, name))
-    .filter((path) => existsSync(path));
+  const manifests = [];
+  for (const name of ["action.yml", "action.yaml"]) {
+    const path = join(actionDirectory, name);
+    let stats;
+    try {
+      stats = lstatSync(path);
+    } catch (error) {
+      if (error?.code === "ENOENT") continue;
+      throw error;
+    }
+    if (!stats.isFile()) {
+      throw new Error(`${relative(ROOT, path)} is not a regular file`);
+    }
+
+    const expectedRealPath = resolve(REAL_ROOT, relative(ROOT, path));
+    if (realpathSync(path) !== expectedRealPath) {
+      throw new Error(`${relative(ROOT, path)} resolves through a symlink`);
+    }
+    manifests.push(path);
+  }
+  return manifests;
+}
+
+const missingPolicyFiles = REQUIRED_POLICY_FILES.filter(
+  (path) => !isRegularFile(join(ROOT, path)),
+);
+if (missingPolicyFiles.length > 0) {
+  console.error("Required action-pin policy workflows are missing:");
+  for (const path of missingPolicyFiles) console.error(`- ${path}`);
+  process.exit(1);
 }
 
 const failures = [];
@@ -251,42 +485,136 @@ const queuedFiles = new Set(files);
 
 for (let fileIndex = 0; fileIndex < files.length; fileIndex++) {
   const file = files[fileIndex];
-  const lines = readFileSync(file, "utf8").split(/\r?\n/);
-  let blockScalar = null;
+  const relativeFile = relative(ROOT, file);
+  const source = readFileSync(file, "utf8");
+  const lineCounter = new LineCounter();
+  const document = parseDocument(source, {
+    lineCounter,
+    prettyErrors: false,
+    uniqueKeys: true,
+  });
 
-  lines.forEach((line, lineIndex) => {
-    if (blockScalar && isBlockScalarContent(line, blockScalar)) return;
-    blockScalar = blockScalarState(line);
-
-    for (const rawValue of extractUsesRawValues(line)) {
-      const value = normalizeUsesValue(rawValue);
-      if (isLocalAction(value)) {
-        for (const manifest of localActionManifestPaths(file, value)) {
-          if (!queuedFiles.has(manifest)) {
-            queuedFiles.add(manifest);
-            files.push(manifest);
-          }
-        }
-        continue;
-      }
-
-      if (isPinnedExternalAction(value) && hasReleaseTagComment(rawValue)) {
-        continue;
-      }
-
+  const yamlProblems = [...document.errors, ...document.warnings];
+  if (yamlProblems.length > 0) {
+    for (const error of yamlProblems) {
       failures.push({
-        file: relative(ROOT, file),
-        line: lineIndex + 1,
-        value,
+        file: relativeFile,
+        line:
+          Array.isArray(error.pos) && error.pos.length > 0
+            ? lineCounter.linePos(error.pos[0]).line
+            : 1,
+        problem: `invalid YAML (${error.message})`,
       });
     }
-  });
+    continue;
+  }
+
+  try {
+    assertPolicyWorkflowStructure(relativeFile, document);
+  } catch (error) {
+    failures.push({
+      file: relativeFile,
+      line: 1,
+      problem: `invalid action-pin policy workflow (${error instanceof Error ? error.message : String(error)})`,
+    });
+    continue;
+  }
+
+  let references;
+  try {
+    references = collectUses(document.contents, document);
+  } catch (error) {
+    failures.push({
+      file: relativeFile,
+      line: 1,
+      problem: `invalid YAML structure (${error instanceof Error ? error.message : String(error)})`,
+    });
+    continue;
+  }
+
+  const referencesPerLine = new Map();
+  for (const reference of references) {
+    const line = lineNumber(reference.commentNode, lineCounter);
+    referencesPerLine.set(line, (referencesPerLine.get(line) ?? 0) + 1);
+  }
+
+  for (const reference of references) {
+    let resolvedValue;
+    try {
+      resolvedValue = resolveAliases(reference.valueNode, document);
+    } catch (error) {
+      failures.push({
+        file: relativeFile,
+        line: lineNumber(reference.keyNode, lineCounter),
+        problem: `invalid YAML alias (${error instanceof Error ? error.message : String(error)})`,
+      });
+      continue;
+    }
+
+    const value =
+      isScalar(resolvedValue) && typeof resolvedValue.value === "string"
+        ? resolvedValue.value.trim()
+        : "";
+    const commentLine = lineNumber(reference.commentNode, lineCounter);
+    const singleLine =
+      lineNumber(reference.keyNode, lineCounter) ===
+      lineNumber(reference.valueNode, lineCounter);
+    const inlineScalar =
+      isScalar(resolvedValue) &&
+      resolvedValue.type !== "BLOCK_FOLDED" &&
+      resolvedValue.type !== "BLOCK_LITERAL";
+    if (!singleLine || !inlineScalar) {
+      failures.push({
+        file: relativeFile,
+        line: lineNumber(reference.keyNode, lineCounter),
+        value,
+      });
+      continue;
+    }
+
+    if (isLocalAction(value)) {
+      let manifests;
+      try {
+        manifests = localActionManifestPaths(file, value);
+      } catch (error) {
+        failures.push({
+          file: relativeFile,
+          line: lineNumber(reference.keyNode, lineCounter),
+          problem: `unsafe local action manifest (${error instanceof Error ? error.message : String(error)})`,
+        });
+        continue;
+      }
+
+      for (const manifest of manifests) {
+        if (!queuedFiles.has(manifest)) {
+          queuedFiles.add(manifest);
+          files.push(manifest);
+        }
+      }
+      continue;
+    }
+
+    if (
+      isPinnedExternalAction(value) &&
+      referencesPerLine.get(commentLine) === 1 &&
+      hasReleaseTagComment(reference.commentNode, source)
+    ) {
+      continue;
+    }
+
+    failures.push({
+      file: relativeFile,
+      line: lineNumber(reference.keyNode, lineCounter),
+      value,
+    });
+  }
 }
 
 if (failures.length > 0) {
   console.error("Unpinned or undocumented GitHub Actions references found:");
   for (const failure of failures) {
-    console.error(`- ${failure.file}:${failure.line} uses: ${failure.value}`);
+    const detail = failure.problem ?? `uses: ${failure.value}`;
+    console.error(`- ${failure.file}:${failure.line} ${detail}`);
   }
   console.error(
     "Third-party actions must use a full 40-character commit SHA and keep " +

--- a/scripts/check-github-action-pins.mjs
+++ b/scripts/check-github-action-pins.mjs
@@ -6,7 +6,7 @@
  */
 
 import { lstatSync, readdirSync, readFileSync, realpathSync } from "node:fs";
-import { dirname, join, relative, resolve } from "node:path";
+import { isAbsolute, join, relative, resolve, sep } from "node:path";
 import process from "node:process";
 import { isDeepStrictEqual } from "node:util";
 import {
@@ -56,18 +56,6 @@ const NORMALIZED_POLICY_WORKFLOWS = new Map([
               },
             },
             {
-              name: "Check out pull request",
-              uses: "actions/checkout@<sha>",
-              with: {
-                repository:
-                  "${{ github.event.pull_request.head.repo.full_name }}",
-                ref: "${{ github.event.pull_request.head.sha }}",
-                path: "pr-head",
-                "persist-credentials": false,
-                "allow-unsafe-pr-checkout": true,
-              },
-            },
-            {
               name: "Setup PNPM",
               uses: "pnpm/action-setup@<sha>",
               with: { version: "10.24.0" },
@@ -85,13 +73,26 @@ const NORMALIZED_POLICY_WORKFLOWS = new Map([
             {
               name: "Test action-pin policy",
               "working-directory": "trusted-base",
-              run: "node scripts/check-github-action-pins.test.mjs",
+              run: "pnpm ci:action-pins:test",
+            },
+            {
+              name: "Fetch pull request Actions YAML",
+              "working-directory": "trusted-base",
+              env: {
+                GITHUB_TOKEN: "${{ github.token }}",
+                PR_HEAD_REPOSITORY:
+                  "${{ github.event.pull_request.head.repo.full_name }}",
+                PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}",
+                ACTION_PIN_OUTPUT_DIR: "${{ runner.temp }}/action-pin-pr-head",
+              },
+              run: "node scripts/fetch-action-pin-yaml.mjs",
             },
             {
               name: "Enforce immutable action pins",
               "working-directory": "trusted-base",
               env: {
-                GITHUB_ACTION_PINS_ROOT: "${{ github.workspace }}/pr-head",
+                GITHUB_ACTION_PINS_ROOT:
+                  "${{ runner.temp }}/action-pin-pr-head",
               },
               run: "node scripts/check-github-action-pins.mjs",
             },
@@ -137,7 +138,7 @@ const NORMALIZED_POLICY_WORKFLOWS = new Map([
             },
             {
               name: "Test proposed action-pin policy",
-              run: "node scripts/check-github-action-pins.test.mjs",
+              run: "pnpm ci:action-pins:test",
             },
             {
               name: "Scan proposed action pins",
@@ -367,12 +368,13 @@ function lineNumber(node, lineCounter) {
 function collectUses(root, document) {
   const references = [];
 
-  /** @param {unknown} executable */
-  const addDirectUses = (executable) => {
+  /** @param {unknown} executable @param {"action" | "workflow"} kind */
+  const addDirectUses = (executable, kind) => {
     const uses = findPair(executable, "uses", document);
     if (!uses) return;
 
     const reference = {
+      kind,
       keyNode: uses.key,
       valueNode: uses.value,
       // If the executable mapping is itself an alias, the version comment
@@ -385,7 +387,8 @@ function collectUses(root, document) {
         (existing) =>
           existing.keyNode === reference.keyNode &&
           existing.valueNode === reference.valueNode &&
-          existing.commentNode === reference.commentNode,
+          existing.commentNode === reference.commentNode &&
+          existing.kind === reference.kind,
       )
     ) {
       return;
@@ -397,7 +400,7 @@ function collectUses(root, document) {
   const addSteps = (stepsNode) => {
     const steps = resolveAliases(stepsNode, document);
     if (!isSeq(steps)) return;
-    for (const step of steps.items) addDirectUses(step);
+    for (const step of steps.items) addDirectUses(step, "action");
   };
 
   const jobsPair = findPair(root, "jobs", document);
@@ -405,7 +408,7 @@ function collectUses(root, document) {
   if (isMap(jobs)) {
     for (const jobPair of jobs.items) {
       const job = jobPair.value;
-      addDirectUses(job);
+      addDirectUses(job, "workflow");
       addSteps(findPair(job, "steps", document)?.value);
     }
   }
@@ -418,7 +421,7 @@ function collectUses(root, document) {
 }
 
 /** @param {string} value */
-function isLocalAction(value) {
+function isLocalReference(value) {
   return value.startsWith("./") || value.startsWith("../");
 }
 
@@ -433,17 +436,19 @@ function isInsideRoot(root, path) {
   const relativePath = relative(root, path);
   return (
     relativePath === "" ||
-    (!relativePath.startsWith("..") && !relativePath.startsWith("/"))
+    (relativePath !== ".." &&
+      !relativePath.startsWith(`..${sep}`) &&
+      !isAbsolute(relativePath))
   );
 }
 
-/** @param {string} fromFile @param {string} value */
-function localActionManifestPaths(fromFile, value) {
-  const actionDirectory = value.startsWith("../")
-    ? resolve(dirname(fromFile), value)
-    : resolve(ROOT, value);
+/** @param {string} value */
+function localActionManifestPaths(value) {
+  const actionDirectory = resolve(ROOT, value);
 
-  if (!isInsideRoot(ROOT, actionDirectory)) return [];
+  if (!isInsideRoot(ROOT, actionDirectory)) {
+    throw new Error("local action path escapes the repository root");
+  }
 
   const manifests = [];
   for (const name of ["action.yml", "action.yaml"]) {
@@ -465,7 +470,48 @@ function localActionManifestPaths(fromFile, value) {
     }
     manifests.push(path);
   }
+  if (manifests.length === 0) {
+    throw new Error(
+      `${relative(ROOT, actionDirectory) || "."} does not contain action.yml or action.yaml`,
+    );
+  }
   return manifests;
+}
+
+/** @param {string} value */
+function localReusableWorkflowPath(value) {
+  if (!value.startsWith("./.github/workflows/")) {
+    throw new Error(
+      "local reusable workflows must use ./.github/workflows/<file>.yml",
+    );
+  }
+  const path = resolve(ROOT, value);
+  const relativePath = relative(ROOT, path);
+  if (
+    !isInsideRoot(ROOT, path) ||
+    !relativePath.startsWith(".github/workflows/") ||
+    !/\.ya?ml$/.test(relativePath)
+  ) {
+    throw new Error("local reusable workflow path is unsafe");
+  }
+
+  let stats;
+  try {
+    stats = lstatSync(path);
+  } catch (error) {
+    if (error?.code === "ENOENT") {
+      throw new Error(`${relativePath} does not exist`);
+    }
+    throw error;
+  }
+  if (!stats.isFile()) {
+    throw new Error(`${relativePath} is not a regular file`);
+  }
+  const expectedRealPath = resolve(REAL_ROOT, relativePath);
+  if (realpathSync(path) !== expectedRealPath) {
+    throw new Error(`${relativePath} resolves through a symlink`);
+  }
+  return path;
 }
 
 const missingPolicyFiles = REQUIRED_POLICY_FILES.filter(
@@ -572,23 +618,26 @@ for (let fileIndex = 0; fileIndex < files.length; fileIndex++) {
       continue;
     }
 
-    if (isLocalAction(value)) {
-      let manifests;
+    if (isLocalReference(value)) {
+      let localFiles;
       try {
-        manifests = localActionManifestPaths(file, value);
+        localFiles =
+          reference.kind === "workflow"
+            ? [localReusableWorkflowPath(value)]
+            : localActionManifestPaths(value);
       } catch (error) {
         failures.push({
           file: relativeFile,
           line: lineNumber(reference.keyNode, lineCounter),
-          problem: `unsafe local action manifest (${error instanceof Error ? error.message : String(error)})`,
+          problem: `unsafe local ${reference.kind === "workflow" ? "reusable workflow" : "action manifest"} (${error instanceof Error ? error.message : String(error)})`,
         });
         continue;
       }
 
-      for (const manifest of manifests) {
-        if (!queuedFiles.has(manifest)) {
-          queuedFiles.add(manifest);
-          files.push(manifest);
+      for (const localFile of localFiles) {
+        if (!queuedFiles.has(localFile)) {
+          queuedFiles.add(localFile);
+          files.push(localFile);
         }
       }
       continue;

--- a/scripts/check-github-action-pins.mjs
+++ b/scripts/check-github-action-pins.mjs
@@ -1,0 +1,181 @@
+#!/usr/bin/env node
+/**
+ * Reject mutable third-party `uses:` references in GitHub workflow and
+ * composite-action YAML. Local actions are allowed; referenced manifests are
+ * followed recursively so actions outside `.github/actions` are covered too.
+ */
+
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { dirname, join, relative, resolve } from "node:path";
+import process from "node:process";
+
+// Script-local fixture knob, not an input to the Turbo task graph.
+// eslint-disable-next-line turbo/no-undeclared-env-vars
+const ROOT = resolve(process.env["GITHUB_ACTION_PINS_ROOT"] ?? process.cwd());
+const PINNED_REF = /^[0-9a-f]{40}$/i;
+const SCAN_DIRS = [".github/workflows", ".github/actions"];
+
+/** @param {string} path */
+function isYaml(path) {
+  return path.endsWith(".yml") || path.endsWith(".yaml");
+}
+
+/** @param {string} directory */
+function* walkYaml(directory) {
+  if (!existsSync(directory)) return;
+
+  for (const entry of readdirSync(directory, { withFileTypes: true })) {
+    const path = join(directory, entry.name);
+    if (entry.isDirectory()) {
+      yield* walkYaml(path);
+    } else if (entry.isFile() && isYaml(path)) {
+      yield path;
+    }
+  }
+}
+
+/** @param {string} raw */
+function splitInlineComment(raw) {
+  let quote = "";
+
+  for (let index = 0; index < raw.length; index++) {
+    const character = raw[index];
+    const escapedDoubleQuote =
+      character === '"' && quote === '"' && raw[index - 1] === "\\";
+
+    if ((character === '"' || character === "'") && !escapedDoubleQuote) {
+      quote = quote === character ? "" : quote === "" ? character : quote;
+    }
+
+    if (character === "#" && quote === "") {
+      return {
+        value: raw.slice(0, index).trim(),
+        comment: raw.slice(index + 1).trim(),
+      };
+    }
+  }
+
+  return { value: raw.trim(), comment: "" };
+}
+
+/** @param {string} raw */
+function normalizeUsesValue(raw) {
+  const { value } = splitInlineComment(raw);
+  if (
+    (value.startsWith('"') && value.endsWith('"')) ||
+    (value.startsWith("'") && value.endsWith("'"))
+  ) {
+    return value.slice(1, -1).trim();
+  }
+  return value;
+}
+
+/** @param {string} line */
+function extractUsesRawValue(line) {
+  const plain = line.match(
+    /^\s*(?:-\s*)?(?:"uses"|'uses'|uses)\s*:\s*(.+?)\s*$/,
+  );
+  if (plain) return plain[1] ?? "";
+
+  const { value: lineWithoutComment, comment } = splitInlineComment(line);
+  const flow = lineWithoutComment.match(
+    /^\s*-\s*\{.*(?:"uses"|'uses'|uses)\s*:\s*([^,}]+).*}\s*$/,
+  );
+  if (!flow) return null;
+
+  const value = flow[1] ?? "";
+  return comment ? `${value} # ${comment}` : value;
+}
+
+/** @param {string} value */
+function isLocalAction(value) {
+  return value.startsWith("./") || value.startsWith("../");
+}
+
+/** @param {string} value */
+function isPinnedExternalAction(value) {
+  const atIndex = value.lastIndexOf("@");
+  return atIndex !== -1 && PINNED_REF.test(value.slice(atIndex + 1));
+}
+
+/** @param {string} raw */
+function hasReleaseTagComment(raw) {
+  const { comment } = splitInlineComment(raw);
+  return /^v\d+(?:[.\w-].*)?$/.test(comment);
+}
+
+/** @param {string} root @param {string} path */
+function isInsideRoot(root, path) {
+  const relativePath = relative(root, path);
+  return (
+    relativePath === "" ||
+    (!relativePath.startsWith("..") && !relativePath.startsWith("/"))
+  );
+}
+
+/** @param {string} fromFile @param {string} value */
+function localActionManifestPaths(fromFile, value) {
+  const actionDirectory = value.startsWith("../")
+    ? resolve(dirname(fromFile), value)
+    : resolve(ROOT, value);
+
+  if (!isInsideRoot(ROOT, actionDirectory)) return [];
+
+  return ["action.yml", "action.yaml"]
+    .map((name) => join(actionDirectory, name))
+    .filter((path) => existsSync(path));
+}
+
+const failures = [];
+const files = SCAN_DIRS.flatMap((directory) => [
+  ...walkYaml(join(ROOT, directory)),
+]).sort();
+const queuedFiles = new Set(files);
+
+for (let fileIndex = 0; fileIndex < files.length; fileIndex++) {
+  const file = files[fileIndex];
+  const lines = readFileSync(file, "utf8").split(/\r?\n/);
+
+  lines.forEach((line, lineIndex) => {
+    const rawValue = extractUsesRawValue(line);
+    if (rawValue == null) return;
+
+    const value = normalizeUsesValue(rawValue);
+    if (value === "") return;
+
+    if (isLocalAction(value)) {
+      for (const manifest of localActionManifestPaths(file, value)) {
+        if (!queuedFiles.has(manifest)) {
+          queuedFiles.add(manifest);
+          files.push(manifest);
+        }
+      }
+      return;
+    }
+
+    if (isPinnedExternalAction(value) && hasReleaseTagComment(rawValue)) return;
+
+    failures.push({
+      file: relative(ROOT, file),
+      line: lineIndex + 1,
+      value,
+    });
+  });
+}
+
+if (failures.length > 0) {
+  console.error("Unpinned or undocumented GitHub Actions references found:");
+  for (const failure of failures) {
+    console.error(`- ${failure.file}:${failure.line} uses: ${failure.value}`);
+  }
+  console.error(
+    "Third-party actions must use a full 40-character commit SHA and keep " +
+      "the release tag as an inline comment, for example: " +
+      "`uses: org/action@<sha> # v1.2.3`.",
+  );
+  process.exit(1);
+}
+
+console.log(
+  `All ${files.length} workflow/composite-action YAML files use pinned external actions.`,
+);

--- a/scripts/check-github-action-pins.mjs
+++ b/scripts/check-github-action-pins.mjs
@@ -73,7 +73,7 @@ function normalizeUsesValue(raw) {
 /** @param {string} line */
 function extractUsesRawValue(line) {
   const plain = line.match(
-    /^\s*(?:-\s*)?(?:"uses"|'uses'|uses)\s*:\s*(.+?)\s*$/,
+    /^\s*(?:-\s*)?(?:"uses"|'uses'|uses)\s*:\s*(.*?)\s*$/,
   );
   if (plain) return plain[1] ?? "";
 
@@ -141,8 +141,6 @@ for (let fileIndex = 0; fileIndex < files.length; fileIndex++) {
     if (rawValue == null) return;
 
     const value = normalizeUsesValue(rawValue);
-    if (value === "") return;
-
     if (isLocalAction(value)) {
       for (const manifest of localActionManifestPaths(file, value)) {
         if (!queuedFiles.has(manifest)) {

--- a/scripts/check-github-action-pins.test.mjs
+++ b/scripts/check-github-action-pins.test.mjs
@@ -125,6 +125,33 @@ jobs:
   }
 });
 
+test("rejects multiline uses values", () => {
+  const root = fixtureRoot("multiline-fail");
+  try {
+    write(
+      root,
+      ".github/workflows/ci.yml",
+      `
+jobs:
+  test:
+    steps:
+      - uses:
+          actions/checkout@v7
+`,
+    );
+
+    const result = runChecker(root);
+    equal(result.status, 1, result.stdout);
+    contains(
+      result.stderr,
+      ".github/workflows/ci.yml:5 uses:",
+      "multiline key location",
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test("rejects mutable tags in composite actions", () => {
   const root = fixtureRoot("composite-fail");
   try {

--- a/scripts/check-github-action-pins.test.mjs
+++ b/scripts/check-github-action-pins.test.mjs
@@ -282,6 +282,115 @@ runs:
   }
 });
 
+test("rejects local action references without a materialized manifest", () => {
+  const root = fixtureRoot("local-missing-fail");
+  try {
+    write(
+      root,
+      ".github/workflows/ci.yml",
+      `
+jobs:
+  test:
+    steps:
+      - uses: ./tools/actions/missing
+`,
+    );
+
+    const result = runChecker(root);
+    equal(result.status, 1, result.stdout);
+    contains(
+      result.stderr,
+      "does not contain action.yml or action.yaml",
+      "missing local action manifest",
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("rejects local action paths that escape the repository root", () => {
+  const root = fixtureRoot("local-escape-fail");
+  try {
+    write(
+      root,
+      ".github/workflows/ci.yml",
+      `
+jobs:
+  test:
+    steps:
+      - uses: ../outside
+`,
+    );
+
+    const result = runChecker(root);
+    equal(result.status, 1, result.stdout);
+    contains(
+      result.stderr,
+      "local action path escapes the repository root",
+      "escaping local action",
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("accepts existing local reusable workflows", () => {
+  const root = fixtureRoot("local-workflow-pass");
+  try {
+    write(
+      root,
+      ".github/workflows/ci.yml",
+      `
+jobs:
+  call:
+    uses: ./.github/workflows/reusable.yml
+`,
+    );
+    write(
+      root,
+      ".github/workflows/reusable.yml",
+      `
+on: workflow_call
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@${PINNED_SHA} # v7.0.0
+`,
+    );
+
+    const result = runChecker(root);
+    equal(result.status, 0, result.stderr);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("rejects missing local reusable workflows", () => {
+  const root = fixtureRoot("local-workflow-missing-fail");
+  try {
+    write(
+      root,
+      ".github/workflows/ci.yml",
+      `
+jobs:
+  call:
+    uses: ./.github/workflows/missing.yml
+`,
+    );
+
+    const result = runChecker(root);
+    equal(result.status, 1, result.stdout);
+    contains(
+      result.stderr,
+      "unsafe local reusable workflow",
+      "missing local reusable workflow",
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test("rejects mutable flow-style steps", () => {
   const root = fixtureRoot("flow-fail");
   try {
@@ -1096,13 +1205,19 @@ test("isolates trusted enforcement from PR-head source validation", () => {
   contains(source, "\n  pull_request:", "source-validation trigger");
   excludes(source, "pull_request_target:", "source workflow trusted trigger");
   contains(source, "persist-credentials: false", "credential-free checkout");
-  equal(
-    trustedSteps.find((step) => step.name === "Check out pull request").with[
-      "allow-unsafe-pr-checkout"
-    ],
-    true,
-    "fork-head checkout opt-in",
+  excludes(trusted, "Check out pull request", "untrusted checkout step");
+  excludes(trusted, "allow-unsafe-pr-checkout", "unsafe checkout opt-in");
+  const trustedCheckouts = trustedSteps.filter((step) =>
+    step.uses?.startsWith("actions/checkout@"),
   );
+  equal(trustedCheckouts.length, 1, "only one trusted checkout");
+  equal(
+    trustedCheckouts[0].with.ref,
+    "${{ github.event.pull_request.base.sha }}",
+    "checkout stays on exact base SHA",
+  );
+  excludes(trusted, "download-artifact", "untrusted artifact download");
+  excludes(trusted, "unzip", "untrusted archive extraction");
   for (const step of trustedSteps.filter((candidate) => candidate.run)) {
     equal(
       step["working-directory"],
@@ -1134,6 +1249,45 @@ test("isolates trusted enforcement from PR-head source validation", () => {
     "--frozen-lockfile --ignore-scripts --filter .",
     "source dependency install",
   );
+  const fetchStep = trustedSteps.find(
+    (step) => step.name === "Fetch pull request Actions YAML",
+  );
+  equal(
+    fetchStep.run,
+    "node scripts/fetch-action-pin-yaml.mjs",
+    "trusted fetcher",
+  );
+  equal(
+    fetchStep.env.GITHUB_TOKEN,
+    "${{ github.token }}",
+    "fetch-only token env",
+  );
+  equal(
+    trustedSteps.filter((step) => step.env?.GITHUB_TOKEN).length,
+    1,
+    "token is exposed only to the trusted fetch step",
+  );
+  equal(
+    fetchStep.env.PR_HEAD_REPOSITORY,
+    "${{ github.event.pull_request.head.repo.full_name }}",
+    "exact fork repository input",
+  );
+  equal(
+    fetchStep.env.PR_HEAD_SHA,
+    "${{ github.event.pull_request.head.sha }}",
+    "exact PR head SHA input",
+  );
+  equal(
+    fetchStep.env.ACTION_PIN_OUTPUT_DIR,
+    "${{ runner.temp }}/action-pin-pr-head",
+    "isolated materializer output",
+  );
+  equal(
+    trustedSteps.find((step) => step.name === "Enforce immutable action pins")
+      .env.GITHUB_ACTION_PINS_ROOT,
+    "${{ runner.temp }}/action-pin-pr-head",
+    "materialized scanner root",
+  );
   excludes(source, "Enforce proposed", "source validation wording");
   equal(
     trustedWorkflow.jobs["action-pins"].name ===
@@ -1143,8 +1297,8 @@ test("isolates trusted enforcement from PR-head source validation", () => {
   );
   contains(
     source,
-    "node scripts/check-github-action-pins.test.mjs",
-    "proposed policy tests",
+    "pnpm ci:action-pins:test",
+    "proposed scanner and fetcher tests",
   );
   contains(
     source,

--- a/scripts/check-github-action-pins.test.mjs
+++ b/scripts/check-github-action-pins.test.mjs
@@ -1,0 +1,304 @@
+#!/usr/bin/env node
+/** Fixture tests for scripts/check-github-action-pins.mjs. */
+
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import process from "node:process";
+
+const SCRIPT = resolve("scripts/check-github-action-pins.mjs");
+const PINNED_SHA = "0123456789abcdef0123456789abcdef01234567";
+const tests = [];
+
+/** @param {string} name @param {() => void} run */
+function test(name, run) {
+  tests.push({ name, run });
+}
+
+/** @param {string} name */
+function fixtureRoot(name) {
+  return mkdtempSync(join(tmpdir(), `action-pin-${name}-`));
+}
+
+/** @param {string} root @param {string} path @param {string} content */
+function write(root, path, content) {
+  const fullPath = join(root, path);
+  mkdirSync(dirname(fullPath), { recursive: true });
+  writeFileSync(fullPath, content, "utf8");
+}
+
+/** @param {string} root */
+function runChecker(root) {
+  return spawnSync(process.execPath, [SCRIPT], {
+    cwd: resolve("."),
+    env: { ...process.env, GITHUB_ACTION_PINS_ROOT: root },
+    encoding: "utf8",
+  });
+}
+
+/** @param {unknown} actual @param {unknown} expected @param {string} message */
+function equal(actual, expected, message) {
+  if (actual !== expected) {
+    throw new Error(`${message}: expected ${expected}, got ${actual}`);
+  }
+}
+
+/** @param {string} haystack @param {string} needle @param {string} message */
+function contains(haystack, needle, message) {
+  if (!haystack.includes(needle)) {
+    throw new Error(`${message}: missing ${needle}\n${haystack}`);
+  }
+}
+
+test("accepts documented SHA pins and recursive local actions", () => {
+  const root = fixtureRoot("pass");
+  try {
+    write(
+      root,
+      ".github/workflows/ci.yml",
+      `
+jobs:
+  test:
+    steps:
+      - uses: actions/checkout@${PINNED_SHA} # v7.0.0
+      - { uses: actions/cache@${PINNED_SHA} } # v6.1.0
+      - uses: ./.github/actions/setup
+`,
+    );
+    write(
+      root,
+      ".github/actions/setup/action.yml",
+      `
+runs:
+  using: composite
+  steps:
+    - uses: ./tools/actions/nested
+`,
+    );
+    write(
+      root,
+      "tools/actions/nested/action.yaml",
+      `
+runs:
+  using: composite
+  steps:
+    - uses: 'actions/setup-node@${PINNED_SHA}' # v6.4.0
+`,
+    );
+
+    const result = runChecker(root);
+    equal(result.status, 0, result.stderr);
+    contains(
+      result.stdout,
+      "All 3 workflow/composite-action YAML files",
+      "recursive scan count",
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("rejects mutable workflow tags with quoted keys and values", () => {
+  const root = fixtureRoot("workflow-fail");
+  try {
+    write(
+      root,
+      ".github/workflows/ci.yml",
+      `
+jobs:
+  test:
+    steps:
+      - uses: actions/checkout@v7
+      - "uses": actions/setup-node@v6
+      - uses: 'actions/cache@main'
+`,
+    );
+
+    const result = runChecker(root);
+    equal(result.status, 1, result.stdout);
+    contains(result.stderr, "ci.yml:5 uses: actions/checkout@v7", "tag");
+    contains(result.stderr, "ci.yml:6 uses: actions/setup-node@v6", "key");
+    contains(result.stderr, "ci.yml:7 uses: actions/cache@main", "value");
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("rejects mutable tags in composite actions", () => {
+  const root = fixtureRoot("composite-fail");
+  try {
+    write(
+      root,
+      ".github/actions/setup/action.yml",
+      `
+runs:
+  using: composite
+  steps:
+    - uses: pnpm/action-setup@v4
+`,
+    );
+
+    const result = runChecker(root);
+    equal(result.status, 1, result.stdout);
+    contains(
+      result.stderr,
+      ".github/actions/setup/action.yml:5 uses: pnpm/action-setup@v4",
+      "composite location",
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("rejects mutable tags reached through local action references", () => {
+  const root = fixtureRoot("local-target-fail");
+  try {
+    write(
+      root,
+      ".github/workflows/ci.yml",
+      `
+jobs:
+  test:
+    steps:
+      - uses: ./tools/actions/custom
+`,
+    );
+    write(
+      root,
+      "tools/actions/custom/action.yml",
+      `
+runs:
+  using: composite
+  steps:
+    - uses: actions/setup-node@v6
+`,
+    );
+
+    const result = runChecker(root);
+    equal(result.status, 1, result.stdout);
+    contains(
+      result.stderr,
+      "tools/actions/custom/action.yml:5 uses: actions/setup-node@v6",
+      "referenced manifest location",
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("rejects mutable flow-style steps", () => {
+  const root = fixtureRoot("flow-fail");
+  try {
+    write(
+      root,
+      ".github/workflows/ci.yml",
+      `
+jobs:
+  test:
+    steps:
+      - { uses: actions/checkout@v7 }
+      - { uses: actions/cache@v6 } # v6.1.0
+`,
+    );
+
+    const result = runChecker(root);
+    equal(result.status, 1, result.stdout);
+    contains(result.stderr, "uses: actions/checkout@v7", "first flow step");
+    contains(result.stderr, "uses: actions/cache@v6", "second flow step");
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("rejects SHA pins without release-tag comments", () => {
+  const root = fixtureRoot("missing-comment");
+  try {
+    write(
+      root,
+      ".github/workflows/ci.yml",
+      `
+jobs:
+  test:
+    steps:
+      - uses: actions/checkout@${PINNED_SHA}
+`,
+    );
+
+    const result = runChecker(root);
+    equal(result.status, 1, result.stdout);
+    contains(
+      result.stderr,
+      `.github/workflows/ci.yml:5 uses: actions/checkout@${PINNED_SHA}`,
+      "missing comment location",
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("rejects non-version comments", () => {
+  const root = fixtureRoot("bad-comment");
+  try {
+    write(
+      root,
+      ".github/workflows/ci.yml",
+      `
+jobs:
+  test:
+    steps:
+      - uses: actions/checkout@${PINNED_SHA} # pinned
+`,
+    );
+
+    const result = runChecker(root);
+    equal(result.status, 1, result.stdout);
+    contains(result.stderr, "uses: actions/checkout@", "non-version comment");
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("rejects missing refs and short SHAs", () => {
+  const root = fixtureRoot("bad-ref");
+  try {
+    write(
+      root,
+      ".github/workflows/ci.yml",
+      `
+jobs:
+  test:
+    steps:
+      - uses: actions/cache
+      - uses: actions/setup-node@0123456789abcdef # v6.4.0
+`,
+    );
+
+    const result = runChecker(root);
+    equal(result.status, 1, result.stdout);
+    contains(result.stderr, "uses: actions/cache", "missing ref");
+    contains(
+      result.stderr,
+      "uses: actions/setup-node@0123456789abcdef",
+      "short SHA",
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+let failures = 0;
+for (const { name, run } of tests) {
+  try {
+    run();
+    console.log(`ok - ${name}`);
+  } catch (error) {
+    failures++;
+    console.error(`not ok - ${name}`);
+    console.error(error instanceof Error ? error.stack : String(error));
+  }
+}
+
+if (failures > 0) process.exit(1);
+
+console.log(`\n${tests.length} github action pin tests passed.`);

--- a/scripts/check-github-action-pins.test.mjs
+++ b/scripts/check-github-action-pins.test.mjs
@@ -2,13 +2,31 @@
 /** Fixture tests for scripts/check-github-action-pins.mjs. */
 
 import { spawnSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import process from "node:process";
+import { parse } from "yaml";
 
 const SCRIPT = resolve("scripts/check-github-action-pins.mjs");
 const PINNED_SHA = "0123456789abcdef0123456789abcdef01234567";
+const POLICY_WORKFLOW_PATHS = [
+  ".github/workflows/action-pins.yml",
+  ".github/workflows/action-pins-source.yml",
+];
+const POLICY_WORKFLOW_FIXTURES = new Map(
+  POLICY_WORKFLOW_PATHS.map((path) => [
+    path,
+    readFileSync(resolve(path), "utf8"),
+  ]),
+);
 const tests = [];
 
 /** @param {string} name @param {() => void} run */
@@ -18,7 +36,11 @@ function test(name, run) {
 
 /** @param {string} name */
 function fixtureRoot(name) {
-  return mkdtempSync(join(tmpdir(), `action-pin-${name}-`));
+  const root = mkdtempSync(join(tmpdir(), `action-pin-${name}-`));
+  for (const path of POLICY_WORKFLOW_PATHS) {
+    write(root, path, POLICY_WORKFLOW_FIXTURES.get(path));
+  }
+  return root;
 }
 
 /** @param {string} root @param {string} path @param {string} content */
@@ -48,6 +70,13 @@ function equal(actual, expected, message) {
 function contains(haystack, needle, message) {
   if (!haystack.includes(needle)) {
     throw new Error(`${message}: missing ${needle}\n${haystack}`);
+  }
+}
+
+/** @param {string} haystack @param {string} needle @param {string} message */
+function excludes(haystack, needle, message) {
+  if (haystack.includes(needle)) {
+    throw new Error(`${message}: unexpectedly found ${needle}\n${haystack}`);
   }
 }
 
@@ -91,7 +120,7 @@ runs:
     equal(result.status, 0, result.stderr);
     contains(
       result.stdout,
-      "All 3 workflow/composite-action YAML files",
+      "All 5 workflow/composite-action YAML files",
       "recursive scan count",
     );
   } finally {
@@ -214,6 +243,45 @@ runs:
   }
 });
 
+test("rejects symlinked local action manifests", () => {
+  const root = fixtureRoot("local-symlink-fail");
+  try {
+    write(
+      root,
+      ".github/workflows/ci.yml",
+      `
+jobs:
+  test:
+    steps:
+      - uses: ./.github/actions/linked
+`,
+    );
+    write(
+      root,
+      "shared/action.yml",
+      `
+runs:
+  using: composite
+  steps:
+    - uses: actions/setup-node@v6
+`,
+    );
+    const link = join(root, ".github/actions/linked/action.yml");
+    mkdirSync(dirname(link), { recursive: true });
+    symlinkSync("../../../shared/action.yml", link);
+
+    const result = runChecker(root);
+    equal(result.status, 1, result.stdout);
+    contains(
+      result.stderr,
+      "unsafe local action manifest",
+      "symlinked manifest",
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test("rejects mutable flow-style steps", () => {
   const root = fixtureRoot("flow-fail");
   try {
@@ -286,6 +354,49 @@ jobs:
   }
 });
 
+test("rejects mutable flow-style reusable workflow jobs", () => {
+  const root = fixtureRoot("flow-reusable-job-fail");
+  try {
+    write(
+      root,
+      ".github/workflows/ci.yml",
+      `
+jobs:
+  call: { uses: org/repo/.github/workflows/reuse.yml@v1 }
+`,
+    );
+
+    const result = runChecker(root);
+    equal(result.status, 1, result.stdout);
+    contains(
+      result.stderr,
+      "uses: org/repo/.github/workflows/reuse.yml@v1",
+      "flow-style reusable workflow",
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("accepts pinned flow-style reusable workflow jobs", () => {
+  const root = fixtureRoot("flow-reusable-job-pass");
+  try {
+    write(
+      root,
+      ".github/workflows/ci.yml",
+      `
+jobs:
+  call: { uses: org/repo/.github/workflows/reuse.yml@${PINNED_SHA} } # v1.2.3
+`,
+    );
+
+    const result = runChecker(root);
+    equal(result.status, 0, result.stderr);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test("ignores uses input names in nested flow mappings", () => {
   const root = fixtureRoot("nested-flow-pass");
   try {
@@ -303,6 +414,55 @@ jobs:
 
     const result = runChecker(root);
     equal(result.status, 0, result.stderr);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("ignores uses input names in nested block mappings", () => {
+  const root = fixtureRoot("nested-block-pass");
+  try {
+    write(
+      root,
+      ".github/workflows/ci.yml",
+      `
+jobs:
+  test:
+    steps:
+      - uses: actions/checkout@${PINNED_SHA} # v7.0.0
+        with:
+          uses: "some-input"
+`,
+    );
+
+    const result = runChecker(root);
+    equal(result.status, 0, result.stderr);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("resumes scanning after nested block mappings", () => {
+  const root = fixtureRoot("after-nested-block-fail");
+  try {
+    write(
+      root,
+      ".github/workflows/ci.yml",
+      `
+jobs:
+  test:
+    steps:
+      - uses: actions/checkout@${PINNED_SHA} # v7.0.0
+        with:
+          uses: "some-input"
+      - uses: actions/cache@v6
+`,
+    );
+
+    const result = runChecker(root);
+    equal(result.status, 1, result.stdout);
+    contains(result.stderr, "uses: actions/cache@v6", "following action step");
+    excludes(result.stderr, "some-input", "nested input name");
   } finally {
     rmSync(root, { recursive: true, force: true });
   }
@@ -459,6 +619,538 @@ jobs:
   } finally {
     rmSync(root, { recursive: true, force: true });
   }
+});
+
+test("rejects mutable actions behind quoted structural keys", () => {
+  const root = fixtureRoot("quoted-structure-fail");
+  try {
+    write(
+      root,
+      ".github/workflows/ci.yml",
+      `
+"jobs":
+  test:
+    "steps":
+      - "uses": actions/checkout@v7
+`,
+    );
+
+    const result = runChecker(root);
+    equal(result.status, 1, result.stdout);
+    contains(result.stderr, "uses: actions/checkout@v7", "quoted structure");
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("rejects mutable actions in indentless step sequences", () => {
+  const root = fixtureRoot("indentless-steps-fail");
+  try {
+    write(
+      root,
+      ".github/workflows/ci.yml",
+      `
+jobs:
+  test:
+    steps:
+    - uses: actions/checkout@v7
+`,
+    );
+
+    const result = runChecker(root);
+    equal(result.status, 1, result.stdout);
+    contains(result.stderr, "uses: actions/checkout@v7", "indentless step");
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("rejects mutable actions in fully flow-style workflows", () => {
+  const root = fixtureRoot("fully-flow-fail");
+  try {
+    write(
+      root,
+      ".github/workflows/ci.yml",
+      `
+jobs: { test: { steps: [{ uses: actions/checkout@v7 }] } }
+`,
+    );
+
+    const result = runChecker(root);
+    equal(result.status, 1, result.stdout);
+    contains(result.stderr, "uses: actions/checkout@v7", "fully flow step");
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("rejects mutable reusable jobs in multiline flow mappings", () => {
+  const root = fixtureRoot("multiline-flow-job-fail");
+  try {
+    write(
+      root,
+      ".github/workflows/ci.yml",
+      `
+jobs:
+  call: {
+    uses: org/repo/.github/workflows/reuse.yml@v1
+  }
+`,
+    );
+
+    const result = runChecker(root);
+    equal(result.status, 1, result.stdout);
+    contains(
+      result.stderr,
+      "uses: org/repo/.github/workflows/reuse.yml@v1",
+      "multiline flow job",
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("rejects mutable actions behind explicit, alias, and tagged uses keys", () => {
+  const root = fixtureRoot("semantic-keys-fail");
+  try {
+    write(
+      root,
+      ".github/workflows/ci.yml",
+      `
+name: &uses-key uses
+jobs:
+  test:
+    steps:
+      - ? "uses"
+        : actions/checkout@v7
+      - ? *uses-key
+        : actions/setup-node@v6
+      - !!str uses: actions/cache@v6
+`,
+    );
+
+    const result = runChecker(root);
+    equal(result.status, 1, result.stdout);
+    contains(result.stderr, "uses: actions/checkout@v7", "explicit key");
+    contains(result.stderr, "uses: actions/setup-node@v6", "alias key");
+    contains(result.stderr, "uses: actions/cache@v6", "tagged key");
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("rejects duplicate semantic uses keys introduced by aliases", () => {
+  const root = fixtureRoot("duplicate-alias-key-fail");
+  try {
+    write(
+      root,
+      ".github/workflows/ci.yml",
+      `
+name: &uses-key uses
+jobs:
+  test:
+    steps:
+      - uses: actions/checkout@${PINNED_SHA} # v7.0.0
+        ? *uses-key
+        : actions/cache@v6
+`,
+    );
+
+    const result = runChecker(root);
+    equal(result.status, 1, result.stdout);
+    contains(
+      result.stderr,
+      "duplicate semantic `uses` keys",
+      "alias duplicate",
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("rejects unresolved structural aliases", () => {
+  const root = fixtureRoot("unresolved-alias-fail");
+  try {
+    write(root, ".github/workflows/ci.yml", "jobs: *missing\n");
+
+    const result = runChecker(root);
+    equal(result.status, 1, result.stdout);
+    contains(
+      result.stderr,
+      "unresolved YAML alias `*missing`",
+      "missing alias",
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("ignores nested paths that only happen to end in steps.uses", () => {
+  const root = fixtureRoot("exact-paths-pass");
+  try {
+    write(
+      root,
+      ".github/workflows/ci.yml",
+      `
+jobs:
+  test:
+    strategy:
+      matrix:
+        include:
+          - steps:
+              uses: matrix-input
+    steps:
+      - uses: actions/checkout@${PINNED_SHA} # v7.0.0
+        with:
+          steps:
+            uses: action-input
+`,
+    );
+
+    const result = runChecker(root);
+    equal(result.status, 0, result.stderr);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("rejects pinned multiline uses values", () => {
+  const root = fixtureRoot("pinned-multiline-fail");
+  try {
+    write(
+      root,
+      ".github/workflows/ci.yml",
+      `
+jobs:
+  test:
+    steps:
+      - uses:
+          actions/checkout@${PINNED_SHA} # v7.0.0
+`,
+    );
+
+    const result = runChecker(root);
+    equal(result.status, 1, result.stdout);
+    contains(
+      result.stderr,
+      `.github/workflows/ci.yml:5 uses: actions/checkout@${PINNED_SHA}`,
+      "pinned multiline value",
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("rejects folded and literal uses scalars", () => {
+  for (const [name, indicator] of [
+    ["folded", ">-"],
+    ["literal", "|-"],
+  ]) {
+    const root = fixtureRoot(`${name}-scalar-fail`);
+    try {
+      write(
+        root,
+        ".github/workflows/ci.yml",
+        `
+jobs:
+  test:
+    steps:
+      - uses: ${indicator} # v7.0.0
+          actions/checkout@${PINNED_SHA}
+`,
+      );
+
+      const result = runChecker(root);
+      equal(result.status, 1, result.stdout);
+      contains(
+        result.stderr,
+        `.github/workflows/ci.yml:5 uses: actions/checkout@${PINNED_SHA}`,
+        `${name} scalar`,
+      );
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  }
+});
+
+test("does not share one release comment across multiple actions", () => {
+  const root = fixtureRoot("shared-comment-fail");
+  try {
+    write(
+      root,
+      ".github/workflows/ci.yml",
+      `
+jobs: { test: { steps: [{ uses: org/first@${PINNED_SHA} }, { uses: org/second@${PINNED_SHA} }] } } # v1.2.3
+`,
+    );
+
+    const result = runChecker(root);
+    equal(result.status, 1, result.stdout);
+    contains(result.stderr, `uses: org/first@${PINNED_SHA}`, "first action");
+    contains(result.stderr, `uses: org/second@${PINNED_SHA}`, "second action");
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("requires alias values to document the executable use site", () => {
+  const root = fixtureRoot("alias-comment-fail");
+  try {
+    write(
+      root,
+      ".github/workflows/ci.yml",
+      `
+name: &checkout-ref actions/checkout@${PINNED_SHA} # v7.0.0
+jobs:
+  test:
+    steps:
+      - uses: *checkout-ref
+`,
+    );
+
+    const result = runChecker(root);
+    equal(result.status, 1, result.stdout);
+    contains(
+      result.stderr,
+      `uses: actions/checkout@${PINNED_SHA}`,
+      "alias use",
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("accepts documented alias values at the executable use site", () => {
+  const root = fixtureRoot("alias-comment-pass");
+  try {
+    write(
+      root,
+      ".github/workflows/ci.yml",
+      `
+name: &checkout-ref actions/checkout@${PINNED_SHA}
+jobs:
+  test:
+    steps:
+      - uses: *checkout-ref # v7.0.0
+`,
+    );
+
+    const result = runChecker(root);
+    equal(result.status, 0, result.stderr);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("deduplicates reused anchored step sequences", () => {
+  const root = fixtureRoot("reused-step-sequence-pass");
+  try {
+    write(
+      root,
+      ".github/workflows/ci.yml",
+      `
+jobs:
+  first:
+    steps: &shared-steps
+      - uses: actions/checkout@${PINNED_SHA} # v7.0.0
+  second:
+    steps: *shared-steps
+`,
+    );
+
+    const result = runChecker(root);
+    equal(result.status, 0, result.stderr);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("requires policy paths to be regular files", () => {
+  const directoryRoot = fixtureRoot("policy-directory-fail");
+  try {
+    const path = join(directoryRoot, ".github/workflows/action-pins.yml");
+    rmSync(path);
+    mkdirSync(path);
+
+    const result = runChecker(directoryRoot);
+    equal(result.status, 1, result.stdout);
+    contains(result.stderr, "action-pins.yml", "directory policy path");
+  } finally {
+    rmSync(directoryRoot, { recursive: true, force: true });
+  }
+
+  const symlinkRoot = fixtureRoot("policy-symlink-fail");
+  try {
+    const path = join(symlinkRoot, ".github/workflows/action-pins.yml");
+    rmSync(path);
+    symlinkSync(
+      join(symlinkRoot, ".github/workflows/action-pins-source.yml"),
+      path,
+    );
+
+    const result = runChecker(symlinkRoot);
+    equal(result.status, 1, result.stdout);
+    contains(result.stderr, "action-pins.yml", "symlink policy path");
+  } finally {
+    rmSync(symlinkRoot, { recursive: true, force: true });
+  }
+});
+
+test("requires both action-pin policy workflows", () => {
+  for (const path of POLICY_WORKFLOW_PATHS) {
+    const root = fixtureRoot("missing-policy");
+    try {
+      rmSync(join(root, path));
+
+      const result = runChecker(root);
+      equal(result.status, 1, result.stdout);
+      contains(result.stderr, path, "missing policy workflow");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  }
+});
+
+test("rejects same-name no-op replacements for both policy workflows", () => {
+  for (const [path, name, jobId, checkName] of [
+    [
+      ".github/workflows/action-pins.yml",
+      "GitHub Actions Policy",
+      "action-pins",
+      "Action Pin Policy",
+    ],
+    [
+      ".github/workflows/action-pins-source.yml",
+      "GitHub Actions Policy Source",
+      "policy-source",
+      "Action Pin Policy Source",
+    ],
+  ]) {
+    const root = fixtureRoot("noop-policy-fail");
+    try {
+      write(
+        root,
+        path,
+        `
+name: ${name}
+on: pull_request
+permissions:
+  contents: read
+jobs:
+  ${jobId}:
+    name: ${checkName}
+    runs-on: ubuntu-latest
+    steps:
+      - run: true
+`,
+      );
+
+      const result = runChecker(root);
+      equal(result.status, 1, result.stdout);
+      contains(result.stderr, path, "policy path");
+      contains(
+        result.stderr,
+        "invalid action-pin policy workflow",
+        "trusted structure failure",
+      );
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  }
+});
+
+test("allows immutable action SHA bumps in canonical policy workflows", () => {
+  for (const path of POLICY_WORKFLOW_PATHS) {
+    const root = fixtureRoot("policy-sha-bump-pass");
+    try {
+      const updated = POLICY_WORKFLOW_FIXTURES.get(path).replace(
+        /@[0-9a-f]{40}/,
+        `@${PINNED_SHA}`,
+      );
+      write(root, path, updated);
+
+      const result = runChecker(root);
+      equal(result.status, 0, result.stderr);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  }
+});
+
+test("isolates trusted enforcement from PR-head source validation", () => {
+  const trusted = readFileSync(
+    resolve(".github/workflows/action-pins.yml"),
+    "utf8",
+  );
+  const source = readFileSync(
+    resolve(".github/workflows/action-pins-source.yml"),
+    "utf8",
+  );
+  const trustedWorkflow = parse(trusted);
+  const sourceWorkflow = parse(source);
+  const trustedSteps = trustedWorkflow.jobs["action-pins"].steps;
+  const sourceSteps = sourceWorkflow.jobs["policy-source"].steps;
+
+  contains(trusted, "pull_request_target:", "trusted trigger");
+  excludes(trusted, "\n  pull_request:", "trusted workflow PR-head trigger");
+  contains(source, "\n  pull_request:", "source-validation trigger");
+  excludes(source, "pull_request_target:", "source workflow trusted trigger");
+  contains(source, "persist-credentials: false", "credential-free checkout");
+  equal(
+    trustedSteps.find((step) => step.name === "Check out pull request").with[
+      "allow-unsafe-pr-checkout"
+    ],
+    true,
+    "fork-head checkout opt-in",
+  );
+  for (const step of trustedSteps.filter((candidate) => candidate.run)) {
+    equal(
+      step["working-directory"],
+      "trusted-base",
+      `${step.name} runs only trusted code`,
+    );
+  }
+  contains(
+    trustedSteps.find((step) => step.name === "Setup PNPM").uses,
+    "pnpm/action-setup@",
+    "trusted PNPM setup",
+  );
+  contains(
+    sourceSteps.find((step) => step.name === "Setup PNPM").uses,
+    "pnpm/action-setup@",
+    "source PNPM setup",
+  );
+  contains(
+    trustedSteps.find(
+      (step) => step.name === "Install trusted policy dependencies",
+    ).run,
+    "--frozen-lockfile --ignore-scripts --filter .",
+    "trusted dependency install",
+  );
+  contains(
+    sourceSteps.find(
+      (step) => step.name === "Install proposed policy dependencies",
+    ).run,
+    "--frozen-lockfile --ignore-scripts --filter .",
+    "source dependency install",
+  );
+  excludes(source, "Enforce proposed", "source validation wording");
+  equal(
+    trustedWorkflow.jobs["action-pins"].name ===
+      sourceWorkflow.jobs["policy-source"].name,
+    false,
+    "distinct required check names",
+  );
+  contains(
+    source,
+    "node scripts/check-github-action-pins.test.mjs",
+    "proposed policy tests",
+  );
+  contains(
+    source,
+    "node scripts/check-github-action-pins.mjs",
+    "proposed policy scan",
+  );
 });
 
 let failures = 0;

--- a/scripts/check-github-action-pins.test.mjs
+++ b/scripts/check-github-action-pins.test.mjs
@@ -238,6 +238,153 @@ jobs:
   }
 });
 
+test("rejects flow-style uses before later uses-like text", () => {
+  const root = fixtureRoot("flow-decoy-fail");
+  try {
+    write(
+      root,
+      ".github/workflows/ci.yml",
+      `
+jobs:
+  test:
+    steps:
+      - { uses: actions/checkout@v7, name: "uses: ./ignored" }
+`,
+    );
+
+    const result = runChecker(root);
+    equal(result.status, 1, result.stdout);
+    contains(
+      result.stderr,
+      "uses: actions/checkout@v7",
+      "first flow mapping field",
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("rejects explicit uses keys in flow-style steps", () => {
+  const root = fixtureRoot("flow-explicit-key-fail");
+  try {
+    write(
+      root,
+      ".github/workflows/ci.yml",
+      `
+jobs:
+  test:
+    steps:
+      - { ? uses : actions/checkout@v7 }
+`,
+    );
+
+    const result = runChecker(root);
+    equal(result.status, 1, result.stdout);
+    contains(result.stderr, "uses: actions/checkout@v7", "explicit flow key");
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("ignores uses input names in nested flow mappings", () => {
+  const root = fixtureRoot("nested-flow-pass");
+  try {
+    write(
+      root,
+      ".github/workflows/ci.yml",
+      `
+jobs:
+  test:
+    steps:
+      - uses: actions/checkout@${PINNED_SHA} # v7.0.0
+        with: { uses: "some-input" }
+`,
+    );
+
+    const result = runChecker(root);
+    equal(result.status, 0, result.stderr);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("rejects mutable uses keys with YAML anchors", () => {
+  const root = fixtureRoot("anchor-fail");
+  try {
+    write(
+      root,
+      ".github/workflows/ci.yml",
+      `
+jobs:
+  test:
+    steps:
+      - &checkout uses: actions/checkout@v7
+`,
+    );
+
+    const result = runChecker(root);
+    equal(result.status, 1, result.stdout);
+    contains(result.stderr, "uses: actions/checkout@v7", "anchored uses key");
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("ignores uses-like text inside block scalars", () => {
+  const root = fixtureRoot("block-scalars-pass");
+  try {
+    write(
+      root,
+      ".github/workflows/ci.yml",
+      `
+jobs:
+  test:
+    steps:
+      - run: |
+          echo "example:"
+          - uses: actions/checkout@v7
+        shell: bash
+      - run: >-
+          uses: actions/cache@v6
+      - uses: actions/setup-node@${PINNED_SHA} # v6.4.0
+`,
+    );
+
+    const result = runChecker(root);
+    equal(result.status, 0, result.stderr);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("resumes scanning after block scalars", () => {
+  const root = fixtureRoot("after-block-scalar-fail");
+  try {
+    write(
+      root,
+      ".github/workflows/ci.yml",
+      `
+jobs:
+  test:
+    steps:
+      - run: |
+          uses: actions/cache@v6
+      - uses: actions/checkout@v7
+`,
+    );
+
+    const result = runChecker(root);
+    equal(result.status, 1, result.stdout);
+    contains(
+      result.stderr,
+      ".github/workflows/ci.yml:7 uses: actions/checkout@v7",
+      "step after block scalar",
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test("rejects SHA pins without release-tag comments", () => {
   const root = fixtureRoot("missing-comment");
   try {

--- a/scripts/fetch-action-pin-yaml.mjs
+++ b/scripts/fetch-action-pin-yaml.mjs
@@ -1,0 +1,396 @@
+#!/usr/bin/env node
+/**
+ * Materialize only GitHub Actions YAML from an exact pull-request head commit.
+ * The trusted pull_request_target job uses this instead of checking out the
+ * untrusted head, so PR files can only become inert scanner input.
+ */
+
+import { Buffer } from "node:buffer";
+import { lstatSync, mkdirSync, realpathSync, writeFileSync } from "node:fs";
+import { dirname, isAbsolute, relative, resolve } from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+/* eslint-disable turbo/no-undeclared-env-vars -- CI-only workflow inputs. */
+
+const API_BASE = "https://api.github.com";
+const API_VERSION = "2022-11-28";
+const OBJECT_SHA = /^[0-9a-f]{40}$/i;
+const REPOSITORY = /^([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+)$/;
+const MAX_TREE_ENTRIES = 20_000;
+const MAX_SELECTED_FILES = 512;
+const MAX_FILE_BYTES = 1024 * 1024;
+const MAX_TOTAL_BYTES = 8 * 1024 * 1024;
+const REQUIRED_POLICY_PATHS = new Set([
+  ".github/workflows/action-pins.yml",
+  ".github/workflows/action-pins-source.yml",
+]);
+const ACTION_REF_PATH = /(?:^|\/)action\.ya?ml$/;
+const WORKFLOW_PATH = /^\.github\/workflows\/.+\.ya?ml$/;
+const REPOSITORY_ACTION_PATH = /^\.github\/actions\/.+\.ya?ml$/;
+
+/** @param {unknown} value @param {string} label */
+function requireString(value, label) {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error(`${label} must be a non-empty string`);
+  }
+  return value;
+}
+
+/** @param {string} repository */
+export function parseRepository(repository) {
+  const value = requireString(repository, "PR_HEAD_REPOSITORY");
+  if (value.length > 200) throw new Error("PR_HEAD_REPOSITORY is too long");
+  const match = value.match(REPOSITORY);
+  if (
+    !match ||
+    match[1] === "." ||
+    match[1] === ".." ||
+    match[2] === "." ||
+    match[2] === ".."
+  ) {
+    throw new Error("PR_HEAD_REPOSITORY must be an owner/repository slug");
+  }
+  return { owner: match[1], repository: match[2] };
+}
+
+/** @param {string} sha @param {string} label */
+function requireObjectSha(sha, label) {
+  const value = requireString(sha, label);
+  if (!OBJECT_SHA.test(value)) {
+    throw new Error(`${label} must be a full 40-character Git object SHA`);
+  }
+  return value.toLowerCase();
+}
+
+/** @param {unknown} value */
+function requireRecord(value) {
+  if (value == null || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("GitHub API returned an invalid JSON object");
+  }
+  return value;
+}
+
+/** @param {string} path */
+export function validateTreePath(path) {
+  const value = requireString(path, "tree path");
+  if (
+    Buffer.byteLength(value) > 4096 ||
+    value.startsWith("/") ||
+    value.includes("\\") ||
+    [...value].some((character) => {
+      const codePoint = character.codePointAt(0);
+      return codePoint <= 0x1f || codePoint === 0x7f;
+    })
+  ) {
+    throw new Error(`unsafe Git tree path: ${JSON.stringify(value)}`);
+  }
+
+  const segments = value.split("/");
+  if (
+    segments.some(
+      (segment) =>
+        segment === "" ||
+        segment === "." ||
+        segment === ".." ||
+        Buffer.byteLength(segment) > 255,
+    )
+  ) {
+    throw new Error(`unsafe Git tree path: ${JSON.stringify(value)}`);
+  }
+  return value;
+}
+
+/** @param {string} path */
+function isActionPinInput(path) {
+  return (
+    WORKFLOW_PATH.test(path) ||
+    REPOSITORY_ACTION_PATH.test(path) ||
+    ACTION_REF_PATH.test(path)
+  );
+}
+
+/** @param {unknown} rawEntry */
+function validateTreeEntry(rawEntry) {
+  const entry = requireRecord(rawEntry);
+  const path = validateTreePath(entry.path);
+  const type = requireString(entry.type, `tree entry type for ${path}`);
+  const mode = requireString(entry.mode, `tree entry mode for ${path}`);
+  const sha = requireObjectSha(entry.sha, `tree entry SHA for ${path}`);
+
+  if (type === "tree" && mode === "040000") {
+    return { path, type, mode, sha, size: null };
+  }
+  if (
+    type === "blob" &&
+    (mode === "100644" || mode === "100755" || mode === "120000")
+  ) {
+    if (!Number.isSafeInteger(entry.size) || entry.size < 0) {
+      throw new Error(
+        `tree entry size for ${path} must be a non-negative integer`,
+      );
+    }
+    return { path, type, mode, sha, size: entry.size };
+  }
+  if (type === "commit" || mode === "160000") {
+    if (type !== "commit" || mode !== "160000") {
+      throw new Error(
+        `unsupported Git tree entry type/mode for ${path}: ${type}/${mode}`,
+      );
+    }
+    return { path, type, mode, sha, size: null };
+  }
+  throw new Error(
+    `unsupported Git tree entry type/mode for ${path}: ${type}/${mode}`,
+  );
+}
+
+/** @param {unknown} payload @param {string} expectedSha @param {number} expectedSize */
+export function decodeBlob(payload, expectedSha, expectedSize) {
+  const blob = requireRecord(payload);
+  const sha = requireObjectSha(blob.sha, "blob SHA");
+  if (sha !== expectedSha)
+    throw new Error("GitHub blob SHA did not match the tree entry");
+  if (blob.encoding !== "base64")
+    throw new Error("GitHub blob encoding was not base64");
+  if (blob.size !== expectedSize)
+    throw new Error("GitHub blob size did not match the tree entry");
+
+  if (typeof blob.content !== "string") {
+    throw new Error("blob content must be a string");
+  }
+  const content = blob.content;
+  const compact = content.replace(/\r?\n/g, "");
+  const base64 =
+    /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/;
+  if (!base64.test(compact))
+    throw new Error("GitHub blob content was not valid base64");
+
+  const bytes = Buffer.from(compact, "base64");
+  if (bytes.length !== expectedSize) {
+    throw new Error("Decoded GitHub blob size did not match the tree entry");
+  }
+  if (bytes.includes(0))
+    throw new Error("GitHub Actions YAML must not contain NUL bytes");
+  new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+  return bytes;
+}
+
+/**
+ * @param {string} path
+ * @param {{ token: string, fetchImpl: typeof fetch }} options
+ */
+async function requestJson(path, { token, fetchImpl }) {
+  const url = new URL(path, API_BASE);
+  let response;
+  try {
+    response = await fetchImpl(url, {
+      method: "GET",
+      redirect: "error",
+      signal: AbortSignal.timeout(15_000),
+      headers: {
+        Accept: "application/vnd.github+json",
+        Authorization: `Bearer ${token}`,
+        "User-Agent": "mento-action-pin-policy",
+        "X-GitHub-Api-Version": API_VERSION,
+      },
+    });
+  } catch (error) {
+    throw new Error(
+      `GitHub API request failed for ${url.pathname}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+  if (!response.ok) {
+    throw new Error(
+      `GitHub API request failed for ${url.pathname}: HTTP ${response.status}`,
+    );
+  }
+  try {
+    return await response.json();
+  } catch {
+    throw new Error(`GitHub API returned invalid JSON for ${url.pathname}`);
+  }
+}
+
+/**
+ * @param {{ repository: string, commitSha: string, token: string, fetchImpl?: typeof fetch }} options
+ */
+export async function fetchActionPinFiles({
+  repository,
+  commitSha,
+  token,
+  fetchImpl = fetch,
+}) {
+  const { owner, repository: name } = parseRepository(repository);
+  const headSha = requireObjectSha(commitSha, "PR_HEAD_SHA");
+  const apiToken = requireString(token, "GITHUB_TOKEN");
+  if (/\s/.test(apiToken) || apiToken.length > 2048) {
+    throw new Error("GITHUB_TOKEN has an invalid format");
+  }
+  if (typeof fetchImpl !== "function")
+    throw new Error("fetchImpl must be a function");
+
+  const repositoryPath = `/repos/${encodeURIComponent(owner)}/${encodeURIComponent(name)}`;
+  const requestOptions = { token: apiToken, fetchImpl };
+  const commit = requireRecord(
+    await requestJson(
+      `${repositoryPath}/git/commits/${headSha}`,
+      requestOptions,
+    ),
+  );
+  if (requireObjectSha(commit.sha, "commit response SHA") !== headSha) {
+    throw new Error("GitHub commit response did not match PR_HEAD_SHA");
+  }
+  const treeSha = requireObjectSha(
+    requireRecord(commit.tree).sha,
+    "commit tree SHA",
+  );
+
+  const treeUrl = `${repositoryPath}/git/trees/${treeSha}?recursive=1`;
+  const treePayload = requireRecord(await requestJson(treeUrl, requestOptions));
+  if (requireObjectSha(treePayload.sha, "tree response SHA") !== treeSha) {
+    throw new Error("GitHub tree response did not match the commit tree");
+  }
+  if (treePayload.truncated !== false) {
+    throw new Error(
+      "GitHub recursive tree response was truncated or incomplete",
+    );
+  }
+  if (!Array.isArray(treePayload.tree)) {
+    throw new Error("GitHub tree response did not include a tree array");
+  }
+  if (treePayload.tree.length > MAX_TREE_ENTRIES) {
+    throw new Error(
+      `GitHub tree exceeds the ${MAX_TREE_ENTRIES}-entry policy limit`,
+    );
+  }
+
+  const seenPaths = new Set();
+  const selected = [];
+  for (const rawEntry of treePayload.tree) {
+    const entry = validateTreeEntry(rawEntry);
+    if (seenPaths.has(entry.path))
+      throw new Error(`duplicate Git tree path: ${entry.path}`);
+    seenPaths.add(entry.path);
+    if (!isActionPinInput(entry.path)) continue;
+    if (
+      entry.type !== "blob" ||
+      (entry.mode !== "100644" && entry.mode !== "100755")
+    ) {
+      throw new Error(
+        `action-pin input must be a regular Git blob: ${entry.path}`,
+      );
+    }
+    selected.push(entry);
+  }
+
+  for (const requiredPath of REQUIRED_POLICY_PATHS) {
+    if (!selected.some((entry) => entry.path === requiredPath)) {
+      throw new Error(
+        `required action-pin policy workflow is missing: ${requiredPath}`,
+      );
+    }
+  }
+  if (selected.length > MAX_SELECTED_FILES) {
+    throw new Error(
+      `action-pin input exceeds the ${MAX_SELECTED_FILES}-file policy limit`,
+    );
+  }
+  const totalSize = selected.reduce((sum, entry) => {
+    if (entry.size > MAX_FILE_BYTES) {
+      throw new Error(
+        `${entry.path} exceeds the ${MAX_FILE_BYTES}-byte policy limit`,
+      );
+    }
+    return sum + entry.size;
+  }, 0);
+  if (totalSize > MAX_TOTAL_BYTES) {
+    throw new Error(
+      `action-pin input exceeds the ${MAX_TOTAL_BYTES}-byte policy limit`,
+    );
+  }
+
+  selected.sort((left, right) => left.path.localeCompare(right.path));
+  const blobs = new Map();
+  const files = new Map();
+  for (const entry of selected) {
+    let bytes = blobs.get(entry.sha);
+    if (!bytes) {
+      const payload = await requestJson(
+        `${repositoryPath}/git/blobs/${entry.sha}`,
+        requestOptions,
+      );
+      bytes = decodeBlob(payload, entry.sha, entry.size);
+      blobs.set(entry.sha, bytes);
+    } else if (bytes.length !== entry.size) {
+      throw new Error(
+        `duplicate blob SHA had inconsistent sizes: ${entry.sha}`,
+      );
+    }
+    files.set(entry.path, bytes);
+  }
+  return { files, repository: `${owner}/${name}`, commitSha: headSha };
+}
+
+/**
+ * @param {{ repository: string, commitSha: string, token: string, outputDir: string, fetchImpl?: typeof fetch }} options
+ */
+export async function materializeActionPinFiles(options) {
+  const outputDir = requireString(options.outputDir, "ACTION_PIN_OUTPUT_DIR");
+  if (
+    !isAbsolute(outputDir) ||
+    resolve(outputDir) === dirname(resolve(outputDir))
+  ) {
+    throw new Error("ACTION_PIN_OUTPUT_DIR must be an absolute non-root path");
+  }
+  try {
+    lstatSync(outputDir);
+    throw new Error("ACTION_PIN_OUTPUT_DIR must not already exist");
+  } catch (error) {
+    if (error?.code !== "ENOENT") throw error;
+  }
+  const parent = dirname(outputDir);
+  if (!lstatSync(parent).isDirectory()) {
+    throw new Error("ACTION_PIN_OUTPUT_DIR parent must be a directory");
+  }
+  realpathSync(parent);
+
+  const result = await fetchActionPinFiles(options);
+  mkdirSync(outputDir, { mode: 0o700 });
+  for (const [path, bytes] of result.files) {
+    const destination = resolve(outputDir, path);
+    const relativePath = relative(outputDir, destination);
+    if (
+      relativePath === ".." ||
+      relativePath.startsWith("../") ||
+      isAbsolute(relativePath)
+    ) {
+      throw new Error(`refused to materialize unsafe path: ${path}`);
+    }
+    mkdirSync(dirname(destination), { recursive: true, mode: 0o700 });
+    writeFileSync(destination, bytes, { flag: "wx", mode: 0o600 });
+  }
+  return { ...result, outputDir };
+}
+
+async function runFromEnvironment() {
+  const result = await materializeActionPinFiles({
+    repository: process.env["PR_HEAD_REPOSITORY"],
+    commitSha: process.env["PR_HEAD_SHA"],
+    token: process.env["GITHUB_TOKEN"],
+    outputDir: process.env["ACTION_PIN_OUTPUT_DIR"],
+  });
+  console.log(
+    `Materialized ${result.files.size} GitHub Actions YAML files from ${result.repository}@${result.commitSha}.`,
+  );
+}
+
+if (
+  process.argv[1] &&
+  resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+) {
+  runFromEnvironment().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  });
+}

--- a/scripts/fetch-action-pin-yaml.test.mjs
+++ b/scripts/fetch-action-pin-yaml.test.mjs
@@ -1,0 +1,465 @@
+#!/usr/bin/env node
+/** Fixture tests for scripts/fetch-action-pin-yaml.mjs. */
+
+import assert from "node:assert/strict";
+import { Buffer } from "node:buffer";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import process from "node:process";
+import {
+  decodeBlob,
+  fetchActionPinFiles,
+  materializeActionPinFiles,
+  parseRepository,
+  validateTreePath,
+} from "./fetch-action-pin-yaml.mjs";
+
+const HEAD_SHA = "a".repeat(40);
+const TREE_SHA = "b".repeat(40);
+const TOKEN = "github-test-token";
+const REQUIRED_CONTENT = new Map([
+  [".github/workflows/action-pins.yml", "name: GitHub Actions Policy\n"],
+  [
+    ".github/workflows/action-pins-source.yml",
+    "name: GitHub Actions Policy Source\n",
+  ],
+]);
+const tests = [];
+
+/** @param {string} name @param {() => void | Promise<void>} run */
+function test(name, run) {
+  tests.push({ name, run });
+}
+
+/** @param {number} index */
+function objectSha(index) {
+  return index.toString(16).padStart(40, "0");
+}
+
+/** @param {string} path @param {string | Buffer} content @param {number} index */
+function blobEntry(path, content, index) {
+  const bytes = Buffer.from(content);
+  return {
+    entry: {
+      path,
+      mode: "100644",
+      type: "blob",
+      sha: objectSha(index),
+      size: bytes.length,
+    },
+    payload: {
+      sha: objectSha(index),
+      size: bytes.length,
+      encoding: "base64",
+      content: bytes.toString("base64"),
+    },
+  };
+}
+
+/** @param {Array<{ path: string, content: string | Buffer }>} extras */
+function repositoryFixture(extras = []) {
+  const files = [
+    ...[...REQUIRED_CONTENT].map(([path, content]) => ({ path, content })),
+    ...extras,
+  ].map(({ path, content }, index) => blobEntry(path, content, index + 1));
+  return {
+    entries: files.map(({ entry }) => entry),
+    blobs: new Map(files.map(({ entry, payload }) => [entry.sha, payload])),
+  };
+}
+
+/** @param {unknown} value @param {number} [status] */
+function jsonResponse(value, status = 200) {
+  return new Response(JSON.stringify(value), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+/**
+ * @param {{
+ *   entries?: unknown[],
+ *   blobs?: Map<string, unknown>,
+ *   commit?: unknown,
+ *   tree?: unknown,
+ *   intercept?: (url: URL, options: RequestInit) => Response | undefined,
+ * }} fixture
+ */
+function fakeGitHubApi(fixture = {}) {
+  const base = repositoryFixture();
+  const entries = fixture.entries ?? base.entries;
+  const blobs = fixture.blobs ?? base.blobs;
+  const calls = [];
+  const fetchImpl = async (input, options) => {
+    const url = new URL(input);
+    calls.push({ url, options });
+    const intercepted = fixture.intercept?.(url, options);
+    if (intercepted) return intercepted;
+
+    if (url.pathname.endsWith(`/git/commits/${HEAD_SHA}`)) {
+      return jsonResponse(
+        fixture.commit ?? { sha: HEAD_SHA, tree: { sha: TREE_SHA } },
+      );
+    }
+    if (url.pathname.endsWith(`/git/trees/${TREE_SHA}`)) {
+      return jsonResponse(
+        fixture.tree ?? { sha: TREE_SHA, truncated: false, tree: entries },
+      );
+    }
+    const blobSha = url.pathname.match(/\/git\/blobs\/([0-9a-f]{40})$/)?.[1];
+    if (blobSha && blobs.has(blobSha)) return jsonResponse(blobs.get(blobSha));
+    return jsonResponse({ message: "Not Found" }, 404);
+  };
+  return { calls, fetchImpl };
+}
+
+/** @param {typeof fetch} fetchImpl */
+function fetchOptions(fetchImpl) {
+  return {
+    repository: "fork-owner/frontend-monorepo-fork",
+    commitSha: HEAD_SHA,
+    token: TOKEN,
+    fetchImpl,
+  };
+}
+
+test("materializes only allowlisted YAML from an exact fork head", async () => {
+  const fixture = repositoryFixture([
+    { path: ".github/workflows/ci.yaml", content: "jobs: {}\n" },
+    { path: ".github/actions/setup/action.yml", content: "runs: {}\n" },
+    { path: "tools/custom/action.yaml", content: "runs: {}\n" },
+    { path: ".github/actions/setup/script.js", content: "throw 1;\n" },
+    { path: "README.md", content: "ignored\n" },
+  ]);
+  const api = fakeGitHubApi(fixture);
+  const parent = mkdtempSync(join(tmpdir(), "action-pin-fetch-pass-"));
+  const outputDir = join(parent, "pr-head");
+  try {
+    const result = await materializeActionPinFiles({
+      ...fetchOptions(api.fetchImpl),
+      outputDir,
+    });
+
+    assert.deepEqual(
+      [...result.files.keys()],
+      [
+        ".github/actions/setup/action.yml",
+        ".github/workflows/action-pins-source.yml",
+        ".github/workflows/action-pins.yml",
+        ".github/workflows/ci.yaml",
+        "tools/custom/action.yaml",
+      ],
+    );
+    assert.equal(
+      readFileSync(join(outputDir, ".github/workflows/ci.yaml"), "utf8"),
+      "jobs: {}\n",
+    );
+    assert.equal(existsSync(join(outputDir, "README.md")), false);
+    assert.equal(
+      existsSync(join(outputDir, ".github/actions/setup/script.js")),
+      false,
+    );
+    assert.equal(statSync(outputDir).mode & 0o777, 0o700);
+    assert.equal(api.calls[0].url.host, "api.github.com");
+    assert.equal(
+      api.calls[0].url.pathname,
+      `/repos/fork-owner/frontend-monorepo-fork/git/commits/${HEAD_SHA}`,
+    );
+    for (const { url, options } of api.calls) {
+      assert.equal(url.host, "api.github.com");
+      assert.equal(options.redirect, "error");
+      assert.equal(options.headers.Authorization, `Bearer ${TOKEN}`);
+    }
+  } finally {
+    rmSync(parent, { recursive: true, force: true });
+  }
+});
+
+test("rejects malformed repository, SHA, and token inputs before fetching", async () => {
+  let calls = 0;
+  const fetchImpl = async () => {
+    calls++;
+    throw new Error("unexpected fetch");
+  };
+
+  for (const options of [
+    { repository: "owner/../repo", commitSha: HEAD_SHA, token: TOKEN },
+    { repository: "owner/repo", commitSha: "main", token: TOKEN },
+    { repository: "owner/repo", commitSha: HEAD_SHA, token: "bad token" },
+  ]) {
+    await assert.rejects(
+      fetchActionPinFiles({ ...options, fetchImpl }),
+      /PR_HEAD_REPOSITORY|PR_HEAD_SHA|GITHUB_TOKEN/,
+    );
+  }
+  assert.equal(calls, 0);
+  assert.deepEqual(parseRepository("fork-owner/repo.name"), {
+    owner: "fork-owner",
+    repository: "repo.name",
+  });
+});
+
+test("rejects commit and tree identity mismatches", async () => {
+  const wrongCommit = fakeGitHubApi({
+    commit: { sha: "c".repeat(40), tree: { sha: TREE_SHA } },
+  });
+  await assert.rejects(
+    fetchActionPinFiles(fetchOptions(wrongCommit.fetchImpl)),
+    /commit response did not match/,
+  );
+
+  const wrongTree = fakeGitHubApi({
+    tree: { sha: "c".repeat(40), truncated: false, tree: [] },
+  });
+  await assert.rejects(
+    fetchActionPinFiles(fetchOptions(wrongTree.fetchImpl)),
+    /tree response did not match/,
+  );
+});
+
+test("fails closed when the recursive tree is truncated", async () => {
+  const api = fakeGitHubApi({
+    tree: { sha: TREE_SHA, truncated: true, tree: [] },
+  });
+  await assert.rejects(
+    fetchActionPinFiles(fetchOptions(api.fetchImpl)),
+    /truncated or incomplete/,
+  );
+});
+
+test("rejects unsafe and duplicate Git tree paths", async () => {
+  for (const path of [
+    "../action.yml",
+    "/action.yml",
+    "a\\action.yml",
+    "a//action.yml",
+  ]) {
+    assert.throws(() => validateTreePath(path), /unsafe Git tree path/);
+  }
+
+  const fixture = repositoryFixture();
+  const api = fakeGitHubApi({
+    entries: [...fixture.entries, fixture.entries[0]],
+    blobs: fixture.blobs,
+  });
+  await assert.rejects(
+    fetchActionPinFiles(fetchOptions(api.fetchImpl)),
+    /duplicate Git tree path/,
+  );
+});
+
+test("ignores unrelated links but rejects selected symlinks and submodules", async () => {
+  const fixture = repositoryFixture();
+  const unrelatedEntries = [
+    ...fixture.entries,
+    {
+      path: "docs/latest",
+      mode: "120000",
+      type: "blob",
+      sha: objectSha(90),
+      size: 6,
+    },
+    {
+      path: "vendor/docs",
+      mode: "160000",
+      type: "commit",
+      sha: objectSha(91),
+    },
+  ];
+  const unrelated = fakeGitHubApi({
+    entries: unrelatedEntries,
+    blobs: fixture.blobs,
+  });
+  const result = await fetchActionPinFiles(fetchOptions(unrelated.fetchImpl));
+  assert.equal(result.files.size, 2);
+
+  for (const unsafeEntry of [
+    {
+      path: ".github/actions/evil/action.yml",
+      mode: "120000",
+      type: "blob",
+      sha: objectSha(92),
+      size: 9,
+    },
+    {
+      path: "vendor/action.yaml",
+      mode: "160000",
+      type: "commit",
+      sha: objectSha(93),
+    },
+  ]) {
+    const api = fakeGitHubApi({
+      entries: [...fixture.entries, unsafeEntry],
+      blobs: fixture.blobs,
+    });
+    await assert.rejects(
+      fetchActionPinFiles(fetchOptions(api.fetchImpl)),
+      /must be a regular Git blob/,
+    );
+  }
+});
+
+test("requires both policy workflows and enforces selected-file size limits", async () => {
+  const fixture = repositoryFixture();
+  const missing = fakeGitHubApi({
+    entries: fixture.entries.slice(1),
+    blobs: fixture.blobs,
+  });
+  await assert.rejects(
+    fetchActionPinFiles(fetchOptions(missing.fetchImpl)),
+    /required action-pin policy workflow is missing/,
+  );
+
+  const oversized = {
+    ...fixture.entries[0],
+    path: ".github/workflows/oversized.yml",
+    sha: objectSha(99),
+    size: 1024 * 1024 + 1,
+  };
+  const tooLarge = fakeGitHubApi({
+    entries: [...fixture.entries, oversized],
+    blobs: fixture.blobs,
+  });
+  await assert.rejects(
+    fetchActionPinFiles(fetchOptions(tooLarge.fetchImpl)),
+    /exceeds the 1048576-byte policy limit/,
+  );
+});
+
+test("fails closed on GitHub API errors and malformed JSON", async () => {
+  const denied = fakeGitHubApi({
+    intercept: (url) =>
+      url.pathname.includes("/git/commits/")
+        ? jsonResponse({ message: "denied" }, 403)
+        : undefined,
+  });
+  await assert.rejects(
+    fetchActionPinFiles(fetchOptions(denied.fetchImpl)),
+    /HTTP 403/,
+  );
+
+  const malformed = fakeGitHubApi({
+    intercept: (url) =>
+      url.pathname.includes("/git/commits/")
+        ? new Response("not json", { status: 200 })
+        : undefined,
+  });
+  await assert.rejects(
+    fetchActionPinFiles(fetchOptions(malformed.fetchImpl)),
+    /invalid JSON/,
+  );
+});
+
+test("rejects inconsistent and malformed blob payloads", () => {
+  const bytes = Buffer.from("name: workflow\n");
+  const sha = objectSha(100);
+  const valid = {
+    sha,
+    size: bytes.length,
+    encoding: "base64",
+    content: bytes.toString("base64"),
+  };
+  assert.deepEqual(decodeBlob(valid, sha, bytes.length), bytes);
+
+  for (const [payload, error] of [
+    [{ ...valid, sha: objectSha(101) }, /did not match the tree entry/],
+    [{ ...valid, size: bytes.length + 1 }, /size did not match/],
+    [{ ...valid, encoding: "utf-8" }, /encoding was not base64/],
+    [{ ...valid, content: "***" }, /not valid base64/],
+    [
+      {
+        ...valid,
+        size: 2,
+        content: Buffer.from([0xc3, 0x28]).toString("base64"),
+      },
+      /encoded data was not valid|valid for encoding/,
+    ],
+    [
+      {
+        ...valid,
+        size: 3,
+        content: Buffer.from([97, 0, 98]).toString("base64"),
+      },
+      /must not contain NUL bytes/,
+    ],
+  ]) {
+    assert.throws(() => decodeBlob(payload, sha, payload.size), error);
+  }
+});
+
+test("does not create output when a blob cannot be verified", async () => {
+  const fixture = repositoryFixture();
+  const corruptBlobs = new Map(fixture.blobs);
+  const first = fixture.entries[0];
+  corruptBlobs.set(first.sha, {
+    ...corruptBlobs.get(first.sha),
+    content: "***",
+  });
+  const api = fakeGitHubApi({ entries: fixture.entries, blobs: corruptBlobs });
+  const parent = mkdtempSync(join(tmpdir(), "action-pin-fetch-fail-"));
+  const outputDir = join(parent, "pr-head");
+  try {
+    await assert.rejects(
+      materializeActionPinFiles({
+        ...fetchOptions(api.fetchImpl),
+        outputDir,
+      }),
+      /not valid base64/,
+    );
+    assert.equal(existsSync(outputDir), false);
+  } finally {
+    rmSync(parent, { recursive: true, force: true });
+  }
+});
+
+test("requires a fresh absolute output directory", async () => {
+  const api = fakeGitHubApi();
+  await assert.rejects(
+    materializeActionPinFiles({
+      ...fetchOptions(api.fetchImpl),
+      outputDir: "relative/pr-head",
+    }),
+    /absolute non-root path/,
+  );
+  assert.equal(api.calls.length, 0);
+
+  const parent = mkdtempSync(join(tmpdir(), "action-pin-fetch-existing-"));
+  const outputDir = join(parent, "pr-head");
+  mkdirSync(outputDir);
+  try {
+    await assert.rejects(
+      materializeActionPinFiles({
+        ...fetchOptions(api.fetchImpl),
+        outputDir,
+      }),
+      /must not already exist/,
+    );
+    assert.equal(api.calls.length, 0);
+  } finally {
+    rmSync(parent, { recursive: true, force: true });
+  }
+});
+
+let failures = 0;
+for (const { name, run } of tests) {
+  try {
+    await run();
+    console.log(`ok - ${name}`);
+  } catch (error) {
+    failures++;
+    console.error(`not ok - ${name}`);
+    console.error(error instanceof Error ? error.stack : String(error));
+  }
+}
+
+if (failures > 0) process.exit(1);
+
+console.log(`\n${tests.length} action-pin REST materializer tests passed.`);


### PR DESCRIPTION
## The Problem

The repository still had mutable third-party GitHub Action references and no always-run guard preventing workflow or composite-action changes from reintroducing them. A line-oriented checker would also be bypassable by valid YAML aliases, quoted or tagged keys, flow collections, and reusable-workflow syntax. The first trusted-enforcement design checked out the untrusted PR head in a `pull_request_target` job, which CodeQL correctly treated as a cache-poisoning trust-boundary risk even though the checkout was intended as data only.

## The Solution

- Pin the remaining checkout and Claude action references to verified 40-character commit SHAs while retaining readable release comments.
- Add a semantic YAML policy checker that scans executable `uses` paths in workflows and composite actions, follows local actions and reusable workflows recursively, rejects missing/unsafe local manifests, mutable refs, and undocumented pins, and fails closed on malformed or ambiguous policy YAML.
- Run trusted base-branch enforcement in `Action Pin Policy` and proposed checker/fixture validation in the credential-free `Action Pin Policy Source` check.
- Remove the PR-head checkout from `pull_request_target`. Trusted base code now reads the exact fork repository and 40-character head SHA through GitHub's commit/tree/blob REST APIs, validates identities, paths, modes, truncation, file counts, sizes, base64, and UTF-8, then materializes only workflow/composite-action YAML as inert scanner input under `runner.temp`.
- Scope the read-only token to the trusted fetch step; never extract an archive, execute a PR file, persist PR credentials, or populate a cache from PR-controlled content.
- Have trusted code validate the canonical triggers, permissions, job names, commands, fetch boundary, and scanner root of both policy workflows so a PR cannot substitute a same-name no-op check.
- Restrict authenticated on-demand Claude invocations to repository owners and members, and skip secret-backed automatic review on fork PRs.
- Document `pnpm ci:action-pins`, the combined scanner/materializer fixture command, both required contexts, and the protected governance path for policy-code changes.

## Validation

- `CI=true pnpm install --frozen-lockfile --ignore-scripts`
- `pnpm ci:action-pins:test`: 43/43 semantic scanner fixtures and 11/11 REST materializer fixtures passed
- `pnpm ci:action-pins`: all 15 workflow/composite-action YAML files passed
- Trunk/actionlint: all changed files and both policy workflows passed
- `pnpm check-types`: 8/8 tasks passed
- `pnpm knip`: passed with one pre-existing Tailwind configuration hint
- Fresh-context autoreview of the exact final diff: no findings, patch correct at 0.93 confidence
- Deterministic autoreview: clean
- Pre-push repository gate: 960-file Trunk check, 8/8 typechecks, and Knip passed

## Post-merge activation

Add both exact status contexts, `Action Pin Policy` and `Action Pin Policy Source`, to the `main` branch ruleset after the workflows land on the default branch. Policy workflow, checker, or fixture changes must also require protected human/code-owner review or an organization required-workflow rule; the two PR-controlled status contexts are not a tamper-proof approval boundary by themselves.

## Ship Checklist

- [x] `$ship` skill used
- [x] current `origin/main` merged without rewriting history
- [x] local deterministic and fresh-context semantic review run
- [x] focused and repository validation run
- [x] every review comment replied to or queued for current-head closeout
