### PR TITLE
fix(ci): grant preview controller PR comment access

### DIFF
--- a/.github/workflows/vercel-preview-controller.yml
+++ b/.github/workflows/vercel-preview-controller.yml
@@ -153,8 +153,7 @@ jobs:
     timeout-minutes: 5
     permissions:
       contents: read
-      issues: write
-      pull-requests: read
+      pull-requests: write
       statuses: write
     outputs:
       pr_number: ${{ steps.receipt.outputs.pr_number }}
@@ -203,8 +202,7 @@ jobs:
       actions: write
       contents: read
       deployments: read
-      issues: write
-      pull-requests: read
+      pull-requests: write
       statuses: write
     steps:
       - name: Check out trusted controller
@@ -344,8 +342,7 @@ jobs:
     timeout-minutes: 5
     permissions:
       contents: read
-      issues: write
-      pull-requests: read
+      pull-requests: write
       statuses: write
     outputs:
       pr_number: ${{ steps.receipt.outputs.pr_number }}
@@ -394,8 +391,7 @@ jobs:
       actions: write
       contents: read
       deployments: read
-      issues: write
-      pull-requests: read
+      pull-requests: write
       statuses: write
     steps:
       - name: Check out trusted controller
@@ -439,8 +435,7 @@ jobs:
       actions: write
       contents: read
       deployments: read
-      issues: write
-      pull-requests: read
+      pull-requests: write
       statuses: write
     steps:
       - name: Check out trusted controller
@@ -584,8 +579,7 @@ jobs:
       actions: write
       contents: read
       deployments: write
-      issues: write
-      pull-requests: read
+      pull-requests: write
       statuses: write
     steps:
       - name: Check out trusted controller

--- a/.github/workflows/vercel-preview-worker.yml
+++ b/.github/workflows/vercel-preview-worker.yml
@@ -293,8 +293,7 @@ jobs:
     permissions:
       contents: read
       deployments: write
-      issues: write
-      pull-requests: read
+      pull-requests: write
     steps:
       - name: Check out trusted evidence controller only
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/scripts/vercel-preview-controller.test.mjs
+++ b/scripts/vercel-preview-controller.test.mjs
@@ -1715,6 +1715,43 @@ test("malformed successful planner output is recorded as fail-closed UI impact",
   assert.equal(fixture.commitStatuses.at(-1).state, "pending");
 });
 
