### PR TITLE
ci: centralize pnpm workflow setup

### DIFF
--- a/.github/actions/pnpm-install/action.yml
+++ b/.github/actions/pnpm-install/action.yml
@@ -1,0 +1,45 @@
+name: Install pnpm dependencies
+description: Set up pnpm and Node.js, restore the pnpm cache, and install from the lockfile
+
+# Callers must check out the repository before invoking this action. Keeping the
+# package-manager bootstrap here gives every dependency-installing workflow one
+# cache implementation and one frozen-lockfile policy.
+inputs:
+  node-version:
+    description: Node.js version to install
+    required: false
+    default: "22"
+  registry-url:
+    description: Optional package registry URL for publishing workflows
+    required: false
+    default: ""
+  cache:
+    description: Whether actions/setup-node should cache the pnpm store
+    required: false
+    default: "true"
+
+runs:
+  using: composite
+  steps:
+    - name: Set up pnpm
+      uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v4
+
+    - name: Set up Node.js with pnpm cache
+      if: inputs.cache == 'true'
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      with:
+        node-version: ${{ inputs.node-version }}
+        cache: pnpm
+        registry-url: ${{ inputs.registry-url }}
+
+    - name: Set up Node.js without package-manager cache
+      if: inputs.cache != 'true'
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      with:
+        node-version: ${{ inputs.node-version }}
+        package-manager-cache: false
+        registry-url: ${{ inputs.registry-url }}
+
+    - name: Install dependencies
+      shell: bash
+      run: pnpm install --frozen-lockfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,30 +58,8 @@ jobs:
         with:
           fetch-depth: 2
 
