### PR TITLE
test(ci): guard Turbopack bundle prerequisites

### DIFF
--- a/docs/quality-budgets.md
+++ b/docs/quality-budgets.md
@@ -20,6 +20,11 @@ The bundle-only command intentionally does not build. This keeps it useful for
 checking an existing production artifact; it reports a missing build explicitly.
 CI guarantees freshness by running `pnpm build` immediately before the checker.
 
+The canonical gate is sequential: when an early step fails, later build and
+bundle steps have not been validated. After fixing a failed step or rebasing
+over a framework or toolchain change, run the full `pnpm quality:budgets`
+command against the latest `main`, not only the previously failing subcommand.
+
 ## Coverage floors
 
 The baselines below were measured with Node 22, Vitest 3.2.6, and

--- a/scripts/check-bundle-size.test.mjs
+++ b/scripts/check-bundle-size.test.mjs
@@ -1,5 +1,11 @@
 import assert from "node:assert/strict";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, test } from "node:test";
@@ -88,6 +94,25 @@ test("defines a bounded production-route budget for every Next app", () => {
     assert.ok(
       budget.maxRouteGzipBytes <= budget.observedMaxRouteGzipBytes * 1.11,
       `${budget.name} must not carry more than 11% baseline headroom`,
+    );
+  }
+});
+
+test("requires Turbopack builds for every budgeted app", () => {
+  for (const budget of BUNDLE_BUDGETS) {
+    const packageJson = JSON.parse(
+      readFileSync(
+        new URL(`../${budget.appDirectory}/package.json`, import.meta.url),
+        "utf8",
+      ),
+    );
+    const buildScript = packageJson.scripts?.build;
+
+    assert.equal(typeof buildScript, "string");
+    assert.match(
+      buildScript,
+      /(?:^|\s)--turbopack(?:\s|$)/,
+      `${budget.name} must use Turbopack so route bundle stats are generated`,
     );
   }
 });


### PR DESCRIPTION
## The Problem

The Quality Budgets gate runs sequentially, so an early failure can hide downstream build/bundle incompatibilities. Its bundle checker depends on Turbopack's route stats, but the zero-network tests did not assert that every budgeted app still builds with Turbopack.

## The Solution

Document that repairs and framework/toolchain rebases must run the full canonical gate against latest main. Add a fast structural test that every budgeted app build script retains `--turbopack`, failing before expensive production builds if the checker prerequisite drifts.

## Validation

- `pnpm quality:budgets:test` (30/30)
- `trunk check --ignore-git-state`
- Pre-push Trunk, full monorepo typecheck, Knip
- Fresh-context autoreview: no findings

## Ship Checklist

- [x] ship skill used
- [x] local review run
- [x] validation run

Follow-up to #509.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and CI self-test only; no changes to bundle measurement or app runtime behavior.
> 
> **Overview**
> Documents that **`pnpm quality:budgets`** runs steps in order, so a failure early in the gate means build and bundle checks were not run. After fixing a step or rebasing over toolchain changes, contributors should rerun the **full** canonical command on latest **`main`**, not only the subcommand that failed.
> 
> Adds a fast zero-network test that every app in **`BUNDLE_BUDGETS`** still has a **`build`** script containing **`--turbopack`**, so the route-stats bundle checker cannot silently break if an app drops Turbopack before expensive production builds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef94704517872fd406b93be41d31de79e8d43fe8. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->