### PR TITLE
docs(architecture): record Vercel deployment ownership

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,3 +17,4 @@
 - [ ] PR title follows the [conventions](https://www.notion.so/Git-Branching-and-Commit-Message-Conventions-18f66f7d06444cfcbac5725ffbc7c04a?pvs=4#9355048863c549ef92fe210a8a1298aa)
 - [ ] Performed a self-review of my own changes
 - [ ] Relevant automated checks and smoke tests pass
+- [ ] Architecture decision? Link the ADR under `docs/adr/`, or state `Not applicable — <reason>` in the PR body (see `docs/pr-checklists/architecture-decisions.md`).

--- a/.trunk/configs/.markdownlint.yaml
+++ b/.trunk/configs/.markdownlint.yaml
@@ -1,2 +1,6 @@
 # Prettier friendly markdownlint config (all formatting rules disabled)
 extends: markdownlint/style/prettier
+# MD025: ADR frontmatter `title:` is metadata, not a rendered H1. ADRs still
+# use exactly one visible top-level heading in the document body.
+MD025:
+  front_matter_title: ""

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -85,6 +85,12 @@ actions:
   disabled:
     - trunk-check-pre-push # Disabled in favor of trunk-check-all-pre-push which checks all files
   definitions:
+    - id: adr-reminder-pre-push
+      display_name: Architecture Decision Reminder Pre-Push
+      description: Remind authors when a high-signal architecture surface lacks an ADR
+      run: pnpm adr:check
+      triggers:
+        - git_hooks: [pre-push]
     - id: check-types-pre-push
       display_name: Check Types Pre-Push
       description: Run `turbo run check-types` before pushing code
@@ -106,6 +112,7 @@ actions:
 
   enabled:
     - trunk-fmt-pre-commit # Auto-format files when committing
+    - adr-reminder-pre-push # Advise when a new workflow or workspace may need an ADR
     - trunk-check-all-pre-push # Run comprehensive checks on all files before pushing
     - check-types-pre-push # Run type checking before pushing
     - check-knip-pre-push # Run knip before pushing

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,12 @@
 
 Read `CLAUDE.md` for repo-local frontend conventions and commands.
 
+## Architecture decisions
+
+Architectural decisions live under `docs/adr/`. Use
+`docs/pr-checklists/architecture-decisions.md` to decide whether a change needs
+one, and run the advisory `pnpm adr:check` reminder before publishing.
+
 ## Pull request state
 
 Always create pull requests as normal, ready-for-review PRs directly. Never

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,8 @@ pnpm check-types                     # TypeScript type checking; builds workspac
 pnpm ci:action-pins                  # Verify third-party GitHub Actions use documented SHA pins
 pnpm ci:action-pins:test             # Test the action-pin scanner and REST materializer
 pnpm ci:change-plan:test             # Test PR scoping, full main pushes, mandatory Trunk, and fail-closed behavior
+pnpm adr:check                       # Advisory reminder for new architecture-significant workflows/workspaces
+pnpm adr:check:test                  # Test the offline ADR trigger and repository wiring
 pnpm vercel:cost:test                # Test redacted Vercel cost normalization and closeout gates
 pnpm vercel:cost:analyze --input <private-aggregate.json> --format markdown  # Generate public-safe #523 evidence
 trunk check --fix                     # Lint with autofix

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ frontend-monorepo/
 ├── .github/                  # GitHub workflows
 │   └── workflows/            # CI/CD workflows
 ├── .trunk/                   # Trunk CLI configuration and cache
+├── docs/
+│   └── adr/                  # Architecture decision records and lifecycle
 ├── turbo.json                # Turborepo configuration
 └── pnpm-workspace.yaml       # PNPM workspace configuration
 ```
@@ -128,6 +130,12 @@ pnpm ci:action-pins
 
 # Run the action-pin scanner and REST materializer fixture suites
 pnpm ci:action-pins:test
+
+# Remind on newly added architecture-significant workflows/workspaces
+pnpm adr:check
+
+# Test the offline ADR reminder and repository wiring
+pnpm adr:check:test
 
 # Test the network-free Vercel planning and prebuilt-build primitives
 pnpm vercel:primitives:test
@@ -413,7 +421,8 @@ feat(ui): add new button component
 **Git Hooks**: Trunk automatically manages git hooks that will:
 
 - **Pre-commit**: Format and lint staged files
-- **Pre-push**: Run comprehensive checks before pushing
+- **Pre-push**: Run comprehensive checks and the advisory `pnpm adr:check`
+  reminder before pushing
 - **Commit-msg**: Validate commit message format
 
 ## CI/CD Pipeline
@@ -425,7 +434,13 @@ The repository is set up with GitHub Actions for CI:
   check enforces production-source coverage and gzip route limits. Its general
   CI failure notifier opens or updates one issue for an operational workflow
   failure and closes the issue after recovery.
-- **CD**: Deployments are currently handled by the Vercel Git integration — each app is a Vercel project that builds on push to main (previews on PRs). Dependabot branches skip Vercel previews because GitHub Actions already builds and validates them. GitHub Actions does not deploy yet. The tested planning, deployment-ID, and build-environment foundations for the tracked custom-CI migration are documented in [`docs/vercel-deployments.md`](docs/vercel-deployments.md); those primitives do not change deployment ownership by themselves.
+- **CD**: The accepted direction is for GitHub Actions to own compilation and
+  prebuilt deployment orchestration while Vercel remains the hosting/runtime
+  platform. The migration is still rolling out, so Vercel Git remains
+  authoritative for paths not explicitly cut over. Dependabot branches skip
+  Vercel previews. See [ADR 0001](docs/adr/0001-github-actions-vercel-deployment-orchestration.md)
+  for the boundary and [`docs/vercel-deployments.md`](docs/vercel-deployments.md)
+  for the current implementation/runbook state.
 
 Dependency-installing jobs use `.github/actions/pnpm-install`, which pins the
 Node/pnpm bootstrap, relies on `actions/setup-node` as the single pnpm-store

--- a/docs/adr/0001-github-actions-vercel-deployment-orchestration.md
+++ b/docs/adr/0001-github-actions-vercel-deployment-orchestration.md
@@ -1,0 +1,372 @@
+---
+title: GitHub Actions owns Vercel build and deployment orchestration; Vercel remains hosting and runtime
+status: active
+owner: eng
+canonical: true
+last_verified: 2026-07-15
+scope: ci/deployment
+date: 2026-07
+---
+
+# ADR 0001 — GitHub Actions owns Vercel build and deployment orchestration; Vercel remains hosting and runtime
+
+**Status:** Accepted (Jul 2026); phased rollout in progress.
+**Scope:** ci/deployment
+
+## Context
+
+The monorepo's CI already compiles application code on GitHub Actions while
+Vercel's Git integration compiles the same commits again for four frontend
+projects. That duplicate work increased Vercel build-machine usage and made
+build cost depend on every native preview and `main` deployment. The hosting
+features that follow compilation—immutable deployments, CDN delivery,
+Functions, custom environments, domains, preview URLs, and runtime services—are
+still valuable and are not the source of the duplication.
+
+The decision therefore separates **who builds and orchestrates** from **who
+hosts and serves**:
+
+```text
+trusted pull request or main commit
+  -> GitHub Actions on a standard hosted runner
+     -> fail-closed affected-target plan
+     -> vercel pull
+     -> vercel build
+     -> verify the exact prebuilt output
+     -> vercel deploy --prebuilt
+     -> smoke, status, and controlled activation
+  -> Vercel deployment, CDN, domains, Functions, and runtime
+```
+
+This is not simply a runner substitution. Native Vercel Git currently provides
+branch metadata, environment selection, preview discovery, domain movement,
+and deployment statuses. A custom controller must replace those semantics
+explicitly without weakening the preview experience or exposing deployment
+credentials to untrusted code.
+
+The live target topology also prevents a blanket production design:
+
+| Source            | Vercel target                                         | Public surface         | Required ownership after rollout                                  |
+| ----------------- | ----------------------------------------------------- | ---------------------- | ----------------------------------------------------------------- |
+| app `main`        | custom environment `v3` with preview system semantics | `app.mento.org`        | GitHub builds/deploys `--target=v3` and controls reviewed aliases |
+| app `v2`          | Vercel production                                     | `v2-app.mento.org`     | Vercel Git remains owner                                          |
+| governance `main` | Vercel production                                     | `governance.mento.org` | GitHub stages, verifies, and promotes exact deployments           |
+| reserve `main`    | Vercel production                                     | `reserve.mento.org`    | GitHub stages, verifies, and promotes exact deployments           |
+| UI `main`         | Vercel production                                     | `ui.mento.org`         | GitHub stages, verifies, and promotes exact deployments           |
+
+The app's custom `v3` environment must retain `VERCEL_ENV=preview`,
+`VERCEL_TARGET_ENV=v3`, and `NEXT_PUBLIC_VERCEL_ENV=preview`. It must never be
+implemented by promoting the app project's legacy production target, because
+that target belongs to `v2`.
+
+The forces behind the choice are:
+
+- materially reduce Vercel build-minute spend while retaining Vercel hosting;
+- keep the first eligible preview automatic for every trusted human pull
+  request—previews must not become opt-in;
+- avoid waste from intermediate pushes without making correct scheduling depend
+  on local developer behavior or GitHub concurrency ordering;
+- skip proven non-runtime changes, but deploy all affected targets on ambiguous
+  history, paths, or planner failures;
+- preserve exact source SHA, branch, environment, and deployment identity from
+  build through smoke and activation;
+- keep fork and Dependabot code outside every Vercel credential boundary;
+- preserve app `v2` and make a partially activated multi-project `main` release
+  recoverable.
+
+## Decision
+
+### Ownership boundary
+
+GitHub Actions will own compilation and deployment orchestration for ordinary
+trusted pull-request previews and `main` releases. Vercel remains the deployment
+store, hosting platform, CDN, domain/alias provider, Functions runtime, and
+runtime-service provider. The Vercel GitHub integration is retained for source
+metadata and the legacy app `v2` path; only automatic Git builds replaced by a
+proven Actions path are disabled.
+
+All builds use standard GitHub-hosted runners. Build and
+`vercel deploy --prebuilt` run in the same job; `.vercel/output` is not uploaded
+as a GitHub artifact or passed across a trust boundary. The Vercel CLI is pinned
+to an exact version. Each attempt receives a deterministic Next.js deployment
+ID derived from target, exact SHA, Actions run ID, and run attempt, and the
+verified output carrying that ID is the output uploaded.
+
+This decision relies on the current GitHub billing treatment for standard
+hosted runners in public repositories. Larger runners are excluded because
+they remain charged, and artifact/cache storage is measured separately rather
+than described as free. A future repository visibility or billing-policy change
+requires re-evaluation.
+
+### Preview controller
+
+A same-repository, non-Dependabot pull request that changes a runtime target
+receives a preview automatically on its first eligible push. Later eligible
+pushes remain automatic. Documentation-, test-, or other proven non-runtime
+changes report an explained skip. Forks and Dependabot receive neither Vercel
+credentials nor a deployment.
+
+Bursty pushes use a deterministic **first-plus-latest** controller rather than
+asking developers to batch correctly:
+
+1. A trusted metadata-only controller records immutable PR event receipts and
+   per-target state outside lossy workflow concurrency.
+2. The first eligible exact SHA is dispatched exactly once, even if a later
+   event's Actions run starts first.
+3. While that worker runs, later pushes replace only `latest_desired_sha`.
+4. When the active worker is terminal, the controller dispatches the latest
+   desired SHA exactly once if it differs from the completed SHA.
+5. Duplicate delivery, reconciliation, worker retries, and callbacks are
+   idempotent no-ops for an already recorded target/SHA key.
+
+This preserves the initial visual/functional review guarantee, converges to the
+current PR head, and deterministically drops only superseded intermediate
+builds. GitHub `concurrency` may serialize reconciliation, but it is not the
+selection algorithm because pending-run replacement and start ordering cannot
+guarantee which event runs first.
+
+Each worker creates or reuses one GitHub Deployment whose `ref` is the selected
+40-character SHA, then reports queued, in-progress, and a truthful terminal
+status. Every selected target runs direct smoke against its immutable URL before
+success. App and governance additionally retain the temporary native
+`deployment_status` adapter only while Vercel Git still produces those events;
+a status created with the repository `GITHUB_TOKEN` is evidence, not a trigger
+contract.
+
+### Path-aware planning
+
+Deployment planning is repository-owned, deterministic, and offline-testable.
+It uses the real Turborepo package graph and a small reviewed list of proven
+non-runtime paths. Unknown paths, empty or unresolved diffs, shallow history,
+non-ancestral ranges, malformed planner output, or graph errors select all four
+targets rather than silently skipping a required deployment.
+
+For previews, planning compares the immutable base and snapshotted PR head. For
+`main`, planning compares the SHA currently served by each logical target with
+the exact new `main` SHA; it does not rely on `github.event.before`, because
+coalesced or superseded runs can skip intervening commits.
+
+### Main release transaction
+
+The main controller runs only from the trusted default-branch workflow
+definition after the exact `CI/CD` run and exact `Build and Test` job succeed
+for the deployment SHA. It rechecks that the candidate is still current `main`
+before the transaction and immediately before and after every public mutation.
+
+Governance, reserve, and UI are built as unaliased staged production
+deployments, inspected, and runtime/browser verified before any domain moves.
+They are then promoted sequentially by exact immutable deployment ID. The app
+`v3` prebuilt candidate is built and verified under custom-environment semantics
+before mutation, but `vercel deploy --prebuilt --target=v3` runs last because
+that upload is itself the activation mutation when attached `v3` domains move.
+The controller then verifies every reviewed alias and assigns only those that do
+not already point to the exact deployment as intended. `--prod` and
+`vercel promote` are forbidden for the app `main -> v3` path.
+
+Before mutation, the controller records the exact prior deployment and every
+protected alias for every selected target. It journals intent before each
+command and verifies the observed mapping afterward. Stale-main detection,
+failure, cancellation, timeout, or unknown command outcome initiates
+reverse-order compensation to that captured set. Unexpected operator-owned
+mappings stop for manual review rather than being overwritten. The design does
+not claim cross-project atomicity; it provides a bounded, auditable transaction
+with explicit compensation.
+
+### Trust and credential boundary
+
+- Pull-request code is never executed by a credentialed
+  `pull_request_target` controller. If that event is used, it handles metadata
+  only; trusted default-branch workflow code dispatches and revalidates the
+  separately scoped worker.
+- A worker snapshots and checks out one exact SHA and revalidates that it
+  belongs to an open eligible same-repository PR before exposing preview
+  credentials. It may still deploy the selected first SHA after the PR advances.
+- Production credentials are scoped to a dedicated main-restricted GitHub
+  environment. Preview and production capabilities are separate where the
+  provider permits it.
+- Tokens, pulled environment files, output directories, cookies, bypass values,
+  and raw provider responses never enter artifacts, issue comments, summaries,
+  or logs. System variables absent from prebuilt builds are supplied from an
+  audited allowlist rather than assumed.
+- GitHub Deployment creation is explicit and idempotent. Actions environments
+  used only for credentials suppress implicit event-SHA deployments, and
+  Vercel is not asked to create a duplicate GitHub Deployment.
+
+### Phased cutover and rollback
+
+Vercel Git remains authoritative until each Actions path has shadow or pilot
+evidence. Preview paths cut over before `main`; the three ordinary production
+targets prove no-domain staging, and app `v3` proves its activation semantics,
+before the final reviewed ownership change.
+
+`git.deploymentEnabled` branch rules disable only replaced native paths. The app
+configuration always retains `v2: true`. There is no permanent state in which
+native Vercel Git and GitHub Actions both automatically activate the same
+target/SHA. Recovery restores GitHub's controller to shadow mode and restores
+the prior Vercel Git branch rules in the same reviewed change, then proves the
+native canary path before treating Vercel Git as owner again.
+
+Ordinary targets recover with exact captured deployment IDs and verify every
+domain after rollback. App `v3` recovers each reviewed alias independently to
+its captured immutable URL, then verifies `v2-app.mento.org` is unchanged.
+Commands such as `latest` are never rollback evidence.
+
+### Cost and success gate
+
+The migration succeeds only after at least seven complete post-cutover days and
+ten eligible trusted PR pushes show at least a 90% target-mix-normalized
+reduction in raw Vercel Build CPU minutes for the migrated paths. Evidence also
+tracks standard/larger runner usage, storage added by the migration, queue and
+build durations, duplicate attempts, first-preview delivery, path-planning
+correctness, smoke results, and preserved app `v2` activity.
+
+Account-specific prices, allocations, invoices, and absolute cost values remain
+private. Public evidence contains redacted aggregates and reproducible formulas
+only. If the threshold, correctness, security, or service-quality gates fail,
+the epic remains open and the unexplained build source gets a focused follow-up
+instead of being normalized away.
+
+## Alternatives considered
+
+### Keep native Vercel Git and add path-aware protection
+
+Vercel supports `ignoreCommand`, and a shared fail-open-on-ambiguity diff script
+could skip demonstrably irrelevant changes without much repository complexity.
+`git.deploymentEnabled` can also disable selected branches entirely. These are
+useful interim controls and are part of the reversible cutover.
+
+Rejected as the final architecture: an ignored build is still represented as a
+canceled deployment and can occupy a concurrent-build slot; the command also
+must reconstruct a trustworthy diff in Vercel's sometimes shallow or Gitless
+builder context. More importantly, it leaves compilation and orchestration on
+Vercel and cannot provide one exact-SHA, multi-project main transaction. It
+reduces waste but does not remove the duplicated build owner.
+
+### Optimize only the native Vercel builds
+
+Dependabot skipping, production-only source-map work, tighter Turbo inputs, and
+better cache behavior are worthwhile and remain in place. Rejected as the sole
+solution because cache hits and faster builds lower duration but retain a
+second compilation for every eligible commit and leave cost coupled to Vercel
+build billing.
+
+### Make previews opt-in
+
+Rejected. A preview on the first eligible push is part of feature verification,
+not optional convenience. Labels, comments, or manual dispatch before the first
+preview would trade a deterministic product-quality guarantee for cost. The
+chosen first-plus-latest controller removes only superseded intermediate work.
+
+### Permanent dual ownership
+
+Rejected. Allowing Vercel Git and Actions to deploy the same target would create
+duplicate cost, competing GitHub Deployments, and races over aliases/domains.
+Dual execution is allowed only during a bounded non-authoritative pilot or
+shadow proof where exactly one path can serve public traffic.
+
+### GitHub-hosted prebuilt uploads
+
+Chosen. Standard GitHub-hosted runners provide clean managed execution for this
+public repository, while Vercel's Build Output API and
+`vercel deploy --prebuilt` preserve the platform's deployment/runtime layer.
+The approach meets the cost boundary without adding runner fleet operations.
+
+### Self-hosted Actions runners
+
+Rejected for this migration. Actions does not charge self-hosted runner minutes,
+but maintainers would own machines, patching, isolation, scaling, queueing, and
+cleanup. Jobs are not guaranteed a clean instance. That operational and trust
+surface is unjustified while standard public-repository runners meet the need.
+
+### Leave Vercel entirely
+
+Rejected. Replacing Vercel hosting, domains, CDN, Functions, preview URLs,
+custom environments, and runtime integrations would greatly expand scope and
+operational risk. The cost problem is duplicated compilation, not demonstrated
+failure of the hosting/runtime platform.
+
+## Consequences
+
+- Vercel remote build minutes for migrated paths should fall substantially,
+  while GitHub Actions runner time and queue latency increase and must be
+  observed.
+- Deployment workflows become production controllers, so exact-SHA provenance,
+  current-main checks, journaling, idempotency, timeout handling, browser smoke,
+  and rollback tests are correctness requirements rather than optional polish.
+- Preview behavior stays automatic for trusted human PRs, Dependabot stays
+  preview-disabled, and bursty work converges through durable first-plus-latest
+  state instead of developer convention.
+- The affected-target planner centralizes path-aware protection and must fail
+  closed to all targets when it cannot prove a narrower result.
+- Vercel remains an operational dependency. This decision does not reduce CDN,
+  Functions, bandwidth, image optimization, or other runtime costs.
+- The legacy app `v2` path intentionally remains exceptional and must be tested
+  independently during every ownership change and rollback exercise.
+- The ADR should be reconsidered if repository visibility changes, standard
+  runner billing or limits materially change, Actions reliability/latency is
+  worse than the acceptance bounds, normalized savings miss the threshold, or
+  Vercel introduces a simpler build-offload mechanism with equivalent security
+  and transaction semantics.
+
+## Evidence
+
+### Tracked rollout
+
+Status at decision adoption on 2026-07-15:
+
+| Issue                                                                  | Responsibility                                                 | Adoption status                                            |
+| ---------------------------------------------------------------------- | -------------------------------------------------------------- | ---------------------------------------------------------- |
+| [#515](https://github.com/mento-protocol/frontend-monorepo/issues/515) | Epic and non-negotiable behavior                               | Open; rollout owner                                        |
+| [#516](https://github.com/mento-protocol/frontend-monorepo/issues/516) | Planner, deployment ID, environment primitives                 | Complete                                                   |
+| [#517](https://github.com/mento-protocol/frontend-monorepo/issues/517) | Maintainer-provisioned credentials and mapping                 | Open                                                       |
+| [#518](https://github.com/mento-protocol/frontend-monorepo/issues/518) | Manual no-cutover UI pilot and cost go/no-go                   | Open; pilot implementation merged, live acceptance pending |
+| [#519](https://github.com/mento-protocol/frontend-monorepo/issues/519) | Automatic UI previews and durable batching                     | Open                                                       |
+| [#520](https://github.com/mento-protocol/frontend-monorepo/issues/520) | App, governance, and reserve preview cutover                   | Open                                                       |
+| [#521](https://github.com/mento-protocol/frontend-monorepo/issues/521) | Main shadow proof and app `v3` semantics                       | Open                                                       |
+| [#522](https://github.com/mento-protocol/frontend-monorepo/issues/522) | Main transaction, cutover, rollback, and app `v2` preservation | Open                                                       |
+| [#523](https://github.com/mento-protocol/frontend-monorepo/issues/523) | Observation, savings proof, and migration cleanup              | Open; analyzer preparation merged, observation not started |
+
+Merged implementation evidence:
+
+- [PR #513](https://github.com/mento-protocol/frontend-monorepo/pull/513) —
+  Dependabot preview suppression and smaller native build work.
+- [PR #524](https://github.com/mento-protocol/frontend-monorepo/pull/524) —
+  fail-closed planning, deployment IDs, build-environment contract, and pinned
+  prebuilt prerequisites; closes #516.
+- [PR #525](https://github.com/mento-protocol/frontend-monorepo/pull/525) —
+  manual exact-SHA UI prebuilt pilot implementation; #518 remains open pending
+  its privileged run and evidence.
+- [PR #528](https://github.com/mento-protocol/frontend-monorepo/pull/528) —
+  public-safe cost-analysis tooling in preparation for #523; it does not start
+  the observation window.
+
+Canonical repository evidence:
+
+- [`docs/vercel-deployments.md`](../vercel-deployments.md) — current target,
+  environment, build, pilot, and security runbook.
+- `scripts/plan-vercel-deployments.mjs` and its offline fixtures — fail-closed
+  affected-target planning.
+- `scripts/vercel-prebuilt.mjs` and `scripts/vercel-build-environment.mjs` —
+  pinned-version, deployment-ID, output, and environment contracts.
+- `.github/workflows/vercel-prebuilt-pilot.yml` and
+  `.github/workflows/_vercel-prebuilt.yml` — merged manual pilot path, not an
+  automatic cutover.
+- [`docs/vercel-cost-validation.md`](../vercel-cost-validation.md) — private
+  evidence boundary and public aggregate acceptance calculations.
+
+Primary platform references, verified at adoption:
+
+- [GitHub Actions billing](https://docs.github.com/en/billing/concepts/product-billing/github-actions)
+  and [GitHub-hosted runners](https://docs.github.com/en/actions/reference/runners/github-hosted-runners)
+  — standard hosted runners for public repositories and the larger-runner
+  exception.
+- [GitHub self-hosted runners](https://docs.github.com/en/actions/concepts/runners/self-hosted-runners)
+  — operator ownership and persistence trade-offs.
+- [Vercel CLI deploy](https://vercel.com/docs/cli/deploy) — prebuilt upload
+  behavior and the build-time system-variable caveat.
+- [Vercel Git configuration](https://vercel.com/docs/project-configuration/git-configuration)
+  — branch-selective `git.deploymentEnabled` behavior.
+- [Vercel project configuration](https://vercel.com/docs/project-configuration/vercel-json)
+  — `ignoreCommand` exit semantics.
+- [Vercel project settings](https://vercel.com/docs/project-configuration/project-settings)
+  — ignored-build deployment and concurrent-slot behavior.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,44 @@
+---
+title: Architecture Decision Records
+status: active
+owner: eng
+canonical: false
+---
+
+# Architecture Decision Records
+
+This directory records the architectural **why** for the frontend monorepo.
+Each ADR captures a decision that constrains future work, had a real
+alternative, and cannot be understood completely from the implementation
+alone. Bug fixes, routine dependency updates, and direction-neutral refactors
+do not need ADRs.
+
+An ADR is decision context, not proof of current behavior. Verify current code,
+configuration, workflow state, and live infrastructure before operating on the
+system.
+
+## Lifecycle
+
+Frontmatter `status` is `active` while a decision is in force and `archived`
+after it is superseded or retired. The decision lifecycle appears separately
+in the body as **Accepted** or **Superseded by ADR NNNN**. In-force decisions
+use `canonical: true` and include `last_verified`, `scope`, and `date`.
+
+Do not rewrite history when direction changes. Add a new ADR, set the old ADR
+to `status: archived`, and add a `superseded_by:` pointer.
+
+## Adding an ADR
+
+Use the three-part test and writing procedure in
+[`docs/pr-checklists/architecture-decisions.md`](../pr-checklists/architecture-decisions.md).
+Add the ADR in the same pull request that makes the decision and add it to the
+index below. The advisory `pnpm adr:check` command reminds authors when a diff
+adds a high-signal surface without a numbered ADR.
+
+## Index
+
+### CI and deployment
+
+| ADR                                                            | Decision                                                                                  |
+| -------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
+| [0001](0001-github-actions-vercel-deployment-orchestration.md) | GitHub Actions owns Vercel build/deployment orchestration; Vercel remains hosting/runtime |

--- a/docs/pr-checklists/architecture-decisions.md
+++ b/docs/pr-checklists/architecture-decisions.md
@@ -1,0 +1,81 @@
+---
+title: Architecture Decision Records — when and how
+status: active
+owner: eng
+canonical: true
+last_verified: 2026-07-15
+---
+
+# Architecture Decision Records — when and how
+
+Architectural decisions are recorded under [`docs/adr/`](../adr/README.md).
+Use this checklist when a pull request changes a long-lived system boundary,
+workflow, workspace, or engineering policy.
+
+## Does this change need an ADR?
+
+Write an ADR when all three statements are true:
+
+1. **It constrains future work.** A later implementation could do the opposite
+   and be wrong without realizing a direction had already been chosen.
+2. **There was a real alternative.** The team selected one plausible path over
+   another.
+3. **The rationale is not obvious from the code.** The diff shows what changed,
+   but not why this design should remain.
+
+Add the ADR in the same pull request as the decision. Routine fixes, dependency
+bumps, one-off features, and refactors that do not change direction are not
+ADRs. A focused code comment is enough when it captures the full rationale at
+the only relevant call site.
+
+## Trigger surfaces
+
+`pnpm adr:check` examines files newly added relative to `origin/main` and emits
+an advisory reminder when it finds either of these without a new numbered ADR:
+
+- a GitHub Actions workflow at `.github/workflows/*.yml` or `*.yaml`;
+- a top-level app or package manifest at `apps/*/package.json` or
+  `packages/*/package.json`.
+
+The deliberately narrow trigger set favors signal over exhaustive detection.
+Changes can still need an ADR even when the reminder stays quiet: replacing a
+hosting platform, changing preview or promotion semantics, changing a trust
+boundary, selecting a shared state model, or introducing a repository-wide
+policy are common examples.
+
+The default check is quiet unless it has a reminder and always exits zero. Use
+strict mode only when an explicit hard gate is appropriate:
+
+```bash
+pnpm adr:check
+pnpm adr:check --strict
+pnpm adr:check --base <base-sha> --head <head-sha> --strict
+```
+
+Use `--include-untracked` during local drafting if the trigger file or ADR has
+not been staged. The Trunk pre-push action runs advisory mode; CI does not force
+strict mode.
+
+## How to write one
+
+1. Use the next free four-digit number and a kebab-case filename:
+   `docs/adr/NNNN-short-title.md`.
+2. Include frontmatter with `status: active`, `owner: eng`, `canonical: true`,
+   `last_verified: <today>`, `scope`, and `date`. Put **Accepted** in the body,
+   not in the frontmatter `status` field.
+3. Include the core sections **Status**, **Context**, **Decision**,
+   **Alternatives considered**, **Consequences**, and **Evidence**.
+4. Describe ownership and trust boundaries, failure behavior, rollback, and
+   measurable reconsideration criteria when they apply.
+5. Cite public issues, merged pull requests, canonical files, and primary
+   documentation. Do not copy credentials, private billing values, or other
+   operational secrets into an ADR.
+6. Add the ADR to [`docs/adr/README.md`](../adr/README.md) and confirm the root
+   `AGENTS.md` pointer remains accurate.
+
+## When the reminder is not applicable
+
+A trigger file can be mechanically new without introducing a new direction.
+In that case, leave the ADR out and answer the pull-request template's
+**Architecture decision?** prompt with `Not applicable — <technical reason>`.
+The reminder is intended to force a conscious answer, not manufacture records.

--- a/docs/vercel-deployments.md
+++ b/docs/vercel-deployments.md
@@ -3,8 +3,11 @@
 This runbook documents the repository-owned planning and build primitives used
 by the GitHub Actions deployment migration tracked in [issue
 #515](https://github.com/mento-protocol/frontend-monorepo/issues/515). It does
-not change deployment ownership by itself. Until the later cutover issues ship,
-the Vercel Git integration remains the deployment owner.
+not change deployment ownership by itself. The ownership boundary and its
+trade-offs are recorded in
+[ADR 0001](adr/0001-github-actions-vercel-deployment-orchestration.md). Until the
+later cutover issues ship, the Vercel Git integration remains the deployment
+owner for paths not explicitly cut over.
 
 ## Pinned prerequisites
 
@@ -248,10 +251,11 @@ The primitive suite has no network or Vercel dependency:
 pnpm vercel:primitives:test
 ```
 
-It is also the first stage of the canonical root `pnpm test` command. The suite
-covers app/package graph fixtures, fail-closed cases, output ordering, every
-deployment-ID constraint, prebuilt-config matching, prerequisite versions, all
-target/environment classifications, and redaction-safe missing-variable errors.
+It also runs near the start of the canonical root `pnpm test` command, after the
+offline ADR-reminder tests. The suite covers app/package graph fixtures,
+fail-closed cases, output ordering, every deployment-ID constraint,
+prebuilt-config matching, prerequisite versions, all target/environment
+classifications, and redaction-safe missing-variable errors.
 
 This foundation issue performs no Vercel API call, build upload, deployment,
 alias mutation, environment mutation, or Git-ownership change.

--- a/package.json
+++ b/package.json
@@ -2,6 +2,8 @@
   "name": "frontend-monorepo",
   "private": true,
   "scripts": {
+    "adr:check": "node scripts/check-adr-reminder.mjs",
+    "adr:check:test": "node --test scripts/check-adr-reminder.test.mjs",
     "blockexplorer:start": "docker run -d --name otterscan -p 5100:80 -e ERIGON_URL=http://localhost:8545 otterscan/otterscan:latest",
     "blockexplorer:stop": "docker stop otterscan && docker rm otterscan",
     "build": "turbo run build",
@@ -39,7 +41,7 @@
     "supply-chain:lockfile-lint:test": "node scripts/lockfile-lint.test.mjs",
     "supply-chain:version-skew": "node scripts/version-skew-check.mjs",
     "supply-chain:version-skew:test": "node scripts/version-skew-check.test.mjs",
-    "test": "pnpm vercel:primitives:test && pnpm vercel:workflow:test && pnpm vercel:cost:test && turbo run test",
+    "test": "pnpm adr:check:test && pnpm vercel:primitives:test && pnpm vercel:workflow:test && pnpm vercel:cost:test && turbo run test",
     "test:coverage": "turbo run test:coverage",
     "vercel:cost:analyze": "node scripts/vercel-cost-analysis.mjs",
     "vercel:cost:test": "node --test scripts/vercel-cost-analysis.test.mjs",

--- a/scripts/check-adr-reminder.mjs
+++ b/scripts/check-adr-reminder.mjs
@@ -1,0 +1,176 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+import process from "node:process";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const DEFAULT_BASE = "origin/main";
+const ADR_PATH_RE = /^docs\/adr\/\d{4}-[a-z0-9][a-z0-9-]*\.md$/;
+const WORKFLOW_PATH_RE = /^\.github\/workflows\/[^/]+\.ya?ml$/;
+const WORKSPACE_MANIFEST_RE = /^(?:apps|packages)\/[^/]+\/package\.json$/;
+
+function normalizePaths(paths) {
+  return [...new Set(paths.filter(Boolean))].sort();
+}
+
+export function classifyAddedPaths(paths) {
+  const addedPaths = normalizePaths(paths);
+  const adrPaths = addedPaths.filter((path) => ADR_PATH_RE.test(path));
+  const triggers = [];
+
+  for (const path of addedPaths) {
+    if (WORKFLOW_PATH_RE.test(path)) {
+      triggers.push({ kind: "new GitHub Actions workflow", path });
+    } else if (WORKSPACE_MANIFEST_RE.test(path)) {
+      triggers.push({ kind: "new app or package workspace", path });
+    }
+  }
+
+  return {
+    addedPaths,
+    adrPaths,
+    triggers,
+    needsAdr: triggers.length > 0 && adrPaths.length === 0,
+  };
+}
+
+function parseArguments(argv) {
+  const options = {
+    base: DEFAULT_BASE,
+    head: undefined,
+    includeUntracked: false,
+    strict: false,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    if (argument === "--strict") {
+      options.strict = true;
+    } else if (argument === "--include-untracked") {
+      options.includeUntracked = true;
+    } else if (argument === "--base" || argument === "--head") {
+      const value = argv[index + 1];
+      if (!value || value.startsWith("-")) {
+        throw new Error(`${argument} requires a non-option git revision`);
+      }
+      options[argument.slice(2)] = value;
+      index += 1;
+    } else {
+      throw new Error(`unknown argument: ${argument}`);
+    }
+  }
+
+  return options;
+}
+
+function splitNullDelimited(output) {
+  return output.toString("utf8").split("\0").filter(Boolean);
+}
+
+function gitDiffAddedPaths(revisions) {
+  return splitNullDelimited(
+    execFileSync(
+      "git",
+      [
+        "diff",
+        "--no-renames",
+        "--diff-filter=A",
+        "--name-only",
+        "-z",
+        ...revisions,
+        "--",
+      ],
+      { stdio: ["ignore", "pipe", "pipe"] },
+    ),
+  );
+}
+
+function gitMergeBase(base, head) {
+  return execFileSync("git", ["merge-base", base, head], {
+    stdio: ["ignore", "pipe", "pipe"],
+  })
+    .toString("utf8")
+    .trim();
+}
+
+function gitAddedPaths({ base, head, includeUntracked }) {
+  const branchHead = head ?? "HEAD";
+  const mergeBase = gitMergeBase(base, branchHead);
+  const paths =
+    head === undefined
+      ? [
+          ...gitDiffAddedPaths([mergeBase, branchHead]),
+          ...gitDiffAddedPaths([branchHead]),
+        ]
+      : gitDiffAddedPaths([mergeBase, branchHead]);
+
+  if (includeUntracked && head === undefined) {
+    paths.push(
+      ...splitNullDelimited(
+        execFileSync(
+          "git",
+          ["ls-files", "--others", "--exclude-standard", "-z"],
+          { stdio: ["ignore", "pipe", "pipe"] },
+        ),
+      ),
+    );
+  }
+
+  return normalizePaths(paths);
+}
+
+function reminderMessage(result) {
+  const lines = result.triggers.map(({ kind, path }) => `  - ${kind}: ${path}`);
+  return [
+    "Architecture decision reminder: this change adds a high-signal surface:",
+    ...lines,
+    "No numbered ADR was added under docs/adr/.",
+    "If this makes an architectural decision, add the ADR in this PR. Otherwise explain why it is not applicable on the PR's Architecture decision line.",
+    "See docs/pr-checklists/architecture-decisions.md.",
+  ].join("\n");
+}
+
+export function evaluateAddedPaths(paths, { strict = false } = {}) {
+  const result = classifyAddedPaths(paths);
+  return {
+    ...result,
+    exitCode: result.needsAdr && strict ? 1 : 0,
+    message: result.needsAdr ? reminderMessage(result) : "",
+  };
+}
+
+function isCliEntrypoint() {
+  return (
+    process.argv[1] !== undefined &&
+    fileURLToPath(import.meta.url) === resolve(process.argv[1])
+  );
+}
+
+if (isCliEntrypoint()) {
+  let options;
+  try {
+    options = parseArguments(process.argv.slice(2));
+  } catch (error) {
+    console.error(`ADR check failed: ${error.message}`);
+    process.exitCode = 2;
+  }
+
+  if (options) {
+    try {
+      const result = evaluateAddedPaths(gitAddedPaths(options), options);
+      if (result.message) console.log(result.message);
+      process.exitCode = result.exitCode;
+    } catch (error) {
+      const message = `ADR check could not compare ${options.base}${options.head ? ` to ${options.head}` : " to the working tree"}: ${error.message}`;
+      if (options.strict) {
+        console.error(message);
+        process.exitCode = 2;
+      } else {
+        console.warn(
+          `${message}\nAdvisory mode is not blocking this operation.`,
+        );
+      }
+    }
+  }
+}

--- a/scripts/check-adr-reminder.test.mjs
+++ b/scripts/check-adr-reminder.test.mjs
@@ -1,0 +1,272 @@
+import assert from "node:assert/strict";
+import { execFileSync, spawnSync } from "node:child_process";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import process from "node:process";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+import {
+  classifyAddedPaths,
+  evaluateAddedPaths,
+} from "./check-adr-reminder.mjs";
+
+const scriptPath = fileURLToPath(
+  new URL("./check-adr-reminder.mjs", import.meta.url),
+);
+
+function addFile(root, path, contents = "test\n") {
+  const absolutePath = join(root, path);
+  mkdirSync(dirname(absolutePath), { recursive: true });
+  writeFileSync(absolutePath, contents);
+}
+
+function commitAll(root, message) {
+  execFileSync("git", ["add", "--all"], { cwd: root });
+  execFileSync(
+    "git",
+    [
+      "-c",
+      "user.name=ADR Test",
+      "-c",
+      "user.email=adr-test@example.invalid",
+      "-c",
+      "commit.gpgsign=false",
+      "-c",
+      "core.hooksPath=/dev/null",
+      "commit",
+      "--quiet",
+      "-m",
+      message,
+    ],
+    { cwd: root },
+  );
+}
+
+function withRepository(callback) {
+  const root = mkdtempSync(join(tmpdir(), "adr-reminder-"));
+  try {
+    execFileSync("git", ["-c", "init.defaultBranch=main", "init", "--quiet"], {
+      cwd: root,
+    });
+    addFile(root, "README.md", "initial\n");
+    commitAll(root, "initial");
+    callback(root);
+  } finally {
+    rmSync(root, { force: true, recursive: true });
+  }
+}
+
+test("detects newly added workflows and top-level workspace manifests", () => {
+  const result = classifyAddedPaths([
+    ".github/workflows/deploy.yml",
+    ".github/workflows/release.yaml",
+    "apps/explorer/package.json",
+    "packages/analytics/package.json",
+  ]);
+
+  assert.equal(result.needsAdr, true);
+  assert.deepEqual(
+    result.triggers.map(({ path }) => path),
+    [
+      ".github/workflows/deploy.yml",
+      ".github/workflows/release.yaml",
+      "apps/explorer/package.json",
+      "packages/analytics/package.json",
+    ],
+  );
+});
+
+test("stays quiet for lower-signal paths and nested example manifests", () => {
+  const result = evaluateAddedPaths([
+    ".github/actions/setup/action.yml",
+    "apps/explorer/examples/demo/package.json",
+    "docs/runbook.md",
+    "package.json",
+    "packages/ui/src/button.tsx",
+  ]);
+
+  assert.equal(result.needsAdr, false);
+  assert.equal(result.message, "");
+  assert.equal(result.exitCode, 0);
+});
+
+test("an added numbered ADR satisfies the reminder", () => {
+  const result = evaluateAddedPaths(
+    [".github/workflows/deploy.yml", "docs/adr/0002-deployment-controller.md"],
+    { strict: true },
+  );
+
+  assert.equal(result.needsAdr, false);
+  assert.deepEqual(result.adrPaths, ["docs/adr/0002-deployment-controller.md"]);
+  assert.equal(result.exitCode, 0);
+});
+
+test("advisory mode reports but does not fail; strict mode fails", () => {
+  const advisory = evaluateAddedPaths([".github/workflows/deploy.yml"]);
+  const strict = evaluateAddedPaths([".github/workflows/deploy.yml"], {
+    strict: true,
+  });
+
+  assert.match(advisory.message, /Architecture decision reminder/);
+  assert.match(advisory.message, /new GitHub Actions workflow/);
+  assert.equal(advisory.exitCode, 0);
+  assert.equal(strict.exitCode, 1);
+});
+
+test("CLI only considers newly added files in the git diff", () => {
+  withRepository((root) => {
+    addFile(root, ".github/workflows/existing.yml", "name: Existing\n");
+    commitAll(root, "add existing workflow");
+    writeFileSync(
+      join(root, ".github/workflows/existing.yml"),
+      "name: Modified\n",
+    );
+
+    const modified = spawnSync(
+      process.execPath,
+      [scriptPath, "--base", "HEAD", "--strict"],
+      { cwd: root, encoding: "utf8" },
+    );
+    assert.equal(modified.status, 0, modified.stderr);
+    assert.equal(modified.stdout, "");
+
+    addFile(root, ".github/workflows/new.yml", "name: New\n");
+    execFileSync("git", ["add", "--all"], { cwd: root });
+
+    const advisory = spawnSync(
+      process.execPath,
+      [scriptPath, "--base", "HEAD"],
+      { cwd: root, encoding: "utf8" },
+    );
+    assert.equal(advisory.status, 0, advisory.stderr);
+    assert.match(advisory.stdout, /\.github\/workflows\/new\.yml/);
+
+    const strict = spawnSync(
+      process.execPath,
+      [scriptPath, "--base", "HEAD", "--strict"],
+      { cwd: root, encoding: "utf8" },
+    );
+    assert.equal(strict.status, 1, strict.stderr);
+  });
+});
+
+test("CLI can include untracked files and recognizes a same-change ADR", () => {
+  withRepository((root) => {
+    addFile(root, "apps/new-app/package.json", "{}\n");
+
+    const hidden = spawnSync(
+      process.execPath,
+      [scriptPath, "--base", "HEAD", "--strict"],
+      { cwd: root, encoding: "utf8" },
+    );
+    assert.equal(hidden.status, 0, hidden.stderr);
+
+    const included = spawnSync(
+      process.execPath,
+      [scriptPath, "--base", "HEAD", "--include-untracked", "--strict"],
+      { cwd: root, encoding: "utf8" },
+    );
+    assert.equal(included.status, 1, included.stderr);
+
+    addFile(root, "docs/adr/0002-new-app.md", "# ADR\n");
+    const accompanied = spawnSync(
+      process.execPath,
+      [scriptPath, "--base", "HEAD", "--include-untracked", "--strict"],
+      { cwd: root, encoding: "utf8" },
+    );
+    assert.equal(accompanied.status, 0, accompanied.stderr);
+    assert.equal(accompanied.stdout, "");
+  });
+});
+
+test("CLI audits committed push content even when the working tree differs", () => {
+  withRepository((root) => {
+    execFileSync("git", ["branch", "base"], { cwd: root });
+    addFile(root, ".github/workflows/deploy.yml", "name: Deploy\n");
+    commitAll(root, "add deployment workflow");
+    rmSync(join(root, ".github/workflows/deploy.yml"));
+
+    const result = spawnSync(
+      process.execPath,
+      [scriptPath, "--base", "base", "--strict"],
+      { cwd: root, encoding: "utf8" },
+    );
+
+    assert.equal(result.status, 1, result.stderr);
+    assert.match(result.stdout, /\.github\/workflows\/deploy\.yml/);
+  });
+});
+
+test("CLI compares divergent branches from their merge base", () => {
+  withRepository((root) => {
+    addFile(root, ".github/workflows/existing.yml", "name: Existing\n");
+    commitAll(root, "add existing workflow");
+    execFileSync("git", ["branch", "feature"], { cwd: root });
+
+    rmSync(join(root, ".github/workflows/existing.yml"));
+    commitAll(root, "remove existing workflow on main");
+    execFileSync("git", ["switch", "--quiet", "feature"], { cwd: root });
+
+    const result = spawnSync(
+      process.execPath,
+      [scriptPath, "--base", "main", "--strict"],
+      { cwd: root, encoding: "utf8" },
+    );
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(result.stdout, "");
+  });
+});
+
+test("repository wiring keeps the reminder advisory and discoverable", () => {
+  const packageJson = JSON.parse(
+    readFileSync(new URL("../package.json", import.meta.url), "utf8"),
+  );
+  const trunk = readFileSync(
+    new URL("../.trunk/trunk.yaml", import.meta.url),
+    "utf8",
+  );
+  const markdownlint = readFileSync(
+    new URL("../.trunk/configs/.markdownlint.yaml", import.meta.url),
+    "utf8",
+  );
+  const template = readFileSync(
+    new URL("../.github/pull_request_template.md", import.meta.url),
+    "utf8",
+  );
+  const agents = readFileSync(new URL("../AGENTS.md", import.meta.url), "utf8");
+  const claude = readFileSync(new URL("../CLAUDE.md", import.meta.url), "utf8");
+  const readme = readFileSync(new URL("../README.md", import.meta.url), "utf8");
+
+  assert.equal(
+    packageJson.scripts["adr:check"],
+    "node scripts/check-adr-reminder.mjs",
+  );
+  assert.equal(
+    packageJson.scripts["adr:check:test"],
+    "node --test scripts/check-adr-reminder.test.mjs",
+  );
+  assert.match(packageJson.scripts.test, /pnpm adr:check:test/);
+  assert.match(
+    trunk,
+    /- id: adr-reminder-pre-push\n(?: {6}[^\n]+\n)* {6}run: pnpm adr:check\n {6}triggers:\n {8}- git_hooks: \[pre-push\]/,
+  );
+  assert.match(
+    trunk,
+    /enabled:\n(?: {4}- [^\n]+\n)* {4}- adr-reminder-pre-push(?:\s+# [^\n]+)?/,
+  );
+  assert.doesNotMatch(trunk, /run: pnpm adr:check --strict/);
+  assert.match(markdownlint, /MD025:\n {2}front_matter_title: (?:""|'')/);
+  assert.match(template, /Architecture decision\?/);
+  assert.match(agents, /docs\/adr\//);
+  assert.match(claude, /pnpm adr:check/);
+  assert.match(readme, /pnpm adr:check/);
+});


### PR DESCRIPTION
## The Problem

- The frontend monorepo had no durable architecture-decision process, while the ongoing Vercel cost migration changes long-lived build, deployment, trust, and rollback boundaries that should not be inferred from workflow code alone.

## The Solution

- Adapt the lightweight ADR lifecycle and author checklist used in `monitoring-monorepo` for this repository.
- Record ADR 0001: GitHub Actions owns Vercel build and deployment orchestration, while Vercel remains the hosting/runtime platform and legacy app `v2` remains Vercel-Git owned.
- Add a narrow, offline-tested `pnpm adr:check` reminder for newly added workflows/workspaces. It is advisory locally and supports explicit `--strict` use without becoming a mandatory CI gate.
- Update repository guidance, the PR template, and the current Vercel runbook to point to the decision and distinguish accepted direction from rollout state.

Tracked rollout: #515.

## Validation

- `pnpm test` — passed across all root and workspace suites.
- `pnpm adr:check:test` — 9/9 passed, including divergent-history and inherited-Git-config fixtures.
- `pnpm pr:description:test` — 25/25 passed.
- `pnpm adr:check --base origin/main --head HEAD --strict` — passed.
- Targeted Trunk checks across all 12 changed files — clean.
- `git diff --check` — clean.

## Ship Checklist

- [x] PR title follows the conventions
- [x] Performed a self-review of my own changes
- [x] Relevant automated checks and smoke tests pass
- [x] Architecture decision: [`docs/adr/0001-github-actions-vercel-deployment-orchestration.md`](https://github.com/mento-protocol/frontend-monorepo/blob/970a1dc79df866f25d6c7e1db72f92e148b7be46/docs/adr/0001-github-actions-vercel-deployment-orchestration.md)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and advisory developer tooling only; no production app, auth, or deployment workflow behavior changes in this diff.
> 
> **Overview**
> Adds a **lightweight ADR lifecycle** under `docs/adr/` (index README, author checklist in `docs/pr-checklists/architecture-decisions.md`) and **ADR 0001**, which records that trusted PR/`main` builds and deployment orchestration move to GitHub Actions (`vercel build` + `vercel deploy --prebuilt`) while Vercel stays hosting/runtime, with phased cutover, trust boundaries, and app `v2` remaining on Vercel Git.
> 
> Ships **`scripts/check-adr-reminder.mjs`** with offline tests: on newly added paths vs `origin/main`, it nudges when a new `.github/workflows/*` file or `apps|packages/*/package.json` appears without a matching `docs/adr/NNNN-*.md`. Default mode is **advisory** (exit 0); `--strict` can fail. **Trunk pre-push** runs `pnpm adr:check` without strict mode.
> 
> **Process wiring**: PR template “Architecture decision?” line, `AGENTS.md` / `CLAUDE.md` / `README.md` pointers, README CD blurb aligned to ADR 0001, `docs/vercel-deployments.md` cross-link, markdownlint **MD025** tweak for ADR frontmatter, and root `pnpm test` now starts with `adr:check:test`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 970a1dc79df866f25d6c7e1db72f92e148b7be46. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->