### PR TITLE
feat(ci): add manual Vercel prebuilt preview pilot

### DIFF
--- a/.github/workflows/_vercel-prebuilt.yml
+++ b/.github/workflows/_vercel-prebuilt.yml
@@ -1,0 +1,381 @@
+name: Reusable Vercel Prebuilt
+
+on:
+  workflow_call:
+    inputs:
+      logical_target:
+        description: Logical deployment target
+        required: true
+        type: string
+      workspace_package:
+        description: Target workspace package name
+        required: true
+        type: string
+      expected_root_directory:
+        description: Vercel project Root Directory relative to the monorepo root
+        required: true
+        type: string
+      vercel_org_id:
+        description: Vercel organization ID repository variable
+        required: true
+        type: string
+      vercel_project_id:
+        description: Vercel project ID repository variable
+        required: true
+        type: string
+      vercel_environment:
+        description: Vercel environment used by pull
+        required: true
+        type: string
+      vercel_target:
+        description: Vercel build and deploy target
+        required: true
+        type: string
+      commit_sha:
+        description: Immutable lowercase 40-character commit SHA
+        required: true
+        type: string
+      git_branch:
+        description: Validated same-repository branch containing commit_sha
+        required: true
+        type: string
+      deployment_mode:
+        description: Deployment mode (preview, custom target, or staged production)
+        required: true
+        type: string
+      deploy_permitted:
+        description: Explicit caller authorization to upload a deployment
+        required: true
+        type: boolean
+      github_environment:
+        description: Deterministic GitHub Deployment environment name
+        required: true
+        type: string
+      deployment_idempotency_key:
+        description: Caller-owned exact-SHA GitHub Deployment idempotency key
+        required: true
+        type: string
+      turbo_team:
+        description: Existing Turbo remote-cache team variable
+        required: true
+        type: string
+      pull_request_number:
+        description: Optional pull request provenance
+        required: false
+        default: ""
+        type: string
+      provenance:
+        description: Optional non-secret controller provenance
+        required: false
+        default: ""
+        type: string
+    secrets:
+      vercel_token:
+        description: Preview-scoped Vercel CLI token
+        required: true
+      turbo_token:
+        description: Turbo remote-cache token
+        required: true
+      turbo_remote_cache_signature_key:
+        description: Turbo signed-cache verification key
+        required: true
+      vercel_automation_bypass_secret:
+        description: Optional Vercel deployment-protection bypass for smoke
+        required: false
+    outputs:
+      deployment_url:
+        description: Immutable verified Vercel deployment URL
+        value: ${{ jobs.prebuilt.outputs.deployment_url }}
+      vercel_deployment_id:
+        description: Vercel deployment ID
+        value: ${{ jobs.prebuilt.outputs.vercel_deployment_id }}
+      github_deployment_id:
+        description: Canonical GitHub Deployment ID
+        value: ${{ jobs.prebuilt.outputs.github_deployment_id }}
+      final_state:
+        description: Final canonical GitHub Deployment state
+        value: ${{ jobs.prebuilt.outputs.final_state }}
+      commit_sha:
+        description: Exact checked-out commit SHA
+        value: ${{ jobs.prebuilt.outputs.commit_sha }}
+      logical_target:
+        description: Logical deployment target
+        value: ${{ jobs.prebuilt.outputs.logical_target }}
+      build_duration_ms:
+        description: Measured Vercel build duration in milliseconds
+        value: ${{ jobs.prebuilt.outputs.build_duration_ms }}
+      deploy_duration_ms:
+        description: Measured Vercel upload duration in milliseconds
+        value: ${{ jobs.prebuilt.outputs.deploy_duration_ms }}
+      total_duration_ms:
+        description: Measured controller duration in milliseconds
+        value: ${{ jobs.prebuilt.outputs.total_duration_ms }}
+
+permissions:
+  contents: read
+  deployments: write
+
+concurrency:
+  group: ${{ inputs.deployment_idempotency_key }}
+  cancel-in-progress: false
+
+jobs:
+  prebuilt:
+    name: Prebuilt ${{ inputs.logical_target }} preview
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      deployments: write
+    outputs:
+      deployment_url: ${{ steps.smoke.outputs.smoke_deployment_url || steps.deploy.outputs.vercel_deployment_url }}
+      vercel_deployment_id: ${{ steps.deploy.outputs.vercel_deployment_id }}
+      github_deployment_id: ${{ steps.create.outputs.github_deployment_id }}
+      final_state: ${{ steps.success.outputs.github_deployment_state || steps.finalizer.outputs.github_deployment_state }}
+      commit_sha: ${{ steps.source.outputs.checked_out_sha }}
+      logical_target: ${{ inputs.logical_target }}
+      build_duration_ms: ${{ steps.build.outputs.build_duration_ms }}
+      deploy_duration_ms: ${{ steps.deploy.outputs.deploy_duration_ms }}
+      total_duration_ms: ${{ steps.total.outputs.total_duration_ms }}
+    steps:
+      - name: Check out trusted workflow controller
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 1
+          path: controller
+          persist-credentials: false
+          ref: ${{ github.workflow_sha }}
+
+      - name: Check out exact deployment source and full history
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+          path: source
+          persist-credentials: false
+          ref: ${{ inputs.commit_sha }}
+
+      - name: Set up pinned pnpm
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v4
+        with:
+          version: 10.24.0
+
+      - name: Set up pinned Node.js and pnpm cache
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: source/pnpm-lock.yaml
+
+      - name: Validate pilot contract and prepare immutable build identity
+        id: prepare
+        env:
+          DEPLOYMENT_IDEMPOTENCY_KEY: ${{ inputs.deployment_idempotency_key }}
+          DEPLOYMENT_MODE: ${{ inputs.deployment_mode }}
+          DEPLOY_PERMITTED: ${{ inputs.deploy_permitted }}
+          DEPLOY_SHA: ${{ inputs.commit_sha }}
+          EXPECTED_ROOT_DIRECTORY: ${{ inputs.expected_root_directory }}
+          GIT_BRANCH: ${{ inputs.git_branch }}
+          GITHUB_DEPLOYMENT_ENVIRONMENT: ${{ inputs.github_environment }}
+          LOGICAL_TARGET: ${{ inputs.logical_target }}
+          VERCEL_ENVIRONMENT: ${{ inputs.vercel_environment }}
+          VERCEL_ORG_ID: ${{ inputs.vercel_org_id }}
+          VERCEL_PROJECT_ID: ${{ inputs.vercel_project_id }}
+          VERCEL_TARGET: ${{ inputs.vercel_target }}
+          WORKFLOW_RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}
+          WORKSPACE_PACKAGE: ${{ inputs.workspace_package }}
+        run: node "$GITHUB_WORKSPACE/controller/scripts/vercel-prebuilt-workflow.mjs" prepare
+
+      - name: Validate same-repository branch reachability and exact HEAD
+        id: source
+        env:
+          DEPLOY_SHA: ${{ inputs.commit_sha }}
+          GIT_BRANCH: ${{ inputs.git_branch }}
+          SOURCE_PATH: ${{ github.workspace }}/source
+        run: node "$GITHUB_WORKSPACE/controller/scripts/vercel-prebuilt-workflow.mjs" validate-source
+
+      - name: Install frozen dependencies
+        working-directory: source
+        run: pnpm install --frozen-lockfile
+
+      - name: Verify pinned Vercel prerequisites
+        working-directory: source
+        run: pnpm vercel:versions:check
+
+      - name: Materialize trusted repo-level UI project mapping
+        env:
+          EXPECTED_ROOT_DIRECTORY: ${{ inputs.expected_root_directory }}
+          SOURCE_PATH: ${{ github.workspace }}/source
+          VERCEL_ORG_ID: ${{ inputs.vercel_org_id }}
+          VERCEL_PROJECT_ID: ${{ inputs.vercel_project_id }}
+        run: node "$GITHUB_WORKSPACE/controller/scripts/vercel-prebuilt-workflow.mjs" prepare-link
+
+      - name: Create or reuse canonical GitHub Deployment
+        id: create
+        env:
+          DEPLOYMENT_IDEMPOTENCY_KEY: ${{ inputs.deployment_idempotency_key }}
+          DEPLOYMENT_PROVENANCE: ${{ inputs.provenance }}
+          DEPLOY_SHA: ${{ steps.source.outputs.checked_out_sha }}
+          GIT_BRANCH: ${{ inputs.git_branch }}
+          GITHUB_DEPLOYMENT_ENVIRONMENT: ${{ inputs.github_environment }}
+          GITHUB_TOKEN: ${{ github.token }}
+          LOGICAL_TARGET: ${{ inputs.logical_target }}
+          PULL_REQUEST_NUMBER: ${{ inputs.pull_request_number }}
+          WORKFLOW_RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}
+        run: node "$GITHUB_WORKSPACE/controller/scripts/github-deployment.mjs" ensure
+
+      - name: Mark GitHub Deployment queued
+        env:
+          GITHUB_DEPLOYMENT_ID: ${{ steps.create.outputs.github_deployment_id }}
+          GITHUB_DEPLOYMENT_STATE: queued
+          GITHUB_TOKEN: ${{ github.token }}
+          WORKFLOW_RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}
+        run: node "$GITHUB_WORKSPACE/controller/scripts/github-deployment.mjs" status
+
+      - name: Mark GitHub Deployment in progress
+        env:
+          GITHUB_DEPLOYMENT_ID: ${{ steps.create.outputs.github_deployment_id }}
+          GITHUB_DEPLOYMENT_STATE: in_progress
+          GITHUB_TOKEN: ${{ github.token }}
+          WORKFLOW_RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}
+        run: node "$GITHUB_WORKSPACE/controller/scripts/github-deployment.mjs" status
+
+      - name: Pull branch-specific UI preview settings
+        id: pull
+        env:
+          GIT_BRANCH: ${{ inputs.git_branch }}
+          SOURCE_PATH: ${{ github.workspace }}/source
+          VERCEL_ORG_ID: ${{ inputs.vercel_org_id }}
+          VERCEL_PROJECT_ID: ${{ inputs.vercel_project_id }}
+          VERCEL_TOKEN: ${{ secrets.vercel_token }}
+        run: node "$GITHUB_WORKSPACE/controller/scripts/vercel-prebuilt-workflow.mjs" pull
+
+      - name: Assert pulled UI project mapping
+        env:
+          EXPECTED_ROOT_DIRECTORY: ${{ inputs.expected_root_directory }}
+          SOURCE_PATH: ${{ github.workspace }}/source
+          VERCEL_ORG_ID: ${{ inputs.vercel_org_id }}
+          VERCEL_PROJECT_ID: ${{ inputs.vercel_project_id }}
+        run: node "$GITHUB_WORKSPACE/controller/scripts/vercel-prebuilt-workflow.mjs" validate-pull
+
+      - name: Validate app-root preview build variables
+        working-directory: source
+        env:
+          CI: 1
+          NEXT_PUBLIC_VERCEL_ENV: preview
+          VERCEL: 1
+          VERCEL_ENV: preview
+          VERCEL_TARGET_ENV: preview
+        run: >-
+          node "$GITHUB_WORKSPACE/controller/scripts/vercel-build-environment.mjs"
+          check --target ui --environment preview
+          --project-directory apps/ui.mento.org
+
+      - name: Build and assert the UI prebuilt output
+        id: build
+        env:
+          CI: 1
+          EXPECTED_ROOT_DIRECTORY: ${{ inputs.expected_root_directory }}
+          GIT_BRANCH: ${{ inputs.git_branch }}
+          MENTO_NEXT_DEPLOYMENT_ID: ${{ steps.prepare.outputs.next_deployment_id }}
+          NEXT_PUBLIC_VERCEL_ENV: preview
+          SOURCE_PATH: ${{ github.workspace }}/source
+          TURBO_REMOTE_CACHE_SIGNATURE_KEY: ${{ secrets.turbo_remote_cache_signature_key }}
+          TURBO_TEAM: ${{ inputs.turbo_team }}
+          TURBO_TOKEN: ${{ secrets.turbo_token }}
+          VERCEL: 1
+          VERCEL_ENV: preview
+          VERCEL_GIT_COMMIT_REF: ${{ inputs.git_branch }}
+          VERCEL_GIT_COMMIT_SHA: ${{ steps.source.outputs.checked_out_sha }}
+          VERCEL_GIT_PROVIDER: github
+          VERCEL_GIT_REPO_OWNER: mento-protocol
+          VERCEL_GIT_REPO_SLUG: frontend-monorepo
+          VERCEL_ORG_ID: ${{ inputs.vercel_org_id }}
+          VERCEL_PROJECT_ID: ${{ inputs.vercel_project_id }}
+          VERCEL_TARGET_ENV: preview
+          VERCEL_TOKEN: ${{ secrets.vercel_token }}
+        run: |
+          node "$GITHUB_WORKSPACE/controller/scripts/vercel-prebuilt-workflow.mjs" build
+          node "$GITHUB_WORKSPACE/controller/scripts/vercel-prebuilt-workflow.mjs" assert-output
+
+      - name: Upload the verified prebuilt output
+        id: deploy
+        env:
+          DEPLOY_SHA: ${{ steps.source.outputs.checked_out_sha }}
+          GIT_BRANCH: ${{ inputs.git_branch }}
+          SOURCE_PATH: ${{ github.workspace }}/source
+          VERCEL_ORG_ID: ${{ inputs.vercel_org_id }}
+          VERCEL_PROJECT_ID: ${{ inputs.vercel_project_id }}
+          VERCEL_TOKEN: ${{ secrets.vercel_token }}
+        run: node "$GITHUB_WORKSPACE/controller/scripts/vercel-prebuilt-workflow.mjs" deploy
+
+      - name: Verify and smoke the immutable preview
+        id: smoke
+        env:
+          DEPLOY_SHA: ${{ steps.source.outputs.checked_out_sha }}
+          GITHUB_DEPLOYMENT_ID: ${{ steps.create.outputs.github_deployment_id }}
+          MENTO_NEXT_DEPLOYMENT_ID: ${{ steps.prepare.outputs.next_deployment_id }}
+          SOURCE_PATH: ${{ github.workspace }}/source
+          VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.vercel_automation_bypass_secret }}
+          VERCEL_DEPLOYMENT_ID: ${{ steps.deploy.outputs.vercel_deployment_id }}
+          VERCEL_DEPLOYMENT_URL: ${{ steps.deploy.outputs.vercel_deployment_url }}
+          VERCEL_ORG_ID: ${{ inputs.vercel_org_id }}
+          VERCEL_PROJECT_ID: ${{ inputs.vercel_project_id }}
+          VERCEL_TOKEN: ${{ secrets.vercel_token }}
+        run: |
+          node "$GITHUB_WORKSPACE/controller/scripts/vercel-prebuilt-workflow.mjs" verify
+          node "$GITHUB_WORKSPACE/controller/scripts/vercel-prebuilt-workflow.mjs" smoke
+
+      - name: Measure total controller duration
+        id: total
+        if: always() && steps.prepare.outputs.started_at_ms != ''
+        env:
+          STARTED_AT_MS: ${{ steps.prepare.outputs.started_at_ms }}
+        run: node "$GITHUB_WORKSPACE/controller/scripts/vercel-prebuilt-workflow.mjs" total
+
+      - name: Mark GitHub Deployment successful after smoke
+        id: success
+        env:
+          GITHUB_DEPLOYMENT_ID: ${{ steps.create.outputs.github_deployment_id }}
+          GITHUB_DEPLOYMENT_STATE: success
+          GITHUB_TOKEN: ${{ github.token }}
+          VERCEL_DEPLOYMENT_URL: ${{ steps.smoke.outputs.smoke_deployment_url }}
+          WORKFLOW_RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}
+        run: node "$GITHUB_WORKSPACE/controller/scripts/github-deployment.mjs" status
+
+      - name: Record comparison evidence
+        if: steps.success.outcome == 'success'
+        env:
+          BUILD_DURATION_MS: ${{ steps.build.outputs.build_duration_ms }}
+          COMMIT_SHA: ${{ steps.smoke.outputs.smoke_commit_sha }}
+          DEPLOY_DURATION_MS: ${{ steps.deploy.outputs.deploy_duration_ms }}
+          GITHUB_DEPLOYMENT_ID: ${{ steps.smoke.outputs.smoke_github_deployment_id }}
+          TOTAL_DURATION_MS: ${{ steps.total.outputs.total_duration_ms }}
+          VERCEL_DEPLOYMENT_ID: ${{ steps.smoke.outputs.smoke_deployment_id }}
+          VERCEL_DEPLOYMENT_URL: ${{ steps.smoke.outputs.smoke_deployment_url }}
+        run: |
+          {
+            echo "### GitHub prebuilt pilot"
+            echo
+            echo "- Commit: \`$COMMIT_SHA\`"
+            echo "- GitHub Deployment: \`$GITHUB_DEPLOYMENT_ID\`"
+            echo "- Vercel Deployment: \`$VERCEL_DEPLOYMENT_ID\`"
+            echo "- Immutable URL: $VERCEL_DEPLOYMENT_URL"
+            echo "- Build: \`$BUILD_DURATION_MS ms\`"
+            echo "- Deploy/upload: \`$DEPLOY_DURATION_MS ms\`"
+            echo "- Controller total: \`$TOTAL_DURATION_MS ms\`"
+            echo
+            echo "Turbo cache hit/miss details are preserved in the build log above."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Close a non-terminal GitHub Deployment
+        id: finalizer
+        if: always() && steps.create.outputs.github_deployment_id != '' && steps.success.outcome != 'success'
+        env:
+          BUILD_OUTCOME: ${{ steps.build.outcome }}
+          DEPLOY_OUTCOME: ${{ steps.deploy.outcome }}
+          GITHUB_DEPLOYMENT_ID: ${{ steps.create.outputs.github_deployment_id }}
+          GITHUB_TOKEN: ${{ github.token }}
+          JOB_STATUS: ${{ job.status }}
+          SMOKE_OUTCOME: ${{ steps.smoke.outcome }}
+          WORKFLOW_RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}
+        run: node "$GITHUB_WORKSPACE/controller/scripts/github-deployment.mjs" finalize

--- a/.github/workflows/_vercel-prebuilt.yml
+++ b/.github/workflows/_vercel-prebuilt.yml
@@ -79,13 +79,10 @@ on:
       turbo_remote_cache_signature_key:
         description: Turbo signed-cache verification key
         required: true
-      vercel_automation_bypass_secret:
-        description: Optional Vercel deployment-protection bypass for smoke
-        required: false
     outputs:
       deployment_url:
         description: Immutable verified Vercel deployment URL
-        value: ${{ jobs.prebuilt.outputs.deployment_url }}
+        value: ${{ jobs.finalize.outputs.deployment_url }}
       vercel_deployment_id:
         description: Vercel deployment ID
         value: ${{ jobs.prebuilt.outputs.vercel_deployment_id }}
@@ -94,7 +91,7 @@ on:
         value: ${{ jobs.prebuilt.outputs.github_deployment_id }}
       final_state:
         description: Final canonical GitHub Deployment state
-        value: ${{ jobs.prebuilt.outputs.final_state }}
+        value: ${{ jobs.finalize.outputs.final_state }}
       commit_sha:
         description: Exact checked-out commit SHA
         value: ${{ jobs.prebuilt.outputs.commit_sha }}
@@ -109,11 +106,9 @@ on:
         value: ${{ jobs.prebuilt.outputs.deploy_duration_ms }}
       total_duration_ms:
         description: Measured controller duration in milliseconds
-        value: ${{ jobs.prebuilt.outputs.total_duration_ms }}
+        value: ${{ jobs.finalize.outputs.total_duration_ms }}
 
-permissions:
-  contents: read
-  deployments: write
+permissions: {}
 
 concurrency:
   group: ${{ inputs.deployment_idempotency_key }}
@@ -128,15 +123,15 @@ jobs:
       contents: read
       deployments: write
     outputs:
