### PR TITLE
fix(ci): stage standalone pnpm payload

### DIFF
--- a/.github/workflows/_vercel-prebuilt.yml
+++ b/.github/workflows/_vercel-prebuilt.yml
@@ -156,6 +156,7 @@ jobs:
           ref: ${{ inputs.commit_sha }}
 
       - name: Set up pinned pnpm
+        id: pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v4
         with:
           dest: ${{ runner.temp }}/mento-pnpm-tools
@@ -209,6 +210,7 @@ jobs:
           CANDIDATE_SOURCE_PATH: ${{ runner.temp }}/mento-vercel-candidate-source
           DEPLOY_SHA: ${{ steps.source.outputs.checked_out_sha }}
           PNPM_ACTION_DEST: ${{ runner.temp }}/mento-pnpm-tools
+          PNPM_BIN_DEST: ${{ steps.pnpm.outputs.bin_dest }}
           SOURCE_PATH: ${{ github.workspace }}/source
           TRUSTED_VERCEL_TOOLS_PATH: ${{ runner.temp }}/mento-vercel-trusted-tools
         run: |
@@ -250,7 +252,11 @@ jobs:
           fi
           trusted_bin_dir="$TRUSTED_VERCEL_TOOLS_PATH/bin"
           setup_node_bin="$(realpath "$(command -v node)")"
