### PR TITLE
fix(ci): run isolated installs with JavaScript pnpm

### DIFF
--- a/.github/workflows/_vercel-prebuilt.yml
+++ b/.github/workflows/_vercel-prebuilt.yml
@@ -269,19 +269,25 @@ jobs:
             "$GITHUB_WORKSPACE/controller/scripts/vercel-prebuilt-workflow.mjs" \
             stage-runtime
           node_bin="$trusted_bin_dir/node"
-          pnpm_bin="$trusted_bin_dir/pnpm"
-          for protected_binary in "$node_bin" "$pnpm_bin"; do
+          pnpm_bootstrap="$trusted_bin_dir/pnpm-bootstrap"
+          for protected_directory in "$TRUSTED_VERCEL_TOOLS_PATH" "$trusted_bin_dir"; do
+            if [ "$(/usr/bin/stat -c %a "$protected_directory")" != "755" ]; then
+              echo "Protected runtime directory is not cross-identity readable" >&2
+              exit 1
+            fi
+          done
+          for protected_binary in "$node_bin" "$pnpm_bootstrap"; do
             mode="$(/usr/bin/stat -c %a "$protected_binary")"
             if [ ! -f "$protected_binary" ] ||
               [ -L "$protected_binary" ] ||
               [ "$(/usr/bin/stat -c %u "$protected_binary")" != "$(id -u)" ] ||
               [ "$(/usr/bin/stat -c %h "$protected_binary")" != "1" ] ||
