### PR TITLE
test(governance): restore Apollo coverage budget

### DIFF
--- a/apps/governance.mento.org/app/graphql/apollo.client.test.ts
+++ b/apps/governance.mento.org/app/graphql/apollo.client.test.ts
@@ -6,7 +6,7 @@ vi.mock("@/env.mjs", () => ({
     NEXT_PUBLIC_BLOCKSCOUT_GRAPHQL_URL: "https://example.com/blockscout",
     NEXT_PUBLIC_BLOCKSCOUT_GRAPHQL_URL_CELO_SEPOLIA:
       "https://example.com/blockscout-sepolia",
-    NEXT_PUBLIC_GRAPH_API_KEY: "",
+    NEXT_PUBLIC_GRAPH_API_KEY: "test-graph-api-key",
     NEXT_PUBLIC_SUBGRAPH_URL: "https://example.com/subgraph",
     NEXT_PUBLIC_SUBGRAPH_URL_CELO_SEPOLIA:
       "https://example.com/subgraph-sepolia",
@@ -28,11 +28,82 @@ const query = gql`
   }
 `;
 
+const transportQuery = gql`
+  query ApolloTransportTest {
+    proposals {
+      proposalId
+    }
+  }
+`;
+
+function emptyProposalResponse() {
+  return new Response(JSON.stringify({ data: { proposals: [] } }), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
 afterEach(() => {
   vi.unstubAllGlobals();
 });
 
 describe("makeClient", () => {
+  it.each([
+    {
+      apiName: "celoExplorer",
+      authorization: null,
+      expectedUrl: "https://example.com/blockscout",
+    },
+    {
+      apiName: "celoExplorerCeloSepolia",
+      authorization: null,
+      expectedUrl: "https://example.com/blockscout-sepolia",
+    },
+    {
+      apiName: "subgraph",
+      authorization: "Bearer test-graph-api-key",
+      expectedUrl: "https://example.com/subgraph",
+    },
+    {
+      apiName: "subgraphCeloSepolia",
+      authorization: "Bearer test-graph-api-key",
+      expectedUrl: "https://example.com/subgraph-sepolia",
+    },
+    {
+      apiName: undefined,
+      authorization: null,
+      expectedUrl: "https://example.com/subgraph",
+    },
+  ])(
+    "routes $apiName operations to $expectedUrl",
+    async ({ apiName, authorization, expectedUrl }) => {
+      const fetchMock = vi.fn().mockResolvedValue(emptyProposalResponse());
+      vi.stubGlobal("fetch", fetchMock);
+
+      const result = await makeClient().query({
+        query: transportQuery,
+        fetchPolicy: "network-only",
+        context: {
+          ...(apiName && { apiName }),
+          headers: { "x-test-header": "preserved" },
+        },
+      });
+
+      expect(result.error).toBeUndefined();
+      expect(fetchMock).toHaveBeenCalledOnce();
+
+      const [url, options] = fetchMock.mock.calls[0] as [
+        RequestInfo | URL,
+        RequestInit,
+      ];
+      const headers = new Headers(options.headers);
+
+      expect(url).toBe(expectedUrl);
+      expect(headers.get("authorization")).toBe(authorization);
+      expect(headers.get("x-test-header")).toBe("preserved");
+    },
+  );
+
   it("resolves local proposal fields in network queries", async () => {
     vi.stubGlobal(
       "fetch",

--- a/docs/quality-budgets.md
+++ b/docs/quality-budgets.md
@@ -12,7 +12,7 @@ made required or tuned independently.
 pnpm quality:budgets:test  # bundle checker, notifier, and workflow structure tests
 pnpm quality:coverage      # all four Vitest workspaces with thresholds
 pnpm build                 # production artifacts required by the bundle checker
-pnpm quality:bundle:check  # inspect .next/app-build-manifest.json for every app
+pnpm quality:bundle:check  # inspect Turbopack route bundle stats for every app
 pnpm quality:budgets       # canonical full sequence used in CI
 ```
 
@@ -44,22 +44,23 @@ full configured source surface.
 
 ## Production bundle budgets
 
-`scripts/check-bundle-size.mjs` reads each production
-`.next/app-build-manifest.json`, deduplicates the JavaScript files loaded by a
-route, gzip-compresses each file at level 9, and fails on the largest route. It
-does not count CSS, server chunks, source maps, or the same shared chunk twice.
+`scripts/check-bundle-size.mjs` reads each production Turbopack
+`.next/diagnostics/route-bundle-stats.json`, deduplicates the JavaScript files
+loaded by a route, gzip-compresses each file at level 9, and fails on the
+largest route. It does not count CSS, server chunks, source maps, or the same
+shared chunk twice.
 
-The observed values came from successful `main` CI run
-[`29320972122`](https://github.com/mento-protocol/frontend-monorepo/actions/runs/29320972122)
-at `8e7f2e66` on 2026-07-14. Next's build table rounds displayed baselines; the
-enforced limits are exact bytes in the checker.
+The observed values were remeasured with Next 16.2.10 at `87ce21c` on
+2026-07-14 using the deterministic environment from
+`.github/workflows/quality-budgets.yml`. Displayed baselines are rounded; the
+measurements and enforced limits are exact bytes in the checker.
 
 | App                    | Largest observed route    | Observed gzip baseline | Exact enforced limit | Headroom |
 | ---------------------- | ------------------------- | ---------------------: | -------------------: | -------: |
-| `app.mento.org`        | `/bridge`                 |                1.60 MB |      1,760,000 bytes |    10.0% |
-| `governance.mento.org` | `/proposals/[id]`         |                1.18 MB |      1,300,000 bytes |    10.2% |
-| `reserve.mento.org`    | `/`                       |                 670 kB |        740,000 bytes |    10.4% |
-| `ui.mento.org`         | `/specialized-components` |                 461 kB |        510,000 bytes |    10.6% |
+| `app.mento.org`        | `/bridge`                 |                1.60 MB |      1,760,000 bytes |     9.8% |
+| `governance.mento.org` | `/proposals/[id]`         |                1.20 MB |      1,300,000 bytes |     8.5% |
+| `reserve.mento.org`    | `/`                       |                 688 kB |        740,000 bytes |     7.6% |
+| `ui.mento.org`         | `/specialized-components` |                 487 kB |        510,000 bytes |     4.7% |
 
 When a deliberate feature exceeds a limit:
 

--- a/docs/quality-budgets.md
+++ b/docs/quality-budgets.md
@@ -34,7 +34,7 @@ material regressions.
 | Workspace                   | Measured statements | Measured branches | Measured functions | Measured lines | Enforced statements | Enforced branches | Enforced functions | Enforced lines |
 | --------------------------- | ------------------: | ----------------: | -----------------: | -------------: | ------------------: | ----------------: | -----------------: | -------------: |
 | `app.mento.org`             |              31.25% |            73.75% |             73.64% |         31.25% |                 30% |               72% |                72% |            30% |
-| `governance.mento.org`      |               8.77% |            61.53% |             51.63% |          8.77% |                  8% |               60% |                50% |             8% |
+| `governance.mento.org`      |               9.52% |            61.90% |             51.28% |          9.52% |                  8% |               60% |                50% |             8% |
 | `@mento-protocol/ui`        |               5.40% |            82.07% |             81.37% |          5.40% |                  5% |               80% |                80% |             5% |
 | `@repo/web3` critical files |              98.62% |            95.31% |            100.00% |         98.62% |                 90% |               90% |                90% |            90% |
 

--- a/scripts/check-bundle-size.mjs
+++ b/scripts/check-bundle-size.mjs
@@ -10,61 +10,73 @@ export const BUNDLE_BUDGETS = [
   {
     name: "app.mento.org",
     appDirectory: "apps/app.mento.org",
-    observedMaxRouteGzipBytes: 1_600_000,
+    observedMaxRouteGzipBytes: 1_602_714,
     maxRouteGzipBytes: 1_760_000,
   },
   {
     name: "governance.mento.org",
     appDirectory: "apps/governance.mento.org",
-    observedMaxRouteGzipBytes: 1_180_000,
+    observedMaxRouteGzipBytes: 1_198_702,
     maxRouteGzipBytes: 1_300_000,
   },
   {
     name: "reserve.mento.org",
     appDirectory: "apps/reserve.mento.org",
-    observedMaxRouteGzipBytes: 670_000,
+    observedMaxRouteGzipBytes: 687_703,
     maxRouteGzipBytes: 740_000,
   },
   {
     name: "ui.mento.org",
     appDirectory: "apps/ui.mento.org",
-    observedMaxRouteGzipBytes: 461_000,
+    observedMaxRouteGzipBytes: 486_905,
     maxRouteGzipBytes: 510_000,
   },
 ];
 
-function parseManifest(manifestPath) {
-  let manifest;
+function parseRouteBundleStats(statsPath) {
+  let rows;
 
   try {
-    manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+    rows = JSON.parse(readFileSync(statsPath, "utf8"));
   } catch (error) {
     throw new Error(
-      `Cannot read ${manifestPath}. Run a production build before checking bundle budgets.`,
+      `Cannot read ${statsPath}. Run a Turbopack production build before checking bundle budgets.`,
       { cause: error },
     );
   }
 
-  if (
-    manifest === null ||
-    typeof manifest !== "object" ||
-    manifest.pages === null ||
-    typeof manifest.pages !== "object" ||
-    Array.isArray(manifest.pages)
-  ) {
-    throw new Error(`${manifestPath} does not contain a valid pages manifest.`);
+  if (!Array.isArray(rows)) {
+    throw new Error(`${statsPath} does not contain a valid route stats array.`);
   }
 
-  return manifest.pages;
+  for (const [index, row] of rows.entries()) {
+    if (
+      row === null ||
+      typeof row !== "object" ||
+      typeof row.route !== "string" ||
+      row.route.length === 0 ||
+      typeof row.firstLoadUncompressedJsBytes !== "number" ||
+      !Number.isFinite(row.firstLoadUncompressedJsBytes) ||
+      row.firstLoadUncompressedJsBytes < 0 ||
+      !Array.isArray(row.firstLoadChunkPaths) ||
+      !row.firstLoadChunkPaths.every((path) => typeof path === "string")
+    ) {
+      throw new Error(
+        `${statsPath} contains an invalid route at index ${index}.`,
+      );
+    }
+  }
+
+  return rows;
 }
 
-function resolveBuildAsset(buildDirectory, relativePath) {
-  const assetPath = resolve(buildDirectory, relativePath);
+function resolveBuildAsset(appDirectory, buildDirectory, relativePath) {
+  const assetPath = resolve(appDirectory, relativePath);
   const buildPrefix = `${resolve(buildDirectory)}${sep}`;
 
   if (!assetPath.startsWith(buildPrefix)) {
     throw new Error(
-      `Bundle manifest asset escapes the build directory: ${relativePath}`,
+      `Bundle stats asset escapes the build directory: ${relativePath}`,
     );
   }
 
@@ -82,20 +94,15 @@ function gzipFileSize(path, cache) {
 }
 
 export function measureAppBundle(repoRoot, budget) {
-  const buildDirectory = resolve(repoRoot, budget.appDirectory, ".next");
-  const pages = parseManifest(
-    resolve(buildDirectory, "app-build-manifest.json"),
+  const appDirectory = resolve(repoRoot, budget.appDirectory);
+  const buildDirectory = resolve(appDirectory, ".next");
+  const routeStats = parseRouteBundleStats(
+    resolve(buildDirectory, "diagnostics", "route-bundle-stats.json"),
   );
   const gzipSizes = new Map();
   const routes = [];
 
-  for (const [route, assets] of Object.entries(pages)) {
-    if (!Array.isArray(assets)) {
-      throw new Error(
-        `Bundle manifest route ${route} does not contain an asset list.`,
-      );
-    }
-
+  for (const { route, firstLoadChunkPaths: assets } of routeStats) {
     const javascriptAssets = [
       ...new Set(assets.filter((asset) => asset.endsWith(".js"))),
     ];
@@ -104,7 +111,10 @@ export function measureAppBundle(repoRoot, budget) {
     const gzipBytes = javascriptAssets.reduce(
       (total, asset) =>
         total +
-        gzipFileSize(resolveBuildAsset(buildDirectory, asset), gzipSizes),
+        gzipFileSize(
+          resolveBuildAsset(appDirectory, buildDirectory, asset),
+          gzipSizes,
+        ),
       0,
     );
     routes.push({ route, gzipBytes, javascriptAssets });

--- a/scripts/check-bundle-size.test.mjs
+++ b/scripts/check-bundle-size.test.mjs
@@ -24,6 +24,7 @@ function fixture() {
   const buildDirectory = join(repoRoot, "apps/example/.next");
   const chunksDirectory = join(buildDirectory, "static/chunks");
   mkdirSync(chunksDirectory, { recursive: true });
+  mkdirSync(join(buildDirectory, "diagnostics"), { recursive: true });
 
   writeFileSync(join(chunksDirectory, "shared.js"), "shared".repeat(2_000));
   writeFileSync(join(chunksDirectory, "small.js"), "small".repeat(500));
@@ -32,19 +33,32 @@ function fixture() {
     Array.from({ length: 4_000 }, (_, index) => `${index};`).join(""),
   );
   writeFileSync(
-    join(buildDirectory, "app-build-manifest.json"),
-    JSON.stringify({
-      pages: {
-        "/small/page": [
-          "static/chunks/shared.js",
-          "static/chunks/shared.js",
-          "static/chunks/small.js",
-          "static/chunks/styles.css",
+    join(buildDirectory, "diagnostics/route-bundle-stats.json"),
+    JSON.stringify([
+      {
+        route: "/small",
+        firstLoadUncompressedJsBytes: 1,
+        firstLoadChunkPaths: [
+          ".next/static/chunks/shared.js",
+          ".next/static/chunks/shared.js",
+          ".next/static/chunks/small.js",
+          ".next/static/chunks/styles.css",
         ],
-        "/large/page": ["static/chunks/shared.js", "static/chunks/large.js"],
-        "/api/route": [],
       },
-    }),
+      {
+        route: "/large",
+        firstLoadUncompressedJsBytes: 1,
+        firstLoadChunkPaths: [
+          ".next/static/chunks/shared.js",
+          ".next/static/chunks/large.js",
+        ],
+      },
+      {
+        route: "/api/route",
+        firstLoadUncompressedJsBytes: 0,
+        firstLoadChunkPaths: [],
+      },
+    ]),
   );
 
   return {
@@ -82,10 +96,10 @@ test("measures unique gzip-compressed JavaScript per production route", () => {
   const { repoRoot, budget } = fixture();
   const measurement = measureAppBundle(repoRoot, budget);
 
-  assert.equal(measurement.largestRoute.route, "/large/page");
+  assert.equal(measurement.largestRoute.route, "/large");
   assert.deepEqual(
     measurement.routes.map(({ route }) => route),
-    ["/large/page", "/small/page"],
+    ["/large", "/small"],
   );
   assert.equal(measurement.routes[1].javascriptAssets.length, 2);
 });
@@ -110,15 +124,21 @@ test("fails only when the largest route exceeds its configured budget", () => {
   assert.equal(failure.overBudgetBytes, 1);
 });
 
-test("rejects manifest assets outside the Next build directory", () => {
+test("rejects route stats assets outside the Next build directory", () => {
   const { repoRoot, budget } = fixture();
-  const manifestPath = join(
+  const statsPath = join(
     repoRoot,
-    "apps/example/.next/app-build-manifest.json",
+    "apps/example/.next/diagnostics/route-bundle-stats.json",
   );
   writeFileSync(
-    manifestPath,
-    JSON.stringify({ pages: { "/page": ["../../outside.js"] } }),
+    statsPath,
+    JSON.stringify([
+      {
+        route: "/",
+        firstLoadUncompressedJsBytes: 1,
+        firstLoadChunkPaths: [".next/../outside.js"],
+      },
+    ]),
   );
 
   assert.throws(
@@ -129,10 +149,41 @@ test("rejects manifest assets outside the Next build directory", () => {
 
 test("explains that a production build is required when output is absent", () => {
   const { repoRoot, budget } = fixture();
-  rmSync(join(repoRoot, "apps/example/.next/app-build-manifest.json"));
+  rmSync(
+    join(repoRoot, "apps/example/.next/diagnostics/route-bundle-stats.json"),
+  );
 
   assert.throws(
     () => measureAppBundle(repoRoot, budget),
-    /Run a production build before checking bundle budgets/,
+    /Run a Turbopack production build before checking bundle budgets/,
+  );
+});
+
+test("rejects malformed route bundle stats", () => {
+  const { repoRoot, budget } = fixture();
+  const statsPath = join(
+    repoRoot,
+    "apps/example/.next/diagnostics/route-bundle-stats.json",
+  );
+
+  writeFileSync(statsPath, JSON.stringify({ route: "/" }));
+  assert.throws(
+    () => measureAppBundle(repoRoot, budget),
+    /does not contain a valid route stats array/,
+  );
+
+  writeFileSync(
+    statsPath,
+    JSON.stringify([
+      {
+        route: "/",
+        firstLoadUncompressedJsBytes: "unknown",
+        firstLoadChunkPaths: [],
+      },
+    ]),
+  );
+  assert.throws(
+    () => measureAppBundle(repoRoot, budget),
+    /contains an invalid route at index 0/,
   );
 });


### PR DESCRIPTION
## The Problem

The `main` Quality Budgets gate exposes two merge-order gaps after the Next.js 16 migration. The Apollo client test executes `apollo.client.ts` without covering its endpoint and authorization branches, dropping governance branch coverage to 59.61% against the enforced 60% floor. Once coverage passes, the bundle checker also targets the removed `.next/app-build-manifest.json` artifact.

## The Solution

Add table-driven Apollo transport tests for both Blockscout endpoints, both subgraph endpoints, and the default route. Migrate bundle measurement to Next 16's Turbopack route diagnostics, with schema validation, `.next` path containment, chunk deduplication, and gzip measurement of the actual client files. Refresh the documented Next 16 measurements while keeping every enforced threshold unchanged.

## Validation

- `pnpm --filter governance.mento.org exec vitest run app/graphql/apollo.client.test.ts`
- `pnpm --filter governance.mento.org test:coverage`
- `pnpm quality:coverage`
- `pnpm quality:budgets:test`
- `pnpm build` with the Quality Budgets CI environment
- `pnpm quality:bundle:check`
- `pnpm --filter governance.mento.org check-types`
- `trunk check --ignore-git-state`
- Pre-push Trunk, monorepo typecheck, and Knip hooks

## Ship Checklist

- [x] Fresh-context semantic autoreview found no findings
- [x] Deterministic autoreview found no findings
- [x] Local validation passed

Addresses #508
