### PR TITLE
fix(ci): allow preview deployment recovery

### DIFF
--- a/.github/workflows/vercel-preview-controller.yml
+++ b/.github/workflows/vercel-preview-controller.yml
@@ -201,7 +201,7 @@ jobs:
     permissions:
       actions: write
       contents: read
-      deployments: read
+      deployments: write
       pull-requests: write
       statuses: write
     steps:
@@ -390,7 +390,7 @@ jobs:
     permissions:
       actions: write
       contents: read
-      deployments: read
+      deployments: write
       pull-requests: write
       statuses: write
     steps:
@@ -434,7 +434,7 @@ jobs:
     permissions:
       actions: write
       contents: read
-      deployments: read
+      deployments: write
       pull-requests: write
       statuses: write
     steps:

--- a/scripts/vercel-preview-workflows.test.mjs
+++ b/scripts/vercel-preview-workflows.test.mjs
@@ -304,13 +304,25 @@ test("every controller write-token job checks out only trusted workflow code", (
 });
 
 test("every controller reconciliation binds selections to its immutable workflow SHA", () => {
-  for (const jobName of [
-    "reconcile-event",
-    "reconcile-bootstrap",
-    "reconcile-request",
-    "recover-worker-result",
-  ]) {
-    const step = controller.jobs[jobName].steps.find((candidate) =>
+  const reconciliationJobs = Object.entries(controller.jobs).filter(([, job]) =>
+    JSON.stringify(job).includes("reconcilePreview"),
+  );
+  assert.deepEqual(
+    reconciliationJobs.map(([jobName]) => jobName),
+    [
+      "reconcile-event",
+      "reconcile-bootstrap",
+      "reconcile-request",
+      "recover-worker-result",
+    ],
+  );
+  for (const [jobName, job] of reconciliationJobs) {
+    assert.equal(
+      job.permissions.deployments,
+      "write",
+      `${jobName} may recover a completed worker by creating or terminalizing its Deployment`,
+    );
+    const step = job.steps.find((candidate) =>
       String(candidate.with?.script ?? "").includes("reconcilePreview"),
     );
     assert.ok(step, `${jobName} must invoke reconcilePreview`);


### PR DESCRIPTION
## The Problem

The Vercel preview controller can recover a completed worker from durable state when a terminal callback is missed. That recovery can create or terminalize the worker's canonical GitHub Deployment.

Live controller run [29515624657](https://github.com/mento-protocol/frontend-monorepo/actions/runs/29515624657) reached that path for PR #537, then failed with:

```text
POST /repos/mento-protocol/frontend-monorepo/deployments - 403
x-accepted-github-permissions: deployments=write
```

`reconcile-event`, `reconcile-bootstrap`, and `reconcile-request` all invoke `reconcilePreview`, but granted only `deployments: read`. The dedicated worker-result recovery path already had the required write permission.

## The Solution

Grant `deployments: write` to the three reconciliation jobs that can enter completed-worker recovery. The write permission remains isolated to trusted default-branch controller jobs that never check out or execute PR code.

The structural workflow test now discovers every job that calls `reconcilePreview`, asserts the exact caller set, and requires Deployment write permission for each caller. This prevents a future reconciliation entrypoint from silently reintroducing the same runtime 403.

Part of #519.

## Validation

- `pnpm vercel:preview:test` — 86 passed
- `pnpm test` — passed, including all workspace tests
- `pnpm quality:budgets:test` — 30 passed
- `pnpm ci:action-pins`
- `pnpm ci:action-pins:test` — 50 scanner + 11 REST materializer tests passed
- `pnpm adr:check`
- `pnpm pr:description:test` — 25 passed
- `pnpm exec trunk check .github/workflows/vercel-preview-controller.yml scripts/vercel-preview-workflows.test.mjs`
- mandatory pre-push Trunk, type-check, and Knip hooks
- deterministic autoreview — clean

## Ship Checklist

- [x] ship skill used
- [x] local review run
- [x] validation run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped CI permission fix on trusted controller jobs only; no application or PR checkout code paths change.
> 
> **Overview**
> Fixes **403** failures when the Vercel preview controller **recovers a completed worker** and must **create or terminalize** the canonical GitHub Deployment.
> 
> **`reconcile-event`**, **`reconcile-bootstrap`**, and **`reconcile-request`** now use **`deployments: write`** instead of **`deployments: read`**, matching the recovery path that already had write access. Jobs still run trusted default-branch controller code only.
> 
> The workflow test **discovers every job that calls `reconcilePreview`**, locks the caller set to those three plus **`recover-worker-result`**, and **requires `deployments: write`** on each so a new reconciliation entrypoint cannot reintroduce the same permission gap.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b79477b75f73add5d0fcc646c8a36ec84852bb3f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->