+test("closed event receipt is immutable, idempotent, and publishes no status", async () => {
+  const closed = event({
+    run: 120,
+    action: "closed",
+    head: SHA.A,
+    updated: timestamp(2),
+  });
+  const snapshot = structuredClone(closed);
+  delete snapshot.plan;
+  const pullRequest = pull({
+    head: SHA.A,
+    state: "closed",
+    updated: timestamp(2),
+    closed: timestamp(2),
+  });
+  const fixture = fakeGitHub({ pullRequest, comments: [] });
+  const core = fakeCore();
+  const options = {
+    github: fixture.github,
+    context: fakeContext({ runId: 120 }),
+    core,
+    snapshotRaw: JSON.stringify(snapshot),
+    planRaw: "",
+    plannerOutcome: "skipped",
+  };
+
+  const first = await recordEventReceipt(options);
+  const second = await recordEventReceipt(options);
+
+  assert.equal(first.plan.reason, "closed");
+  assert.deepEqual(second, first);
+  assert.equal(core.outputs.get("pr_number"), "519");
+  assert.equal(fixture.comments.length, 1);
+  assert.match(fixture.comments[0].body, /"event_action": "closed"/);
+  assert.equal(fixture.commitStatuses.length, 0);
+});
+
 test("trusted workflow_run follow-up publishes Dependabot unsupported status only for the exact current head", async () => {
   const workflowRun = dependabotIntakeRun();
   assert.deepEqual(validateDependabotIntakeWorkflowRun(workflowRun), {

--- a/scripts/vercel-preview-workflows.test.mjs
+++ b/scripts/vercel-preview-workflows.test.mjs
@@ -211,8 +211,7 @@ test("planner materializes only trusted-base code without shared caches", () => 
 test("immutable receipt writers are durable and outside lossy reconciliation concurrency", () => {
   const expected = {
     contents: "read",
-    issues: "write",
-    "pull-requests": "read",
+    "pull-requests": "write",
     statuses: "write",
   };
   for (const jobName of ["receipt-event", "receipt-bootstrap"]) {
@@ -237,6 +236,28 @@ test("immutable receipt writers are durable and outside lossy reconciliation con
       false,
     );
   }
+});
+
+test("every PR comment writer uses the pull-request resource permission", () => {
+  const controllerCommentWriters = [
+    ["receipt-event", "recordEventReceipt"],
+    ["reconcile-event", "reconcilePreview"],
+    ["receipt-bootstrap", "recordEventReceipt"],
+    ["reconcile-bootstrap", "reconcilePreview"],
+    ["reconcile-request", "reconcilePreview"],
+    ["recover-worker-result", "recoverWorkerResult"],
+  ];
+  for (const [jobName, entrypoint] of controllerCommentWriters) {
+    const job = controller.jobs[jobName];
+    assert.match(JSON.stringify(job), new RegExp(entrypoint));
+    assert.equal(job.permissions["pull-requests"], "write");
+    assert.equal(Object.hasOwn(job.permissions, "issues"), false);
+  }
+
+  const workerEvidence = worker.jobs["record-worker-evidence"];
+  assert.match(JSON.stringify(workerEvidence), /recordWorkerEvidence/);
+  assert.equal(workerEvidence.permissions["pull-requests"], "write");
+  assert.equal(Object.hasOwn(workerEvidence.permissions, "issues"), false);
 });
 
 test("every controller write-token job checks out only trusted workflow code", () => {
@@ -453,8 +474,7 @@ test("completed-worker recovery is authoritative for missing and orphaned Deploy
     actions: "write",
     contents: "read",
     deployments: "write",
-    issues: "write",
-    "pull-requests": "read",
+    "pull-requests": "write",
     statuses: "write",
   });
   assert.match(JSON.stringify(recovery), /recoverWorkerResult/);


### PR DESCRIPTION
## The Problem

The first live Vercel Preview Controller closed-event run failed while persisting its immutable PR receipt. The job called the PR comment API with `issues: write` but only `pull-requests: read`, and GitHub returned `403 Resource not accessible by integration`.

## The Solution

Use the resource-specific `pull-requests: write` permission for every controller and worker job that creates or updates durable PR comments, while removing the now-unneeded `issues: write` permission. Keep failures fail-closed and add regression coverage for all comment writers plus closed-event receipt idempotency.

Supports #519.

## Validation

- `pnpm vercel:preview:test` — 75/75 passed
- `pnpm ci:action-pins`
- `pnpm quality:budgets:test` — 30/30 passed
- `pnpm check-types`
- `trunk check .github/workflows/vercel-preview-controller.yml .github/workflows/vercel-preview-worker.yml scripts/vercel-preview-workflows.test.mjs scripts/vercel-preview-controller.test.mjs`
- Fresh-context Codex autoreview — clean, confidence 0.96
- Deterministic local autoreview — clean
- Pre-push Trunk, typecheck, and Knip hooks — passed

## Ship Checklist

- [x] ship skill used
- [x] local review run
- [x] validation run
- [ ] merged closed-event controller canary succeeds

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI permission scope changes only; no application runtime or secrets logic changed. Slightly broader PR write access on already-trusted controller jobs is intentional and aligned with existing comment-writing behavior.
> 
> **Overview**
> Fixes **403 Resource not accessible by integration** when the Vercel Preview Controller persists immutable PR receipts (including **closed** events) by posting durable comments on pull requests.
> 
> **Workflow permissions:** Every controller job that writes PR comments (`receipt-event`, `reconcile-event`, `receipt-bootstrap`, `reconcile-bootstrap`, `reconcile-request`, `recover-worker-result`) and the worker `record-worker-evidence` job now use **`pull-requests: write`** instead of **`issues: write`** with **`pull-requests: read`**, matching GitHub’s resource-specific scope for PR comment APIs. **`issues: write`** is removed from those jobs.
> 
> **Tests:** Workflow tests assert all comment-writing jobs require `pull-requests: write` and must not declare `issues`. A controller unit test covers **closed** event receipts as immutable, idempotent, with **no commit status** published.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b3fe153d3a5afb3f8406140219d80ce3d32b109. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->