### PR TITLE
chore(ci): enforce structured PR descriptions

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,17 +1,19 @@
-# Description
+<!-- markdownlint-disable MD041 -->
 
-_Provide a clear and concise summary of what this pull request changes and why. Explain the main goals and the expected impact (e.g., Updated token names accordingly to the rebranding)._
+## The Problem
 
-## Other changes
+- [Describe the problem, user impact, or maintenance risk this PR addresses.]
 
-_Describe any minor or "drive-by" changes here. (e.g., Updated the `zod` package dependency)_
+## The Solution
 
-## Testing
+- [Explain how this PR solves the problem in plain English.]
 
-_Explain how you tested your changes. List manual steps, automated tests, or checks performed to confirm your changes work as intended (e.g., Go to the App-Mento and swap on mainnet and testnet chains)._
+## Validation
 
-## Checklist before requesting a review
+- [List commands and results, plus any manual verification.]
+
+## Ship Checklist
 
 - [ ] PR title follows the [conventions](https://www.notion.so/Git-Branching-and-Commit-Message-Conventions-18f66f7d06444cfcbac5725ffbc7c04a?pvs=4#9355048863c549ef92fe210a8a1298aa)
-- [ ] Performed a self-review of my own code changes
-- [ ] Smoke Test Run/s passed on the CI
+- [ ] Performed a self-review of my own changes
+- [ ] Relevant automated checks and smoke tests pass

--- a/.github/workflows/pr-description.yml
+++ b/.github/workflows/pr-description.yml
@@ -1,0 +1,63 @@
+name: PR Description
+
+# This workflow is intended to become a required status after it lands on the
+# default branch. It deliberately has no paths filter, and synchronize reruns
+# it for every new head SHA. Editing the PR body also reruns it immediately.
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, edited, synchronize, reopened, ready_for_review]
+
+concurrency:
+  group: ${{ github.workflow }}-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: PR description format
+    # Draft descriptions are allowed to evolve. Dependabot uses generated
+    # bodies that cannot follow the repository template. GitHub reports an
+    # intentionally skipped job as successful, so either case remains safe if
+    # this job is configured as a required status.
+    if: >-
+      github.event.pull_request.draft == false &&
+      github.event.pull_request.user.login != 'dependabot[bot]'
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout trusted validator
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+          ref: ${{ github.event.pull_request.base.sha }}
+          path: trusted-base
+
+      - name: Checkout bootstrap validator
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+          ref: ${{ github.event.pull_request.head.sha }}
+          path: pr-head
+
+      - name: Validate PR description
+        # Never interpolate user-controlled PR content into the shell script.
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          set -euo pipefail
+
+          if [ -f trusted-base/scripts/check-pr-description.mjs ]; then
+            node trusted-base/scripts/check-pr-description.mjs
+          elif [ -f pr-head/scripts/check-pr-description.mjs ]; then
+            echo "::warning::The trusted base does not have the validator yet; using the PR copy to bootstrap this policy."
+            node pr-head/scripts/check-pr-description.mjs
+          else
+            echo "::error::PR-description validator is missing from both the target branch and PR head."
+            exit 1
+          fi

--- a/.github/workflows/pr-description.yml
+++ b/.github/workflows/pr-description.yml
@@ -45,7 +45,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           path: pr-head
 
-      - name: Validate PR description
+      - name: Test and validate PR description
         # Never interpolate user-controlled PR content into the shell script.
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
@@ -53,11 +53,14 @@ jobs:
           set -euo pipefail
 
           if [ -f trusted-base/scripts/check-pr-description.mjs ]; then
-            node trusted-base/scripts/check-pr-description.mjs
+            validator_root=trusted-base
           elif [ -f pr-head/scripts/check-pr-description.mjs ]; then
             echo "::warning::The trusted base does not have the validator yet; using the PR copy to bootstrap this policy."
-            node pr-head/scripts/check-pr-description.mjs
+            validator_root=pr-head
           else
             echo "::error::PR-description validator is missing from both the target branch and PR head."
             exit 1
           fi
+
+          node "$validator_root/scripts/check-pr-description.test.mjs"
+          node "$validator_root/scripts/check-pr-description.mjs"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,8 @@ that the checkout was unavailable.
 Every non-draft, non-Dependabot pull request body must start with the exact
 top-level headings `## The Problem` then `## The Solution` as its first two H2
 sections. Only HTML comments may appear before `## The Problem`. Validate the
