### PR TITLE
fix(ci): allow protected pnpm version transition

### DIFF
--- a/scripts/check-github-action-pins.mjs
+++ b/scripts/check-github-action-pins.mjs
@@ -29,6 +29,12 @@ const REQUIRED_POLICY_FILES = [
   ".github/workflows/action-pins.yml",
   ".github/workflows/action-pins-source.yml",
 ];
+const POLICY_PNPM_JOB_IDS = new Map([
+  [".github/workflows/action-pins.yml", "action-pins"],
+  [".github/workflows/action-pins-source.yml", "policy-source"],
+]);
+const ALLOWED_POLICY_PNPM_VERSIONS = ["10.24.0", "10.34.4"];
+const CANONICAL_POLICY_PNPM_VERSION = ALLOWED_POLICY_PNPM_VERSIONS[0];
 const VERCEL_PREVIEW_CONTROLLER =
   ".github/workflows/vercel-preview-controller.yml";
 const VERCEL_PREVIEW_CONTROLLER_TRIGGERS = {
@@ -333,12 +339,57 @@ function normalizePolicyWorkflow(value) {
 }
 
 /**
+ * The protected workflows need one merge on the old pnpm version before they
+ * can move to the new one. Normalize only the exact Setup PNPM field after
+ * validating its temporary allowlist; every other workflow value remains part
+ * of the strict structural comparison.
+ * @param {string} path
+ * @param {unknown} workflow
+ */
+function normalizePolicyPnpmVersion(path, workflow) {
+  const jobId = POLICY_PNPM_JOB_IDS.get(path);
+  if (
+    !jobId ||
+    workflow == null ||
+    typeof workflow !== "object" ||
+    Array.isArray(workflow)
+  ) {
+    return workflow;
+  }
+
+  const steps = workflow.jobs?.[jobId]?.steps;
+  if (!Array.isArray(steps)) return workflow;
+
+  const setupSteps = steps.filter(
+    (step) =>
+      step != null &&
+      typeof step === "object" &&
+      !Array.isArray(step) &&
+      step.name === "Setup PNPM" &&
+      step.uses === "pnpm/action-setup@<sha>",
+  );
+  if (setupSteps.length !== 1) return workflow;
+
+  const setupStep = setupSteps[0];
+  const version = setupStep.with?.version;
+  if (!ALLOWED_POLICY_PNPM_VERSIONS.includes(version)) {
+    throw new Error(
+      `Setup PNPM version must be one of: ${ALLOWED_POLICY_PNPM_VERSIONS.join(", ")}`,
+    );
+  }
+
+  setupStep.with.version = CANONICAL_POLICY_PNPM_VERSION;
+  return workflow;
+}
+
+/**
  * These workflows form the policy's trust boundary. The target workflow runs
  * only base-branch code; the source workflow exercises proposed checker code
  * without credentials. Validate their complete executable structure from the
  * trusted checker so a PR cannot replace either required check with a no-op.
- * Action SHAs are normalized; other canonical changes intentionally use the
- * protected two-PR transition documented in README.md.
+ * Action SHAs and the explicitly allowed pnpm transition are normalized; other
+ * canonical changes intentionally use the protected two-PR transition
+ * documented in README.md.
  * @param {string} path
  * @param {import("yaml").Document} document
  */
@@ -347,7 +398,10 @@ function assertPolicyWorkflowStructure(path, document) {
   if (!expected) return;
 
   assertUniqueSemanticMappings(document.contents, document);
-  const actual = normalizePolicyWorkflow(document.toJS({ maxAliasCount: 100 }));
+  const actual = normalizePolicyPnpmVersion(
+    path,
+    normalizePolicyWorkflow(document.toJS({ maxAliasCount: 100 })),
+  );
   if (!isDeepStrictEqual(actual, expected)) {
     throw new Error("does not match the trusted action-pin workflow structure");
   }

--- a/scripts/check-github-action-pins.test.mjs
+++ b/scripts/check-github-action-pins.test.mjs
@@ -27,6 +27,7 @@ const POLICY_WORKFLOW_FIXTURES = new Map(
     readFileSync(resolve(path), "utf8"),
   ]),
 );
+const CURRENT_POLICY_PNPM_VERSION = "10.24.0";
 const VERCEL_PREVIEW_CONTROLLER_PATH =
   ".github/workflows/vercel-preview-controller.yml";
 const VERCEL_PREVIEW_CONTROLLER_FIXTURE = readFileSync(
@@ -63,6 +64,16 @@ function runChecker(root) {
     env: { ...process.env, GITHUB_ACTION_PINS_ROOT: root },
     encoding: "utf8",
   });