-      deployment_url: ${{ steps.smoke.outputs.smoke_deployment_url || steps.deploy.outputs.vercel_deployment_url }}
+      verified_deployment_url: ${{ steps.verify.outputs.verified_deployment_url }}
       vercel_deployment_id: ${{ steps.deploy.outputs.vercel_deployment_id }}
       github_deployment_id: ${{ steps.create.outputs.github_deployment_id }}
-      final_state: ${{ steps.success.outputs.github_deployment_state || steps.finalizer.outputs.github_deployment_state }}
       commit_sha: ${{ steps.source.outputs.checked_out_sha }}
       logical_target: ${{ inputs.logical_target }}
+      next_deployment_id: ${{ steps.prepare.outputs.next_deployment_id }}
+      started_at_ms: ${{ steps.prepare.outputs.started_at_ms }}
       build_duration_ms: ${{ steps.build.outputs.build_duration_ms }}
       deploy_duration_ms: ${{ steps.deploy.outputs.deploy_duration_ms }}
-      total_duration_ms: ${{ steps.total.outputs.total_duration_ms }}
     steps:
       - name: Check out trusted workflow controller
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -308,50 +303,99 @@ jobs:
           VERCEL_TOKEN: ${{ secrets.vercel_token }}
         run: node "$GITHUB_WORKSPACE/controller/scripts/vercel-prebuilt-workflow.mjs" deploy
 
-      - name: Verify and smoke the immutable preview
-        id: smoke
+      - name: Verify immutable Vercel deployment metadata
+        id: verify
         env:
-          DEPLOY_SHA: ${{ steps.source.outputs.checked_out_sha }}
-          GITHUB_DEPLOYMENT_ID: ${{ steps.create.outputs.github_deployment_id }}
-          MENTO_NEXT_DEPLOYMENT_ID: ${{ steps.prepare.outputs.next_deployment_id }}
           SOURCE_PATH: ${{ github.workspace }}/source
-          VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.vercel_automation_bypass_secret }}
           VERCEL_DEPLOYMENT_ID: ${{ steps.deploy.outputs.vercel_deployment_id }}
           VERCEL_DEPLOYMENT_URL: ${{ steps.deploy.outputs.vercel_deployment_url }}
           VERCEL_ORG_ID: ${{ inputs.vercel_org_id }}
           VERCEL_PROJECT_ID: ${{ inputs.vercel_project_id }}
           VERCEL_TOKEN: ${{ secrets.vercel_token }}
-        run: |
-          node "$GITHUB_WORKSPACE/controller/scripts/vercel-prebuilt-workflow.mjs" verify
-          node "$GITHUB_WORKSPACE/controller/scripts/vercel-prebuilt-workflow.mjs" smoke
+        run: node "$GITHUB_WORKSPACE/controller/scripts/vercel-prebuilt-workflow.mjs" verify
 
-      - name: Measure total controller duration
-        id: total
-        if: always() && steps.prepare.outputs.started_at_ms != ''
+  smoke:
+    name: Smoke verified ${{ inputs.logical_target }} preview
+    needs: prebuilt
+    if: needs.prebuilt.result == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    outputs:
+      deployment_url: ${{ steps.smoke.outputs.smoke_deployment_url }}
+      smoke_commit_sha: ${{ steps.smoke.outputs.smoke_commit_sha }}
+    steps:
+      - name: Check out trusted smoke controller only
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 1
+          path: controller
+          persist-credentials: false
+          ref: ${{ github.workflow_sha }}
+
+      - name: Smoke immutable UI preview without deployment credentials
+        id: smoke
         env:
-          STARTED_AT_MS: ${{ steps.prepare.outputs.started_at_ms }}
+          DEPLOY_SHA: ${{ needs.prebuilt.outputs.commit_sha }}
+          GITHUB_DEPLOYMENT_ID: ${{ needs.prebuilt.outputs.github_deployment_id }}
+          MENTO_NEXT_DEPLOYMENT_ID: ${{ needs.prebuilt.outputs.next_deployment_id }}
+          VERCEL_DEPLOYMENT_ID: ${{ needs.prebuilt.outputs.vercel_deployment_id }}
+          VERCEL_DEPLOYMENT_URL: ${{ needs.prebuilt.outputs.verified_deployment_url }}
+        run: node "$GITHUB_WORKSPACE/controller/scripts/vercel-prebuilt-workflow.mjs" smoke
+
+  finalize:
+    name: Finalize ${{ inputs.logical_target }} deployment lifecycle
+    needs: [prebuilt, smoke]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      deployments: write
+    outputs:
+      deployment_url: ${{ steps.complete.outputs.verified_deployment_url }}
+      final_state: ${{ steps.complete.outputs.github_deployment_state }}
+      total_duration_ms: ${{ steps.total.outputs.total_duration_ms }}
+    steps:
+      - name: Check out trusted lifecycle controller only
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 1
+          path: controller
+          persist-credentials: false
+          ref: ${{ github.workflow_sha }}
+
+      - name: Measure total controller duration (best effort)
+        id: total
+        if: needs.prebuilt.outputs.started_at_ms != ''
+        continue-on-error: true
+        env:
+          STARTED_AT_MS: ${{ needs.prebuilt.outputs.started_at_ms }}
         run: node "$GITHUB_WORKSPACE/controller/scripts/vercel-prebuilt-workflow.mjs" total
 
-      - name: Mark GitHub Deployment successful after smoke
-        id: success
+      - name: Post truthful terminal GitHub Deployment state
+        id: complete
         env:
-          GITHUB_DEPLOYMENT_ID: ${{ steps.create.outputs.github_deployment_id }}
-          GITHUB_DEPLOYMENT_STATE: success
+          GITHUB_DEPLOYMENT_ID: ${{ needs.prebuilt.outputs.github_deployment_id }}
           GITHUB_TOKEN: ${{ github.token }}
-          VERCEL_DEPLOYMENT_URL: ${{ steps.smoke.outputs.smoke_deployment_url }}
+          PREBUILT_RESULT: ${{ needs.prebuilt.result }}
+          SMOKE_RESULT: ${{ needs.smoke.result }}
+          VERCEL_DEPLOYMENT_URL: ${{ needs.smoke.outputs.deployment_url }}
           WORKFLOW_RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}
-        run: node "$GITHUB_WORKSPACE/controller/scripts/github-deployment.mjs" status
+        run: node "$GITHUB_WORKSPACE/controller/scripts/github-deployment.mjs" complete
 
-      - name: Record comparison evidence
-        if: steps.success.outcome == 'success'
+      - name: Record comparison evidence (best effort)
+        if: steps.complete.outputs.github_deployment_state == 'success'
+        continue-on-error: true
         env:
-          BUILD_DURATION_MS: ${{ steps.build.outputs.build_duration_ms }}
-          COMMIT_SHA: ${{ steps.smoke.outputs.smoke_commit_sha }}
-          DEPLOY_DURATION_MS: ${{ steps.deploy.outputs.deploy_duration_ms }}
-          GITHUB_DEPLOYMENT_ID: ${{ steps.smoke.outputs.smoke_github_deployment_id }}
+          BUILD_DURATION_MS: ${{ needs.prebuilt.outputs.build_duration_ms }}
+          COMMIT_SHA: ${{ needs.smoke.outputs.smoke_commit_sha }}
+          DEPLOY_DURATION_MS: ${{ needs.prebuilt.outputs.deploy_duration_ms }}
+          GITHUB_DEPLOYMENT_ID: ${{ needs.prebuilt.outputs.github_deployment_id }}
           TOTAL_DURATION_MS: ${{ steps.total.outputs.total_duration_ms }}
-          VERCEL_DEPLOYMENT_ID: ${{ steps.smoke.outputs.smoke_deployment_id }}
-          VERCEL_DEPLOYMENT_URL: ${{ steps.smoke.outputs.smoke_deployment_url }}
+          VERCEL_DEPLOYMENT_ID: ${{ needs.prebuilt.outputs.vercel_deployment_id }}
+          VERCEL_DEPLOYMENT_URL: ${{ steps.complete.outputs.verified_deployment_url }}
         run: |
           {
             echo "### GitHub prebuilt pilot"
@@ -366,16 +410,3 @@ jobs:
             echo
             echo "Turbo cache hit/miss details are preserved in the build log above."
           } >> "$GITHUB_STEP_SUMMARY"
-
-      - name: Close a non-terminal GitHub Deployment
-        id: finalizer
-        if: always() && steps.create.outputs.github_deployment_id != '' && steps.success.outcome != 'success'
-        env:
-          BUILD_OUTCOME: ${{ steps.build.outcome }}
-          DEPLOY_OUTCOME: ${{ steps.deploy.outcome }}
-          GITHUB_DEPLOYMENT_ID: ${{ steps.create.outputs.github_deployment_id }}
-          GITHUB_TOKEN: ${{ github.token }}
-          JOB_STATUS: ${{ job.status }}
-          SMOKE_OUTCOME: ${{ steps.smoke.outcome }}
-          WORKFLOW_RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}
-        run: node "$GITHUB_WORKSPACE/controller/scripts/github-deployment.mjs" finalize

--- a/.github/workflows/_vercel-prebuilt.yml
+++ b/.github/workflows/_vercel-prebuilt.yml
@@ -171,6 +171,8 @@ jobs:
           EXPECTED_ROOT_DIRECTORY: ${{ inputs.expected_root_directory }}
           GIT_BRANCH: ${{ inputs.git_branch }}
           GITHUB_DEPLOYMENT_ENVIRONMENT: ${{ inputs.github_environment }}
+          GITHUB_EVENT_REF: ${{ github.ref }}
+          GITHUB_WORKFLOW_DEFINITION: ${{ github.workflow_ref }}
           LOGICAL_TARGET: ${{ inputs.logical_target }}
           VERCEL_ENVIRONMENT: ${{ inputs.vercel_environment }}
           VERCEL_ORG_ID: ${{ inputs.vercel_org_id }}
@@ -190,11 +192,20 @@ jobs:
 
       - name: Install frozen dependencies
         working-directory: source
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile --ignore-scripts
+
+      - name: Restore trusted controller after source installation
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          clean: true
+          fetch-depth: 1
+          path: controller
+          persist-credentials: false
+          ref: ${{ github.workflow_sha }}
 
       - name: Verify pinned Vercel prerequisites
         working-directory: source
-        run: pnpm vercel:versions:check
+        run: node "$GITHUB_WORKSPACE/controller/scripts/vercel-prebuilt.mjs" check-versions
 
       - name: Materialize trusted repo-level UI project mapping
         env:
@@ -265,7 +276,7 @@ jobs:
           check --target ui --environment preview
           --project-directory apps/ui.mento.org
 
-      - name: Build and assert the UI prebuilt output
+      - name: Build the UI prebuilt output
         id: build
         env:
           CI: 1
@@ -288,9 +299,23 @@ jobs:
           VERCEL_PROJECT_ID: ${{ inputs.vercel_project_id }}
           VERCEL_TARGET_ENV: preview
           VERCEL_TOKEN: ${{ secrets.vercel_token }}
-        run: |
-          node "$GITHUB_WORKSPACE/controller/scripts/vercel-prebuilt-workflow.mjs" build
-          node "$GITHUB_WORKSPACE/controller/scripts/vercel-prebuilt-workflow.mjs" assert-output
+        run: node "$GITHUB_WORKSPACE/controller/scripts/vercel-prebuilt-workflow.mjs" build
+
+      - name: Restore trusted controller after source build
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          clean: true
+          fetch-depth: 1
+          path: controller
+          persist-credentials: false
+          ref: ${{ github.workflow_sha }}
+
+      - name: Assert the UI prebuilt output
+        env:
+          EXPECTED_ROOT_DIRECTORY: ${{ inputs.expected_root_directory }}
+          MENTO_NEXT_DEPLOYMENT_ID: ${{ steps.prepare.outputs.next_deployment_id }}
+          SOURCE_PATH: ${{ github.workspace }}/source
+        run: node "$GITHUB_WORKSPACE/controller/scripts/vercel-prebuilt-workflow.mjs" assert-output
 
       - name: Upload the verified prebuilt output
         id: deploy

--- a/.github/workflows/vercel-prebuilt-pilot.yml
+++ b/.github/workflows/vercel-prebuilt-pilot.yml
@@ -51,5 +51,4 @@ jobs:
     secrets:
       turbo_remote_cache_signature_key: ${{ secrets.TURBO_REMOTE_CACHE_SIGNATURE_KEY }}
       turbo_token: ${{ secrets.TURBO_TOKEN }}
-      vercel_automation_bypass_secret: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
       vercel_token: ${{ secrets.VERCEL_TOKEN_PREVIEW }}

--- a/.github/workflows/vercel-prebuilt-pilot.yml
+++ b/.github/workflows/vercel-prebuilt-pilot.yml
@@ -1,0 +1,55 @@
+name: Vercel Prebuilt Pilot
+
+# checkov:skip=CKV_GHA_7: This manual exact-SHA deployment pilot requires selectors that are validated before use.
+
+on:
+  workflow_dispatch:
+    inputs:
+      target:
+        description: Logical target (UI only for this pilot)
+        required: true
+        type: choice
+        default: ui
+        options:
+          - ui
+      commit_sha:
+        description: Immutable lowercase 40-character commit SHA
+        required: true
+        type: string
+      git_branch:
+        description: Same-repository branch containing commit_sha
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  deployments: write
+
+jobs:
+  deploy-ui-preview:
+    name: Deploy UI prebuilt preview
+    permissions:
+      contents: read
+      deployments: write
+    uses: ./.github/workflows/_vercel-prebuilt.yml
+    with:
+      commit_sha: ${{ inputs.commit_sha }}
+      deploy_permitted: true
+      deployment_idempotency_key: vercel-pilot:v1:ui:sha:${{ inputs.commit_sha }}:run:${{ github.run_id }}:attempt:${{ github.run_attempt }}
+      deployment_mode: preview
+      expected_root_directory: apps/ui.mento.org
+      git_branch: ${{ inputs.git_branch }}
+      github_environment: vercel-preview-ui
+      logical_target: ${{ inputs.target }}
+      provenance: manual-pilot
+      turbo_team: ${{ vars.TURBO_TEAM }}
+      vercel_environment: preview
+      vercel_org_id: ${{ vars.VERCEL_ORG_ID }}
+      vercel_project_id: ${{ vars.VERCEL_PROJECT_ID_UI }}
+      vercel_target: preview
+      workspace_package: ui.mento.org
+    secrets:
+      turbo_remote_cache_signature_key: ${{ secrets.TURBO_REMOTE_CACHE_SIGNATURE_KEY }}
+      turbo_token: ${{ secrets.TURBO_TOKEN }}
+      vercel_automation_bypass_secret: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
+      vercel_token: ${{ secrets.VERCEL_TOKEN_PREVIEW }}

--- a/.github/workflows/vercel-prebuilt-pilot.yml
+++ b/.github/workflows/vercel-prebuilt-pilot.yml
@@ -28,6 +28,9 @@ permissions:
 jobs:
   deploy-ui-preview:
     name: Deploy UI prebuilt preview
+    if: >-
+      github.ref == 'refs/heads/main' &&
+      github.workflow_ref == 'mento-protocol/frontend-monorepo/.github/workflows/vercel-prebuilt-pilot.yml@refs/heads/main'
     permissions:
       contents: read
       deployments: write

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,7 @@ pnpm fork:monad                      # Local anvil fork of Monad mainnet (chain 
 pnpm fork:seed:monad                 # Monad sibling of fork:seed (Reserve collateral + swap-to-seed, idempotent)
 pnpm pr:description:test             # Test the required PR-description format validator
 pnpm vercel:primitives:test          # Test affected planning, custom deployment IDs, and build-env contracts
+pnpm vercel:workflow:test            # Test the manual prebuilt pilot, REST lifecycle, CLI args, and direct smoke
 pnpm vercel:versions:check           # Verify pinned Next.js/Vercel CLI custom-ID prerequisites
 pnpm vercel:plan --base <sha> --head <sha>  # Emit the fail-closed Vercel target plan
 gh pr view --json body --jq .body | pnpm pr:description:check  # Validate the current PR body

--- a/README.md
+++ b/README.md
@@ -132,6 +132,9 @@ pnpm ci:action-pins:test
 # Test the network-free Vercel planning and prebuilt-build primitives
 pnpm vercel:primitives:test
 