-format with `pnpm pr:description:check`; run the validator tests with
-`pnpm pr:description:test`. The `PR description format` job is designed to be
-a required status and therefore must keep running without path filters.
+current PR with
+`gh pr view --json body --jq .body | pnpm pr:description:check`; run the
+validator tests with `pnpm pr:description:test`. The `PR description format`
+job is designed to be a required status and therefore must keep running without
+path filters.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,3 +27,12 @@ for frontend implementation details. It is a router, not live truth; verify
 current values through the source-specific repo, API, RPC, or frontend path it
 points to. When answering, mention which master-context card you used or state
 that the checkout was unavailable.
+
+## Pull request descriptions
+
+Every non-draft, non-Dependabot pull request body must start with the exact
+top-level headings `## The Problem` then `## The Solution` as its first two H2
+sections. Only HTML comments may appear before `## The Problem`. Validate the
+format with `pnpm pr:description:check`; run the validator tests with
+`pnpm pr:description:test`. The `PR description format` job is designed to be
+a required status and therefore must keep running without path filters.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,7 @@ trunk fmt                             # Format
 pnpm test                            # Run tests
 pnpm fork:mainnet                    # Local anvil fork of Celo mainnet (--celo --auto-impersonate)
 pnpm fork:seed                       # Fund fork accounts + re-report oracle prices (idempotent)
+pnpm pr:description:test             # Test the required PR-description format validator
 ```
 
 Always use `--filter` to avoid building/running everything unnecessarily.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,6 +45,7 @@ pnpm test                            # Run tests
 pnpm fork:mainnet                    # Local anvil fork of Celo mainnet (--celo --auto-impersonate)
 pnpm fork:seed                       # Fund fork accounts + re-report oracle prices (idempotent)
 pnpm pr:description:test             # Test the required PR-description format validator
+gh pr view --json body --jq .body | pnpm pr:description:check  # Validate the current PR body
 ```
 
 Always use `--filter` to avoid building/running everything unnecessarily.

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
     "knip": "knip",
     "lint": "npx @trunkio/launcher check",
     "lint:fix": "npx @trunkio/launcher check --fix",
+    "pr:description:check": "node scripts/check-pr-description.mjs",
+    "pr:description:test": "node scripts/check-pr-description.test.mjs",
     "rebuild": "pnpm run clean && turbo run build",
     "supply-chain:lockfile-lint": "node scripts/lockfile-lint.mjs",
     "supply-chain:lockfile-lint:test": "node scripts/lockfile-lint.test.mjs",

--- a/scripts/check-pr-description.mjs
+++ b/scripts/check-pr-description.mjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import process from "node:process";
 import { fileURLToPath } from "node:url";
