### PR TITLE
fix(ci): unblock Vercel preview follow-ups

### DIFF
--- a/.github/workflows/_vercel-prebuilt.yml
+++ b/.github/workflows/_vercel-prebuilt.yml
@@ -231,6 +231,7 @@ jobs:
             exit 1
           fi
 
+          /bin/chmod 0711 "$RUNNER_TEMP"
           /bin/mkdir -m 0755 "$TRUSTED_VERCEL_TOOLS_PATH"
           node_bin="$(realpath "$(command -v node)")"
           pnpm_bin="$(realpath "$(command -v pnpm)")"
@@ -284,7 +285,7 @@ jobs:
             "$node_bin" \
             "$pnpm_bin"; do
             if [ ! -e "$protected_path" ] || candidate_can_write "$protected_path"; then
-              echo "Candidate can modify a protected runner path" >&2
+              echo "Candidate can modify a protected runner path: $protected_path" >&2
               exit 1
             fi
           done

--- a/.github/workflows/vercel-preview-controller.yml
+++ b/.github/workflows/vercel-preview-controller.yml
@@ -192,7 +192,7 @@ jobs:
   reconcile-event:
     name: Reconcile durable preview state
     needs: receipt-event
-    if: needs.receipt-event.result == 'success'
+    if: always() && needs.receipt-event.result == 'success'
     concurrency:
       group: vercel-preview-controller-pr-${{ needs.receipt-event.outputs.pr_number }}
       cancel-in-progress: false

--- a/docs/vercel-deployments.md
+++ b/docs/vercel-deployments.md
@@ -379,14 +379,17 @@ separately from `vercel build`. The signed Turbo remote build cache remains
 enabled and its hit/miss evidence remains part of the comparison.
 
 Before candidate installation, the worker proves the checked-out index tree is
-the exact selected commit tree. A trusted, bounded materializer then lists that
-exact commit with `git ls-tree`, reads every raw blob with `git cat-file`, and
-writes only supported regular files and symbolic links into a fresh fixed path
-under `RUNNER_TEMP`. It rejects unsafe paths, unsupported modes (including
-gitlinks), oversized trees, and filesystem collisions. Reading raw objects
-deliberately bypasses both archive attributes (`export-ignore` and
-`export-subst`) and checkout filters (`eol`, `ident`, and custom filters), so the
-candidate always receives the selected commit's stored bytes.
+the exact selected commit tree. Before any candidate process starts, it
+normalizes `RUNNER_TEMP` to runner-owned `0711` permissions and proves the
+candidate UID cannot write that parent. A trusted, bounded materializer then
+lists the exact commit with `git ls-tree`, reads every raw blob with
+`git cat-file`, and writes only supported regular files and symbolic links into
+a fresh fixed child path that is subsequently handed to the candidate UID. It
+rejects unsafe paths, unsupported modes (including gitlinks), oversized trees,
+and filesystem collisions. Reading raw objects deliberately bypasses both
+archive attributes (`export-ignore` and `export-subst`) and checkout filters
+(`eol`, `ident`, and custom filters), so the candidate always receives the
+selected commit's stored bytes.
 
 ### Root Directory and command sequence
 