+# Test the manual UI prebuilt workflow, GitHub Deployment lifecycle, and smoke controller
+pnpm vercel:workflow:test
+
 # Verify exact Next.js and Vercel CLI custom deployment-ID prerequisites
 pnpm vercel:versions:check
 ```

--- a/docs/vercel-deployments.md
+++ b/docs/vercel-deployments.md
@@ -255,3 +255,165 @@ target/environment classifications, and redaction-safe missing-variable errors.
 
 This foundation issue performs no Vercel API call, build upload, deployment,
 alias mutation, environment mutation, or Git-ownership change.
+
+## Manual UI prebuilt pilot
+
+`.github/workflows/vercel-prebuilt-pilot.yml` is the only entry point for the
+first prebuilt preview. It has only a manual `workflow_dispatch` trigger and
+accepts exactly three selectors: the fixed `ui` target, an immutable lowercase
+40-character commit SHA, and the same-repository branch that contains that SHA.
+It does not replace or disable the Vercel Git integration. Native Vercel Git
+previews remain the source of truth while this pilot gathers functional and
+timing evidence.
+
+The caller maps only the UI preview configuration:
+
+- repository variables `VERCEL_ORG_ID`, `VERCEL_PROJECT_ID_UI`, and
+  `TURBO_TEAM`;
+- repository secrets `VERCEL_TOKEN_PREVIEW`, `TURBO_TOKEN`, and
+  `TURBO_REMOTE_CACHE_SIGNATURE_KEY`;
+- optional repository secret `VERCEL_AUTOMATION_BYPASS_SECRET`, used only as
+  an HTTP header by direct preview smoke when deployment protection requires
+  it.
+
+The reusable worker declares each secret separately. It never inherits all
+caller secrets, never receives a production Vercel token, never selects a
+production GitHub environment, and never passes a token on a command line.
+
+### Dispatch
+
+Choose a SHA that already has a native Vercel Git UI preview and a branch that
+contains it. Verify both locally before dispatching:
+
+```bash
+SHA="<lowercase-40-character-sha>"
+BRANCH="<same-repository-branch>"
+git check-ref-format --branch "$BRANCH"
+git fetch --no-tags origin "refs/heads/$BRANCH:refs/remotes/origin/$BRANCH"
+git merge-base --is-ancestor "$SHA" "refs/remotes/origin/$BRANCH"
+gh workflow run vercel-prebuilt-pilot.yml \
+  --ref main \
+  -f target=ui \
+  -f commit_sha="$SHA" \
+  -f git_branch="$BRANCH"
+```
+
+The workflow independently rejects malformed, option-like, newline-bearing,
+missing, or unreachable refs. It checks out the exact SHA with full history and
+uses the recorded `HEAD` for the custom Next deployment ID, Vercel metadata,
+GitHub Deployment ref, smoke evidence, and outputs.
+
+Do not dispatch from a pull-request ref. The workflow controller is checked out
+from `github.workflow_sha`; the requested source is checked out separately and
+is never executed automatically with preview credentials.
+
+### Root Directory and command sequence
+
+The pinned Vercel CLI commands all execute with the monorepo root as their
+working directory. Before `vercel pull`, the worker writes an ignored,
+ephemeral repo-level link from the trusted repository variables. This is what
+lets CLI `56.2.0` resolve the UI project's configured Root Directory while all
+commands remain at the monorepo root. The mapping and project-local state are:
+
+```text
+.vercel/repo.json
+apps/ui.mento.org/.vercel/project.json
+apps/ui.mento.org/.vercel/.env.preview.local
+apps/ui.mento.org/.vercel/output/
+```
+
+The repo link contains only the organization ID, project ID, `origin` remote
+name, and `apps/ui.mento.org` directory mapping; it contains no token or
+environment value. The worker rejects symlinked repo-level Vercel state and
+asserts both the repo link and pulled app settings before building. The
+controller validates the ID variables but deliberately withholds them from the
+Vercel CLI child process: CLI `56.2.0` otherwise gives those variables
+precedence over `repo.json` and loses the monorepo Root Directory mapping.
+
+The worker runs this sequence in one standard `ubuntu-latest` job:
+
+1. materialize the exact repo-level UI link from repository variables;
+2. `vercel pull --yes --environment preview --git-branch <validated-branch>`;
+3. `pnpm vercel:env:check --target ui --environment preview
+--project-directory apps/ui.mento.org` with the explicit preview system
+   constants overriding pulled values;
+4. `vercel build --yes --target preview` with the signed Turbo remote cache,
+   immutable Git metadata, and generated `MENTO_NEXT_DEPLOYMENT_ID`;
+5. assertions for the UI project mapping, Build Output API v3 config, custom
+   deployment ID, preview target, and pinned CLI build record;
+6. `vercel deploy --prebuilt --target preview --archive=tgz --format=json`;
+7. `vercel inspect --wait --timeout 5m --format=json`, then direct HTTP smoke of
+   the immutable URL, navigation, custom build identity, representative JS/CSS/
+   font assets, and preview security headers.
+
+The upload command supplies `githubCommitOrg`, `githubCommitRepo`,
+`githubCommitSha`, and `githubCommitRef`. It intentionally omits
+`githubDeployment=1`, so Vercel cannot create a duplicate GitHub Deployment.
+The build output never becomes a GitHub artifact and never crosses jobs.
+
+### Canonical GitHub Deployment
+
+The worker owns one explicit REST Deployment for the exact SHA. It uses only
+`contents: read` and `deployments: write`; no job-level Actions environment is
+declared, so GitHub does not create an implicit event-SHA Deployment. The create
+request uses `auto_merge: false`, empty required contexts, the deterministic
+`vercel-preview-ui` environment, and transient/non-production flags.
+
+The run-scoped pilot key is:
+
+```text
+vercel-pilot:v1:ui:sha:<sha>:run:<run_id>:attempt:<run_attempt>
+```
+
+Retries with that exact key reuse the existing record. A deliberate workflow
+rerun has a different attempt key and creates a new pilot attempt. Only
+non-secret provenance is stored in the payload.
+
+Statuses progress through `queued` and `in_progress`. `success` is posted with
+the immutable Vercel `environment_url` and Actions `log_url` only after direct
+smoke passes. Build, deploy, or smoke failures post `failure`; cancellation or
+controller/infrastructure failures post `error`. An `if: always()` finalizer
+closes any record that did not reach success.
+
+A Deployment or status created with the repository `GITHUB_TOKEN` does not
+trigger another workflow run. Therefore `.github/workflows/preview-smoke.yml`
+will not recurse for this pilot. Direct smoke in the reusable worker is the
+required success gate. Do not add a PAT to force `deployment_status` recursion.
+
+### Evidence and browser verification
+
+The run summary records the exact SHA, immutable URL, Vercel Deployment ID,
+GitHub Deployment ID, build duration, upload duration, and total controller
+duration. Turbo prints remote-cache hit/miss evidence in the build log. Compare
+those values with the same-SHA native Vercel Git preview, but do not infer
+billing savings from elapsed time alone.
+
+Before treating the pilot as accepted, follow the repository browser protocol
+on the immutable GitHub-built URL: verify page rendering and primary
+navigation, inspect console errors and failed network requests, confirm static
+assets/fonts, and compare security headers plus the Vercel toolbar/CSP behavior
+with the native preview. Attach the URL and concise evidence to the PR or issue.
+
+The final automatic cutover remains blocked on the cost go/no-go evidence in
+issue #518: machine tiers, On-Demand Concurrent Builds state, actual billed
+usage/contracted MIUs, GitHub public-repository runner treatment, and a
+conservative monthly estimate.
+
+### Cleanup
+
+After evidence is saved, a maintainer may remove only the pilot's immutable
+preview using the preview-scoped CLI credential:
+
+```bash
+export VERCEL_TOKEN="<preview-scoped-token>"
+pnpm exec vercel remove "<immutable-vercel-deployment-url-or-id>" --yes
+```
+
+Confirm the value is the unique pilot URL or `dpl_` ID from the run summary.
+Never pass a production domain or alias, and do not change Vercel Git settings.
+
+The complete zero-network pilot/controller suite is:
+
+```bash
+pnpm vercel:workflow:test
+```

--- a/docs/vercel-deployments.md
+++ b/docs/vercel-deployments.md
@@ -289,6 +289,12 @@ the job holds preview-only Vercel and Turbo credentials. Fork sources cannot be
 selected, and the workflow rejects Dependabot branches. If the source is not
 trusted, do not dispatch the pilot.
 
+The dispatch is accepted only from `refs/heads/main`. The caller invokes the
+reusable worker from the same main commit, and the worker validates the caller
+workflow identity again before any candidate code or credentialed step runs. A
+dispatch that selects another branch or tag is rejected before the reusable
+job receives its preview credentials.
+
 Choose a SHA that already has a native Vercel Git UI preview and a branch that
 contains it. Verify both locally before dispatching:
 
@@ -310,9 +316,13 @@ missing, or unreachable refs. It checks out the exact SHA with full history and
 uses the recorded `HEAD` for the custom Next deployment ID, Vercel metadata,
 GitHub Deployment ref, smoke evidence, and outputs.
 
-Do not dispatch from a pull-request ref. The workflow controller is checked out
-from `github.workflow_sha`; the requested source is checked out separately and
-is never executed automatically with preview credentials.
+Do not dispatch from a pull-request ref. After the main-only guard, the workflow
+controller is checked out from the trusted `github.workflow_sha`; the requested
+source is checked out separately and is never executed automatically with
+preview credentials. Candidate dependency lifecycle scripts are disabled. The
+worker also restores the controller from its trusted workflow SHA after
+dependency installation and again after the candidate build, before upload and
+inspection.
 
 ### Root Directory and command sequence
 

--- a/docs/vercel-deployments.md
+++ b/docs/vercel-deployments.md
@@ -342,9 +342,11 @@ The worker runs this sequence in one standard `ubuntu-latest` job:
 5. assertions for the UI project mapping, Build Output API v3 config, custom
    deployment ID, preview target, and pinned CLI build record;
 6. `vercel deploy --prebuilt --target preview --archive=tgz --format=json`;
-7. `vercel inspect --wait --timeout 5m --format=json`, then direct HTTP smoke of
-   the immutable URL, navigation, custom build identity, representative JS/CSS/
-   font assets, and preview security headers.
+7. `vercel inspect --wait --timeout 5m --format=json --scope <org-id>`, then
+   direct HTTP smoke of the immutable URL, navigation, custom build identity,
+   representative JS/CSS/font assets, and preview security headers. The
+   explicit scope prevents inspection from falling back to the token owner's
+   default Vercel team.
 
 The upload command supplies `githubCommitOrg`, `githubCommitRepo`,
 `githubCommitSha`, and `githubCommitRef`. It intentionally omits

--- a/docs/vercel-deployments.md
+++ b/docs/vercel-deployments.md
@@ -282,6 +282,13 @@ reachable for this pilot.
 
 ### Dispatch
 
+This is a privileged maintainer action, not an automatic PR trigger. Dispatch
+only after reviewing the selected SHA and accepting its same-repository author
+as trusted: dependency installation and the UI build execute that source while
+the job holds preview-only Vercel and Turbo credentials. Fork sources cannot be
+selected, and the workflow rejects Dependabot branches. If the source is not
+trusted, do not dispatch the pilot.
+
 Choose a SHA that already has a native Vercel Git UI preview and a branch that
 contains it. Verify both locally before dispatching:
 

--- a/docs/vercel-deployments.md
+++ b/docs/vercel-deployments.md
@@ -271,14 +271,14 @@ The caller maps only the UI preview configuration:
 - repository variables `VERCEL_ORG_ID`, `VERCEL_PROJECT_ID_UI`, and
   `TURBO_TEAM`;
 - repository secrets `VERCEL_TOKEN_PREVIEW`, `TURBO_TOKEN`, and
-  `TURBO_REMOTE_CACHE_SIGNATURE_KEY`;
-- optional repository secret `VERCEL_AUTOMATION_BYPASS_SECRET`, used only as
-  an HTTP header by direct preview smoke when deployment protection requires
-  it.
+  `TURBO_REMOTE_CACHE_SIGNATURE_KEY`.
 
 The reusable worker declares each secret separately. It never inherits all
 caller secrets, never receives a production Vercel token, never selects a
-production GitHub environment, and never passes a token on a command line.
+production GitHub environment, and never passes a token on a command line. The
+separate smoke job receives no Vercel or Turbo credential and has only
+`contents: read` permission; the immutable preview must therefore be publicly
+reachable for this pilot.
 
 ### Dispatch
 
@@ -330,7 +330,8 @@ controller validates the ID variables but deliberately withholds them from the
 Vercel CLI child process: CLI `56.2.0` otherwise gives those variables
 precedence over `repo.json` and loses the monorepo Root Directory mapping.
 
-The worker runs this sequence in one standard `ubuntu-latest` job:
+The credentialed worker runs this sequence in one standard `ubuntu-latest`
+job:
 
 1. materialize the exact repo-level UI link from repository variables;
 2. `vercel pull --yes --environment preview --git-branch <validated-branch>`;
@@ -342,11 +343,17 @@ The worker runs this sequence in one standard `ubuntu-latest` job:
 5. assertions for the UI project mapping, Build Output API v3 config, custom
    deployment ID, preview target, and pinned CLI build record;
 6. `vercel deploy --prebuilt --target preview --archive=tgz --format=json`;
-7. `vercel inspect --wait --timeout 5m --format=json --scope <org-id>`, then
-   direct HTTP smoke of the immutable URL, navigation, custom build identity,
-   representative JS/CSS/font assets, and preview security headers. The
+7. `vercel inspect --wait --timeout 5m --format=json --scope <org-id>`. The
    explicit scope prevents inspection from falling back to the token owner's
    default Vercel team.
+
+Only after that job emits the verified immutable URL does a second trusted job
+perform direct HTTP smoke of the URL, navigation, custom build identity,
+representative JS/CSS/font assets, and preview security headers. That smoke job
+checks out only `github.workflow_sha`; it never checks out or executes the
+deployment source, downloads an executable artifact, or receives a
+Vercel/Turbo/protection-bypass credential. A third always-run trusted job owns
+the terminal GitHub Deployment status.
 
 The upload command supplies `githubCommitOrg`, `githubCommitRepo`,
 `githubCommitSha`, and `githubCommitRef`. It intentionally omits
@@ -374,8 +381,12 @@ non-secret provenance is stored in the payload.
 Statuses progress through `queued` and `in_progress`. `success` is posted with
 the immutable Vercel `environment_url` and Actions `log_url` only after direct
 smoke passes. Build, deploy, or smoke failures post `failure`; cancellation or
-controller/infrastructure failures post `error`. An `if: always()` finalizer
-closes any record that did not reach success.
+controller/infrastructure failures post `error`. The `if: always()` lifecycle
+job closes any record that did not reach success. It is independent of
+best-effort timing and run-summary steps, so a metrics failure cannot overwrite
+a verified deployment's lifecycle truth. The reusable workflow publishes
+`deployment_url` only from the smoke-backed success step; it never falls back
+to the unverified upload output.
 
 A Deployment or status created with the repository `GITHUB_TOKEN` does not
 trigger another workflow run. Therefore `.github/workflows/preview-smoke.yml`

--- a/package.json
+++ b/package.json
@@ -39,14 +39,15 @@
     "supply-chain:lockfile-lint:test": "node scripts/lockfile-lint.test.mjs",
     "supply-chain:version-skew": "node scripts/version-skew-check.mjs",
     "supply-chain:version-skew:test": "node scripts/version-skew-check.test.mjs",
-    "test": "pnpm vercel:primitives:test && turbo run test",
+    "test": "pnpm vercel:primitives:test && pnpm vercel:workflow:test && turbo run test",
     "test:coverage": "turbo run test:coverage",
     "vercel:deployment-id": "node scripts/vercel-prebuilt.mjs deployment-id",
     "vercel:env:check": "node scripts/vercel-build-environment.mjs check",
     "vercel:plan": "node scripts/plan-vercel-deployments.mjs",
     "vercel:prebuilt:assert": "node scripts/vercel-prebuilt.mjs assert-output",
     "vercel:primitives:test": "node --test scripts/plan-vercel-deployments.test.mjs scripts/vercel-build-environment.test.mjs scripts/vercel-prebuilt.test.mjs",
-    "vercel:versions:check": "node scripts/vercel-prebuilt.mjs check-versions"
+    "vercel:versions:check": "node scripts/vercel-prebuilt.mjs check-versions",
+    "vercel:workflow:test": "node --test scripts/github-deployment.test.mjs scripts/vercel-prebuilt-workflow.test.mjs scripts/vercel-prebuilt-workflows.test.mjs"
   },
   "devDependencies": {
     "@eslint/js": "catalog:",

--- a/scripts/github-deployment.mjs
+++ b/scripts/github-deployment.mjs
@@ -267,6 +267,20 @@ export function selectFinalDeploymentState({
   return "error";
 }
 
+export function selectWorkflowDeploymentState({ prebuiltResult, smokeResult }) {
+  const allowed = new Set(["success", "failure", "cancelled", "skipped"]);
+  if (!allowed.has(prebuiltResult) || !allowed.has(smokeResult)) {
+    throw new Error("Reusable workflow job result is invalid");
+  }
+  if (prebuiltResult === "success" && smokeResult === "success") {
+    return "success";
+  }
+  if (prebuiltResult === "failure" || smokeResult === "failure") {
+    return "failure";
+  }
+  return "error";
+}
+
 function createGitHubApi({
   token,
   apiUrl,
@@ -385,6 +399,24 @@ async function finalizeFromEnvironment() {
   await statusFromEnvironment(state);
 }
 
+async function completeFromEnvironment() {
+  const state = selectWorkflowDeploymentState({
+    prebuiltResult: environment("PREBUILT_RESULT"),
+    smokeResult: environment("SMOKE_RESULT"),
+  });
+  if (!/^[1-9][0-9]*$/.test(environment("GITHUB_DEPLOYMENT_ID") ?? "")) {
+    appendOutput("github_deployment_state", "error");
+    return;
+  }
+  await statusFromEnvironment(state);
+  if (state === "success") {
+    appendOutput(
+      "verified_deployment_url",
+      httpsUrl(environment("VERCEL_DEPLOYMENT_URL"), "Deployment URL"),
+    );
+  }
+}
+
 function isCliEntrypoint() {
   return (
     process.argv[1] !== undefined &&
@@ -400,7 +432,11 @@ if (isCliEntrypoint()) {
     await statusFromEnvironment();
   } else if (command === "finalize") {
     await finalizeFromEnvironment();
+  } else if (command === "complete") {
+    await completeFromEnvironment();
   } else {
-    throw new Error("Usage: github-deployment.mjs ensure|status|finalize");
+    throw new Error(
+      "Usage: github-deployment.mjs ensure|status|finalize|complete",
+    );
   }
 }

--- a/scripts/github-deployment.mjs
+++ b/scripts/github-deployment.mjs
@@ -1,0 +1,406 @@
+#!/usr/bin/env node
+
+/* eslint-disable turbo/no-undeclared-env-vars -- GitHub Actions supplies these controller-only values outside Turbo tasks. */
+
+import { appendFileSync } from "node:fs";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+import { resolve } from "node:path";
+
+const CONTROLLER_SCHEMA = "mento-vercel-prebuilt/v1";
+const DEPLOYMENT_STATES = [
+  "queued",
+  "in_progress",
+  "success",
+  "failure",
+  "error",
+];
+
+const SHA_PATTERN = /^[0-9a-f]{40}$/;
+
+function requiredText(value, label, { maximum = 255 } = {}) {
+  if (
+    typeof value !== "string" ||
+    value.length === 0 ||
+    value.length > maximum ||
+    hasControlCharacters(value)
+  ) {
+    throw new Error(`${label} is missing or invalid`);
+  }
+  return value;
+}
+
+function hasControlCharacters(value) {
+  return [...value].some((character) => {
+    const codePoint = character.codePointAt(0);
+    return codePoint <= 31 || codePoint === 127;
+  });
+}
+
+function exactSha(value) {
+  if (typeof value !== "string" || !SHA_PATTERN.test(value)) {
+    throw new Error("Commit SHA must be an immutable lowercase 40-digit SHA");
+  }
+  return value;
+}
+
+function httpsUrl(value, label) {
+  requiredText(value, label, { maximum: 2_048 });
+  let parsed;
+  try {
+    parsed = new URL(value);
+  } catch {
+    throw new Error(`${label} must be an HTTPS URL`);
+  }
+  if (parsed.protocol !== "https:" || parsed.username || parsed.password) {
+    throw new Error(`${label} must be an HTTPS URL without credentials`);
+  }
+  return parsed.toString();
+}
+
+function optionalPullRequestNumber(value) {
+  if (value === undefined || value === null || value === "") return undefined;
+  if (!/^[1-9][0-9]*$/.test(String(value))) {
+    throw new Error("Pull request number must be a positive integer");
+  }
+  return Number(value);
+}
+
+function buildDeploymentPayload({
+  idempotencyKey,
+  logicalTarget,
+  sha,
+  gitRef,
+  workflowRunUrl,
+  pullRequestNumber,
+  provenance,
+}) {
+  const payload = {
+    controller_schema: CONTROLLER_SCHEMA,
+    idempotency_key: requiredText(idempotencyKey, "Idempotency key"),
+    logical_target: requiredText(logicalTarget, "Logical target", {
+      maximum: 64,
+    }),
+    sha: exactSha(sha),
+    git_ref: requiredText(gitRef, "Git ref"),
+    workflow_run_url: httpsUrl(workflowRunUrl, "Workflow run URL"),
+  };
+  const prNumber = optionalPullRequestNumber(pullRequestNumber);
+  if (prNumber !== undefined) payload.pull_request_number = prNumber;
+  if (provenance !== undefined && provenance !== "") {
+    payload.provenance = requiredText(provenance, "Provenance");
+  }
+  return payload;
+}
+
+export function buildCreateDeploymentRequest(options) {
+  const environment = requiredText(
+    options.environment,
+    "Deployment environment",
+  );
+  return {
+    ref: exactSha(options.sha),
+    auto_merge: false,
+    required_contexts: [],
+    environment,
+    transient_environment: true,
+    production_environment: false,
+    description: `Vercel prebuilt ${requiredText(
+      options.logicalTarget,
+      "Logical target",
+      { maximum: 64 },
+    )} preview`,
+    payload: buildDeploymentPayload(options),
+  };
+}
+
+function parsedPayload(value) {
+  if (value && typeof value === "object") return value;
+  if (typeof value !== "string") return null;
+  try {
+    const parsed = JSON.parse(value);
+    return parsed && typeof parsed === "object" ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function deploymentMatches(deployment, request) {
+  const payload = parsedPayload(deployment?.payload);
+  return (
+    deployment?.sha === request.ref &&
+    deployment?.environment === request.environment &&
+    payload?.controller_schema === request.payload.controller_schema &&
+    payload?.idempotency_key === request.payload.idempotency_key &&
+    payload?.logical_target === request.payload.logical_target &&
+    payload?.sha === request.payload.sha
+  );
+}
+
+async function listEveryPage(api, { path, query }) {
+  const results = [];
+  for (let page = 1; ; page += 1) {
+    const response = await api({
+      method: "GET",
+      path,
+      query: page === 1 ? query : { ...query, page: String(page) },
+    });
+    if (!Array.isArray(response)) {
+      throw new Error("GitHub paginated lookup returned an invalid response");
+    }
+    results.push(...response);
+    if (response.length < Number(query.per_page)) return results;
+  }
+}
+
+export async function ensureGitHubDeployment({ request, api }) {
+  const existing = await listEveryPage(api, {
+    path: "/deployments",
+    query: {
+      sha: request.ref,
+      environment: request.environment,
+      per_page: "100",
+    },
+  });
+  const match = existing.find((deployment) =>
+    deploymentMatches(deployment, request),
+  );
+  if (match) {
+    return { deploymentId: String(match.id), reused: true };
+  }
+
+  const created = await api({
+    method: "POST",
+    path: "/deployments",
+    body: request,
+  });
+  if (!created?.id) {
+    throw new Error("GitHub deployment creation returned no deployment ID");
+  }
+  return { deploymentId: String(created.id), reused: false };
+}
+
+export function buildStatusRequest({
+  state,
+  environmentUrl,
+  logUrl,
+  description,
+}) {
+  if (!DEPLOYMENT_STATES.includes(state)) {
+    throw new Error(`Unsupported GitHub deployment state: ${String(state)}`);
+  }
+  const request = {
+    state,
+    log_url: httpsUrl(logUrl, "Actions log URL"),
+    description: requiredText(description, "Status description", {
+      maximum: 140,
+    }),
+    auto_inactive: false,
+  };
+  if (environmentUrl) {
+    request.environment_url = httpsUrl(
+      environmentUrl,
+      "Deployment environment URL",
+    );
+  }
+  if (state === "success" && !request.environment_url) {
+    throw new Error(
+      "A successful deployment status requires an environment URL",
+    );
+  }
+  if (state !== "success" && environmentUrl) {
+    throw new Error("Only a successful status may publish an environment URL");
+  }
+  return request;
+}
+
+function statusMatches(status, request) {
+  return (
+    status?.state === request.state &&
+    (status?.environment_url ?? null) === (request.environment_url ?? null) &&
+    (status?.log_url ?? null) === request.log_url &&
+    status?.description === request.description
+  );
+}
+
+export async function ensureGitHubDeploymentStatus({
+  deploymentId,
+  request,
+  api,
+}) {
+  if (!/^[1-9][0-9]*$/.test(String(deploymentId))) {
+    throw new Error("GitHub deployment ID must be a positive integer");
+  }
+  const path = `/deployments/${deploymentId}/statuses`;
+  const existing = await listEveryPage(api, {
+    path,
+    query: { per_page: "100" },
+  });
+  const match = existing.find((status) => statusMatches(status, request));
+  if (match) return { statusId: String(match.id), reused: true };
+
+  const created = await api({ method: "POST", path, body: request });
+  if (!created?.id) {
+    throw new Error("GitHub deployment status creation returned no status ID");
+  }
+  return { statusId: String(created.id), reused: false };
+}
+
+export function selectFinalDeploymentState({
+  jobStatus,
+  buildOutcome,
+  deployOutcome,
+  smokeOutcome,
+}) {
+  if (
+    [buildOutcome, deployOutcome, smokeOutcome].some(
+      (outcome) => outcome === "failure",
+    )
+  ) {
+    return "failure";
+  }
+  if (jobStatus === "success") {
+    throw new Error(
+      "A successful job must post success after smoke, not finalize",
+    );
+  }
+  return "error";
+}
+
+function createGitHubApi({
+  token,
+  apiUrl,
+  repository,
+  fetchImplementation = fetch,
+}) {
+  requiredText(token, "GitHub token", { maximum: 16_384 });
+  const [owner, repo, ...extra] = requiredText(
+    repository,
+    "GitHub repository",
+  ).split("/");
+  if (!owner || !repo || extra.length > 0) {
+    throw new Error("GitHub repository must be owner/name");
+  }
+  const baseUrl = new URL(
+    `/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}`,
+    `${requiredText(apiUrl, "GitHub API URL")}/`,
+  );
+
+  return async ({ method, path, query, body }) => {
+    const url = new URL(`${baseUrl.pathname}${path}`, baseUrl);
+    for (const [name, value] of Object.entries(query ?? {})) {
+      url.searchParams.set(name, value);
+    }
+    const response = await fetchImplementation(url, {
+      method,
+      headers: {
+        Accept: "application/vnd.github+json",
+        Authorization: `Bearer ${token}`,
+        "X-GitHub-Api-Version": "2022-11-28",
+        ...(body ? { "Content-Type": "application/json" } : {}),
+      },
+      ...(body ? { body: JSON.stringify(body) } : {}),
+    });
+    if (!response.ok) {
+      throw new Error(
+        `GitHub API ${method} ${path} failed (${response.status})`,
+      );
+    }
+    return response.json();
+  };
+}
+
+function appendOutput(name, value) {
+  const output = process.env.GITHUB_OUTPUT;
+  if (!output) throw new Error("GITHUB_OUTPUT is required");
+  appendFileSync(output, `${name}=${value}\n`);
+}
+
+function environment(name) {
+  return process.env[name];
+}
+
+function apiFromEnvironment() {
+  return createGitHubApi({
+    token: environment("GITHUB_TOKEN"),
+    apiUrl: environment("GITHUB_API_URL") ?? "https://api.github.com",
+    repository: environment("GITHUB_REPOSITORY"),
+  });
+}
+
+async function ensureFromEnvironment() {
+  const request = buildCreateDeploymentRequest({
+    idempotencyKey: environment("DEPLOYMENT_IDEMPOTENCY_KEY"),
+    logicalTarget: environment("LOGICAL_TARGET"),
+    sha: environment("DEPLOY_SHA"),
+    gitRef: environment("GIT_BRANCH"),
+    workflowRunUrl: environment("WORKFLOW_RUN_URL"),
+    pullRequestNumber: environment("PULL_REQUEST_NUMBER"),
+    provenance: environment("DEPLOYMENT_PROVENANCE"),
+    environment: environment("GITHUB_DEPLOYMENT_ENVIRONMENT"),
+  });
+  const result = await ensureGitHubDeployment({
+    request,
+    api: apiFromEnvironment(),
+  });
+  appendOutput("github_deployment_id", result.deploymentId);
+  appendOutput("github_deployment_reused", String(result.reused));
+}
+
+function statusDescription(state) {
+  const descriptions = {
+    queued: "Prebuilt preview queued",
+    in_progress: "Prebuilt preview build and verification running",
+    success: "Prebuilt preview verified",
+    failure: "Prebuilt preview build, deploy, or smoke failed",
+    error: "Prebuilt preview controller or infrastructure error",
+  };
+  return descriptions[state];
+}
+
+async function statusFromEnvironment(stateOverride) {
+  const state = stateOverride ?? environment("GITHUB_DEPLOYMENT_STATE");
+  const request = buildStatusRequest({
+    state,
+    environmentUrl:
+      state === "success" ? environment("VERCEL_DEPLOYMENT_URL") : undefined,
+    logUrl: environment("WORKFLOW_RUN_URL"),
+    description: statusDescription(state),
+  });
+  await ensureGitHubDeploymentStatus({
+    deploymentId: environment("GITHUB_DEPLOYMENT_ID"),
+    request,
+    api: apiFromEnvironment(),
+  });
+  appendOutput("github_deployment_state", state);
+}
+
+async function finalizeFromEnvironment() {
+  const state = selectFinalDeploymentState({
+    jobStatus: environment("JOB_STATUS"),
+    buildOutcome: environment("BUILD_OUTCOME"),
+    deployOutcome: environment("DEPLOY_OUTCOME"),
+    smokeOutcome: environment("SMOKE_OUTCOME"),
+  });
+  await statusFromEnvironment(state);
+}
+
+function isCliEntrypoint() {
+  return (
+    process.argv[1] !== undefined &&
+    fileURLToPath(import.meta.url) === resolve(process.argv[1])
+  );
+}
+
+if (isCliEntrypoint()) {
+  const command = process.argv[2];
+  if (command === "ensure") {
+    await ensureFromEnvironment();
+  } else if (command === "status") {
+    await statusFromEnvironment();
+  } else if (command === "finalize") {
+    await finalizeFromEnvironment();
+  } else {
+    throw new Error("Usage: github-deployment.mjs ensure|status|finalize");
+  }
+}

--- a/scripts/github-deployment.test.mjs
+++ b/scripts/github-deployment.test.mjs
@@ -1,0 +1,270 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  buildCreateDeploymentRequest,
+  buildStatusRequest,
+  ensureGitHubDeployment,
+  ensureGitHubDeploymentStatus,
+  selectFinalDeploymentState,
+} from "./github-deployment.mjs";
+
+const SHA = "0123456789abcdef0123456789abcdef01234567";
+const RUN_URL =
+  "https://github.com/mento-protocol/frontend-monorepo/actions/runs/123/attempts/1";
+
+function deploymentRequest(overrides = {}) {
+  return buildCreateDeploymentRequest({
+    idempotencyKey: `vercel-pilot:v1:ui:sha:${SHA}:run:123:attempt:1`,
+    logicalTarget: "ui",
+    sha: SHA,
+    gitRef: "feature/ui-pilot",
+    workflowRunUrl: RUN_URL,
+    pullRequestNumber: "518",
+    provenance: "manual-pilot",
+    environment: "vercel-preview-ui",
+    ...overrides,
+  });
+}
+
+test("create request is exact-SHA, transient, non-production, and secretless", () => {
+  const request = deploymentRequest();
+  assert.deepEqual(request, {
+    ref: SHA,
+    auto_merge: false,
+    required_contexts: [],
+    environment: "vercel-preview-ui",
+    transient_environment: true,
+    production_environment: false,
+    description: "Vercel prebuilt ui preview",
+    payload: {
+      controller_schema: "mento-vercel-prebuilt/v1",
+      idempotency_key: `vercel-pilot:v1:ui:sha:${SHA}:run:123:attempt:1`,
+      logical_target: "ui",
+      sha: SHA,
+      git_ref: "feature/ui-pilot",
+      workflow_run_url: RUN_URL,
+      pull_request_number: 518,
+      provenance: "manual-pilot",
+    },
+  });
+  assert.doesNotMatch(
+    JSON.stringify(request),
+    /token|secret|authorization|bypass/i,
+  );
+  assert.throws(
+    () => deploymentRequest({ sha: "main" }),
+    /immutable lowercase 40-digit SHA/,
+  );
+  assert.throws(
+    () => deploymentRequest({ workflowRunUrl: "http://github.com/run/1" }),
+    /HTTPS URL/,
+  );
+});
+
+test("same idempotency identity reuses one GitHub Deployment", async () => {
+  const request = deploymentRequest();
+  const calls = [];
+  const existing = {
+    id: 91,
+    sha: SHA,
+    environment: request.environment,
+    payload: request.payload,
+  };
+  const api = async (call) => {
+    calls.push(call);
+    return call.method === "GET" ? [existing] : { id: 92 };
+  };
+  assert.deepEqual(await ensureGitHubDeployment({ request, api }), {
+    deploymentId: "91",
+    reused: true,
+  });
+  assert.deepEqual(calls, [
+    {
+      method: "GET",
+      path: "/deployments",
+      query: {
+        sha: SHA,
+        environment: "vercel-preview-ui",
+        per_page: "100",
+      },
+    },
+  ]);
+});
+
+test("a distinct run-attempt idempotency key creates a new Deployment", async () => {
+  const previous = deploymentRequest();
+  const request = deploymentRequest({
+    idempotencyKey: `vercel-pilot:v1:ui:sha:${SHA}:run:123:attempt:2`,
+  });
+  const calls = [];
+  const api = async (call) => {
+    calls.push(call);
+    if (call.method === "GET") {
+      return [
+        {
+          id: 91,
+          sha: SHA,
+          environment: previous.environment,
+          payload: JSON.stringify(previous.payload),
+        },
+      ];
+    }
+    return { id: 92 };
+  };
+  assert.deepEqual(await ensureGitHubDeployment({ request, api }), {
+    deploymentId: "92",
+    reused: false,
+  });
+  assert.equal(calls.length, 2);
+  assert.deepEqual(calls[1], {
+    method: "POST",
+    path: "/deployments",
+    body: request,
+  });
+});
+
+test("idempotency lookup follows every same-SHA Deployment page", async () => {
+  const request = deploymentRequest();
+  const calls = [];
+  const api = async (call) => {
+    calls.push(call);
+    if (call.method === "POST") throw new Error("must not create a duplicate");
+    if (call.query.page === "2") {
+      return [
+        {
+          id: 191,
+          sha: SHA,
+          environment: request.environment,
+          payload: request.payload,
+        },
+      ];
+    }
+    return Array.from({ length: 100 }, (_, index) => ({
+      id: index + 1,
+      sha: SHA,
+      environment: request.environment,
+      payload: { ...request.payload, idempotency_key: `different-${index}` },
+    }));
+  };
+  assert.deepEqual(await ensureGitHubDeployment({ request, api }), {
+    deploymentId: "191",
+    reused: true,
+  });
+  assert.equal(calls.length, 2);
+  assert.equal(calls[1].query.page, "2");
+});
+
+test("status requests require smoke URL evidence before success", () => {
+  assert.deepEqual(
+    buildStatusRequest({
+      state: "success",
+      environmentUrl: "https://ui-pilot-abc.vercel.app",
+      logUrl: RUN_URL,
+      description: "Prebuilt preview verified",
+    }),
+    {
+      state: "success",
+      environment_url: "https://ui-pilot-abc.vercel.app/",
+      log_url: RUN_URL,
+      description: "Prebuilt preview verified",
+      auto_inactive: false,
+    },
+  );
+  assert.throws(
+    () =>
+      buildStatusRequest({
+        state: "success",
+        logUrl: RUN_URL,
+        description: "Prebuilt preview verified",
+      }),
+    /requires an environment URL/,
+  );
+  assert.throws(
+    () =>
+      buildStatusRequest({
+        state: "failure",
+        environmentUrl: "https://ui-pilot-abc.vercel.app",
+        logUrl: RUN_URL,
+        description: "failed",
+      }),
+    /Only a successful status/,
+  );
+  assert.throws(
+    () =>
+      buildStatusRequest({
+        state: "success",
+        environmentUrl: "http://ui-pilot-abc.vercel.app",
+        logUrl: RUN_URL,
+        description: "Prebuilt preview verified",
+      }),
+    /HTTPS URL/,
+  );
+});
+
+test("status writes are idempotent for a deployment lifecycle", async () => {
+  const request = buildStatusRequest({
+    state: "in_progress",
+    logUrl: RUN_URL,
+    description: "Prebuilt preview build and verification running",
+  });
+  let posts = 0;
+  const existing = {
+    id: 11,
+    state: request.state,
+    log_url: request.log_url,
+    environment_url: null,
+    description: request.description,
+  };
+  const api = async ({ method }) => {
+    if (method === "GET") return [existing];
+    posts += 1;
+    return { id: 12 };
+  };
+  assert.deepEqual(
+    await ensureGitHubDeploymentStatus({
+      deploymentId: "91",
+      request,
+      api,
+    }),
+    { statusId: "11", reused: true },
+  );
+  assert.equal(posts, 0);
+});
+
+test("finalizer maps build/deploy/smoke failures to failure and infrastructure to error", () => {
+  for (const failingOutcome of [
+    "buildOutcome",
+    "deployOutcome",
+    "smokeOutcome",
+  ]) {
+    assert.equal(
+      selectFinalDeploymentState({
+        jobStatus: "failure",
+        buildOutcome: "success",
+        deployOutcome: "success",
+        smokeOutcome: "success",
+        [failingOutcome]: "failure",
+      }),
+      "failure",
+    );
+  }
+  assert.equal(
+    selectFinalDeploymentState({
+      jobStatus: "cancelled",
+      buildOutcome: "success",
+      deployOutcome: "skipped",
+      smokeOutcome: "skipped",
+    }),
+    "error",
+  );
+  assert.equal(
+    selectFinalDeploymentState({
+      jobStatus: "failure",
+      buildOutcome: "skipped",
+      deployOutcome: "skipped",
+      smokeOutcome: "skipped",
+    }),
+    "error",
+  );
+});

--- a/scripts/github-deployment.test.mjs
+++ b/scripts/github-deployment.test.mjs
@@ -7,6 +7,7 @@ import {
   ensureGitHubDeployment,
   ensureGitHubDeploymentStatus,
   selectFinalDeploymentState,
+  selectWorkflowDeploymentState,
 } from "./github-deployment.mjs";
 
 const SHA = "0123456789abcdef0123456789abcdef01234567";
@@ -266,5 +267,42 @@ test("finalizer maps build/deploy/smoke failures to failure and infrastructure t
       smokeOutcome: "skipped",
     }),
     "error",
+  );
+});
+
+test("cross-job finalization follows build and smoke truth only", () => {
+  assert.equal(
+    selectWorkflowDeploymentState({
+      prebuiltResult: "success",
+      smokeResult: "success",
+    }),
+    "success",
+  );
+  for (const [prebuiltResult, smokeResult] of [
+    ["failure", "skipped"],
+    ["success", "failure"],
+  ]) {
+    assert.equal(
+      selectWorkflowDeploymentState({ prebuiltResult, smokeResult }),
+      "failure",
+    );
+  }
+  for (const [prebuiltResult, smokeResult] of [
+    ["cancelled", "skipped"],
+    ["success", "cancelled"],
+    ["skipped", "skipped"],
+  ]) {
+    assert.equal(
+      selectWorkflowDeploymentState({ prebuiltResult, smokeResult }),
+      "error",
+    );
+  }
+  assert.throws(
+    () =>
+      selectWorkflowDeploymentState({
+        prebuiltResult: "success",
+        smokeResult: "unknown",
+      }),
+    /job result is invalid/,
   );
 });

--- a/scripts/vercel-prebuilt-workflow.mjs
+++ b/scripts/vercel-prebuilt-workflow.mjs
@@ -235,7 +235,7 @@ export function buildVercelDeployArguments({
   return arguments_;
 }
 
-export function buildVercelInspectArguments(deploymentUrl) {
+export function buildVercelInspectArguments(deploymentUrl, vercelOrgId) {
   return [
     "inspect",
     immutableVercelUrl(deploymentUrl),
@@ -243,6 +243,8 @@ export function buildVercelInspectArguments(deploymentUrl) {
     "--timeout",
     "5m",
     "--format=json",
+    "--scope",
+    requiredText(vercelOrgId, "Vercel organization ID"),
   ];
 }
 
@@ -707,7 +709,10 @@ function deployFromEnvironment() {
 
 function verifyFromEnvironment() {
   const raw = runVercel(
-    buildVercelInspectArguments(process.env.VERCEL_DEPLOYMENT_URL),
+    buildVercelInspectArguments(
+      process.env.VERCEL_DEPLOYMENT_URL,
+      process.env.VERCEL_ORG_ID,
+    ),
     { capture: true },
   );
   assertVercelInspection(raw, {

--- a/scripts/vercel-prebuilt-workflow.mjs
+++ b/scripts/vercel-prebuilt-workflow.mjs
@@ -470,15 +470,6 @@ export function assertPrebuiltOutput({
   return outputDirectory;
 }
 
-function smokeHeaders(bypassSecret) {
-  return bypassSecret
-    ? {
-        "x-vercel-protection-bypass": bypassSecret,
-        "x-vercel-set-bypass-cookie": "true",
-      }
-    : {};
-}
-
 function requireHeader(response, name, expected) {
   const value = response.headers.get(name);
   if (
@@ -499,13 +490,10 @@ async function successfulText(response, label) {
 export async function smokeUiPreview({
   deploymentUrl,
   deploymentId,
-  bypassSecret,
   fetchImplementation = fetch,
 }) {
   const baseUrl = immutableVercelUrl(deploymentUrl);
-  const headers = smokeHeaders(bypassSecret);
   const mainResponse = await fetchImplementation(baseUrl, {
-    headers,
     redirect: "follow",
   });
   const html = await successfulText(mainResponse, "UI preview");
@@ -532,7 +520,7 @@ export async function smokeUiPreview({
 
   const navigationResponse = await fetchImplementation(
     new URL("/form-components", baseUrl),
-    { headers, redirect: "follow" },
+    { redirect: "follow" },
   );
   const navigationHtml = await successfulText(
     navigationResponse,
@@ -557,7 +545,6 @@ export async function smokeUiPreview({
   }
   for (const asset of representatives) {
     const response = await fetchImplementation(new URL(asset, baseUrl), {
-      headers,
       redirect: "follow",
     });
     if (!response.ok) {
@@ -719,6 +706,11 @@ function verifyFromEnvironment() {
     deploymentId: process.env.VERCEL_DEPLOYMENT_ID,
     deploymentUrl: process.env.VERCEL_DEPLOYMENT_URL,
   });
+  output("verified_deployment_id", process.env.VERCEL_DEPLOYMENT_ID);
+  output(
+    "verified_deployment_url",
+    immutableVercelUrl(process.env.VERCEL_DEPLOYMENT_URL),
+  );
 }
 
 async function smokeFromEnvironment() {
@@ -728,7 +720,6 @@ async function smokeFromEnvironment() {
   const result = await smokeUiPreview({
     deploymentUrl: process.env.VERCEL_DEPLOYMENT_URL,
     deploymentId: process.env.MENTO_NEXT_DEPLOYMENT_ID,
-    bypassSecret: process.env.VERCEL_AUTOMATION_BYPASS_SECRET,
   });
   output("smoke_deployment_url", result.deploymentUrl);
   output("smoke_deployment_id", process.env.VERCEL_DEPLOYMENT_ID);

--- a/scripts/vercel-prebuilt-workflow.mjs
+++ b/scripts/vercel-prebuilt-workflow.mjs
@@ -80,6 +80,9 @@ export function validateGitBranch(branch, run = spawnSync) {
 export function validatePilotContract(values) {
   validateExactSha(values.commitSha);
   validateGitBranch(values.gitBranch);
+  if (values.gitBranch.startsWith("dependabot/")) {
+    throw new Error("Dependabot branches cannot receive preview credentials");
+  }
 
   const expected = {
     logicalTarget: values.logicalTarget,

--- a/scripts/vercel-prebuilt-workflow.mjs
+++ b/scripts/vercel-prebuilt-workflow.mjs
@@ -108,6 +108,15 @@ export function validatePilotContract(values) {
       "The pilot may run only in mento-protocol/frontend-monorepo",
     );
   }
+  if (values.githubRef !== "refs/heads/main") {
+    throw new Error("The pilot workflow must be dispatched from main");
+  }
+  if (
+    values.githubWorkflowRef !==
+    "mento-protocol/frontend-monorepo/.github/workflows/vercel-prebuilt-pilot.yml@refs/heads/main"
+  ) {
+    throw new Error("The pilot caller must be the trusted main workflow");
+  }
   requiredText(values.vercelOrgId, "Vercel organization ID");
   requiredText(values.vercelProjectId, "Vercel project ID");
   requiredText(values.idempotencyKey, "Deployment idempotency key");
@@ -645,6 +654,8 @@ function contractFromEnvironment() {
     idempotencyKey: process.env.DEPLOYMENT_IDEMPOTENCY_KEY,
     workflowRunUrl: process.env.WORKFLOW_RUN_URL,
     githubRepository: process.env.GITHUB_REPOSITORY,
+    githubRef: process.env.GITHUB_EVENT_REF,
+    githubWorkflowRef: process.env.GITHUB_WORKFLOW_DEFINITION,
   };
 }
 

--- a/scripts/vercel-prebuilt-workflow.mjs
+++ b/scripts/vercel-prebuilt-workflow.mjs
@@ -484,22 +484,71 @@ function requireHeader(response, name, expected) {
   }
 }
 
-async function successfulText(response, label) {
+function successfulText(response, body, label) {
   if (!response.ok)
     throw new Error(`${label} returned HTTP ${response.status}`);
-  return response.text();
+  if (typeof body !== "string") {
+    throw new Error(`${label} returned an invalid body`);
+  }
+  return body;
+}
+
+async function fetchWithTimeout({
+  fetchImplementation,
+  url,
+  options,
+  bodyType,
+  label,
+  timeoutMs,
+}) {
+  if (!Number.isSafeInteger(timeoutMs) || timeoutMs < 1 || timeoutMs > 30_000) {
+    throw new Error("Preview smoke request timeout is invalid");
+  }
+  const controller = new AbortController();
+  let timeout;
+  try {
+    const request = (async () => {
+      const response = await fetchImplementation(url, {
+        ...options,
+        signal: controller.signal,
+      });
+      if (!response.ok) return { response, body: undefined };
+      const body =
+        bodyType === "text"
+          ? await response.text()
+          : await response.arrayBuffer();
+      return { response, body };
+    })();
+    return await Promise.race([
+      request,
+      new Promise((_, reject) => {
+        timeout = setTimeout(() => {
+          controller.abort();
+          reject(new Error(`${label} timed out`));
+        }, timeoutMs);
+      }),
+    ]);
+  } finally {
+    clearTimeout(timeout);
+  }
 }
 
 export async function smokeUiPreview({
   deploymentUrl,
   deploymentId,
   fetchImplementation = fetch,
+  requestTimeoutMs = 15_000,
 }) {
   const baseUrl = immutableVercelUrl(deploymentUrl);
-  const mainResponse = await fetchImplementation(baseUrl, {
-    redirect: "follow",
+  const { response: mainResponse, body: mainBody } = await fetchWithTimeout({
+    fetchImplementation,
+    url: baseUrl,
+    options: { redirect: "follow" },
+    bodyType: "text",
+    label: "UI preview",
+    timeoutMs: requestTimeoutMs,
   });
-  const html = await successfulText(mainResponse, "UI preview");
+  const html = successfulText(mainResponse, mainBody, "UI preview");
   if (!html.includes("Basic Components")) {
     throw new Error("UI preview did not render the Basic Components page");
   }
@@ -521,12 +570,18 @@ export async function smokeUiPreview({
     /https:\/\/vercel\.live/,
   );
 
-  const navigationResponse = await fetchImplementation(
-    new URL("/form-components", baseUrl),
-    { redirect: "follow" },
-  );
-  const navigationHtml = await successfulText(
+  const { response: navigationResponse, body: navigationBody } =
+    await fetchWithTimeout({
+      fetchImplementation,
+      url: new URL("/form-components", baseUrl),
+      options: { redirect: "follow" },
+      bodyType: "text",
+      label: "UI preview navigation",
+      timeoutMs: requestTimeoutMs,
+    });
+  const navigationHtml = successfulText(
     navigationResponse,
+    navigationBody,
     "UI preview navigation",
   );
   if (!navigationHtml.includes("Form Components")) {
@@ -547,8 +602,13 @@ export async function smokeUiPreview({
     );
   }
   for (const asset of representatives) {
-    const response = await fetchImplementation(new URL(asset, baseUrl), {
-      redirect: "follow",
+    const { response } = await fetchWithTimeout({
+      fetchImplementation,
+      url: new URL(asset, baseUrl),
+      options: { redirect: "follow" },
+      bodyType: "bytes",
+      label: "UI preview static asset",
+      timeoutMs: requestTimeoutMs,
     });
     if (!response.ok) {
       throw new Error(

--- a/scripts/vercel-prebuilt-workflow.mjs
+++ b/scripts/vercel-prebuilt-workflow.mjs
@@ -1,0 +1,769 @@
+#!/usr/bin/env node
+
+/* eslint-disable turbo/no-undeclared-env-vars -- GitHub Actions supplies these controller-only values outside Turbo tasks. */
+
+import { spawnSync } from "node:child_process";
+import {
+  appendFileSync,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readFileSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { resolve, join } from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+import {
+  assertPrebuiltDeploymentId,
+  generateVercelDeploymentId,
+} from "./vercel-prebuilt.mjs";
+
+export const PILOT_TARGET = {
+  logicalTarget: "ui",
+  workspacePackage: "ui.mento.org",
+  expectedRootDirectory: "apps/ui.mento.org",
+  githubEnvironment: "vercel-preview-ui",
+  vercelEnvironment: "preview",
+  vercelTarget: "preview",
+  deploymentMode: "preview",
+};
+
+const SHA_PATTERN = /^[0-9a-f]{40}$/;
+const VERCEL_DEPLOYMENT_ID_PATTERN = /^dpl_[A-Za-z0-9]+$/;
+function requiredText(value, label, { maximum = 2_048 } = {}) {
+  if (
+    typeof value !== "string" ||
+    value.length === 0 ||
+    value.length > maximum ||
+    hasControlCharacters(value)
+  ) {
+    throw new Error(`${label} is missing or invalid`);
+  }
+  return value;
+}
+
+function hasControlCharacters(value) {
+  return [...value].some((character) => {
+    const codePoint = character.codePointAt(0);
+    return codePoint <= 31 || codePoint === 127;
+  });
+}
+
+export function validateExactSha(value) {
+  if (typeof value !== "string" || !SHA_PATTERN.test(value)) {
+    throw new Error("Commit SHA must be an immutable lowercase 40-digit SHA");
+  }
+  return value;
+}
+
+export function validateGitBranch(branch, run = spawnSync) {
+  requiredText(branch, "Git branch");
+  if (
+    branch.startsWith("-") ||
+    branch.startsWith("refs/") ||
+    branch.trim() !== branch
+  ) {
+    throw new Error("Git branch is option-like or contains surrounding space");
+  }
+  const result = run("git", ["check-ref-format", "--branch", branch], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  if (result.status !== 0)
+    throw new Error("Git branch is not a valid branch ref");
+  return branch;
+}
+
+export function validatePilotContract(values) {
+  validateExactSha(values.commitSha);
+  validateGitBranch(values.gitBranch);
+
+  const expected = {
+    logicalTarget: values.logicalTarget,
+    workspacePackage: values.workspacePackage,
+    expectedRootDirectory: values.expectedRootDirectory,
+    githubEnvironment: values.githubEnvironment,
+    vercelEnvironment: values.vercelEnvironment,
+    vercelTarget: values.vercelTarget,
+    deploymentMode: values.deploymentMode,
+  };
+  for (const [name, actual] of Object.entries(expected)) {
+    if (actual !== PILOT_TARGET[name]) {
+      throw new Error(
+        `The manual pilot requires ${name}=${PILOT_TARGET[name]}`,
+      );
+    }
+  }
+  if (values.deployPermitted !== "true" && values.deployPermitted !== true) {
+    throw new Error("The caller did not permit this deployment");
+  }
+  if (values.githubRepository !== "mento-protocol/frontend-monorepo") {
+    throw new Error(
+      "The pilot may run only in mento-protocol/frontend-monorepo",
+    );
+  }
+  requiredText(values.vercelOrgId, "Vercel organization ID");
+  requiredText(values.vercelProjectId, "Vercel project ID");
+  requiredText(values.idempotencyKey, "Deployment idempotency key");
+  requiredText(values.workflowRunUrl, "Workflow run URL");
+  return values;
+}
+
+function git(repoRoot, arguments_, run = spawnSync) {
+  return run("git", ["-C", repoRoot, ...arguments_], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+}
+
+function requireGitSuccess(result, message) {
+  if (result.status !== 0) throw new Error(message);
+  return result.stdout.trim();
+}
+
+function remoteMatchesRepository(remoteUrl, repository) {
+  const escaped = repository.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return new RegExp(
+    `^(?:https://github\\.com/|git@github\\.com:|ssh://git@github\\.com/)?${escaped}(?:\\.git)?/?$`,
+  ).test(remoteUrl);
+}
+
+export function validateSourceCheckout({
+  repoRoot,
+  commitSha,
+  gitBranch,
+  githubRepository,
+  run = spawnSync,
+}) {
+  const sha = validateExactSha(commitSha);
+  const branch = validateGitBranch(gitBranch, run);
+  const head = requireGitSuccess(
+    git(repoRoot, ["rev-parse", "--verify", "HEAD^{commit}"], run),
+    "Unable to resolve the checked-out commit",
+  );
+  if (head !== sha)
+    throw new Error("Checked-out HEAD does not match commit_sha");
+
+  const remote = requireGitSuccess(
+    git(repoRoot, ["remote", "get-url", "origin"], run),
+    "Unable to resolve the origin remote",
+  );
+  if (!remoteMatchesRepository(remote, githubRepository)) {
+    throw new Error("Origin is not the expected same-repository GitHub remote");
+  }
+
+  requireGitSuccess(
+    git(
+      repoRoot,
+      [
+        "fetch",
+        "--force",
+        "--no-tags",
+        "origin",
+        `refs/heads/${branch}:refs/remotes/origin/${branch}`,
+      ],
+      run,
+    ),
+    "The requested same-repository branch does not exist",
+  );
+  requireGitSuccess(
+    git(
+      repoRoot,
+      ["merge-base", "--is-ancestor", sha, `refs/remotes/origin/${branch}`],
+      run,
+    ),
+    "commit_sha is not reachable from git_branch",
+  );
+  return { commitSha: head, gitBranch: branch };
+}
+
+export function buildVercelPullArguments({ gitBranch, projectId }) {
+  validateGitBranch(gitBranch);
+  return [
+    "pull",
+    "--yes",
+    "--environment",
+    "preview",
+    "--git-branch",
+    gitBranch,
+    "--project",
+    requiredText(projectId, "Vercel project ID"),
+  ];
+}
+
+export function buildVercelBuildArguments({ projectId }) {
+  return [
+    "build",
+    "--yes",
+    "--target",
+    "preview",
+    "--project",
+    requiredText(projectId, "Vercel project ID"),
+  ];
+}
+
+export function buildVercelDeployArguments({
+  projectId,
+  commitSha,
+  gitBranch,
+}) {
+  const sha = validateExactSha(commitSha);
+  const branch = validateGitBranch(gitBranch);
+  const arguments_ = [
+    "deploy",
+    "--prebuilt",
+    "--target",
+    "preview",
+    "--archive=tgz",
+    "--format=json",
+    "--yes",
+    "--project",
+    requiredText(projectId, "Vercel project ID"),
+    "--meta",
+    "githubCommitOrg=mento-protocol",
+    "--meta",
+    "githubCommitRepo=frontend-monorepo",
+    "--meta",
+    `githubCommitSha=${sha}`,
+    "--meta",
+    `githubCommitRef=${branch}`,
+  ];
+  assertSafeVercelArguments(arguments_);
+  return arguments_;
+}
+
+export function buildVercelInspectArguments(deploymentUrl) {
+  return [
+    "inspect",
+    immutableVercelUrl(deploymentUrl),
+    "--wait",
+    "--timeout",
+    "5m",
+    "--format=json",
+  ];
+}
+
+export function assertSafeVercelArguments(arguments_) {
+  if (arguments_[0] === "promote") {
+    throw new Error("Forbidden Vercel CLI command: promote");
+  }
+  for (const [index, argument] of arguments_.entries()) {
+    if (argument === "--prod" || argument.startsWith("--prod=")) {
+      throw new Error("Forbidden Vercel CLI flag: --prod");
+    }
+    if (argument === "--token" || argument.startsWith("--token=")) {
+      throw new Error(
+        "Vercel tokens must be passed only through the environment",
+      );
+    }
+    const metadata =
+      argument === "--meta"
+        ? arguments_[index + 1]
+        : argument.startsWith("--meta=")
+          ? argument.slice("--meta=".length)
+          : undefined;
+    if (metadata?.split("=", 1)[0] === "githubDeployment") {
+      throw new Error("Forbidden Vercel metadata key: githubDeployment");
+    }
+  }
+  return arguments_;
+}
+
+function assertPlainDirectory(path, label) {
+  if (!existsSync(path)) return;
+  const entry = lstatSync(path);
+  if (entry.isSymbolicLink() || !entry.isDirectory()) {
+    throw new Error(`${label} must be a real directory`);
+  }
+}
+
+function assertPlainFile(path, label) {
+  if (!existsSync(path)) return;
+  const entry = lstatSync(path);
+  if (entry.isSymbolicLink() || !entry.isFile()) {
+    throw new Error(`${label} must be a regular file`);
+  }
+}
+
+export function materializeVercelRepoLink({
+  repoRoot,
+  expectedRootDirectory,
+  vercelOrgId,
+  vercelProjectId,
+}) {
+  requiredText(repoRoot, "Source path");
+  if (expectedRootDirectory !== PILOT_TARGET.expectedRootDirectory) {
+    throw new Error("The repo link must target the UI project Root Directory");
+  }
+  const link = {
+    remoteName: "origin",
+    projects: [
+      {
+        id: requiredText(vercelProjectId, "Vercel project ID"),
+        directory: expectedRootDirectory,
+        orgId: requiredText(vercelOrgId, "Vercel organization ID"),
+      },
+    ],
+  };
+  const vercelDirectory = join(repoRoot, ".vercel");
+  assertPlainDirectory(vercelDirectory, "Repo-level Vercel state");
+  mkdirSync(vercelDirectory, { recursive: true });
+  const linkPath = join(vercelDirectory, "repo.json");
+  assertPlainFile(linkPath, "Repo-level Vercel link");
+  writeFileSync(linkPath, `${JSON.stringify(link, null, 2)}\n`, {
+    encoding: "utf8",
+    mode: 0o600,
+  });
+  return link;
+}
+
+export function environmentForVercelCli(environment) {
+  const cliEnvironment = { ...environment };
+  // CLI 56.2.0 gives these variables precedence over repo.json and would lose
+  // the monorepo Root Directory mapping. The controller has already validated
+  // the IDs and materialized them in the trusted repo link.
+  delete cliEnvironment.VERCEL_ORG_ID;
+  delete cliEnvironment.VERCEL_PROJECT_ID;
+  return cliEnvironment;
+}
+
+function immutableVercelUrl(value) {
+  const withProtocol = value?.startsWith("http") ? value : `https://${value}`;
+  let parsed;
+  try {
+    parsed = new URL(withProtocol);
+  } catch {
+    throw new Error("Vercel returned an invalid deployment URL");
+  }
+  if (
+    parsed.protocol !== "https:" ||
+    !parsed.hostname.endsWith(".vercel.app") ||
+    parsed.username ||
+    parsed.password
+  ) {
+    throw new Error("Vercel returned a non-immutable or non-HTTPS preview URL");
+  }
+  parsed.hash = "";
+  return parsed.toString().replace(/\/$/, "");
+}
+
+export function parseVercelDeploymentJson(raw) {
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new Error("Vercel deploy returned invalid JSON");
+  }
+  if (parsed?.status && parsed.status !== "ok") {
+    throw new Error("Vercel deploy did not report a successful upload");
+  }
+  const deployment = parsed?.deployment ?? parsed;
+  if (
+    !deployment ||
+    !VERCEL_DEPLOYMENT_ID_PATTERN.test(String(deployment.id ?? ""))
+  ) {
+    throw new Error("Vercel deploy returned no valid deployment ID");
+  }
+  return {
+    deploymentId: deployment.id,
+    deploymentUrl: immutableVercelUrl(deployment.url),
+    readyState: deployment.readyState,
+    target: deployment.target,
+  };
+}
+
+export function assertVercelInspection(raw, { deploymentId, deploymentUrl }) {
+  let inspection;
+  try {
+    inspection = JSON.parse(raw);
+  } catch {
+    throw new Error("Vercel inspect returned invalid JSON");
+  }
+  if (
+    inspection.id !== deploymentId ||
+    immutableVercelUrl(inspection.url) !== immutableVercelUrl(deploymentUrl) ||
+    inspection.readyState !== "READY" ||
+    inspection.target !== "preview"
+  ) {
+    throw new Error(
+      "Vercel inspection does not match the expected ready preview",
+    );
+  }
+  return inspection;
+}
+
+export function assertPulledProject({
+  repoRoot,
+  expectedRootDirectory,
+  vercelOrgId,
+  vercelProjectId,
+}) {
+  const repoLinkPath = join(repoRoot, ".vercel", "repo.json");
+  const settingsPath = join(
+    repoRoot,
+    expectedRootDirectory,
+    ".vercel",
+    "project.json",
+  );
+  let repoLink;
+  let project;
+  try {
+    repoLink = JSON.parse(readFileSync(repoLinkPath, "utf8"));
+    project = JSON.parse(readFileSync(settingsPath, "utf8"));
+  } catch {
+    throw new Error("Vercel pull did not materialize valid project settings");
+  }
+  const linkedProject = repoLink.projects?.[0];
+  if (
+    repoLink.remoteName !== "origin" ||
+    repoLink.projects?.length !== 1 ||
+    linkedProject?.orgId !== vercelOrgId ||
+    linkedProject?.id !== vercelProjectId ||
+    linkedProject?.directory !== expectedRootDirectory ||
+    project.settings?.rootDirectory !== expectedRootDirectory
+  ) {
+    throw new Error(
+      "Pulled Vercel project mapping does not match the UI target",
+    );
+  }
+  return project;
+}
+
+export function assertPrebuiltOutput({
+  repoRoot,
+  expectedRootDirectory,
+  deploymentId,
+}) {
+  const outputDirectory = join(
+    repoRoot,
+    expectedRootDirectory,
+    ".vercel",
+    "output",
+  );
+  const configPath = join(outputDirectory, "config.json");
+  if (!statSync(configPath).isFile()) {
+    throw new Error("Prebuilt output config is not a file");
+  }
+  const config = JSON.parse(readFileSync(configPath, "utf8"));
+  if (config.version !== 3) {
+    throw new Error("Prebuilt output is not Build Output API version 3");
+  }
+  let buildRecord;
+  try {
+    buildRecord = JSON.parse(
+      readFileSync(join(outputDirectory, "builds.json"), "utf8"),
+    );
+  } catch {
+    throw new Error("Prebuilt output is missing its Vercel CLI build record");
+  }
+  if (buildRecord.target !== "preview" || buildRecord.cliVersion !== "56.2.0") {
+    throw new Error(
+      "Prebuilt output target or pinned Vercel CLI version is invalid",
+    );
+  }
+  assertPrebuiltDeploymentId(outputDirectory, deploymentId);
+  return outputDirectory;
+}
+
+function smokeHeaders(bypassSecret) {
+  return bypassSecret
+    ? {
+        "x-vercel-protection-bypass": bypassSecret,
+        "x-vercel-set-bypass-cookie": "true",
+      }
+    : {};
+}
+
+function requireHeader(response, name, expected) {
+  const value = response.headers.get(name);
+  if (
+    expected instanceof RegExp
+      ? !expected.test(value ?? "")
+      : value !== expected
+  ) {
+    throw new Error(`Preview response has an invalid ${name} header`);
+  }
+}
+
+async function successfulText(response, label) {
+  if (!response.ok)
+    throw new Error(`${label} returned HTTP ${response.status}`);
+  return response.text();
+}
+
+export async function smokeUiPreview({
+  deploymentUrl,
+  deploymentId,
+  bypassSecret,
+  fetchImplementation = fetch,
+}) {
+  const baseUrl = immutableVercelUrl(deploymentUrl);
+  const headers = smokeHeaders(bypassSecret);
+  const mainResponse = await fetchImplementation(baseUrl, {
+    headers,
+    redirect: "follow",
+  });
+  const html = await successfulText(mainResponse, "UI preview");
+  if (!html.includes("Basic Components")) {
+    throw new Error("UI preview did not render the Basic Components page");
+  }
+  if (!html.includes(`data-dpl-id="${deploymentId}"`)) {
+    throw new Error(
+      "UI preview HTML does not carry the expected build deployment ID",
+    );
+  }
+  requireHeader(
+    mainResponse,
+    "content-security-policy",
+    "frame-ancestors 'none'",
+  );
+  requireHeader(mainResponse, "x-frame-options", "DENY");
+  requireHeader(mainResponse, "x-content-type-options", "nosniff");
+  requireHeader(
+    mainResponse,
+    "content-security-policy-report-only",
+    /https:\/\/vercel\.live/,
+  );
+
+  const navigationResponse = await fetchImplementation(
+    new URL("/form-components", baseUrl),
+    { headers, redirect: "follow" },
+  );
+  const navigationHtml = await successfulText(
+    navigationResponse,
+    "UI preview navigation",
+  );
+  if (!navigationHtml.includes("Form Components")) {
+    throw new Error("UI preview primary navigation destination did not render");
+  }
+
+  const assets = [
+    ...html.matchAll(/(?:src|href)="([^" ]*\/_next\/static\/[^" ]+)"/g),
+  ].map((match) => match[1].replaceAll("&amp;", "&"));
+  const representatives = [".js", ".css", ".woff2"].map((extension) =>
+    assets.find((asset) =>
+      new URL(asset, baseUrl).pathname.endsWith(extension),
+    ),
+  );
+  if (representatives.some((asset) => asset === undefined)) {
+    throw new Error(
+      "UI preview HTML is missing script, stylesheet, or font assets",
+    );
+  }
+  for (const asset of representatives) {
+    const response = await fetchImplementation(new URL(asset, baseUrl), {
+      headers,
+      redirect: "follow",
+    });
+    if (!response.ok) {
+      throw new Error(
+        `UI preview static asset returned HTTP ${response.status}`,
+      );
+    }
+  }
+  return {
+    deploymentUrl: baseUrl,
+    deploymentId,
+    checkedAssets: representatives.length,
+  };
+}
+
+function output(name, value) {
+  if (!process.env.GITHUB_OUTPUT) throw new Error("GITHUB_OUTPUT is required");
+  appendFileSync(process.env.GITHUB_OUTPUT, `${name}=${value}\n`);
+}
+
+function contractFromEnvironment() {
+  return {
+    logicalTarget: process.env.LOGICAL_TARGET,
+    workspacePackage: process.env.WORKSPACE_PACKAGE,
+    expectedRootDirectory: process.env.EXPECTED_ROOT_DIRECTORY,
+    githubEnvironment: process.env.GITHUB_DEPLOYMENT_ENVIRONMENT,
+    vercelEnvironment: process.env.VERCEL_ENVIRONMENT,
+    vercelTarget: process.env.VERCEL_TARGET,
+    deploymentMode: process.env.DEPLOYMENT_MODE,
+    deployPermitted: process.env.DEPLOY_PERMITTED,
+    commitSha: process.env.DEPLOY_SHA,
+    gitBranch: process.env.GIT_BRANCH,
+    vercelOrgId: process.env.VERCEL_ORG_ID,
+    vercelProjectId: process.env.VERCEL_PROJECT_ID,
+    idempotencyKey: process.env.DEPLOYMENT_IDEMPOTENCY_KEY,
+    workflowRunUrl: process.env.WORKFLOW_RUN_URL,
+    githubRepository: process.env.GITHUB_REPOSITORY,
+  };
+}
+
+function requiredEnvironment(names) {
+  for (const name of names) requiredText(process.env[name], name);
+}
+
+function runVercel(arguments_, { capture = false } = {}) {
+  assertSafeVercelArguments(arguments_);
+  requiredEnvironment(["VERCEL_TOKEN", "VERCEL_ORG_ID", "VERCEL_PROJECT_ID"]);
+  const result = spawnSync("pnpm", ["exec", "vercel", ...arguments_], {
+    cwd: process.env.SOURCE_PATH,
+    env: environmentForVercelCli(process.env),
+    encoding: "utf8",
+    stdio: capture
+      ? ["ignore", "pipe", "inherit"]
+      : ["inherit", "inherit", "inherit"],
+  });
+  if (result.status !== 0) {
+    throw new Error(`Pinned Vercel CLI command failed: ${arguments_[0]}`);
+  }
+  return capture ? result.stdout : "";
+}
+
+function prepareFromEnvironment() {
+  validatePilotContract(contractFromEnvironment());
+  const deploymentId = generateVercelDeploymentId({
+    target: process.env.LOGICAL_TARGET,
+    commitSha: process.env.DEPLOY_SHA,
+    runId: process.env.GITHUB_RUN_ID,
+    runAttempt: process.env.GITHUB_RUN_ATTEMPT,
+  });
+  output("checked_out_sha", process.env.DEPLOY_SHA);
+  output("next_deployment_id", deploymentId);
+  output("started_at_ms", String(Date.now()));
+}
+
+function validateSourceFromEnvironment() {
+  const result = validateSourceCheckout({
+    repoRoot: process.env.SOURCE_PATH,
+    commitSha: process.env.DEPLOY_SHA,
+    gitBranch: process.env.GIT_BRANCH,
+    githubRepository: process.env.GITHUB_REPOSITORY,
+  });
+  output("checked_out_sha", result.commitSha);
+}
+
+function pullFromEnvironment() {
+  runVercel(
+    buildVercelPullArguments({
+      gitBranch: process.env.GIT_BRANCH,
+      projectId: process.env.VERCEL_PROJECT_ID,
+    }),
+  );
+}
+
+function prepareLinkFromEnvironment() {
+  materializeVercelRepoLink({
+    repoRoot: process.env.SOURCE_PATH,
+    expectedRootDirectory: process.env.EXPECTED_ROOT_DIRECTORY,
+    vercelOrgId: process.env.VERCEL_ORG_ID,
+    vercelProjectId: process.env.VERCEL_PROJECT_ID,
+  });
+}
+
+function validatePullFromEnvironment() {
+  assertPulledProject({
+    repoRoot: process.env.SOURCE_PATH,
+    expectedRootDirectory: process.env.EXPECTED_ROOT_DIRECTORY,
+    vercelOrgId: process.env.VERCEL_ORG_ID,
+    vercelProjectId: process.env.VERCEL_PROJECT_ID,
+  });
+}
+
+function buildFromEnvironment() {
+  requiredEnvironment([
+    "TURBO_TEAM",
+    "TURBO_TOKEN",
+    "TURBO_REMOTE_CACHE_SIGNATURE_KEY",
+    "MENTO_NEXT_DEPLOYMENT_ID",
+  ]);
+  const started = Date.now();
+  runVercel(
+    buildVercelBuildArguments({ projectId: process.env.VERCEL_PROJECT_ID }),
+  );
+  output("build_duration_ms", String(Date.now() - started));
+}
+
+function assertOutputFromEnvironment() {
+  assertPrebuiltOutput({
+    repoRoot: process.env.SOURCE_PATH,
+    expectedRootDirectory: process.env.EXPECTED_ROOT_DIRECTORY,
+    deploymentId: process.env.MENTO_NEXT_DEPLOYMENT_ID,
+  });
+}
+
+function deployFromEnvironment() {
+  const started = Date.now();
+  const raw = runVercel(
+    buildVercelDeployArguments({
+      projectId: process.env.VERCEL_PROJECT_ID,
+      commitSha: process.env.DEPLOY_SHA,
+      gitBranch: process.env.GIT_BRANCH,
+    }),
+    { capture: true },
+  );
+  const deployment = parseVercelDeploymentJson(raw);
+  output("vercel_deployment_id", deployment.deploymentId);
+  output("vercel_deployment_url", deployment.deploymentUrl);
+  output("deploy_duration_ms", String(Date.now() - started));
+}
+
+function verifyFromEnvironment() {
+  const raw = runVercel(
+    buildVercelInspectArguments(process.env.VERCEL_DEPLOYMENT_URL),
+    { capture: true },
+  );
+  assertVercelInspection(raw, {
+    deploymentId: process.env.VERCEL_DEPLOYMENT_ID,
+    deploymentUrl: process.env.VERCEL_DEPLOYMENT_URL,
+  });
+}
+
+async function smokeFromEnvironment() {
+  if (!/^[1-9][0-9]*$/.test(process.env.GITHUB_DEPLOYMENT_ID ?? "")) {
+    throw new Error("Smoke requires the canonical GitHub Deployment ID");
+  }
+  const result = await smokeUiPreview({
+    deploymentUrl: process.env.VERCEL_DEPLOYMENT_URL,
+    deploymentId: process.env.MENTO_NEXT_DEPLOYMENT_ID,
+    bypassSecret: process.env.VERCEL_AUTOMATION_BYPASS_SECRET,
+  });
+  output("smoke_deployment_url", result.deploymentUrl);
+  output("smoke_deployment_id", process.env.VERCEL_DEPLOYMENT_ID);
+  output("smoke_github_deployment_id", process.env.GITHUB_DEPLOYMENT_ID);
+  output("smoke_commit_sha", process.env.DEPLOY_SHA);
+}
+
+function totalFromEnvironment() {
+  if (!/^[0-9]+$/.test(process.env.STARTED_AT_MS ?? "")) {
+    throw new Error("Workflow start time is invalid");
+  }
+  output(
+    "total_duration_ms",
+    String(Date.now() - Number(process.env.STARTED_AT_MS)),
+  );
+}
+
+function isCliEntrypoint() {
+  return (
+    process.argv[1] !== undefined &&
+    fileURLToPath(import.meta.url) === resolve(process.argv[1])
+  );
+}
+
+if (isCliEntrypoint()) {
+  const command = process.argv[2];
+  if (command === "prepare") prepareFromEnvironment();
+  else if (command === "validate-source") validateSourceFromEnvironment();
+  else if (command === "prepare-link") prepareLinkFromEnvironment();
+  else if (command === "pull") pullFromEnvironment();
+  else if (command === "validate-pull") validatePullFromEnvironment();
+  else if (command === "build") buildFromEnvironment();
+  else if (command === "assert-output") assertOutputFromEnvironment();
+  else if (command === "deploy") deployFromEnvironment();
+  else if (command === "verify") verifyFromEnvironment();
+  else if (command === "smoke") await smokeFromEnvironment();
+  else if (command === "total") totalFromEnvironment();
+  else {
+    throw new Error(
+      "Usage: vercel-prebuilt-workflow.mjs prepare|validate-source|prepare-link|pull|validate-pull|build|assert-output|deploy|verify|smoke|total",
+    );
+  }
+}