@@ -8,74 +9,138 @@ const PROBLEM_HEADING_RE = /^##\s+The Problem\s*$/;
 const SOLUTION_HEADING_RE = /^##\s+The Solution\s*$/;
 const PLACEHOLDER_RE =
   /\[(?:Describe the problem|Explain how this PR solves|List commands and results)/;
+const CODE_BLOCK_MARKER = "PR_DESCRIPTION_FENCED_CODE";
+const INLINE_CODE_MARKER = "PR_DESCRIPTION_INLINE_CODE";
 
 function linesOf(body) {
   return body.split(/\r?\n/);
 }
 
-function stripHtmlComments(body) {
-  let inComment = false;
-  const kept = [];
-
-  for (const originalLine of linesOf(body)) {
-    let line = originalLine;
-    let output = "";
-    let strippedComment = false;
-
-    while (line !== "") {
-      if (inComment) {
-        const close = line.indexOf("-->");
-        if (close === -1) break;
-        inComment = false;
-        strippedComment = true;
-        line = line.slice(close + 3);
-        continue;
-      }
-
-      const open = line.indexOf("<!--");
-      if (open === -1) {
-        output += line;
-        break;
-      }
-
-      output += line.slice(0, open);
-      strippedComment = true;
-      const close = line.indexOf("-->", open + 4);
-      if (close === -1) {
-        inComment = true;
-        break;
-      }
-      line = line.slice(close + 3);
-    }
-
-    if (strippedComment && output.trim() === "") continue;
-    kept.push(strippedComment ? output.trimStart() : output);
-  }
-
-  return kept.join("\n");
+function backtickRunLength(body, start) {
+  let end = start;
+  while (body[end] === "`") end += 1;
+  return end - start;
 }
 
-function stripFencedBlocks(body) {
-  let fence = null;
-  const kept = [];
+function isInlineBlockBoundary(line) {
+  return (
+    /^\s*$/.test(line) ||
+    /^[ \t]{0,3}(?:#{1,6}(?:[ \t]+|$)|`{3,}|~{3,}|>|<!--)/.test(line) ||
+    /^[ \t]{0,3}(?:=+|-+)[ \t]*$/.test(line)
+  );
+}
 
-  for (const line of linesOf(body)) {
-    if (fence === null) {
-      const opening = /^\s*(`{3,}|~{3,})/.exec(line);
-      if (opening) {
-        fence = { character: opening[1][0], length: opening[1].length };
-        continue;
-      }
-      kept.push(line);
+function inlineBlockEnd(body, start) {
+  let newline = body.indexOf("\n", start);
+
+  while (newline !== -1) {
+    const nextLineStart = newline + 1;
+    const nextNewline = body.indexOf("\n", nextLineStart);
+    const nextLineEnd = nextNewline === -1 ? body.length : nextNewline;
+    const rawLine = body.slice(nextLineStart, nextLineEnd);
+    const line = rawLine.endsWith("\r") ? rawLine.slice(0, -1) : rawLine;
+    if (isInlineBlockBoundary(line)) return newline;
+    newline = nextNewline;
+  }
+
+  return body.length;
+}
+
+function findClosingBackticks(body, start, length, end) {
+  let cursor = start;
+
+  while (cursor < end) {
+    const candidate = body.indexOf("`", cursor);
+    if (candidate === -1 || candidate >= end) return -1;
+    const candidateLength = backtickRunLength(body, candidate);
+    if (candidateLength === length) return candidate;
+    cursor = candidate + candidateLength;
+  }
+
+  return -1;
+}
+
+function maskNonStructuralMarkdown(body) {
+  let output = "";
+  let cursor = 0;
+  let inComment = false;
+  let fence = null;
+
+  while (cursor < body.length) {
+    if (fence !== null) {
+      const newline = body.indexOf("\n", cursor);
+      const lineEnd = newline === -1 ? body.length : newline;
+      const rawLine = body.slice(cursor, lineEnd);
+      const line = rawLine.endsWith("\r") ? rawLine.slice(0, -1) : rawLine;
+      const closing = new RegExp(
+        `^[ \\t]{0,3}${fence.character}{${fence.length},}[ \\t]*$`,
+      );
+      if (closing.test(line)) fence = null;
+      if (newline !== -1) output += "\n";
+      cursor = newline === -1 ? body.length : newline + 1;
       continue;
     }
 
-    const escaped = fence.character === "`" ? "`" : "~";
-    const closing = new RegExp(`^\\s*${escaped}{${fence.length},}\\s*$`);
-    if (closing.test(line)) fence = null;
+    if (inComment) {
+      if (body.startsWith("-->", cursor)) {
+        inComment = false;
+        cursor += 3;
+      } else {
+        if (body[cursor] === "\n") output += "\n";
+        cursor += 1;
+      }
+      continue;
+    }
+
+    const atLineStart = cursor === 0 || body[cursor - 1] === "\n";
+    if (atLineStart) {
+      const newline = body.indexOf("\n", cursor);
+      const lineEnd = newline === -1 ? body.length : newline;
+      const rawLine = body.slice(cursor, lineEnd);
+      const line = rawLine.endsWith("\r") ? rawLine.slice(0, -1) : rawLine;
+      const opening = /^[ \\t]{0,3}(`{3,}|~{3,})/.exec(line);
+      if (opening) {
+        fence = { character: opening[1][0], length: opening[1].length };
+        output += CODE_BLOCK_MARKER;
+        if (newline !== -1) output += "\n";
+        cursor = newline === -1 ? body.length : newline + 1;
+        continue;
+      }
+    }
+
+    if (body.startsWith("<!--", cursor)) {
+      inComment = true;
+      cursor += 4;
+      continue;
+    }
+
+    if (body[cursor] !== "`") {
+      output += body[cursor];
+      cursor += 1;
+      continue;
+    }
+
+    const openingLength = backtickRunLength(body, cursor);
+    const contentStart = cursor + openingLength;
+    const closing = findClosingBackticks(
+      body,
+      contentStart,
+      openingLength,
+      inlineBlockEnd(body, contentStart),
+    );
+    if (closing === -1) {
+      output += "`".repeat(openingLength);
+      cursor = contentStart;
+      continue;
+    }
+
+    const codeContent = body.slice(contentStart, closing);
+    output += INLINE_CODE_MARKER;
+    output += "\n".repeat(codeContent.split("\n").length - 1);
+    cursor = closing + openingLength;
   }
 
-  return { body: kept.join("\n"), hasUnclosedFence: fence !== null };
+  return { body: output, hasUnclosedFence: fence !== null };
 }
 
 function firstNonBlankLine(body) {
@@ -103,10 +168,9 @@ export function validatePrDescription(body) {
     };
   }
 
-  const commentStripped = stripHtmlComments(body);
-  const firstLine = firstNonBlankLine(commentStripped);
-  const { body: fenceStripped, hasUnclosedFence } =
-    stripFencedBlocks(commentStripped);
+  // A single state machine preserves Markdown precedence: fences and inline
+  // code mask comment-like text only when they begin outside an HTML comment.
+  const { body: structure, hasUnclosedFence } = maskNonStructuralMarkdown(body);
 
   if (hasUnclosedFence) {
     return {
@@ -116,7 +180,8 @@ export function validatePrDescription(body) {
     };
   }
 
-  const secondHeading = h2Headings(fenceStripped)[1] ?? "";
+  const firstLine = firstNonBlankLine(structure);
+  const secondHeading = h2Headings(structure)[1] ?? "";
   if (
     !PROBLEM_HEADING_RE.test(firstLine) ||
     !SOLUTION_HEADING_RE.test(secondHeading)
@@ -135,6 +200,17 @@ export function validatePrDescription(body) {
   };
 }
 
+function readCliBody() {
+  // Workflow-local input, not a Turbo task dependency.
+
+  if (Object.hasOwn(process.env, "PR_BODY")) {
+    // eslint-disable-next-line turbo/no-undeclared-env-vars
+    return process.env.PR_BODY ?? "";
+  }
+
+  return process.stdin.isTTY ? "" : readFileSync(0, "utf8");
+}
+
 function isCliEntrypoint() {
   return (
     process.argv[1] !== undefined &&
@@ -143,9 +219,7 @@ function isCliEntrypoint() {
 }
 
 if (isCliEntrypoint()) {
-  // Workflow-local input, not a Turbo task dependency.
-  // eslint-disable-next-line turbo/no-undeclared-env-vars
-  const result = validatePrDescription(process.env.PR_BODY ?? "");
+  const result = validatePrDescription(readCliBody());
   if (result.ok) {
     console.log(result.message);
   } else {

--- a/scripts/check-pr-description.mjs
+++ b/scripts/check-pr-description.mjs
@@ -1,0 +1,155 @@
+#!/usr/bin/env node
+
+import { resolve } from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+const PROBLEM_HEADING_RE = /^##\s+The Problem\s*$/;
+const SOLUTION_HEADING_RE = /^##\s+The Solution\s*$/;
+const PLACEHOLDER_RE =
+  /\[(?:Describe the problem|Explain how this PR solves|List commands and results)/;
+
+function linesOf(body) {
+  return body.split(/\r?\n/);
+}
+
+function stripHtmlComments(body) {
+  let inComment = false;
+  const kept = [];
+
+  for (const originalLine of linesOf(body)) {
+    let line = originalLine;
+    let output = "";
+    let strippedComment = false;
+
+    while (line !== "") {
+      if (inComment) {
+        const close = line.indexOf("-->");
+        if (close === -1) break;
+        inComment = false;
+        strippedComment = true;
+        line = line.slice(close + 3);
+        continue;
+      }
+
+      const open = line.indexOf("<!--");
+      if (open === -1) {
+        output += line;
+        break;
+      }
+
+      output += line.slice(0, open);
+      strippedComment = true;
+      const close = line.indexOf("-->", open + 4);
+      if (close === -1) {
+        inComment = true;
+        break;
+      }
+      line = line.slice(close + 3);
+    }
+
+    if (strippedComment && output.trim() === "") continue;
+    kept.push(strippedComment ? output.trimStart() : output);
+  }
+
+  return kept.join("\n");
+}
+
+function stripFencedBlocks(body) {
+  let fence = null;
+  const kept = [];
+
+  for (const line of linesOf(body)) {
+    if (fence === null) {
+      const opening = /^\s*(`{3,}|~{3,})/.exec(line);
+      if (opening) {
+        fence = { character: opening[1][0], length: opening[1].length };
+        continue;
+      }
+      kept.push(line);
+      continue;
+    }
+
+    const escaped = fence.character === "`" ? "`" : "~";
+    const closing = new RegExp(`^\\s*${escaped}{${fence.length},}\\s*$`);
+    if (closing.test(line)) fence = null;
+  }
+
+  return { body: kept.join("\n"), hasUnclosedFence: fence !== null };
+}
+
+function firstNonBlankLine(body) {
+  return linesOf(body).find((line) => line.trim() !== "") ?? "";
+}
+
+function h2Headings(body) {
+  return linesOf(body).filter((line) => /^##\s/.test(line));
+}
+
+export function validatePrDescription(body) {
+  if (body.trim() === "") {
+    return {
+      ok: false,
+      message:
+        "PR description is empty. It must start with '## The Problem' then '## The Solution'.",
+    };
+  }
+
+  if (PLACEHOLDER_RE.test(body)) {
+    return {
+      ok: false,
+      message:
+        "PR description still contains template placeholders. Replace each bracketed prompt with real content.",
+    };
+  }
+
+  const commentStripped = stripHtmlComments(body);
+  const firstLine = firstNonBlankLine(commentStripped);
+  const { body: fenceStripped, hasUnclosedFence } =
+    stripFencedBlocks(commentStripped);
+
+  if (hasUnclosedFence) {
+    return {
+      ok: false,
+      message:
+        "PR description contains an unclosed fenced code block. Close it before the required sections.",
+    };
+  }
+
+  const secondHeading = h2Headings(fenceStripped)[1] ?? "";
+  if (
+    !PROBLEM_HEADING_RE.test(firstLine) ||
+    !SOLUTION_HEADING_RE.test(secondHeading)
+  ) {
+    return {
+      ok: false,
+      message:
+        "PR description must start with exact '## The Problem' then '## The Solution' headings as its first two sections. Only HTML comments may precede '## The Problem'.",
+    };
+  }
+
+  return {
+    ok: true,
+    message:
+      "PR description OK: it starts with '## The Problem' then '## The Solution' and has no template placeholders.",
+  };
+}
+
+function isCliEntrypoint() {
+  return (
+    process.argv[1] !== undefined &&
+    fileURLToPath(import.meta.url) === resolve(process.argv[1])
+  );
+}
+
+if (isCliEntrypoint()) {
+  // Workflow-local input, not a Turbo task dependency.
+  // eslint-disable-next-line turbo/no-undeclared-env-vars
+  const result = validatePrDescription(process.env.PR_BODY ?? "");
+  if (result.ok) {
+    console.log(result.message);
+  } else {
+    console.log(`::error::${result.message}`);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/check-pr-description.mjs
+++ b/scripts/check-pr-description.mjs
@@ -60,10 +60,22 @@ function findClosingBackticks(body, start, length, end) {
   return -1;
 }
 
+function previousLineIsBlank(body, lineStart) {
+  if (lineStart === 0) return true;
+  const previousLineEnd = lineStart - 1;
+  const previousLineStart = body.lastIndexOf("\n", previousLineEnd - 1) + 1;
+  return /^\s*$/.test(body.slice(previousLineStart, previousLineEnd));
+}
+
+function isIndentedCodeLine(line) {
+  return /^(?: {4}|\t)/.test(line);
+}
+
 function maskNonStructuralMarkdown(body) {
   let output = "";
   let cursor = 0;
   let inComment = false;
+  let inIndentedCode = false;
   let fence = null;
 
   while (cursor < body.length) {
@@ -98,7 +110,26 @@ function maskNonStructuralMarkdown(body) {
       const lineEnd = newline === -1 ? body.length : newline;
       const rawLine = body.slice(cursor, lineEnd);
       const line = rawLine.endsWith("\r") ? rawLine.slice(0, -1) : rawLine;
-      const opening = /^[ \\t]{0,3}(`{3,}|~{3,})/.exec(line);
+
+      if (inIndentedCode) {
+        if (/^\s*$/.test(line) || isIndentedCodeLine(line)) {
+          if (!/^\s*$/.test(line)) output += CODE_BLOCK_MARKER;
+          if (newline !== -1) output += "\n";
+          cursor = newline === -1 ? body.length : newline + 1;
+          continue;
+        }
+        inIndentedCode = false;
+      }
+
+      if (isIndentedCodeLine(line) && previousLineIsBlank(body, cursor)) {
+        inIndentedCode = true;
+        output += CODE_BLOCK_MARKER;
+        if (newline !== -1) output += "\n";
+        cursor = newline === -1 ? body.length : newline + 1;
+        continue;
+      }
+
+      const opening = /^[ \t]{0,3}(`{3,}|~{3,})/.exec(line);
       if (opening) {
         fence = { character: opening[1][0], length: opening[1].length };
         output += CODE_BLOCK_MARKER;
@@ -160,16 +191,9 @@ export function validatePrDescription(body) {
     };
   }
 
-  if (PLACEHOLDER_RE.test(body)) {
-    return {
-      ok: false,
-      message:
-        "PR description still contains template placeholders. Replace each bracketed prompt with real content.",
-    };
-  }
-
-  // A single state machine preserves Markdown precedence: fences and inline
-  // code mask comment-like text only when they begin outside an HTML comment.
+  // A single state machine preserves Markdown precedence: fenced/indented
+  // code and inline code mask comment-like text only when they begin outside
+  // an HTML comment.
   const { body: structure, hasUnclosedFence } = maskNonStructuralMarkdown(body);
 
   if (hasUnclosedFence) {
@@ -177,6 +201,14 @@ export function validatePrDescription(body) {
       ok: false,
       message:
         "PR description contains an unclosed fenced code block. Close it before the required sections.",
+    };
+  }
+
+  if (PLACEHOLDER_RE.test(structure)) {
+    return {
+      ok: false,
+      message:
+        "PR description still contains template placeholders. Replace each bracketed prompt with real content.",
     };
   }
 

--- a/scripts/check-pr-description.test.mjs
+++ b/scripts/check-pr-description.test.mjs
@@ -94,6 +94,23 @@ test("fails unfilled template placeholders", () => {
   );
 });
 
+test("allows template prompt text when rendered as code or hidden in a comment", () => {
+  assertPass(
+    validBody(`
+
+## Validation
+
+- Example: \`[List commands and results, plus any manual verification.]\`
+
+\`\`\`md
+[Describe the problem, user impact, or maintenance risk this PR addresses.]
+\`\`\`
+
+<!-- [Explain how this PR solves the problem in plain English.] -->
+`),
+  );
+});
+
 test("fails content before The Problem", () => {
   assertFail(
     `# Summary\n\n${validBody()}`,
@@ -147,6 +164,24 @@ Context.
 - Tests pass.
 `,
     /then '## The Solution'/,
+  );
+});
+
+test("does not treat a t-prefixed fence as fenced code", () => {
+  assertFail(
+    `## The Problem
+
+Context.
+
+t\`\`\`md
+## Background
+\`\`\`
+
+## The Solution
+
+Implementation.
+`,
+    /unclosed fenced code block/,
   );
 });
 
@@ -215,6 +250,26 @@ still rendered as code\`
 ## Background
 
 \`-->\`
+
+## The Solution
+
+Implementation.
+`,
+    /then '## The Solution'/,
+  );
+});
+
+test("does not interpret comment markers in indented code as HTML comments", () => {
+  assertFail(
+    `## The Problem
+
+Context.
+
+    <!--
+
+## Background
+
+    -->
 
 ## The Solution
 

--- a/scripts/check-pr-description.test.mjs
+++ b/scripts/check-pr-description.test.mjs
@@ -150,6 +150,109 @@ Context.
   );
 });
 
+test("does not treat HTML comment markers rendered as inline code as comments", () => {
+  assertFail(
+    `## The Problem
+
+Context.
+
+\`<!--\`
+
+## Background
+
+More context.
+
+\`-->\`
+
+## The Solution
+
+Implementation.
+`,
+    /then '## The Solution'/,
+  );
+});
+
+test("does not pair inline-code delimiters across Markdown blocks", () => {
+  assertFail(
+    `## The Problem
+
+Context \`
+
+## Background
+
+Details \`
+
+## The Solution
+
+Implementation.
+`,
+    /then '## The Solution'/,
+  );
+});
+
+test("allows inline code to span soft line breaks within one block", () => {
+  assertPass(
+    `## The Problem
+
+\`<!--
+still rendered as code -->\`
+
+## The Solution
+
+Implementation.
+`,
+  );
+});
+
+test("allows inline code to span an indented paragraph continuation", () => {
+  assertFail(
+    `## The Problem
+
+\`code begins
+    <!--
+still rendered as code\`
+
+## Background
+
+\`-->\`
+
+## The Solution
+
+Implementation.
+`,
+    /then '## The Solution'/,
+  );
+});
+
+test("closes HTML comments before interpreting backticks inside them", () => {
+  assertFail(
+    `<!--
+\`-->\`
+
+## Background
+
+-->
+
+${validBody()}`,
+    /must start with exact '## The Problem'/,
+  );
+});
+
+test("ignores HTML comment markers and headings inside fenced code", () => {
+  assertPass(
+    validBody(`
+
+## Details
+
+\`\`\`md
+<!--
+## Example heading
+-->
+\`\`\`
+`),
+  );
+});
+
 test("fails an unclosed fenced block", () => {
   assertFail(
     validBody(`
@@ -196,6 +299,18 @@ test("CLI guard accepts a valid body from a relative script path", () => {
     cwd: repoRoot,
     encoding: "utf8",
     env: { ...process.env, PR_BODY: validBody() },
+  });
+  assert.match(output, /PR description OK/);
+});
+
+test("CLI guard accepts a valid body from stdin", () => {
+  const environment = { ...process.env };
+  delete environment.PR_BODY;
+  const output = execFileSync(process.execPath, [relativeScriptPath], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env: environment,
+    input: validBody(),
   });
   assert.match(output, /PR description OK/);
 });

--- a/scripts/check-pr-description.test.mjs
+++ b/scripts/check-pr-description.test.mjs
@@ -1,0 +1,201 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { relative } from "node:path";
+import process from "node:process";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+import { validatePrDescription } from "./check-pr-description.mjs";
+
+const repoRoot = fileURLToPath(new URL("../", import.meta.url));
+const relativeScriptPath = relative(
+  repoRoot,
+  fileURLToPath(new URL("./check-pr-description.mjs", import.meta.url)),
+);
+const pullRequestTemplate = readFileSync(
+  new URL("../.github/pull_request_template.md", import.meta.url),
+  "utf8",
+);
+
+function validBody(extra = "") {
+  return `## The Problem
+
+- Reviewers need consistent context for every change.
+
+## The Solution
+
+- Validate the two required opening sections in CI.
+${extra}`;
+}
+
+function assertPass(body) {
+  const result = validatePrDescription(body);
+  assert.equal(result.ok, true, result.message);
+}
+
+function assertFail(body, expected) {
+  const result = validatePrDescription(body);
+  assert.equal(result.ok, false, "expected validation to fail");
+  assert.match(result.message, expected);
+}
+
+test("passes the required headings followed by optional sections", () => {
+  assertPass(
+    validBody(`
+
+## Validation
+
+- node scripts/check-pr-description.test.mjs
+`),
+  );
+});
+
+test("keeps the repository template aligned with the validator", () => {
+  assertFail(pullRequestTemplate, /template placeholders/);
+  assertPass(
+    pullRequestTemplate
+      .replace(
+        "[Describe the problem, user impact, or maintenance risk this PR addresses.]",
+        "Existing PR descriptions do not provide consistent context.",
+      )
+      .replace(
+        "[Explain how this PR solves the problem in plain English.]",
+        "Validate the required opening sections in CI.",
+      )
+      .replace(
+        "[List commands and results, plus any manual verification.]",
+        "node scripts/check-pr-description.test.mjs",
+      ),
+  );
+});
+
+test("allows HTML comments before the opening heading", () => {
+  assertPass(`<!-- markdownlint-disable MD041 -->\n\n${validBody()}`);
+});
+
+test("allows trailing heading whitespace and CRLF newlines", () => {
+  assertPass(
+    validBody().replaceAll("\n", "\r\n").replace("Problem\r", "Problem  \r"),
+  );
+});
+
+test("fails an empty body", () => {
+  assertFail(" \n", /PR description is empty/);
+});
+
+test("fails unfilled template placeholders", () => {
+  assertFail(
+    validBody(`
+
+- [List commands and results, plus any manual verification.]
+`),
+    /template placeholders/,
+  );
+});
+
+test("fails content before The Problem", () => {
+  assertFail(
+    `# Summary\n\n${validBody()}`,
+    /must start with exact '## The Problem'/,
+  );
+});
+
+test("fails when The Solution is not the second H2 section", () => {
+  assertFail(
+    validBody().replace(
+      "## The Solution",
+      "## Background\n\nContext.\n\n## The Solution",
+    ),
+    /then '## The Solution'/,
+  );
+});
+
+test("fails swapped opening sections", () => {
+  assertFail(
+    `## The Solution\n\nFirst.\n\n## The Problem\n\nSecond.\n`,
+    /must start with exact '## The Problem'/,
+  );
+});
+
+test("fails near-miss required headings", () => {
+  for (const heading of [
+    "# The Problem",
+    "## the Problem",
+    "## The Problem:",
+    "### The Problem",
+  ]) {
+    assertFail(
+      validBody().replace("## The Problem", heading),
+      /must start with exact '## The Problem'/,
+    );
+  }
+});
+
+test("does not count a fenced heading as The Solution", () => {
+  assertFail(
+    `## The Problem
+
+Context.
+
+\`\`\`md
+## The Solution
+\`\`\`
+
+## Validation
+
+- Tests pass.
+`,
+    /then '## The Solution'/,
+  );
+});
+
+test("fails an unclosed fenced block", () => {
+  assertFail(
+    validBody(`
+
+## Details
+
+\`\`\`text
+unfinished
+`),
+    /unclosed fenced code block/,
+  );
+});
+
+test("ignores required headings inside HTML comments", () => {
+  assertFail(
+    `<!--
+## The Problem
+## The Solution
+-->
+
+## Summary
+`,
+    /must start with exact '## The Problem'/,
+  );
+});
+
+test("CLI guard rejects an invalid body from a relative script path", () => {
+  let error;
+  try {
+    execFileSync(process.execPath, [relativeScriptPath], {
+      cwd: repoRoot,
+      encoding: "utf8",
+      env: { ...process.env, PR_BODY: "# Summary\n" },
+    });
+  } catch (caught) {
+    error = caught;
+  }
+  assert.ok(error instanceof Error, "expected CLI validation to fail");
+  assert.match(error.stdout, /must start with exact '## The Problem'/);
+});
+
+test("CLI guard accepts a valid body from a relative script path", () => {
+  const output = execFileSync(process.execPath, [relativeScriptPath], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env: { ...process.env, PR_BODY: validBody() },
+  });
+  assert.match(output, /PR description OK/);
+});


### PR DESCRIPTION
## The Problem

- Pull requests can omit the context reviewers need to understand why a change exists and how it addresses the underlying problem.
- The repository has no automated check that keeps PR descriptions aligned with a consistent structure.

## The Solution

- Replace the PR template with mandatory `## The Problem` and `## The Solution` opening sections.
- Add a tested Markdown-aware validator and an always-run, least-privilege workflow that uses the trusted base copy after the bootstrap PR.
- Document local validation and keep the validator, template, and workflow conventions discoverable for future contributors and agents.

## Validation

- `pnpm pr:description:test` — 22 tests passed.
- `trunk check .github/pull_request_template.md .github/workflows/pr-description.yml AGENTS.md CLAUDE.md package.json scripts/check-pr-description.mjs scripts/check-pr-description.test.mjs` — no issues.
- Pre-push hooks — Trunk checked 952 files, all 8 type-check tasks passed, and Knip passed with its existing configuration hint.
- Deterministic autoreview — clean.
- Independent semantic autoreview — all verified findings fixed; final pass returned no findings at 0.93 confidence.

## Post-merge

- Add `PR description format` to the main branch ruleset required status checks only after this workflow exists on the default branch. Enabling it earlier would leave unrelated PRs unable to report the new context.

## Ship Checklist

- [x] ship skill used
- [x] local review run
- [x] validation run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Process and CI-only changes with no impact on application runtime, auth, or on-chain behavior.
> 
> **Overview**
> Introduces a **Problem → Solution** structure for pull request bodies and enforces it in CI so reviewers get consistent context on every change.
> 
> The PR template is rewritten around `## The Problem`, `## The Solution`, `## Validation`, and `## Ship Checklist`. A new `scripts/check-pr-description.mjs` validator requires those first two H2 sections in order (only HTML comments may precede them), rejects unfilled template placeholders, and uses Markdown-aware masking so headings inside fences, inline code, or comments cannot satisfy the rule. `pnpm pr:description:check` and `pnpm pr:description:test` expose the same logic locally.
> 
> A **PR description format** GitHub Actions job runs on every non-draft PR to `main` (no path filter, reruns on body edits), skips Dependabot, passes the body via `PR_BODY` without shell interpolation, and prefers the validator from the merge base with a bootstrap fallback from the PR head. `AGENTS.md` and `CLAUDE.md` document the policy and commands.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b80fee837142d1624d5a97efbef4e801a97691a0. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->