--- a/scripts/vercel-prebuilt-workflow.test.mjs
+++ b/scripts/vercel-prebuilt-workflow.test.mjs
@@ -1615,6 +1615,17 @@ test("candidate execution is UID-isolated and hands upload to runner-owned state
   assert.match(isolationBlock, /--package-import-method copy/);
   assert.match(isolationBlock, /trusted-install-modules-dir/);
   assert.match(isolationBlock, /--modules-dir "\$trusted_modules_dir"/);
+  const runnerTempHardenIndex = isolationBlock.indexOf(
+    '/bin/chmod 0711 "$RUNNER_TEMP"',
+  );
+  const runnerTempProtectionIndex = isolationBlock.indexOf(
+    '"$RUNNER_TEMP" \\',
+    runnerTempHardenIndex,
+  );
+  const materializeIndex = isolationBlock.indexOf("materialize-source");
+  assert.notEqual(runnerTempHardenIndex, -1);
+  assert.ok(runnerTempProtectionIndex > runnerTempHardenIndex);
+  assert.ok(materializeIndex > runnerTempProtectionIndex);
   assert.match(
     isolationBlock,
     /--virtual-store-dir "\$trusted_modules_dir\/\.pnpm"/,

--- a/scripts/vercel-preview-controller.mjs
+++ b/scripts/vercel-preview-controller.mjs
@@ -55,6 +55,9 @@ const MAX_RECEIPTS = 200;
 const MAX_HISTORY = 40;
 const WORKER_RUN_PAGE_SIZE = 100;
 const MAX_WORKER_RUN_PAGES = 3;
+const WORKER_RUN_IDENTITY_ATTEMPTS = 5;
+const WORKER_RUN_IDENTITY_RETRY_MS = 500;
+const WORKER_RUN_NAME_PARSE_ERROR = "Worker run name is not strictly parseable";
 const WORKER_RECOVERY_BEFORE_MS = 2 * 60 * 1_000;
 const WORKER_RECOVERY_AFTER_MS = 15 * 60 * 1_000;
 const UPLOAD_STARTED_DESCRIPTION = "Prebuilt preview upload starting";
@@ -727,7 +730,7 @@ export function parseWorkerRunName(value) {
   const match = String(value ?? "").match(
     /^Vercel preview worker \| pr=([1-9][0-9]{0,9}) \| target=ui \| sha=([0-9a-f]{40}) \| key=([0-9a-f]{24})$/,
   );
-  invariant(match, "Worker run name is not strictly parseable");
+  invariant(match, WORKER_RUN_NAME_PARSE_ERROR);
   return {
     pr: pullRequestNumber(match[1]),
     target: PREVIEW_TARGET,
@@ -2338,9 +2341,30 @@ export function validateWorkerRunIdentity(run, selected) {
   };
 }
 
-async function getValidatedWorkerRun(github, context, runId, selected) {
-  const data = await getWorkerRun(github, context, runId, selected);
-  return validateWorkerRunIdentity(data, selected);
+async function getValidatedWorkerRun(
+  github,
+  context,
+  runId,
+  selected,
+  { waitForRetry = wait } = {},
+) {
+  const pause = waitForRetry ?? wait;
+  let pendingTitleError;
+  for (let attempt = 0; attempt < WORKER_RUN_IDENTITY_ATTEMPTS; attempt += 1) {
+    const data = await getWorkerRun(github, context, runId, selected);
+    try {
+      return validateWorkerRunIdentity(data, selected);
+    } catch (error) {
+      if (error?.message !== WORKER_RUN_NAME_PARSE_ERROR) {
+        throw error;
+      }
+      pendingTitleError = error;
+      if (attempt < WORKER_RUN_IDENTITY_ATTEMPTS - 1) {
+        await pause(WORKER_RUN_IDENTITY_RETRY_MS);
+      }
+    }
+  }
+  throw pendingTitleError;
 }
 
 async function getWorkerRun(github, context, runId, selected) {
@@ -2363,7 +2387,12 @@ async function getWorkerRun(github, context, runId, selected) {
   return response.data;
 }
 
-async function dispatchWorker(github, context, selected) {
+async function dispatchWorker(
+  github,
+  context,
+  selected,
+  { waitForRunDetails = wait } = {},
+) {
   const response = await github.request(
     "POST /repos/{owner}/{repo}/actions/workflows/{workflow_id}/dispatches",
     {
@@ -2395,7 +2424,9 @@ async function dispatchWorker(github, context, selected) {
     data.workflow_run_id ?? data.id,
     "Dispatched workflow run ID",
   );
-  return getValidatedWorkerRun(github, context, workflowRunId, selected);
+  return getValidatedWorkerRun(github, context, workflowRunId, selected, {
+    waitForRetry: waitForRunDetails,
+  });
 }
 
 async function shaIsStillAssociated(github, context, pull, sha) {
@@ -2734,7 +2765,9 @@ export async function reconcilePreview({
         let runDetails = recoveredRun;
         if (!runDetails) {
           try {
-            runDetails = await dispatchWorker(github, context, selected);
+            runDetails = await dispatchWorker(github, context, selected, {
+              waitForRunDetails: waitForRecovery,
+            });
           } catch (error) {
             if (error instanceof WorkerWorkflowShaMismatchError) {
               await recordSupersededIntent({
@@ -3513,6 +3546,7 @@ export async function recoverWorkerResult({
     context,
     runId,
     selection,
+    { waitForRetry: waitForRecovery },
   );
   if (selection.workflow_run_id === null) {
     invariant(

--- a/scripts/vercel-preview-controller.mjs
+++ b/scripts/vercel-preview-controller.mjs
@@ -2298,7 +2298,15 @@ async function recoverMatchingWorkerRun(
 
 export function validateWorkerRunIdentity(run, selected) {
   plainObject(run, "Worker run");
-  invariant(run.name === WORKER_WORKFLOW_NAME, "Worker workflow name mismatch");
+  const displayTitle = boundedText(
+    run.display_title,
+    "Worker run display title",
+  );
+  const workflowName = boundedText(run.name, "Worker workflow name");
+  invariant(
+    workflowName === WORKER_WORKFLOW_NAME || workflowName === displayTitle,
+    "Worker workflow name mismatch",
+  );
   const workflowPath = `.github/workflows/${WORKER_WORKFLOW}`;
   invariant(
     run.path === workflowPath || run.path === `${workflowPath}@main`,
@@ -2308,7 +2316,7 @@ export function validateWorkerRunIdentity(run, selected) {
   invariant(run.head_branch === "main", "Worker default ref mismatch");
   const workflowSha = exactSha(run.head_sha, "Worker workflow SHA");
   const runAttempt = exactRunAttempt(run.run_attempt ?? 1);
-  const parsed = parseWorkerRunName(run.display_title);
+  const parsed = parseWorkerRunName(displayTitle);
   invariant(
     parsed.pr === selected.pr &&
       parsed.sha === selected.sha &&

--- a/scripts/vercel-preview-controller.test.mjs
+++ b/scripts/vercel-preview-controller.test.mjs
@@ -1750,6 +1750,26 @@ test("closed event receipt is immutable, idempotent, and publishes no status", a
   assert.equal(fixture.comments.length, 1);
   assert.match(fixture.comments[0].body, /"event_action": "closed"/);
   assert.equal(fixture.commitStatuses.length, 0);
+
+  const opened = event({
+    run: 119,
+    action: "opened",
+    head: SHA.A,
+    updated: timestamp(1),
+  });
+  const reconcileFixture = fakeGitHub({
+    pullRequest,
+    comments: [eventComment(opened), eventComment(first, 2)],
+  });
+  const state = await reconcilePreview({
+    github: reconcileFixture.github,
+    context: fakeContext({ runId: 120 }),
+    core: fakeCore(),
+    prNumber: 519,
+  });
+
+  assert.equal(state.closed, true);
+  assert.equal(reconcileFixture.dispatches.length, 0);
 });
 
 test("trusted workflow_run follow-up publishes Dependabot unsupported status only for the exact current head", async () => {

--- a/scripts/vercel-preview-controller.test.mjs
+++ b/scripts/vercel-preview-controller.test.mjs
@@ -1907,8 +1907,14 @@ test("strict worker identity uses display_title plus workflow path, ref, SHA, an
     ).workflow_run_id,
     8_000,
   );
+  assert.equal(
+    validateWorkerRunIdentity({ ...run, name: run.display_title }, selection)
+      .workflow_run_id,
+    8_000,
+  );
   for (const override of [
     { display_title: "Vercel Preview Worker" },
+    { name: "Another Workflow" },
     { path: ".github/workflows/vercel-preview-worker.yml@feature" },
     { path: ".github/workflows/other.yml@main" },
     { event: "push" },
@@ -2118,7 +2124,8 @@ test("intended dispatch recovery attaches exactly one run and fails closed on am
     pullRequest,
   });
   const intended = persistIntent(selected);
-  const existingRun = workerRun(selected.nextDispatch);
+  const listedRun = workerRun(selected.nextDispatch);
+  const existingRun = { ...listedRun, name: listedRun.display_title };
   const recovered = fakeGitHub({
     pullRequest,
     comments: [eventComment(opened), stateComment(intended)],

--- a/scripts/vercel-preview-controller.test.mjs
+++ b/scripts/vercel-preview-controller.test.mjs
@@ -1480,6 +1480,7 @@ function fakeGitHub({
   pullCommits = [pullRequest.head.sha],
   deployments: initialDeployments = [],
   deploymentStatuses = new Map(),
+  workflowRunDisplayTitles = [],
 } = {}) {
   const comments = structuredClone(initialComments);
   const runs = structuredClone(initialRuns);
@@ -1495,6 +1496,8 @@ function fakeGitHub({
   const createdDeploymentStatuses = [];
   const workflowRunAttemptRequests = [];
   const workflowRunListRequests = [];
+  const workflowRunRequests = [];
+  const transientDisplayTitles = [...workflowRunDisplayTitles];
   const attemptFailures = [...workflowRunAttemptFailures];
   const commentUpdateFailures = [...updateCommentFailures];
   let nextCommentId = 100;
@@ -1554,7 +1557,16 @@ function fakeGitHub({
         getWorkflowRun: async ({ run_id }) => {
           const data = runs.find(({ id }) => id === run_id);
           assert.ok(data, `fixture run ${run_id} must exist`);
-          return { data: structuredClone(data) };
+          workflowRunRequests.push(run_id);
+          const displayTitle = transientDisplayTitles.shift();
+          return {
+            data: structuredClone({
+              ...data,
+              ...(displayTitle === undefined
+                ? {}
+                : { display_title: displayTitle }),
+            }),
+          };
         },
       },
       repos: {
@@ -1660,6 +1672,7 @@ function fakeGitHub({
     createdDeploymentStatuses,
     workflowRunAttemptRequests,
     workflowRunListRequests,
+    workflowRunRequests,
   };
 }
 
@@ -1953,7 +1966,7 @@ test("worker preflight rejects expected A versus actual B before any API access"
   assert.equal(apiCalls, 0);
 });
 
-test("durable dispatch persists intent, requires HTTP 200 run details, and re-queries the exact run", async () => {
+test("durable dispatch persists intent and waits for the exact run title to materialize", async () => {
   const opened = event({
     run: 121,
     action: "opened",
@@ -1964,6 +1977,7 @@ test("durable dispatch persists intent, requires HTTP 200 run details, and re-qu
   const fixture = fakeGitHub({
     pullRequest,
     comments: [eventComment(opened)],
+    workflowRunDisplayTitles: ["Vercel Preview Worker"],
   });
   const core = fakeCore();
   const state = await reconcilePreview({
@@ -1977,9 +1991,37 @@ test("durable dispatch persists intent, requires HTTP 200 run details, and re-qu
   assert.equal(state.ui.active.dispatch_state, "dispatched");
   assert.equal(state.ui.active.workflow_run_id, 8_000);
   assert.equal(state.ui.active.workflow_sha, SHA.E);
+  assert.deepEqual(fixture.workflowRunRequests, [8_000, 8_000]);
   assert.equal(core.outputs.get("dispatched_run_id"), "8000");
   assert.equal(fixture.commitStatuses.at(-1).context, "Vercel Preview");
   assert.equal(fixture.commitStatuses.at(-1).sha, SHA.A);
+});
+
+test("durable dispatch fails closed when the exact run title never materializes", async () => {
+  const opened = event({
+    run: 121,
+    action: "opened",
+    head: SHA.A,
+    updated: timestamp(1),
+  });
+  const fixture = fakeGitHub({
+    pullRequest: pull({ head: SHA.A, updated: timestamp(1) }),
+    comments: [eventComment(opened)],
+    workflowRunDisplayTitles: Array(5).fill("Vercel Preview Worker"),
+  });
+
+  await assert.rejects(
+    reconcilePreview({
+      github: fixture.github,
+      context: fakeContext(),
+      core: fakeCore(),
+      prNumber: 519,
+      waitForRecovery: async () => {},
+    }),
+    /Worker run name is not strictly parseable/,
+  );
+  assert.deepEqual(fixture.workflowRunRequests, Array(5).fill(8_000));
+  assert.equal(fixture.commitStatuses.at(-1).state, "error");
 });
 
 test("a dispatch racing a main advance is terminalized and automatically reselected", async () => {
@@ -2451,15 +2493,20 @@ test("completed callback durably binds an intended dispatch after a controller c
     pullRequest,
     comments: [eventComment(opened), stateComment(intended)],
     runs: [completed],
+    workflowRunDisplayTitles: ["Vercel Preview Worker"],
   });
   const core = fakeCore();
+  const waits = [];
   const outcome = await recoverWorkerResult({
     github: fixture.github,
     context: fakeContext({ workflowRun: completed }),
     core,
+    waitForRecovery: async (milliseconds) => waits.push(milliseconds),
   });
   assert.equal(outcome.terminal_reason, "worker-cancelled");
   assert.equal(core.outputs.get("recovered_intended_run_id"), "8000");
+  assert.deepEqual(waits, [500]);
+  assert.deepEqual(fixture.workflowRunRequests, [8_000, 8_000]);
   const controllerState = fixture.comments.find(({ body }) =>
     body.startsWith("<!-- vercel-preview-controller:v1 -->"),
   );

--- a/scripts/vercel-preview-workflows.test.mjs
+++ b/scripts/vercel-preview-workflows.test.mjs
@@ -238,6 +238,24 @@ test("immutable receipt writers are durable and outside lossy reconciliation con
   }
 });
 
+test("closed events reconcile after their optional planner is skipped", () => {
+  const planner = controller.jobs["plan-event"];
+  const receipt = controller.jobs["receipt-event"];
+  const reconcile = controller.jobs["reconcile-event"];
+
+  assert.equal(
+    planner.if,
+    "needs.snapshot-event.outputs.plan_required == 'true'",
+  );
+  assert.deepEqual(receipt.needs, ["snapshot-event", "plan-event"]);
+  assert.match(receipt.if, /^always\(\) &&/);
+  assert.equal(reconcile.needs, "receipt-event");
+  assert.equal(
+    reconcile.if,
+    "always() && needs.receipt-event.result == 'success'",
+  );
+});
+
 test("every PR comment writer uses the pull-request resource permission", () => {
   const controllerCommentWriters = [
     ["receipt-event", "recordEventReceipt"],


### PR DESCRIPTION
## The Problem

The merged preview controller can persist a closed-event receipt, but its durable reconciliation job is skipped when the optional planner job is skipped. That leaves closed PR state unreconciled even though the receipt succeeds.

The first exact-SHA UI pilot also exposed a GitHub-hosted runner mismatch: the candidate UID could write `RUNNER_TEMP`, so the isolation job failed before reaching `vercel pull` or using `VERCEL_TOKEN_PREVIEW`. Fixed-name trusted CLI, pull-staging, and upload paths must remain protected from candidate pre-creation or replacement.

The first live automatic canary then showed that GitHub's newly dispatched run can exist before its input-derived `display_title` has materialized. Treating that brief API state as a permanent identity failure left the controller intent stranded even though the eventual title was valid.

The recovery path exposed a second GitHub API shape: runs returned by the workflow-runs list endpoint can put the custom `display_title` in both `name` and `display_title`, whereas the single-run endpoint can retain the canonical workflow name in `name`. Requiring only the latter shape rejected the controller's own valid worker.

## The Solution

- Evaluate closed-event reconciliation with `always()` while still requiring the receipt job to succeed.
- Normalize `RUNNER_TEMP` to runner-owned `0711` before any candidate process starts, retain the explicit candidate write-denial check, and include the failing protected path in diagnostics.
- Boundedly re-query only an unparseable newly dispatched run title; every parseable identity mismatch still fails immediately, and a title that never materializes still fails closed.
- Accept either documented GitHub worker-run `name` shape only when the exact `display_title`, workflow path, event, ref, workflow SHA, attempt, PR, commit, and idempotency key all pass the existing strict identity checks.
- Add deterministic workflow/state-machine regressions for closed PRs and runner-temp hardening order.
- Document the runner-temp permission boundary in the Vercel deployment runbook.

## Validation

- `pnpm vercel:workflow:test` — 65/65 passing
- `pnpm vercel:preview:test` — 77/77 passing
- `pnpm quality:budgets:test` — 30/30 passing
- `pnpm ci:action-pins`
- `trunk fmt` and `trunk check` on all changed files
- `git diff --check`
- full pre-push type checks and Knip
- fresh-context security/correctness reviews — clean, confidence 0.97–0.98

After merge, the same immutable pilot SHA will be rerun to validate the manually provisioned preview token and complete the native-vs-GitHub comparison evidence.

Supports #518.
Supports #519.