--- a/scripts/vercel-prebuilt-workflow.test.mjs
+++ b/scripts/vercel-prebuilt-workflow.test.mjs
@@ -103,11 +103,12 @@ test("source validation proves exact HEAD is reachable from the same-repo branch
       }),
       { commitSha: sha, gitBranch: "main" },
     );
+    const mismatchedSha = `${sha.startsWith("0") ? "1" : "0"}${sha.slice(1)}`;
     assert.throws(
       () =>
         validateSourceCheckout({
           repoRoot: source,
-          commitSha: `1${sha.slice(1)}`,
+          commitSha: mismatchedSha,
           gitBranch: "main",
           githubRepository: remote,
         }),

--- a/scripts/vercel-prebuilt-workflow.test.mjs
+++ b/scripts/vercel-prebuilt-workflow.test.mjs
@@ -407,7 +407,11 @@ test("direct UI smoke binds URL, custom build ID, navigation, assets, and header
   </body></html>`;
   const fetchImplementation = async (url, options) => {
     const parsed = new URL(url);
-    requested.push({ url: parsed.toString(), headers: options.headers });
+    requested.push({
+      url: parsed.toString(),
+      headers: options.headers,
+      signal: options.signal,
+    });
     if (parsed.pathname === "/form-components") {
       return new Response("<h1>Form Components</h1>");
     }
@@ -439,6 +443,7 @@ test("direct UI smoke binds URL, custom build ID, navigation, assets, and header
   );
   assert.equal(requested.length, 5);
   assert.ok(requested.every(({ headers }) => headers === undefined));
+  assert.ok(requested.every(({ signal }) => signal instanceof AbortSignal));
 });
 
 test("direct UI smoke fails closed on missing build identity or security evidence", async () => {
@@ -457,5 +462,32 @@ test("direct UI smoke fails closed on missing build identity or security evidenc
       fetchImplementation: async () => response,
     }),
     /does not carry the expected build deployment ID/,
+  );
+});
+
+test("direct UI smoke bounds every network request", async () => {
+  await assert.rejects(
+    smokeUiPreview({
+      deploymentUrl: DEPLOYMENT_URL,
+      deploymentId: DEPLOYMENT_ID,
+      fetchImplementation: async () => new Promise(() => {}),
+      requestTimeoutMs: 5,
+    }),
+    /UI preview timed out/,
+  );
+});
+
+test("direct UI smoke bounds response body consumption", async () => {
+  const stalledBody = new ReadableStream({
+    start() {},
+  });
+  await assert.rejects(
+    smokeUiPreview({
+      deploymentUrl: DEPLOYMENT_URL,
+      deploymentId: DEPLOYMENT_ID,
+      fetchImplementation: async () => new Response(stalledBody),
+      requestTimeoutMs: 5,
+    }),
+    /UI preview timed out/,
   );
 });

--- a/scripts/vercel-prebuilt-workflow.test.mjs
+++ b/scripts/vercel-prebuilt-workflow.test.mjs
@@ -428,7 +428,6 @@ test("direct UI smoke binds URL, custom build ID, navigation, assets, and header
     await smokeUiPreview({
       deploymentUrl: DEPLOYMENT_URL,
       deploymentId: DEPLOYMENT_ID,
-      bypassSecret: "redacted-fixture-secret",
       fetchImplementation,
     }),
     {
@@ -438,12 +437,7 @@ test("direct UI smoke binds URL, custom build ID, navigation, assets, and header
     },
   );
   assert.equal(requested.length, 5);
-  assert.ok(
-    requested.every(
-      ({ headers }) =>
-        headers["x-vercel-protection-bypass"] === "redacted-fixture-secret",
-    ),
-  );
+  assert.ok(requested.every(({ headers }) => headers === undefined));
 });
 
 test("direct UI smoke fails closed on missing build identity or security evidence", async () => {

--- a/scripts/vercel-prebuilt-workflow.test.mjs
+++ b/scripts/vercel-prebuilt-workflow.test.mjs
@@ -41,6 +41,9 @@ function pilotContract(overrides = {}) {
     workflowRunUrl:
       "https://github.com/mento-protocol/frontend-monorepo/actions/runs/1",
     githubRepository: "mento-protocol/frontend-monorepo",
+    githubRef: "refs/heads/main",
+    githubWorkflowRef:
+      "mento-protocol/frontend-monorepo/.github/workflows/vercel-prebuilt-pilot.yml@refs/heads/main",
     ...overrides,
   };
 }
@@ -55,6 +58,11 @@ test("pilot contract accepts only the UI preview mapping and exact SHA", () => {
     { gitBranch: "dependabot/npm_and_yarn/example-1.0.0" },
     { deployPermitted: false },
     { githubRepository: "someone/fork" },
+    { githubRef: "refs/heads/feature/ui-pilot" },
+    {
+      githubWorkflowRef:
+        "mento-protocol/frontend-monorepo/.github/workflows/vercel-prebuilt-pilot.yml@refs/heads/feature",
+    },
   ]) {
     assert.throws(() => validatePilotContract(pilotContract(overrides)));
   }

--- a/scripts/vercel-prebuilt-workflow.test.mjs
+++ b/scripts/vercel-prebuilt-workflow.test.mjs
@@ -1,0 +1,460 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+
+import {
+  assertPrebuiltOutput,
+  assertPulledProject,
+  assertSafeVercelArguments,
+  assertVercelInspection,
+  buildVercelBuildArguments,
+  buildVercelDeployArguments,
+  buildVercelInspectArguments,
+  buildVercelPullArguments,
+  environmentForVercelCli,
+  materializeVercelRepoLink,
+  parseVercelDeploymentJson,
+  PILOT_TARGET,
+  smokeUiPreview,
+  validateExactSha,
+  validateGitBranch,
+  validatePilotContract,
+  validateSourceCheckout,
+} from "./vercel-prebuilt-workflow.mjs";
+
+const SHA = "0123456789abcdef0123456789abcdef01234567";
+const DEPLOYMENT_ID = "m-ui-0123456789abcdef012";
+const DEPLOYMENT_URL = "https://ui-pilot-abc.vercel.app";
+
+function pilotContract(overrides = {}) {
+  return {
+    ...PILOT_TARGET,
+    deployPermitted: true,
+    commitSha: SHA,
+    gitBranch: "feature/ui-pilot",
+    vercelOrgId: "team_example",
+    vercelProjectId: "prj_example",
+    idempotencyKey: `vercel-pilot:v1:ui:sha:${SHA}:run:1:attempt:1`,
+    workflowRunUrl:
+      "https://github.com/mento-protocol/frontend-monorepo/actions/runs/1",
+    githubRepository: "mento-protocol/frontend-monorepo",
+    ...overrides,
+  };
+}
+
+test("pilot contract accepts only the UI preview mapping and exact SHA", () => {
+  assert.deepEqual(validatePilotContract(pilotContract()), pilotContract());
+  for (const overrides of [
+    { logicalTarget: "app" },
+    { deploymentMode: "staged-production" },
+    { vercelTarget: "production" },
+    { commitSha: "main" },
+    { deployPermitted: false },
+    { githubRepository: "someone/fork" },
+  ]) {
+    assert.throws(() => validatePilotContract(pilotContract(overrides)));
+  }
+});
+
+test("branch and SHA validation rejects mutable, option-like, and control input", () => {
+  assert.equal(validateExactSha(SHA), SHA);
+  assert.equal(validateGitBranch("feature/ui-pilot"), "feature/ui-pilot");
+  for (const branch of ["-main", " main", "main\nother", "refs/heads/main"]) {
+    assert.throws(() => validateGitBranch(branch));
+  }
+  for (const sha of ["main", SHA.toUpperCase(), SHA.slice(1), "0".repeat(64)]) {
+    assert.throws(() => validateExactSha(sha));
+  }
+});
+
+test("source validation proves exact HEAD is reachable from the same-repo branch", () => {
+  const directory = mkdtempSync(join(tmpdir(), "vercel-source-"));
+  const remote = join(directory, "remote.git");
+  const source = join(directory, "source");
+  try {
+    execFileSync("git", ["init", "--bare", remote]);
+    execFileSync("git", ["init", "-b", "main", source]);
+    execFileSync("git", [
+      "-C",
+      source,
+      "config",
+      "user.email",
+      "ci@example.com",
+    ]);
+    execFileSync("git", ["-C", source, "config", "user.name", "CI"]);
+    writeFileSync(join(source, "fixture.txt"), "main\n");
+    execFileSync("git", ["-C", source, "add", "fixture.txt"]);
+    execFileSync("git", ["-C", source, "commit", "-m", "fixture"]);
+    execFileSync("git", ["-C", source, "remote", "add", "origin", remote]);
+    execFileSync("git", ["-C", source, "push", "origin", "main"]);
+    const sha = execFileSync("git", ["-C", source, "rev-parse", "HEAD"], {
+      encoding: "utf8",
+    }).trim();
+
+    assert.deepEqual(
+      validateSourceCheckout({
+        repoRoot: source,
+        commitSha: sha,
+        gitBranch: "main",
+        githubRepository: remote,
+      }),
+      { commitSha: sha, gitBranch: "main" },
+    );
+    assert.throws(
+      () =>
+        validateSourceCheckout({
+          repoRoot: source,
+          commitSha: `1${sha.slice(1)}`,
+          gitBranch: "main",
+          githubRepository: remote,
+        }),
+      /HEAD does not match/,
+    );
+  } finally {
+    rmSync(directory, { force: true, recursive: true });
+  }
+});
+
+test("source validation rejects a commit not reachable from the supplied branch", () => {
+  const directory = mkdtempSync(join(tmpdir(), "vercel-source-"));
+  const remote = join(directory, "remote.git");
+  const source = join(directory, "source");
+  try {
+    execFileSync("git", ["init", "--bare", remote]);
+    execFileSync("git", ["init", "-b", "main", source]);
+    execFileSync("git", [
+      "-C",
+      source,
+      "config",
+      "user.email",
+      "ci@example.com",
+    ]);
+    execFileSync("git", ["-C", source, "config", "user.name", "CI"]);
+    writeFileSync(join(source, "fixture.txt"), "main\n");
+    execFileSync("git", ["-C", source, "add", "fixture.txt"]);
+    execFileSync("git", ["-C", source, "commit", "-m", "main"]);
+    execFileSync("git", ["-C", source, "remote", "add", "origin", remote]);
+    execFileSync("git", ["-C", source, "push", "origin", "main"]);
+    execFileSync("git", ["-C", source, "switch", "--orphan", "other"]);
+    writeFileSync(join(source, "fixture.txt"), "other\n");
+    execFileSync("git", ["-C", source, "add", "fixture.txt"]);
+    execFileSync("git", ["-C", source, "commit", "-m", "other"]);
+    const sha = execFileSync("git", ["-C", source, "rev-parse", "HEAD"], {
+      encoding: "utf8",
+    }).trim();
+
+    assert.throws(
+      () =>
+        validateSourceCheckout({
+          repoRoot: source,
+          commitSha: sha,
+          gitBranch: "main",
+          githubRepository: remote,
+        }),
+      /not reachable/,
+    );
+  } finally {
+    rmSync(directory, { force: true, recursive: true });
+  }
+});
+
+test("pinned CLI arguments preserve preview branch and exact commit metadata", () => {
+  assert.deepEqual(
+    buildVercelPullArguments({
+      gitBranch: "feature/ui-pilot",
+      projectId: "prj_example",
+    }),
+    [
+      "pull",
+      "--yes",
+      "--environment",
+      "preview",
+      "--git-branch",
+      "feature/ui-pilot",
+      "--project",
+      "prj_example",
+    ],
+  );
+  assert.deepEqual(buildVercelBuildArguments({ projectId: "prj_example" }), [
+    "build",
+    "--yes",
+    "--target",
+    "preview",
+    "--project",
+    "prj_example",
+  ]);
+  const deploy = buildVercelDeployArguments({
+    projectId: "prj_example",
+    commitSha: SHA,
+    gitBranch: "feature/ui-pilot",
+  });
+  assert.deepEqual(deploy, [
+    "deploy",
+    "--prebuilt",
+    "--target",
+    "preview",
+    "--archive=tgz",
+    "--format=json",
+    "--yes",
+    "--project",
+    "prj_example",
+    "--meta",
+    "githubCommitOrg=mento-protocol",
+    "--meta",
+    "githubCommitRepo=frontend-monorepo",
+    "--meta",
+    `githubCommitSha=${SHA}`,
+    "--meta",
+    "githubCommitRef=feature/ui-pilot",
+  ]);
+  assert.doesNotMatch(deploy.join(" "), /githubDeployment=1|--prod|promote/);
+  assert.throws(
+    () => assertSafeVercelArguments(["deploy", "--meta", "githubDeployment=1"]),
+    /Forbidden/,
+  );
+  assert.throws(
+    () => assertSafeVercelArguments(["deploy", "--token=secret"]),
+    /environment/,
+  );
+  assert.doesNotThrow(() =>
+    assertSafeVercelArguments([
+      "deploy",
+      "--meta",
+      "githubCommitRef=feature/promote---prod-copy",
+    ]),
+  );
+  assert.deepEqual(buildVercelInspectArguments(DEPLOYMENT_URL), [
+    "inspect",
+    DEPLOYMENT_URL,
+    "--wait",
+    "--timeout",
+    "5m",
+    "--format=json",
+  ]);
+});
+
+test("deploy and inspect JSON retain one immutable URL and Vercel ID", () => {
+  const expected = {
+    deploymentId: "dpl_Abc123",
+    deploymentUrl: DEPLOYMENT_URL,
+    readyState: "BUILDING",
+    target: "preview",
+  };
+  assert.deepEqual(
+    parseVercelDeploymentJson(
+      JSON.stringify({
+        status: "ok",
+        deployment: {
+          id: expected.deploymentId,
+          url: expected.deploymentUrl,
+          readyState: expected.readyState,
+          target: expected.target,
+        },
+      }),
+    ),
+    expected,
+  );
+  assert.deepEqual(
+    parseVercelDeploymentJson(
+      JSON.stringify({
+        id: expected.deploymentId,
+        url: expected.deploymentUrl,
+        readyState: expected.readyState,
+        target: expected.target,
+      }),
+    ),
+    expected,
+  );
+  assert.equal(
+    assertVercelInspection(
+      JSON.stringify({
+        id: expected.deploymentId,
+        url: expected.deploymentUrl,
+        readyState: "READY",
+        target: "preview",
+      }),
+      expected,
+    ).readyState,
+    "READY",
+  );
+  assert.throws(
+    () =>
+      assertVercelInspection(
+        JSON.stringify({
+          id: expected.deploymentId,
+          url: expected.deploymentUrl,
+          readyState: "ERROR",
+          target: "preview",
+        }),
+        expected,
+      ),
+    /does not match/,
+  );
+});
+
+test("Vercel CLI receives the repo link instead of ID variables that override it", () => {
+  assert.deepEqual(
+    environmentForVercelCli({
+      CI: "1",
+      VERCEL_ORG_ID: "team_example",
+      VERCEL_PROJECT_ID: "prj_example",
+      VERCEL_TOKEN: "fixture-token",
+    }),
+    { CI: "1", VERCEL_TOKEN: "fixture-token" },
+  );
+});
+
+test("pulled project and prebuilt output bind the configured UI root and build ID", () => {
+  const directory = mkdtempSync(join(tmpdir(), "vercel-project-"));
+  const projectDirectory = join(directory, "apps", "ui.mento.org", ".vercel");
+  const outputDirectory = join(projectDirectory, "output");
+  try {
+    mkdirSync(outputDirectory, { recursive: true });
+    assert.deepEqual(
+      materializeVercelRepoLink({
+        repoRoot: directory,
+        expectedRootDirectory: "apps/ui.mento.org",
+        vercelOrgId: "team_example",
+        vercelProjectId: "prj_example",
+      }),
+      {
+        remoteName: "origin",
+        projects: [
+          {
+            id: "prj_example",
+            directory: "apps/ui.mento.org",
+            orgId: "team_example",
+          },
+        ],
+      },
+    );
+    writeFileSync(
+      join(projectDirectory, "project.json"),
+      JSON.stringify({
+        settings: { rootDirectory: "apps/ui.mento.org" },
+      }),
+    );
+    writeFileSync(
+      join(outputDirectory, "config.json"),
+      JSON.stringify({ version: 3, deploymentId: DEPLOYMENT_ID }),
+    );
+    writeFileSync(
+      join(outputDirectory, "builds.json"),
+      JSON.stringify({ target: "preview", cliVersion: "56.2.0" }),
+    );
+    assert.equal(
+      assertPulledProject({
+        repoRoot: directory,
+        expectedRootDirectory: "apps/ui.mento.org",
+        vercelOrgId: "team_example",
+        vercelProjectId: "prj_example",
+      }).settings.rootDirectory,
+      "apps/ui.mento.org",
+    );
+    assert.equal(
+      assertPrebuiltOutput({
+        repoRoot: directory,
+        expectedRootDirectory: "apps/ui.mento.org",
+        deploymentId: DEPLOYMENT_ID,
+      }),
+      outputDirectory,
+    );
+    writeFileSync(
+      join(directory, ".vercel", "repo.json"),
+      JSON.stringify({
+        remoteName: "origin",
+        projects: [
+          {
+            id: "prj_other",
+            directory: "apps/ui.mento.org",
+            orgId: "team_example",
+          },
+        ],
+      }),
+    );
+    assert.throws(
+      () =>
+        assertPulledProject({
+          repoRoot: directory,
+          expectedRootDirectory: "apps/ui.mento.org",
+          vercelOrgId: "team_example",
+          vercelProjectId: "prj_example",
+        }),
+      /does not match/,
+    );
+  } finally {
+    rmSync(directory, { force: true, recursive: true });
+  }
+});
+
+test("direct UI smoke binds URL, custom build ID, navigation, assets, and headers", async () => {
+  const requested = [];
+  const html = `<!doctype html><html data-dpl-id="${DEPLOYMENT_ID}"><body>
+    <h1>Basic Components</h1>
+    <script src="/_next/static/chunks/app.js?dpl=${DEPLOYMENT_ID}"></script>
+    <link href="/_next/static/css/app.css?dpl=${DEPLOYMENT_ID}" rel="stylesheet">
+    <link href="/_next/static/media/inter.woff2" rel="preload">
+  </body></html>`;
+  const fetchImplementation = async (url, options) => {
+    const parsed = new URL(url);
+    requested.push({ url: parsed.toString(), headers: options.headers });
+    if (parsed.pathname === "/form-components") {
+      return new Response("<h1>Form Components</h1>");
+    }
+    if (parsed.pathname.startsWith("/_next/static/")) {
+      return new Response("asset");
+    }
+    return new Response(html, {
+      headers: {
+        "content-security-policy": "frame-ancestors 'none'",
+        "content-security-policy-report-only":
+          "default-src 'self'; frame-src https://vercel.live",
+        "x-content-type-options": "nosniff",
+        "x-frame-options": "DENY",
+      },
+    });
+  };
+
+  assert.deepEqual(
+    await smokeUiPreview({
+      deploymentUrl: DEPLOYMENT_URL,
+      deploymentId: DEPLOYMENT_ID,
+      bypassSecret: "redacted-fixture-secret",
+      fetchImplementation,
+    }),
+    {
+      deploymentUrl: DEPLOYMENT_URL,
+      deploymentId: DEPLOYMENT_ID,
+      checkedAssets: 3,
+    },
+  );
+  assert.equal(requested.length, 5);
+  assert.ok(
+    requested.every(
+      ({ headers }) =>
+        headers["x-vercel-protection-bypass"] === "redacted-fixture-secret",
+    ),
+  );
+});
+
+test("direct UI smoke fails closed on missing build identity or security evidence", async () => {
+  const response = new Response("<h1>Basic Components</h1>", {
+    headers: {
+      "content-security-policy": "frame-ancestors 'none'",
+      "content-security-policy-report-only": "frame-src https://vercel.live",
+      "x-content-type-options": "nosniff",
+      "x-frame-options": "DENY",
+    },
+  });
+  await assert.rejects(
+    smokeUiPreview({
+      deploymentUrl: DEPLOYMENT_URL,
+      deploymentId: DEPLOYMENT_ID,
+      fetchImplementation: async () => response,
+    }),
+    /does not carry the expected build deployment ID/,
+  );
+});

--- a/scripts/vercel-prebuilt-workflow.test.mjs
+++ b/scripts/vercel-prebuilt-workflow.test.mjs
@@ -52,6 +52,7 @@ test("pilot contract accepts only the UI preview mapping and exact SHA", () => {
     { deploymentMode: "staged-production" },
     { vercelTarget: "production" },
     { commitSha: "main" },
+    { gitBranch: "dependabot/npm_and_yarn/example-1.0.0" },
     { deployPermitted: false },
     { githubRepository: "someone/fork" },
   ]) {

--- a/scripts/vercel-prebuilt-workflow.test.mjs
+++ b/scripts/vercel-prebuilt-workflow.test.mjs
@@ -226,14 +226,19 @@ test("pinned CLI arguments preserve preview branch and exact commit metadata", (
       "githubCommitRef=feature/promote---prod-copy",
     ]),
   );
-  assert.deepEqual(buildVercelInspectArguments(DEPLOYMENT_URL), [
-    "inspect",
-    DEPLOYMENT_URL,
-    "--wait",
-    "--timeout",
-    "5m",
-    "--format=json",
-  ]);
+  assert.deepEqual(
+    buildVercelInspectArguments(DEPLOYMENT_URL, "team_example"),
+    [
+      "inspect",
+      DEPLOYMENT_URL,
+      "--wait",
+      "--timeout",
+      "5m",
+      "--format=json",
+      "--scope",
+      "team_example",
+    ],
+  );
 });
 
 test("deploy and inspect JSON retain one immutable URL and Vercel ID", () => {

--- a/scripts/vercel-prebuilt-workflows.test.mjs
+++ b/scripts/vercel-prebuilt-workflows.test.mjs
@@ -1,0 +1,209 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { test } from "node:test";
+
+import { parse } from "yaml";
+
+function read(relativePath) {
+  return readFileSync(new URL(`../${relativePath}`, import.meta.url), "utf8");
+}
+
+function workflow(relativePath) {
+  return parse(read(relativePath));
+}
+
+const reusablePath = ".github/workflows/_vercel-prebuilt.yml";
+const pilotPath = ".github/workflows/vercel-prebuilt-pilot.yml";
+
+test("manual pilot exposes only the three UI-only deployment selectors", () => {
+  const pilot = workflow(pilotPath);
+  assert.deepEqual(Object.keys(pilot.on), ["workflow_dispatch"]);
+  assert.deepEqual(Object.keys(pilot.on.workflow_dispatch.inputs), [
+    "target",
+    "commit_sha",
+    "git_branch",
+  ]);
+  assert.deepEqual(pilot.on.workflow_dispatch.inputs.target.options, ["ui"]);
+  assert.equal(pilot.on.workflow_dispatch.inputs.target.default, "ui");
+  assert.equal(pilot.on.workflow_dispatch.inputs.commit_sha.required, true);
+  assert.equal(pilot.on.workflow_dispatch.inputs.git_branch.required, true);
+  assert.equal(
+    pilot.jobs["deploy-ui-preview"].with.logical_target,
+    "${{ inputs.target }}",
+  );
+  assert.equal(
+    pilot.jobs["deploy-ui-preview"].with.expected_root_directory,
+    "apps/ui.mento.org",
+  );
+  assert.equal(pilot.jobs["deploy-ui-preview"].with.deployment_mode, "preview");
+  assert.equal(pilot.jobs["deploy-ui-preview"].with.vercel_target, "preview");
+  assert.equal(
+    pilot.jobs["deploy-ui-preview"].with.vercel_environment,
+    "preview",
+  );
+});
+
+test("caller and worker have only contents-read and deployments-write permissions", () => {
+  const expected = { contents: "read", deployments: "write" };
+  const pilot = workflow(pilotPath);
+  const reusable = workflow(reusablePath);
+  assert.deepEqual(pilot.permissions, expected);
+  assert.deepEqual(pilot.jobs["deploy-ui-preview"].permissions, expected);
+  assert.deepEqual(reusable.permissions, expected);
+  assert.deepEqual(reusable.jobs.prebuilt.permissions, expected);
+  assert.equal(Object.hasOwn(reusable.jobs.prebuilt, "environment"), false);
+});
+
+test("reusable workflow declares exact inputs, explicit secrets, and evidence outputs", () => {
+  const reusable = workflow(reusablePath);
+  const call = reusable.on.workflow_call;
+  for (const input of [
+    "logical_target",
+    "workspace_package",
+    "expected_root_directory",
+    "vercel_org_id",
+    "vercel_project_id",
+    "vercel_environment",
+    "vercel_target",
+    "commit_sha",
+    "git_branch",
+    "deployment_mode",
+    "deploy_permitted",
+    "github_environment",
+    "deployment_idempotency_key",
+    "turbo_team",
+  ]) {
+    assert.equal(
+      call.inputs[input].required,
+      true,
+      `${input} must be required`,
+    );
+  }
+  assert.deepEqual(Object.keys(call.secrets), [
+    "vercel_token",
+    "turbo_token",
+    "turbo_remote_cache_signature_key",
+    "vercel_automation_bypass_secret",
+  ]);
+  assert.deepEqual(Object.keys(call.outputs), [
+    "deployment_url",
+    "vercel_deployment_id",
+    "github_deployment_id",
+    "final_state",
+    "commit_sha",
+    "logical_target",
+    "build_duration_ms",
+    "deploy_duration_ms",
+    "total_duration_ms",
+  ]);
+  assert.doesNotMatch(read(pilotPath), /secrets:\s*inherit/);
+});
+
+test("pilot maps only preview credentials and never exposes a production path", () => {
+  const raw = read(pilotPath);
+  assert.match(raw, /VERCEL_TOKEN_PREVIEW/);
+  assert.match(raw, /VERCEL_PROJECT_ID_UI/);
+  assert.match(raw, /VERCEL_AUTOMATION_BYPASS_SECRET/);
+  assert.doesNotMatch(raw, /VERCEL_TOKEN_PRODUCTION|vercel-cli-production/);
+  assert.doesNotMatch(raw, /--prod|\bpromote\b|production_environment/);
+  assert.doesNotMatch(raw, /pull_request(?:_target)?:|\bpush:|\bschedule:/);
+});
+
+test("exact source, build, and upload remain in one standard-runner job", () => {
+  const reusable = workflow(reusablePath);
+  assert.deepEqual(Object.keys(reusable.jobs), ["prebuilt"]);
+  const job = reusable.jobs.prebuilt;
+  assert.equal(job["runs-on"], "ubuntu-latest");
+  assert.equal(job["timeout-minutes"], 30);
+  const names = job.steps.map((step) => step.name);
+  assert.ok(
+    names.indexOf("Check out exact deployment source and full history") <
+      names.indexOf("Build and assert the UI prebuilt output"),
+  );
+  assert.ok(
+    names.indexOf("Materialize trusted repo-level UI project mapping") <
+      names.indexOf("Pull branch-specific UI preview settings"),
+  );
+  assert.ok(
+    names.indexOf("Build and assert the UI prebuilt output") <
+      names.indexOf("Upload the verified prebuilt output"),
+  );
+  assert.doesNotMatch(
+    read(reusablePath),
+    /actions\/upload-artifact|\.vercel\/output.*artifact/,
+  );
+});
+
+test("monorepo-root CLI execution and app-root env validation use one mapping", () => {
+  const raw = read(reusablePath);
+  assert.match(raw, /SOURCE_PATH: \$\{\{ github\.workspace \}\}\/source/);
+  assert.match(raw, /--project-directory apps\/ui\.mento\.org/);
+  assert.match(raw, /working-directory: source/);
+  assert.doesNotMatch(
+    raw,
+    /working-directory: (?:source\/)?apps\/ui\.mento\.org/,
+  );
+});
+
+test("success follows direct smoke and the always finalizer closes orphaned records", () => {
+  const reusable = workflow(reusablePath);
+  const steps = reusable.jobs.prebuilt.steps;
+  const smokeIndex = steps.findIndex(
+    ({ name }) => name === "Verify and smoke the immutable preview",
+  );
+  const successIndex = steps.findIndex(
+    ({ name }) => name === "Mark GitHub Deployment successful after smoke",
+  );
+  const finalizer = steps.find(
+    ({ name }) => name === "Close a non-terminal GitHub Deployment",
+  );
+  assert.ok(smokeIndex >= 0 && successIndex > smokeIndex);
+  assert.match(steps[smokeIndex].run, / verify\n.* smoke/s);
+  assert.match(
+    steps[successIndex].env.VERCEL_DEPLOYMENT_URL,
+    /steps\.smoke\.outputs\.smoke_deployment_url/,
+  );
+  assert.match(finalizer.if, /always\(\)/);
+  assert.match(finalizer.run, /github-deployment\.mjs" finalize/);
+  assert.equal(
+    steps[smokeIndex].env.GITHUB_DEPLOYMENT_ID,
+    steps[successIndex].env.GITHUB_DEPLOYMENT_ID,
+  );
+  assert.match(
+    reusable.jobs.prebuilt.outputs.github_deployment_id,
+    /steps\.create\.outputs\.github_deployment_id/,
+  );
+});
+
+test("workflow restores signed Turbo cache and immutable Vercel build metadata", () => {
+  const raw = read(reusablePath);
+  for (const value of [
+    "TURBO_TEAM",
+    "TURBO_TOKEN",
+    "TURBO_REMOTE_CACHE_SIGNATURE_KEY",
+    "MENTO_NEXT_DEPLOYMENT_ID",
+    "VERCEL_GIT_COMMIT_SHA",
+    "VERCEL_GIT_COMMIT_REF",
+    "VERCEL_GIT_REPO_OWNER",
+    "VERCEL_GIT_REPO_SLUG",
+    "NEXT_PUBLIC_VERCEL_ENV",
+    "VERCEL_TARGET_ENV",
+  ]) {
+    assert.match(raw, new RegExp(`${value}:`), `${value} must be explicit`);
+  }
+  assert.doesNotMatch(raw, /githubDeployment=1/);
+  assert.doesNotMatch(raw, /--token/);
+});
+
+test("manual pilot is intentionally absent from operational failure notifications", () => {
+  const notifier = read(".github/workflows/ci-failure-notifier.yml");
+  assert.doesNotMatch(notifier, /Vercel Prebuilt Pilot/);
+});
+
+test("runbook records GITHUB_TOKEN non-recursion and the no-PAT direct-smoke rule", () => {
+  const docs = read("docs/vercel-deployments.md");
+  assert.match(docs, /GITHUB_TOKEN/);
+  assert.match(docs, /does not\s+trigger another workflow run/);
+  assert.match(docs, /Do not add a PAT/);
+  assert.match(docs, /workflow_dispatch/);
+});

--- a/scripts/vercel-prebuilt-workflows.test.mjs
+++ b/scripts/vercel-prebuilt-workflows.test.mjs
@@ -43,15 +43,22 @@ test("manual pilot exposes only the three UI-only deployment selectors", () => {
   );
 });
 
-test("caller and worker have only contents-read and deployments-write permissions", () => {
-  const expected = { contents: "read", deployments: "write" };
+test("build, smoke, and finalizer jobs keep separate least-privilege tokens", () => {
+  const deploymentWriter = { contents: "read", deployments: "write" };
   const pilot = workflow(pilotPath);
   const reusable = workflow(reusablePath);
-  assert.deepEqual(pilot.permissions, expected);
-  assert.deepEqual(pilot.jobs["deploy-ui-preview"].permissions, expected);
-  assert.deepEqual(reusable.permissions, expected);
-  assert.deepEqual(reusable.jobs.prebuilt.permissions, expected);
-  assert.equal(Object.hasOwn(reusable.jobs.prebuilt, "environment"), false);
+  assert.deepEqual(pilot.permissions, deploymentWriter);
+  assert.deepEqual(
+    pilot.jobs["deploy-ui-preview"].permissions,
+    deploymentWriter,
+  );
+  assert.deepEqual(reusable.permissions, {});
+  assert.deepEqual(reusable.jobs.prebuilt.permissions, deploymentWriter);
+  assert.deepEqual(reusable.jobs.smoke.permissions, { contents: "read" });
+  assert.deepEqual(reusable.jobs.finalize.permissions, deploymentWriter);
+  for (const job of Object.values(reusable.jobs)) {
+    assert.equal(Object.hasOwn(job, "environment"), false);
+  }
 });
 
 test("reusable workflow declares exact inputs, explicit secrets, and evidence outputs", () => {
@@ -83,7 +90,6 @@ test("reusable workflow declares exact inputs, explicit secrets, and evidence ou
     "vercel_token",
     "turbo_token",
     "turbo_remote_cache_signature_key",
-    "vercel_automation_bypass_secret",
   ]);
   assert.deepEqual(Object.keys(call.outputs), [
     "deployment_url",
@@ -103,7 +109,7 @@ test("pilot maps only preview credentials and never exposes a production path", 
   const raw = read(pilotPath);
   assert.match(raw, /VERCEL_TOKEN_PREVIEW/);
   assert.match(raw, /VERCEL_PROJECT_ID_UI/);
-  assert.match(raw, /VERCEL_AUTOMATION_BYPASS_SECRET/);
+  assert.doesNotMatch(raw, /VERCEL_AUTOMATION_BYPASS_SECRET|bypass/i);
   assert.doesNotMatch(raw, /VERCEL_TOKEN_PRODUCTION|vercel-cli-production/);
   assert.doesNotMatch(raw, /--prod|\bpromote\b|production_environment/);
   assert.doesNotMatch(raw, /pull_request(?:_target)?:|\bpush:|\bschedule:/);
@@ -111,7 +117,11 @@ test("pilot maps only preview credentials and never exposes a production path", 
 
 test("exact source, build, and upload remain in one standard-runner job", () => {
   const reusable = workflow(reusablePath);
-  assert.deepEqual(Object.keys(reusable.jobs), ["prebuilt"]);
+  assert.deepEqual(Object.keys(reusable.jobs), [
+    "prebuilt",
+    "smoke",
+    "finalize",
+  ]);
   const job = reusable.jobs.prebuilt;
   assert.equal(job["runs-on"], "ubuntu-latest");
   assert.equal(job["timeout-minutes"], 30);
@@ -145,33 +155,78 @@ test("monorepo-root CLI execution and app-root env validation use one mapping", 
   );
 });
 
-test("success follows direct smoke and the always finalizer closes orphaned records", () => {
+test("uncredentialed smoke gates the always-run trusted lifecycle finalizer", () => {
   const reusable = workflow(reusablePath);
-  const steps = reusable.jobs.prebuilt.steps;
-  const smokeIndex = steps.findIndex(
-    ({ name }) => name === "Verify and smoke the immutable preview",
+  const smoke = reusable.jobs.smoke;
+  const finalize = reusable.jobs.finalize;
+  assert.equal(smoke.needs, "prebuilt");
+  assert.match(smoke.if, /needs\.prebuilt\.result == 'success'/);
+  assert.deepEqual(finalize.needs, ["prebuilt", "smoke"]);
+  assert.equal(finalize.if, "always()");
+  assert.deepEqual(
+    smoke.steps.map(({ name }) => name),
+    [
+      "Check out trusted smoke controller only",
+      "Smoke immutable UI preview without deployment credentials",
+    ],
   );
-  const successIndex = steps.findIndex(
-    ({ name }) => name === "Mark GitHub Deployment successful after smoke",
+  const smokeStep = smoke.steps[1];
+  assert.match(smokeStep.run, /vercel-prebuilt-workflow\.mjs" smoke/);
+  assert.doesNotMatch(
+    JSON.stringify(smoke),
+    /VERCEL_TOKEN|TURBO_TOKEN|TURBO_REMOTE_CACHE_SIGNATURE_KEY|BYPASS|secrets\./i,
   );
-  const finalizer = steps.find(
-    ({ name }) => name === "Close a non-terminal GitHub Deployment",
+  const complete = finalize.steps.find(
+    ({ name }) => name === "Post truthful terminal GitHub Deployment state",
   );
-  assert.ok(smokeIndex >= 0 && successIndex > smokeIndex);
-  assert.match(steps[smokeIndex].run, / verify\n.* smoke/s);
-  assert.match(
-    steps[successIndex].env.VERCEL_DEPLOYMENT_URL,
-    /steps\.smoke\.outputs\.smoke_deployment_url/,
-  );
-  assert.match(finalizer.if, /always\(\)/);
-  assert.match(finalizer.run, /github-deployment\.mjs" finalize/);
-  assert.equal(
-    steps[smokeIndex].env.GITHUB_DEPLOYMENT_ID,
-    steps[successIndex].env.GITHUB_DEPLOYMENT_ID,
-  );
+  assert.match(complete.run, /github-deployment\.mjs" complete/);
+  assert.match(complete.env.VERCEL_DEPLOYMENT_URL, /needs\.smoke\.outputs/);
+  assert.match(complete.env.PREBUILT_RESULT, /needs\.prebuilt\.result/);
+  assert.match(complete.env.SMOKE_RESULT, /needs\.smoke\.result/);
   assert.match(
     reusable.jobs.prebuilt.outputs.github_deployment_id,
     /steps\.create\.outputs\.github_deployment_id/,
+  );
+});
+
+test("public deployment URL exists only after smoke-backed success", () => {
+  const reusable = workflow(reusablePath);
+  assert.equal(
+    reusable.on.workflow_call.outputs.deployment_url.value,
+    "${{ jobs.finalize.outputs.deployment_url }}",
+  );
+  assert.equal(
+    reusable.jobs.finalize.outputs.deployment_url,
+    "${{ steps.complete.outputs.verified_deployment_url }}",
+  );
+  assert.doesNotMatch(
+    reusable.on.workflow_call.outputs.deployment_url.value,
+    /jobs\.prebuilt|\|\|/,
+  );
+  assert.doesNotMatch(
+    JSON.stringify(reusable.jobs.prebuilt.outputs),
+    /deployment_url.*\|\|/,
+  );
+});
+
+test("best-effort metrics cannot override verified lifecycle truth", () => {
+  const reusable = workflow(reusablePath);
+  const steps = reusable.jobs.finalize.steps;
+  const total = steps.find(
+    ({ name }) => name === "Measure total controller duration (best effort)",
+  );
+  const complete = steps.find(
+    ({ name }) => name === "Post truthful terminal GitHub Deployment state",
+  );
+  const evidence = steps.find(
+    ({ name }) => name === "Record comparison evidence (best effort)",
+  );
+  assert.equal(total["continue-on-error"], true);
+  assert.equal(evidence["continue-on-error"], true);
+  assert.equal(Object.hasOwn(complete, "continue-on-error"), false);
+  assert.match(
+    evidence.if,
+    /steps\.complete\.outputs\.github_deployment_state == 'success'/,
   );
 });
 

--- a/scripts/vercel-prebuilt-workflows.test.mjs
+++ b/scripts/vercel-prebuilt-workflows.test.mjs
@@ -41,6 +41,18 @@ test("manual pilot exposes only the three UI-only deployment selectors", () => {
     pilot.jobs["deploy-ui-preview"].with.vercel_environment,
     "preview",
   );
+  assert.match(
+    pilot.jobs["deploy-ui-preview"].if,
+    /github\.ref == 'refs\/heads\/main'/,
+  );
+  assert.match(
+    pilot.jobs["deploy-ui-preview"].if,
+    /vercel-prebuilt-pilot\.yml@refs\/heads\/main/,
+  );
+  assert.equal(
+    pilot.jobs["deploy-ui-preview"].uses,
+    "./.github/workflows/_vercel-prebuilt.yml",
+  );
 });
 
 test("build, smoke, and finalizer jobs keep separate least-privilege tokens", () => {
@@ -128,19 +140,60 @@ test("exact source, build, and upload remain in one standard-runner job", () => 
   const names = job.steps.map((step) => step.name);
   assert.ok(
     names.indexOf("Check out exact deployment source and full history") <
-      names.indexOf("Build and assert the UI prebuilt output"),
+      names.indexOf("Build the UI prebuilt output"),
   );
   assert.ok(
     names.indexOf("Materialize trusted repo-level UI project mapping") <
       names.indexOf("Pull branch-specific UI preview settings"),
   );
   assert.ok(
-    names.indexOf("Build and assert the UI prebuilt output") <
+    names.indexOf("Build the UI prebuilt output") <
       names.indexOf("Upload the verified prebuilt output"),
   );
   assert.doesNotMatch(
     read(reusablePath),
     /actions\/upload-artifact|\.vercel\/output.*artifact/,
+  );
+});
+
+test("main-only controller is restored after every candidate-code phase", () => {
+  const pilot = workflow(pilotPath);
+  const reusable = workflow(reusablePath);
+  const steps = reusable.jobs.prebuilt.steps;
+  const names = steps.map(({ name }) => name);
+  const trustedCheckouts = steps.filter(
+    ({ uses }) => uses?.startsWith("actions/checkout@") && uses !== undefined,
+  );
+  assert.match(pilot.jobs["deploy-ui-preview"].if, /refs\/heads\/main/);
+  for (const checkout of trustedCheckouts.filter(
+    ({ with: options }) => options?.path === "controller",
+  )) {
+    assert.equal(checkout.with.ref, "${{ github.workflow_sha }}");
+    assert.equal(checkout.with["persist-credentials"], false);
+  }
+  const install = steps.find(
+    ({ name }) => name === "Install frozen dependencies",
+  );
+  assert.match(install.run, /--ignore-scripts/);
+  assert.ok(
+    names.indexOf("Install frozen dependencies") <
+      names.indexOf("Restore trusted controller after source installation"),
+  );
+  assert.ok(
+    names.indexOf("Restore trusted controller after source installation") <
+      names.indexOf("Create or reuse canonical GitHub Deployment"),
+  );
+  assert.ok(
+    names.indexOf("Build the UI prebuilt output") <
+      names.indexOf("Restore trusted controller after source build"),
+  );
+  assert.ok(
+    names.indexOf("Restore trusted controller after source build") <
+      names.indexOf("Assert the UI prebuilt output"),
+  );
+  assert.ok(
+    names.indexOf("Assert the UI prebuilt output") <
+      names.indexOf("Upload the verified prebuilt output"),
   );
 });
 


### PR DESCRIPTION
## The Problem

- Issue #518 needs a safe manual proof that `ui.mento.org` can be built on a GitHub-hosted runner and uploaded to Vercel as a prebuilt preview.
- The pilot must bind every step to one immutable same-repository SHA, preserve the monorepo Root Directory mapping, avoid production/custom-environment activation, and create a truthful GitHub Deployment lifecycle without relying on Vercel's Git integration.

## The Solution

- Add a UI-only manual caller that runs only from the trusted `main` workflow definition, and a reusable prebuilt workflow that checks out and restores that controller separately from the exact deployment source, proves branch reachability, and keeps build/upload in one standard-runner job.
- Materialize the pinned Vercel CLI 56.2.0 repo link, load pulled app-root preview variables, propagate the custom Next deployment ID, scope post-upload inspection to the configured Vercel team, and reject production, promotion, token-argument, or implicit GitHub Deployment paths.
- Create/reuse one exact-SHA GitHub Deployment, isolate build/upload credentials from a separate credential-free runtime-smoke job, and use an always-run trusted finalizer to drive `queued -> in_progress -> success|failure|error`. Publish the immutable Vercel URL only after navigation, asset, security-header, and deployment-ID checks pass.
- Add network-free lifecycle/workflow/CLI fixtures and update the canonical runbook and command inventory.

The workflow is not dispatched by this PR. `VERCEL_TOKEN_PREVIEW` is not provisioned yet, so #518 remains open until the merged manual pilot is run and its deployment/browser evidence is attached.

## Validation

- `pnpm test` — passed (50 Vercel primitives, 33 workflow/lifecycle tests, and all package tests)
- `pnpm check-types` — passed
- `pnpm lint` — passed (11 changed files)
- `pnpm format:check` — passed
- `pnpm knip` — passed; only the two pre-existing configuration hints remain
- `pnpm ci:action-pins` — passed (19 workflow/composite YAML files)
- `pnpm ci:action-pins:test` — passed (43 policy tests, 11 REST materializer tests)
- `pnpm quality:budgets:test` — passed (30 tests)
- `pnpm vercel:versions:check` — passed (`next@16.2.10`, `vercel@56.2.0`)
- Independent semantic review on the clean `origin/main...HEAD` diff — clean; no high-confidence P1/P2 findings
- Native PR preview browser check — passed on `ui.mento.org`: Basic Components rendered, Form Components navigation worked, and the console remained error-free
- Custom prebuilt pilot verification — intentionally pending the separately provisioned preview token and post-merge manual run

## Ship Checklist

- [x] PR title follows the [conventions](https://www.notion.so/Git-Branching-and-Commit-Message-Conventions-18f66f7d06444cfcbac5725ffbc7c04a?pvs=4#9355048863c549ef92fe210a8a1298aa)
- [x] Performed a self-review of my own changes
- [x] Relevant automated checks and smoke tests pass

Refs #518