+}
+
+/** @param {string} path @param {string} version */
+function policyWorkflowWithPnpmVersion(path, version) {
+  const source = POLICY_WORKFLOW_FIXTURES.get(path);
+  const current = `version: ${CURRENT_POLICY_PNPM_VERSION}`;
+  if (typeof source !== "string" || source.split(current).length !== 2) {
+    throw new Error(`${path} must contain exactly one ${current}`);
+  }
+  return source.replace(current, `version: ${version}`);
 }
 
 /** @param {unknown} actual @param {unknown} expected @param {string} message */
@@ -1261,6 +1272,66 @@ test("allows immutable action SHA bumps in canonical policy workflows", () => {
 
       const result = runChecker(root);
       equal(result.status, 0, result.stderr);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  }
+});
+
+test("allows both exact pnpm versions during the protected transition", () => {
+  for (const version of ["10.24.0", "10.34.4"]) {
+    for (const path of POLICY_WORKFLOW_PATHS) {
+      const root = fixtureRoot(`policy-pnpm-${version}-pass`);
+      try {
+        write(root, path, policyWorkflowWithPnpmVersion(path, version));
+
+        const result = runChecker(root);
+        equal(result.status, 0, result.stderr);
+      } finally {
+        rmSync(root, { recursive: true, force: true });
+      }
+    }
+  }
+});
+
+test("rejects pnpm versions outside the protected transition", () => {
+  for (const path of POLICY_WORKFLOW_PATHS) {
+    const root = fixtureRoot("policy-pnpm-arbitrary-fail");
+    try {
+      write(root, path, policyWorkflowWithPnpmVersion(path, "10.34.5"));
+
+      const result = runChecker(root);
+      equal(result.status, 1, result.stdout);
+      contains(result.stderr, path, "policy path");
+      contains(
+        result.stderr,
+        "Setup PNPM version must be one of: 10.24.0, 10.34.4",
+        "allowed pnpm versions",
+      );
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  }
+});
+
+test("keeps non-pnpm policy fields strict during the transition", () => {
+  for (const path of POLICY_WORKFLOW_PATHS) {
+    const root = fixtureRoot("policy-pnpm-other-field-fail");
+    try {
+      const updated = policyWorkflowWithPnpmVersion(path, "10.34.4").replace(
+        "node-version: 22",
+        "node-version: 23",
+      );
+      write(root, path, updated);
+
+      const result = runChecker(root);
+      equal(result.status, 1, result.stdout);
+      contains(result.stderr, path, "policy path");
+      contains(
+        result.stderr,
+        "does not match the trusted action-pin workflow structure",
+        "strict non-pnpm field",
+      );
     } finally {
       rmSync(root, { recursive: true, force: true });
     }


### PR DESCRIPTION
## The Problem

The protected action-pin workflows are structurally fixed to pnpm 10.24.0. A direct workflow upgrade to pnpm 10.34.4 would therefore be rejected by the trusted base-branch checker, preventing the documented protected two-PR transition.

## The Solution

- Allow exactly pnpm 10.24.0 or 10.34.4 at the canonical `Setup PNPM` version field.
- Validate that temporary allowlist before normalizing the version for the existing full-structure comparison.
- Test both allowed versions, reject an arbitrary third version, and prove unrelated workflow fields remain strict.
- Leave the protected workflow files and root `packageManager` unchanged for this prerequisite merge.

## Validation

- `pnpm ci:action-pins:test`
- `pnpm ci:action-pins`
- `pnpm exec prettier --check scripts/check-github-action-pins.mjs scripts/check-github-action-pins.test.mjs`
- `pnpm exec eslint scripts/check-github-action-pins.mjs scripts/check-github-action-pins.test.mjs`
- `trunk check scripts/check-github-action-pins.mjs scripts/check-github-action-pins.test.mjs`
- `pnpm adr:check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CI policy validation scripts and tests; no runtime app, auth, or data paths are touched.
> 
> **Overview**
> The action-pin policy checker used to require protected workflows (`action-pins.yml`, `action-pins-source.yml`) to match a canonical structure that **only** allowed pnpm **10.24.0**, which blocked the documented two-PR bump to **10.34.4**.
> 
> This change adds a **temporary allowlist** (`10.24.0` and `10.34.4`) for the **Setup PNPM** step on the mapped policy jobs. It validates that version before deep-structural comparison, then **normalizes** it to `10.24.0` so either allowed value still matches the trusted template. Any other pnpm version fails with an explicit error; unrelated fields (e.g. `node-version`) stay strictly compared.
> 
> Tests cover both allowed versions on both policy workflows, rejection of arbitrary versions, and that non-pnpm mutations still fail structure checks. **Protected workflow YAML and root `packageManager` are unchanged** in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a982782395291031abb4c55f1ffe9f6645103757. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->