### PR TITLE
fix(vercel): isolate prebuilt candidate build

### DIFF
--- a/.github/workflows/_vercel-prebuilt.yml
+++ b/.github/workflows/_vercel-prebuilt.yml
@@ -159,7 +159,9 @@ jobs:
         with:
           node-version: 22
           cache: pnpm
-          cache-dependency-path: source/pnpm-lock.yaml
+          cache-dependency-path: |
+            controller/pnpm-lock.yaml
+            source/pnpm-lock.yaml
 
       - name: Validate pilot contract and prepare immutable build identity
         id: prepare
@@ -190,9 +192,198 @@ jobs:
           SOURCE_PATH: ${{ github.workspace }}/source
         run: node "$GITHUB_WORKSPACE/controller/scripts/vercel-prebuilt-workflow.mjs" validate-source
 
+      - name: Prepare isolated exact-SHA source and protected Vercel CLI
+        id: isolation
+        env:
+          CANDIDATE_HOME_PATH: ${{ runner.temp }}/mento-vercel-candidate-home
+          CANDIDATE_SOURCE_PATH: ${{ runner.temp }}/mento-vercel-candidate-source
+          DEPLOY_SHA: ${{ steps.source.outputs.checked_out_sha }}
+          SOURCE_PATH: ${{ github.workspace }}/source
+          TRUSTED_VERCEL_TOOLS_PATH: ${{ runner.temp }}/mento-vercel-trusted-tools
+        run: |
+          set -euo pipefail
+          umask 077
+
+          build_user=mento-vercel-build
+          if getent passwd "$build_user" >/dev/null || getent group "$build_user" >/dev/null; then
+            echo "Dedicated candidate identity already exists" >&2
+            exit 1
+          fi
+          sudo --non-interactive /usr/sbin/useradd \
+            --system \
+            --no-create-home \
+            --home-dir /nonexistent \
+            --shell /usr/sbin/nologin \
+            --user-group \
+            "$build_user"
+          build_uid="$(id -u "$build_user")"
+          build_gid="$(id -g "$build_user")"
+          if sudo --non-interactive /usr/bin/pgrep -u "$build_uid" >/dev/null 2>&1; then
+            echo "Dedicated candidate identity unexpectedly owns a process" >&2
+            exit 1
+          fi
+
+          /bin/mkdir -m 0755 "$TRUSTED_VERCEL_TOOLS_PATH"
+          node_bin="$(realpath "$(command -v node)")"
+          pnpm_bin="$(realpath "$(command -v pnpm)")"
+          trusted_modules_dir="$(
+            CONTROLLER_PATH="$GITHUB_WORKSPACE/controller" \
+            TRUSTED_VERCEL_TOOLS_PATH="$TRUSTED_VERCEL_TOOLS_PATH" \
+              "$node_bin" \
+              "$GITHUB_WORKSPACE/controller/scripts/vercel-prebuilt-workflow.mjs" \
+              trusted-install-modules-dir
+          )"
+          if [ -z "$trusted_modules_dir" ] || [[ "$trusted_modules_dir" = /* ]]; then
+            echo "Trusted pnpm modules path is not a relative path" >&2
+            exit 1
+          fi
+          pnpm --dir "$GITHUB_WORKSPACE/controller" --filter frontend-monorepo install \
+            --frozen-lockfile \
+            --ignore-scripts \
+            --modules-dir "$trusted_modules_dir" \
+            --package-import-method copy \
+            --virtual-store-dir "$trusted_modules_dir/.pnpm"
+          /bin/chmod -R a+rX,go-w "$TRUSTED_VERCEL_TOOLS_PATH"
+          vercel_cli="$(realpath "$TRUSTED_VERCEL_TOOLS_PATH/node_modules/vercel/dist/index.js")"
+          case "$vercel_cli" in
+            "$TRUSTED_VERCEL_TOOLS_PATH"/*) ;;
+            *) echo "Pinned Vercel CLI escaped its protected directory" >&2; exit 1 ;;
+          esac
+          if [ ! -f "$vercel_cli" ] || [ -L "$vercel_cli" ]; then
+            echo "Pinned Vercel CLI is not a regular file" >&2
+            exit 1
+          fi
+          "$node_bin" "$vercel_cli" --version >/dev/null
+          candidate_can_write() {
+            sudo --non-interactive /usr/bin/env -i PATH=/usr/bin:/bin \
+              /usr/bin/setpriv \
+              --reuid="$build_uid" \
+              --regid="$build_gid" \
+              --clear-groups \
+              --no-new-privs \
+              -- \
+              /usr/bin/test -w "$1"
+          }
+          for protected_path in \
+            "$GITHUB_WORKSPACE" \
+            "$GITHUB_WORKSPACE/controller" \
+            "$RUNNER_TEMP" \
+            "$SOURCE_PATH" \
+            "$SOURCE_PATH/.git" \
+            "$SOURCE_PATH/package.json" \
+            "$SOURCE_PATH/pnpm-lock.yaml" \
+            "$TRUSTED_VERCEL_TOOLS_PATH" \
+            "$node_bin" \
+            "$pnpm_bin"; do
+            if [ ! -e "$protected_path" ] || candidate_can_write "$protected_path"; then
+              echo "Candidate can modify a protected runner path" >&2
+              exit 1
+            fi
+          done
+          if [ -e "$SOURCE_PATH/node_modules" ] && candidate_can_write "$SOURCE_PATH/node_modules"; then
+            echo "Candidate can modify canonical node_modules" >&2
+            exit 1
+          fi
+
+          archive="${RUNNER_TEMP}/mento-vercel-candidate-source.tar"
+          trap '/bin/rm -f -- "$archive"' EXIT
+          git -C "$SOURCE_PATH" archive \
+            --format=tar \
+            --output="$archive" \
+            "$DEPLOY_SHA"
+          if [ "$(git get-tar-commit-id < "$archive")" != "$DEPLOY_SHA" ]; then
+            echo "Candidate archive provenance does not match the exact SHA" >&2
+            exit 1
+          fi
+          /bin/chmod 0444 "$archive"
+          sudo --non-interactive /usr/bin/install \
+            -d -o "$build_uid" -g "$build_gid" -m 0755 \
+            "$CANDIDATE_SOURCE_PATH"
+          sudo --non-interactive /usr/bin/env -i PATH=/usr/bin:/bin \
+            /usr/bin/setpriv \
+            --reuid="$build_uid" \
+            --regid="$build_gid" \
+            --clear-groups \
+            --no-new-privs \
+            -- \
+            /bin/tar -xf "$archive" -C "$CANDIDATE_SOURCE_PATH"
+          sudo --non-interactive /usr/bin/install \
+            -d -o "$build_uid" -g "$build_gid" -m 0700 \
+            "$CANDIDATE_HOME_PATH" \
+            "$CANDIDATE_HOME_PATH/cache" \
+            "$CANDIDATE_HOME_PATH/config" \
+            "$CANDIDATE_HOME_PATH/data" \
+            "$CANDIDATE_HOME_PATH/tmp"
+          printf '{"commitSha":"%s"}\n' "$DEPLOY_SHA" \
+            > "${CANDIDATE_SOURCE_PATH}.provenance.json"
+          /bin/chmod 0600 "${CANDIDATE_SOURCE_PATH}.provenance.json"
+
+          echo "build_uid=$build_uid" >> "$GITHUB_OUTPUT"
+          echo "build_gid=$build_gid" >> "$GITHUB_OUTPUT"
+
       - name: Install frozen dependencies
-        working-directory: source
-        run: pnpm install --frozen-lockfile --ignore-scripts
+        env:
+          BUILD_GID: ${{ steps.isolation.outputs.build_gid }}
+          BUILD_UID: ${{ steps.isolation.outputs.build_uid }}
+          CANDIDATE_HOME_PATH: ${{ runner.temp }}/mento-vercel-candidate-home
+          CANDIDATE_SOURCE_PATH: ${{ runner.temp }}/mento-vercel-candidate-source
+        run: |
+          set -euo pipefail
+          terminate_candidate() {
+            sudo --non-interactive /usr/bin/pkill -KILL -u "$BUILD_UID" >/dev/null 2>&1 || true
+            for _ in $(seq 1 50); do
+              if ! sudo --non-interactive /usr/bin/pgrep -u "$BUILD_UID" >/dev/null 2>&1; then
+                return 0
+              fi
+              /bin/sleep 0.1
+            done
+            sudo --non-interactive /usr/bin/pgrep -a -u "$BUILD_UID" >&2 || true
+            echo "Candidate processes survived the UID-wide kill" >&2
+            return 1
+          }
+          command_token=""
+          trap 'status=$?; terminate_candidate || status=1; if [ -n "$command_token" ]; then echo "::$command_token::"; fi; exit "$status"' EXIT
+          if sudo --non-interactive /usr/bin/pgrep -u "$BUILD_UID" >/dev/null 2>&1; then
+            echo "Candidate identity owns a process before dependency installation" >&2
+            exit 1
+          fi
+          node_bin="$(realpath "$(command -v node)")"
+          pnpm_bin="$(realpath "$(command -v pnpm)")"
+          safe_path="$(dirname "$node_bin"):$(dirname "$pnpm_bin"):/usr/local/bin:/usr/bin:/bin"
+          command_token="mento-$(/usr/bin/openssl rand -hex 16)"
+          echo "::stop-commands::$command_token"
+          set +e
+          sudo --non-interactive /usr/bin/env -i \
+            CI=1 \
+            HOME="$CANDIDATE_HOME_PATH" \
+            HTTP_PROXY="${HTTP_PROXY:-}" \
+            HTTPS_PROXY="${HTTPS_PROXY:-}" \
+            LANG="${LANG:-C.UTF-8}" \
+            LC_ALL="${LC_ALL:-C.UTF-8}" \
+            NODE_EXTRA_CA_CERTS="${NODE_EXTRA_CA_CERTS:-}" \
+            NO_PROXY="${NO_PROXY:-}" \
+            PATH="$safe_path" \
+            SSL_CERT_FILE="${SSL_CERT_FILE:-}" \
+            TMPDIR="$CANDIDATE_HOME_PATH/tmp" \
+            XDG_CACHE_HOME="$CANDIDATE_HOME_PATH/cache" \
+            XDG_CONFIG_HOME="$CANDIDATE_HOME_PATH/config" \
+            XDG_DATA_HOME="$CANDIDATE_HOME_PATH/data" \
+            /usr/bin/setpriv \
+            --reuid="$BUILD_UID" \
+            --regid="$BUILD_GID" \
+            --clear-groups \
+            --no-new-privs \
+            -- \
+            "$pnpm_bin" --dir "$CANDIDATE_SOURCE_PATH" install --frozen-lockfile --ignore-scripts \
+            2>&1
+          candidate_status=$?
+          set -e
+          terminate_candidate
+          echo "::$command_token::"
+          command_token=""
+          if [ "$candidate_status" -ne 0 ]; then
+            exit "$candidate_status"
+          fi
 
       - name: Restore trusted controller after source installation
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -207,13 +398,15 @@ jobs:
         working-directory: source
         run: node "$GITHUB_WORKSPACE/controller/scripts/vercel-prebuilt.mjs" check-versions
 
-      - name: Materialize trusted repo-level UI project mapping
+      - name: Prepare fresh runner-owned Vercel pull staging
         env:
           EXPECTED_ROOT_DIRECTORY: ${{ inputs.expected_root_directory }}
-          SOURCE_PATH: ${{ github.workspace }}/source
+          PULL_STAGING_PATH: ${{ runner.temp }}/mento-vercel-pull-staging
           VERCEL_ORG_ID: ${{ inputs.vercel_org_id }}
           VERCEL_PROJECT_ID: ${{ inputs.vercel_project_id }}
-        run: node "$GITHUB_WORKSPACE/controller/scripts/vercel-prebuilt-workflow.mjs" prepare-link
+        run: |
+          umask 077
+          node "$GITHUB_WORKSPACE/controller/scripts/vercel-prebuilt-workflow.mjs" prepare-pull-staging
 
       - name: Create or reuse canonical GitHub Deployment
         id: create
@@ -249,42 +442,120 @@ jobs:
         id: pull
         env:
           GIT_BRANCH: ${{ inputs.git_branch }}
-          SOURCE_PATH: ${{ github.workspace }}/source
+          SOURCE_PATH: ${{ runner.temp }}/mento-vercel-pull-staging
+          TRUSTED_VERCEL_TOOLS_PATH: ${{ runner.temp }}/mento-vercel-trusted-tools
           VERCEL_ORG_ID: ${{ inputs.vercel_org_id }}
           VERCEL_PROJECT_ID: ${{ inputs.vercel_project_id }}
           VERCEL_TOKEN: ${{ secrets.vercel_token }}
-        run: node "$GITHUB_WORKSPACE/controller/scripts/vercel-prebuilt-workflow.mjs" pull
+        run: |
+          umask 077
+          node "$GITHUB_WORKSPACE/controller/scripts/vercel-prebuilt-workflow.mjs" pull
 
-      - name: Assert pulled UI project mapping
+      - name: Assert isolated runner-owned Vercel pull result
         env:
           EXPECTED_ROOT_DIRECTORY: ${{ inputs.expected_root_directory }}
-          SOURCE_PATH: ${{ github.workspace }}/source
+          PULL_STAGING_PATH: ${{ runner.temp }}/mento-vercel-pull-staging
           VERCEL_ORG_ID: ${{ inputs.vercel_org_id }}
           VERCEL_PROJECT_ID: ${{ inputs.vercel_project_id }}
-        run: node "$GITHUB_WORKSPACE/controller/scripts/vercel-prebuilt-workflow.mjs" validate-pull
+        run: node "$GITHUB_WORKSPACE/controller/scripts/vercel-prebuilt-workflow.mjs" validate-pull-staging
 
-      - name: Validate app-root preview build variables
-        working-directory: source
+      - name: Validate runner-owned UI preview build variables
         env:
           CI: 1
           NEXT_PUBLIC_VERCEL_ENV: preview
+          PULL_STAGING_PATH: ${{ runner.temp }}/mento-vercel-pull-staging
           VERCEL: 1
           VERCEL_ENV: preview
           VERCEL_TARGET_ENV: preview
         run: >-
           node "$GITHUB_WORKSPACE/controller/scripts/vercel-build-environment.mjs"
           check --target ui --environment preview
-          --project-directory apps/ui.mento.org
+          --project-directory "$PULL_STAGING_PATH/apps/ui.mento.org"
+
+      - name: Stage trusted UI project settings into candidate source
+        env:
+          BUILD_GID: ${{ steps.isolation.outputs.build_gid }}
+          BUILD_UID: ${{ steps.isolation.outputs.build_uid }}
+          CANDIDATE_SOURCE_PATH: ${{ runner.temp }}/mento-vercel-candidate-source
+          EXPECTED_ROOT_DIRECTORY: ${{ inputs.expected_root_directory }}
+          PULL_STAGING_PATH: ${{ runner.temp }}/mento-vercel-pull-staging
+          VERCEL_ORG_ID: ${{ inputs.vercel_org_id }}
+          VERCEL_PROJECT_ID: ${{ inputs.vercel_project_id }}
+        run: |
+          set -euo pipefail
+          if sudo --non-interactive /usr/bin/pgrep -u "$BUILD_UID" >/dev/null 2>&1; then
+            echo "Candidate identity owns a process before project settings are staged" >&2
+            exit 1
+          fi
+          node_bin="$(realpath "$(command -v node)")"
+          sudo --non-interactive /usr/bin/env -i \
+            BUILD_GID="$BUILD_GID" \
+            BUILD_UID="$BUILD_UID" \
+            CANDIDATE_SOURCE_PATH="$CANDIDATE_SOURCE_PATH" \
+            EXPECTED_ROOT_DIRECTORY="$EXPECTED_ROOT_DIRECTORY" \
+            PATH="$(dirname "$node_bin"):/usr/bin:/bin" \
+            PULL_STAGING_GID="$(id -g)" \
+            PULL_STAGING_PATH="$PULL_STAGING_PATH" \
+            PULL_STAGING_UID="$(id -u)" \
+            RUNNER_TEMP="$RUNNER_TEMP" \
+            VERCEL_ORG_ID="$VERCEL_ORG_ID" \
+            VERCEL_PROJECT_ID="$VERCEL_PROJECT_ID" \
+            "$node_bin" \
+            "$GITHUB_WORKSPACE/controller/scripts/vercel-prebuilt-workflow.mjs" \
+            stage-pull
+          if sudo --non-interactive /usr/bin/pgrep -u "$BUILD_UID" >/dev/null 2>&1; then
+            echo "Candidate identity acquired a process while project settings were staged" >&2
+            exit 1
+          fi
+
+      - name: Assert isolated UI project mapping
+        env:
+          BUILD_GID: ${{ steps.isolation.outputs.build_gid }}
+          BUILD_UID: ${{ steps.isolation.outputs.build_uid }}
+          CANDIDATE_SOURCE_PATH: ${{ runner.temp }}/mento-vercel-candidate-source
+          EXPECTED_ROOT_DIRECTORY: ${{ inputs.expected_root_directory }}
+          VERCEL_ORG_ID: ${{ inputs.vercel_org_id }}
+          VERCEL_PROJECT_ID: ${{ inputs.vercel_project_id }}
+        run: |
+          set -euo pipefail
+          if sudo --non-interactive /usr/bin/pgrep -u "$BUILD_UID" >/dev/null 2>&1; then
+            echo "Candidate identity owns a process before project settings are validated" >&2
+            exit 1
+          fi
+          node_bin="$(realpath "$(command -v node)")"
+          sudo --non-interactive /usr/bin/env -i \
+            BUILD_GID="$BUILD_GID" \
+            BUILD_UID="$BUILD_UID" \
+            CANDIDATE_SOURCE_PATH="$CANDIDATE_SOURCE_PATH" \
+            EXPECTED_ROOT_DIRECTORY="$EXPECTED_ROOT_DIRECTORY" \
+            PATH="$(dirname "$node_bin"):/usr/bin:/bin" \
+            PULL_STAGING_GID="$(id -g)" \
+            PULL_STAGING_UID="$(id -u)" \
+            RUNNER_TEMP="$RUNNER_TEMP" \
+            VERCEL_ORG_ID="$VERCEL_ORG_ID" \
+            VERCEL_PROJECT_ID="$VERCEL_PROJECT_ID" \
+            "$node_bin" \
+            "$GITHUB_WORKSPACE/controller/scripts/vercel-prebuilt-workflow.mjs" \
+            validate-candidate-pull
+          if sudo --non-interactive /usr/bin/pgrep -u "$BUILD_UID" >/dev/null 2>&1; then
+            echo "Candidate identity acquired a process while project settings were validated" >&2
+            exit 1
+          fi
 
       - name: Build the UI prebuilt output
         id: build
         env:
+          BUILD_GID: ${{ steps.isolation.outputs.build_gid }}
+          BUILD_UID: ${{ steps.isolation.outputs.build_uid }}
+          CANDIDATE_HOME_PATH: ${{ runner.temp }}/mento-vercel-candidate-home
           CI: 1
+          DEPLOY_SHA: ${{ steps.source.outputs.checked_out_sha }}
           EXPECTED_ROOT_DIRECTORY: ${{ inputs.expected_root_directory }}
           GIT_BRANCH: ${{ inputs.git_branch }}
           MENTO_NEXT_DEPLOYMENT_ID: ${{ steps.prepare.outputs.next_deployment_id }}
           NEXT_PUBLIC_VERCEL_ENV: preview
-          SOURCE_PATH: ${{ github.workspace }}/source
+          SOURCE_PATH: ${{ runner.temp }}/mento-vercel-candidate-source
+          TRUSTED_VERCEL_TOOLS_PATH: ${{ runner.temp }}/mento-vercel-trusted-tools
           TURBO_REMOTE_CACHE_SIGNATURE_KEY: ${{ secrets.turbo_remote_cache_signature_key }}
           TURBO_TEAM: ${{ inputs.turbo_team }}
           TURBO_TOKEN: ${{ secrets.turbo_token }}
@@ -298,8 +569,107 @@ jobs:
           VERCEL_ORG_ID: ${{ inputs.vercel_org_id }}
           VERCEL_PROJECT_ID: ${{ inputs.vercel_project_id }}
           VERCEL_TARGET_ENV: preview
-          VERCEL_TOKEN: ${{ secrets.vercel_token }}
-        run: node "$GITHUB_WORKSPACE/controller/scripts/vercel-prebuilt-workflow.mjs" build
+          # No VERCEL_TOKEN: build is local-only from the validated pulled state.
+        run: |
+          set -euo pipefail
+          terminate_candidate() {
+            sudo --non-interactive /usr/bin/pkill -KILL -u "$BUILD_UID" >/dev/null 2>&1 || true
+            for _ in $(seq 1 50); do
+              if ! sudo --non-interactive /usr/bin/pgrep -u "$BUILD_UID" >/dev/null 2>&1; then
+                return 0
+              fi
+              /bin/sleep 0.1
+            done
+            sudo --non-interactive /usr/bin/pgrep -a -u "$BUILD_UID" >&2 || true
+            echo "Candidate processes survived the UID-wide kill" >&2
+            return 1
+          }
+          command_token=""
+          trap 'status=$?; terminate_candidate || status=1; if [ -n "$command_token" ]; then echo "::$command_token::"; fi; exit "$status"' EXIT
+          if sudo --non-interactive /usr/bin/pgrep -u "$BUILD_UID" >/dev/null 2>&1; then
+            echo "Candidate identity owns a process before the build" >&2
+            exit 1
+          fi
+
+          node_bin="$(realpath "$(command -v node)")"
+          pnpm_bin="$(realpath "$(command -v pnpm)")"
+          vercel_cli="$(realpath "$TRUSTED_VERCEL_TOOLS_PATH/node_modules/vercel/dist/index.js")"
+          case "$vercel_cli" in
+            "$TRUSTED_VERCEL_TOOLS_PATH"/*) ;;
+            *) echo "Pinned Vercel CLI escaped its protected directory" >&2; exit 1 ;;
+          esac
+          safe_path="$(dirname "$node_bin"):$(dirname "$pnpm_bin"):/usr/local/bin:/usr/bin:/bin"
+          sudo --non-interactive /usr/bin/env -i \
+            BUILD_GID="$BUILD_GID" \
+            BUILD_UID="$BUILD_UID" \
+            DEPLOY_SHA="$DEPLOY_SHA" \
+            EXPECTED_ROOT_DIRECTORY="$EXPECTED_ROOT_DIRECTORY" \
+            MENTO_NEXT_DEPLOYMENT_ID="$MENTO_NEXT_DEPLOYMENT_ID" \
+            PATH="$(dirname "$node_bin"):/usr/bin:/bin" \
+            PULL_STAGING_GID="$(id -g)" \
+            PULL_STAGING_UID="$(id -u)" \
+            RUNNER_TEMP="$RUNNER_TEMP" \
+            SOURCE_PATH="$SOURCE_PATH" \
+            TURBO_REMOTE_CACHE_SIGNATURE_KEY="$TURBO_REMOTE_CACHE_SIGNATURE_KEY" \
+            TURBO_TEAM="$TURBO_TEAM" \
+            TURBO_TOKEN="$TURBO_TOKEN" \
+            VERCEL_GIT_COMMIT_SHA="$VERCEL_GIT_COMMIT_SHA" \
+            VERCEL_ORG_ID="$VERCEL_ORG_ID" \
+            VERCEL_PROJECT_ID="$VERCEL_PROJECT_ID" \
+            "$node_bin" \
+            "$GITHUB_WORKSPACE/controller/scripts/vercel-prebuilt-workflow.mjs" \
+            build
+          started_at_ms="$(date +%s%3N)"
+          cd "$SOURCE_PATH"
+          command_token="mento-$(/usr/bin/openssl rand -hex 16)"
+          echo "::stop-commands::$command_token"
+          set +e
+          sudo --non-interactive /usr/bin/env -i \
+            CI=1 \
+            HOME="$CANDIDATE_HOME_PATH" \
+            HTTP_PROXY="${HTTP_PROXY:-}" \
+            HTTPS_PROXY="${HTTPS_PROXY:-}" \
+            LANG="${LANG:-C.UTF-8}" \
+            LC_ALL="${LC_ALL:-C.UTF-8}" \
+            MENTO_NEXT_DEPLOYMENT_ID="$MENTO_NEXT_DEPLOYMENT_ID" \
+            NEXT_PUBLIC_VERCEL_ENV="$NEXT_PUBLIC_VERCEL_ENV" \
+            NODE_EXTRA_CA_CERTS="${NODE_EXTRA_CA_CERTS:-}" \
+            NO_PROXY="${NO_PROXY:-}" \
+            PATH="$safe_path" \
+            SSL_CERT_FILE="${SSL_CERT_FILE:-}" \
+            TMPDIR="$CANDIDATE_HOME_PATH/tmp" \
+            TURBO_REMOTE_CACHE_SIGNATURE_KEY="$TURBO_REMOTE_CACHE_SIGNATURE_KEY" \
+            TURBO_TEAM="$TURBO_TEAM" \
+            TURBO_TOKEN="$TURBO_TOKEN" \
+            VERCEL="$VERCEL" \
+            VERCEL_ENV="$VERCEL_ENV" \
+            VERCEL_GIT_COMMIT_REF="$VERCEL_GIT_COMMIT_REF" \
+            VERCEL_GIT_COMMIT_SHA="$VERCEL_GIT_COMMIT_SHA" \
+            VERCEL_GIT_PROVIDER="$VERCEL_GIT_PROVIDER" \
+            VERCEL_GIT_REPO_OWNER="$VERCEL_GIT_REPO_OWNER" \
+            VERCEL_GIT_REPO_SLUG="$VERCEL_GIT_REPO_SLUG" \
+            VERCEL_TARGET_ENV="$VERCEL_TARGET_ENV" \
+            XDG_CACHE_HOME="$CANDIDATE_HOME_PATH/cache" \
+            XDG_CONFIG_HOME="$CANDIDATE_HOME_PATH/config" \
+            XDG_DATA_HOME="$CANDIDATE_HOME_PATH/data" \
+            /usr/bin/setpriv \
+            --reuid="$BUILD_UID" \
+            --regid="$BUILD_GID" \
+            --clear-groups \
+            --no-new-privs \
+            -- \
+            "$node_bin" "$vercel_cli" build --yes --target preview --project "$VERCEL_PROJECT_ID" \
+            2>&1
+          candidate_status=$?
+          set -e
+          terminate_candidate
+          echo "::$command_token::"
+          command_token=""
+          if [ "$candidate_status" -ne 0 ]; then
+            exit "$candidate_status"
+          fi
+          trap - EXIT
+          echo "build_duration_ms=$(($(date +%s%3N) - started_at_ms))" >> "$GITHUB_OUTPUT"
 
       - name: Restore trusted controller after source build
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -312,17 +682,139 @@ jobs:
 
       - name: Assert the UI prebuilt output
         env:
+          BUILD_UID: ${{ steps.isolation.outputs.build_uid }}
+          DEPLOY_SHA: ${{ steps.source.outputs.checked_out_sha }}
+          EXPECTED_OUTPUT_GID: ${{ steps.isolation.outputs.build_gid }}
+          EXPECTED_OUTPUT_UID: ${{ steps.isolation.outputs.build_uid }}
           EXPECTED_ROOT_DIRECTORY: ${{ inputs.expected_root_directory }}
+          LOGICAL_TARGET: ${{ inputs.logical_target }}
           MENTO_NEXT_DEPLOYMENT_ID: ${{ steps.prepare.outputs.next_deployment_id }}
-          SOURCE_PATH: ${{ github.workspace }}/source
+          SOURCE_PATH: ${{ runner.temp }}/mento-vercel-candidate-source
+          VERCEL_ORG_ID: ${{ inputs.vercel_org_id }}
+          VERCEL_PROJECT_ID: ${{ inputs.vercel_project_id }}
+        run: |
+          set -euo pipefail
+          if sudo --non-interactive /usr/bin/pgrep -u "$BUILD_UID" >/dev/null 2>&1; then
+            echo "Candidate identity owns a process before output validation" >&2
+            exit 1
+          fi
+          node_bin="$(realpath "$(command -v node)")"
+          sudo --non-interactive /usr/bin/env -i \
+            DEPLOY_SHA="$DEPLOY_SHA" \
+            EXPECTED_OUTPUT_GID="$EXPECTED_OUTPUT_GID" \
+            EXPECTED_OUTPUT_UID="$EXPECTED_OUTPUT_UID" \
+            EXPECTED_PROVENANCE_UID="$(id -u)" \
+            EXPECTED_ROOT_DIRECTORY="$EXPECTED_ROOT_DIRECTORY" \
+            LOGICAL_TARGET="$LOGICAL_TARGET" \
+            MENTO_NEXT_DEPLOYMENT_ID="$MENTO_NEXT_DEPLOYMENT_ID" \
+            PATH="$(dirname "$node_bin"):/usr/bin:/bin" \
+            SOURCE_PATH="$SOURCE_PATH" \
+            VERCEL_ORG_ID="$VERCEL_ORG_ID" \
+            VERCEL_PROJECT_ID="$VERCEL_PROJECT_ID" \
+            "$node_bin" \
+            "$GITHUB_WORKSPACE/controller/scripts/vercel-prebuilt-workflow.mjs" \
+            assert-output
+          if sudo --non-interactive /usr/bin/pgrep -u "$BUILD_UID" >/dev/null 2>&1; then
+            echo "Candidate identity acquired a process while output was validated" >&2
+            exit 1
+          fi
+
+      - name: Revalidate runner-owned pulled UI settings after the build
+        env:
+          EXPECTED_ROOT_DIRECTORY: ${{ inputs.expected_root_directory }}
+          PULL_STAGING_PATH: ${{ runner.temp }}/mento-vercel-pull-staging
+          VERCEL_ORG_ID: ${{ inputs.vercel_org_id }}
+          VERCEL_PROJECT_ID: ${{ inputs.vercel_project_id }}
+        run: node "$GITHUB_WORKSPACE/controller/scripts/vercel-prebuilt-workflow.mjs" validate-pull-staging
+
+      - name: Create immutable runner-owned upload handoff
+        id: handoff
+        env:
+          BUILD_UID: ${{ steps.isolation.outputs.build_uid }}
+          CANDIDATE_HOME_PATH: ${{ runner.temp }}/mento-vercel-candidate-home
+          CANDIDATE_SOURCE_PATH: ${{ runner.temp }}/mento-vercel-candidate-source
+          DEPLOY_SHA: ${{ steps.source.outputs.checked_out_sha }}
+          EXPECTED_ROOT_DIRECTORY: ${{ inputs.expected_root_directory }}
+          PULL_STAGING_PATH: ${{ runner.temp }}/mento-vercel-pull-staging
+          UPLOAD_SOURCE_PATH: ${{ runner.temp }}/mento-vercel-upload-source
+        run: |
+          set -euo pipefail
+          umask 077
+          assert_candidate_stopped() {
+            if sudo --non-interactive /usr/bin/pgrep -u "$BUILD_UID" >/dev/null 2>&1; then
+              sudo --non-interactive /usr/bin/pgrep -a -u "$BUILD_UID" >&2 || true
+              echo "Candidate identity still owns a process" >&2
+              return 1
+            fi
+          }
+          assert_candidate_stopped
+          /usr/bin/install -d -m 0755 \
+            "$UPLOAD_SOURCE_PATH/$EXPECTED_ROOT_DIRECTORY/.vercel/output"
+          sudo --non-interactive /bin/cp -R \
+            --no-dereference \
+            --preserve=mode,timestamps \
+            "$CANDIDATE_SOURCE_PATH/$EXPECTED_ROOT_DIRECTORY/.vercel/output/." \
+            "$UPLOAD_SOURCE_PATH/$EXPECTED_ROOT_DIRECTORY/.vercel/output/"
+          assert_candidate_stopped
+          sudo --non-interactive /bin/chown -R "$(id -u):$(id -g)" \
+            "$UPLOAD_SOURCE_PATH"
+          /bin/chmod -R u-s,g-s,o-t "$UPLOAD_SOURCE_PATH"
+          /bin/chmod -R u+rwX,go+rX,go-w "$UPLOAD_SOURCE_PATH"
+          /usr/bin/install -D -m 0600 \
+            "$PULL_STAGING_PATH/$EXPECTED_ROOT_DIRECTORY/.vercel/project.json" \
+            "$UPLOAD_SOURCE_PATH/$EXPECTED_ROOT_DIRECTORY/.vercel/project.json"
+          printf '{"commitSha":"%s"}\n' "$DEPLOY_SHA" \
+            > "${UPLOAD_SOURCE_PATH}.provenance.json"
+          /bin/chmod 0600 "${UPLOAD_SOURCE_PATH}.provenance.json"
+
+          assert_candidate_stopped
+          sudo --non-interactive /usr/sbin/userdel mento-vercel-build
+          if getent group mento-vercel-build >/dev/null; then
+            sudo --non-interactive /usr/sbin/groupdel mento-vercel-build
+          fi
+          sudo --non-interactive /bin/rm -rf -- "$CANDIDATE_SOURCE_PATH"
+          sudo --non-interactive /bin/rm -rf -- "$CANDIDATE_HOME_PATH"
+          /bin/rm -f -- "${CANDIDATE_SOURCE_PATH}.provenance.json"
+          case "$PULL_STAGING_PATH" in
+            "$RUNNER_TEMP"/mento-vercel-pull-staging) ;;
+            *) echo "Refusing to remove unexpected pull staging" >&2; exit 1 ;;
+          esac
+          /bin/rm -rf -- "$PULL_STAGING_PATH"
+
+          echo "upload_uid=$(id -u)" >> "$GITHUB_OUTPUT"
+          echo "upload_gid=$(id -g)" >> "$GITHUB_OUTPUT"
+
+      - name: Materialize runner-owned upload UI project mapping
+        env:
+          EXPECTED_ROOT_DIRECTORY: ${{ inputs.expected_root_directory }}
+          SOURCE_PATH: ${{ runner.temp }}/mento-vercel-upload-source
+          VERCEL_ORG_ID: ${{ inputs.vercel_org_id }}
+          VERCEL_PROJECT_ID: ${{ inputs.vercel_project_id }}
+        run: node "$GITHUB_WORKSPACE/controller/scripts/vercel-prebuilt-workflow.mjs" prepare-link
+
+      - name: Assert immutable runner-owned upload handoff
+        env:
+          DEPLOY_SHA: ${{ steps.source.outputs.checked_out_sha }}
+          EXPECTED_OUTPUT_GID: ${{ steps.handoff.outputs.upload_gid }}
+          EXPECTED_OUTPUT_UID: ${{ steps.handoff.outputs.upload_uid }}
+          EXPECTED_ROOT_DIRECTORY: ${{ inputs.expected_root_directory }}
+          LOGICAL_TARGET: ${{ inputs.logical_target }}
+          MENTO_NEXT_DEPLOYMENT_ID: ${{ steps.prepare.outputs.next_deployment_id }}
+          SOURCE_PATH: ${{ runner.temp }}/mento-vercel-upload-source
+          VERCEL_ORG_ID: ${{ inputs.vercel_org_id }}
+          VERCEL_PROJECT_ID: ${{ inputs.vercel_project_id }}
         run: node "$GITHUB_WORKSPACE/controller/scripts/vercel-prebuilt-workflow.mjs" assert-output
 
       - name: Upload the verified prebuilt output
         id: deploy
         env:
           DEPLOY_SHA: ${{ steps.source.outputs.checked_out_sha }}
+          EXPECTED_ROOT_DIRECTORY: ${{ inputs.expected_root_directory }}
           GIT_BRANCH: ${{ inputs.git_branch }}
-          SOURCE_PATH: ${{ github.workspace }}/source
+          LOGICAL_TARGET: ${{ inputs.logical_target }}
+          MENTO_NEXT_DEPLOYMENT_ID: ${{ steps.prepare.outputs.next_deployment_id }}
+          SOURCE_PATH: ${{ runner.temp }}/mento-vercel-upload-source
+          TRUSTED_VERCEL_TOOLS_PATH: ${{ runner.temp }}/mento-vercel-trusted-tools
           VERCEL_ORG_ID: ${{ inputs.vercel_org_id }}
           VERCEL_PROJECT_ID: ${{ inputs.vercel_project_id }}
           VERCEL_TOKEN: ${{ secrets.vercel_token }}
@@ -331,13 +823,58 @@ jobs:
       - name: Verify immutable Vercel deployment metadata
         id: verify
         env:
-          SOURCE_PATH: ${{ github.workspace }}/source
+          SOURCE_PATH: ${{ runner.temp }}/mento-vercel-upload-source
+          TRUSTED_VERCEL_TOOLS_PATH: ${{ runner.temp }}/mento-vercel-trusted-tools
           VERCEL_DEPLOYMENT_ID: ${{ steps.deploy.outputs.vercel_deployment_id }}
           VERCEL_DEPLOYMENT_URL: ${{ steps.deploy.outputs.vercel_deployment_url }}
           VERCEL_ORG_ID: ${{ inputs.vercel_org_id }}
           VERCEL_PROJECT_ID: ${{ inputs.vercel_project_id }}
           VERCEL_TOKEN: ${{ secrets.vercel_token }}
         run: node "$GITHUB_WORKSPACE/controller/scripts/vercel-prebuilt-workflow.mjs" verify
+
+      - name: Remove isolated build and upload state
+        if: always()
+        env:
+          CANDIDATE_HOME_PATH: ${{ runner.temp }}/mento-vercel-candidate-home
+          CANDIDATE_SOURCE_PATH: ${{ runner.temp }}/mento-vercel-candidate-source
+          PULL_STAGING_PATH: ${{ runner.temp }}/mento-vercel-pull-staging
+          TRUSTED_VERCEL_TOOLS_PATH: ${{ runner.temp }}/mento-vercel-trusted-tools
+          UPLOAD_SOURCE_PATH: ${{ runner.temp }}/mento-vercel-upload-source
+        run: |
+          set -euo pipefail
+          if getent passwd mento-vercel-build >/dev/null; then
+            build_uid="$(id -u mento-vercel-build)"
+            sudo --non-interactive /usr/bin/pkill -KILL -u "$build_uid" >/dev/null 2>&1 || true
+            for _ in $(seq 1 50); do
+              if ! sudo --non-interactive /usr/bin/pgrep -u "$build_uid" >/dev/null 2>&1; then
+                break
+              fi
+              /bin/sleep 0.1
+            done
+            if sudo --non-interactive /usr/bin/pgrep -u "$build_uid" >/dev/null 2>&1; then
+              echo "Candidate processes survived final cleanup" >&2
+              exit 1
+            fi
+            sudo --non-interactive /usr/sbin/userdel mento-vercel-build
+          fi
+          if getent group mento-vercel-build >/dev/null; then
+            sudo --non-interactive /usr/sbin/groupdel mento-vercel-build
+          fi
+          for path in "$CANDIDATE_HOME_PATH" "$CANDIDATE_SOURCE_PATH" "$PULL_STAGING_PATH" "$TRUSTED_VERCEL_TOOLS_PATH" "$UPLOAD_SOURCE_PATH"; do
+            case "$path" in
+              "$RUNNER_TEMP"/mento-vercel-*) ;;
+              *) echo "Refusing to clean an unexpected path" >&2; exit 1 ;;
+            esac
+          done
+          sudo --non-interactive /bin/rm -rf -- \
+            "$CANDIDATE_HOME_PATH" \
+            "$CANDIDATE_SOURCE_PATH" \
+            "$PULL_STAGING_PATH" \
+            "$UPLOAD_SOURCE_PATH"
+          /bin/rm -rf -- "$TRUSTED_VERCEL_TOOLS_PATH"
+          /bin/rm -f -- \
+            "${CANDIDATE_SOURCE_PATH}.provenance.json" \
+            "${UPLOAD_SOURCE_PATH}.provenance.json"
 
   smoke:
     name: Smoke verified ${{ inputs.logical_target }} preview

--- a/.github/workflows/_vercel-prebuilt.yml
+++ b/.github/workflows/_vercel-prebuilt.yml
@@ -285,28 +285,22 @@ jobs:
             exit 1
           fi
 
-          archive="${RUNNER_TEMP}/mento-vercel-candidate-source.tar"
-          trap '/bin/rm -f -- "$archive"' EXIT
-          git -C "$SOURCE_PATH" archive \
-            --format=tar \
-            --output="$archive" \
-            "$DEPLOY_SHA"
-          if [ "$(git get-tar-commit-id < "$archive")" != "$DEPLOY_SHA" ]; then
-            echo "Candidate archive provenance does not match the exact SHA" >&2
+          source_tree="$(/usr/bin/git -C "$SOURCE_PATH" write-tree)"
+          expected_tree="$(
+            /usr/bin/git -C "$SOURCE_PATH" rev-parse "$DEPLOY_SHA^{tree}"
+          )"
+          if [ "$source_tree" != "$expected_tree" ]; then
+            echo "Candidate source index does not match the exact SHA tree" >&2
             exit 1
           fi
-          /bin/chmod 0444 "$archive"
-          sudo --non-interactive /usr/bin/install \
-            -d -o "$build_uid" -g "$build_gid" -m 0755 \
+          /usr/bin/install -d -m 0755 "$CANDIDATE_SOURCE_PATH"
+          /usr/bin/git -C "$SOURCE_PATH" checkout-index \
+            --all \
+            --force \
+            --prefix="${CANDIDATE_SOURCE_PATH}/"
+          sudo --non-interactive /bin/chown \
+            -R --no-dereference "$build_uid:$build_gid" \
             "$CANDIDATE_SOURCE_PATH"
-          sudo --non-interactive /usr/bin/env -i PATH=/usr/bin:/bin \
-            /usr/bin/setpriv \
-            --reuid="$build_uid" \
-            --regid="$build_gid" \
-            --clear-groups \
-            --no-new-privs \
-            -- \
-            /bin/tar -xf "$archive" -C "$CANDIDATE_SOURCE_PATH"
           sudo --non-interactive /usr/bin/install \
             -d -o "$build_uid" -g "$build_gid" -m 0700 \
             "$CANDIDATE_HOME_PATH" \

--- a/.github/workflows/_vercel-prebuilt.yml
+++ b/.github/workflows/_vercel-prebuilt.yml
@@ -293,11 +293,9 @@ jobs:
             echo "Candidate source index does not match the exact SHA tree" >&2
             exit 1
           fi
-          /usr/bin/install -d -m 0755 "$CANDIDATE_SOURCE_PATH"
-          /usr/bin/git -C "$SOURCE_PATH" checkout-index \
-            --all \
-            --force \
-            --prefix="${CANDIDATE_SOURCE_PATH}/"
+          "$node_bin" \
+            "$GITHUB_WORKSPACE/controller/scripts/vercel-prebuilt-workflow.mjs" \
+            materialize-source
           sudo --non-interactive /bin/chown \
             -R --no-dereference "$build_uid:$build_gid" \
             "$CANDIDATE_SOURCE_PATH"

--- a/docs/vercel-deployments.md
+++ b/docs/vercel-deployments.md
@@ -363,10 +363,14 @@ separately from `vercel build`. The signed Turbo remote build cache remains
 enabled and its hit/miss evidence remains part of the comparison.
 
 Before candidate installation, the worker proves the checked-out index tree is
-the exact selected commit tree, then materializes only that index with
-`git checkout-index` into the isolated candidate root. It deliberately does not
-use `git archive`: candidate-controlled `export-ignore` and `export-subst`
-attributes must not omit files or rewrite bytes in the selected source.
+the exact selected commit tree. A trusted, bounded materializer then lists that
+exact commit with `git ls-tree`, reads every raw blob with `git cat-file`, and
+writes only supported regular files and symbolic links into a fresh fixed path
+under `RUNNER_TEMP`. It rejects unsafe paths, unsupported modes (including
+gitlinks), oversized trees, and filesystem collisions. Reading raw objects
+deliberately bypasses both archive attributes (`export-ignore` and
+`export-subst`) and checkout filters (`eol`, `ident`, and custom filters), so the
+candidate always receives the selected commit's stored bytes.
 
 ### Root Directory and command sequence
 

--- a/docs/vercel-deployments.md
+++ b/docs/vercel-deployments.md
@@ -344,12 +344,14 @@ lifecycle scripts, and copies packages into a runner-owned directory outside
 the checkout. Its `--modules-dir` and `--virtual-store-dir` values are validated
 relative paths from the controller to that directory; pnpm treats an absolute
 `--modules-dir` as project-relative and would otherwise materialize the CLI at
-the wrong path. Before any credentialed command, the worker proves the CLI
+the wrong path. The zero-network fixture requires the already-hydrated package
+store with `--offline`; it cannot contact the registry to repair missing data.
+Before any credentialed command, the worker proves the CLI
 resolves inside the protected directory, its package version is exactly
 `56.2.0`, the candidate UID cannot write it, and `node <cli> --version`
 executes successfully. The workflow test suite repeats this with the actual
-pinned pnpm install in a temporary checkout, preferring the already-hydrated
-package store while retaining a frozen-lockfile failure boundary.
+pinned pnpm install in a temporary checkout while retaining a frozen-lockfile
+failure boundary.
 
 The candidate dependency install intentionally does **not** reuse setup-node's
 writable pnpm store. Its isolated `HOME` and XDG directories place that store
@@ -359,6 +361,12 @@ Actions post-step could save from the trusted `main` run. Treat candidate
 dependency installation as a cold, measured pilot cost; record its duration
 separately from `vercel build`. The signed Turbo remote build cache remains
 enabled and its hit/miss evidence remains part of the comparison.
+
+Before candidate installation, the worker proves the checked-out index tree is
+the exact selected commit tree, then materializes only that index with
+`git checkout-index` into the isolated candidate root. It deliberately does not
+use `git archive`: candidate-controlled `export-ignore` and `export-subst`
+attributes must not omit files or rewrite bytes in the selected source.
 
 ### Root Directory and command sequence
 

--- a/docs/vercel-deployments.md
+++ b/docs/vercel-deployments.md
@@ -296,10 +296,12 @@ reachable for this pilot.
 
 This is a privileged maintainer action, not an automatic PR trigger. Dispatch
 only after reviewing the selected SHA and accepting its same-repository author
-as trusted: dependency installation and the UI build execute that source while
-the job holds preview-only Vercel and Turbo credentials. Fork sources cannot be
-selected, and the workflow rejects Dependabot branches. If the source is not
-trusted, do not dispatch the pilot.
+as trusted: dependency installation and the UI build execute that source with
+the pulled UI preview variables and signed Turbo cache credentials. The
+candidate process never receives the Vercel token, but it can read its own
+build inputs and execute arbitrary build code. Fork sources cannot be selected,
+and the workflow rejects Dependabot branches. If the source is not trusted, do
+not dispatch the pilot.
 
 The dispatch is accepted only from `refs/heads/main`. The caller invokes the
 reusable worker from the same main commit, and the worker validates the caller
@@ -336,13 +338,38 @@ worker also restores the controller from its trusted workflow SHA after
 dependency installation and again after the candidate build, before upload and
 inspection.
 
+The Vercel CLI is a separate trusted tool install. Pinned pnpm `10.24.0` reads
+the main controller's exact `package.json` and frozen `pnpm-lock.yaml`, disables
+lifecycle scripts, and copies packages into a runner-owned directory outside
+the checkout. Its `--modules-dir` and `--virtual-store-dir` values are validated
+relative paths from the controller to that directory; pnpm treats an absolute
+`--modules-dir` as project-relative and would otherwise materialize the CLI at
+the wrong path. Before any credentialed command, the worker proves the CLI
+resolves inside the protected directory, its package version is exactly
+`56.2.0`, the candidate UID cannot write it, and `node <cli> --version`
+executes successfully. The workflow test suite repeats this with the actual
+pinned pnpm install in a temporary checkout, preferring the already-hydrated
+package store while retaining a frozen-lockfile failure boundary.
+
+The candidate dependency install intentionally does **not** reuse setup-node's
+writable pnpm store. Its isolated `HOME` and XDG directories place that store
+under the disposable candidate home, which is deleted before upload. Sharing a
+runner store here would let selected source code mutate cache state that an
+Actions post-step could save from the trusted `main` run. Treat candidate
+dependency installation as a cold, measured pilot cost; record its duration
+separately from `vercel build`. The signed Turbo remote build cache remains
+enabled and its hit/miss evidence remains part of the comparison.
+
 ### Root Directory and command sequence
 
-The pinned Vercel CLI commands all execute with the monorepo root as their
-working directory. Before `vercel pull`, the worker writes an ignored,
-ephemeral repo-level link from the trusted repository variables. This is what
-lets CLI `56.2.0` resolve the UI project's configured Root Directory while all
-commands remain at the monorepo root. The mapping and project-local state are:
+The pinned Vercel CLI commands execute from monorepo-shaped roots. Before
+`vercel pull`, the worker creates a fresh runner-owned staging tree at a fixed
+path under `RUNNER_TEMP`. That tree contains only real
+`apps/ui.mento.org` directory components and an ephemeral repo-level link built
+from trusted repository variables; it contains no checked-out candidate file.
+This lets CLI `56.2.0` resolve the configured UI Root Directory without giving
+the token-bearing pull command a candidate-controlled write path. The pulled
+mapping and project-local state are:
 
 ```text
 .vercel/repo.json
@@ -353,8 +380,24 @@ apps/ui.mento.org/.vercel/output/
 
 The repo link contains only the organization ID, project ID, `origin` remote
 name, and `apps/ui.mento.org` directory mapping; it contains no token or
-environment value. The worker rejects symlinked repo-level Vercel state and
-asserts both the repo link and pulled app settings before building. The
+environment value. After pull, the worker recursively requires the staging
+tree to contain exactly the expected directories and three regular files
+(`repo.json`, `project.json`, and `.env.preview.local`), all runner-owned,
+single-linked, size-bounded, and inaccessible to other users. It rejects
+symlinks, hardlinks, special nodes, extra entries, unsafe ownership, and unsafe
+permissions. With the candidate UID stopped, a trusted root helper removes any
+candidate-provided `.vercel` paths and copies only those three files into new
+candidate-owned directories. Before that copy, the worker validates the UI
+preview build-variable contract directly against the runner-owned staging
+tree. After the copy, clean-environment trusted root helpers validate the exact
+candidate-owned tree and read only the non-secret repo/project mapping: first
+after staging, again with exact-SHA provenance immediately before build, and
+once more for the project/output contract after the candidate build has been
+stopped. These helpers may traverse and `lstat` the candidate-owned `0700` /
+`0600` state, but they never parse the candidate copy of
+`.env.preview.local`; environment values are parsed only from the runner-owned
+staging tree. The internal `validate-candidate-pull` controller action exists
+for this privileged check and is not an operator-facing command. The
 controller validates the ID variables but deliberately withholds them from the
 Vercel CLI child process: CLI `56.2.0` otherwise gives those variables
 precedence over `repo.json` and loses the monorepo Root Directory mapping.
@@ -362,19 +405,33 @@ precedence over `repo.json` and loses the monorepo Root Directory mapping.
 The credentialed worker runs this sequence in one standard `ubuntu-latest`
 job:
 
-1. materialize the exact repo-level UI link from repository variables;
-2. `vercel pull --yes --environment preview --git-branch <validated-branch>`;
-3. `pnpm vercel:env:check --target ui --environment preview
---project-directory apps/ui.mento.org` with the explicit preview system
-   constants overriding pulled values;
-4. `vercel build --yes --target preview` with the signed Turbo remote cache,
-   immutable Git metadata, and generated `MENTO_NEXT_DEPLOYMENT_ID`;
-5. assertions for the UI project mapping, Build Output API v3 config, custom
-   deployment ID, preview target, and pinned CLI build record;
-6. `vercel deploy --prebuilt --target preview --archive=tgz --format=json`;
-7. `vercel inspect --wait --timeout 5m --format=json --scope <org-id>`. The
-   explicit scope prevents inspection from falling back to the token owner's
-   default Vercel team.
+1. create the fresh runner-owned pull staging and exact repo-level UI link;
+2. run `vercel pull --yes --environment preview --git-branch
+<validated-branch>` only inside that staging tree;
+3. recursively validate the pulled tree;
+4. run the equivalent of `pnpm vercel:env:check --target ui --environment
+preview --project-directory "$RUNNER_TEMP/mento-vercel-pull-staging/apps/ui.mento.org"`
+   against that runner-owned tree, with explicit preview system constants
+   overriding pulled values;
+5. copy only the three required files into freshly created candidate `.vercel`
+   directories, then use the trusted privileged controller to prove their
+   exact ownership, permissions, shape, and project mapping while the candidate
+   UID has no process;
+6. immediately before build, repeat the trusted privileged exact-SHA
+   provenance, candidate-tree, and project-mapping checks;
+7. `vercel build --yes --target preview` as the isolated candidate UID with the
+   signed Turbo remote cache, immutable Git metadata, and generated
+   `MENTO_NEXT_DEPLOYMENT_ID`;
+8. stop all candidate-UID processes, then use the trusted privileged controller
+   to assert the UI project mapping, Build Output API v3 config, custom
+   deployment ID, preview target, pinned CLI build record, output ownership,
+   and runner-owned exact-SHA provenance;
+9. create a runner-owned upload handoff containing only the validated output,
+   trusted project settings, repo link, and exact-SHA provenance;
+10. `vercel deploy --prebuilt --target preview --archive=tgz --format=json`;
+11. `vercel inspect --wait --timeout 5m --format=json --scope <org-id>`. The
+    explicit scope prevents inspection from falling back to the token owner's
+    default Vercel team.
 
 Only after that job emits the verified immutable URL does a second trusted job
 perform direct HTTP smoke of the URL, navigation, custom build identity,

--- a/knip.json
+++ b/knip.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://unpkg.com/knip@5/schema.json",
-  "ignoreBinaries": ["anvil", "cast"],
+  "ignoreBinaries": ["anvil", "cast", "mkfifo"],
   "ignoreWorkspaces": ["packages/typescript-config"],
   "ignore": [
     ".trunk/**",

--- a/scripts/vercel-prebuilt-workflow.mjs
+++ b/scripts/vercel-prebuilt-workflow.mjs
@@ -2,20 +2,25 @@
 
 /* eslint-disable turbo/no-undeclared-env-vars -- GitHub Actions supplies these controller-only values outside Turbo tasks. */
 
+import { Buffer } from "node:buffer";
 import { spawnSync } from "node:child_process";
 import {
   appendFileSync,
   chmodSync,
   chownSync,
+  closeSync,
   constants as fsConstants,
   copyFileSync,
   existsSync,
+  fchmodSync,
   lstatSync,
   mkdirSync,
+  openSync,
   readFileSync,
   readdirSync,
   realpathSync,
   rmSync,
+  symlinkSync,
   writeFileSync,
 } from "node:fs";
 import {
@@ -69,6 +74,11 @@ const VERCEL_CLI_BASE_ENVIRONMENT = [
 const PULL_STAGING_DIRECTORY = "mento-vercel-pull-staging";
 const CANDIDATE_SOURCE_DIRECTORY = "mento-vercel-candidate-source";
 const PULLED_ENVIRONMENT_FILE = ".env.preview.local";
+const MAX_SOURCE_ENTRIES = 20_000;
+const MAX_SOURCE_PATH_BYTES = 4_096;
+const MAX_SOURCE_BLOB_BYTES = 32 * 1_024 * 1_024;
+const MAX_SOURCE_TREE_BYTES = 16 * 1_024 * 1_024;
+const MAX_SOURCE_TOTAL_BYTES = 128 * 1_024 * 1_024;
 function requiredText(value, label, { maximum = 2_048 } = {}) {
   if (
     typeof value !== "string" ||
@@ -392,6 +402,286 @@ function assertRunnerTempChild({
     throw new Error("Isolated path is not the expected RUNNER_TEMP child");
   }
   return join(realRunnerTemp, expectedName);
+}
+
+function rawGitEnvironment() {
+  return {
+    GIT_CONFIG_GLOBAL: "/dev/null",
+    GIT_CONFIG_NOSYSTEM: "1",
+    GIT_NO_LAZY_FETCH: "1",
+    GIT_NO_REPLACE_OBJECTS: "1",
+    GIT_OPTIONAL_LOCKS: "0",
+    GIT_TERMINAL_PROMPT: "0",
+    HOME: "/nonexistent",
+    LANG: "C",
+    LC_ALL: "C",
+    PATH: "/usr/bin:/bin",
+  };
+}
+
+function rawGit(
+  repoRoot,
+  arguments_,
+  { input, maximumOutput, run = spawnSync },
+) {
+  const result = run(
+    "/usr/bin/git",
+    ["--no-pager", "--no-replace-objects", "-C", repoRoot, ...arguments_],
+    {
+      encoding: null,
+      env: rawGitEnvironment(),
+      input,
+      maxBuffer: maximumOutput,
+      stdio: ["pipe", "pipe", "pipe"],
+    },
+  );
+  if (result.error || result.status !== 0 || !Buffer.isBuffer(result.stdout)) {
+    throw new Error(`Unable to read exact Git ${arguments_[0]} objects`);
+  }
+  return result.stdout;
+}
+
+function decodeGitPath(pathBytes) {
+  if (pathBytes.length === 0 || pathBytes.length > MAX_SOURCE_PATH_BYTES) {
+    throw new Error("Exact Git tree contains an invalid path length");
+  }
+  let path;
+  try {
+    path = new TextDecoder("utf-8", { fatal: true }).decode(pathBytes);
+  } catch {
+    throw new Error("Exact Git tree contains a non-UTF-8 path");
+  }
+  const components = path.split("/");
+  if (
+    isAbsolute(path) ||
+    components.some(
+      (component) =>
+        component.length === 0 ||
+        component === "." ||
+        component === ".." ||
+        component.toLowerCase() === ".git" ||
+        hasControlCharacters(component),
+    )
+  ) {
+    throw new Error("Exact Git tree contains an unsafe path");
+  }
+  return { components, path };
+}
+
+function parseExactGitTree(rawTree) {
+  const entries = [];
+  const paths = new Set();
+  let offset = 0;
+  while (offset < rawTree.length) {
+    const end = rawTree.indexOf(0, offset);
+    if (end === -1) {
+      throw new Error("Exact Git tree is not NUL terminated");
+    }
+    const record = rawTree.subarray(offset, end);
+    const separator = record.indexOf(0x09);
+    if (separator === -1) {
+      throw new Error("Exact Git tree entry has invalid metadata");
+    }
+    const metadata = record.subarray(0, separator).toString("ascii");
+    const match = /^(\d{6}) ([a-z]+) ([0-9a-f]{40})$/.exec(metadata);
+    if (!match) {
+      throw new Error("Exact Git tree entry has invalid metadata");
+    }
+    const [, mode, type, oid] = match;
+    if (
+      type !== "blob" ||
+      (mode !== "100644" && mode !== "100755" && mode !== "120000")
+    ) {
+      throw new Error("Exact Git tree contains an unsupported entry");
+    }
+    const { components, path } = decodeGitPath(record.subarray(separator + 1));
+    if (paths.has(path)) {
+      throw new Error("Exact Git tree contains a duplicate path");
+    }
+    paths.add(path);
+    entries.push({ components, mode, oid, path });
+    if (entries.length > MAX_SOURCE_ENTRIES) {
+      throw new Error("Exact Git tree contains too many entries");
+    }
+    offset = end + 1;
+  }
+  return entries;
+}
+
+function loadRawGitBlobs(repoRoot, entries, run) {
+  const objectIds = [...new Set(entries.map(({ oid }) => oid))];
+  if (objectIds.length === 0) return new Map();
+  const input = Buffer.from(`${objectIds.join("\n")}\n`, "ascii");
+  const rawSizes = rawGit(
+    repoRoot,
+    ["cat-file", "--batch-check=%(objectname) %(objecttype) %(objectsize)"],
+    {
+      input,
+      maximumOutput: MAX_SOURCE_TREE_BYTES,
+      run,
+    },
+  );
+  const sizeLines = rawSizes.toString("ascii").split("\n");
+  if (sizeLines.at(-1) !== "") {
+    throw new Error("Raw Git blob size response is not newline terminated");
+  }
+  sizeLines.pop();
+  if (sizeLines.length !== objectIds.length) {
+    throw new Error("Raw Git blob size response is incomplete");
+  }
+  const sizes = new Map();
+  for (const [index, line] of sizeLines.entries()) {
+    const match = /^([0-9a-f]{40}) blob ([0-9]+)$/.exec(line);
+    const expectedOid = objectIds[index];
+    if (!match || match[1] !== expectedOid) {
+      throw new Error("Exact Git tree references a non-blob object");
+    }
+    const size = Number(match[2]);
+    if (!Number.isSafeInteger(size) || size > MAX_SOURCE_BLOB_BYTES) {
+      throw new Error("Exact Git tree contains an oversized blob");
+    }
+    sizes.set(expectedOid, size);
+  }
+  let totalBytes = 0;
+  for (const { oid } of entries) {
+    totalBytes += sizes.get(oid);
+    if (totalBytes > MAX_SOURCE_TOTAL_BYTES) {
+      throw new Error("Exact Git tree exceeds the source byte limit");
+    }
+  }
+
+  const rawBlobs = rawGit(repoRoot, ["cat-file", "--batch"], {
+    input,
+    maximumOutput: MAX_SOURCE_TOTAL_BYTES + MAX_SOURCE_TREE_BYTES,
+    run,
+  });
+  const blobs = new Map();
+  let offset = 0;
+  for (const expectedOid of objectIds) {
+    const headerEnd = rawBlobs.indexOf(0x0a, offset);
+    if (headerEnd === -1) {
+      throw new Error("Raw Git blob response is missing a header");
+    }
+    const header = rawBlobs.subarray(offset, headerEnd).toString("ascii");
+    const match = /^([0-9a-f]{40}) blob ([0-9]+)$/.exec(header);
+    const expectedSize = sizes.get(expectedOid);
+    if (
+      !match ||
+      match[1] !== expectedOid ||
+      Number(match[2]) !== expectedSize
+    ) {
+      throw new Error("Raw Git blob response does not match the exact tree");
+    }
+    const bodyStart = headerEnd + 1;
+    const bodyEnd = bodyStart + expectedSize;
+    if (bodyEnd >= rawBlobs.length || rawBlobs[bodyEnd] !== 0x0a) {
+      throw new Error("Raw Git blob response is truncated");
+    }
+    blobs.set(expectedOid, Buffer.from(rawBlobs.subarray(bodyStart, bodyEnd)));
+    offset = bodyEnd + 1;
+  }
+  if (offset !== rawBlobs.length) {
+    throw new Error("Raw Git blob response contains trailing data");
+  }
+  return blobs;
+}
+
+function ensureMaterializedParent(root, components) {
+  let current = root;
+  for (const component of components.slice(0, -1)) {
+    current = join(current, component);
+    const entry = optionalEntry(current);
+    if (entry) {
+      if (entry.isSymbolicLink() || !entry.isDirectory()) {
+        throw new Error("Exact Git tree has a non-directory path component");
+      }
+      continue;
+    }
+    mkdirSync(current, { mode: 0o755 });
+    chmodSync(current, 0o755);
+  }
+}
+
+export function materializeExactGitTree({
+  runnerTemp,
+  sourceRoot,
+  candidateRoot,
+  commitSha,
+  expectedUid = process.getuid?.(),
+  expectedGid = process.getgid?.(),
+  run = spawnSync,
+}) {
+  const sha = validateExactSha(commitSha);
+  requiredText(sourceRoot, "Exact Git source path", {
+    maximum: MAX_SOURCE_PATH_BYTES,
+  });
+  const canonicalSourceRoot = realpathSync(sourceRoot);
+  const sourceEntry = lstatSync(canonicalSourceRoot);
+  if (!sourceEntry.isDirectory()) {
+    throw new Error("Exact Git source must be a real directory");
+  }
+  const canonicalCandidateRoot = assertRunnerTempChild({
+    runnerTemp,
+    path: candidateRoot,
+    expectedName: CANDIDATE_SOURCE_DIRECTORY,
+    expectedUid,
+    expectedGid,
+  });
+  if (optionalEntry(canonicalCandidateRoot)) {
+    throw new Error("Candidate source path must be fresh");
+  }
+  const rawTree = rawGit(
+    canonicalSourceRoot,
+    ["ls-tree", "-r", "-z", "--full-tree", sha],
+    { maximumOutput: MAX_SOURCE_TREE_BYTES, run },
+  );
+  const entries = parseExactGitTree(rawTree);
+  const blobs = loadRawGitBlobs(canonicalSourceRoot, entries, run);
+
+  mkdirSync(canonicalCandidateRoot, { mode: 0o755 });
+  chmodSync(canonicalCandidateRoot, 0o755);
+  for (const entry of entries) {
+    ensureMaterializedParent(canonicalCandidateRoot, entry.components);
+    const destination = join(canonicalCandidateRoot, ...entry.components);
+    if (optionalEntry(destination)) {
+      throw new Error("Exact Git tree contains a filesystem collision");
+    }
+    const blob = blobs.get(entry.oid);
+    if (!blob) throw new Error("Exact Git tree blob was not loaded");
+    if (entry.mode === "120000") {
+      if (
+        blob.length === 0 ||
+        blob.length > MAX_SOURCE_PATH_BYTES ||
+        blob.includes(0)
+      ) {
+        throw new Error("Exact Git tree contains an invalid symbolic link");
+      }
+      symlinkSync(blob, destination);
+      continue;
+    }
+    if (typeof fsConstants.O_NOFOLLOW !== "number") {
+      throw new Error("This platform cannot safely materialize Git blobs");
+    }
+    const descriptor = openSync(
+      destination,
+      fsConstants.O_CREAT |
+        fsConstants.O_EXCL |
+        fsConstants.O_NOFOLLOW |
+        fsConstants.O_WRONLY,
+      0o600,
+    );
+    try {
+      writeFileSync(descriptor, blob);
+      fchmodSync(descriptor, entry.mode === "100755" ? 0o755 : 0o644);
+    } finally {
+      closeSync(descriptor);
+    }
+  }
+  return {
+    bytes: entries.reduce((total, { oid }) => total + blobs.get(oid).length, 0),
+    entries: entries.length,
+    sourceRoot: canonicalCandidateRoot,
+  };
 }
 
 function assertExactFilesystemTree(
@@ -1403,6 +1693,15 @@ function validateSourceFromEnvironment() {
   output("checked_out_sha", result.commitSha);
 }
 
+function materializeSourceFromEnvironment() {
+  materializeExactGitTree({
+    runnerTemp: process.env.RUNNER_TEMP,
+    sourceRoot: process.env.SOURCE_PATH,
+    candidateRoot: process.env.CANDIDATE_SOURCE_PATH,
+    commitSha: process.env.DEPLOY_SHA,
+  });
+}
+
 function pullFromEnvironment() {
   runVercel(
     buildVercelPullArguments({
@@ -1615,6 +1914,7 @@ if (isCliEntrypoint()) {
   const command = process.argv[2];
   if (command === "prepare") prepareFromEnvironment();
   else if (command === "validate-source") validateSourceFromEnvironment();
+  else if (command === "materialize-source") materializeSourceFromEnvironment();
   else if (command === "prepare-link") prepareLinkFromEnvironment();
   else if (command === "prepare-pull-staging")
     preparePullStagingFromEnvironment();
@@ -1639,7 +1939,7 @@ if (isCliEntrypoint()) {
   else if (command === "total") totalFromEnvironment();
   else {
     throw new Error(
-      "Usage: vercel-prebuilt-workflow.mjs prepare|validate-source|prepare-link|prepare-pull-staging|pull|validate-pull|validate-pull-staging|stage-pull|validate-candidate-pull|build|assert-output|trusted-install-modules-dir|deploy|verify|smoke|total",
+      "Usage: vercel-prebuilt-workflow.mjs prepare|validate-source|materialize-source|prepare-link|prepare-pull-staging|pull|validate-pull|validate-pull-staging|stage-pull|validate-candidate-pull|build|assert-output|trusted-install-modules-dir|deploy|verify|smoke|total",
     );
   }
 }

--- a/scripts/vercel-prebuilt-workflow.mjs
+++ b/scripts/vercel-prebuilt-workflow.mjs
@@ -5,14 +5,28 @@
 import { spawnSync } from "node:child_process";
 import {
   appendFileSync,
+  chmodSync,
+  chownSync,
+  constants as fsConstants,
+  copyFileSync,
   existsSync,
   lstatSync,
   mkdirSync,
   readFileSync,
-  statSync,
+  readdirSync,
+  realpathSync,
+  rmSync,
   writeFileSync,
 } from "node:fs";
-import { resolve, join } from "node:path";
+import {
+  basename,
+  dirname,
+  isAbsolute,
+  join,
+  relative,
+  resolve,
+  sep,
+} from "node:path";
 import process from "node:process";
 import { fileURLToPath } from "node:url";
 
@@ -33,6 +47,28 @@ export const PILOT_TARGET = {
 
 const SHA_PATTERN = /^[0-9a-f]{40}$/;
 const VERCEL_DEPLOYMENT_ID_PATTERN = /^dpl_[A-Za-z0-9]+$/;
+const VERCEL_CLI_BASE_ENVIRONMENT = [
+  "CI",
+  "FORCE_COLOR",
+  "HOME",
+  "HTTP_PROXY",
+  "HTTPS_PROXY",
+  "LANG",
+  "LC_ALL",
+  "NODE_EXTRA_CA_CERTS",
+  "NO_PROXY",
+  "PATH",
+  "SSL_CERT_FILE",
+  "TERM",
+  "TMPDIR",
+  "TZ",
+  "http_proxy",
+  "https_proxy",
+  "no_proxy",
+];
+const PULL_STAGING_DIRECTORY = "mento-vercel-pull-staging";
+const CANDIDATE_SOURCE_DIRECTORY = "mento-vercel-candidate-source";
+const PULLED_ENVIRONMENT_FILE = ".env.preview.local";
 function requiredText(value, label, { maximum = 2_048 } = {}) {
   if (
     typeof value !== "string" ||
@@ -302,6 +338,110 @@ function assertPlainFile(path, label) {
   }
 }
 
+function optionalEntry(path) {
+  try {
+    return lstatSync(path);
+  } catch (error) {
+    if (error?.code === "ENOENT") return undefined;
+    throw error;
+  }
+}
+
+function pilotRootDirectory(value) {
+  requiredText(value, "Expected Root Directory");
+  if (
+    value !== PILOT_TARGET.expectedRootDirectory ||
+    isAbsolute(value) ||
+    value === ".." ||
+    value.startsWith(`..${sep}`)
+  ) {
+    throw new Error("Expected Root Directory is not the UI pilot root");
+  }
+  return value;
+}
+
+function assertRunnerTempChild({
+  runnerTemp,
+  path,
+  expectedName,
+  expectedUid = process.getuid?.(),
+  expectedGid = process.getgid?.(),
+}) {
+  requiredText(runnerTemp, "Runner temporary directory");
+  requiredText(path, "Isolated path");
+  if (!isAbsolute(runnerTemp) || !isAbsolute(path)) {
+    throw new Error("Runner isolation paths must be absolute");
+  }
+  const uid = numericIdentity(expectedUid, "Expected runner UID");
+  const gid = numericIdentity(expectedGid, "Expected runner GID");
+  const realRunnerTemp = realpathSync(runnerTemp);
+  const runnerEntry = lstatSync(realRunnerTemp);
+  if (
+    runnerEntry.isSymbolicLink() ||
+    !runnerEntry.isDirectory() ||
+    runnerEntry.uid !== uid ||
+    runnerEntry.gid !== gid ||
+    (runnerEntry.mode & 0o7022) !== 0
+  ) {
+    throw new Error("Runner temporary directory is not protected");
+  }
+  if (
+    basename(path) !== expectedName ||
+    realpathSync(dirname(path)) !== realRunnerTemp
+  ) {
+    throw new Error("Isolated path is not the expected RUNNER_TEMP child");
+  }
+  return join(realRunnerTemp, expectedName);
+}
+
+function assertExactFilesystemTree(
+  root,
+  expectedEntries,
+  { expectedUid = process.getuid?.(), expectedGid = process.getgid?.(), label },
+) {
+  const uid = numericIdentity(expectedUid, `Expected ${label} UID`);
+  const gid = numericIdentity(expectedGid, `Expected ${label} GID`);
+  const expected = new Map(expectedEntries);
+  const seen = new Set();
+  const pending = [root];
+  while (pending.length > 0) {
+    const path = pending.pop();
+    const relativePath = relative(root, path);
+    const specification = expected.get(relativePath);
+    if (!specification) {
+      throw new Error(`${label} contains an unexpected filesystem entry`);
+    }
+    const entry = lstatSync(path);
+    if (entry.uid !== uid || entry.gid !== gid || (entry.mode & 0o7077) !== 0) {
+      throw new Error(`${label} contains unsafe ownership or permissions`);
+    }
+    if (entry.isSymbolicLink()) {
+      throw new Error(`${label} contains a symbolic link`);
+    }
+    if (specification.type === "directory") {
+      if (!entry.isDirectory()) {
+        throw new Error(`${label} contains a non-directory component`);
+      }
+      for (const child of readdirSync(path)) pending.push(join(path, child));
+    } else {
+      if (!entry.isFile()) {
+        throw new Error(`${label} contains a special filesystem node`);
+      }
+      if (entry.nlink !== 1) {
+        throw new Error(`${label} contains a hard-linked file`);
+      }
+      if (entry.size > specification.maximumSize) {
+        throw new Error(`${label} contains an oversized file`);
+      }
+    }
+    seen.add(relativePath);
+  }
+  if (seen.size !== expected.size) {
+    throw new Error(`${label} is missing a required filesystem entry`);
+  }
+  return root;
+}
+
 export function materializeVercelRepoLink({
   repoRoot,
   expectedRootDirectory,
@@ -309,9 +449,7 @@ export function materializeVercelRepoLink({
   vercelProjectId,
 }) {
   requiredText(repoRoot, "Source path");
-  if (expectedRootDirectory !== PILOT_TARGET.expectedRootDirectory) {
-    throw new Error("The repo link must target the UI project Root Directory");
-  }
+  pilotRootDirectory(expectedRootDirectory);
   const link = {
     remoteName: "origin",
     projects: [
@@ -334,14 +472,406 @@ export function materializeVercelRepoLink({
   return link;
 }
 
-export function environmentForVercelCli(environment) {
-  const cliEnvironment = { ...environment };
+function pulledStateEntries(expectedRootDirectory) {
+  return [
+    ["", { type: "directory" }],
+    [".vercel", { type: "directory" }],
+    [join(".vercel", "repo.json"), { type: "file", maximumSize: 64 * 1_024 }],
+    ["apps", { type: "directory" }],
+    [expectedRootDirectory, { type: "directory" }],
+    [join(expectedRootDirectory, ".vercel"), { type: "directory" }],
+    [
+      join(expectedRootDirectory, ".vercel", "project.json"),
+      { type: "file", maximumSize: 256 * 1_024 },
+    ],
+    [
+      join(expectedRootDirectory, ".vercel", PULLED_ENVIRONMENT_FILE),
+      { type: "file", maximumSize: 16 * 1_024 * 1_024 },
+    ],
+  ];
+}
+
+function assertExactPulledConfiguration({
+  repoRoot,
+  expectedRootDirectory,
+  expectedUid,
+  expectedGid,
+  label,
+}) {
+  const stateEntries = pulledStateEntries(expectedRootDirectory);
+  const repoStateEntries = stateEntries
+    .filter(([path]) => path === ".vercel" || path.startsWith(`.vercel${sep}`))
+    .map(([path, specification]) => [relative(".vercel", path), specification]);
+  const appStateRoot = join(expectedRootDirectory, ".vercel");
+  const appStateEntries = stateEntries
+    .filter(
+      ([path]) =>
+        path === appStateRoot || path.startsWith(`${appStateRoot}${sep}`),
+    )
+    .map(([path, specification]) => [
+      relative(appStateRoot, path),
+      specification,
+    ]);
+  assertExactFilesystemTree(join(repoRoot, ".vercel"), repoStateEntries, {
+    expectedUid,
+    expectedGid,
+    label,
+  });
+  assertExactFilesystemTree(join(repoRoot, appStateRoot), appStateEntries, {
+    expectedUid,
+    expectedGid,
+    label,
+  });
+}
+
+export function prepareVercelPullStaging({
+  runnerTemp,
+  stagingRoot,
+  expectedRootDirectory,
+  vercelOrgId,
+  vercelProjectId,
+}) {
+  pilotRootDirectory(expectedRootDirectory);
+  const canonicalStagingRoot = assertRunnerTempChild({
+    runnerTemp,
+    path: stagingRoot,
+    expectedName: PULL_STAGING_DIRECTORY,
+  });
+  if (optionalEntry(canonicalStagingRoot)) {
+    throw new Error("Vercel pull staging must be fresh");
+  }
+  mkdirSync(canonicalStagingRoot, { mode: 0o700 });
+  let current = canonicalStagingRoot;
+  for (const component of expectedRootDirectory.split("/")) {
+    current = join(current, component);
+    mkdirSync(current, { mode: 0o700 });
+  }
+  const link = materializeVercelRepoLink({
+    repoRoot: canonicalStagingRoot,
+    expectedRootDirectory,
+    vercelOrgId,
+    vercelProjectId,
+  });
+  chmodSync(join(canonicalStagingRoot, ".vercel"), 0o700);
+  chmodSync(join(canonicalStagingRoot, ".vercel", "repo.json"), 0o600);
+  return link;
+}
+
+export function assertVercelPullStaging({
+  runnerTemp,
+  stagingRoot,
+  expectedRootDirectory,
+  vercelOrgId,
+  vercelProjectId,
+  expectedUid = process.getuid?.(),
+  expectedGid = process.getgid?.(),
+}) {
+  pilotRootDirectory(expectedRootDirectory);
+  const canonicalStagingRoot = assertRunnerTempChild({
+    runnerTemp,
+    path: stagingRoot,
+    expectedName: PULL_STAGING_DIRECTORY,
+    expectedUid,
+    expectedGid,
+  });
+  if (realpathSync(stagingRoot) !== canonicalStagingRoot) {
+    throw new Error("Vercel pull staging resolves outside RUNNER_TEMP");
+  }
+  assertExactFilesystemTree(
+    canonicalStagingRoot,
+    pulledStateEntries(expectedRootDirectory),
+    {
+      expectedUid,
+      expectedGid,
+      label: "Vercel pull staging",
+    },
+  );
+  return assertPulledProject({
+    repoRoot: canonicalStagingRoot,
+    expectedRootDirectory,
+    vercelOrgId,
+    vercelProjectId,
+  });
+}
+
+function assertCandidateRootComponents({
+  runnerTemp,
+  candidateRoot,
+  expectedRootDirectory,
+  buildUid,
+  buildGid,
+  runnerUid,
+  runnerGid,
+}) {
+  const canonicalCandidateRoot = assertRunnerTempChild({
+    runnerTemp,
+    path: candidateRoot,
+    expectedName: CANDIDATE_SOURCE_DIRECTORY,
+    expectedUid: runnerUid,
+    expectedGid: runnerGid,
+  });
+  if (realpathSync(candidateRoot) !== canonicalCandidateRoot) {
+    throw new Error("Candidate source resolves outside RUNNER_TEMP");
+  }
+  let current = canonicalCandidateRoot;
+  for (const [path, label] of [
+    [canonicalCandidateRoot, "Candidate source"],
+    ...expectedRootDirectory.split("/").map((component) => {
+      current = join(current, component);
+      return [current, "Candidate UI Root Directory"];
+    }),
+  ]) {
+    const entry = lstatSync(path);
+    if (
+      entry.isSymbolicLink() ||
+      !entry.isDirectory() ||
+      entry.uid !== buildUid ||
+      entry.gid !== buildGid
+    ) {
+      throw new Error(`${label} contains an unsafe path component`);
+    }
+  }
+  return canonicalCandidateRoot;
+}
+
+function assertCandidateVercelPull({
+  runnerTemp,
+  candidateRoot,
+  expectedRootDirectory,
+  vercelOrgId,
+  vercelProjectId,
+  buildUid,
+  buildGid,
+  runnerUid,
+  runnerGid,
+}) {
+  const candidateUid = numericIdentity(buildUid, "Candidate build UID");
+  const candidateGid = numericIdentity(buildGid, "Candidate build GID");
+  const trustedUid = numericIdentity(runnerUid, "Runner UID");
+  const trustedGid = numericIdentity(runnerGid, "Runner GID");
+  const canonicalCandidateRoot = assertCandidateRootComponents({
+    runnerTemp,
+    candidateRoot,
+    expectedRootDirectory,
+    buildUid: candidateUid,
+    buildGid: candidateGid,
+    runnerUid: trustedUid,
+    runnerGid: trustedGid,
+  });
+  assertExactPulledConfiguration({
+    repoRoot: canonicalCandidateRoot,
+    expectedRootDirectory,
+    expectedUid: candidateUid,
+    expectedGid: candidateGid,
+    label: "Candidate Vercel state",
+  });
+  return assertPulledProject({
+    repoRoot: canonicalCandidateRoot,
+    expectedRootDirectory,
+    vercelOrgId,
+    vercelProjectId,
+  });
+}
+
+export function stageVercelPullForCandidate({
+  runnerTemp,
+  stagingRoot,
+  candidateRoot,
+  expectedRootDirectory,
+  vercelOrgId,
+  vercelProjectId,
+  buildUid,
+  buildGid,
+  runnerUid,
+  runnerGid,
+}) {
+  const candidateUid = numericIdentity(buildUid, "Candidate build UID");
+  const candidateGid = numericIdentity(buildGid, "Candidate build GID");
+  const trustedUid = numericIdentity(runnerUid, "Runner UID");
+  const trustedGid = numericIdentity(runnerGid, "Runner GID");
+  assertVercelPullStaging({
+    runnerTemp,
+    stagingRoot,
+    expectedRootDirectory,
+    vercelOrgId,
+    vercelProjectId,
+    expectedUid: trustedUid,
+    expectedGid: trustedGid,
+  });
+  const canonicalCandidateRoot = assertCandidateRootComponents({
+    runnerTemp,
+    candidateRoot,
+    expectedRootDirectory,
+    buildUid: candidateUid,
+    buildGid: candidateGid,
+    runnerUid: trustedUid,
+    runnerGid: trustedGid,
+  });
+  const candidateRepoState = join(canonicalCandidateRoot, ".vercel");
+  const candidateAppState = join(
+    canonicalCandidateRoot,
+    expectedRootDirectory,
+    ".vercel",
+  );
+  for (const path of [candidateRepoState, candidateAppState]) {
+    rmSync(path, { force: true, recursive: true });
+    mkdirSync(path, { mode: 0o700 });
+    chownSync(path, candidateUid, candidateGid);
+    chmodSync(path, 0o700);
+  }
+  const copies = [
+    [join(".vercel", "repo.json"), join(".vercel", "repo.json")],
+    [
+      join(expectedRootDirectory, ".vercel", "project.json"),
+      join(expectedRootDirectory, ".vercel", "project.json"),
+    ],
+    [
+      join(expectedRootDirectory, ".vercel", PULLED_ENVIRONMENT_FILE),
+      join(expectedRootDirectory, ".vercel", PULLED_ENVIRONMENT_FILE),
+    ],
+  ];
+  for (const [sourcePath, destinationPath] of copies) {
+    const destination = join(canonicalCandidateRoot, destinationPath);
+    copyFileSync(
+      join(stagingRoot, sourcePath),
+      destination,
+      fsConstants.COPYFILE_EXCL,
+    );
+    chownSync(destination, candidateUid, candidateGid);
+    chmodSync(destination, 0o600);
+  }
+  return assertCandidateVercelPull({
+    runnerTemp,
+    candidateRoot: canonicalCandidateRoot,
+    expectedRootDirectory,
+    vercelOrgId,
+    vercelProjectId,
+    buildUid: candidateUid,
+    buildGid: candidateGid,
+    runnerUid: trustedUid,
+    runnerGid: trustedGid,
+  });
+}
+
+export function environmentForVercelCli(environment, allowedNames = []) {
+  const cliEnvironment = {};
+  for (const name of new Set([
+    ...VERCEL_CLI_BASE_ENVIRONMENT,
+    ...allowedNames,
+  ])) {
+    const value = environment[name];
+    if (value === undefined || value === "") continue;
+    cliEnvironment[name] = requiredText(value, name, { maximum: 32_768 });
+  }
   // CLI 56.2.0 gives these variables precedence over repo.json and would lose
   // the monorepo Root Directory mapping. The controller has already validated
   // the IDs and materialized them in the trusted repo link.
   delete cliEnvironment.VERCEL_ORG_ID;
   delete cliEnvironment.VERCEL_PROJECT_ID;
   return cliEnvironment;
+}
+
+export function trustedPnpmInstallLayout({ controllerRoot, toolsRoot }) {
+  requiredText(controllerRoot, "Trusted controller path");
+  requiredText(toolsRoot, "Trusted Vercel tools path");
+  if (!isAbsolute(controllerRoot) || !isAbsolute(toolsRoot)) {
+    throw new Error("Trusted pnpm install paths must be absolute");
+  }
+
+  const realControllerRoot = realpathSync(controllerRoot);
+  const realToolsRoot = realpathSync(toolsRoot);
+  const controllerEntry = lstatSync(realControllerRoot);
+  const toolsEntry = lstatSync(realToolsRoot);
+  const currentUid = process.getuid?.();
+  if (
+    currentUid === undefined ||
+    controllerEntry.isSymbolicLink() ||
+    !controllerEntry.isDirectory() ||
+    controllerEntry.uid !== currentUid ||
+    (controllerEntry.mode & 0o022) !== 0 ||
+    toolsEntry.isSymbolicLink() ||
+    !toolsEntry.isDirectory() ||
+    toolsEntry.uid !== currentUid ||
+    (toolsEntry.mode & 0o022) !== 0
+  ) {
+    throw new Error("Trusted pnpm install roots are not runner-protected");
+  }
+
+  const toolsFromController = relative(realControllerRoot, realToolsRoot);
+  if (
+    toolsFromController !== ".." &&
+    !toolsFromController.startsWith(`..${sep}`)
+  ) {
+    throw new Error("Trusted Vercel tools must be outside the checkout");
+  }
+
+  const modulesPath = join(realToolsRoot, "node_modules");
+  const modulesDir = relative(realControllerRoot, modulesPath);
+  if (
+    modulesDir === "" ||
+    isAbsolute(modulesDir) ||
+    hasControlCharacters(modulesDir) ||
+    resolve(realControllerRoot, modulesDir) !== modulesPath
+  ) {
+    throw new Error("Trusted pnpm modules path is invalid");
+  }
+  return {
+    modulesDir,
+    virtualStoreDir: join(modulesDir, ".pnpm"),
+  };
+}
+
+export function trustedVercelCliPath(toolsPath) {
+  requiredText(toolsPath, "Trusted Vercel tools path");
+  if (!isAbsolute(toolsPath)) {
+    throw new Error("Trusted Vercel tools path must be absolute");
+  }
+  const toolsEntry = lstatSync(toolsPath);
+  const currentUid = process.getuid?.();
+  if (
+    toolsEntry.isSymbolicLink() ||
+    !toolsEntry.isDirectory() ||
+    currentUid === undefined ||
+    toolsEntry.uid !== currentUid ||
+    (toolsEntry.mode & 0o022) !== 0
+  ) {
+    throw new Error("Trusted Vercel tools directory is not runner-owned");
+  }
+
+  const realToolsPath = realpathSync(toolsPath);
+  const cliPath = realpathSync(
+    join(toolsPath, "node_modules", "vercel", "dist", "index.js"),
+  );
+  const pathFromTools = relative(realToolsPath, cliPath);
+  if (
+    pathFromTools === "" ||
+    pathFromTools === ".." ||
+    pathFromTools.startsWith(`..${sep}`) ||
+    isAbsolute(pathFromTools)
+  ) {
+    throw new Error("Trusted Vercel CLI resolves outside its tools directory");
+  }
+  const cliEntry = lstatSync(cliPath);
+  if (
+    cliEntry.isSymbolicLink() ||
+    !cliEntry.isFile() ||
+    cliEntry.uid !== currentUid ||
+    (cliEntry.mode & 0o022) !== 0
+  ) {
+    throw new Error("Trusted Vercel CLI is not a protected runner-owned file");
+  }
+  const packagePath = resolve(cliPath, "..", "..", "package.json");
+  const packageEntry = lstatSync(packagePath);
+  if (
+    packageEntry.isSymbolicLink() ||
+    !packageEntry.isFile() ||
+    packageEntry.uid !== currentUid ||
+    (packageEntry.mode & 0o022) !== 0 ||
+    JSON.parse(readFileSync(packagePath, "utf8")).version !== "56.2.0"
+  ) {
+    throw new Error("Trusted Vercel CLI version is not the pinned release");
+  }
+  return cliPath;
 }
 
 function immutableVercelUrl(value) {
@@ -415,28 +945,57 @@ export function assertPulledProject({
   vercelOrgId,
   vercelProjectId,
 }) {
+  requiredText(repoRoot, "Source path");
+  pilotRootDirectory(expectedRootDirectory);
+  const realRepoRoot = realpathSync(repoRoot);
+  const targetRoot = join(repoRoot, expectedRootDirectory);
+  const pathFromRepo = relative(realRepoRoot, realpathSync(targetRoot));
+  if (
+    pathFromRepo === "" ||
+    pathFromRepo === ".." ||
+    pathFromRepo.startsWith(`..${sep}`) ||
+    isAbsolute(pathFromRepo)
+  ) {
+    throw new Error("Expected Root Directory escapes the source path");
+  }
   const repoLinkPath = join(repoRoot, ".vercel", "repo.json");
-  const settingsPath = join(
-    repoRoot,
-    expectedRootDirectory,
-    ".vercel",
-    "project.json",
-  );
+  const settingsPath = join(targetRoot, ".vercel", "project.json");
   let repoLink;
   let project;
   try {
+    for (const [path, label, directory] of [
+      [repoRoot, "Source path", true],
+      [join(repoRoot, ".vercel"), "Repo-level Vercel state", true],
+      [repoLinkPath, "Repo-level Vercel link", false],
+      [targetRoot, "UI Root Directory", true],
+      [join(targetRoot, ".vercel"), "UI Vercel state", true],
+      [settingsPath, "Pulled Vercel project settings", false],
+    ]) {
+      const entry = lstatSync(path);
+      if (
+        entry.isSymbolicLink() ||
+        (directory ? !entry.isDirectory() : !entry.isFile())
+      ) {
+        throw new Error(`${label} has an unsafe filesystem type`);
+      }
+    }
     repoLink = JSON.parse(readFileSync(repoLinkPath, "utf8"));
     project = JSON.parse(readFileSync(settingsPath, "utf8"));
   } catch {
     throw new Error("Vercel pull did not materialize valid project settings");
   }
   const linkedProject = repoLink.projects?.[0];
+  const projectHasNoIdentity =
+    project.orgId === undefined && project.projectId === undefined;
+  const projectHasExactIdentity =
+    project.orgId === vercelOrgId && project.projectId === vercelProjectId;
   if (
     repoLink.remoteName !== "origin" ||
     repoLink.projects?.length !== 1 ||
     linkedProject?.orgId !== vercelOrgId ||
     linkedProject?.id !== vercelProjectId ||
     linkedProject?.directory !== expectedRootDirectory ||
+    (!projectHasNoIdentity && !projectHasExactIdentity) ||
     project.settings?.rootDirectory !== expectedRootDirectory
   ) {
     throw new Error(
@@ -450,6 +1009,8 @@ export function assertPrebuiltOutput({
   repoRoot,
   expectedRootDirectory,
   deploymentId,
+  expectedUid = process.getuid?.(),
+  expectedGid = process.getgid?.(),
 }) {
   const outputDirectory = join(
     repoRoot,
@@ -458,8 +1019,10 @@ export function assertPrebuiltOutput({
     "output",
   );
   const configPath = join(outputDirectory, "config.json");
-  if (!statSync(configPath).isFile()) {
-    throw new Error("Prebuilt output config is not a file");
+  assertSafeOutputTree(outputDirectory, { expectedUid, expectedGid });
+  const configEntry = lstatSync(configPath);
+  if (configEntry.isSymbolicLink() || !configEntry.isFile()) {
+    throw new Error("Prebuilt output config is not a regular file");
   }
   const config = JSON.parse(readFileSync(configPath, "utf8"));
   if (config.version !== 3) {
@@ -480,6 +1043,137 @@ export function assertPrebuiltOutput({
   }
   assertPrebuiltDeploymentId(outputDirectory, deploymentId);
   return outputDirectory;
+}
+
+function numericIdentity(value, label) {
+  const numeric = typeof value === "string" ? Number(value) : value;
+  if (!Number.isSafeInteger(numeric) || numeric < 0) {
+    throw new Error(`${label} is invalid`);
+  }
+  return numeric;
+}
+
+function assertSafeOutputTree(
+  outputDirectory,
+  { expectedUid = process.getuid?.(), expectedGid = process.getgid?.() } = {},
+) {
+  const uid = numericIdentity(expectedUid, "Expected output UID");
+  const gid = numericIdentity(expectedGid, "Expected output GID");
+  const pending = [outputDirectory];
+  let entries = 0;
+  while (pending.length > 0) {
+    const path = pending.pop();
+    const entry = lstatSync(path);
+    entries += 1;
+    if (entries > 250_000) {
+      throw new Error("Prebuilt output contains too many filesystem entries");
+    }
+    if (entry.uid !== uid || entry.gid !== gid) {
+      throw new Error(
+        "Prebuilt output contains an entry with unsafe ownership",
+      );
+    }
+    if (
+      uid === process.getuid?.() &&
+      ((entry.mode & 0o022) !== 0 || (entry.mode & 0o7000) !== 0)
+    ) {
+      throw new Error("Runner-owned prebuilt output has unsafe permissions");
+    }
+    if (entry.isSymbolicLink()) {
+      throw new Error("Prebuilt output contains a symbolic link");
+    }
+    if (entry.isDirectory()) {
+      for (const child of readdirSync(path)) pending.push(join(path, child));
+      continue;
+    }
+    if (!entry.isFile()) {
+      throw new Error("Prebuilt output contains a special filesystem node");
+    }
+    if (uid === process.getuid?.() && entry.nlink !== 1) {
+      throw new Error("Prebuilt output contains a hard-linked file");
+    }
+  }
+  return outputDirectory;
+}
+
+function assertCandidateProvenance(
+  repoRoot,
+  commitSha,
+  expectedUid = process.getuid?.(),
+) {
+  const provenancePath = `${repoRoot}.provenance.json`;
+  const provenanceUid = numericIdentity(
+    expectedUid,
+    "Expected provenance owner UID",
+  );
+  let provenance;
+  try {
+    const entry = lstatSync(provenancePath);
+    if (
+      entry.isSymbolicLink() ||
+      !entry.isFile() ||
+      entry.uid !== provenanceUid ||
+      (entry.mode & 0o022) !== 0
+    ) {
+      throw new Error("unsafe provenance file");
+    }
+    provenance = JSON.parse(readFileSync(provenancePath, "utf8"));
+  } catch {
+    throw new Error("Prebuilt source provenance is missing or invalid");
+  }
+  const sha = validateExactSha(commitSha);
+  if (
+    !provenance ||
+    typeof provenance !== "object" ||
+    Array.isArray(provenance) ||
+    Object.keys(provenance).length !== 1 ||
+    provenance.commitSha !== sha
+  ) {
+    throw new Error("Prebuilt source provenance does not match the exact SHA");
+  }
+  return provenance;
+}
+
+export function assertPrebuiltReadyForUpload({
+  repoRoot,
+  logicalTarget,
+  expectedRootDirectory,
+  vercelOrgId,
+  vercelProjectId,
+  deploymentId,
+  commitSha,
+  expectedUid = process.getuid?.(),
+  expectedGid = process.getgid?.(),
+  expectedProvenanceUid = process.getuid?.(),
+}) {
+  if (
+    logicalTarget !== PILOT_TARGET.logicalTarget ||
+    expectedRootDirectory !== PILOT_TARGET.expectedRootDirectory
+  ) {
+    throw new Error("Prebuilt upload is not the UI pilot target");
+  }
+  assertCandidateProvenance(repoRoot, commitSha, expectedProvenanceUid);
+  assertPulledProject({
+    repoRoot,
+    expectedRootDirectory,
+    vercelOrgId,
+    vercelProjectId,
+  });
+  return assertPrebuiltOutput({
+    repoRoot,
+    expectedRootDirectory,
+    deploymentId,
+    expectedUid,
+    expectedGid,
+  });
+}
+
+export async function withValidatedPrebuiltUpload(options, upload) {
+  if (typeof upload !== "function") {
+    throw new Error("Prebuilt upload callback is invalid");
+  }
+  assertPrebuiltReadyForUpload(options);
+  return upload();
 }
 
 function requireHeader(response, name, expected) {
@@ -665,10 +1359,16 @@ function requiredEnvironment(names) {
 
 function runVercel(arguments_, { capture = false } = {}) {
   assertSafeVercelArguments(arguments_);
-  requiredEnvironment(["VERCEL_TOKEN", "VERCEL_ORG_ID", "VERCEL_PROJECT_ID"]);
-  const result = spawnSync("pnpm", ["exec", "vercel", ...arguments_], {
+  requiredEnvironment([
+    "TRUSTED_VERCEL_TOOLS_PATH",
+    "VERCEL_TOKEN",
+    "VERCEL_ORG_ID",
+    "VERCEL_PROJECT_ID",
+  ]);
+  const cliPath = trustedVercelCliPath(process.env.TRUSTED_VERCEL_TOOLS_PATH);
+  const result = spawnSync(process.execPath, [cliPath, ...arguments_], {
     cwd: process.env.SOURCE_PATH,
-    env: environmentForVercelCli(process.env),
+    env: environmentForVercelCli(process.env, ["VERCEL_TOKEN"]),
     encoding: "utf8",
     stdio: capture
       ? ["ignore", "pipe", "inherit"]
@@ -721,6 +1421,57 @@ function prepareLinkFromEnvironment() {
   });
 }
 
+function preparePullStagingFromEnvironment() {
+  prepareVercelPullStaging({
+    runnerTemp: process.env.RUNNER_TEMP,
+    stagingRoot: process.env.PULL_STAGING_PATH,
+    expectedRootDirectory: process.env.EXPECTED_ROOT_DIRECTORY,
+    vercelOrgId: process.env.VERCEL_ORG_ID,
+    vercelProjectId: process.env.VERCEL_PROJECT_ID,
+  });
+}
+
+function validatePullStagingFromEnvironment() {
+  assertVercelPullStaging({
+    runnerTemp: process.env.RUNNER_TEMP,
+    stagingRoot: process.env.PULL_STAGING_PATH,
+    expectedRootDirectory: process.env.EXPECTED_ROOT_DIRECTORY,
+    vercelOrgId: process.env.VERCEL_ORG_ID,
+    vercelProjectId: process.env.VERCEL_PROJECT_ID,
+    expectedUid: process.env.PULL_STAGING_UID ?? process.getuid?.(),
+    expectedGid: process.env.PULL_STAGING_GID ?? process.getgid?.(),
+  });
+}
+
+function stagePullFromEnvironment() {
+  stageVercelPullForCandidate({
+    runnerTemp: process.env.RUNNER_TEMP,
+    stagingRoot: process.env.PULL_STAGING_PATH,
+    candidateRoot: process.env.CANDIDATE_SOURCE_PATH,
+    expectedRootDirectory: process.env.EXPECTED_ROOT_DIRECTORY,
+    vercelOrgId: process.env.VERCEL_ORG_ID,
+    vercelProjectId: process.env.VERCEL_PROJECT_ID,
+    buildUid: process.env.BUILD_UID,
+    buildGid: process.env.BUILD_GID,
+    runnerUid: process.env.PULL_STAGING_UID,
+    runnerGid: process.env.PULL_STAGING_GID,
+  });
+}
+
+function validateCandidatePullFromEnvironment() {
+  assertCandidateVercelPull({
+    runnerTemp: process.env.RUNNER_TEMP,
+    candidateRoot: process.env.CANDIDATE_SOURCE_PATH,
+    expectedRootDirectory: process.env.EXPECTED_ROOT_DIRECTORY,
+    vercelOrgId: process.env.VERCEL_ORG_ID,
+    vercelProjectId: process.env.VERCEL_PROJECT_ID,
+    buildUid: process.env.BUILD_UID,
+    buildGid: process.env.BUILD_GID,
+    runnerUid: process.env.PULL_STAGING_UID,
+    runnerGid: process.env.PULL_STAGING_GID,
+  });
+}
+
 function validatePullFromEnvironment() {
   assertPulledProject({
     repoRoot: process.env.SOURCE_PATH,
@@ -732,35 +1483,77 @@ function validatePullFromEnvironment() {
 
 function buildFromEnvironment() {
   requiredEnvironment([
+    "BUILD_GID",
+    "BUILD_UID",
+    "DEPLOY_SHA",
+    "EXPECTED_ROOT_DIRECTORY",
+    "PULL_STAGING_GID",
+    "PULL_STAGING_UID",
+    "RUNNER_TEMP",
+    "SOURCE_PATH",
     "TURBO_TEAM",
     "TURBO_TOKEN",
     "TURBO_REMOTE_CACHE_SIGNATURE_KEY",
     "MENTO_NEXT_DEPLOYMENT_ID",
+    "VERCEL_GIT_COMMIT_SHA",
+    "VERCEL_ORG_ID",
+    "VERCEL_PROJECT_ID",
   ]);
-  const started = Date.now();
-  runVercel(
-    buildVercelBuildArguments({ projectId: process.env.VERCEL_PROJECT_ID }),
+  if (process.env.VERCEL_GIT_COMMIT_SHA !== process.env.DEPLOY_SHA) {
+    throw new Error("Build commit metadata does not match the exact SHA");
+  }
+  assertCandidateProvenance(
+    process.env.SOURCE_PATH,
+    process.env.DEPLOY_SHA,
+    process.env.PULL_STAGING_UID,
   );
-  output("build_duration_ms", String(Date.now() - started));
-}
-
-function assertOutputFromEnvironment() {
-  assertPrebuiltOutput({
-    repoRoot: process.env.SOURCE_PATH,
+  assertCandidateVercelPull({
+    runnerTemp: process.env.RUNNER_TEMP,
+    candidateRoot: process.env.SOURCE_PATH,
     expectedRootDirectory: process.env.EXPECTED_ROOT_DIRECTORY,
-    deploymentId: process.env.MENTO_NEXT_DEPLOYMENT_ID,
+    vercelOrgId: process.env.VERCEL_ORG_ID,
+    vercelProjectId: process.env.VERCEL_PROJECT_ID,
+    buildUid: process.env.BUILD_UID,
+    buildGid: process.env.BUILD_GID,
+    runnerUid: process.env.PULL_STAGING_UID,
+    runnerGid: process.env.PULL_STAGING_GID,
   });
 }
 
-function deployFromEnvironment() {
+function assertOutputFromEnvironment() {
+  assertPrebuiltReadyForUpload({
+    repoRoot: process.env.SOURCE_PATH,
+    logicalTarget: process.env.LOGICAL_TARGET,
+    expectedRootDirectory: process.env.EXPECTED_ROOT_DIRECTORY,
+    vercelOrgId: process.env.VERCEL_ORG_ID,
+    vercelProjectId: process.env.VERCEL_PROJECT_ID,
+    deploymentId: process.env.MENTO_NEXT_DEPLOYMENT_ID,
+    commitSha: process.env.DEPLOY_SHA,
+    expectedUid: process.env.EXPECTED_OUTPUT_UID,
+    expectedGid: process.env.EXPECTED_OUTPUT_GID,
+    expectedProvenanceUid:
+      process.env.EXPECTED_PROVENANCE_UID ?? process.getuid?.(),
+  });
+}
+
+async function deployFromEnvironment() {
   const started = Date.now();
-  const raw = runVercel(
-    buildVercelDeployArguments({
-      projectId: process.env.VERCEL_PROJECT_ID,
+  const arguments_ = buildVercelDeployArguments({
+    projectId: process.env.VERCEL_PROJECT_ID,
+    commitSha: process.env.DEPLOY_SHA,
+    gitBranch: process.env.GIT_BRANCH,
+  });
+  const raw = await withValidatedPrebuiltUpload(
+    {
+      repoRoot: process.env.SOURCE_PATH,
+      logicalTarget: process.env.LOGICAL_TARGET,
+      expectedRootDirectory: process.env.EXPECTED_ROOT_DIRECTORY,
+      vercelOrgId: process.env.VERCEL_ORG_ID,
+      vercelProjectId: process.env.VERCEL_PROJECT_ID,
+      deploymentId: process.env.MENTO_NEXT_DEPLOYMENT_ID,
       commitSha: process.env.DEPLOY_SHA,
-      gitBranch: process.env.GIT_BRANCH,
-    }),
-    { capture: true },
+    },
+    async () => runVercel(arguments_, { capture: true }),
   );
   const deployment = parseVercelDeploymentJson(raw);
   output("vercel_deployment_id", deployment.deploymentId);
@@ -823,17 +1616,30 @@ if (isCliEntrypoint()) {
   if (command === "prepare") prepareFromEnvironment();
   else if (command === "validate-source") validateSourceFromEnvironment();
   else if (command === "prepare-link") prepareLinkFromEnvironment();
+  else if (command === "prepare-pull-staging")
+    preparePullStagingFromEnvironment();
   else if (command === "pull") pullFromEnvironment();
   else if (command === "validate-pull") validatePullFromEnvironment();
+  else if (command === "validate-pull-staging")
+    validatePullStagingFromEnvironment();
+  else if (command === "stage-pull") stagePullFromEnvironment();
+  else if (command === "validate-candidate-pull")
+    validateCandidatePullFromEnvironment();
   else if (command === "build") buildFromEnvironment();
   else if (command === "assert-output") assertOutputFromEnvironment();
-  else if (command === "deploy") deployFromEnvironment();
+  else if (command === "trusted-install-modules-dir") {
+    const layout = trustedPnpmInstallLayout({
+      controllerRoot: process.env.CONTROLLER_PATH,
+      toolsRoot: process.env.TRUSTED_VERCEL_TOOLS_PATH,
+    });
+    process.stdout.write(`${layout.modulesDir}\n`);
+  } else if (command === "deploy") await deployFromEnvironment();
   else if (command === "verify") verifyFromEnvironment();
   else if (command === "smoke") await smokeFromEnvironment();
   else if (command === "total") totalFromEnvironment();
   else {
     throw new Error(
-      "Usage: vercel-prebuilt-workflow.mjs prepare|validate-source|prepare-link|pull|validate-pull|build|assert-output|deploy|verify|smoke|total",
+      "Usage: vercel-prebuilt-workflow.mjs prepare|validate-source|prepare-link|prepare-pull-staging|pull|validate-pull|validate-pull-staging|stage-pull|validate-candidate-pull|build|assert-output|trusted-install-modules-dir|deploy|verify|smoke|total",
     );
   }
 }

--- a/scripts/vercel-prebuilt-workflow.test.mjs
+++ b/scripts/vercel-prebuilt-workflow.test.mjs
@@ -7,6 +7,7 @@ import {
   mkdirSync,
   mkdtempSync,
   readFileSync,
+  readlinkSync,
   realpathSync,
   rmSync,
   symlinkSync,
@@ -810,7 +811,7 @@ test("trusted Vercel CLI must be exact-versioned and runner-protected", () => {
 });
 
 test(
-  "pinned pnpm materializes and executes Vercel 56.2.0 in the protected relative layout",
+  "pinned pnpm materializes and executes Vercel 56.2.0 offline in the protected relative layout",
   { timeout: 120_000 },
   () => {
     const fixtureRoot = mkdtempSync(
@@ -860,7 +861,7 @@ test(
           "copy",
           "--virtual-store-dir",
           layout.virtualStoreDir,
-          "--prefer-offline",
+          "--offline",
         ],
         {
           encoding: "utf8",
@@ -893,6 +894,71 @@ test(
     }
   },
 );
+
+test("checkout-index preserves files and bytes ignored or substituted by git archive", () => {
+  const repository = mkdtempSync(join(tmpdir(), "vercel-index-source-"));
+  const candidate = mkdtempSync(join(tmpdir(), "vercel-index-candidate-"));
+  try {
+    execFileSync("git", ["init", "--quiet"], { cwd: repository });
+    writeFileSync(
+      join(repository, ".gitattributes"),
+      "ignored.txt export-ignore\nsubstituted.txt export-subst\n",
+    );
+    writeFileSync(join(repository, "ignored.txt"), "must remain\n");
+    writeFileSync(join(repository, "substituted.txt"), "$Format:%H$\n");
+    writeFileSync(join(repository, "executable.sh"), "#!/bin/sh\nexit 0\n");
+    chmodSync(join(repository, "executable.sh"), 0o755);
+    writeFileSync(join(repository, "plain.txt"), "plain\n");
+    chmodSync(join(repository, "plain.txt"), 0o644);
+    symlinkSync("ignored.txt", join(repository, "linked.txt"));
+    execFileSync("git", ["add", "."], { cwd: repository });
+    execFileSync(
+      "git",
+      [
+        "-c",
+        "user.name=Test",
+        "-c",
+        "user.email=test@example.com",
+        "commit",
+        "--quiet",
+        "-m",
+        "fixture",
+      ],
+      { cwd: repository },
+    );
+
+    execFileSync(
+      "git",
+      ["checkout-index", "--all", "--force", `--prefix=${candidate}${sep}`],
+      { cwd: repository },
+    );
+    assert.equal(
+      readFileSync(join(candidate, "ignored.txt"), "utf8"),
+      "must remain\n",
+    );
+    assert.equal(
+      readFileSync(join(candidate, "substituted.txt"), "utf8"),
+      "$Format:%H$\n",
+    );
+    assert.equal(
+      lstatSync(join(candidate, "linked.txt")).isSymbolicLink(),
+      true,
+    );
+    assert.equal(readlinkSync(join(candidate, "linked.txt")), "ignored.txt");
+    assert.notEqual(
+      lstatSync(join(candidate, "executable.sh")).mode & 0o111,
+      0,
+    );
+    assert.equal(lstatSync(join(candidate, "plain.txt")).mode & 0o111, 0);
+    assert.throws(
+      () => lstatSync(join(candidate, ".git")),
+      (error) => error?.code === "ENOENT",
+    );
+  } finally {
+    rmSync(repository, { force: true, recursive: true });
+    rmSync(candidate, { force: true, recursive: true });
+  }
+});
 
 test("candidate execution is UID-isolated and hands upload to runner-owned state", () => {
   const raw = readFileSync(
@@ -951,6 +1017,39 @@ test("candidate execution is UID-isolated and hands upload to runner-owned state
   );
   assert.doesNotMatch(isolationBlock, /--no-frozen-lockfile/);
   assert.doesNotMatch(isolationBlock, /"dependencies":\{"vercel":"56\.2\.0"\}/);
+  const assertExactSourceMaterialization = (block) => {
+    const markers = [
+      '/usr/bin/git -C "$SOURCE_PATH" write-tree',
+      '/usr/bin/git -C "$SOURCE_PATH" rev-parse "$DEPLOY_SHA^{tree}"',
+      'if [ "$source_tree" != "$expected_tree" ]; then',
+      '/usr/bin/git -C "$SOURCE_PATH" checkout-index',
+      '-R --no-dereference "$build_uid:$build_gid"',
+    ];
+    let previous = -1;
+    for (const marker of markers) {
+      const index = block.indexOf(marker);
+      assert.notEqual(index, -1, `missing exact-source marker: ${marker}`);
+      assert.ok(
+        index > previous,
+        `out-of-order exact-source marker: ${marker}`,
+      );
+      previous = index;
+    }
+    assert.doesNotMatch(block, /git -C "\$SOURCE_PATH" archive/);
+    assert.doesNotMatch(block, /get-tar-commit-id/);
+  };
+  assertExactSourceMaterialization(isolationBlock);
+  for (const mutation of [
+    isolationBlock.replace("$DEPLOY_SHA^{tree}", "HEAD^{tree}"),
+    isolationBlock.replace(
+      'if [ "$source_tree" != "$expected_tree" ]; then',
+      'if [ "$source_tree" = "$source_tree" ]; then',
+    ),
+    isolationBlock.replace("-R --no-dereference", "-R"),
+  ]) {
+    assert.notEqual(mutation, isolationBlock);
+    assert.throws(() => assertExactSourceMaterialization(mutation));
+  }
 
   const installBlock = raw.slice(
     raw.indexOf("- name: Install frozen dependencies"),

--- a/scripts/vercel-prebuilt-workflow.test.mjs
+++ b/scripts/vercel-prebuilt-workflow.test.mjs
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { Buffer } from "node:buffer";
 import { execFileSync } from "node:child_process";
 import {
   chmodSync,
@@ -31,6 +32,7 @@ import {
   buildVercelInspectArguments,
   buildVercelPullArguments,
   environmentForVercelCli,
+  materializeExactGitTree,
   materializeVercelRepoLink,
   parseVercelDeploymentJson,
   PILOT_TARGET,
@@ -895,17 +897,29 @@ test(
   },
 );
 
-test("checkout-index preserves files and bytes ignored or substituted by git archive", () => {
-  const repository = mkdtempSync(join(tmpdir(), "vercel-index-source-"));
-  const candidate = mkdtempSync(join(tmpdir(), "vercel-index-candidate-"));
+test("raw Git-object materialization bypasses archive and checkout filters", () => {
+  const repository = mkdtempSync(join(tmpdir(), "vercel-raw-source-"));
+  const runnerTemp = mkdtempSync(join(tmpdir(), "vercel-raw-runner-"));
+  const candidate = join(runnerTemp, "mento-vercel-candidate-source");
+  const checkoutCandidate = mkdtempSync(
+    join(tmpdir(), "vercel-filtered-candidate-"),
+  );
   try {
+    chmodSync(runnerTemp, 0o700);
     execFileSync("git", ["init", "--quiet"], { cwd: repository });
     writeFileSync(
       join(repository, ".gitattributes"),
-      "ignored.txt export-ignore\nsubstituted.txt export-subst\n",
+      [
+        "*.txt text eol=crlf ident",
+        "ignored.txt export-ignore",
+        "substituted.txt export-subst",
+        "",
+      ].join("\n"),
     );
     writeFileSync(join(repository, "ignored.txt"), "must remain\n");
     writeFileSync(join(repository, "substituted.txt"), "$Format:%H$\n");
+    writeFileSync(join(repository, "identity.txt"), "$Id$\n");
+    writeFileSync(join(repository, "line-endings.txt"), "one\ntwo\n");
     writeFileSync(join(repository, "executable.sh"), "#!/bin/sh\nexit 0\n");
     chmodSync(join(repository, "executable.sh"), 0o755);
     writeFileSync(join(repository, "plain.txt"), "plain\n");
@@ -926,19 +940,47 @@ test("checkout-index preserves files and bytes ignored or substituted by git arc
       ],
       { cwd: repository },
     );
+    const commitSha = execFileSync("git", ["rev-parse", "HEAD"], {
+      cwd: repository,
+      encoding: "utf8",
+    }).trim();
 
+    const result = materializeExactGitTree({
+      runnerTemp,
+      sourceRoot: repository,
+      candidateRoot: candidate,
+      commitSha,
+    });
+    assert.equal(result.sourceRoot, realpathSync(candidate));
+    assert.ok(result.entries >= 8);
     execFileSync(
       "git",
-      ["checkout-index", "--all", "--force", `--prefix=${candidate}${sep}`],
+      [
+        "checkout-index",
+        "--all",
+        "--force",
+        `--prefix=${checkoutCandidate}${sep}`,
+      ],
       { cwd: repository },
     );
-    assert.equal(
-      readFileSync(join(candidate, "ignored.txt"), "utf8"),
-      "must remain\n",
+    for (const path of [
+      "ignored.txt",
+      "substituted.txt",
+      "identity.txt",
+      "line-endings.txt",
+    ]) {
+      const blob = execFileSync("git", ["cat-file", "blob", `HEAD:${path}`], {
+        cwd: repository,
+      });
+      assert.deepEqual(readFileSync(join(candidate, path)), blob);
+    }
+    assert.match(
+      readFileSync(join(checkoutCandidate, "identity.txt"), "utf8"),
+      /^\$Id: [0-9a-f]{40} \$\r\n$/,
     );
-    assert.equal(
-      readFileSync(join(candidate, "substituted.txt"), "utf8"),
-      "$Format:%H$\n",
+    assert.deepEqual(
+      readFileSync(join(checkoutCandidate, "line-endings.txt")),
+      Buffer.from("one\r\ntwo\r\n"),
     );
     assert.equal(
       lstatSync(join(candidate, "linked.txt")).isSymbolicLink(),
@@ -954,9 +996,93 @@ test("checkout-index preserves files and bytes ignored or substituted by git arc
       () => lstatSync(join(candidate, ".git")),
       (error) => error?.code === "ENOENT",
     );
+    assert.throws(
+      () =>
+        materializeExactGitTree({
+          runnerTemp,
+          sourceRoot: repository,
+          candidateRoot: candidate,
+          commitSha,
+        }),
+      /must be fresh/,
+    );
   } finally {
     rmSync(repository, { force: true, recursive: true });
-    rmSync(candidate, { force: true, recursive: true });
+    rmSync(runnerTemp, { force: true, recursive: true });
+    rmSync(checkoutCandidate, { force: true, recursive: true });
+  }
+});
+
+test("raw Git-object materialization rejects gitlinks before writing", () => {
+  const repository = mkdtempSync(join(tmpdir(), "vercel-gitlink-source-"));
+  const runnerTemp = mkdtempSync(join(tmpdir(), "vercel-gitlink-runner-"));
+  const candidate = join(runnerTemp, "mento-vercel-candidate-source");
+  try {
+    chmodSync(runnerTemp, 0o700);
+    execFileSync("git", ["init", "--quiet"], { cwd: repository });
+    writeFileSync(join(repository, "plain.txt"), "plain\n");
+    execFileSync("git", ["add", "."], { cwd: repository });
+    execFileSync(
+      "git",
+      [
+        "-c",
+        "user.name=Test",
+        "-c",
+        "user.email=test@example.com",
+        "commit",
+        "--quiet",
+        "-m",
+        "base",
+      ],
+      { cwd: repository },
+    );
+    const baseCommit = execFileSync("git", ["rev-parse", "HEAD"], {
+      cwd: repository,
+      encoding: "utf8",
+    }).trim();
+    execFileSync(
+      "git",
+      ["update-index", "--add", "--cacheinfo", `160000,${baseCommit},vendor`],
+      { cwd: repository },
+    );
+    const tree = execFileSync("git", ["write-tree"], {
+      cwd: repository,
+      encoding: "utf8",
+    }).trim();
+    const gitlinkCommit = execFileSync(
+      "git",
+      [
+        "-c",
+        "user.name=Test",
+        "-c",
+        "user.email=test@example.com",
+        "commit-tree",
+        tree,
+        "-p",
+        baseCommit,
+        "-m",
+        "gitlink",
+      ],
+      { cwd: repository, encoding: "utf8" },
+    ).trim();
+
+    assert.throws(
+      () =>
+        materializeExactGitTree({
+          runnerTemp,
+          sourceRoot: repository,
+          candidateRoot: candidate,
+          commitSha: gitlinkCommit,
+        }),
+      /unsupported entry/,
+    );
+    assert.throws(
+      () => lstatSync(candidate),
+      (error) => error?.code === "ENOENT",
+    );
+  } finally {
+    rmSync(repository, { force: true, recursive: true });
+    rmSync(runnerTemp, { force: true, recursive: true });
   }
 });
 
@@ -1022,7 +1148,7 @@ test("candidate execution is UID-isolated and hands upload to runner-owned state
       '/usr/bin/git -C "$SOURCE_PATH" write-tree',
       '/usr/bin/git -C "$SOURCE_PATH" rev-parse "$DEPLOY_SHA^{tree}"',
       'if [ "$source_tree" != "$expected_tree" ]; then',
-      '/usr/bin/git -C "$SOURCE_PATH" checkout-index',
+      "materialize-source",
       '-R --no-dereference "$build_uid:$build_gid"',
     ];
     let previous = -1;
@@ -1035,7 +1161,12 @@ test("candidate execution is UID-isolated and hands upload to runner-owned state
       );
       previous = index;
     }
+    assert.match(
+      block,
+      /"\$GITHUB_WORKSPACE\/controller\/scripts\/vercel-prebuilt-workflow\.mjs" \\\n\s+materialize-source/,
+    );
     assert.doesNotMatch(block, /git -C "\$SOURCE_PATH" archive/);
+    assert.doesNotMatch(block, /git -C "\$SOURCE_PATH" checkout-index/);
     assert.doesNotMatch(block, /get-tar-commit-id/);
   };
   assertExactSourceMaterialization(isolationBlock);
@@ -1045,6 +1176,7 @@ test("candidate execution is UID-isolated and hands upload to runner-owned state
       'if [ "$source_tree" != "$expected_tree" ]; then',
       'if [ "$source_tree" = "$source_tree" ]; then',
     ),
+    isolationBlock.replace("materialize-source", "prepare-link"),
     isolationBlock.replace("-R --no-dereference", "-R"),
   ]) {
     assert.notEqual(mutation, isolationBlock);

--- a/scripts/vercel-prebuilt-workflow.test.mjs
+++ b/scripts/vercel-prebuilt-workflow.test.mjs
@@ -1,14 +1,29 @@
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import {
+  chmodSync,
+  linkSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
+import process from "node:process";
 import { test } from "node:test";
+import { fileURLToPath } from "node:url";
 
 import {
   assertPrebuiltOutput,
+  assertPrebuiltReadyForUpload,
   assertPulledProject,
   assertSafeVercelArguments,
+  assertVercelPullStaging,
   assertVercelInspection,
   buildVercelBuildArguments,
   buildVercelDeployArguments,
@@ -18,16 +33,113 @@ import {
   materializeVercelRepoLink,
   parseVercelDeploymentJson,
   PILOT_TARGET,
+  prepareVercelPullStaging,
   smokeUiPreview,
+  stageVercelPullForCandidate,
+  trustedPnpmInstallLayout,
+  trustedVercelCliPath,
   validateExactSha,
   validateGitBranch,
   validatePilotContract,
   validateSourceCheckout,
+  withValidatedPrebuiltUpload,
 } from "./vercel-prebuilt-workflow.mjs";
 
 const SHA = "0123456789abcdef0123456789abcdef01234567";
 const DEPLOYMENT_ID = "m-ui-0123456789abcdef012";
 const DEPLOYMENT_URL = "https://ui-pilot-abc.vercel.app";
+const REPOSITORY_ROOT = fileURLToPath(new URL("..", import.meta.url));
+const BUILD_ENVIRONMENT_SCRIPT = fileURLToPath(
+  new URL("./vercel-build-environment.mjs", import.meta.url),
+);
+
+function checkUiPreviewEnvironment(projectDirectory) {
+  return execFileSync(
+    process.execPath,
+    [
+      BUILD_ENVIRONMENT_SCRIPT,
+      "check",
+      "--target",
+      "ui",
+      "--environment",
+      "preview",
+      "--project-directory",
+      projectDirectory,
+    ],
+    {
+      cwd: REPOSITORY_ROOT,
+      encoding: "utf8",
+      env: {
+        CI: "1",
+        NEXT_PUBLIC_VERCEL_ENV: "preview",
+        VERCEL: "1",
+        VERCEL_ENV: "preview",
+        VERCEL_TARGET_ENV: "preview",
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    },
+  );
+}
+
+function uploadFixture() {
+  const repoRoot = mkdtempSync(join(tmpdir(), "vercel-upload-ui-"));
+  const vercelOrgId = "team_example";
+  const vercelProjectId = "prj_ui";
+  const projectState = join(
+    repoRoot,
+    PILOT_TARGET.expectedRootDirectory,
+    ".vercel",
+  );
+  const outputDirectory = join(projectState, "output");
+  mkdirSync(outputDirectory, { recursive: true });
+  materializeVercelRepoLink({
+    repoRoot,
+    expectedRootDirectory: PILOT_TARGET.expectedRootDirectory,
+    vercelOrgId,
+    vercelProjectId,
+  });
+  writeFileSync(
+    join(projectState, "project.json"),
+    JSON.stringify({
+      orgId: vercelOrgId,
+      projectId: vercelProjectId,
+      settings: { rootDirectory: PILOT_TARGET.expectedRootDirectory },
+    }),
+  );
+  writeFileSync(
+    join(outputDirectory, "config.json"),
+    JSON.stringify({ version: 3, deploymentId: DEPLOYMENT_ID }),
+  );
+  writeFileSync(
+    join(outputDirectory, "builds.json"),
+    JSON.stringify({ target: "preview", cliVersion: "56.2.0" }),
+  );
+  mkdirSync(join(outputDirectory, "static", "nested"), { recursive: true });
+  writeFileSync(join(outputDirectory, "static", "nested", "asset.js"), "ok");
+  writeFileSync(
+    `${repoRoot}.provenance.json`,
+    JSON.stringify({ commitSha: SHA }),
+    { mode: 0o600 },
+  );
+  return {
+    repoRoot,
+    projectState,
+    outputDirectory,
+    options: {
+      repoRoot,
+      logicalTarget: PILOT_TARGET.logicalTarget,
+      expectedRootDirectory: PILOT_TARGET.expectedRootDirectory,
+      vercelOrgId,
+      vercelProjectId,
+      deploymentId: DEPLOYMENT_ID,
+      commitSha: SHA,
+    },
+    cleanup() {
+      rmSync(repoRoot, { force: true, recursive: true });
+      rmSync(`${repoRoot}.provenance.json`, { force: true });
+    },
+  };
+}
 
 function pilotContract(overrides = {}) {
   return {
@@ -45,6 +157,53 @@ function pilotContract(overrides = {}) {
     githubWorkflowRef:
       "mento-protocol/frontend-monorepo/.github/workflows/vercel-prebuilt-pilot.yml@refs/heads/main",
     ...overrides,
+  };
+}
+
+function pulledStagingFixture() {
+  const runnerTemp = mkdtempSync(join(tmpdir(), "vercel-pull-runner-"));
+  const stagingRoot = join(runnerTemp, "mento-vercel-pull-staging");
+  const candidateRoot = join(runnerTemp, "mento-vercel-candidate-source");
+  const vercelOrgId = "team_example";
+  const vercelProjectId = "prj_ui";
+  const expectedRootDirectory = PILOT_TARGET.expectedRootDirectory;
+  prepareVercelPullStaging({
+    runnerTemp,
+    stagingRoot,
+    expectedRootDirectory,
+    vercelOrgId,
+    vercelProjectId,
+  });
+  const appState = join(stagingRoot, expectedRootDirectory, ".vercel");
+  mkdirSync(appState, { mode: 0o700 });
+  writeFileSync(
+    join(appState, "project.json"),
+    JSON.stringify({ settings: { rootDirectory: expectedRootDirectory } }),
+    { mode: 0o600 },
+  );
+  writeFileSync(
+    join(appState, ".env.preview.local"),
+    "NEXT_PUBLIC_STORAGE_URL=https://storage.example\n",
+    { mode: 0o600 },
+  );
+  return {
+    runnerTemp,
+    stagingRoot,
+    candidateRoot,
+    appState,
+    expectedRootDirectory,
+    vercelOrgId,
+    vercelProjectId,
+    options: {
+      runnerTemp,
+      stagingRoot,
+      expectedRootDirectory,
+      vercelOrgId,
+      vercelProjectId,
+    },
+    cleanup() {
+      rmSync(runnerTemp, { force: true, recursive: true });
+    },
   };
 }
 
@@ -312,13 +471,703 @@ test("deploy and inspect JSON retain one immutable URL and Vercel ID", () => {
 
 test("Vercel CLI receives the repo link instead of ID variables that override it", () => {
   assert.deepEqual(
-    environmentForVercelCli({
+    environmentForVercelCli(
+      {
+        BASH_ENV: "/tmp/candidate-bash-env",
+        CI: "1",
+        GITHUB_ENV: "/tmp/github-env",
+        GITHUB_OUTPUT: "/tmp/github-output",
+        GITHUB_PATH: "/tmp/github-path",
+        NODE_OPTIONS: "--require=/tmp/candidate.cjs",
+        PATH: "/trusted/bin:/usr/bin:/bin",
+        RUNNER_TEMP: "/tmp/runner",
+        VERCEL_ORG_ID: "team_example",
+        VERCEL_PROJECT_ID: "prj_example",
+        VERCEL_TOKEN: "fixture-token",
+      },
+      ["VERCEL_ORG_ID", "VERCEL_PROJECT_ID", "VERCEL_TOKEN"],
+    ),
+    {
       CI: "1",
-      VERCEL_ORG_ID: "team_example",
-      VERCEL_PROJECT_ID: "prj_example",
+      PATH: "/trusted/bin:/usr/bin:/bin",
       VERCEL_TOKEN: "fixture-token",
-    }),
-    { CI: "1", VERCEL_TOKEN: "fixture-token" },
+    },
+  );
+});
+
+test("Vercel pull staging is a fresh exact runner-temp tree", () => {
+  const fixture = pulledStagingFixture();
+  try {
+    assert.equal(
+      assertVercelPullStaging(fixture.options).settings.rootDirectory,
+      fixture.expectedRootDirectory,
+    );
+    assert.equal(lstatSync(fixture.stagingRoot).mode & 0o777, 0o700);
+    assert.equal(
+      lstatSync(join(fixture.stagingRoot, ".vercel", "repo.json")).mode & 0o777,
+      0o600,
+    );
+    assert.throws(
+      () => prepareVercelPullStaging(fixture.options),
+      /must be fresh/,
+    );
+    assert.throws(
+      () =>
+        prepareVercelPullStaging({
+          ...fixture.options,
+          stagingRoot: join(fixture.runnerTemp, "candidate-selected"),
+        }),
+      /expected RUNNER_TEMP child/,
+    );
+  } finally {
+    fixture.cleanup();
+  }
+});
+
+test("UI preview environment validation reads only trusted pull staging", () => {
+  const fixture = pulledStagingFixture();
+  try {
+    const canonicalProject = join(
+      fixture.runnerTemp,
+      "source",
+      fixture.expectedRootDirectory,
+    );
+    mkdirSync(canonicalProject, { recursive: true });
+    assert.throws(() => checkUiPreviewEnvironment(canonicalProject));
+
+    const stagingProject = join(
+      fixture.stagingRoot,
+      fixture.expectedRootDirectory,
+    );
+    const stagingEnvironment = join(
+      stagingProject,
+      ".vercel",
+      ".env.preview.local",
+    );
+    assert.equal(lstatSync(stagingEnvironment).mode & 0o777, 0o600);
+    assert.match(
+      checkUiPreviewEnvironment(stagingProject),
+      /verified for ui\/preview/,
+    );
+
+    const candidateProject = join(
+      fixture.candidateRoot,
+      fixture.expectedRootDirectory,
+    );
+    mkdirSync(candidateProject, { recursive: true });
+    stageVercelPullForCandidate({
+      ...fixture.options,
+      candidateRoot: fixture.candidateRoot,
+      buildUid: process.getuid(),
+      buildGid: process.getgid(),
+      runnerUid: process.getuid(),
+      runnerGid: process.getgid(),
+    });
+    const candidateEnvironment = join(
+      candidateProject,
+      ".vercel",
+      ".env.preview.local",
+    );
+    assert.equal(lstatSync(candidateEnvironment).mode & 0o777, 0o600);
+    chmodSync(candidateEnvironment, 0o000);
+    if (process.getuid() !== 0) {
+      assert.throws(() => checkUiPreviewEnvironment(candidateProject));
+    }
+  } finally {
+    fixture.cleanup();
+  }
+});
+
+test("Vercel pull staging rejects links, hardlinks, special files, and unsafe state", () => {
+  const mutations = [
+    {
+      name: "repo link symlink",
+      mutate: (fixture) => {
+        const path = join(fixture.stagingRoot, ".vercel", "repo.json");
+        const outside = join(fixture.runnerTemp, "outside-repo.json");
+        writeFileSync(outside, "untouched");
+        rmSync(path);
+        symlinkSync(outside, path);
+      },
+    },
+    {
+      name: "app Vercel directory symlink",
+      mutate: (fixture) => {
+        const outside = join(fixture.runnerTemp, "outside-state");
+        mkdirSync(outside);
+        rmSync(fixture.appState, { recursive: true });
+        symlinkSync(outside, fixture.appState);
+      },
+    },
+    ...["project.json", ".env.preview.local"].map((name) => ({
+      name: `${name} symlink`,
+      mutate: (fixture) => {
+        const path = join(fixture.appState, name);
+        const outside = join(fixture.runnerTemp, `outside-${name}`);
+        writeFileSync(outside, "untouched");
+        rmSync(path);
+        symlinkSync(outside, path);
+      },
+    })),
+    {
+      name: "hard-linked settings",
+      mutate: (fixture) => {
+        const environmentPath = join(fixture.appState, ".env.preview.local");
+        rmSync(environmentPath);
+        linkSync(join(fixture.appState, "project.json"), environmentPath);
+      },
+    },
+    {
+      name: "FIFO settings",
+      mutate: (fixture) => {
+        const environmentPath = join(fixture.appState, ".env.preview.local");
+        rmSync(environmentPath);
+        execFileSync("mkfifo", [environmentPath]);
+      },
+    },
+    {
+      name: "unexpected file",
+      mutate: (fixture) =>
+        writeFileSync(join(fixture.appState, "candidate.txt"), "unsafe", {
+          mode: 0o600,
+        }),
+    },
+    {
+      name: "group-writable settings",
+      mutate: (fixture) =>
+        chmodSync(join(fixture.appState, "project.json"), 0o620),
+    },
+  ];
+  for (const mutation of mutations) {
+    const fixture = pulledStagingFixture();
+    try {
+      mutation.mutate(fixture);
+      assert.throws(
+        () => assertVercelPullStaging(fixture.options),
+        undefined,
+        mutation.name,
+      );
+    } finally {
+      fixture.cleanup();
+    }
+  }
+
+  const ownership = pulledStagingFixture();
+  try {
+    assert.throws(() =>
+      assertVercelPullStaging({
+        ...ownership.options,
+        expectedUid: process.getuid() + 1,
+        expectedGid: process.getgid(),
+      }),
+    );
+  } finally {
+    ownership.cleanup();
+  }
+});
+
+test("candidate Vercel links cannot redirect trusted pulled-state copies", () => {
+  const mutations = [
+    {
+      name: "repo .vercel",
+      prepare: ({ candidateRoot, outsideDirectory }) =>
+        symlinkSync(outsideDirectory, join(candidateRoot, ".vercel")),
+    },
+    {
+      name: "app .vercel",
+      prepare: ({ appRoot, outsideDirectory }) =>
+        symlinkSync(outsideDirectory, join(appRoot, ".vercel")),
+    },
+    ...["project.json", ".env.preview.local"].map((name) => ({
+      name,
+      prepare: ({ appRoot, sentinelPath }) => {
+        const state = join(appRoot, ".vercel");
+        mkdirSync(state);
+        symlinkSync(sentinelPath, join(state, name));
+      },
+    })),
+  ];
+  for (const mutation of mutations) {
+    const fixture = pulledStagingFixture();
+    try {
+      const appRoot = join(
+        fixture.candidateRoot,
+        fixture.expectedRootDirectory,
+      );
+      mkdirSync(appRoot, { recursive: true });
+      const outsideDirectory = join(fixture.runnerTemp, "trusted-controller");
+      const sentinelPath = join(outsideDirectory, "sentinel.txt");
+      mkdirSync(outsideDirectory);
+      writeFileSync(sentinelPath, "untouched", { mode: 0o600 });
+      mutation.prepare({
+        candidateRoot: fixture.candidateRoot,
+        appRoot,
+        outsideDirectory,
+        sentinelPath,
+      });
+
+      assert.equal(
+        stageVercelPullForCandidate({
+          ...fixture.options,
+          candidateRoot: fixture.candidateRoot,
+          buildUid: process.getuid(),
+          buildGid: process.getgid(),
+          runnerUid: process.getuid(),
+          runnerGid: process.getgid(),
+        }).settings.rootDirectory,
+        fixture.expectedRootDirectory,
+        mutation.name,
+      );
+      assert.equal(readFileSync(sentinelPath, "utf8"), "untouched");
+      for (const path of [
+        join(fixture.candidateRoot, ".vercel", "repo.json"),
+        join(appRoot, ".vercel", "project.json"),
+        join(appRoot, ".vercel", ".env.preview.local"),
+      ]) {
+        assert.equal(lstatSync(path).isFile(), true, mutation.name);
+        assert.equal(lstatSync(path).isSymbolicLink(), false, mutation.name);
+        assert.equal(lstatSync(path).mode & 0o777, 0o600, mutation.name);
+      }
+    } finally {
+      fixture.cleanup();
+    }
+  }
+});
+
+test("candidate staging rejects a source root that escapes RUNNER_TEMP", () => {
+  const fixture = pulledStagingFixture();
+  const outside = mkdtempSync(join(tmpdir(), "vercel-candidate-outside-"));
+  try {
+    mkdirSync(join(outside, fixture.expectedRootDirectory), {
+      recursive: true,
+    });
+    symlinkSync(outside, fixture.candidateRoot);
+    assert.throws(() =>
+      stageVercelPullForCandidate({
+        ...fixture.options,
+        candidateRoot: fixture.candidateRoot,
+        buildUid: process.getuid(),
+        buildGid: process.getgid(),
+        runnerUid: process.getuid(),
+        runnerGid: process.getgid(),
+      }),
+    );
+  } finally {
+    rmSync(outside, { force: true, recursive: true });
+    fixture.cleanup();
+  }
+});
+
+test("candidate staging rejects source components with the wrong owner", () => {
+  const fixture = pulledStagingFixture();
+  try {
+    mkdirSync(join(fixture.candidateRoot, fixture.expectedRootDirectory), {
+      recursive: true,
+    });
+    assert.throws(() =>
+      stageVercelPullForCandidate({
+        ...fixture.options,
+        candidateRoot: fixture.candidateRoot,
+        buildUid: process.getuid() + 1,
+        buildGid: process.getgid(),
+        runnerUid: process.getuid(),
+        runnerGid: process.getgid(),
+      }),
+    );
+  } finally {
+    fixture.cleanup();
+  }
+});
+
+test("trusted Vercel CLI must be exact-versioned and runner-protected", () => {
+  const toolsPath = mkdtempSync(join(tmpdir(), "vercel-tools-"));
+  const packagePath = join(toolsPath, "node_modules", "vercel");
+  const cliPath = join(packagePath, "dist", "index.js");
+  try {
+    mkdirSync(join(packagePath, "dist"), { recursive: true });
+    writeFileSync(cliPath, "export {};\n");
+    writeFileSync(
+      join(packagePath, "package.json"),
+      JSON.stringify({ version: "56.2.0" }),
+    );
+    assert.equal(trustedVercelCliPath(toolsPath), realpathSync(cliPath));
+
+    writeFileSync(
+      join(packagePath, "package.json"),
+      JSON.stringify({ version: "56.2.1" }),
+    );
+    assert.throws(() => trustedVercelCliPath(toolsPath), /pinned release/);
+    writeFileSync(
+      join(packagePath, "package.json"),
+      JSON.stringify({ version: "56.2.0" }),
+    );
+
+    chmodSync(toolsPath, 0o777);
+    assert.throws(() => trustedVercelCliPath(toolsPath), /runner-owned/);
+  } finally {
+    rmSync(toolsPath, { force: true, recursive: true });
+  }
+});
+
+test(
+  "pinned pnpm materializes and executes Vercel 56.2.0 in the protected relative layout",
+  { timeout: 120_000 },
+  () => {
+    const fixtureRoot = mkdtempSync(
+      join(dirname(REPOSITORY_ROOT), ".vercel-tools-layout-"),
+    );
+    const controllerRoot = join(fixtureRoot, "controller");
+    const toolsRoot = join(fixtureRoot, "trusted-tools");
+    const archivePath = join(fixtureRoot, "controller.tar");
+    try {
+      mkdirSync(controllerRoot, { mode: 0o755 });
+      mkdirSync(toolsRoot, { mode: 0o755 });
+      execFileSync("git", [
+        "-C",
+        REPOSITORY_ROOT,
+        "archive",
+        "--format=tar",
+        `--output=${archivePath}`,
+        "HEAD",
+      ]);
+      execFileSync("tar", ["-xf", archivePath, "-C", controllerRoot]);
+
+      const layout = trustedPnpmInstallLayout({ controllerRoot, toolsRoot });
+      assert.equal(
+        resolve(controllerRoot, layout.modulesDir),
+        join(toolsRoot, "node_modules"),
+      );
+      assert.equal(isAbsolute(layout.modulesDir), false);
+      assert.equal(layout.virtualStoreDir, join(layout.modulesDir, ".pnpm"));
+      assert.equal(
+        execFileSync("pnpm", ["--version"], { encoding: "utf8" }).trim(),
+        "10.24.0",
+      );
+
+      execFileSync(
+        "pnpm",
+        [
+          "--dir",
+          controllerRoot,
+          "--filter",
+          "frontend-monorepo",
+          "install",
+          "--frozen-lockfile",
+          "--ignore-scripts",
+          "--modules-dir",
+          layout.modulesDir,
+          "--package-import-method",
+          "copy",
+          "--virtual-store-dir",
+          layout.virtualStoreDir,
+          "--prefer-offline",
+        ],
+        {
+          encoding: "utf8",
+          env: { ...process.env, CI: "true" },
+          stdio: ["ignore", "pipe", "pipe"],
+        },
+      );
+      execFileSync("chmod", ["-R", "a+rX,go-w", toolsRoot]);
+
+      const cliPath = trustedVercelCliPath(toolsRoot);
+      const pathFromTools = relative(realpathSync(toolsRoot), cliPath);
+      assert.notEqual(pathFromTools, "");
+      assert.equal(pathFromTools === "..", false);
+      assert.equal(pathFromTools.startsWith(`..${sep}`), false);
+      assert.equal(
+        execFileSync(process.execPath, [cliPath, "--version"], {
+          encoding: "utf8",
+          stdio: ["ignore", "pipe", "pipe"],
+        }).trim(),
+        "56.2.0",
+      );
+      assert.equal(
+        JSON.parse(
+          readFileSync(resolve(cliPath, "..", "..", "package.json"), "utf8"),
+        ).version,
+        "56.2.0",
+      );
+    } finally {
+      rmSync(fixtureRoot, { force: true, recursive: true });
+    }
+  },
+);
+
+test("candidate execution is UID-isolated and hands upload to runner-owned state", () => {
+  const raw = readFileSync(
+    new URL("../.github/workflows/_vercel-prebuilt.yml", import.meta.url),
+    "utf8",
+  );
+  assert.match(raw, /\/usr\/bin\/setpriv/g);
+  assert.match(raw, /--clear-groups/g);
+  assert.match(raw, /--no-new-privs/g);
+  assert.match(raw, /\/usr\/bin\/env -i/g);
+  assert.match(raw, /\/usr\/bin\/pkill -KILL -u "\$BUILD_UID"/g);
+  assert.match(raw, /\/usr\/bin\/pgrep -u "\$BUILD_UID"/g);
+  assert.match(raw, /Create immutable runner-owned upload handoff/);
+  assert.match(raw, /mento-vercel-upload-source/);
+  assert.match(raw, /userdel mento-vercel-build/);
+  assert.match(raw, /node_modules\/vercel\/dist\/index\.js/);
+  assert.match(raw, /candidate_can_write/);
+  for (const protectedPath of [
+    "GITHUB_WORKSPACE/controller",
+    "RUNNER_TEMP",
+    "SOURCE_PATH/.git",
+    "SOURCE_PATH/node_modules",
+    "SOURCE_PATH/package.json",
+    "SOURCE_PATH/pnpm-lock.yaml",
+    "TRUSTED_VERCEL_TOOLS_PATH",
+    "node_bin",
+    "pnpm_bin",
+  ]) {
+    assert.match(raw, new RegExp(protectedPath.replace("/", "\\/")));
+  }
+  assert.doesNotMatch(raw, /sudo\s+(?:-[^\s]+\s+)*-u\s+(?:nobody|65534)/);
+
+  const isolationBlock = raw.slice(
+    raw.indexOf(
+      "- name: Prepare isolated exact-SHA source and protected Vercel CLI",
+    ),
+    raw.indexOf("- name: Install frozen dependencies"),
+  );
+  assert.match(
+    isolationBlock,
+    /pnpm --dir "\$GITHUB_WORKSPACE\/controller" --filter frontend-monorepo install/,
+  );
+  assert.match(isolationBlock, /--frozen-lockfile/);
+  assert.match(isolationBlock, /--ignore-scripts/);
+  assert.match(isolationBlock, /--package-import-method copy/);
+  assert.match(isolationBlock, /trusted-install-modules-dir/);
+  assert.match(isolationBlock, /--modules-dir "\$trusted_modules_dir"/);
+  assert.match(
+    isolationBlock,
+    /--virtual-store-dir "\$trusted_modules_dir\/\.pnpm"/,
+  );
+  assert.match(isolationBlock, /"\$node_bin" "\$vercel_cli" --version/);
+  assert.doesNotMatch(
+    isolationBlock,
+    /--modules-dir "\$TRUSTED_VERCEL_TOOLS_PATH/,
+  );
+  assert.doesNotMatch(isolationBlock, /--no-frozen-lockfile/);
+  assert.doesNotMatch(isolationBlock, /"dependencies":\{"vercel":"56\.2\.0"\}/);
+
+  const installBlock = raw.slice(
+    raw.indexOf("- name: Install frozen dependencies"),
+    raw.indexOf("- name: Restore trusted controller after source installation"),
+  );
+  const buildBlock = raw.slice(
+    raw.indexOf("- name: Build the UI prebuilt output"),
+    raw.indexOf("- name: Restore trusted controller after source build"),
+  );
+  const buildValidationBlock = buildBlock.slice(
+    0,
+    buildBlock.indexOf('started_at_ms="$(date +%s%3N)"'),
+  );
+  const installCandidateBlock = installBlock.slice(
+    installBlock.indexOf("set +e"),
+    installBlock.indexOf("candidate_status=$?"),
+  );
+  const buildCandidateBlock = buildBlock.slice(
+    buildBlock.indexOf("set +e"),
+    buildBlock.indexOf("candidate_status=$?"),
+  );
+  const handoffBlock = raw.slice(
+    raw.indexOf("- name: Create immutable runner-owned upload handoff"),
+    raw.indexOf("- name: Materialize runner-owned upload UI project mapping"),
+  );
+  const candidateOutputValidationBlock = raw.slice(
+    raw.indexOf("- name: Assert the UI prebuilt output"),
+    raw.indexOf(
+      "- name: Revalidate runner-owned pulled UI settings after the build",
+    ),
+  );
+  const uploadOutputValidationBlock = raw.slice(
+    raw.indexOf("- name: Assert immutable runner-owned upload handoff"),
+    raw.indexOf("- name: Upload the verified prebuilt output"),
+  );
+  const pullBlock = raw.slice(
+    raw.indexOf("- name: Pull branch-specific UI preview settings"),
+    raw.indexOf("- name: Assert isolated runner-owned Vercel pull result"),
+  );
+  const stagePullBlock = raw.slice(
+    raw.indexOf(
+      "- name: Stage trusted UI project settings into candidate source",
+    ),
+    raw.indexOf("- name: Assert isolated UI project mapping"),
+  );
+  const validateCandidatePullBlock = raw.slice(
+    raw.indexOf("- name: Assert isolated UI project mapping"),
+    raw.indexOf("- name: Build the UI prebuilt output"),
+  );
+  const environmentValidationIndex = raw.indexOf(
+    "- name: Validate runner-owned UI preview build variables",
+  );
+  const stagePullIndex = raw.indexOf(
+    "- name: Stage trusted UI project settings into candidate source",
+  );
+  const environmentValidationBlock = raw.slice(
+    environmentValidationIndex,
+    stagePullIndex,
+  );
+  const assertSinglePrivilegedControllerInvocation = (block, command) => {
+    const controller =
+      '"$GITHUB_WORKSPACE/controller/scripts/vercel-prebuilt-workflow.mjs"';
+    const lines = block.split("\n");
+    const controllerLines = lines
+      .map((line, index) => ({ line, index }))
+      .filter(({ line }) => line.includes(controller));
+    assert.equal(
+      controllerLines.length,
+      1,
+      `${command} must have exactly one trusted controller invocation`,
+    );
+    const controllerIndex = controllerLines[0].index;
+    assert.equal(lines[controllerIndex + 1]?.trim(), command);
+    const privilegedIndex = lines.findIndex(
+      (line, index) =>
+        index < controllerIndex &&
+        line.includes("sudo --non-interactive /usr/bin/env -i"),
+    );
+    assert.notEqual(
+      privilegedIndex,
+      -1,
+      `${command} must start from a privileged clean environment`,
+    );
+    for (let index = privilegedIndex; index <= controllerIndex; index += 1) {
+      assert.ok(
+        lines[index].trimEnd().endsWith("\\"),
+        `${command} must remain in one privileged continued command`,
+      );
+    }
+  };
+  assert.match(
+    pullBlock,
+    /SOURCE_PATH: \$\{\{ runner\.temp \}\}\/mento-vercel-pull-staging/,
+  );
+  assert.doesNotMatch(pullBlock, /github\.workspace.*source/);
+  assertSinglePrivilegedControllerInvocation(stagePullBlock, "stage-pull");
+  assert.doesNotMatch(stagePullBlock, /\/bin\/cp|canonical_state/);
+  assertSinglePrivilegedControllerInvocation(
+    validateCandidatePullBlock,
+    "validate-candidate-pull",
+  );
+  assert.match(validateCandidatePullBlock, /BUILD_UID="\$BUILD_UID"/);
+  assert.match(validateCandidatePullBlock, /PULL_STAGING_UID="\$\(id -u\)"/);
+  assert.doesNotMatch(validateCandidatePullBlock, /\svalidate-pull\s*$/m);
+  assertSinglePrivilegedControllerInvocation(buildValidationBlock, "build");
+  assert.match(buildValidationBlock, /PULL_STAGING_UID="\$\(id -u\)"/);
+  assert.doesNotMatch(
+    buildValidationBlock,
+    /\n\s+node "\$GITHUB_WORKSPACE\/controller\/scripts\/vercel-prebuilt-workflow\.mjs" build/,
+  );
+  assertSinglePrivilegedControllerInvocation(
+    candidateOutputValidationBlock,
+    "assert-output",
+  );
+  for (const [block, command] of [
+    [stagePullBlock, "stage-pull"],
+    [validateCandidatePullBlock, "validate-candidate-pull"],
+    [buildValidationBlock, "build"],
+    [candidateOutputValidationBlock, "assert-output"],
+  ]) {
+    const withoutPrivilege = block.replace(
+      "sudo --non-interactive /usr/bin/env -i",
+      "/usr/bin/env -i",
+    );
+    assert.notEqual(withoutPrivilege, block);
+    assert.throws(
+      () =>
+        assertSinglePrivilegedControllerInvocation(withoutPrivilege, command),
+      /privileged clean environment/,
+    );
+    assert.throws(
+      () =>
+        assertSinglePrivilegedControllerInvocation(
+          `${block}\nnode "$GITHUB_WORKSPACE/controller/scripts/vercel-prebuilt-workflow.mjs" ${command}\n`,
+          command,
+        ),
+      /exactly one trusted controller invocation/,
+    );
+  }
+  assert.match(
+    candidateOutputValidationBlock,
+    /EXPECTED_PROVENANCE_UID="\$\(id -u\)"/,
+  );
+  assert.doesNotMatch(
+    candidateOutputValidationBlock,
+    /run: node .*vercel-prebuilt-workflow\.mjs" assert-output/,
+  );
+  assert.equal(
+    uploadOutputValidationBlock.match(/vercel-prebuilt-workflow\.mjs/g)?.length,
+    1,
+  );
+  assert.match(
+    uploadOutputValidationBlock,
+    /run: node .*vercel-prebuilt-workflow\.mjs" assert-output/,
+  );
+  assert.doesNotMatch(
+    uploadOutputValidationBlock,
+    /sudo --non-interactive \/usr\/bin\/env -i/,
+  );
+  assert.ok(
+    raw.indexOf("- name: Assert isolated runner-owned Vercel pull result") <
+      environmentValidationIndex,
+  );
+  assert.ok(environmentValidationIndex < stagePullIndex);
+  assert.equal(raw.match(/vercel-build-environment\.mjs/g)?.length, 1);
+  assert.match(
+    environmentValidationBlock,
+    /PULL_STAGING_PATH: \$\{\{ runner\.temp \}\}\/mento-vercel-pull-staging/,
+  );
+  assert.match(
+    environmentValidationBlock,
+    /--project-directory "\$PULL_STAGING_PATH\/apps\/ui\.mento\.org"/,
+  );
+  assert.doesNotMatch(environmentValidationBlock, /working-directory: source/);
+  assert.doesNotMatch(
+    environmentValidationBlock,
+    /mento-vercel-candidate-source/,
+  );
+  assert.match(
+    handoffBlock,
+    /\/bin\/cp -R \\\n\s+--no-dereference \\\n\s+--preserve=mode,timestamps/,
+  );
+  for (const block of [installBlock, buildBlock]) {
+    assert.match(block, /\/usr\/bin\/env -i/);
+    assert.match(block, /::stop-commands::\$command_token/);
+    assert.match(block, /echo "::\$command_token::"/);
+    assert.match(
+      block,
+      /candidate_status=\$\?\n\s+set -e\n\s+terminate_candidate\n\s+echo "::\$command_token::"/,
+    );
+    assert.match(block, /--reuid="\$BUILD_UID"/);
+    assert.match(block, /--regid="\$BUILD_GID"/);
+  }
+  for (const block of [installCandidateBlock, buildCandidateBlock]) {
+    for (const name of [
+      "BASH_ENV",
+      "GITHUB_ENV",
+      "GITHUB_OUTPUT",
+      "GITHUB_PATH",
+      "GITHUB_STEP_SUMMARY",
+      "NODE_OPTIONS",
+      "RUNNER_TEMP",
+    ]) {
+      assert.doesNotMatch(block, new RegExp(`\\n\\s+${name}=`));
+    }
+  }
+  assert.match(installBlock, /XDG_DATA_HOME="\$CANDIDATE_HOME_PATH\/data"/);
+  assert.doesNotMatch(installBlock, /--store-dir|PNPM_STORE/);
+  assert.doesNotMatch(buildBlock, /\n\s+VERCEL_TOKEN:/);
+  assert.doesNotMatch(buildBlock, /\n\s+VERCEL_TOKEN=/);
+  assert.ok(
+    buildBlock.indexOf("pkill -KILL -u") <
+      buildBlock.indexOf("build_duration_ms="),
+  );
+  assert.ok(
+    raw.indexOf("Assert immutable runner-owned upload handoff") <
+      raw.indexOf("Upload the verified prebuilt output"),
   );
 });
 
@@ -349,6 +1198,8 @@ test("pulled project and prebuilt output bind the configured UI root and build I
     writeFileSync(
       join(projectDirectory, "project.json"),
       JSON.stringify({
+        orgId: "team_example",
+        projectId: "prj_example",
         settings: { rootDirectory: "apps/ui.mento.org" },
       }),
     );
@@ -402,6 +1253,156 @@ test("pulled project and prebuilt output bind the configured UI root and build I
     );
   } finally {
     rmSync(directory, { force: true, recursive: true });
+  }
+});
+
+test("UI upload revalidates exact provenance and project mapping immediately", async () => {
+  const mutations = [
+    {
+      name: "missing repo link",
+      mutate: ({ repoRoot }) => rmSync(join(repoRoot, ".vercel", "repo.json")),
+    },
+    {
+      name: "wrong remote",
+      mutate: ({ repoRoot, options }) =>
+        writeFileSync(
+          join(repoRoot, ".vercel", "repo.json"),
+          JSON.stringify({
+            remoteName: "candidate",
+            projects: [
+              {
+                id: options.vercelProjectId,
+                directory: options.expectedRootDirectory,
+                orgId: options.vercelOrgId,
+              },
+            ],
+          }),
+        ),
+    },
+    ...[
+      ["linked org", "orgId", "team_other"],
+      ["linked project", "id", "prj_other"],
+      ["linked root", "directory", "apps/wrong"],
+    ].map(([name, property, value]) => ({
+      name: `wrong ${name}`,
+      mutate: ({ repoRoot }) => {
+        const path = join(repoRoot, ".vercel", "repo.json");
+        const link = JSON.parse(readFileSync(path, "utf8"));
+        link.projects[0][property] = value;
+        writeFileSync(path, JSON.stringify(link));
+      },
+    })),
+    {
+      name: "missing project settings",
+      mutate: ({ projectState }) => rmSync(join(projectState, "project.json")),
+    },
+    ...[
+      ["project org", "orgId", "team_other"],
+      ["project ID", "projectId", "prj_other"],
+    ].map(([name, property, value]) => ({
+      name: `wrong ${name}`,
+      mutate: ({ projectState }) => {
+        const path = join(projectState, "project.json");
+        const project = JSON.parse(readFileSync(path, "utf8"));
+        project[property] = value;
+        writeFileSync(path, JSON.stringify(project));
+      },
+    })),
+    {
+      name: "wrong project root",
+      mutate: ({ projectState }) => {
+        const path = join(projectState, "project.json");
+        const project = JSON.parse(readFileSync(path, "utf8"));
+        project.settings.rootDirectory = "apps/wrong";
+        writeFileSync(path, JSON.stringify(project));
+      },
+    },
+    {
+      name: "wrong exact-SHA provenance",
+      mutate: ({ repoRoot }) =>
+        writeFileSync(
+          `${repoRoot}.provenance.json`,
+          JSON.stringify({ commitSha: `1${SHA.slice(1)}` }),
+        ),
+    },
+  ];
+
+  const valid = uploadFixture();
+  let validUploads = 0;
+  try {
+    assert.equal(
+      assertPrebuiltReadyForUpload(valid.options),
+      valid.outputDirectory,
+    );
+    assert.equal(
+      await withValidatedPrebuiltUpload(valid.options, async () => {
+        validUploads += 1;
+        return "uploaded";
+      }),
+      "uploaded",
+    );
+    assert.equal(validUploads, 1);
+  } finally {
+    valid.cleanup();
+  }
+
+  for (const mutation of mutations) {
+    const fixture = uploadFixture();
+    let uploadCalls = 0;
+    try {
+      mutation.mutate(fixture);
+      await assert.rejects(
+        withValidatedPrebuiltUpload(fixture.options, async () => {
+          uploadCalls += 1;
+        }),
+        undefined,
+        mutation.name,
+      );
+      assert.equal(uploadCalls, 0, mutation.name);
+    } finally {
+      fixture.cleanup();
+    }
+  }
+});
+
+test("UI upload guard rejects links, special nodes, and runner-writable state", () => {
+  const mutateCases = [
+    {
+      name: "symbolic link",
+      mutate: ({ outputDirectory }) =>
+        symlinkSync("/etc/passwd", join(outputDirectory, "static", "escape")),
+    },
+    {
+      name: "hard link",
+      mutate: ({ outputDirectory }) =>
+        linkSync(
+          join(outputDirectory, "config.json"),
+          join(outputDirectory, "static", "hardlink"),
+        ),
+    },
+    {
+      name: "FIFO",
+      mutate: ({ outputDirectory }) =>
+        execFileSync("mkfifo", [join(outputDirectory, "static", "pipe")]),
+    },
+    {
+      name: "world-writable directory",
+      mutate: ({ outputDirectory }) =>
+        chmodSync(join(outputDirectory, "static"), 0o777),
+    },
+  ];
+  for (const mutation of mutateCases) {
+    const fixture = uploadFixture();
+    try {
+      mutation.mutate(fixture);
+      assert.throws(
+        () => assertPrebuiltReadyForUpload(fixture.options),
+        undefined,
+        mutation.name,
+      );
+    } finally {
+      fixture.cleanup();
+    }
   }
 });
 

--- a/scripts/vercel-prebuilt-workflows.test.mjs
+++ b/scripts/vercel-prebuilt-workflows.test.mjs
@@ -143,7 +143,7 @@ test("exact source, build, and upload remain in one standard-runner job", () => 
       names.indexOf("Build the UI prebuilt output"),
   );
   assert.ok(
-    names.indexOf("Materialize trusted repo-level UI project mapping") <
+    names.indexOf("Prepare fresh runner-owned Vercel pull staging") <
       names.indexOf("Pull branch-specific UI preview settings"),
   );
   assert.ok(
@@ -197,14 +197,48 @@ test("main-only controller is restored after every candidate-code phase", () => 
   );
 });
 
-test("monorepo-root CLI execution and app-root env validation use one mapping", () => {
-  const raw = read(reusablePath);
-  assert.match(raw, /SOURCE_PATH: \$\{\{ github\.workspace \}\}\/source/);
-  assert.match(raw, /--project-directory apps\/ui\.mento\.org/);
-  assert.match(raw, /working-directory: source/);
-  assert.doesNotMatch(
-    raw,
-    /working-directory: (?:source\/)?apps\/ui\.mento\.org/,
+test("monorepo CLI and trusted env validation use their exact roots", () => {
+  const reusable = workflow(reusablePath);
+  const steps = reusable.jobs.prebuilt.steps;
+  const names = steps.map(({ name }) => name);
+  const sourceValidation = steps.find(
+    ({ name }) =>
+      name === "Validate same-repository branch reachability and exact HEAD",
+  );
+  const prerequisites = steps.find(
+    ({ name }) => name === "Verify pinned Vercel prerequisites",
+  );
+  const environmentValidation = steps.find(
+    ({ name }) => name === "Validate runner-owned UI preview build variables",
+  );
+
+  assert.equal(
+    sourceValidation.env.SOURCE_PATH,
+    "${{ github.workspace }}/source",
+  );
+  assert.equal(prerequisites["working-directory"], "source");
+  assert.equal(environmentValidation["working-directory"], undefined);
+  assert.equal(
+    environmentValidation.env.PULL_STAGING_PATH,
+    "${{ runner.temp }}/mento-vercel-pull-staging",
+  );
+  assert.match(
+    environmentValidation.run,
+    /--project-directory "\$PULL_STAGING_PATH\/apps\/ui\.mento\.org"/,
+  );
+  assert.deepEqual(
+    steps.filter(({ run }) =>
+      run?.includes("scripts/vercel-build-environment.mjs"),
+    ),
+    [environmentValidation],
+  );
+  assert.ok(
+    names.indexOf("Assert isolated runner-owned Vercel pull result") <
+      names.indexOf("Validate runner-owned UI preview build variables"),
+  );
+  assert.ok(
+    names.indexOf("Validate runner-owned UI preview build variables") <
+      names.indexOf("Stage trusted UI project settings into candidate source"),
   );
 });
 


### PR DESCRIPTION
## The Problem

- The merged manual prebuilt pilot still executed exact-SHA candidate code in a job that later received the Vercel preview token. Candidate-controlled filesystem state could also influence token-bearing `vercel pull` and the prebuilt upload handoff. That boundary was acceptable only for a manually reviewed trusted SHA, but it was not strong enough to reuse safely for automatic preview work.

## The Solution

- Materialize the exact selected commit from raw `git ls-tree`/`git cat-file` objects into a fresh bounded runner-owned tree, then hand it to a dedicated ephemeral build identity. Raw-object reads bypass candidate-controlled archive attributes and checkout filters; unsafe paths, unsupported modes, gitlinks, oversized trees, and filesystem collisions fail closed.
- Run candidate install/build with a minimal environment, cleared groups, and `no-new-privs`; stop workflow-command interpretation around candidate output and terminate every process owned by that identity after each candidate phase.
- Install the exact locked Vercel CLI in a protected runner-owned tools tree, and expose the Vercel token only to trusted pull/deploy/inspect commands—never to dependency installation or the candidate build.
- Run token-bearing `vercel pull` only in a fresh runner-owned staging tree. Recursively reject symlinks, hardlinks, special nodes, unexpected files, unsafe ownership/permissions, and oversized output, then copy only the validated repo link, project settings, and preview environment file into freshly created candidate-owned state.
- Validate candidate-owned state only through trusted `sudo env -i` controller calls while the candidate UID owns no processes. The post-stage mapping check, pre-build provenance/tree check, and post-build output check use explicit runner/candidate ownership; the normal runner never reads candidate-owned `0700`/`0600` state.
- Copy validated Build Output API files into a runner-owned upload handoff after the candidate identity and processes are removed; revalidate project/root/SHA/deployment-ID/output invariants immediately before upload.
- Materialize the trusted CLI with pinned pnpm `10.24.0`, the frozen controller lockfile, disabled lifecycle scripts, copy imports, and an explicit root-package filter. The tested relative modules layout keeps Vercel `56.2.0` inside the runner-owned tools tree.
- Document the residual trusted-SHA/Turbo/build-variable boundary and add adversarial offline fixtures for filesystem, Git filters and attributes, process, ownership, protected-CLI, token, and handoff behavior. The integration fixture performs the real pnpm install and executes the pinned CLI.

This is a security-only follow-up to #518. It does not add an automatic PR trigger, expand beyond `ui.mento.org`, change a Vercel Git setting, or touch production. #518 remains open until the privileged manual pilot and comparison evidence pass.

## Validation

- `pnpm test` — passed: ADR 9/9, Vercel primitives 50/50, workflow 46/46, cost analysis 31/31, and all workspace tests.
- Raw-object fixtures prove exact blob bytes survive `export-ignore`, `export-subst`, `eol=crlf`, and `ident`; preserve executable and symlink semantics; exclude `.git`; and reject gitlinks before writing.
- `pnpm ci:action-pins` and `pnpm ci:action-pins:test` — all 19 workflow/composite-action files scan clean; 54/54 tests passed.
- `pnpm quality:budgets:test` — 30/30 passed.
- `pnpm check-types` — 8/8 tasks passed.
- `pnpm knip` — clean apart from the pre-existing Tailwind configuration hint.
- Trunk checks and `git diff --check` — clean.
- Fresh independent security review of exact head `c8f3d05e` — `ALL_CLEAR`; every GitHub review thread is replied to and resolved.
- Browser verification on native UI deployment `dpl_CutGCxso2KLfuRQexUxfvNVS2KAz`: `/basic-components` rendered with fonts loaded, sidebar navigation reached `/form-components`, Input Field accepted `head-c8f3d05e`, all 22 observed requests returned expected 200/204/304 statuses, the console remained error-free, and the security-header policy remained intact.

## Ship Checklist

- [x] PR title follows the conventions
- [x] Performed a self-review of my own changes
- [x] Relevant automated checks and smoke tests pass
- [x] Architecture decision: [`docs/adr/0001-github-actions-vercel-deployment-orchestration.md`](https://github.com/mento-protocol/frontend-monorepo/blob/main/docs/adr/0001-github-actions-vercel-deployment-orchestration.md)