-      - name: Setup PNPM
-        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v4
-
-      - name: Setup Node.js environment
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version: 22
-          cache: pnpm
-
-      - name: Get pnpm store directory
-        shell: bash
-        run: |
-          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
-
-      - name: Setup pnpm cache
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ${{ env.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-store-
-
-      - name: Install dependencies
-        run: pnpm install
+      - name: Install pnpm dependencies
+        uses: ./.github/actions/pnpm-install
 
       - name: Build
         run: pnpm build

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -218,29 +218,8 @@ jobs:
       - name: Check out code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - name: Setup PNPM
-        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v4
-
-      - name: Setup Node.js environment
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version: 22
-          cache: pnpm
-
-      - name: Get pnpm store directory
-        shell: bash
-        run: echo "STORE_PATH=$(pnpm store path --silent)" >> "$GITHUB_ENV"
-
-      - name: Setup pnpm cache
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ${{ env.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-store-
-
-      - name: Install dependencies
-        run: pnpm install
+      - name: Install pnpm dependencies
+        uses: ./.github/actions/pnpm-install
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@b00af27efadbc7b4ca8b82abbd903b17cc874d2a # v1.9.0
@@ -519,29 +498,8 @@ jobs:
       - name: Check out code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - name: Setup PNPM
-        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v4
-
-      - name: Setup Node.js environment
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version: 22
-          cache: pnpm
-
-      - name: Get pnpm store directory
-        shell: bash
-        run: echo "STORE_PATH=$(pnpm store path --silent)" >> "$GITHUB_ENV"
-
-      - name: Setup pnpm cache
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ${{ env.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-store-
-
-      - name: Install dependencies
-        run: pnpm install
+      - name: Install pnpm dependencies
+        uses: ./.github/actions/pnpm-install
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@b00af27efadbc7b4ca8b82abbd903b17cc874d2a # v1.9.0

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -115,7 +115,7 @@ jobs:
             [[ -z "$file" ]] && continue
 
             case "$file" in
-              .github/workflows/e2e.yml | .npmrc | package.json | pnpm-lock.yaml | pnpm-workspace.yaml | turbo.json | patches/* | scripts/security-headers.mjs | scripts/fork-seed.mjs | scripts/fork-seed.test.mjs)
+              .github/workflows/e2e.yml | .github/actions/pnpm-install/* | .npmrc | package.json | pnpm-lock.yaml | pnpm-workspace.yaml | turbo.json | patches/* | scripts/security-headers.mjs | scripts/fork-seed.mjs | scripts/fork-seed.test.mjs)
                 run_app=true
                 run_gov=true
                 ;;

--- a/.github/workflows/preview-smoke.yml
+++ b/.github/workflows/preview-smoke.yml
@@ -46,29 +46,8 @@ jobs:
       - name: Check out code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - name: Setup PNPM
-        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v4
-
-      - name: Setup Node.js environment
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version: 22
-          cache: pnpm
-
-      - name: Get pnpm store directory
-        shell: bash
-        run: echo "STORE_PATH=$(pnpm store path --silent)" >> "$GITHUB_ENV"
-
-      - name: Setup pnpm cache
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ${{ env.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-store-
-
-      - name: Install dependencies
-        run: pnpm install
+      - name: Install pnpm dependencies
+        uses: ./.github/actions/pnpm-install
 
       # No build step: the spec targets the ALREADY-DEPLOYED preview bundle,
       # not a local build. app-agnostic — runs from app.mento.org's package

--- a/.github/workflows/publish-ui.yml
+++ b/.github/workflows/publish-ui.yml
@@ -23,23 +23,17 @@ jobs:
       - name: Check out code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - name: Setup PNPM
-        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v4
-
-      - name: Setup Node.js environment
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      - name: Install pnpm dependencies
+        uses: ./.github/actions/pnpm-install
         with:
           node-version: 24
-          package-manager-cache: false
+          cache: "false"
           registry-url: https://registry.npmjs.org
 
       - name: Setup npm for trusted publishing
         run: |
           npm install --global npm@11.5.1
           npm --version
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
 
       - name: Validate tag version
         run: |

--- a/.github/workflows/visual.yml
+++ b/.github/workflows/visual.yml
@@ -136,29 +136,8 @@ jobs:
         with:
           fetch-depth: 0 # full history so Argos can compute the merge-base baseline
 
-      - name: Setup PNPM
-        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v4
-
-      - name: Setup Node.js environment
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version: 22
-          cache: pnpm
-
-      - name: Get pnpm store directory
-        shell: bash
-        run: echo "STORE_PATH=$(pnpm store path --silent)" >> "$GITHUB_ENV"
-
-      - name: Setup pnpm cache
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ${{ env.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-store-
-
-      - name: Install dependencies
-        run: pnpm install
+      - name: Install pnpm dependencies
+        uses: ./.github/actions/pnpm-install
 
       - name: Build app
         run: pnpm turbo build --filter=ui.mento.org
@@ -204,29 +183,8 @@ jobs:
         with:
           fetch-depth: 0 # full history so Argos can compute the merge-base baseline
 
-      - name: Setup PNPM
-        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v4
-
-      - name: Setup Node.js environment
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version: 22
-          cache: pnpm
-
-      - name: Get pnpm store directory
-        shell: bash
-        run: echo "STORE_PATH=$(pnpm store path --silent)" >> "$GITHUB_ENV"
-
-      - name: Setup pnpm cache
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ${{ env.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-store-
-
-      - name: Install dependencies
-        run: pnpm install
+      - name: Install pnpm dependencies
+        uses: ./.github/actions/pnpm-install
 
       - name: Build app
         run: pnpm turbo build --filter=app.mento.org

--- a/.github/workflows/visual.yml
+++ b/.github/workflows/visual.yml
@@ -62,7 +62,7 @@ jobs:
             [[ -z "$file" ]] && continue
 
             case "$file" in
-              .github/workflows/visual.yml | .npmrc | package.json | pnpm-lock.yaml | pnpm-workspace.yaml | turbo.json | patches/* | scripts/security-headers.mjs)
+              .github/workflows/visual.yml | .github/actions/pnpm-install/* | .npmrc | package.json | pnpm-lock.yaml | pnpm-workspace.yaml | turbo.json | patches/* | scripts/security-headers.mjs)
                 run_app=true
                 run_ui=true
                 ;;

--- a/README.md
+++ b/README.md
@@ -373,6 +373,12 @@ The repository is set up with GitHub Actions for CI:
 - **CI**: On every PR, it runs linting (via Trunk), type checking, and builds all packages
 - **CD**: Deployments are handled by the Vercel Git integration — each app is a Vercel project that builds on push to main (previews on PRs). GitHub Actions does not deploy.
 
+Dependency-installing jobs use `.github/actions/pnpm-install`, which pins the
+Node/pnpm bootstrap, relies on `actions/setup-node` as the single pnpm-store
+cache owner, and enforces `pnpm install --frozen-lockfile`. Publishing overrides
+the composite's Node version and disables its cache; zero-dependency jobs may
+set up Node directly.
+
 ### Trunk in CI
 
 The CI pipeline uses the [Trunk GitHub Action](https://github.com/trunk-io/trunk-action) to:
@@ -442,7 +448,9 @@ Never commit the key. If you don't set it, nothing breaks — you just lose the 
 <!-- markdown-link-check-disable -->
 
 - [x] ~~Add [syncpack](https://www.npmjs.com/package/syncpack) for consistent dependency versions across all monorepo packages~~ (Now using PNPM catalog)
+
 <!-- markdown-link-check-enable -->
+
 - [ ] Finetune builds. There's probably ways to make the builds of both packages and apps smaller and/or more performant.
 - [ ] Make VS Code's "Go To Definition" on a component jump to the actual TypeScript source file instead of the compiled JS file in ./dist
 - [ ] Enable additional Trunk linters for production CI (security scanning, image optimization)


### PR DESCRIPTION
## The Problem

Seven GitHub Actions jobs duplicated pnpm, Node, cache, and install setup. Most also restored the same pnpm store twice through both `actions/setup-node` and `actions/cache`, adding avoidable CI time and leaving install policy free to drift between workflows.

## The Solution

- Add one local `pnpm-install` composite action that pins the pnpm and Node bootstrap and always installs with `--frozen-lockfile`.
- Make `actions/setup-node` the single pnpm-store cache owner.
- Replace every dependency-installing workflow sequence with the composite while keeping zero-dependency jobs direct.
- Preserve the trusted-publishing workflow's Node 24, npm registry, and cache-disabled behavior through composite inputs.
- Document the setup ownership model in the CI section of the README.

## Validation

- `CI=true pnpm install --frozen-lockfile`
- `actionlint .github/workflows/*.yml`
- targeted `pnpm exec prettier --check`
- targeted `trunk check` (7 files)
- `pnpm check-types` (8/8 tasks)
- `pnpm test` (6/6 tasks; 462 tests across tested workspaces)
- `pnpm knip` (exit 0; one pre-existing Tailwind configuration hint)
- centralization invariant scan: no direct workflow `pnpm install` steps and no manual pnpm-store cache keys remain
- pre-push gates after rebasing: Trunk checked 950 files, type checks passed 8/8, knip passed
- structured autoreview: deterministic guard clean; independent semantic review clean with no findings (0.94 confidence)

## Ship Checklist

- [x] `$ship` workflow followed
- [x] Branch rebased onto current `origin/main`
- [x] Focused and repository gates passed
- [x] Independent semantic and deterministic reviews passed
- [x] No UI source changed; browser verification is not applicable

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow refactor with no application or runtime code changes; main risk is transient CI behavior if cache or Node version inputs differ from before.
> 
> **Overview**
> Introduces a reusable composite action **`.github/actions/pnpm-install`** and wires every dependency-installing GitHub Actions job through it instead of copying the same bootstrap steps.
> 
> The composite pins **pnpm** and **Node** setup, uses **`actions/setup-node`** as the only pnpm-store cache (removing the extra **`actions/cache`** on the store path), and always runs **`pnpm install --frozen-lockfile`**. **`ci`**, **`e2e`**, **`preview-smoke`**, and **`visual`** jobs now call the composite after checkout; **`publish-ui`** passes **`node-version: 24`**, **`cache: "false"`**, and the npm registry URL so trusted publishing behavior stays the same.
> 
> The README CI section documents this ownership model (composite vs direct Node for zero-dependency jobs).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e96a9e2462c72eeb721321546c8be02732e205f7. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->