-          setup_pnpm_bin="$(realpath "$(command -v pnpm)")"
+          if [ "$(realpath "$PNPM_BIN_DEST")" != "$PNPM_ACTION_DEST/node_modules/.bin/bin" ]; then
+            echo "Pinned pnpm action returned an unexpected binary directory" >&2
+            exit 1
+          fi
+          setup_pnpm_bin="$(realpath "$PNPM_BIN_DEST/pnpm")"
           case "$setup_pnpm_bin" in
             "$PNPM_ACTION_DEST"/*) ;;
             *) echo "Pinned pnpm escaped its action-owned directory" >&2; exit 1 ;;

--- a/docs/vercel-deployments.md
+++ b/docs/vercel-deployments.md
@@ -365,9 +365,13 @@ store with `--offline`; it cannot contact the registry to repair missing data.
 The hosted setup-node and pnpm locations are treated only as trusted staging
 inputs because runner-image permissions can make those original paths writable
 by the isolated candidate UID. Before candidate code starts, the worker copies
-Node.js and standalone pnpm into the same runner-owned protected tool
-directory, removes group/other write access from the original pnpm action
-directory, and prepends the protected runtime to subsequent workflow steps.
+Node.js and the exact pinned standalone pnpm executable into the same
+runner-owned protected tool directory, removes group/other write access from
+the original pnpm action directory, and prepends the protected runtime to
+subsequent workflow steps. The pnpm action's PATH entry is a launcher whose
+executable lives below a hashed `global/v*/.../@pnpm/exe/pnpm` directory, so
+the worker requires exactly one protected target reporting `10.24.0` and
+copies that self-contained executable instead of relocating the launcher.
 Before any credentialed command, the worker proves the runtime root, its
 replacement-relevant parents, Node.js, pnpm, and the CLI are not candidate
 writable; it also proves the CLI resolves inside the protected directory, its

--- a/scripts/vercel-prebuilt-workflow.mjs
+++ b/scripts/vercel-prebuilt-workflow.mjs
@@ -74,6 +74,8 @@ const VERCEL_CLI_BASE_ENVIRONMENT = [
 const PULL_STAGING_DIRECTORY = "mento-vercel-pull-staging";
 const CANDIDATE_SOURCE_DIRECTORY = "mento-vercel-candidate-source";
 const TRUSTED_TOOLS_DIRECTORY = "mento-vercel-trusted-tools";
+const PNPM_ACTION_DIRECTORY = "mento-pnpm-tools";
+const PINNED_PNPM_VERSION = "10.24.0";
 const PULLED_ENVIRONMENT_FILE = ".env.preview.local";
 const MAX_SOURCE_ENTRIES = 20_000;
 const MAX_SOURCE_PATH_BYTES = 4_096;
@@ -1112,7 +1114,7 @@ export function environmentForVercelCli(environment, allowedNames = []) {
 
 function assertProtectedRuntimeEntry(
   path,
-  { directory, expectedUid, expectedGid },
+  { directory, expectedUid, expectedGid, requireSingleLink = true },
 ) {
   const entry = lstatSync(path);
   if (
@@ -1121,17 +1123,215 @@ function assertProtectedRuntimeEntry(
     entry.uid !== expectedUid ||
     entry.gid !== expectedGid ||
     (entry.mode & 0o7022) !== 0 ||
-    (!directory && entry.nlink !== 1)
+    (!directory && requireSingleLink && entry.nlink !== 1)
   ) {
     throw new Error("Protected runtime entry is not runner-owned");
   }
   return entry;
 }
 
+function assertProtectedRuntimeDescendant({
+  root,
+  path,
+  directory,
+  expectedUid,
+  expectedGid,
+  requireSingleLink = true,
+}) {
+  const canonicalRoot = realpathSync(root);
+  const canonicalPath = realpathSync(path);
+  const pathFromRoot = relative(canonicalRoot, canonicalPath);
+  if (
+    pathFromRoot === "" ||
+    pathFromRoot === ".." ||
+    pathFromRoot.startsWith(`..${sep}`) ||
+    isAbsolute(pathFromRoot)
+  ) {
+    throw new Error("Protected runtime source escaped its action root");
+  }
+  const entry = assertProtectedRuntimeEntry(canonicalPath, {
+    directory,
+    expectedUid,
+    expectedGid,
+    requireSingleLink,
+  });
+  let parent = dirname(canonicalPath);
+  while (parent !== canonicalRoot) {
+    assertProtectedRuntimeEntry(parent, {
+      directory: true,
+      expectedUid,
+      expectedGid,
+    });
+    const nextParent = dirname(parent);
+    if (nextParent === parent) {
+      throw new Error("Protected runtime source escaped its action root");
+    }
+    parent = nextParent;
+  }
+  return { entry, path: canonicalPath };
+}
+
+function readPnpmVersion(path, run) {
+  const result = run(path, ["--version"], {
+    encoding: "utf8",
+    env: {
+      HOME: "/nonexistent",
+      LANG: "C",
+      LC_ALL: "C",
+      PATH: "/usr/bin:/bin",
+    },
+    timeout: 10_000,
+    windowsHide: true,
+  });
+  if (result.error || result.signal || result.status !== 0) {
+    throw new Error("Pinned pnpm standalone executable did not run");
+  }
+  return result.stdout.trim();
+}
+
+function resolvePinnedPnpmExecutable({
+  runnerTemp,
+  pnpmRoot,
+  pnpmSource,
+  expectedUid = process.getuid?.(),
+  expectedGid = process.getgid?.(),
+  run = spawnSync,
+}) {
+  const uid = numericIdentity(expectedUid, "Expected runner UID");
+  const gid = numericIdentity(expectedGid, "Expected runner GID");
+  const canonicalPnpmRoot = assertRunnerTempChild({
+    runnerTemp,
+    path: pnpmRoot,
+    expectedName: PNPM_ACTION_DIRECTORY,
+    expectedUid: uid,
+    expectedGid: gid,
+  });
+  assertProtectedRuntimeEntry(canonicalPnpmRoot, {
+    directory: true,
+    expectedUid: uid,
+    expectedGid: gid,
+  });
+
+  requiredText(pnpmSource, "Protected pnpm source");
+  if (!isAbsolute(pnpmSource)) {
+    throw new Error("Protected pnpm source must be absolute");
+  }
+  const canonicalPnpmSource = realpathSync(pnpmSource);
+  const expectedLauncher = join(
+    canonicalPnpmRoot,
+    "node_modules",
+    ".bin",
+    "bin",
+    "pnpm",
+  );
+  if (canonicalPnpmSource !== expectedLauncher) {
+    throw new Error("Pinned pnpm source is not the action launcher");
+  }
+  const launcherEntry = assertProtectedRuntimeDescendant({
+    root: canonicalPnpmRoot,
+    path: canonicalPnpmSource,
+    directory: false,
+    expectedUid: uid,
+    expectedGid: gid,
+    requireSingleLink: false,
+  });
+  if (
+    (launcherEntry.entry.mode & 0o111) === 0 ||
+    readPnpmVersion(canonicalPnpmSource, run) !== PINNED_PNPM_VERSION
+  ) {
+    throw new Error("Pinned pnpm launcher is not the requested release");
+  }
+
+  const globalRoot = join(
+    canonicalPnpmRoot,
+    "node_modules",
+    ".bin",
+    "global",
+    "v11",
+  );
+  assertProtectedRuntimeDescendant({
+    root: canonicalPnpmRoot,
+    path: globalRoot,
+    directory: true,
+    expectedUid: uid,
+    expectedGid: gid,
+  });
+
+  const matchingCandidates = new Map();
+  for (const installEntry of readdirSync(globalRoot, {
+    withFileTypes: true,
+  }).sort((left, right) => left.name.localeCompare(right.name))) {
+    if (!installEntry.isDirectory() && !installEntry.isSymbolicLink()) continue;
+    const installRoot = join(globalRoot, installEntry.name);
+    const executableLocator = join(
+      installRoot,
+      "node_modules",
+      "@pnpm",
+      "exe",
+      "pnpm",
+    );
+    const packageJsonLocator = join(
+      installRoot,
+      "node_modules",
+      "@pnpm",
+      "exe",
+      "package.json",
+    );
+    if (!existsSync(executableLocator) || !existsSync(packageJsonLocator)) {
+      continue;
+    }
+    assertProtectedRuntimeDescendant({
+      root: canonicalPnpmRoot,
+      path: installRoot,
+      directory: true,
+      expectedUid: uid,
+      expectedGid: gid,
+    });
+    const packageJson = assertProtectedRuntimeDescendant({
+      root: canonicalPnpmRoot,
+      path: packageJsonLocator,
+      directory: false,
+      expectedUid: uid,
+      expectedGid: gid,
+      requireSingleLink: false,
+    });
+    const executable = assertProtectedRuntimeDescendant({
+      root: canonicalPnpmRoot,
+      path: executableLocator,
+      directory: false,
+      expectedUid: uid,
+      expectedGid: gid,
+      requireSingleLink: false,
+    });
+    const packageMetadata = JSON.parse(readFileSync(packageJson.path, "utf8"));
+    if (packageMetadata.name !== "@pnpm/exe") {
+      throw new Error("Pinned pnpm package identity is invalid");
+    }
+    if (packageMetadata.version !== PINNED_PNPM_VERSION) continue;
+    if (
+      (executable.entry.mode & 0o111) === 0 ||
+      readPnpmVersion(executable.path, run) !== PINNED_PNPM_VERSION
+    ) {
+      throw new Error("Pinned pnpm standalone executable is not exact");
+    }
+    matchingCandidates.set(
+      `${executable.entry.dev}:${executable.entry.ino}`,
+      executable.path,
+    );
+  }
+  if (matchingCandidates.size !== 1) {
+    throw new Error(
+      "Pinned pnpm standalone executable is missing or ambiguous",
+    );
+  }
+  return matchingCandidates.values().next().value;
+}
+
 export function stageTrustedRuntime({
   runnerTemp,
   toolsRoot,
   nodeSource,
+  pnpmRoot,
   pnpmSource,
   expectedUid = process.getuid?.(),
   expectedGid = process.getgid?.(),
@@ -1149,9 +1349,16 @@ export function stageTrustedRuntime({
     throw new Error("Protected runtime destination must be fresh");
   }
 
+  const pnpmExecutable = resolvePinnedPnpmExecutable({
+    runnerTemp,
+    pnpmRoot,
+    pnpmSource,
+    expectedUid: uid,
+    expectedGid: gid,
+  });
   const sources = [
     ["node", nodeSource],
-    ["pnpm", pnpmSource],
+    ["pnpm", pnpmExecutable],
   ].map(([name, source]) => {
     requiredText(source, `Protected ${name} source`);
     if (!isAbsolute(source)) {
@@ -2465,6 +2672,7 @@ function stageTrustedRuntimeFromEnvironment() {
     runnerTemp: process.env.RUNNER_TEMP,
     toolsRoot: process.env.TRUSTED_VERCEL_TOOLS_PATH,
     nodeSource: process.env.NODE_SOURCE_PATH,
+    pnpmRoot: process.env.PNPM_ACTION_DEST,
     pnpmSource: process.env.PNPM_SOURCE_PATH,
   });
 }

--- a/scripts/vercel-prebuilt-workflow.test.mjs
+++ b/scripts/vercel-prebuilt-workflow.test.mjs
@@ -1266,24 +1266,92 @@ test("candidate staging rejects source components with the wrong owner", () => {
   }
 });
 
-test("trusted runtime copies writable hosted tools into independent protected files", () => {
+test("trusted runtime copies hosted Node and the exact standalone pnpm target into independent protected files", () => {
   const sourceRoot = mkdtempSync(join(tmpdir(), "vercel-runtime-source-"));
   const runnerTemp = mkdtempSync(join(tmpdir(), "vercel-runtime-runner-"));
   const toolsRoot = join(runnerTemp, "mento-vercel-trusted-tools");
+  const pnpmRoot = join(runnerTemp, "mento-pnpm-tools");
   const nodeSource = join(sourceRoot, "node");
-  const pnpmSource = join(sourceRoot, "pnpm");
+  const pnpmSource = join(pnpmRoot, "node_modules", ".bin", "bin", "pnpm");
+  const pnpmGlobalRoot = join(
+    pnpmRoot,
+    "node_modules",
+    ".bin",
+    "global",
+    "v11",
+  );
+  const pnpmInstallRoot = join(pnpmGlobalRoot, "install-12345-1700000000000");
+  const pnpmHashRoot = join(pnpmGlobalRoot, "a2d-19f6b3f78e2");
+  const pnpmPackageRoot = join(
+    pnpmRoot,
+    "node_modules",
+    ".bin",
+    "store",
+    "v11",
+    "links",
+    "a2d-19f6b3f78e2",
+    "node_modules",
+    "@pnpm",
+    "exe",
+  );
+  const pnpmPackageLink = join(pnpmInstallRoot, "node_modules", "@pnpm", "exe");
+  const pnpmExecutable = join(pnpmPackageRoot, "pnpm");
+  const pnpmExecutableLocator = join(
+    pnpmHashRoot,
+    "node_modules",
+    "@pnpm",
+    "exe",
+    "pnpm",
+  );
+  const pnpmStoreCopy = join(pnpmRoot, "pnpm-store-copy");
   const nodeContents = "#!/bin/sh\necho node\n";
-  const pnpmContents = "#!/bin/sh\necho pnpm\n";
+  const pnpmSourceContents = [
+    "#!/bin/sh",
+    'basedir=$(dirname "$0")',
+    'exec "$basedir/../global/v11/a2d-19f6b3f78e2/node_modules/@pnpm/exe/pnpm" "$@"',
+    "",
+  ].join("\n");
+  const pnpmExecutableContents = [
+    "#!/bin/sh",
+    'if [ "$1" = "--version" ]; then',
+    '  echo "10.24.0"',
+    "else",
+    '  echo "pnpm"',
+    "fi",
+    "",
+  ].join("\n");
   try {
     chmodSync(sourceRoot, 0o777);
     chmodSync(runnerTemp, 0o711);
     writeFileSync(nodeSource, nodeContents, { mode: 0o777 });
-    writeFileSync(pnpmSource, pnpmContents, { mode: 0o777 });
+    mkdirSync(dirname(pnpmSource), { recursive: true });
+    mkdirSync(dirname(pnpmPackageLink), { recursive: true });
+    mkdirSync(pnpmPackageRoot, { recursive: true });
+    writeFileSync(pnpmSource, pnpmSourceContents, { mode: 0o555 });
+    writeFileSync(
+      join(pnpmPackageRoot, "package.json"),
+      JSON.stringify({ name: "@pnpm/exe", version: "10.24.0" }),
+      { mode: 0o444 },
+    );
+    writeFileSync(pnpmStoreCopy, pnpmExecutableContents, { mode: 0o555 });
+    linkSync(pnpmStoreCopy, pnpmExecutable);
+    symlinkSync(
+      relative(dirname(pnpmPackageLink), pnpmPackageRoot),
+      pnpmPackageLink,
+    );
+    symlinkSync(relative(dirname(pnpmHashRoot), pnpmInstallRoot), pnpmHashRoot);
+    chmodSync(pnpmRoot, 0o755);
+    assert.equal(lstatSync(pnpmExecutable).nlink, 2);
+    assert.equal(
+      realpathSync(pnpmExecutableLocator),
+      realpathSync(pnpmExecutable),
+    );
 
     const staged = stageTrustedRuntime({
       runnerTemp,
       toolsRoot,
       nodeSource,
+      pnpmRoot,
       pnpmSource,
     });
     const canonicalToolsRoot = join(
@@ -1315,15 +1383,25 @@ test("trusted runtime copies writable hosted tools into independent protected fi
     }
 
     writeFileSync(nodeSource, "replaced node\n");
-    writeFileSync(pnpmSource, "replaced pnpm\n");
+    chmodSync(pnpmSource, 0o755);
+    chmodSync(pnpmExecutable, 0o755);
+    writeFileSync(pnpmSource, "replaced pnpm launcher\n");
+    writeFileSync(pnpmExecutable, "replaced pnpm executable\n");
     assert.equal(readFileSync(staged.nodePath, "utf8"), nodeContents);
-    assert.equal(readFileSync(staged.pnpmPath, "utf8"), pnpmContents);
+    assert.equal(readFileSync(staged.pnpmPath, "utf8"), pnpmExecutableContents);
+    assert.equal(
+      execFileSync(staged.pnpmPath, ["--version"], {
+        encoding: "utf8",
+      }).trim(),
+      "10.24.0",
+    );
     assert.throws(
       () =>
         stageTrustedRuntime({
           runnerTemp,
           toolsRoot,
           nodeSource,
+          pnpmRoot,
           pnpmSource,
         }),
       /destination must be fresh/,
@@ -1337,6 +1415,7 @@ test("trusted runtime copies writable hosted tools into independent protected fi
           runnerTemp,
           toolsRoot,
           nodeSource,
+          pnpmRoot,
           pnpmSource,
         }),
       /destination must be fresh/,
@@ -1349,12 +1428,150 @@ test("trusted runtime copies writable hosted tools into independent protected fi
           runnerTemp,
           toolsRoot,
           nodeSource,
+          pnpmRoot,
           pnpmSource,
         }),
       /Runner temporary directory is not protected/,
     );
   } finally {
     rmSync(sourceRoot, { force: true, recursive: true });
+    rmSync(runnerTemp, { force: true, recursive: true });
+  }
+});
+
+test("trusted runtime rejects missing, wrong-version, and ambiguous standalone pnpm targets", () => {
+  const runnerTemp = mkdtempSync(join(tmpdir(), "vercel-runtime-runner-"));
+  const toolsRoot = join(runnerTemp, "mento-vercel-trusted-tools");
+  const pnpmRoot = join(runnerTemp, "mento-pnpm-tools");
+  const nodeSource = join(runnerTemp, "node");
+  const pnpmSource = join(pnpmRoot, "node_modules", ".bin", "bin", "pnpm");
+  const firstExecutable = join(
+    pnpmRoot,
+    "node_modules",
+    ".bin",
+    "global",
+    "v11",
+    "first",
+    "node_modules",
+    "@pnpm",
+    "exe",
+    "pnpm",
+  );
+  const firstPackageJson = join(dirname(firstExecutable), "package.json");
+  const secondExecutable = join(
+    pnpmRoot,
+    "node_modules",
+    ".bin",
+    "global",
+    "v11",
+    "second",
+    "node_modules",
+    "@pnpm",
+    "exe",
+    "pnpm",
+  );
+  const secondPackageJson = join(dirname(secondExecutable), "package.json");
+  const stage = () =>
+    stageTrustedRuntime({
+      runnerTemp,
+      toolsRoot,
+      nodeSource,
+      pnpmRoot,
+      pnpmSource,
+    });
+  try {
+    chmodSync(runnerTemp, 0o711);
+    writeFileSync(nodeSource, "#!/bin/sh\necho node\n", { mode: 0o555 });
+    mkdirSync(dirname(pnpmSource), { recursive: true });
+    mkdirSync(dirname(firstExecutable), { recursive: true });
+    writeFileSync(pnpmSource, "#!/bin/sh\necho 10.24.0\n", { mode: 0o555 });
+    chmodSync(pnpmRoot, 0o755);
+
+    assert.throws(stage, /missing or ambiguous/);
+
+    writeFileSync(
+      firstPackageJson,
+      JSON.stringify({ name: "@pnpm/exe", version: "10.25.0" }),
+      { mode: 0o444 },
+    );
+    writeFileSync(firstExecutable, "#!/bin/sh\necho 10.25.0\n", {
+      mode: 0o555,
+    });
+    assert.throws(stage, /missing or ambiguous/);
+
+    chmodSync(firstExecutable, 0o755);
+    writeFileSync(firstExecutable, "#!/bin/sh\necho 10.24.0\n", {
+      mode: 0o555,
+    });
+    chmodSync(firstPackageJson, 0o644);
+    writeFileSync(
+      firstPackageJson,
+      JSON.stringify({ name: "@pnpm/exe", version: "10.24.0" }),
+    );
+    chmodSync(firstPackageJson, 0o444);
+    mkdirSync(dirname(secondExecutable), { recursive: true });
+    writeFileSync(
+      secondPackageJson,
+      JSON.stringify({ name: "@pnpm/exe", version: "10.24.0" }),
+      { mode: 0o444 },
+    );
+    writeFileSync(secondExecutable, "#!/bin/sh\necho 10.24.0\n", {
+      mode: 0o555,
+    });
+    assert.throws(stage, /missing or ambiguous/);
+  } finally {
+    rmSync(runnerTemp, { force: true, recursive: true });
+  }
+});
+
+test("trusted runtime rejects a standalone pnpm package link outside the action root", () => {
+  const runnerTemp = mkdtempSync(join(tmpdir(), "vercel-runtime-runner-"));
+  const outsideRoot = mkdtempSync(join(tmpdir(), "vercel-runtime-outside-"));
+  const toolsRoot = join(runnerTemp, "mento-vercel-trusted-tools");
+  const pnpmRoot = join(runnerTemp, "mento-pnpm-tools");
+  const nodeSource = join(runnerTemp, "node");
+  const pnpmSource = join(pnpmRoot, "node_modules", ".bin", "bin", "pnpm");
+  const packageLink = join(
+    pnpmRoot,
+    "node_modules",
+    ".bin",
+    "global",
+    "v11",
+    "install",
+    "node_modules",
+    "@pnpm",
+    "exe",
+  );
+  try {
+    chmodSync(runnerTemp, 0o711);
+    writeFileSync(nodeSource, "#!/bin/sh\necho node\n", { mode: 0o555 });
+    mkdirSync(dirname(pnpmSource), { recursive: true });
+    mkdirSync(dirname(packageLink), { recursive: true });
+    writeFileSync(pnpmSource, "#!/bin/sh\necho 10.24.0\n", { mode: 0o555 });
+    writeFileSync(
+      join(outsideRoot, "package.json"),
+      JSON.stringify({ name: "@pnpm/exe", version: "10.24.0" }),
+      { mode: 0o444 },
+    );
+    writeFileSync(join(outsideRoot, "pnpm"), "#!/bin/sh\necho 10.24.0\n", {
+      mode: 0o555,
+    });
+    symlinkSync(outsideRoot, packageLink);
+    chmodSync(pnpmRoot, 0o755);
+
+    assert.throws(
+      () =>
+        stageTrustedRuntime({
+          runnerTemp,
+          toolsRoot,
+          nodeSource,
+          pnpmRoot,
+          pnpmSource,
+        }),
+      /escaped its action root/,
+    );
+  } finally {
+    rmSync(outsideRoot, { force: true, recursive: true });
     rmSync(runnerTemp, { force: true, recursive: true });
   }
 });

--- a/scripts/vercel-prebuilt-workflows.test.mjs
+++ b/scripts/vercel-prebuilt-workflows.test.mjs
@@ -199,10 +199,24 @@ test("prebuilt stages a protected Node and standalone pnpm runtime before candid
   assert.equal(pnpmSetup.with.dest, "${{ runner.temp }}/mento-pnpm-tools");
   assert.equal(pnpmSetup.with.standalone, true);
   assert.equal(pnpmSetup.with.version, "10.24.0");
+  assert.equal(pnpmSetup.id, "pnpm");
   assert.equal(
     isolation.env.PNPM_ACTION_DEST,
     "${{ runner.temp }}/mento-pnpm-tools",
   );
+  assert.equal(
+    isolation.env.PNPM_BIN_DEST,
+    "${{ steps.pnpm.outputs.bin_dest }}",
+  );
+  assert.match(
+    isolation.run,
+    /if \[ "\$\(realpath "\$PNPM_BIN_DEST"\)" != "\$PNPM_ACTION_DEST\/node_modules\/\.bin\/bin" \]; then/,
+  );
+  assert.match(
+    isolation.run,
+    /setup_pnpm_bin="\$\(realpath "\$PNPM_BIN_DEST\/pnpm"\)"/,
+  );
+  assert.doesNotMatch(isolation.run, /command -v pnpm/);
   assert.match(isolation.run, /NODE_SOURCE_PATH="\$setup_node_bin" \\/);
   assert.match(isolation.run, /PNPM_SOURCE_PATH="\$setup_pnpm_bin" \\/);
   assert.match(


### PR DESCRIPTION
## The Problem

The first post-#534 exact-SHA UI pilot ([run 29505041559](https://github.com/mento-protocol/frontend-monorepo/actions/runs/29505041559)) failed before any credentialed Vercel command. `pnpm/action-setup` exposed pnpm 10.24.0 through a launcher whose executable lives below a hashed `global/v11/.../@pnpm/exe/pnpm` path. The trusted-runtime step copied only that launcher, so its relative target disappeared after relocation.

## The Solution

- bind the workflow to the pinned action `bin_dest` output instead of ambient PATH lookup
- canonicalize the pnpm 11 real-install, hash-alias, package-link, and hardlink layout inside the protected action root
- require exactly one runner-owned `@pnpm/exe` 10.24.0 payload and copy that standalone executable into the independent protected runtime
- fail closed on missing, wrong-version, ambiguous, writable, or escaping candidates
- document the launcher-versus-payload boundary and add a regression fixture matching the hosted runner topology

## Validation

- `pnpm vercel:workflow:test` (69/69)
- `pnpm vercel:preview:test` (86/86)
- `pnpm quality:budgets:test` (30/30)
- `pnpm check-types` (8/8 tasks)
- `pnpm ci:action-pins`
- `pnpm adr:check`
- `pnpm knip`
- `trunk check`
- `git diff --check`
- fresh-context security review: clean

## Tracking

Supports #518. The immutable UI pilot will be rerun from `main` after this correction merges.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the CI trusted-runtime staging path that isolates candidate builds from writable toolcache paths; mistakes could break deployments or weaken isolation, but scope is limited to pnpm resolution and copy logic with extensive regression tests.
> 
> **Overview**
> Fixes Vercel prebuilt isolation failing when the trusted-runtime step copied only the **pnpm action launcher**, whose real binary lives under a hashed `global/v*/.../@pnpm/exe/pnpm` path and broke after relocation.
> 
> The reusable workflow now pins the pnpm setup step (`id: pnpm`), passes **`steps.pnpm.outputs.bin_dest`** into isolation, validates that directory, and resolves **`$PNPM_BIN_DEST/pnpm`** instead of **`command -v pnpm`**. **`stageTrustedRuntime`** gains **`resolvePinnedPnpmExecutable`**, which walks the action-owned pnpm 11 layout, requires exactly one runner-owned **`@pnpm/exe` 10.24.0** payload, and copies that standalone executable into the protected tools directory. Fail-closed checks cover missing, wrong-version, ambiguous, or out-of-root candidates; docs and tests mirror the launcher-vs-payload behavior and hosted runner topology.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 286caa2faccf9bb9d4304b2c1ab323a1c8a39098. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->