-              (( (8#$mode & 0022) != 0 )); then
+              [ "$mode" != "555" ]; then
               echo "Protected runtime binary is not an independent runner-owned file" >&2
               exit 1
             fi
           done
-          if [ "$("$pnpm_bin" --version)" != "10.24.0" ]; then
+          if [ "$("$pnpm_bootstrap" --version)" != "10.24.0" ]; then
             echo "Protected pnpm copy does not match the pinned release" >&2
             exit 1
           fi
@@ -296,13 +302,25 @@ jobs:
             echo "Trusted pnpm modules path is not a relative path" >&2
             exit 1
           fi
-          "$pnpm_bin" --dir "$GITHUB_WORKSPACE/controller" --filter frontend-monorepo install \
+          "$pnpm_bootstrap" --dir "$GITHUB_WORKSPACE/controller" --filter frontend-monorepo install \
             --frozen-lockfile \
             --ignore-scripts \
             --modules-dir "$trusted_modules_dir" \
             --package-import-method copy \
             --virtual-store-dir "$trusted_modules_dir/.pnpm"
           /bin/chmod -R a+rX,go-w "$TRUSTED_VERCEL_TOOLS_PATH"
+          pnpm_bin="$(
+            TRUSTED_VERCEL_TOOLS_PATH="$TRUSTED_VERCEL_TOOLS_PATH" \
+              "$node_bin" \
+              "$GITHUB_WORKSPACE/controller/scripts/vercel-prebuilt-workflow.mjs" \
+              stage-pnpm-launcher
+          )"
+          if [ "$pnpm_bin" != "$trusted_bin_dir/pnpm" ] ||
+            [ "$(/usr/bin/stat -c %a "$pnpm_bin")" != "555" ] ||
+            [ "$("$pnpm_bin" --version)" != "10.24.0" ]; then
+            echo "Protected pnpm launcher does not match the pinned release" >&2
+            exit 1
+          fi
           vercel_cli="$(realpath "$TRUSTED_VERCEL_TOOLS_PATH/node_modules/vercel/dist/index.js")"
           case "$vercel_cli" in
             "$TRUSTED_VERCEL_TOOLS_PATH"/*) ;;
@@ -335,6 +353,7 @@ jobs:
             "$TRUSTED_VERCEL_TOOLS_PATH" \
             "$trusted_bin_dir" \
             "$node_bin" \
+            "$pnpm_bootstrap" \
             "$pnpm_bin"; do
             if [ ! -e "$protected_path" ] || candidate_can_write "$protected_path"; then
               echo "Candidate can modify a protected runner path: $protected_path" >&2
@@ -404,6 +423,22 @@ jobs:
           node_bin="$(realpath "$(command -v node)")"
           pnpm_bin="$(realpath "$(command -v pnpm)")"
           safe_path="$(dirname "$node_bin"):$(dirname "$pnpm_bin"):/usr/local/bin:/usr/bin:/bin"
+          if ! sudo --non-interactive /usr/bin/env -i \
+            HOME="$CANDIDATE_HOME_PATH" \
+            LANG="${LANG:-C.UTF-8}" \
+            LC_ALL="${LC_ALL:-C.UTF-8}" \
+            PATH="$safe_path" \
+            /usr/bin/setpriv \
+            --reuid="$BUILD_UID" \
+            --regid="$BUILD_GID" \
+            --clear-groups \
+            --no-new-privs \
+            -- \
+            "$pnpm_bin" --version |
+            /usr/bin/grep -Fxq "10.24.0"; then
+            echo "Isolated candidate cannot execute the protected pnpm launcher" >&2
+            exit 1
+          fi
           command_token="mento-$(/usr/bin/openssl rand -hex 16)"
           echo "::stop-commands::$command_token"
           set +e

--- a/.github/workflows/_vercel-prebuilt.yml
+++ b/.github/workflows/_vercel-prebuilt.yml
@@ -171,7 +171,6 @@ jobs:
           cache-dependency-path: |
             controller/pnpm-lock.yaml
             controller/scripts/vercel-pnpm-runtime/pnpm-lock.yaml
-            source/pnpm-lock.yaml
 
       - name: Validate pilot contract and prepare immutable build identity
         id: prepare

--- a/.github/workflows/_vercel-prebuilt.yml
+++ b/.github/workflows/_vercel-prebuilt.yml
@@ -161,7 +161,7 @@ jobs:
         with:
           dest: ${{ runner.temp }}/mento-pnpm-tools
           standalone: true
-          version: 10.24.0
+          version: 10.34.4
 
       - name: Set up pinned Node.js and pnpm cache
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -170,6 +170,7 @@ jobs:
           cache: pnpm
           cache-dependency-path: |
             controller/pnpm-lock.yaml
+            controller/scripts/vercel-pnpm-runtime/pnpm-lock.yaml
             source/pnpm-lock.yaml
 
       - name: Validate pilot contract and prepare immutable build identity
@@ -287,8 +288,19 @@ jobs:
               exit 1
             fi
           done
-          if [ "$("$pnpm_bootstrap" --version)" != "10.24.0" ]; then
+          if [ "$("$pnpm_bootstrap" --version)" != "10.34.4" ]; then
             echo "Protected pnpm copy does not match the pinned release" >&2
+            exit 1
+          fi
+          pnpm_runtime_root="$(
+            CONTROLLER_PATH="$GITHUB_WORKSPACE/controller" \
+            TRUSTED_VERCEL_TOOLS_PATH="$TRUSTED_VERCEL_TOOLS_PATH" \
+              "$node_bin" \
+              "$GITHUB_WORKSPACE/controller/scripts/vercel-prebuilt-workflow.mjs" \
+              stage-pnpm-runtime
+          )"
+          if [ "$pnpm_runtime_root" != "$TRUSTED_VERCEL_TOOLS_PATH/pnpm-runtime" ]; then
+            echo "Trusted pnpm runtime escaped its protected destination" >&2
             exit 1
           fi
           trusted_modules_dir="$(
@@ -302,12 +314,21 @@ jobs:
             echo "Trusted pnpm modules path is not a relative path" >&2
             exit 1
           fi
-          "$pnpm_bootstrap" --dir "$GITHUB_WORKSPACE/controller" --filter frontend-monorepo install \
-            --frozen-lockfile \
-            --ignore-scripts \
-            --modules-dir "$trusted_modules_dir" \
-            --package-import-method copy \
-            --virtual-store-dir "$trusted_modules_dir/.pnpm"
+          NPM_CONFIG_MANAGE_PACKAGE_MANAGER_VERSIONS=false \
+          NPM_CONFIG_PACKAGE_MANAGER_STRICT_VERSION=false \
+            "$pnpm_bootstrap" --dir "$GITHUB_WORKSPACE/controller" --filter frontend-monorepo install \
+              --frozen-lockfile \
+              --ignore-scripts \
+              --modules-dir "$trusted_modules_dir" \
+              --package-import-method copy \
+              --virtual-store-dir "$trusted_modules_dir/.pnpm"
+          NPM_CONFIG_MANAGE_PACKAGE_MANAGER_VERSIONS=false \
+          NPM_CONFIG_PACKAGE_MANAGER_STRICT_VERSION=false \
+            "$pnpm_bootstrap" --dir "$pnpm_runtime_root" install \
+              --frozen-lockfile \
+              --ignore-scripts \
+              --ignore-workspace \
+              --package-import-method copy
           /bin/chmod -R a+rX,go-w "$TRUSTED_VERCEL_TOOLS_PATH"
           pnpm_bin="$(
             TRUSTED_VERCEL_TOOLS_PATH="$TRUSTED_VERCEL_TOOLS_PATH" \
@@ -317,7 +338,7 @@ jobs:
           )"
           if [ "$pnpm_bin" != "$trusted_bin_dir/pnpm" ] ||
             [ "$(/usr/bin/stat -c %a "$pnpm_bin")" != "555" ] ||
-            [ "$("$pnpm_bin" --version)" != "10.24.0" ]; then
+            [ "$("$pnpm_bin" --version)" != "10.34.4" ]; then
             echo "Protected pnpm launcher does not match the pinned release" >&2
             exit 1
           fi
@@ -354,6 +375,9 @@ jobs:
             "$trusted_bin_dir" \
             "$node_bin" \
             "$pnpm_bootstrap" \
+            "$pnpm_runtime_root" \
+            "$pnpm_runtime_root/package.json" \
+            "$pnpm_runtime_root/pnpm-lock.yaml" \
             "$pnpm_bin"; do
             if [ ! -e "$protected_path" ] || candidate_can_write "$protected_path"; then
               echo "Candidate can modify a protected runner path: $protected_path" >&2
@@ -427,6 +451,8 @@ jobs:
             HOME="$CANDIDATE_HOME_PATH" \
             LANG="${LANG:-C.UTF-8}" \
             LC_ALL="${LC_ALL:-C.UTF-8}" \
+            NPM_CONFIG_MANAGE_PACKAGE_MANAGER_VERSIONS=false \
+            NPM_CONFIG_PACKAGE_MANAGER_STRICT_VERSION=false \
             PATH="$safe_path" \
             /usr/bin/setpriv \
             --reuid="$BUILD_UID" \
@@ -435,7 +461,7 @@ jobs:
             --no-new-privs \
             -- \
             "$pnpm_bin" --version |
-            /usr/bin/grep -Fxq "10.24.0"; then
+            /usr/bin/grep -Fxq "10.34.4"; then
             echo "Isolated candidate cannot execute the protected pnpm launcher" >&2
             exit 1
           fi
@@ -451,6 +477,8 @@ jobs:
             LC_ALL="${LC_ALL:-C.UTF-8}" \
             NODE_EXTRA_CA_CERTS="${NODE_EXTRA_CA_CERTS:-}" \
             NO_PROXY="${NO_PROXY:-}" \
+            NPM_CONFIG_MANAGE_PACKAGE_MANAGER_VERSIONS=false \
+            NPM_CONFIG_PACKAGE_MANAGER_STRICT_VERSION=false \
             PATH="$safe_path" \
             SSL_CERT_FILE="${SSL_CERT_FILE:-}" \
             TMPDIR="$CANDIDATE_HOME_PATH/tmp" \
@@ -1008,7 +1036,7 @@ jobs:
       - name: Set up pinned pnpm for trusted browser smoke
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v4
         with:
-          version: 10.24.0
+          version: 10.34.4
 
       - name: Set up pinned Node.js and trusted pnpm cache
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0

--- a/.github/workflows/_vercel-prebuilt.yml
+++ b/.github/workflows/_vercel-prebuilt.yml
@@ -163,6 +163,63 @@ jobs:
           standalone: true
           version: 10.34.4
 
+      - name: Verify pinned pnpm target before first execution
+        shell: bash
+        env:
+          EXPECTED_PNPM_LINUX_X64_SHA256: e02c01738ce850754cf00111fd97bec24de550e1e963690486f02d9dae1a2193
+          PNPM_ACTION_DEST: ${{ runner.temp }}/mento-pnpm-tools
+          PNPM_BIN_DEST: ${{ steps.pnpm.outputs.bin_dest }}
+        run: |
+          set -euo pipefail
+          if [ "$(/usr/bin/uname -s)" != "Linux" ] ||
+            [ "$(/usr/bin/uname -m)" != "x86_64" ]; then
+            echo "Pinned pnpm target digest supports only the expected Linux x64 runner" >&2
+            exit 1
+          fi
+          if [ ! -d "$PNPM_ACTION_DEST" ] || [ -L "$PNPM_ACTION_DEST" ]; then
+            echo "Pinned pnpm action directory is not a real directory" >&2
+            exit 1
+          fi
+          action_root="$(/usr/bin/realpath "$PNPM_ACTION_DEST")"
+          if [ "$action_root" != "$RUNNER_TEMP/mento-pnpm-tools" ]; then
+            echo "Pinned pnpm action directory escaped RUNNER_TEMP" >&2
+            exit 1
+          fi
+          bin_dest="$(/usr/bin/realpath "$PNPM_BIN_DEST")"
+          if [ "$bin_dest" != "$action_root/node_modules/.bin/bin" ]; then
+            echo "Pinned pnpm action returned an unexpected binary directory" >&2
+            exit 1
+          fi
+          pnpm_target="$(/usr/bin/realpath "$PNPM_BIN_DEST/pnpm")"
+          case "$pnpm_target" in
+            "$action_root"/*) ;;
+            *) echo "Pinned pnpm target escaped its action-owned directory" >&2; exit 1 ;;
+          esac
+          path_pnpm="$(type -P pnpm)"
+          if [ "$(/usr/bin/realpath "$path_pnpm")" != "$pnpm_target" ]; then
+            echo "PATH does not resolve to the pinned pnpm target" >&2
+            exit 1
+          fi
+          if [ ! -f "$pnpm_target" ] ||
+            [ -L "$pnpm_target" ] ||
+            [ "$(/usr/bin/stat -c %u "$pnpm_target")" != "$(/usr/bin/id -u)" ]; then
+            echo "Pinned pnpm target is not a runner-owned regular file" >&2
+            exit 1
+          fi
+          mode="$(/usr/bin/stat -c %a "$pnpm_target")"
+          if (( (8#$mode & 0022) != 0 )); then
+            echo "Pinned pnpm target is group- or world-writable" >&2
+            exit 1
+          fi
+          actual_sha256="$(
+            /usr/bin/sha256sum "$pnpm_target" | /usr/bin/cut -d ' ' -f1
+          )"
+          if [ "$actual_sha256" != "$EXPECTED_PNPM_LINUX_X64_SHA256" ]; then
+            echo "Pinned pnpm target digest does not match the reviewed artifact" >&2
+            exit 1
+          fi
+          "$pnpm_target" --version | /usr/bin/grep -Fxq "10.34.4"
+
       - name: Set up pinned Node.js and pnpm cache
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:

--- a/.github/workflows/action-pins-source.yml
+++ b/.github/workflows/action-pins-source.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup PNPM
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v4
         with:
-          version: 10.24.0
+          version: 10.34.4
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:

--- a/.github/workflows/action-pins.yml
+++ b/.github/workflows/action-pins.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup PNPM
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v4
         with:
-          version: 10.24.0
+          version: 10.34.4
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -35,7 +35,8 @@ jobs:
         with:
           fail-on-severity: high
           fail-on-scopes: runtime
-          # Mirrors osv-scanner.toml ignores. Keep both in sync.
+          # Mirrors the protobufjs 6.x ignores that affect both scanners.
+          # OSV-only metadata corrections are not allowlisted here.
           # protobufjs 6.x advisories: no safe fix path; only remaining consumer is
           # deprecated/unmaintained @confio/ics23@0.6.8 in the wormhole-connect/Cosmos
           # stack, which declares protobufjs ^6.8.8. Forcing 7.x is a semver-major

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -91,7 +91,7 @@ jobs:
       - name: lockfile-lint self-tests
         run: node scripts/lockfile-lint.test.mjs
       - name: lockfile integrity + registry check
-        run: pnpm supply-chain:lockfile-lint
+        run: npm run supply-chain:lockfile-lint
 
   version-skew:
     name: catalog version-skew

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -2,20 +2,24 @@ name: Supply Chain
 
 # Dependency supply-chain gates, decoupled from trunk so the pre-push hook
 # never blocks on lockfile CVEs (see .trunk/trunk.yaml — osv-scanner ignores
-# pnpm-lock.yaml). Three jobs:
+# both lockfiles). Four jobs:
 #
-#   1. osv         — osv-scanner against pnpm-lock.yaml, reading osv-scanner.toml
-#                    (the source of truth for suppressed/expired advisories).
-#                    Runs on every PR + a daily cron (24h disclosure backstop:
-#                    re-surfaces a newly-disclosed CVE or an expired ignoreUntil
-#                    even when no PR touches the lockfile).
-#   2. lockfile-lint — sha512 integrity + registry-poisoning gate.
-#   3. version-skew  — every cataloged dep is "catalog:" or the exact catalog
-#                      version (no silent drift off the shared catalog).
+#   1. osv              — osv-scanner against the application lockfile, reading
+#                         the repository-wide osv-scanner.toml.
+#   2. osv-pnpm-runtime — a separately configured scan of the exact isolated
+#                         trusted-tool lockfile. Its config contains only the
+#                         short-lived pnpm metadata correction, so that advisory
+#                         cannot mask a vulnerable pnpm elsewhere in the repo.
+#                         Both scans run on every PR + a daily cron (24h
+#                         disclosure backstop for new CVEs and expired ignores).
+#   3. lockfile-lint    — sha512 integrity + registry-poisoning gate.
+#   4. version-skew     — every cataloged dep is "catalog:" or the exact catalog
+#                         version (no silent drift off the shared catalog).
 #
-# Suppressions live in osv-scanner.toml. Note they must stay in sync with the
-# `allow-ghsas` list in dependency-review.yml (and its expiry date) — both gate
-# the same advisories from different angles.
+# Suppressions live in osv-scanner.toml. Advisories suppressed in both scanners
+# must stay in sync with the `allow-ghsas` list in dependency-review.yml and its
+# expiry. Scanner-specific metadata false positives remain OSV-only, with source
+# evidence and a short `ignoreUntil`.
 #
 # No path filter on `pull_request`: the osv job is meant to be a required check,
 # and a path-filtered required check that gets skipped sits "pending" forever
@@ -58,6 +62,21 @@ jobs:
       # runs; PRs still block via fail-on-vuln (default true).
       upload-sarif: ${{ github.event_name != 'pull_request' }}
 
+  osv-pnpm-runtime:
+    name: osv-scanner (trusted pnpm runtime)
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    # Keep the malformed-advisory correction scoped to this exact one-package
+    # lockfile instead of suppressing the GHSA repository-wide.
+    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@9a498708959aeaef5ef730655706c5a1df1edbc2 # v2.3.8
+    with:
+      scan-args: |-
+        --config=scripts/vercel-pnpm-runtime/osv-scanner.toml
+        --lockfile=scripts/vercel-pnpm-runtime/pnpm-lock.yaml
+      upload-sarif: ${{ github.event_name != 'pull_request' }}
+
   lockfile-lint:
     name: lockfile integrity + registry
     runs-on: ubuntu-latest
@@ -72,7 +91,9 @@ jobs:
       - name: lockfile-lint self-tests
         run: node scripts/lockfile-lint.test.mjs
       - name: lockfile integrity + registry check
-        run: node scripts/lockfile-lint.mjs
+        run: |
+          node scripts/lockfile-lint.mjs
+          LOCKFILE_LINT_ROOT=scripts/vercel-pnpm-runtime node scripts/lockfile-lint.mjs
 
   version-skew:
     name: catalog version-skew

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -91,9 +91,7 @@ jobs:
       - name: lockfile-lint self-tests
         run: node scripts/lockfile-lint.test.mjs
       - name: lockfile integrity + registry check
-        run: |
-          node scripts/lockfile-lint.mjs
-          LOCKFILE_LINT_ROOT=scripts/vercel-pnpm-runtime node scripts/lockfile-lint.mjs
+        run: pnpm supply-chain:lockfile-lint
 
   version-skew:
     name: catalog version-skew

--- a/.github/workflows/vercel-preview-controller.yml
+++ b/.github/workflows/vercel-preview-controller.yml
@@ -121,7 +121,7 @@ jobs:
       - name: Set up pinned pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v4
         with:
-          version: 10.24.0
+          version: 10.34.4
 
       - name: Set up pinned Node.js without dependency caching
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -313,7 +313,7 @@ jobs:
       - name: Set up pinned pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v4
         with:
-          version: 10.24.0
+          version: 10.34.4
 
       - name: Set up pinned Node.js without dependency caching
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0

--- a/.github/workflows/vercel-preview-worker.yml
+++ b/.github/workflows/vercel-preview-worker.yml
@@ -221,7 +221,7 @@ jobs:
       - name: Set up pinned pnpm for trusted browser smoke
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v4
         with:
-          version: 10.24.0
+          version: 10.34.4
 
       - name: Set up pinned Node.js and trusted pnpm cache
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -40,6 +40,7 @@ lint:
         # so the `trunk check --all` pre-push hook no longer blocks pushes on
         # pre-existing repo-wide lockfile advisories.
         - pnpm-lock.yaml
+        - scripts/vercel-pnpm-runtime/pnpm-lock.yaml
     - linters: [ALL]
       paths:
         - scripts/ralph/** # Ralph autonomous agent tooling — externally managed

--- a/docs/vercel-deployments.md
+++ b/docs/vercel-deployments.md
@@ -354,7 +354,7 @@ worker also restores the controller from its trusted workflow SHA after
 dependency installation and again after the candidate build, before output
 assertion, upload, and inspection.
 
-The Vercel CLI is a separate trusted tool install. Pinned pnpm `10.24.0` reads
+The Vercel CLI is a separate trusted tool install. Pinned pnpm `10.34.4` reads
 the main controller's exact `package.json` and frozen `pnpm-lock.yaml`, disables
 lifecycle scripts, and copies packages into a runner-owned directory outside
 the checkout. Its `--modules-dir` and `--virtual-store-dir` values are validated
@@ -368,16 +368,25 @@ by the isolated candidate UID. Before candidate code starts, the worker copies
 Node.js and the exact pinned standalone pnpm executable into the same
 runner-owned protected tool directory, removes group/other write access from
 the original pnpm action directory, and uses that executable only to install
-the trusted controller's lockfile-pinned tools. The pnpm action's PATH entry is
-a launcher whose executable lives below a hashed
-`global/v*/.../@pnpm/exe/pnpm` directory, so the worker requires exactly one
-protected target reporting `10.24.0` and copies that self-contained executable
-instead of relocating the launcher. Candidate-controlled installs then use the
-separately lockfile-pinned `pnpm` JavaScript package through the protected Node
-runtime. This removes the standalone executable's own image from the
-cross-identity execution path: the pilot failed when that image was not
-effectively readable after switching to the isolated candidate identity, even
-though the runner-owned executable checks had passed.
+trusted controller tools. The pnpm action's PATH entry is a launcher whose
+executable lives below a hashed `global/v*/.../@pnpm/exe/pnpm` directory, so the
+worker requires exactly one protected target reporting `10.34.4` and copies
+that self-contained executable instead of relocating the launcher.
+
+Candidate-controlled installs use a separate JavaScript pnpm runtime pinned by
+`scripts/vercel-pnpm-runtime/package.json` and its standalone frozen lockfile.
+That manifest is deliberately outside the workspace globs, staged under
+`$TRUSTED_VERCEL_TOOLS_PATH/pnpm-runtime`, and installed with lifecycle scripts
+disabled and package copies rather than links to candidate-writable storage.
+The protected launcher always uses protected Node plus that runtime's
+`pnpm.cjs`; it disables pnpm's package-manager self-switch and strict patch
+version check so an older candidate `packageManager` field cannot silently
+downgrade the trusted runtime or reject the intentional patched v10 version.
+This removes the standalone executable's own image from the cross-identity
+execution path: the pilot failed when that image was not effectively readable
+after switching to the isolated candidate identity, even though the
+runner-owned executable checks had passed. Both lockfiles are covered by OSV
+and sha512/registry validation.
 Before any credentialed command, the worker proves the runtime root, its
 replacement-relevant parents, Node.js, pnpm, and the CLI are not candidate
 writable; it also proves the CLI resolves inside the protected directory, its

--- a/docs/vercel-deployments.md
+++ b/docs/vercel-deployments.md
@@ -367,11 +367,17 @@ inputs because runner-image permissions can make those original paths writable
 by the isolated candidate UID. Before candidate code starts, the worker copies
 Node.js and the exact pinned standalone pnpm executable into the same
 runner-owned protected tool directory, removes group/other write access from
-the original pnpm action directory, and prepends the protected runtime to
-subsequent workflow steps. The pnpm action's PATH entry is a launcher whose
-executable lives below a hashed `global/v*/.../@pnpm/exe/pnpm` directory, so
-the worker requires exactly one protected target reporting `10.24.0` and
-copies that self-contained executable instead of relocating the launcher.
+the original pnpm action directory, and uses that executable only to install
+the trusted controller's lockfile-pinned tools. The pnpm action's PATH entry is
+a launcher whose executable lives below a hashed
+`global/v*/.../@pnpm/exe/pnpm` directory, so the worker requires exactly one
+protected target reporting `10.24.0` and copies that self-contained executable
+instead of relocating the launcher. Candidate-controlled installs then use the
+separately lockfile-pinned `pnpm` JavaScript package through the protected Node
+runtime. This removes the standalone executable's own image from the
+cross-identity execution path: the pilot failed when that image was not
+effectively readable after switching to the isolated candidate identity, even
+though the runner-owned executable checks had passed.
 Before any credentialed command, the worker proves the runtime root, its
 replacement-relevant parents, Node.js, pnpm, and the CLI are not candidate
 writable; it also proves the CLI resolves inside the protected directory, its

--- a/docs/vercel-deployments.md
+++ b/docs/vercel-deployments.md
@@ -364,14 +364,22 @@ the wrong path. The zero-network fixture requires the already-hydrated package
 store with `--offline`; it cannot contact the registry to repair missing data.
 The hosted setup-node and pnpm locations are treated only as trusted staging
 inputs because runner-image permissions can make those original paths writable
-by the isolated candidate UID. Before candidate code starts, the worker copies
-Node.js and the exact pinned standalone pnpm executable into the same
-runner-owned protected tool directory, removes group/other write access from
-the original pnpm action directory, and uses that executable only to install
-trusted controller tools. The pnpm action's PATH entry is a launcher whose
-executable lives below a hashed `global/v*/.../@pnpm/exe/pnpm` directory, so the
-worker requires exactly one protected target reporting `10.34.4` and copies
-that self-contained executable instead of relocating the launcher.
+by the isolated candidate UID. The pinned pnpm action installs its own bootstrap
+from a commit-locked npm lockfile, then downloads the requested
+`@pnpm/linux-x64@10.34.4` target; that target declares no lifecycle scripts.
+Before setup-node's cache probe or any other consumer can execute the downloaded
+target, the worker requires the expected Linux x64 runner, canonical
+action-owned path, runner ownership, non-writable mode, and reviewed executable
+SHA-256
+`e02c01738ce850754cf00111fd97bec24de550e1e963690486f02d9dae1a2193`.
+Before candidate code starts, the worker then copies Node.js and that verified
+standalone pnpm executable into the same runner-owned protected tool directory,
+removes group/other write access from the original pnpm action directory, and
+uses the copied executable only to install trusted controller tools. The pnpm
+action's PATH entry is a launcher whose executable lives below a hashed
+`global/v*/.../@pnpm/exe/pnpm` directory, so the worker also requires exactly
+one protected target reporting `10.34.4` and copies that self-contained
+executable instead of relocating the launcher.
 
 Candidate-controlled installs use a separate JavaScript pnpm runtime pinned by
 `scripts/vercel-pnpm-runtime/package.json` and its standalone frozen lockfile.
@@ -382,8 +390,9 @@ Before staging, the controller requires the manifest to match its exact allowed
 fields and binds the complete one-importer lockfile bytes to
 `PINNED_PNPM_RUNTIME_LOCKFILE_SHA256`; this rejects extra dependency/config
 sections, custom tarballs, changed integrity, or extra importers/packages before
-the bootstrap install. A pnpm bump must update the isolated manifest and
-lockfile, `PINNED_PNPM_VERSION`, and that reviewed digest together.
+the bootstrap install. A pnpm bump must update the action input, reviewed Linux
+x64 executable digest, isolated manifest and lockfile, `PINNED_PNPM_VERSION`,
+and lockfile digest together.
 The protected launcher always uses protected Node plus that runtime's
 `pnpm.cjs`; it disables pnpm's package-manager self-switch and strict patch
 version check so an older candidate `packageManager` field cannot silently

--- a/docs/vercel-deployments.md
+++ b/docs/vercel-deployments.md
@@ -378,6 +378,12 @@ Candidate-controlled installs use a separate JavaScript pnpm runtime pinned by
 That manifest is deliberately outside the workspace globs, staged under
 `$TRUSTED_VERCEL_TOOLS_PATH/pnpm-runtime`, and installed with lifecycle scripts
 disabled and package copies rather than links to candidate-writable storage.
+Before staging, the controller requires the manifest to match its exact allowed
+fields and binds the complete one-importer lockfile bytes to
+`PINNED_PNPM_RUNTIME_LOCKFILE_SHA256`; this rejects extra dependency/config
+sections, custom tarballs, changed integrity, or extra importers/packages before
+the bootstrap install. A pnpm bump must update the isolated manifest and
+lockfile, `PINNED_PNPM_VERSION`, and that reviewed digest together.
 The protected launcher always uses protected Node plus that runtime's
 `pnpm.cjs`; it disables pnpm's package-manager self-switch and strict patch
 version check so an older candidate `packageManager` field cannot silently

--- a/knip.json
+++ b/knip.json
@@ -9,7 +9,7 @@
   ],
   "workspaces": {
     ".": {
-      "ignoreDependencies": ["vercel", "zod"]
+      "ignoreDependencies": ["pnpm", "vercel", "zod"]
     },
     "apps/*": {
       "project": "app/**/*.{mjs,tsx,ts}"

--- a/knip.json
+++ b/knip.json
@@ -9,7 +9,7 @@
   ],
   "workspaces": {
     ".": {
-      "ignoreDependencies": ["pnpm", "vercel", "zod"]
+      "ignoreDependencies": ["vercel", "zod"]
     },
     "apps/*": {
       "project": "app/**/*.{mjs,tsx,ts}"

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "quality:bundle:check": "node scripts/check-bundle-size.mjs",
     "quality:coverage": "turbo run test:coverage --filter=app.mento.org --filter=governance.mento.org --filter=@mento-protocol/ui --filter=@repo/web3",
     "rebuild": "pnpm run clean && turbo run build",
-    "supply-chain:lockfile-lint": "node scripts/lockfile-lint.mjs",
+    "supply-chain:lockfile-lint": "node scripts/lockfile-lint.mjs && LOCKFILE_LINT_ROOT=scripts/vercel-pnpm-runtime node scripts/lockfile-lint.mjs",
     "supply-chain:lockfile-lint:test": "node scripts/lockfile-lint.test.mjs",
     "supply-chain:version-skew": "node scripts/version-skew-check.mjs",
     "supply-chain:version-skew:test": "node scripts/version-skew-check.test.mjs",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
     "eslint": "catalog:",
     "eslint-config-prettier": "catalog:",
     "knip": "^6.16.1",
-    "pnpm": "10.24.0",
     "prettier": "^3.9.3",
     "prettier-plugin-tailwindcss": "^0.8.0",
     "turbo": "^2.10.0",
@@ -70,7 +69,7 @@
     "vercel": "56.2.0",
     "yaml": "2.9.0"
   },
-  "packageManager": "pnpm@10.24.0",
+  "packageManager": "pnpm@10.34.4",
   "engines": {
     "node": ">=22"
   },

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "eslint": "catalog:",
     "eslint-config-prettier": "catalog:",
     "knip": "^6.16.1",
+    "pnpm": "10.24.0",
     "prettier": "^3.9.3",
     "prettier-plugin-tailwindcss": "^0.8.0",
     "turbo": "^2.10.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -187,9 +187,6 @@ importers:
       knip:
         specifier: ^6.16.1
         version: 6.25.0
-      pnpm:
-        specifier: 10.24.0
-        version: 10.24.0
       prettier:
         specifier: ^3.9.3
         version: 3.9.3
@@ -2984,7 +2981,7 @@ packages:
     engines: {node: '>=14.0.0'}
 
   '@metamask/jazzicon@https://codeload.github.com/jmrossy/jazzicon/tar.gz/7a8df28':
-    resolution: {tarball: https://codeload.github.com/jmrossy/jazzicon/tar.gz/7a8df28}
+    resolution: {gitHosted: true, tarball: https://codeload.github.com/jmrossy/jazzicon/tar.gz/7a8df28}
     version: 2.1.0
 
   '@metamask/json-rpc-engine@10.2.3':
@@ -11834,11 +11831,6 @@ packages:
   pngjs@5.0.0:
     resolution: {integrity: sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==}
     engines: {node: '>=10.13.0'}
-
-  pnpm@10.24.0:
-    resolution: {integrity: sha512-Af+K5xtEGZA7ZcYPstydNM+LtuBtA73hEu8496NNaQTEJLpmvqXNzxKJAjC/OflYBHMUDtnJRv7zKLblI4o0Wg==}
-    engines: {node: '>=18.12'}
-    hasBin: true
 
   pony-cause@2.1.11:
     resolution: {integrity: sha512-M7LhCsdNbNgiLYiP4WjsfLUuFmCfnjdF6jKe2R9NKl4WFN+HZPGHJZ9lnLP7f9ZnKe3U9nuWD0szirmj+migUg==}
@@ -29507,8 +29499,6 @@ snapshots:
       fsevents: 2.3.2
 
   pngjs@5.0.0: {}
-
-  pnpm@10.24.0: {}
 
   pony-cause@2.1.11: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -187,6 +187,9 @@ importers:
       knip:
         specifier: ^6.16.1
         version: 6.25.0
+      pnpm:
+        specifier: 10.24.0
+        version: 10.24.0
       prettier:
         specifier: ^3.9.3
         version: 3.9.3
@@ -11831,6 +11834,11 @@ packages:
   pngjs@5.0.0:
     resolution: {integrity: sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==}
     engines: {node: '>=10.13.0'}
+
+  pnpm@10.24.0:
+    resolution: {integrity: sha512-Af+K5xtEGZA7ZcYPstydNM+LtuBtA73hEu8496NNaQTEJLpmvqXNzxKJAjC/OflYBHMUDtnJRv7zKLblI4o0Wg==}
+    engines: {node: '>=18.12'}
+    hasBin: true
 
   pony-cause@2.1.11:
     resolution: {integrity: sha512-M7LhCsdNbNgiLYiP4WjsfLUuFmCfnjdF6jKe2R9NKl4WFN+HZPGHJZ9lnLP7f9ZnKe3U9nuWD0szirmj+migUg==}
@@ -29499,6 +29507,8 @@ snapshots:
       fsevents: 2.3.2
 
   pngjs@5.0.0: {}
+
+  pnpm@10.24.0: {}
 
   pony-cause@2.1.11: {}
 

--- a/scripts/check-github-action-pins.mjs
+++ b/scripts/check-github-action-pins.mjs
@@ -29,12 +29,6 @@ const REQUIRED_POLICY_FILES = [
   ".github/workflows/action-pins.yml",
   ".github/workflows/action-pins-source.yml",
 ];
-const POLICY_PNPM_JOB_IDS = new Map([
-  [".github/workflows/action-pins.yml", "action-pins"],
-  [".github/workflows/action-pins-source.yml", "policy-source"],
-]);
-const ALLOWED_POLICY_PNPM_VERSIONS = ["10.24.0", "10.34.4"];
-const CANONICAL_POLICY_PNPM_VERSION = ALLOWED_POLICY_PNPM_VERSIONS[0];
 const VERCEL_PREVIEW_CONTROLLER =
   ".github/workflows/vercel-preview-controller.yml";
 const VERCEL_PREVIEW_CONTROLLER_TRIGGERS = {
@@ -78,7 +72,7 @@ const NORMALIZED_POLICY_WORKFLOWS = new Map([
             {
               name: "Setup PNPM",
               uses: "pnpm/action-setup@<sha>",
-              with: { version: "10.24.0" },
+              with: { version: "10.34.4" },
             },
             {
               name: "Set up Node.js",
@@ -145,7 +139,7 @@ const NORMALIZED_POLICY_WORKFLOWS = new Map([
             {
               name: "Setup PNPM",
               uses: "pnpm/action-setup@<sha>",
-              with: { version: "10.24.0" },
+              with: { version: "10.34.4" },
             },
             {
               name: "Set up Node.js",
@@ -339,57 +333,12 @@ function normalizePolicyWorkflow(value) {
 }
 
 /**
- * The protected workflows need one merge on the old pnpm version before they
- * can move to the new one. Normalize only the exact Setup PNPM field after
- * validating its temporary allowlist; every other workflow value remains part
- * of the strict structural comparison.
- * @param {string} path
- * @param {unknown} workflow
- */
-function normalizePolicyPnpmVersion(path, workflow) {
-  const jobId = POLICY_PNPM_JOB_IDS.get(path);
-  if (
-    !jobId ||
-    workflow == null ||
-    typeof workflow !== "object" ||
-    Array.isArray(workflow)
-  ) {
-    return workflow;
-  }
-
-  const steps = workflow.jobs?.[jobId]?.steps;
-  if (!Array.isArray(steps)) return workflow;
-
-  const setupSteps = steps.filter(
-    (step) =>
-      step != null &&
-      typeof step === "object" &&
-      !Array.isArray(step) &&
-      step.name === "Setup PNPM" &&
-      step.uses === "pnpm/action-setup@<sha>",
-  );
-  if (setupSteps.length !== 1) return workflow;
-
-  const setupStep = setupSteps[0];
-  const version = setupStep.with?.version;
-  if (!ALLOWED_POLICY_PNPM_VERSIONS.includes(version)) {
-    throw new Error(
-      `Setup PNPM version must be one of: ${ALLOWED_POLICY_PNPM_VERSIONS.join(", ")}`,
-    );
-  }
-
-  setupStep.with.version = CANONICAL_POLICY_PNPM_VERSION;
-  return workflow;
-}
-
-/**
  * These workflows form the policy's trust boundary. The target workflow runs
  * only base-branch code; the source workflow exercises proposed checker code
  * without credentials. Validate their complete executable structure from the
  * trusted checker so a PR cannot replace either required check with a no-op.
- * Action SHAs and the explicitly allowed pnpm transition are normalized; other
- * canonical changes intentionally use the protected two-PR transition
- * documented in README.md.
+ * Action SHAs are normalized; other canonical changes intentionally use the
+ * protected two-PR transition documented in README.md.
  * @param {string} path
  * @param {import("yaml").Document} document
  */
@@ -398,10 +347,7 @@ function assertPolicyWorkflowStructure(path, document) {
   if (!expected) return;
 
   assertUniqueSemanticMappings(document.contents, document);
-  const actual = normalizePolicyPnpmVersion(
-    path,
-    normalizePolicyWorkflow(document.toJS({ maxAliasCount: 100 })),
-  );
+  const actual = normalizePolicyWorkflow(document.toJS({ maxAliasCount: 100 }));
   if (!isDeepStrictEqual(actual, expected)) {
     throw new Error("does not match the trusted action-pin workflow structure");
   }

--- a/scripts/check-github-action-pins.test.mjs
+++ b/scripts/check-github-action-pins.test.mjs
@@ -27,7 +27,7 @@ const POLICY_WORKFLOW_FIXTURES = new Map(
     readFileSync(resolve(path), "utf8"),
   ]),
 );
-const CURRENT_POLICY_PNPM_VERSION = "10.24.0";
+const CURRENT_POLICY_PNPM_VERSION = "10.34.4";
 const VERCEL_PREVIEW_CONTROLLER_PATH =
   ".github/workflows/vercel-preview-controller.yml";
 const VERCEL_PREVIEW_CONTROLLER_FIXTURE = readFileSync(
@@ -1278,62 +1278,24 @@ test("allows immutable action SHA bumps in canonical policy workflows", () => {
   }
 });
 
-test("allows both exact pnpm versions during the protected transition", () => {
-  for (const version of ["10.24.0", "10.34.4"]) {
+test("rejects policy pnpm version drift after the protected transition", () => {
+  for (const version of ["10.24.0", "10.34.5"]) {
     for (const path of POLICY_WORKFLOW_PATHS) {
-      const root = fixtureRoot(`policy-pnpm-${version}-pass`);
+      const root = fixtureRoot(`policy-pnpm-${version}-fail`);
       try {
         write(root, path, policyWorkflowWithPnpmVersion(path, version));
 
         const result = runChecker(root);
-        equal(result.status, 0, result.stderr);
+        equal(result.status, 1, result.stdout);
+        contains(result.stderr, path, "policy path");
+        contains(
+          result.stderr,
+          "does not match the trusted action-pin workflow structure",
+          "strict pnpm field",
+        );
       } finally {
         rmSync(root, { recursive: true, force: true });
       }
-    }
-  }
-});
-
-test("rejects pnpm versions outside the protected transition", () => {
-  for (const path of POLICY_WORKFLOW_PATHS) {
-    const root = fixtureRoot("policy-pnpm-arbitrary-fail");
-    try {
-      write(root, path, policyWorkflowWithPnpmVersion(path, "10.34.5"));
-
-      const result = runChecker(root);
-      equal(result.status, 1, result.stdout);
-      contains(result.stderr, path, "policy path");
-      contains(
-        result.stderr,
-        "Setup PNPM version must be one of: 10.24.0, 10.34.4",
-        "allowed pnpm versions",
-      );
-    } finally {
-      rmSync(root, { recursive: true, force: true });
-    }
-  }
-});
-
-test("keeps non-pnpm policy fields strict during the transition", () => {
-  for (const path of POLICY_WORKFLOW_PATHS) {
-    const root = fixtureRoot("policy-pnpm-other-field-fail");
-    try {
-      const updated = policyWorkflowWithPnpmVersion(path, "10.34.4").replace(
-        "node-version: 22",
-        "node-version: 23",
-      );
-      write(root, path, updated);
-
-      const result = runChecker(root);
-      equal(result.status, 1, result.stdout);
-      contains(result.stderr, path, "policy path");
-      contains(
-        result.stderr,
-        "does not match the trusted action-pin workflow structure",
-        "strict non-pnpm field",
-      );
-    } finally {
-      rmSync(root, { recursive: true, force: true });
     }
   }
 });

--- a/scripts/lockfile-lint.mjs
+++ b/scripts/lockfile-lint.mjs
@@ -15,6 +15,10 @@
  *      registry is configured (i.e. all packages resolve from the default
  *      https://registry.npmjs.org).
  *
+ *   3. pnpm advisory guard: while OSV misclassifies patched pnpm 10.x releases,
+ *      reject every actually affected pnpm package version explicitly. This
+ *      keeps the narrowly scoped scanner correction from masking a downgrade.
+ *
  * Ported from monitoring-monorepo. Frontend adaptations:
  *   - The override-floor gate (monitoring's gate 3) is intentionally omitted:
  *     30 of frontend's pnpm.overrides deliberately use `>=patched` floor
@@ -76,6 +80,35 @@ if (!existsSync(lockfilePath)) {
 }
 
 const lockfileText = readFileSync(lockfilePath, "utf8");
+
+/**
+ * GHSA-gj8w-mvpf-x27x affects pnpm <10.34.2 and >=11.0.0 <11.5.3.
+ * Fail closed on non-stable versions while the OSV metadata correction exists.
+ * @param {string} version
+ */
+function isAffectedPnpmVersion(version) {
+  const match = /^(\d+)\.(\d+)\.(\d+)$/.exec(version);
+  if (!match) return true;
+  const value = match.slice(1).map(Number);
+  const compare = (target) => {
+    for (let index = 0; index < value.length; index++) {
+      if (value[index] !== target[index]) return value[index] - target[index];
+    }
+    return 0;
+  };
+  if (value[0] < 10) return true;
+  if (value[0] === 10) return compare([10, 34, 2]) < 0;
+  if (value[0] === 11) return compare([11, 5, 3]) < 0;
+  return false;
+}
+
+for (const match of lockfileText.matchAll(/^ {2}'?pnpm@([^':\s]+)'?:\s*$/gm)) {
+  if (isAffectedPnpmVersion(match[1])) {
+    fail(
+      `pnpm ${match[1]} is affected by GHSA-gj8w-mvpf-x27x; require >=10.34.2 below v11 or >=11.5.3 on v11.`,
+    );
+  }
+}
 
 // Confirm lockfile version — only v9 is understood by this script.
 const versionMatch = lockfileText.match(
@@ -183,9 +216,9 @@ const escapeRegExp = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 const REMOTE_TARBALL_ENTRY = new RegExp(
   REMOTE_TARBALL_ALLOWLIST.map(
     ({ key, tarball }) =>
-      `^ {2}'?${escapeRegExp(key)}'?:\\n\\s+resolution:\\s*\\{tarball:\\s*${escapeRegExp(
+      `^ {2}'?${escapeRegExp(key)}'?:\\n\\s+resolution:\\s*\\{(?:gitHosted:\\s*true,\\s*)?tarball:\\s*${escapeRegExp(
         tarball,
-      )}\\}`,
+      )}\\s*\\}`,
   ).join("|"),
   "gm",
 );

--- a/scripts/lockfile-lint.test.mjs
+++ b/scripts/lockfile-lint.test.mjs
@@ -373,7 +373,7 @@ test("passes when packages: contains a remote https tarball dependency without i
     `lockfileVersion: '9.0'\n\nimporters:\n\npackages:\n\n` +
     `  typescript@5.0.0:\n    resolution: {integrity: ${VALID_SHA512}}\n\n` +
     `  '@metamask/jazzicon@https://codeload.github.com/jmrossy/jazzicon/tar.gz/7a8df28':\n` +
-    `    resolution: {tarball: https://codeload.github.com/jmrossy/jazzicon/tar.gz/7a8df28}\n\n` +
+    `    resolution: {gitHosted: true, tarball: https://codeload.github.com/jmrossy/jazzicon/tar.gz/7a8df28}\n\n` +
     `snapshots:\n`;
   const { exitCode, stdout, stderr } = run(lockfile);
   assert(
@@ -383,6 +383,47 @@ test("passes when packages: contains a remote https tarball dependency without i
   assert(
     stdout.includes("remote-tarball deps exempted"),
     `expected remote-tarball exemption message: ${stdout}`,
+  );
+});
+
+test("fails when an allowlisted tarball resolution has an unknown field", () => {
+  const lockfile =
+    `lockfileVersion: '9.0'\n\nimporters:\n\npackages:\n\n` +
+    `  '@metamask/jazzicon@https://codeload.github.com/jmrossy/jazzicon/tar.gz/7a8df28':\n` +
+    `    resolution: {gitHosted: true, tarball: https://codeload.github.com/jmrossy/jazzicon/tar.gz/7a8df28, registry: https://evil.example}\n\n` +
+    `snapshots:\n`;
+  const { exitCode, stdout, stderr } = run(lockfile);
+  assert(
+    exitCode !== 0,
+    `Expected non-zero (unknown resolution field must fail), got ${exitCode}\n${stdout}\n${stderr}`,
+  );
+  assert(
+    stderr.includes("resolution block without a sha512"),
+    `expected integrity failure: ${stderr}`,
+  );
+});
+
+test("rejects pnpm 10.24.0 while the scanner metadata correction exists", () => {
+  const { exitCode, stdout, stderr } = run(
+    makeLockfile([{ name: "pnpm@10.24.0", integrity: VALID_SHA512 }]),
+  );
+  assert(
+    exitCode !== 0,
+    `Expected vulnerable pnpm to fail, got ${exitCode}\n${stdout}\n${stderr}`,
+  );
+  assert(
+    stderr.includes("pnpm 10.24.0 is affected by GHSA-gj8w-mvpf-x27x"),
+    `expected pnpm advisory failure: ${stderr}`,
+  );
+});
+
+test("accepts patched pnpm 10.34.4 under the scanner metadata correction", () => {
+  const { exitCode, stdout, stderr } = run(
+    makeLockfile([{ name: "pnpm@10.34.4", integrity: VALID_SHA512 }]),
+  );
+  assert(
+    exitCode === 0,
+    `Expected patched pnpm to pass, got ${exitCode}\n${stdout}\n${stderr}`,
   );
 });
 

--- a/scripts/vercel-pnpm-runtime/osv-scanner.toml
+++ b/scripts/vercel-pnpm-runtime/osv-scanner.toml
@@ -1,0 +1,9 @@
+[[IgnoredVulns]]
+id = "GHSA-gj8w-mvpf-x27x"
+# This config is used only with this directory's exact one-package lockfile.
+# GitHub's affected range is <10.34.2 and the maintainer advisory says 10.34.2
+# is patched, but the OSV formal event range incorrectly records the first fix
+# as 11.5.3 and false-flags the pinned pnpm 10.34.4.
+# TODO: Remove once GitHub Advisory Database/OSV corrects the 10.x event range.
+ignoreUntil = 2026-08-16T00:00:00Z
+reason = "Scanner metadata false positive: pnpm 10.34.4 is outside GitHub's <10.34.2 affected range, but OSV's malformed event range reports 11.5.3 as the first fix."

--- a/scripts/vercel-pnpm-runtime/package.json
+++ b/scripts/vercel-pnpm-runtime/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@mento-protocol/vercel-pnpm-runtime",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Isolated pnpm runtime for candidate-controlled Vercel builds",
+  "dependencies": {
+    "pnpm": "10.34.4"
+  }
+}

--- a/scripts/vercel-pnpm-runtime/pnpm-lock.yaml
+++ b/scripts/vercel-pnpm-runtime/pnpm-lock.yaml
@@ -1,0 +1,24 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      pnpm:
+        specifier: 10.34.4
+        version: 10.34.4
+
+packages:
+
+  pnpm@10.34.4:
+    resolution: {integrity: sha512-h2i+VSAK4/Iia2Un/Momh+FLxOXxLXchoPJdo99HkVF3BYZI20F3uvNIEg+guidS2NjZP2vq8f5krhjajelhrw==}
+    engines: {node: '>=18.12'}
+    hasBin: true
+
+snapshots:
+
+  pnpm@10.34.4: {}

--- a/scripts/vercel-prebuilt-workflow.mjs
+++ b/scripts/vercel-prebuilt-workflow.mjs
@@ -75,7 +75,8 @@ const PULL_STAGING_DIRECTORY = "mento-vercel-pull-staging";
 const CANDIDATE_SOURCE_DIRECTORY = "mento-vercel-candidate-source";
 const TRUSTED_TOOLS_DIRECTORY = "mento-vercel-trusted-tools";
 const PNPM_ACTION_DIRECTORY = "mento-pnpm-tools";
-const PINNED_PNPM_VERSION = "10.24.0";
+const PNPM_RUNTIME_DIRECTORY = "pnpm-runtime";
+const PINNED_PNPM_VERSION = "10.34.4";
 const PULLED_ENVIRONMENT_FILE = ".env.preview.local";
 const MAX_SOURCE_ENTRIES = 20_000;
 const MAX_SOURCE_PATH_BYTES = 4_096;
@@ -1421,6 +1422,121 @@ export function stageTrustedRuntime({
   }
 }
 
+export function stageTrustedPnpmRuntimeManifest({ controllerRoot, toolsRoot }) {
+  requiredText(controllerRoot, "Trusted controller path");
+  requiredText(toolsRoot, "Trusted Vercel tools path");
+  if (!isAbsolute(controllerRoot) || !isAbsolute(toolsRoot)) {
+    throw new Error("Trusted pnpm runtime paths must be absolute");
+  }
+
+  const currentUid = process.getuid?.();
+  const currentGid = process.getgid?.();
+  if (currentUid === undefined || currentGid === undefined) {
+    throw new Error("Trusted pnpm runtime requires a POSIX identity");
+  }
+  const canonicalControllerRoot = realpathSync(controllerRoot);
+  const canonicalToolsRoot = realpathSync(toolsRoot);
+  assertProtectedRuntimeEntry(canonicalControllerRoot, {
+    directory: true,
+    expectedUid: currentUid,
+    expectedGid: currentGid,
+  });
+  assertProtectedRuntimeEntry(canonicalToolsRoot, {
+    directory: true,
+    expectedUid: currentUid,
+    expectedGid: currentGid,
+  });
+  const toolsFromController = relative(
+    canonicalControllerRoot,
+    canonicalToolsRoot,
+  );
+  if (
+    toolsFromController !== ".." &&
+    !toolsFromController.startsWith(`..${sep}`)
+  ) {
+    throw new Error("Trusted pnpm runtime must be outside the checkout");
+  }
+
+  const sourceRoot = join(
+    canonicalControllerRoot,
+    "scripts",
+    "vercel-pnpm-runtime",
+  );
+  assertProtectedRuntimeDescendant({
+    root: canonicalControllerRoot,
+    path: sourceRoot,
+    directory: true,
+    expectedUid: currentUid,
+    expectedGid: currentGid,
+  });
+  const sourcePackageJson = assertProtectedRuntimeDescendant({
+    root: canonicalControllerRoot,
+    path: join(sourceRoot, "package.json"),
+    directory: false,
+    expectedUid: currentUid,
+    expectedGid: currentGid,
+  });
+  const sourceLockfile = assertProtectedRuntimeDescendant({
+    root: canonicalControllerRoot,
+    path: join(sourceRoot, "pnpm-lock.yaml"),
+    directory: false,
+    expectedUid: currentUid,
+    expectedGid: currentGid,
+  });
+  const packageMetadata = JSON.parse(
+    readFileSync(sourcePackageJson.path, "utf8"),
+  );
+  if (
+    packageMetadata.name !== "@mento-protocol/vercel-pnpm-runtime" ||
+    packageMetadata.private !== true ||
+    packageMetadata.dependencies?.pnpm !== PINNED_PNPM_VERSION ||
+    Object.keys(packageMetadata.dependencies ?? {}).length !== 1 ||
+    packageMetadata.scripts !== undefined
+  ) {
+    throw new Error("Trusted pnpm runtime manifest is not exact");
+  }
+
+  const runtimeRoot = join(canonicalToolsRoot, PNPM_RUNTIME_DIRECTORY);
+  if (optionalEntry(runtimeRoot)) {
+    throw new Error("Trusted pnpm runtime destination must be fresh");
+  }
+  let created = false;
+  try {
+    mkdirSync(runtimeRoot, { mode: 0o755 });
+    created = true;
+    chmodSync(runtimeRoot, 0o755);
+    assertProtectedRuntimeEntry(runtimeRoot, {
+      directory: true,
+      expectedUid: currentUid,
+      expectedGid: currentGid,
+    });
+    for (const [name, source] of [
+      ["package.json", sourcePackageJson],
+      ["pnpm-lock.yaml", sourceLockfile],
+    ]) {
+      const destination = join(runtimeRoot, name);
+      copyFileSync(source.path, destination, fsConstants.COPYFILE_EXCL);
+      chmodSync(destination, 0o444);
+      const destinationEntry = assertProtectedRuntimeEntry(destination, {
+        directory: false,
+        expectedUid: currentUid,
+        expectedGid: currentGid,
+      });
+      if (
+        realpathSync(destination) !== destination ||
+        (destinationEntry.dev === source.entry.dev &&
+          destinationEntry.ino === source.entry.ino)
+      ) {
+        throw new Error("Trusted pnpm runtime copy is not independent");
+      }
+    }
+    return runtimeRoot;
+  } catch (error) {
+    if (created) rmSync(runtimeRoot, { force: true, recursive: true });
+    throw error;
+  }
+}
+
 export function stageTrustedPnpmLauncher({ toolsRoot }) {
   requiredText(toolsRoot, "Trusted Vercel tools path");
   if (!isAbsolute(toolsRoot)) {
@@ -1456,7 +1572,12 @@ export function stageTrustedPnpmLauncher({ toolsRoot }) {
     requireSingleLink: true,
   });
 
-  const pnpmPackageRoot = join(canonicalToolsRoot, "node_modules", "pnpm");
+  const pnpmPackageRoot = join(
+    canonicalToolsRoot,
+    PNPM_RUNTIME_DIRECTORY,
+    "node_modules",
+    "pnpm",
+  );
   const packageJsonPath = join(pnpmPackageRoot, "package.json");
   const cliPath = join(pnpmPackageRoot, "bin", "pnpm.cjs");
   const packageJson = assertProtectedRuntimeDescendant({
@@ -1493,7 +1614,10 @@ export function stageTrustedPnpmLauncher({ toolsRoot }) {
     [
       "#!/bin/sh",
       "basedir=${0%/*}",
-      'exec "$basedir/node" "$basedir/../node_modules/pnpm/bin/pnpm.cjs" "$@"',
+      "unset NPM_CONFIG_MANAGE_PACKAGE_MANAGER_VERSIONS NPM_CONFIG_PACKAGE_MANAGER_STRICT_VERSION",
+      "export npm_config_manage_package_manager_versions=false",
+      "export npm_config_package_manager_strict_version=false",
+      'exec "$basedir/node" "$basedir/../pnpm-runtime/node_modules/pnpm/bin/pnpm.cjs" "$@"',
       "",
     ].join("\n"),
     { flag: "wx", mode: 0o555 },
@@ -2769,6 +2893,15 @@ function stageTrustedRuntimeFromEnvironment() {
   });
 }
 
+function stageTrustedPnpmRuntimeManifestFromEnvironment() {
+  process.stdout.write(
+    `${stageTrustedPnpmRuntimeManifest({
+      controllerRoot: process.env.CONTROLLER_PATH,
+      toolsRoot: process.env.TRUSTED_VERCEL_TOOLS_PATH,
+    })}\n`,
+  );
+}
+
 function stageTrustedPnpmLauncherFromEnvironment() {
   process.stdout.write(
     `${stageTrustedPnpmLauncher({
@@ -2790,6 +2923,8 @@ if (isCliEntrypoint()) {
   else if (command === "validate-source") validateSourceFromEnvironment();
   else if (command === "materialize-source") materializeSourceFromEnvironment();
   else if (command === "stage-runtime") stageTrustedRuntimeFromEnvironment();
+  else if (command === "stage-pnpm-runtime")
+    stageTrustedPnpmRuntimeManifestFromEnvironment();
   else if (command === "stage-pnpm-launcher")
     stageTrustedPnpmLauncherFromEnvironment();
   else if (command === "prepare-link") prepareLinkFromEnvironment();
@@ -2816,7 +2951,7 @@ if (isCliEntrypoint()) {
   else if (command === "total") totalFromEnvironment();
   else {
     throw new Error(
-      "Usage: vercel-prebuilt-workflow.mjs prepare|validate-source|materialize-source|stage-runtime|stage-pnpm-launcher|prepare-link|prepare-pull-staging|pull|validate-pull|validate-pull-staging|stage-pull|validate-candidate-pull|build|assert-output|trusted-install-modules-dir|deploy|verify|smoke|total",
+      "Usage: vercel-prebuilt-workflow.mjs prepare|validate-source|materialize-source|stage-runtime|stage-pnpm-runtime|stage-pnpm-launcher|prepare-link|prepare-pull-staging|pull|validate-pull|validate-pull-staging|stage-pull|validate-candidate-pull|build|assert-output|trusted-install-modules-dir|deploy|verify|smoke|total",
     );
   }
 }

--- a/scripts/vercel-prebuilt-workflow.mjs
+++ b/scripts/vercel-prebuilt-workflow.mjs
@@ -4,6 +4,7 @@
 
 import { Buffer } from "node:buffer";
 import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import {
   appendFileSync,
   chmodSync,
@@ -77,6 +78,11 @@ const TRUSTED_TOOLS_DIRECTORY = "mento-vercel-trusted-tools";
 const PNPM_ACTION_DIRECTORY = "mento-pnpm-tools";
 const PNPM_RUNTIME_DIRECTORY = "pnpm-runtime";
 const PINNED_PNPM_VERSION = "10.34.4";
+// Exact bytes of the one-importer registry lockfile. This pins the package
+// identity, absence of custom tarball resolution, and sha512 integrity before
+// the runner-owned bootstrap installs anything from it.
+const PINNED_PNPM_RUNTIME_LOCKFILE_SHA256 =
+  "c0dbb0f05ade0e4a8db501e5eb25ebe3c2f2794feed1caec2cf4df6c4583715a";
 const PULLED_ENVIRONMENT_FILE = ".env.preview.local";
 const MAX_SOURCE_ENTRIES = 20_000;
 const MAX_SOURCE_PATH_BYTES = 4_096;
@@ -109,6 +115,19 @@ function hasControlCharacters(value) {
     const codePoint = character.codePointAt(0);
     return codePoint <= 31 || codePoint === 127;
   });
+}
+
+function hasExactObjectKeys(value, expectedKeys) {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    return false;
+  }
+  const actualKeys = Object.keys(value).sort();
+  return (
+    actualKeys.length === expectedKeys.length &&
+    expectedKeys
+      .toSorted()
+      .every((expectedKey, index) => actualKeys[index] === expectedKey)
+  );
 }
 
 export function validateExactSha(value) {
@@ -1487,13 +1506,30 @@ export function stageTrustedPnpmRuntimeManifest({ controllerRoot, toolsRoot }) {
     readFileSync(sourcePackageJson.path, "utf8"),
   );
   if (
+    !hasExactObjectKeys(packageMetadata, [
+      "dependencies",
+      "description",
+      "name",
+      "private",
+      "version",
+    ]) ||
     packageMetadata.name !== "@mento-protocol/vercel-pnpm-runtime" ||
+    packageMetadata.version !== "0.0.0" ||
     packageMetadata.private !== true ||
+    packageMetadata.description !==
+      "Isolated pnpm runtime for candidate-controlled Vercel builds" ||
+    !hasExactObjectKeys(packageMetadata.dependencies, ["pnpm"]) ||
     packageMetadata.dependencies?.pnpm !== PINNED_PNPM_VERSION ||
-    Object.keys(packageMetadata.dependencies ?? {}).length !== 1 ||
     packageMetadata.scripts !== undefined
   ) {
     throw new Error("Trusted pnpm runtime manifest is not exact");
+  }
+  const sourceLockfileContents = readFileSync(sourceLockfile.path);
+  const sourceLockfileDigest = createHash("sha256")
+    .update(sourceLockfileContents)
+    .digest("hex");
+  if (sourceLockfileDigest !== PINNED_PNPM_RUNTIME_LOCKFILE_SHA256) {
+    throw new Error("Trusted pnpm runtime lockfile is not exact");
   }
 
   const runtimeRoot = join(canonicalToolsRoot, PNPM_RUNTIME_DIRECTORY);

--- a/scripts/vercel-prebuilt-workflow.mjs
+++ b/scripts/vercel-prebuilt-workflow.mjs
@@ -1358,7 +1358,7 @@ export function stageTrustedRuntime({
   });
   const sources = [
     ["node", nodeSource],
-    ["pnpm", pnpmExecutable],
+    ["pnpm-bootstrap", pnpmExecutable],
   ].map(([name, source]) => {
     requiredText(source, `Protected ${name} source`);
     if (!isAbsolute(source)) {
@@ -1413,12 +1413,104 @@ export function stageTrustedRuntime({
     return {
       binDirectory,
       nodePath: staged.node,
-      pnpmPath: staged.pnpm,
+      pnpmBootstrapPath: staged["pnpm-bootstrap"],
     };
   } catch (error) {
     if (created) rmSync(canonicalToolsRoot, { force: true, recursive: true });
     throw error;
   }
+}
+
+export function stageTrustedPnpmLauncher({ toolsRoot }) {
+  requiredText(toolsRoot, "Trusted Vercel tools path");
+  if (!isAbsolute(toolsRoot)) {
+    throw new Error("Trusted Vercel tools path must be absolute");
+  }
+  const canonicalToolsRoot = realpathSync(toolsRoot);
+  const currentUid = process.getuid?.();
+  const currentGid = process.getgid?.();
+  if (currentUid === undefined || currentGid === undefined) {
+    throw new Error("Trusted pnpm launcher requires a POSIX identity");
+  }
+  assertProtectedRuntimeEntry(canonicalToolsRoot, {
+    directory: true,
+    expectedUid: currentUid,
+    expectedGid: currentGid,
+  });
+
+  const binDirectory = join(canonicalToolsRoot, "bin");
+  const nodePath = join(binDirectory, "node");
+  assertProtectedRuntimeDescendant({
+    root: canonicalToolsRoot,
+    path: binDirectory,
+    directory: true,
+    expectedUid: currentUid,
+    expectedGid: currentGid,
+  });
+  assertProtectedRuntimeDescendant({
+    root: canonicalToolsRoot,
+    path: nodePath,
+    directory: false,
+    expectedUid: currentUid,
+    expectedGid: currentGid,
+    requireSingleLink: true,
+  });
+
+  const pnpmPackageRoot = join(canonicalToolsRoot, "node_modules", "pnpm");
+  const packageJsonPath = join(pnpmPackageRoot, "package.json");
+  const cliPath = join(pnpmPackageRoot, "bin", "pnpm.cjs");
+  const packageJson = assertProtectedRuntimeDescendant({
+    root: canonicalToolsRoot,
+    path: packageJsonPath,
+    directory: false,
+    expectedUid: currentUid,
+    expectedGid: currentGid,
+    requireSingleLink: true,
+  });
+  const cli = assertProtectedRuntimeDescendant({
+    root: canonicalToolsRoot,
+    path: cliPath,
+    directory: false,
+    expectedUid: currentUid,
+    expectedGid: currentGid,
+    requireSingleLink: true,
+  });
+  const packageMetadata = JSON.parse(readFileSync(packageJson.path, "utf8"));
+  if (
+    packageMetadata.name !== "pnpm" ||
+    packageMetadata.version !== PINNED_PNPM_VERSION ||
+    !cli.entry.isFile()
+  ) {
+    throw new Error("Trusted pnpm package does not match the pinned release");
+  }
+
+  const launcherPath = join(binDirectory, "pnpm");
+  if (optionalEntry(launcherPath)) {
+    throw new Error("Trusted pnpm launcher destination must be fresh");
+  }
+  writeFileSync(
+    launcherPath,
+    [
+      "#!/bin/sh",
+      "basedir=${0%/*}",
+      'exec "$basedir/node" "$basedir/../node_modules/pnpm/bin/pnpm.cjs" "$@"',
+      "",
+    ].join("\n"),
+    { flag: "wx", mode: 0o555 },
+  );
+  chmodSync(launcherPath, 0o555);
+  const launcher = assertProtectedRuntimeDescendant({
+    root: canonicalToolsRoot,
+    path: launcherPath,
+    directory: false,
+    expectedUid: currentUid,
+    expectedGid: currentGid,
+    requireSingleLink: true,
+  });
+  if (realpathSync(launcher.path) !== launcher.path) {
+    throw new Error("Trusted pnpm launcher is not independent");
+  }
+  return launcher.path;
 }
 
 export function trustedPnpmInstallLayout({ controllerRoot, toolsRoot }) {
@@ -2677,6 +2769,14 @@ function stageTrustedRuntimeFromEnvironment() {
   });
 }
 
+function stageTrustedPnpmLauncherFromEnvironment() {
+  process.stdout.write(
+    `${stageTrustedPnpmLauncher({
+      toolsRoot: process.env.TRUSTED_VERCEL_TOOLS_PATH,
+    })}\n`,
+  );
+}
+
 function isCliEntrypoint() {
   return (
     process.argv[1] !== undefined &&
@@ -2690,6 +2790,8 @@ if (isCliEntrypoint()) {
   else if (command === "validate-source") validateSourceFromEnvironment();
   else if (command === "materialize-source") materializeSourceFromEnvironment();
   else if (command === "stage-runtime") stageTrustedRuntimeFromEnvironment();
+  else if (command === "stage-pnpm-launcher")
+    stageTrustedPnpmLauncherFromEnvironment();
   else if (command === "prepare-link") prepareLinkFromEnvironment();
   else if (command === "prepare-pull-staging")
     preparePullStagingFromEnvironment();
@@ -2714,7 +2816,7 @@ if (isCliEntrypoint()) {
   else if (command === "total") totalFromEnvironment();
   else {
     throw new Error(
-      "Usage: vercel-prebuilt-workflow.mjs prepare|validate-source|materialize-source|stage-runtime|prepare-link|prepare-pull-staging|pull|validate-pull|validate-pull-staging|stage-pull|validate-candidate-pull|build|assert-output|trusted-install-modules-dir|deploy|verify|smoke|total",
+      "Usage: vercel-prebuilt-workflow.mjs prepare|validate-source|materialize-source|stage-runtime|stage-pnpm-launcher|prepare-link|prepare-pull-staging|pull|validate-pull|validate-pull-staging|stage-pull|validate-candidate-pull|build|assert-output|trusted-install-modules-dir|deploy|verify|smoke|total",
     );
   }
 }

--- a/scripts/vercel-prebuilt-workflow.test.mjs
+++ b/scripts/vercel-prebuilt-workflow.test.mjs
@@ -45,6 +45,7 @@ import {
   smokeUiPreview,
   stageVercelPullForCandidate,
   stageTrustedPnpmLauncher,
+  stageTrustedPnpmRuntimeManifest,
   stageTrustedRuntime,
   trustedPnpmInstallLayout,
   trustedVercelCliPath,
@@ -1316,7 +1317,7 @@ test("trusted runtime copies hosted Node and the exact standalone pnpm target in
   const pnpmExecutableContents = [
     "#!/bin/sh",
     'if [ "$1" = "--version" ]; then',
-    '  echo "10.24.0"',
+    '  echo "10.34.4"',
     "else",
     '  echo "pnpm"',
     "fi",
@@ -1332,7 +1333,7 @@ test("trusted runtime copies hosted Node and the exact standalone pnpm target in
     writeFileSync(pnpmSource, pnpmSourceContents, { mode: 0o555 });
     writeFileSync(
       join(pnpmPackageRoot, "package.json"),
-      JSON.stringify({ name: "@pnpm/exe", version: "10.24.0" }),
+      JSON.stringify({ name: "@pnpm/exe", version: "10.34.4" }),
       { mode: 0o444 },
     );
     writeFileSync(pnpmStoreCopy, pnpmExecutableContents, { mode: 0o555 });
@@ -1398,7 +1399,7 @@ test("trusted runtime copies hosted Node and the exact standalone pnpm target in
       execFileSync(staged.pnpmBootstrapPath, ["--version"], {
         encoding: "utf8",
       }).trim(),
-      "10.24.0",
+      "10.34.4",
     );
     assert.throws(
       () =>
@@ -1444,10 +1445,80 @@ test("trusted runtime copies hosted Node and the exact standalone pnpm target in
   }
 });
 
+test("trusted pnpm runtime manifest is copied outside the checkout with an exact pinned dependency", () => {
+  const fixtureRoot = mkdtempSync(join(tmpdir(), "vercel-pnpm-runtime-"));
+  const controllerRoot = join(fixtureRoot, "controller");
+  const sourceRoot = join(controllerRoot, "scripts", "vercel-pnpm-runtime");
+  const toolsRoot = join(fixtureRoot, "trusted-tools");
+  try {
+    mkdirSync(sourceRoot, { recursive: true });
+    mkdirSync(toolsRoot, { mode: 0o755 });
+    for (const file of ["package.json", "pnpm-lock.yaml"]) {
+      copyFileSync(
+        join(REPOSITORY_ROOT, "scripts", "vercel-pnpm-runtime", file),
+        join(sourceRoot, file),
+      );
+      chmodSync(join(sourceRoot, file), 0o444);
+    }
+    for (const path of [
+      controllerRoot,
+      join(controllerRoot, "scripts"),
+      sourceRoot,
+      toolsRoot,
+    ]) {
+      chmodSync(path, 0o755);
+    }
+
+    const runtimeRoot = stageTrustedPnpmRuntimeManifest({
+      controllerRoot,
+      toolsRoot,
+    });
+    assert.equal(runtimeRoot, join(realpathSync(toolsRoot), "pnpm-runtime"));
+    for (const file of ["package.json", "pnpm-lock.yaml"]) {
+      const destination = join(runtimeRoot, file);
+      const entry = lstatSync(destination);
+      assert.equal(entry.isFile(), true);
+      assert.equal(entry.isSymbolicLink(), false);
+      assert.equal(entry.uid, process.getuid());
+      assert.equal(entry.gid, process.getgid());
+      assert.equal(entry.mode & 0o777, 0o444);
+      assert.equal(entry.nlink, 1);
+      assert.equal(
+        readFileSync(destination, "utf8"),
+        readFileSync(join(sourceRoot, file), "utf8"),
+      );
+    }
+    assert.throws(
+      () => stageTrustedPnpmRuntimeManifest({ controllerRoot, toolsRoot }),
+      /destination must be fresh/,
+    );
+
+    rmSync(runtimeRoot, { force: true, recursive: true });
+    const manifestPath = join(sourceRoot, "package.json");
+    chmodSync(manifestPath, 0o644);
+    writeFileSync(
+      manifestPath,
+      JSON.stringify({
+        name: "@mento-protocol/vercel-pnpm-runtime",
+        private: true,
+        dependencies: { pnpm: "10.34.3" },
+      }),
+    );
+    chmodSync(manifestPath, 0o444);
+    assert.throws(
+      () => stageTrustedPnpmRuntimeManifest({ controllerRoot, toolsRoot }),
+      /manifest is not exact/,
+    );
+  } finally {
+    rmSync(fixtureRoot, { force: true, recursive: true });
+  }
+});
+
 test("trusted candidate pnpm launcher uses the lockfile-pinned JavaScript package through protected Node", () => {
   const toolsRoot = mkdtempSync(join(tmpdir(), "vercel-pnpm-launcher-"));
   const binDirectory = join(toolsRoot, "bin");
-  const packageRoot = join(toolsRoot, "node_modules", "pnpm");
+  const runtimeRoot = join(toolsRoot, "pnpm-runtime");
+  const packageRoot = join(runtimeRoot, "node_modules", "pnpm");
   const cliPath = join(packageRoot, "bin", "pnpm.cjs");
   const nodePath = join(binDirectory, "node");
   try {
@@ -1458,7 +1529,7 @@ test("trusted candidate pnpm launcher uses the lockfile-pinned JavaScript packag
     });
     writeFileSync(
       join(packageRoot, "package.json"),
-      JSON.stringify({ name: "pnpm", version: "10.24.0" }),
+      JSON.stringify({ name: "pnpm", version: "10.34.4" }),
       { mode: 0o444 },
     );
     writeFileSync(
@@ -1466,7 +1537,9 @@ test("trusted candidate pnpm launcher uses the lockfile-pinned JavaScript packag
       [
         "#!/bin/sh",
         'if [ "$1" = "--version" ]; then',
-        '  echo "10.24.0"',
+        '  [ "$npm_config_manage_package_manager_versions" = "false" ] || exit 3',
+        '  [ "$npm_config_package_manager_strict_version" = "false" ] || exit 4',
+        '  echo "10.34.4"',
         "else",
         "  exit 2",
         "fi",
@@ -1477,7 +1550,8 @@ test("trusted candidate pnpm launcher uses the lockfile-pinned JavaScript packag
     for (const path of [
       toolsRoot,
       binDirectory,
-      join(toolsRoot, "node_modules"),
+      runtimeRoot,
+      join(runtimeRoot, "node_modules"),
       packageRoot,
       dirname(cliPath),
     ]) {
@@ -1493,15 +1567,28 @@ test("trusted candidate pnpm launcher uses the lockfile-pinned JavaScript packag
     assert.equal(launcher.gid, process.getgid());
     assert.equal(launcher.mode & 0o777, 0o555);
     assert.equal(launcher.nlink, 1);
+    const launcherText = readFileSync(launcherPath, "utf8");
     assert.match(
-      readFileSync(launcherPath, "utf8"),
-      /node_modules\/pnpm\/bin\/pnpm\.cjs/,
+      launcherText,
+      /pnpm-runtime\/node_modules\/pnpm\/bin\/pnpm\.cjs/,
+    );
+    assert.match(
+      launcherText,
+      /npm_config_manage_package_manager_versions=false/,
+    );
+    assert.match(
+      launcherText,
+      /unset NPM_CONFIG_MANAGE_PACKAGE_MANAGER_VERSIONS NPM_CONFIG_PACKAGE_MANAGER_STRICT_VERSION/,
+    );
+    assert.match(
+      launcherText,
+      /npm_config_package_manager_strict_version=false/,
     );
     assert.equal(
       execFileSync(launcherPath, ["--version"], {
         encoding: "utf8",
       }).trim(),
-      "10.24.0",
+      "10.34.4",
     );
     assert.throws(
       () => stageTrustedPnpmLauncher({ toolsRoot }),
@@ -1512,7 +1599,7 @@ test("trusted candidate pnpm launcher uses the lockfile-pinned JavaScript packag
     chmodSync(join(packageRoot, "package.json"), 0o644);
     writeFileSync(
       join(packageRoot, "package.json"),
-      JSON.stringify({ name: "pnpm", version: "10.24.1" }),
+      JSON.stringify({ name: "pnpm", version: "10.34.3" }),
       { mode: 0o444 },
     );
     chmodSync(join(packageRoot, "package.json"), 0o444);
@@ -1570,7 +1657,7 @@ test("trusted runtime rejects missing, wrong-version, and ambiguous standalone p
     writeFileSync(nodeSource, "#!/bin/sh\necho node\n", { mode: 0o555 });
     mkdirSync(dirname(pnpmSource), { recursive: true });
     mkdirSync(dirname(firstExecutable), { recursive: true });
-    writeFileSync(pnpmSource, "#!/bin/sh\necho 10.24.0\n", { mode: 0o555 });
+    writeFileSync(pnpmSource, "#!/bin/sh\necho 10.34.4\n", { mode: 0o555 });
     chmodSync(pnpmRoot, 0o755);
 
     assert.throws(stage, /missing or ambiguous/);
@@ -1586,22 +1673,22 @@ test("trusted runtime rejects missing, wrong-version, and ambiguous standalone p
     assert.throws(stage, /missing or ambiguous/);
 
     chmodSync(firstExecutable, 0o755);
-    writeFileSync(firstExecutable, "#!/bin/sh\necho 10.24.0\n", {
+    writeFileSync(firstExecutable, "#!/bin/sh\necho 10.34.4\n", {
       mode: 0o555,
     });
     chmodSync(firstPackageJson, 0o644);
     writeFileSync(
       firstPackageJson,
-      JSON.stringify({ name: "@pnpm/exe", version: "10.24.0" }),
+      JSON.stringify({ name: "@pnpm/exe", version: "10.34.4" }),
     );
     chmodSync(firstPackageJson, 0o444);
     mkdirSync(dirname(secondExecutable), { recursive: true });
     writeFileSync(
       secondPackageJson,
-      JSON.stringify({ name: "@pnpm/exe", version: "10.24.0" }),
+      JSON.stringify({ name: "@pnpm/exe", version: "10.34.4" }),
       { mode: 0o444 },
     );
-    writeFileSync(secondExecutable, "#!/bin/sh\necho 10.24.0\n", {
+    writeFileSync(secondExecutable, "#!/bin/sh\necho 10.34.4\n", {
       mode: 0o555,
     });
     assert.throws(stage, /missing or ambiguous/);
@@ -1633,13 +1720,13 @@ test("trusted runtime rejects a standalone pnpm package link outside the action 
     writeFileSync(nodeSource, "#!/bin/sh\necho node\n", { mode: 0o555 });
     mkdirSync(dirname(pnpmSource), { recursive: true });
     mkdirSync(dirname(packageLink), { recursive: true });
-    writeFileSync(pnpmSource, "#!/bin/sh\necho 10.24.0\n", { mode: 0o555 });
+    writeFileSync(pnpmSource, "#!/bin/sh\necho 10.34.4\n", { mode: 0o555 });
     writeFileSync(
       join(outsideRoot, "package.json"),
-      JSON.stringify({ name: "@pnpm/exe", version: "10.24.0" }),
+      JSON.stringify({ name: "@pnpm/exe", version: "10.34.4" }),
       { mode: 0o444 },
     );
-    writeFileSync(join(outsideRoot, "pnpm"), "#!/bin/sh\necho 10.24.0\n", {
+    writeFileSync(join(outsideRoot, "pnpm"), "#!/bin/sh\necho 10.34.4\n", {
       mode: 0o555,
     });
     symlinkSync(outsideRoot, packageLink);
@@ -1727,7 +1814,7 @@ test(
       assert.equal(layout.virtualStoreDir, join(layout.modulesDir, ".pnpm"));
       assert.equal(
         execFileSync("pnpm", ["--version"], { encoding: "utf8" }).trim(),
-        "10.24.0",
+        "10.34.4",
       );
 
       execFileSync(
@@ -1755,19 +1842,6 @@ test(
         },
       );
       execFileSync("chmod", ["-R", "a+rX,go-w", toolsRoot]);
-      const binDirectory = join(toolsRoot, "bin");
-      mkdirSync(binDirectory, { mode: 0o755 });
-      const nodePath = join(binDirectory, "node");
-      copyFileSync(process.execPath, nodePath);
-      chmodSync(nodePath, 0o555);
-      const pnpmLauncher = stageTrustedPnpmLauncher({ toolsRoot });
-      assert.equal(
-        execFileSync(pnpmLauncher, ["--version"], {
-          encoding: "utf8",
-          stdio: ["ignore", "pipe", "pipe"],
-        }).trim(),
-        "10.24.0",
-      );
 
       const cliPath = trustedVercelCliPath(toolsRoot);
       const pathFromTools = relative(realpathSync(toolsRoot), cliPath);
@@ -2012,6 +2086,7 @@ test("candidate execution is UID-isolated and hands upload to runner-owned state
     "trusted_bin_dir",
     "node_bin",
     "pnpm_bootstrap",
+    "pnpm_runtime_root",
     "pnpm_bin",
   ]) {
     assert.match(raw, new RegExp(protectedPath.replace("/", "\\/")));
@@ -2041,6 +2116,15 @@ test("candidate execution is UID-isolated and hands upload to runner-owned state
     isolationBlock,
     /vercel-prebuilt-workflow\.mjs" \\\n\s+stage-runtime/,
   );
+  assert.match(
+    isolationBlock,
+    /vercel-prebuilt-workflow\.mjs" \\\n\s+stage-pnpm-runtime/,
+  );
+  assert.match(
+    isolationBlock,
+    /"\$pnpm_bootstrap" --dir "\$pnpm_runtime_root" install/,
+  );
+  assert.match(isolationBlock, /--ignore-workspace/);
   assert.match(
     isolationBlock,
     /vercel-prebuilt-workflow\.mjs" \\\n\s+stage-pnpm-launcher/,
@@ -2075,6 +2159,8 @@ test("candidate execution is UID-isolated and hands upload to runner-owned state
     '/bin/chmod -R a+rX,go-w "$PNPM_ACTION_DEST"',
   );
   const protectedRuntimeCopyIndex = isolationBlock.indexOf("stage-runtime");
+  const protectedPnpmRuntimeIndex =
+    isolationBlock.indexOf("stage-pnpm-runtime");
   const protectedLauncherIndex = isolationBlock.indexOf("stage-pnpm-launcher");
   const protectedPathLoopIndex = isolationBlock.indexOf(
     "for protected_path in \\",
@@ -2090,7 +2176,8 @@ test("candidate execution is UID-isolated and hands upload to runner-owned state
   assert.notEqual(runnerTempHardenIndex, -1);
   assert.ok(pnpmActionHardenIndex > runnerTempHardenIndex);
   assert.ok(protectedRuntimeCopyIndex > pnpmActionHardenIndex);
-  assert.ok(protectedLauncherIndex > protectedRuntimeCopyIndex);
+  assert.ok(protectedPnpmRuntimeIndex > protectedRuntimeCopyIndex);
+  assert.ok(protectedLauncherIndex > protectedPnpmRuntimeIndex);
   assert.ok(protectedPathLoopIndex > protectedLauncherIndex);
   assert.ok(runnerTempProtectionIndex > protectedPathLoopIndex);
   assert.ok(trustedPathIndex > runnerTempProtectionIndex);
@@ -2163,7 +2250,7 @@ test("candidate execution is UID-isolated and hands upload to runner-owned state
     installBlock.indexOf("candidate_status=$?"),
   );
   assert.match(installBlock, /"\$pnpm_bin" --version \|/);
-  assert.match(installBlock, /\/usr\/bin\/grep -Fxq "10\.24\.0"/);
+  assert.match(installBlock, /\/usr\/bin\/grep -Fxq "10\.34\.4"/);
   assert.match(
     installBlock,
     /Isolated candidate cannot execute the protected pnpm launcher/,

--- a/scripts/vercel-prebuilt-workflow.test.mjs
+++ b/scripts/vercel-prebuilt-workflow.test.mjs
@@ -2156,6 +2156,26 @@ test("candidate execution is UID-isolated and hands upload to runner-owned state
   assert.match(raw, /mento-vercel-upload-source/);
   assert.match(raw, /dest: \$\{\{ runner\.temp \}\}\/mento-pnpm-tools/);
   assert.match(raw, /standalone: true/);
+  assert.match(
+    raw,
+    /EXPECTED_PNPM_LINUX_X64_SHA256: e02c01738ce850754cf00111fd97bec24de550e1e963690486f02d9dae1a2193/,
+  );
+  const pnpmVerificationBlock = raw.slice(
+    raw.indexOf("- name: Verify pinned pnpm target before first execution"),
+    raw.indexOf("- name: Set up pinned Node.js and pnpm cache"),
+  );
+  assert.match(pnpmVerificationBlock, /uname -s/);
+  assert.match(pnpmVerificationBlock, /uname -m/);
+  assert.match(pnpmVerificationBlock, /path_pnpm="\$\(type -P pnpm\)"/);
+  assert.match(
+    pnpmVerificationBlock,
+    /realpath "\$path_pnpm"\)" != "\$pnpm_target"/,
+  );
+  assert.match(pnpmVerificationBlock, /\/usr\/bin\/sha256sum "\$pnpm_target"/);
+  assert.ok(
+    pnpmVerificationBlock.indexOf('/usr/bin/sha256sum "$pnpm_target"') <
+      pnpmVerificationBlock.indexOf('"$pnpm_target" --version'),
+  );
   assert.match(raw, /userdel mento-vercel-build/);
   assert.match(raw, /node_modules\/vercel\/dist\/index\.js/);
   assert.match(raw, /candidate_can_write/);

--- a/scripts/vercel-prebuilt-workflow.test.mjs
+++ b/scripts/vercel-prebuilt-workflow.test.mjs
@@ -3,6 +3,7 @@ import { Buffer } from "node:buffer";
 import { execFileSync } from "node:child_process";
 import {
   chmodSync,
+  copyFileSync,
   linkSync,
   lstatSync,
   mkdirSync,
@@ -43,6 +44,7 @@ import {
   queryVercelDeployments,
   smokeUiPreview,
   stageVercelPullForCandidate,
+  stageTrustedPnpmLauncher,
   stageTrustedRuntime,
   trustedPnpmInstallLayout,
   trustedVercelCliPath,
@@ -1361,7 +1363,7 @@ test("trusted runtime copies hosted Node and the exact standalone pnpm target in
     assert.deepEqual(staged, {
       binDirectory: join(canonicalToolsRoot, "bin"),
       nodePath: join(canonicalToolsRoot, "bin", "node"),
-      pnpmPath: join(canonicalToolsRoot, "bin", "pnpm"),
+      pnpmBootstrapPath: join(canonicalToolsRoot, "bin", "pnpm-bootstrap"),
     });
     for (const path of [canonicalToolsRoot, staged.binDirectory]) {
       const entry = lstatSync(path);
@@ -1369,15 +1371,15 @@ test("trusted runtime copies hosted Node and the exact standalone pnpm target in
       assert.equal(entry.isSymbolicLink(), false);
       assert.equal(entry.uid, process.getuid());
       assert.equal(entry.gid, process.getgid());
-      assert.equal(entry.mode & 0o7022, 0);
+      assert.equal(entry.mode & 0o777, 0o755);
     }
-    for (const path of [staged.nodePath, staged.pnpmPath]) {
+    for (const path of [staged.nodePath, staged.pnpmBootstrapPath]) {
       const entry = lstatSync(path);
       assert.equal(entry.isFile(), true);
       assert.equal(entry.isSymbolicLink(), false);
       assert.equal(entry.uid, process.getuid());
       assert.equal(entry.gid, process.getgid());
-      assert.equal(entry.mode & 0o7022, 0);
+      assert.equal(entry.mode & 0o777, 0o555);
       assert.equal(entry.nlink, 1);
       assert.equal(realpathSync(path), path);
     }
@@ -1388,9 +1390,12 @@ test("trusted runtime copies hosted Node and the exact standalone pnpm target in
     writeFileSync(pnpmSource, "replaced pnpm launcher\n");
     writeFileSync(pnpmExecutable, "replaced pnpm executable\n");
     assert.equal(readFileSync(staged.nodePath, "utf8"), nodeContents);
-    assert.equal(readFileSync(staged.pnpmPath, "utf8"), pnpmExecutableContents);
     assert.equal(
-      execFileSync(staged.pnpmPath, ["--version"], {
+      readFileSync(staged.pnpmBootstrapPath, "utf8"),
+      pnpmExecutableContents,
+    );
+    assert.equal(
+      execFileSync(staged.pnpmBootstrapPath, ["--version"], {
         encoding: "utf8",
       }).trim(),
       "10.24.0",
@@ -1436,6 +1441,87 @@ test("trusted runtime copies hosted Node and the exact standalone pnpm target in
   } finally {
     rmSync(sourceRoot, { force: true, recursive: true });
     rmSync(runnerTemp, { force: true, recursive: true });
+  }
+});
+
+test("trusted candidate pnpm launcher uses the lockfile-pinned JavaScript package through protected Node", () => {
+  const toolsRoot = mkdtempSync(join(tmpdir(), "vercel-pnpm-launcher-"));
+  const binDirectory = join(toolsRoot, "bin");
+  const packageRoot = join(toolsRoot, "node_modules", "pnpm");
+  const cliPath = join(packageRoot, "bin", "pnpm.cjs");
+  const nodePath = join(binDirectory, "node");
+  try {
+    mkdirSync(binDirectory, { recursive: true });
+    mkdirSync(dirname(cliPath), { recursive: true });
+    writeFileSync(nodePath, ["#!/bin/sh", 'exec /bin/sh "$@"', ""].join("\n"), {
+      mode: 0o555,
+    });
+    writeFileSync(
+      join(packageRoot, "package.json"),
+      JSON.stringify({ name: "pnpm", version: "10.24.0" }),
+      { mode: 0o444 },
+    );
+    writeFileSync(
+      cliPath,
+      [
+        "#!/bin/sh",
+        'if [ "$1" = "--version" ]; then',
+        '  echo "10.24.0"',
+        "else",
+        "  exit 2",
+        "fi",
+        "",
+      ].join("\n"),
+      { mode: 0o444 },
+    );
+    for (const path of [
+      toolsRoot,
+      binDirectory,
+      join(toolsRoot, "node_modules"),
+      packageRoot,
+      dirname(cliPath),
+    ]) {
+      chmodSync(path, 0o755);
+    }
+
+    const launcherPath = stageTrustedPnpmLauncher({ toolsRoot });
+    assert.equal(launcherPath, join(realpathSync(toolsRoot), "bin", "pnpm"));
+    const launcher = lstatSync(launcherPath);
+    assert.equal(launcher.isFile(), true);
+    assert.equal(launcher.isSymbolicLink(), false);
+    assert.equal(launcher.uid, process.getuid());
+    assert.equal(launcher.gid, process.getgid());
+    assert.equal(launcher.mode & 0o777, 0o555);
+    assert.equal(launcher.nlink, 1);
+    assert.match(
+      readFileSync(launcherPath, "utf8"),
+      /node_modules\/pnpm\/bin\/pnpm\.cjs/,
+    );
+    assert.equal(
+      execFileSync(launcherPath, ["--version"], {
+        encoding: "utf8",
+      }).trim(),
+      "10.24.0",
+    );
+    assert.throws(
+      () => stageTrustedPnpmLauncher({ toolsRoot }),
+      /destination must be fresh/,
+    );
+
+    rmSync(launcherPath);
+    chmodSync(join(packageRoot, "package.json"), 0o644);
+    writeFileSync(
+      join(packageRoot, "package.json"),
+      JSON.stringify({ name: "pnpm", version: "10.24.1" }),
+      { mode: 0o444 },
+    );
+    chmodSync(join(packageRoot, "package.json"), 0o444);
+    assert.throws(
+      () => stageTrustedPnpmLauncher({ toolsRoot }),
+      /does not match the pinned release/,
+    );
+  } finally {
+    rmSync(toolsRoot, { force: true, recursive: true });
   }
 });
 
@@ -1628,6 +1714,9 @@ test(
         "HEAD",
       ]);
       execFileSync("tar", ["-xf", archivePath, "-C", controllerRoot]);
+      for (const file of ["package.json", "pnpm-lock.yaml"]) {
+        copyFileSync(join(REPOSITORY_ROOT, file), join(controllerRoot, file));
+      }
 
       const layout = trustedPnpmInstallLayout({ controllerRoot, toolsRoot });
       assert.equal(
@@ -1666,6 +1755,19 @@ test(
         },
       );
       execFileSync("chmod", ["-R", "a+rX,go-w", toolsRoot]);
+      const binDirectory = join(toolsRoot, "bin");
+      mkdirSync(binDirectory, { mode: 0o755 });
+      const nodePath = join(binDirectory, "node");
+      copyFileSync(process.execPath, nodePath);
+      chmodSync(nodePath, 0o555);
+      const pnpmLauncher = stageTrustedPnpmLauncher({ toolsRoot });
+      assert.equal(
+        execFileSync(pnpmLauncher, ["--version"], {
+          encoding: "utf8",
+          stdio: ["ignore", "pipe", "pipe"],
+        }).trim(),
+        "10.24.0",
+      );
 
       const cliPath = trustedVercelCliPath(toolsRoot);
       const pathFromTools = relative(realpathSync(toolsRoot), cliPath);
@@ -1909,6 +2011,7 @@ test("candidate execution is UID-isolated and hands upload to runner-owned state
     "TRUSTED_VERCEL_TOOLS_PATH",
     "trusted_bin_dir",
     "node_bin",
+    "pnpm_bootstrap",
     "pnpm_bin",
   ]) {
     assert.match(raw, new RegExp(protectedPath.replace("/", "\\/")));
@@ -1923,7 +2026,7 @@ test("candidate execution is UID-isolated and hands upload to runner-owned state
   );
   assert.match(
     isolationBlock,
-    /"\$pnpm_bin" --dir "\$GITHUB_WORKSPACE\/controller" --filter frontend-monorepo install/,
+    /"\$pnpm_bootstrap" --dir "\$GITHUB_WORKSPACE\/controller" --filter frontend-monorepo install/,
   );
   assert.match(isolationBlock, /--frozen-lockfile/);
   assert.match(isolationBlock, /--ignore-scripts/);
@@ -1940,11 +2043,19 @@ test("candidate execution is UID-isolated and hands upload to runner-owned state
   );
   assert.match(
     isolationBlock,
+    /vercel-prebuilt-workflow\.mjs" \\\n\s+stage-pnpm-launcher/,
+  );
+  assert.match(
+    isolationBlock,
     /Pinned pnpm escaped its action-owned directory/,
   );
   assert.match(
     isolationBlock,
     /Protected pnpm copy does not match the pinned release/,
+  );
+  assert.match(
+    isolationBlock,
+    /Protected pnpm launcher does not match the pinned release/,
   );
   assert.match(
     isolationBlock,
@@ -1964,6 +2075,7 @@ test("candidate execution is UID-isolated and hands upload to runner-owned state
     '/bin/chmod -R a+rX,go-w "$PNPM_ACTION_DEST"',
   );
   const protectedRuntimeCopyIndex = isolationBlock.indexOf("stage-runtime");
+  const protectedLauncherIndex = isolationBlock.indexOf("stage-pnpm-launcher");
   const protectedPathLoopIndex = isolationBlock.indexOf(
     "for protected_path in \\",
   );
@@ -1978,7 +2090,8 @@ test("candidate execution is UID-isolated and hands upload to runner-owned state
   assert.notEqual(runnerTempHardenIndex, -1);
   assert.ok(pnpmActionHardenIndex > runnerTempHardenIndex);
   assert.ok(protectedRuntimeCopyIndex > pnpmActionHardenIndex);
-  assert.ok(protectedPathLoopIndex > protectedRuntimeCopyIndex);
+  assert.ok(protectedLauncherIndex > protectedRuntimeCopyIndex);
+  assert.ok(protectedPathLoopIndex > protectedLauncherIndex);
   assert.ok(runnerTempProtectionIndex > protectedPathLoopIndex);
   assert.ok(trustedPathIndex > runnerTempProtectionIndex);
   assert.ok(materializeIndex > trustedPathIndex);
@@ -2048,6 +2161,12 @@ test("candidate execution is UID-isolated and hands upload to runner-owned state
   const installCandidateBlock = installBlock.slice(
     installBlock.indexOf("set +e"),
     installBlock.indexOf("candidate_status=$?"),
+  );
+  assert.match(installBlock, /"\$pnpm_bin" --version \|/);
+  assert.match(installBlock, /\/usr\/bin\/grep -Fxq "10\.24\.0"/);
+  assert.match(
+    installBlock,
+    /Isolated candidate cannot execute the protected pnpm launcher/,
   );
   const buildCandidateBlock = buildBlock.slice(
     buildBlock.indexOf("set +e"),

--- a/scripts/vercel-prebuilt-workflow.test.mjs
+++ b/scripts/vercel-prebuilt-workflow.test.mjs
@@ -4,6 +4,7 @@ import { execFileSync } from "node:child_process";
 import {
   chmodSync,
   copyFileSync,
+  existsSync,
   linkSync,
   lstatSync,
   mkdirSync,
@@ -1445,7 +1446,7 @@ test("trusted runtime copies hosted Node and the exact standalone pnpm target in
   }
 });
 
-test("trusted pnpm runtime manifest is copied outside the checkout with an exact pinned dependency", () => {
+test("trusted pnpm runtime manifest and lockfile are exact before copying outside the checkout", () => {
   const fixtureRoot = mkdtempSync(join(tmpdir(), "vercel-pnpm-runtime-"));
   const controllerRoot = join(fixtureRoot, "controller");
   const sourceRoot = join(controllerRoot, "scripts", "vercel-pnpm-runtime");
@@ -1494,21 +1495,105 @@ test("trusted pnpm runtime manifest is copied outside the checkout with an exact
     );
 
     rmSync(runtimeRoot, { force: true, recursive: true });
+    const lockfilePath = join(sourceRoot, "pnpm-lock.yaml");
+    const originalLockfile = readFileSync(lockfilePath, "utf8");
+    const lockfileMutations = [
+      [
+        "changed integrity",
+        originalLockfile.replace("sha512-h2i+VSAK", "sha512-i2i+VSAK"),
+      ],
+      [
+        "custom tarball",
+        originalLockfile.replace(
+          "resolution: {integrity:",
+          "resolution: {tarball: https://packages.example/pnpm.tgz, integrity:",
+        ),
+      ],
+      [
+        "extra importer",
+        originalLockfile.replace(
+          "importers:\n\n  .:",
+          "importers:\n\n  injected:\n    dependencies: {}\n\n  .:",
+        ),
+      ],
+      [
+        "extra package",
+        originalLockfile.replace(
+          "packages:\n\n  pnpm@10.34.4:",
+          "packages:\n\n  injected@1.0.0:\n    resolution: {integrity: sha512-injected}\n\n  pnpm@10.34.4:",
+        ),
+      ],
+      [
+        "extra snapshot",
+        originalLockfile.replace(
+          "snapshots:\n\n  pnpm@10.34.4:",
+          "snapshots:\n\n  injected@1.0.0: {}\n\n  pnpm@10.34.4:",
+        ),
+      ],
+    ];
+    for (const [name, mutatedLockfile] of lockfileMutations) {
+      assert.notEqual(mutatedLockfile, originalLockfile, name);
+      chmodSync(lockfilePath, 0o644);
+      writeFileSync(lockfilePath, mutatedLockfile);
+      chmodSync(lockfilePath, 0o444);
+      assert.throws(
+        () => stageTrustedPnpmRuntimeManifest({ controllerRoot, toolsRoot }),
+        /lockfile is not exact/,
+        name,
+      );
+      assert.equal(existsSync(runtimeRoot), false, name);
+    }
+    chmodSync(lockfilePath, 0o644);
+    writeFileSync(lockfilePath, originalLockfile);
+    chmodSync(lockfilePath, 0o444);
+
     const manifestPath = join(sourceRoot, "package.json");
-    chmodSync(manifestPath, 0o644);
-    writeFileSync(
-      manifestPath,
-      JSON.stringify({
+    const manifestMutations = [
+      {
         name: "@mento-protocol/vercel-pnpm-runtime",
+        version: "0.0.0",
         private: true,
+        description:
+          "Isolated pnpm runtime for candidate-controlled Vercel builds",
         dependencies: { pnpm: "10.34.3" },
-      }),
-    );
-    chmodSync(manifestPath, 0o444);
-    assert.throws(
-      () => stageTrustedPnpmRuntimeManifest({ controllerRoot, toolsRoot }),
-      /manifest is not exact/,
-    );
+      },
+      {
+        name: "@mento-protocol/vercel-pnpm-runtime",
+        version: "0.0.0",
+        private: true,
+        description:
+          "Isolated pnpm runtime for candidate-controlled Vercel builds",
+        dependencies: { injected: "1.0.0", pnpm: "10.34.4" },
+      },
+      {
+        name: "@mento-protocol/vercel-pnpm-runtime",
+        version: "0.0.0",
+        private: true,
+        description:
+          "Isolated pnpm runtime for candidate-controlled Vercel builds",
+        dependencies: { pnpm: "10.34.4" },
+        pnpm: { overrides: { pnpm: "10.34.3" } },
+      },
+      {
+        name: "@mento-protocol/vercel-pnpm-runtime",
+        version: "0.0.0",
+        private: true,
+        description:
+          "Isolated pnpm runtime for candidate-controlled Vercel builds",
+        dependencies: { pnpm: "10.34.4" },
+        packageManager: "pnpm@10.34.4",
+      },
+    ];
+    for (const packageMetadata of manifestMutations) {
+      chmodSync(manifestPath, 0o644);
+      writeFileSync(manifestPath, JSON.stringify(packageMetadata));
+      chmodSync(manifestPath, 0o444);
+      assert.throws(
+        () => stageTrustedPnpmRuntimeManifest({ controllerRoot, toolsRoot }),
+        /manifest is not exact/,
+      );
+      assert.equal(existsSync(runtimeRoot), false);
+    }
   } finally {
     rmSync(fixtureRoot, { force: true, recursive: true });
   }

--- a/scripts/vercel-prebuilt-workflows.test.mjs
+++ b/scripts/vercel-prebuilt-workflows.test.mjs
@@ -213,6 +213,10 @@ test("prebuilt separates trusted standalone bootstrap from candidate JavaScript 
 
   assert.equal(manifest.devDependencies.pnpm, undefined);
   assert.equal(manifest.packageManager, "pnpm@10.34.4");
+  assert.equal(
+    manifest.scripts["supply-chain:lockfile-lint"],
+    "node scripts/lockfile-lint.mjs && LOCKFILE_LINT_ROOT=scripts/vercel-pnpm-runtime node scripts/lockfile-lint.mjs",
+  );
   assert.deepEqual(runtimeManifest.dependencies, { pnpm: "10.34.4" });
   assert.deepEqual(Object.keys(runtimeLock.packages), ["pnpm@10.34.4"]);
   assert.deepEqual(Object.keys(runtimeLock.snapshots), ["pnpm@10.34.4"]);
@@ -232,9 +236,9 @@ test("prebuilt separates trusted standalone bootstrap from candidate JavaScript 
   );
   assert.match(runtimeOsvConfig, /GHSA-gj8w-mvpf-x27x/);
   assert.match(runtimeOsvConfig, /ignoreUntil = 2026-08-16T00:00:00Z/);
-  assert.match(
+  assert.equal(
     supplyChain.jobs["lockfile-lint"].steps.at(-1).run,
-    /LOCKFILE_LINT_ROOT=scripts\/vercel-pnpm-runtime/,
+    "pnpm supply-chain:lockfile-lint",
   );
   const trunkOsvIgnore = trunk.lint.ignore.find(({ linters }) =>
     linters.includes("osv-scanner"),

--- a/scripts/vercel-prebuilt-workflows.test.mjs
+++ b/scripts/vercel-prebuilt-workflows.test.mjs
@@ -188,10 +188,21 @@ test("exact source, build, and upload remain in one standard-runner job", () => 
 
 test("prebuilt separates trusted standalone bootstrap from candidate JavaScript pnpm", () => {
   const reusable = workflow(reusablePath);
+  const supplyChain = workflow(".github/workflows/supply-chain.yml");
+  const trunk = workflow(".trunk/trunk.yaml");
   const steps = reusable.jobs.prebuilt.steps;
   const names = steps.map(({ name }) => name);
   const manifest = JSON.parse(read("package.json"));
+  const runtimeManifest = JSON.parse(
+    read("scripts/vercel-pnpm-runtime/package.json"),
+  );
+  const runtimeLock = parse(read("scripts/vercel-pnpm-runtime/pnpm-lock.yaml"));
+  const rootOsvConfig = read("osv-scanner.toml");
+  const runtimeOsvConfig = read("scripts/vercel-pnpm-runtime/osv-scanner.toml");
   const pnpmSetup = steps.find(({ name }) => name === "Set up pinned pnpm");
+  const nodeSetup = steps.find(
+    ({ name }) => name === "Set up pinned Node.js and pnpm cache",
+  );
   const isolation = steps.find(
     ({ name }) =>
       name === "Prepare isolated exact-SHA source and protected Vercel CLI",
@@ -200,11 +211,46 @@ test("prebuilt separates trusted standalone bootstrap from candidate JavaScript 
     ({ name }) => name === "Install frozen dependencies",
   );
 
-  assert.equal(manifest.devDependencies.pnpm, "10.24.0");
+  assert.equal(manifest.devDependencies.pnpm, undefined);
+  assert.equal(manifest.packageManager, "pnpm@10.34.4");
+  assert.deepEqual(runtimeManifest.dependencies, { pnpm: "10.34.4" });
+  assert.deepEqual(Object.keys(runtimeLock.packages), ["pnpm@10.34.4"]);
+  assert.deepEqual(Object.keys(runtimeLock.snapshots), ["pnpm@10.34.4"]);
+  assert.equal(runtimeLock.importers["."].dependencies.pnpm.version, "10.34.4");
+  assert.doesNotMatch(rootOsvConfig, /GHSA-gj8w-mvpf-x27x/);
+  assert.match(
+    supplyChain.jobs.osv.with["scan-args"],
+    /--config=osv-scanner\.toml[\s\S]*--lockfile=pnpm-lock\.yaml/,
+  );
+  assert.doesNotMatch(
+    supplyChain.jobs.osv.with["scan-args"],
+    /vercel-pnpm-runtime/,
+  );
+  assert.match(
+    supplyChain.jobs["osv-pnpm-runtime"].with["scan-args"],
+    /--config=scripts\/vercel-pnpm-runtime\/osv-scanner\.toml[\s\S]*--lockfile=scripts\/vercel-pnpm-runtime\/pnpm-lock\.yaml/,
+  );
+  assert.match(runtimeOsvConfig, /GHSA-gj8w-mvpf-x27x/);
+  assert.match(runtimeOsvConfig, /ignoreUntil = 2026-08-16T00:00:00Z/);
+  assert.match(
+    supplyChain.jobs["lockfile-lint"].steps.at(-1).run,
+    /LOCKFILE_LINT_ROOT=scripts\/vercel-pnpm-runtime/,
+  );
+  const trunkOsvIgnore = trunk.lint.ignore.find(({ linters }) =>
+    linters.includes("osv-scanner"),
+  );
+  assert.deepEqual(trunkOsvIgnore.paths, [
+    "pnpm-lock.yaml",
+    "scripts/vercel-pnpm-runtime/pnpm-lock.yaml",
+  ]);
   assert.equal(pnpmSetup.with.dest, "${{ runner.temp }}/mento-pnpm-tools");
   assert.equal(pnpmSetup.with.standalone, true);
-  assert.equal(pnpmSetup.with.version, "10.24.0");
+  assert.equal(pnpmSetup.with.version, "10.34.4");
   assert.equal(pnpmSetup.id, "pnpm");
+  assert.match(
+    nodeSetup.with["cache-dependency-path"],
+    /controller\/scripts\/vercel-pnpm-runtime\/pnpm-lock\.yaml/,
+  );
   assert.equal(
     isolation.env.PNPM_ACTION_DEST,
     "${{ runner.temp }}/mento-pnpm-tools",
@@ -230,6 +276,15 @@ test("prebuilt separates trusted standalone bootstrap from candidate JavaScript 
   );
   assert.match(
     isolation.run,
+    /controller\/scripts\/vercel-prebuilt-workflow\.mjs" \\\n\s+stage-pnpm-runtime/,
+  );
+  assert.match(
+    isolation.run,
+    /"\$pnpm_bootstrap" --dir "\$pnpm_runtime_root" install \\/,
+  );
+  assert.match(isolation.run, /--ignore-workspace/);
+  assert.match(
+    isolation.run,
     /printf '%s\\n' "\$trusted_bin_dir" >> "\$GITHUB_PATH"/,
   );
   assert.match(isolation.run, /"\$PNPM_ACTION_DEST" \\/);
@@ -252,8 +307,10 @@ test("prebuilt separates trusted standalone bootstrap from candidate JavaScript 
   assert.match(isolation.run, /"\$pnpm_bootstrap" \\/);
   assert.match(isolation.run, /"\$pnpm_bin"; do/);
   assert.match(install.run, /\/usr\/bin\/setpriv/);
+  assert.match(install.run, /NPM_CONFIG_MANAGE_PACKAGE_MANAGER_VERSIONS=false/);
+  assert.match(install.run, /NPM_CONFIG_PACKAGE_MANAGER_STRICT_VERSION=false/);
   assert.match(install.run, /"\$pnpm_bin" --version \|/);
-  assert.match(install.run, /\/usr\/bin\/grep -Fxq "10\.24\.0"/);
+  assert.match(install.run, /\/usr\/bin\/grep -Fxq "10\.34\.4"/);
   assert.ok(
     names.indexOf("Set up pinned Node.js and pnpm cache") <
       names.indexOf(

--- a/scripts/vercel-prebuilt-workflows.test.mjs
+++ b/scripts/vercel-prebuilt-workflows.test.mjs
@@ -200,6 +200,9 @@ test("prebuilt separates trusted standalone bootstrap from candidate JavaScript 
   const rootOsvConfig = read("osv-scanner.toml");
   const runtimeOsvConfig = read("scripts/vercel-pnpm-runtime/osv-scanner.toml");
   const pnpmSetup = steps.find(({ name }) => name === "Set up pinned pnpm");
+  const pnpmTargetVerification = steps.find(
+    ({ name }) => name === "Verify pinned pnpm target before first execution",
+  );
   const nodeSetup = steps.find(
     ({ name }) => name === "Set up pinned Node.js and pnpm cache",
   );
@@ -238,7 +241,7 @@ test("prebuilt separates trusted standalone bootstrap from candidate JavaScript 
   assert.match(runtimeOsvConfig, /ignoreUntil = 2026-08-16T00:00:00Z/);
   assert.equal(
     supplyChain.jobs["lockfile-lint"].steps.at(-1).run,
-    "pnpm supply-chain:lockfile-lint",
+    "npm run supply-chain:lockfile-lint",
   );
   const trunkOsvIgnore = trunk.lint.ignore.find(({ linters }) =>
     linters.includes("osv-scanner"),
@@ -251,6 +254,45 @@ test("prebuilt separates trusted standalone bootstrap from candidate JavaScript 
   assert.equal(pnpmSetup.with.standalone, true);
   assert.equal(pnpmSetup.with.version, "10.34.4");
   assert.equal(pnpmSetup.id, "pnpm");
+  assert.equal(
+    pnpmTargetVerification.env.EXPECTED_PNPM_LINUX_X64_SHA256,
+    "e02c01738ce850754cf00111fd97bec24de550e1e963690486f02d9dae1a2193",
+  );
+  assert.equal(
+    pnpmTargetVerification.env.PNPM_ACTION_DEST,
+    "${{ runner.temp }}/mento-pnpm-tools",
+  );
+  assert.equal(
+    pnpmTargetVerification.env.PNPM_BIN_DEST,
+    "${{ steps.pnpm.outputs.bin_dest }}",
+  );
+  assert.match(pnpmTargetVerification.run, /uname -s/);
+  assert.match(pnpmTargetVerification.run, /uname -m/);
+  assert.match(
+    pnpmTargetVerification.run,
+    /bin_dest="\$\(\/usr\/bin\/realpath "\$PNPM_BIN_DEST"\)"/,
+  );
+  assert.match(
+    pnpmTargetVerification.run,
+    /pnpm_target="\$\(\/usr\/bin\/realpath "\$PNPM_BIN_DEST\/pnpm"\)"/,
+  );
+  assert.match(pnpmTargetVerification.run, /path_pnpm="\$\(type -P pnpm\)"/);
+  assert.match(
+    pnpmTargetVerification.run,
+    /realpath "\$path_pnpm"\)" != "\$pnpm_target"/,
+  );
+  assert.match(
+    pnpmTargetVerification.run,
+    /\/usr\/bin\/sha256sum "\$pnpm_target"/,
+  );
+  assert.match(
+    pnpmTargetVerification.run,
+    /"\$pnpm_target" --version \| \/usr\/bin\/grep -Fxq "10\.34\.4"/,
+  );
+  assert.ok(
+    pnpmTargetVerification.run.indexOf('/usr/bin/sha256sum "$pnpm_target"') <
+      pnpmTargetVerification.run.indexOf('"$pnpm_target" --version'),
+  );
   assert.deepEqual(
     nodeSetup.with["cache-dependency-path"].trim().split(/\s+/),
     [
@@ -318,6 +360,14 @@ test("prebuilt separates trusted standalone bootstrap from candidate JavaScript 
   assert.match(install.run, /NPM_CONFIG_PACKAGE_MANAGER_STRICT_VERSION=false/);
   assert.match(install.run, /"\$pnpm_bin" --version \|/);
   assert.match(install.run, /\/usr\/bin\/grep -Fxq "10\.34\.4"/);
+  assert.ok(
+    names.indexOf("Set up pinned pnpm") <
+      names.indexOf("Verify pinned pnpm target before first execution"),
+  );
+  assert.ok(
+    names.indexOf("Verify pinned pnpm target before first execution") <
+      names.indexOf("Set up pinned Node.js and pnpm cache"),
+  );
   assert.ok(
     names.indexOf("Set up pinned Node.js and pnpm cache") <
       names.indexOf(

--- a/scripts/vercel-prebuilt-workflows.test.mjs
+++ b/scripts/vercel-prebuilt-workflows.test.mjs
@@ -247,9 +247,12 @@ test("prebuilt separates trusted standalone bootstrap from candidate JavaScript 
   assert.equal(pnpmSetup.with.standalone, true);
   assert.equal(pnpmSetup.with.version, "10.34.4");
   assert.equal(pnpmSetup.id, "pnpm");
-  assert.match(
-    nodeSetup.with["cache-dependency-path"],
-    /controller\/scripts\/vercel-pnpm-runtime\/pnpm-lock\.yaml/,
+  assert.deepEqual(
+    nodeSetup.with["cache-dependency-path"].trim().split(/\s+/),
+    [
+      "controller/pnpm-lock.yaml",
+      "controller/scripts/vercel-pnpm-runtime/pnpm-lock.yaml",
+    ],
   );
   assert.equal(
     isolation.env.PNPM_ACTION_DEST,

--- a/scripts/vercel-prebuilt-workflows.test.mjs
+++ b/scripts/vercel-prebuilt-workflows.test.mjs
@@ -186,16 +186,21 @@ test("exact source, build, and upload remain in one standard-runner job", () => 
   );
 });
 
-test("prebuilt stages a protected Node and standalone pnpm runtime before candidate code", () => {
+test("prebuilt separates trusted standalone bootstrap from candidate JavaScript pnpm", () => {
   const reusable = workflow(reusablePath);
   const steps = reusable.jobs.prebuilt.steps;
   const names = steps.map(({ name }) => name);
+  const manifest = JSON.parse(read("package.json"));
   const pnpmSetup = steps.find(({ name }) => name === "Set up pinned pnpm");
   const isolation = steps.find(
     ({ name }) =>
       name === "Prepare isolated exact-SHA source and protected Vercel CLI",
   );
+  const install = steps.find(
+    ({ name }) => name === "Install frozen dependencies",
+  );
 
+  assert.equal(manifest.devDependencies.pnpm, "10.24.0");
   assert.equal(pnpmSetup.with.dest, "${{ runner.temp }}/mento-pnpm-tools");
   assert.equal(pnpmSetup.with.standalone, true);
   assert.equal(pnpmSetup.with.version, "10.24.0");
@@ -231,7 +236,24 @@ test("prebuilt stages a protected Node and standalone pnpm runtime before candid
   assert.match(isolation.run, /"\$TRUSTED_VERCEL_TOOLS_PATH" \\/);
   assert.match(isolation.run, /"\$trusted_bin_dir" \\/);
   assert.match(isolation.run, /"\$node_bin" \\/);
+  assert.match(
+    isolation.run,
+    /pnpm_bootstrap="\$trusted_bin_dir\/pnpm-bootstrap"/,
+  );
+  assert.match(
+    isolation.run,
+    /Protected runtime directory is not cross-identity readable/,
+  );
+  assert.match(isolation.run, /\[ "\$mode" != "555" \]/);
+  assert.match(
+    isolation.run,
+    /controller\/scripts\/vercel-prebuilt-workflow\.mjs" \\\n\s+stage-pnpm-launcher/,
+  );
+  assert.match(isolation.run, /"\$pnpm_bootstrap" \\/);
   assert.match(isolation.run, /"\$pnpm_bin"; do/);
+  assert.match(install.run, /\/usr\/bin\/setpriv/);
+  assert.match(install.run, /"\$pnpm_bin" --version \|/);
+  assert.match(install.run, /\/usr\/bin\/grep -Fxq "10\.24\.0"/);
   assert.ok(
     names.indexOf("Set up pinned Node.js and pnpm cache") <
       names.indexOf(


### PR DESCRIPTION
## The Problem

The immutable UI pilot had reached the isolated candidate install, but the candidate UID failed before dependency installation because pnpm reopened a protected executable that was not reliably readable/executable across identities on the hosted runner. Keeping pnpm in the root workspace also let package-manager installation and dependency review policy interfere with the runtime boundary this workflow needs to prove.

## The Solution

- Pin pnpm 10.34.4 consistently in the repository and GitHub Actions setup.
- Move the trusted pnpm runtime into a minimal, independently locked package under `scripts/vercel-pnpm-runtime`.
- Materialize that runtime under the runner-owned protected tools directory, then invoke `pnpm.cjs` through the protected Node binary.
- Harden the candidate launcher against uppercase and lowercase package-manager configuration overrides and preflight the exact runtime under the isolated UID/GID.
- Require the trusted runtime manifest to match its exact allowed fields and bind the complete one-importer lockfile to a reviewed SHA-256 before any install.
- Keep the trusted tooling cache keyed only by the controller and isolated-runtime lockfiles; candidate dependency changes use their disposable isolated store and no longer force unrelated trusted-tool cache misses.
- Scan the root and isolated runtime lockfiles separately. Keep the advisory false-positive suppression scoped to the one-package runtime lockfile, while an independent integrity rule rejects actually affected pnpm versions.
- Restrict the existing GitHub tarball exception to its exact canonical lockfile shape and URL.
- Update workflow policy, supply-chain coverage, structural regression tests, and deployment documentation for the split trust boundary.

## Validation

- `CI=true pnpm install --frozen-lockfile`
- `pnpm test`
- `pnpm check-types`
- `pnpm quality:budgets:test`
- `pnpm knip`
- `pnpm ci:action-pins:test`
- `pnpm ci:action-pins`
- `pnpm adr:check`
- `pnpm pr:description:test`
- `pnpm vercel:workflow:test` (71/71)
- `pnpm vercel:preview:test` (86/86)
- root and isolated-runtime lockfile integrity tests
- root and isolated-runtime OSV scans
- `trunk check`
- `git diff --check`

Advances #518. A successful immutable hosted-runner pilot and browser smoke remain mandatory post-merge evidence before closing the pilot issue.
