### PR TITLE
fix(ci): authenticate pnpm bootstrap before execution

### DIFF
--- a/.github/workflows/_vercel-prebuilt.yml
+++ b/.github/workflows/_vercel-prebuilt.yml
@@ -155,79 +155,206 @@ jobs:
           persist-credentials: false
           ref: ${{ inputs.commit_sha }}
 
-      - name: Set up pinned pnpm
-        id: pnpm
-        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v4
-        with:
-          dest: ${{ runner.temp }}/mento-pnpm-tools
-          standalone: true
-          version: 10.34.4
-
-      - name: Verify pinned pnpm target before first execution
-        shell: bash
-        env:
-          EXPECTED_PNPM_LINUX_X64_SHA256: e02c01738ce850754cf00111fd97bec24de550e1e963690486f02d9dae1a2193
-          PNPM_ACTION_DEST: ${{ runner.temp }}/mento-pnpm-tools
-          PNPM_BIN_DEST: ${{ steps.pnpm.outputs.bin_dest }}
-        run: |
-          set -euo pipefail
-          if [ "$(/usr/bin/uname -s)" != "Linux" ] ||
-            [ "$(/usr/bin/uname -m)" != "x86_64" ]; then
-            echo "Pinned pnpm target digest supports only the expected Linux x64 runner" >&2
-            exit 1
-          fi
-          if [ ! -d "$PNPM_ACTION_DEST" ] || [ -L "$PNPM_ACTION_DEST" ]; then
-            echo "Pinned pnpm action directory is not a real directory" >&2
-            exit 1
-          fi
-          action_root="$(/usr/bin/realpath "$PNPM_ACTION_DEST")"
-          if [ "$action_root" != "$RUNNER_TEMP/mento-pnpm-tools" ]; then
-            echo "Pinned pnpm action directory escaped RUNNER_TEMP" >&2
-            exit 1
-          fi
-          bin_dest="$(/usr/bin/realpath "$PNPM_BIN_DEST")"
-          if [ "$bin_dest" != "$action_root/node_modules/.bin/bin" ]; then
-            echo "Pinned pnpm action returned an unexpected binary directory" >&2
-            exit 1
-          fi
-          pnpm_target="$(/usr/bin/realpath "$PNPM_BIN_DEST/pnpm")"
-          case "$pnpm_target" in
-            "$action_root"/*) ;;
-            *) echo "Pinned pnpm target escaped its action-owned directory" >&2; exit 1 ;;
-          esac
-          path_pnpm="$(type -P pnpm)"
-          if [ "$(/usr/bin/realpath "$path_pnpm")" != "$pnpm_target" ]; then
-            echo "PATH does not resolve to the pinned pnpm target" >&2
-            exit 1
-          fi
-          if [ ! -f "$pnpm_target" ] ||
-            [ -L "$pnpm_target" ] ||
-            [ "$(/usr/bin/stat -c %u "$pnpm_target")" != "$(/usr/bin/id -u)" ]; then
-            echo "Pinned pnpm target is not a runner-owned regular file" >&2
-            exit 1
-          fi
-          mode="$(/usr/bin/stat -c %a "$pnpm_target")"
-          if (( (8#$mode & 0022) != 0 )); then
-            echo "Pinned pnpm target is group- or world-writable" >&2
-            exit 1
-          fi
-          actual_sha256="$(
-            /usr/bin/sha256sum "$pnpm_target" | /usr/bin/cut -d ' ' -f1
-          )"
-          if [ "$actual_sha256" != "$EXPECTED_PNPM_LINUX_X64_SHA256" ]; then
-            echo "Pinned pnpm target digest does not match the reviewed artifact" >&2
-            exit 1
-          fi
-          "$pnpm_target" --version | /usr/bin/grep -Fxq "10.34.4"
-
-      - name: Set up pinned Node.js and pnpm cache
+      - name: Set up pinned Node.js without package-manager cache
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
+          package-manager-cache: false
+
+      - name: Stage and authenticate pinned pnpm bootstrap
+        shell: bash
+        env:
+          EXPECTED_PNPM_LINUX_X64_SHA256: e02c01738ce850754cf00111fd97bec24de550e1e963690486f02d9dae1a2193
+          PNPM_BOOTSTRAP_CACHE_PATH: ${{ runner.temp }}/mento-vercel-npm-cache
+          PNPM_BOOTSTRAP_HOME_PATH: ${{ runner.temp }}/mento-vercel-npm-home
+          PNPM_BOOTSTRAP_PATH: ${{ runner.temp }}/mento-vercel-pnpm-bootstrap
+          PNPM_BOOTSTRAP_TMP_PATH: ${{ runner.temp }}/mento-vercel-npm-tmp
+          TRUSTED_VERCEL_TOOLS_PATH: ${{ runner.temp }}/mento-vercel-trusted-tools
+        run: |
+          set -euo pipefail
+          umask 077
+          /bin/chmod 0711 "$RUNNER_TEMP"
+          if [ "$(/usr/bin/uname -s)" != "Linux" ] ||
+            [ "$(/usr/bin/uname -m)" != "x86_64" ]; then
+            echo "Pinned pnpm bootstrap supports only the expected Linux x64 runner" >&2
+            exit 1
+          fi
+          for fresh_path in \
+            "$PNPM_BOOTSTRAP_CACHE_PATH" \
+            "$PNPM_BOOTSTRAP_HOME_PATH" \
+            "$PNPM_BOOTSTRAP_PATH" \
+            "$PNPM_BOOTSTRAP_TMP_PATH" \
+            "$TRUSTED_VERCEL_TOOLS_PATH"; do
+            if [ -e "$fresh_path" ] || [ -L "$fresh_path" ]; then
+              echo "Trusted pnpm bootstrap path already exists: $fresh_path" >&2
+              exit 1
+            fi
+          done
+          /usr/bin/install -d -m 0700 \
+            "$PNPM_BOOTSTRAP_CACHE_PATH" \
+            "$PNPM_BOOTSTRAP_HOME_PATH" \
+            "$PNPM_BOOTSTRAP_TMP_PATH"
+          /usr/bin/install -m 0600 /dev/null \
+            "$PNPM_BOOTSTRAP_HOME_PATH/global.npmrc"
+          /usr/bin/install -m 0600 /dev/null \
+            "$PNPM_BOOTSTRAP_HOME_PATH/user.npmrc"
+
+          setup_node_bin="$(/usr/bin/realpath "$(type -P node)")"
+          setup_node_bin_dir="$(/usr/bin/dirname "$setup_node_bin")"
+          setup_node_root="$(/usr/bin/realpath "$setup_node_bin_dir/..")"
+          npm_cli="$(/usr/bin/realpath "$(type -P npm)")"
+          case "$npm_cli" in
+            "$setup_node_root"/*) ;;
+            *) echo "Pinned npm CLI escaped the setup-node tool root" >&2; exit 1 ;;
+          esac
+          if [ ! -f "$npm_cli" ] || [ -L "$npm_cli" ]; then
+            echo "Pinned npm CLI is not a regular file" >&2
+            exit 1
+          fi
+          for shadowing_binary in \
+            "$setup_node_bin_dir/pnpm" \
+            "$setup_node_bin_dir/pnpx"; do
+            if [ -e "$shadowing_binary" ] || [ -L "$shadowing_binary" ]; then
+              echo "setup-node tool directory unexpectedly shadows authenticated pnpm" >&2
+              exit 1
+            fi
+          done
+
+          bootstrap_root="$(
+            CONTROLLER_PATH="$GITHUB_WORKSPACE/controller" \
+            PNPM_BOOTSTRAP_PATH="$PNPM_BOOTSTRAP_PATH" \
+            RUNNER_TEMP="$RUNNER_TEMP" \
+              "$setup_node_bin" \
+              "$GITHUB_WORKSPACE/controller/scripts/vercel-prebuilt-workflow.mjs" \
+              stage-pnpm-bootstrap
+          )"
+          if [ "$bootstrap_root" != "$PNPM_BOOTSTRAP_PATH" ]; then
+            echo "Trusted pnpm bootstrap escaped its fixed staging root" >&2
+            exit 1
+          fi
+          /usr/bin/env -i \
+            HOME="$PNPM_BOOTSTRAP_HOME_PATH" \
+            HTTPS_PROXY="${HTTPS_PROXY:-}" \
+            HTTP_PROXY="${HTTP_PROXY:-}" \
+            LANG="${LANG:-C.UTF-8}" \
+            LC_ALL="${LC_ALL:-C.UTF-8}" \
+            NODE_EXTRA_CA_CERTS="${NODE_EXTRA_CA_CERTS:-}" \
+            NO_PROXY="${NO_PROXY:-}" \
+            NPM_CONFIG_AUDIT=false \
+            NPM_CONFIG_CACHE="$PNPM_BOOTSTRAP_CACHE_PATH" \
+            NPM_CONFIG_FUND=false \
+            NPM_CONFIG_GLOBALCONFIG="$PNPM_BOOTSTRAP_HOME_PATH/global.npmrc" \
+            NPM_CONFIG_IGNORE_SCRIPTS=true \
+            NPM_CONFIG_REGISTRY=https://registry.npmjs.org/ \
+            NPM_CONFIG_UPDATE_NOTIFIER=false \
+            NPM_CONFIG_USERCONFIG="$PNPM_BOOTSTRAP_HOME_PATH/user.npmrc" \
+            PATH="$setup_node_bin_dir:/usr/bin:/bin" \
+            SSL_CERT_FILE="${SSL_CERT_FILE:-}" \
+            TMPDIR="$PNPM_BOOTSTRAP_TMP_PATH" \
+            "$setup_node_bin" "$npm_cli" ci \
+              --prefix "$PNPM_BOOTSTRAP_PATH" \
+              --ignore-scripts \
+              --no-audit \
+              --no-fund \
+              --omit=dev
+          /bin/chmod -R a+rX,go-w "$PNPM_BOOTSTRAP_PATH"
+          NODE_SOURCE_PATH="$setup_node_bin" \
+          PNPM_BOOTSTRAP_PATH="$PNPM_BOOTSTRAP_PATH" \
+          RUNNER_TEMP="$RUNNER_TEMP" \
+          TRUSTED_VERCEL_TOOLS_PATH="$TRUSTED_VERCEL_TOOLS_PATH" \
+            "$setup_node_bin" \
+            "$GITHUB_WORKSPACE/controller/scripts/vercel-prebuilt-workflow.mjs" \
+            stage-runtime
+
+          trusted_bin_dir="$TRUSTED_VERCEL_TOOLS_PATH/bin"
+          bootstrap_bin_dir="$TRUSTED_VERCEL_TOOLS_PATH/bootstrap-bin"
+          node_bin="$trusted_bin_dir/node"
+          pnpm_bootstrap="$bootstrap_bin_dir/pnpm"
+          for protected_directory in \
+            "$TRUSTED_VERCEL_TOOLS_PATH" \
+            "$trusted_bin_dir" \
+            "$bootstrap_bin_dir"; do
+            if [ "$(/usr/bin/stat -c %a "$protected_directory")" != "755" ]; then
+              echo "Protected runtime directory is not cross-identity readable" >&2
+              exit 1
+            fi
+          done
+          for protected_binary in "$node_bin" "$pnpm_bootstrap"; do
+            mode="$(/usr/bin/stat -c %a "$protected_binary")"
+            if [ ! -f "$protected_binary" ] ||
+              [ -L "$protected_binary" ] ||
+              [ "$(/usr/bin/stat -c %u "$protected_binary")" != "$(/usr/bin/id -u)" ] ||
+              [ "$(/usr/bin/stat -c %h "$protected_binary")" != "1" ] ||
+              [ "$mode" != "555" ]; then
+              echo "Protected runtime binary is not an independent runner-owned file" >&2
+              exit 1
+            fi
+          done
+          protected_sha256="$(
+            /usr/bin/sha256sum "$pnpm_bootstrap" | /usr/bin/cut -d ' ' -f1
+          )"
+          if [ "$protected_sha256" != "$EXPECTED_PNPM_LINUX_X64_SHA256" ]; then
+            echo "Protected pnpm bootstrap digest does not match the reviewed artifact" >&2
+            exit 1
+          fi
+          "$pnpm_bootstrap" --version | /usr/bin/grep -Fxq "10.34.4"
+
+          /bin/rm -rf -- \
+            "$PNPM_BOOTSTRAP_CACHE_PATH" \
+            "$PNPM_BOOTSTRAP_HOME_PATH" \
+            "$PNPM_BOOTSTRAP_PATH" \
+            "$PNPM_BOOTSTRAP_TMP_PATH"
+          printf '%s\n' "$bootstrap_bin_dir" >> "$GITHUB_PATH"
+
+      - name: Prove authenticated pnpm path before cache restore
+        env:
+          EXPECTED_PNPM_LINUX_X64_SHA256: e02c01738ce850754cf00111fd97bec24de550e1e963690486f02d9dae1a2193
+          TRUSTED_VERCEL_TOOLS_PATH: ${{ runner.temp }}/mento-vercel-trusted-tools
+        run: |
+          set -euo pipefail
+          expected_pnpm="$TRUSTED_VERCEL_TOOLS_PATH/bootstrap-bin/pnpm"
+          path_pnpm="$(type -P pnpm)"
+          if [ "$(/usr/bin/realpath "$path_pnpm")" != "$expected_pnpm" ]; then
+            echo "PATH does not resolve to the authenticated pnpm bootstrap" >&2
+            exit 1
+          fi
+          actual_sha256="$(
+            /usr/bin/sha256sum "$path_pnpm" | /usr/bin/cut -d ' ' -f1
+          )"
+          if [ "$actual_sha256" != "$EXPECTED_PNPM_LINUX_X64_SHA256" ]; then
+            echo "Authenticated pnpm bootstrap digest changed before cache restore" >&2
+            exit 1
+          fi
+          "$path_pnpm" --version | /usr/bin/grep -Fxq "10.34.4"
+
+      - name: Restore trusted pnpm cache
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
           cache: pnpm
           cache-dependency-path: |
             controller/pnpm-lock.yaml
             controller/scripts/vercel-pnpm-runtime/pnpm-lock.yaml
+
+      - name: Reverify authenticated pnpm after cache restore
+        env:
+          EXPECTED_PNPM_LINUX_X64_SHA256: e02c01738ce850754cf00111fd97bec24de550e1e963690486f02d9dae1a2193
+          TRUSTED_VERCEL_TOOLS_PATH: ${{ runner.temp }}/mento-vercel-trusted-tools
+        run: |
+          set -euo pipefail
+          expected_pnpm="$TRUSTED_VERCEL_TOOLS_PATH/bootstrap-bin/pnpm"
+          path_pnpm="$(type -P pnpm)"
+          if [ "$(/usr/bin/realpath "$path_pnpm")" != "$expected_pnpm" ]; then
+            echo "Cache restore changed the authenticated pnpm path" >&2
+            exit 1
+          fi
+          actual_sha256="$(
+            /usr/bin/sha256sum "$path_pnpm" | /usr/bin/cut -d ' ' -f1
+          )"
+          if [ "$actual_sha256" != "$EXPECTED_PNPM_LINUX_X64_SHA256" ]; then
+            echo "Authenticated pnpm bootstrap digest changed after cache restore" >&2
+            exit 1
+          fi
+          "$path_pnpm" --version | /usr/bin/grep -Fxq "10.34.4"
 
       - name: Validate pilot contract and prepare immutable build identity
         id: prepare
@@ -266,8 +393,7 @@ jobs:
           CANDIDATE_HOME_PATH: ${{ runner.temp }}/mento-vercel-candidate-home
           CANDIDATE_SOURCE_PATH: ${{ runner.temp }}/mento-vercel-candidate-source
           DEPLOY_SHA: ${{ steps.source.outputs.checked_out_sha }}
-          PNPM_ACTION_DEST: ${{ runner.temp }}/mento-pnpm-tools
-          PNPM_BIN_DEST: ${{ steps.pnpm.outputs.bin_dest }}
+          EXPECTED_PNPM_LINUX_X64_SHA256: e02c01738ce850754cf00111fd97bec24de550e1e963690486f02d9dae1a2193
           SOURCE_PATH: ${{ github.workspace }}/source
           TRUSTED_VERCEL_TOOLS_PATH: ${{ runner.temp }}/mento-vercel-trusted-tools
         run: |
@@ -294,40 +420,20 @@ jobs:
           fi
 
           /bin/chmod 0711 "$RUNNER_TEMP"
-          if [ ! -d "$PNPM_ACTION_DEST" ] || [ -L "$PNPM_ACTION_DEST" ]; then
-            echo "Pinned pnpm action directory is not a real directory" >&2
-            exit 1
-          fi
-          if [ "$(realpath "$PNPM_ACTION_DEST")" != "$RUNNER_TEMP/mento-pnpm-tools" ]; then
-            echo "Pinned pnpm action directory escaped RUNNER_TEMP" >&2
-            exit 1
-          fi
-          /bin/chmod -R a+rX,go-w "$PNPM_ACTION_DEST"
-          if [ -e "$TRUSTED_VERCEL_TOOLS_PATH" ] || [ -L "$TRUSTED_VERCEL_TOOLS_PATH" ]; then
-            echo "Protected runtime destination already exists" >&2
+          if [ ! -d "$TRUSTED_VERCEL_TOOLS_PATH" ] ||
+            [ -L "$TRUSTED_VERCEL_TOOLS_PATH" ] ||
+            [ "$(realpath "$TRUSTED_VERCEL_TOOLS_PATH")" != "$RUNNER_TEMP/mento-vercel-trusted-tools" ]; then
+            echo "Protected runtime root is not the authenticated fixed directory" >&2
             exit 1
           fi
           trusted_bin_dir="$TRUSTED_VERCEL_TOOLS_PATH/bin"
-          setup_node_bin="$(realpath "$(command -v node)")"
-          if [ "$(realpath "$PNPM_BIN_DEST")" != "$PNPM_ACTION_DEST/node_modules/.bin/bin" ]; then
-            echo "Pinned pnpm action returned an unexpected binary directory" >&2
-            exit 1
-          fi
-          setup_pnpm_bin="$(realpath "$PNPM_BIN_DEST/pnpm")"
-          case "$setup_pnpm_bin" in
-            "$PNPM_ACTION_DEST"/*) ;;
-            *) echo "Pinned pnpm escaped its action-owned directory" >&2; exit 1 ;;
-          esac
-          NODE_SOURCE_PATH="$setup_node_bin" \
-          PNPM_SOURCE_PATH="$setup_pnpm_bin" \
-          RUNNER_TEMP="$RUNNER_TEMP" \
-          TRUSTED_VERCEL_TOOLS_PATH="$TRUSTED_VERCEL_TOOLS_PATH" \
-            "$setup_node_bin" \
-            "$GITHUB_WORKSPACE/controller/scripts/vercel-prebuilt-workflow.mjs" \
-            stage-runtime
+          bootstrap_bin_dir="$TRUSTED_VERCEL_TOOLS_PATH/bootstrap-bin"
           node_bin="$trusted_bin_dir/node"
-          pnpm_bootstrap="$trusted_bin_dir/pnpm-bootstrap"
-          for protected_directory in "$TRUSTED_VERCEL_TOOLS_PATH" "$trusted_bin_dir"; do
+          pnpm_bootstrap="$bootstrap_bin_dir/pnpm"
+          for protected_directory in \
+            "$TRUSTED_VERCEL_TOOLS_PATH" \
+            "$trusted_bin_dir" \
+            "$bootstrap_bin_dir"; do
             if [ "$(/usr/bin/stat -c %a "$protected_directory")" != "755" ]; then
               echo "Protected runtime directory is not cross-identity readable" >&2
               exit 1
@@ -344,10 +450,38 @@ jobs:
               exit 1
             fi
           done
-          if [ "$("$pnpm_bootstrap" --version)" != "10.34.4" ]; then
+          protected_sha256="$(
+            /usr/bin/sha256sum "$pnpm_bootstrap" | /usr/bin/cut -d ' ' -f1
+          )"
+          if [ "$protected_sha256" != "$EXPECTED_PNPM_LINUX_X64_SHA256" ] ||
+            [ "$("$pnpm_bootstrap" --version)" != "10.34.4" ]; then
             echo "Protected pnpm copy does not match the pinned release" >&2
             exit 1
           fi
+          trusted_pnpm_store="$("$pnpm_bootstrap" store path --silent)"
+          if [ -z "$trusted_pnpm_store" ] || [[ "$trusted_pnpm_store" != /* ]]; then
+            echo "Trusted pnpm cache path is not absolute" >&2
+            exit 1
+          fi
+          if [ -e "$trusted_pnpm_store" ] || [ -L "$trusted_pnpm_store" ]; then
+            if [ ! -d "$trusted_pnpm_store" ] || [ -L "$trusted_pnpm_store" ]; then
+              echo "Trusted pnpm cache path is not a real directory" >&2
+              exit 1
+            fi
+          else
+            /usr/bin/install -d -m 0700 "$trusted_pnpm_store"
+          fi
+          trusted_pnpm_store="$(realpath "$trusted_pnpm_store")"
+          case "$trusted_pnpm_store" in
+            "$HOME"/*) ;;
+            *) echo "Trusted pnpm cache escaped the runner home" >&2; exit 1 ;;
+          esac
+          if [ "$(/usr/bin/stat -c %u "$trusted_pnpm_store")" != "$(id -u)" ]; then
+            echo "Trusted pnpm cache is not runner-owned" >&2
+            exit 1
+          fi
+          trusted_pnpm_store_parent="$(dirname "$trusted_pnpm_store")"
+          /bin/chmod -R go-w "$trusted_pnpm_store"
           pnpm_runtime_root="$(
             CONTROLLER_PATH="$GITHUB_WORKSPACE/controller" \
             TRUSTED_VERCEL_TOOLS_PATH="$TRUSTED_VERCEL_TOOLS_PATH" \
@@ -426,11 +560,13 @@ jobs:
             "$SOURCE_PATH/.git" \
             "$SOURCE_PATH/package.json" \
             "$SOURCE_PATH/pnpm-lock.yaml" \
-            "$PNPM_ACTION_DEST" \
             "$TRUSTED_VERCEL_TOOLS_PATH" \
             "$trusted_bin_dir" \
+            "$bootstrap_bin_dir" \
             "$node_bin" \
             "$pnpm_bootstrap" \
+            "$trusted_pnpm_store_parent" \
+            "$trusted_pnpm_store" \
             "$pnpm_runtime_root" \
             "$pnpm_runtime_root/package.json" \
             "$pnpm_runtime_root/pnpm-lock.yaml" \
@@ -1020,6 +1156,10 @@ jobs:
         env:
           CANDIDATE_HOME_PATH: ${{ runner.temp }}/mento-vercel-candidate-home
           CANDIDATE_SOURCE_PATH: ${{ runner.temp }}/mento-vercel-candidate-source
+          PNPM_BOOTSTRAP_CACHE_PATH: ${{ runner.temp }}/mento-vercel-npm-cache
+          PNPM_BOOTSTRAP_HOME_PATH: ${{ runner.temp }}/mento-vercel-npm-home
+          PNPM_BOOTSTRAP_PATH: ${{ runner.temp }}/mento-vercel-pnpm-bootstrap
+          PNPM_BOOTSTRAP_TMP_PATH: ${{ runner.temp }}/mento-vercel-npm-tmp
           PULL_STAGING_PATH: ${{ runner.temp }}/mento-vercel-pull-staging
           TRUSTED_VERCEL_TOOLS_PATH: ${{ runner.temp }}/mento-vercel-trusted-tools
           UPLOAD_SOURCE_PATH: ${{ runner.temp }}/mento-vercel-upload-source
@@ -1043,7 +1183,16 @@ jobs:
           if getent group mento-vercel-build >/dev/null; then
             sudo --non-interactive /usr/sbin/groupdel mento-vercel-build
           fi
-          for path in "$CANDIDATE_HOME_PATH" "$CANDIDATE_SOURCE_PATH" "$PULL_STAGING_PATH" "$TRUSTED_VERCEL_TOOLS_PATH" "$UPLOAD_SOURCE_PATH"; do
+          for path in \
+            "$CANDIDATE_HOME_PATH" \
+            "$CANDIDATE_SOURCE_PATH" \
+            "$PNPM_BOOTSTRAP_CACHE_PATH" \
+            "$PNPM_BOOTSTRAP_HOME_PATH" \
+            "$PNPM_BOOTSTRAP_PATH" \
+            "$PNPM_BOOTSTRAP_TMP_PATH" \
+            "$PULL_STAGING_PATH" \
+            "$TRUSTED_VERCEL_TOOLS_PATH" \
+            "$UPLOAD_SOURCE_PATH"; do
             case "$path" in
               "$RUNNER_TEMP"/mento-vercel-*) ;;
               *) echo "Refusing to clean an unexpected path" >&2; exit 1 ;;
@@ -1052,6 +1201,10 @@ jobs:
           sudo --non-interactive /bin/rm -rf -- \
             "$CANDIDATE_HOME_PATH" \
             "$CANDIDATE_SOURCE_PATH" \
+            "$PNPM_BOOTSTRAP_CACHE_PATH" \
+            "$PNPM_BOOTSTRAP_HOME_PATH" \
+            "$PNPM_BOOTSTRAP_PATH" \
+            "$PNPM_BOOTSTRAP_TMP_PATH" \
             "$PULL_STAGING_PATH" \
             "$UPLOAD_SOURCE_PATH"
           /bin/rm -rf -- "$TRUSTED_VERCEL_TOOLS_PATH"

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -2,7 +2,7 @@ name: Supply Chain
 
 # Dependency supply-chain gates, decoupled from trunk so the pre-push hook
 # never blocks on lockfile CVEs (see .trunk/trunk.yaml — osv-scanner ignores
-# both lockfiles). Four jobs:
+# the dependency lockfiles). Five jobs:
 #
 #   1. osv              — osv-scanner against the application lockfile, reading
 #                         the repository-wide osv-scanner.toml.
@@ -10,16 +10,19 @@ name: Supply Chain
 #                         trusted-tool lockfile. Its config contains only the
 #                         short-lived pnpm metadata correction, so that advisory
 #                         cannot mask a vulnerable pnpm elsewhere in the repo.
-#                         Both scans run on every PR + a daily cron (24h
-#                         disclosure backstop for new CVEs and expired ignores).
-#   3. lockfile-lint    — sha512 integrity + registry-poisoning gate.
-#   4. version-skew     — every cataloged dep is "catalog:" or the exact catalog
+#   3. osv-pnpm-bootstrap — scans the exact npm-locked Linux bootstrap artifact
+#                           without sharing the pnpm-runtime suppression.
+#                           All scans run on every PR + a daily cron (24h
+#                           disclosure backstop for new CVEs and expired ignores).
+#   4. lockfile-lint    — sha512 integrity + registry-poisoning gate, plus a
+#                         real Linux npm-ci proof for the bootstrap lock.
+#   5. version-skew     — every cataloged dep is "catalog:" or the exact catalog
 #                         version (no silent drift off the shared catalog).
 #
-# Suppressions live in osv-scanner.toml. Advisories suppressed in both scanners
-# must stay in sync with the `allow-ghsas` list in dependency-review.yml and its
-# expiry. Scanner-specific metadata false positives remain OSV-only, with source
-# evidence and a short `ignoreUntil`.
+# Suppressions live in osv-scanner.toml. Advisories suppressed across configured
+# scanners must stay in sync with the `allow-ghsas` list in
+# dependency-review.yml and its expiry. Scanner-specific metadata false
+# positives remain OSV-only, with source evidence and a short `ignoreUntil`.
 #
 # No path filter on `pull_request`: the osv job is meant to be a required check,
 # and a path-filtered required check that gets skipped sits "pending" forever
@@ -77,6 +80,18 @@ jobs:
         --lockfile=scripts/vercel-pnpm-runtime/pnpm-lock.yaml
       upload-sarif: ${{ github.event_name != 'pull_request' }}
 
+  osv-pnpm-bootstrap:
+    name: osv-scanner (trusted pnpm bootstrap)
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@9a498708959aeaef5ef730655706c5a1df1edbc2 # v2.3.8
+    with:
+      scan-args: |-
+        --lockfile=scripts/vercel-pnpm-bootstrap/package-lock.json
+      upload-sarif: ${{ github.event_name != 'pull_request' }}
+
   lockfile-lint:
     name: lockfile integrity + registry
     runs-on: ubuntu-latest
@@ -92,6 +107,17 @@ jobs:
         run: node scripts/lockfile-lint.test.mjs
       - name: lockfile integrity + registry check
         run: npm run supply-chain:lockfile-lint
+      - name: Install and authenticate the Linux pnpm bootstrap
+        working-directory: scripts/vercel-pnpm-bootstrap
+        run: |
+          set -euo pipefail
+          npm ci --ignore-scripts --no-audit --no-fund
+          pnpm_binary=node_modules/@pnpm/linux-x64/pnpm
+          test -f "$pnpm_binary"
+          test ! -L "$pnpm_binary"
+          echo "e02c01738ce850754cf00111fd97bec24de550e1e963690486f02d9dae1a2193  $pnpm_binary" |
+            sha256sum --check --strict
+          "$pnpm_binary" --version | grep -Fxq "10.34.4"
 
   version-skew:
     name: catalog version-skew

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -40,6 +40,7 @@ lint:
         # so the `trunk check --all` pre-push hook no longer blocks pushes on
         # pre-existing repo-wide lockfile advisories.
         - pnpm-lock.yaml
+        - scripts/vercel-pnpm-bootstrap/package-lock.json
         - scripts/vercel-pnpm-runtime/pnpm-lock.yaml
     - linters: [ALL]
       paths:

--- a/docs/vercel-deployments.md
+++ b/docs/vercel-deployments.md
@@ -362,24 +362,41 @@ relative paths from the controller to that directory; pnpm treats an absolute
 `--modules-dir` as project-relative and would otherwise materialize the CLI at
 the wrong path. The zero-network fixture requires the already-hydrated package
 store with `--offline`; it cannot contact the registry to repair missing data.
-The hosted setup-node and pnpm locations are treated only as trusted staging
-inputs because runner-image permissions can make those original paths writable
-by the isolated candidate UID. The pinned pnpm action installs its own bootstrap
-from a commit-locked npm lockfile, then downloads the requested
-`@pnpm/linux-x64@10.34.4` target; that target declares no lifecycle scripts.
-Before setup-node's cache probe or any other consumer can execute the downloaded
-target, the worker requires the expected Linux x64 runner, canonical
-action-owned path, runner ownership, non-writable mode, and reviewed executable
+The hosted setup-node location is treated only as a trusted staging input
+because runner-image permissions can make that original path writable by the
+isolated candidate UID. The credentialed build job does not use
+`pnpm/action-setup`: its standalone update path installs `@pnpm/exe`, whose
+`preinstall` lifecycle runs before a downloaded target can be authenticated.
+Instead, pinned setup-node first provides Node.js and its bundled npm with
+package-manager caching explicitly disabled. Trusted controller code validates
+the exact manifest and complete npm lockfile under
+`scripts/vercel-pnpm-bootstrap`, then copies them into a fresh fixed directory
+under `RUNNER_TEMP`.
+
+That lock has one dependency only: `@pnpm/linux-x64@10.34.4` from the official
+npm registry with its reviewed sha512 SRI. The worker runs `npm ci` outside the
+checkout with lifecycle scripts, audit, and funding calls disabled; ambient npm
+configuration, cache, home, and temporary state are replaced with fresh
+runner-owned paths. It never executes npm's `.bin` shim. Trusted code requires
+the literal installed `node_modules/@pnpm/linux-x64/pnpm` to remain inside the
+fixed staging root, be a single-link runner-owned regular file, declare the
+expected Linux x64 package metadata and no lifecycle scripts, and match
 SHA-256
 `e02c01738ce850754cf00111fd97bec24de550e1e963690486f02d9dae1a2193`.
-Before candidate code starts, the worker then copies Node.js and that verified
-standalone pnpm executable into the same runner-owned protected tool directory,
-removes group/other write access from the original pnpm action directory, and
-uses the copied executable only to install trusted controller tools. The pnpm
-action's PATH entry is a launcher whose executable lives below a hashed
-`global/v*/.../@pnpm/exe/pnpm` directory, so the worker also requires exactly
-one protected target reporting `10.34.4` and copies that self-contained
-executable instead of relocating the launcher.
+Only after that source digest passes does the worker make an independent
+read-only copy under the protected tool directory, re-hash the copy, execute
+its absolute path to require version `10.34.4`, and remove the extraction plus
+npm cache.
+
+The protected copy is then placed on `PATH` and revalidated before a second,
+cache-only setup-node invocation. That invocation deliberately has no
+`node-version`, `node-version-file`, or architecture input, so pinned
+setup-node skips Node installation and cannot prepend another Node tool
+directory before it asks the already-authenticated pnpm for its store path.
+The resolved store is runner-owned and proven non-writable by the candidate.
+Before candidate code starts, Node.js is likewise copied into the protected
+tool directory, and only the protected copies install trusted controller
+tools.
 
 Candidate-controlled installs use a separate JavaScript pnpm runtime pinned by
 `scripts/vercel-pnpm-runtime/package.json` and its standalone frozen lockfile.
@@ -390,9 +407,12 @@ Before staging, the controller requires the manifest to match its exact allowed
 fields and binds the complete one-importer lockfile bytes to
 `PINNED_PNPM_RUNTIME_LOCKFILE_SHA256`; this rejects extra dependency/config
 sections, custom tarballs, changed integrity, or extra importers/packages before
-the bootstrap install. A pnpm bump must update the action input, reviewed Linux
-x64 executable digest, isolated manifest and lockfile, `PINNED_PNPM_VERSION`,
-and lockfile digest together.
+the bootstrap install. A pnpm bump must update the bootstrap npm manifest and
+lockfile, reviewed registry SRI and Linux x64 executable digest, isolated
+JavaScript-runtime manifest and pnpm lockfile, `PINNED_PNPM_VERSION`, and both
+complete-lockfile digests together. On a non-Linux development host,
+`npm install --package-lock-only --force` may be used only to regenerate this
+Linux-specific lock; the CI installation must never use `--force`.
 The protected launcher always uses protected Node plus that runtime's
 `pnpm.cjs`; it disables pnpm's package-manager self-switch and strict patch
 version check so an older candidate `packageManager` field cannot silently
@@ -400,8 +420,11 @@ downgrade the trusted runtime or reject the intentional patched v10 version.
 This removes the standalone executable's own image from the cross-identity
 execution path: the pilot failed when that image was not effectively readable
 after switching to the isolated candidate identity, even though the
-runner-owned executable checks had passed. Both lockfiles are covered by OSV
-and sha512/registry validation.
+runner-owned executable checks had passed. The root and candidate-runtime pnpm
+locks remain covered by OSV and sha512/registry validation. The bootstrap npm
+lock has a separate OSV job, exact byte/shape validation, npm's SRI
+enforcement, and a Linux CI installation that hashes the executable before
+running it.
 Before any credentialed command, the worker proves the runtime root, its
 replacement-relevant parents, Node.js, pnpm, and the CLI are not candidate
 writable; it also proves the CLI resolves inside the protected directory, its
@@ -411,13 +434,14 @@ the actual pinned pnpm version in a temporary checkout while retaining a
 frozen-lockfile failure boundary.
 
 The candidate dependency install intentionally does **not** reuse setup-node's
-writable pnpm store. Its isolated `HOME` and XDG directories place that store
-under the disposable candidate home, which is deleted before upload. Sharing a
-runner store here would let selected source code mutate cache state that an
-Actions post-step could save from the trusted `main` run. Treat candidate
-dependency installation as a cold, measured pilot cost; record its duration
-separately from `vercel build`. The signed Turbo remote build cache remains
-enabled and its hit/miss evidence remains part of the comparison.
+runner-owned pnpm store, even though the candidate is proven unable to write it.
+Its isolated `HOME` and XDG directories place that store under the disposable
+candidate home, which is deleted before upload. Sharing a runner store here
+would let selected source code mutate cache state that an Actions post-step
+could save from the trusted `main` run if an isolation boundary regressed.
+Treat candidate dependency installation as a cold, measured pilot cost; record
+its duration separately from `vercel build`. The signed Turbo remote build
+cache remains enabled and its hit/miss evidence remains part of the comparison.
 
 Before candidate installation, the worker proves the checked-out index tree is
 the exact selected commit tree. Before any candidate process starts, it

--- a/scripts/vercel-pnpm-bootstrap/package-lock.json
+++ b/scripts/vercel-pnpm-bootstrap/package-lock.json
@@ -1,0 +1,33 @@
+{
+  "name": "@mento-protocol/vercel-pnpm-bootstrap",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@mento-protocol/vercel-pnpm-bootstrap",
+      "version": "0.0.0",
+      "dependencies": {
+        "@pnpm/linux-x64": "10.34.4"
+      }
+    },
+    "node_modules/@pnpm/linux-x64": {
+      "version": "10.34.4",
+      "resolved": "https://registry.npmjs.org/@pnpm/linux-x64/-/linux-x64-10.34.4.tgz",
+      "integrity": "sha512-6gsJT9HUs1kBsJANC5SEJNRGAMzjGMKgxEtCvPLYd7NIktbh1GH5Ktcu7nLYcbxX8SirCHHzhZiMolW0mvzoqA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "pnpm": "pnpm"
+      },
+      "funding": {
+        "url": "https://opencollective.com/pnpm"
+      }
+    }
+  }
+}

--- a/scripts/vercel-pnpm-bootstrap/package.json
+++ b/scripts/vercel-pnpm-bootstrap/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@mento-protocol/vercel-pnpm-bootstrap",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Integrity-pinned Linux pnpm bootstrap for trusted Vercel builds",
+  "dependencies": {
+    "@pnpm/linux-x64": "10.34.4"
+  }
+}

--- a/scripts/vercel-prebuilt-workflow.mjs
+++ b/scripts/vercel-prebuilt-workflow.mjs
@@ -75,12 +75,20 @@ const VERCEL_CLI_BASE_ENVIRONMENT = [
 const PULL_STAGING_DIRECTORY = "mento-vercel-pull-staging";
 const CANDIDATE_SOURCE_DIRECTORY = "mento-vercel-candidate-source";
 const TRUSTED_TOOLS_DIRECTORY = "mento-vercel-trusted-tools";
-const PNPM_ACTION_DIRECTORY = "mento-pnpm-tools";
+const PNPM_BOOTSTRAP_DIRECTORY = "mento-vercel-pnpm-bootstrap";
 const PNPM_RUNTIME_DIRECTORY = "pnpm-runtime";
 const PINNED_PNPM_VERSION = "10.34.4";
-// Exact bytes of the one-importer registry lockfile. This pins the package
-// identity, absence of custom tarball resolution, and sha512 integrity before
-// the runner-owned bootstrap installs anything from it.
+const PINNED_PNPM_BOOTSTRAP_LOCKFILE_SHA256 =
+  "1f8083495d03d348edb41b529f266807173860558b346128ae63f29f2f331c4d";
+const PINNED_PNPM_LINUX_X64_RESOLVED =
+  "https://registry.npmjs.org/@pnpm/linux-x64/-/linux-x64-10.34.4.tgz";
+const PINNED_PNPM_LINUX_X64_INTEGRITY =
+  "sha512-6gsJT9HUs1kBsJANC5SEJNRGAMzjGMKgxEtCvPLYd7NIktbh1GH5Ktcu7nLYcbxX8SirCHHzhZiMolW0mvzoqA==";
+const PINNED_PNPM_LINUX_X64_SHA256 =
+  "e02c01738ce850754cf00111fd97bec24de550e1e963690486f02d9dae1a2193";
+// Exact bytes of the one-importer JavaScript runtime lockfile. This pins the
+// package identity, absence of custom tarball resolution, and sha512 integrity
+// before the authenticated bootstrap installs anything from it.
 const PINNED_PNPM_RUNTIME_LOCKFILE_SHA256 =
   "c0dbb0f05ade0e4a8db501e5eb25ebe3c2f2794feed1caec2cf4df6c4583715a";
 const PULLED_ENVIRONMENT_FILE = ".env.preview.local";
@@ -1167,7 +1175,7 @@ function assertProtectedRuntimeDescendant({
     pathFromRoot.startsWith(`..${sep}`) ||
     isAbsolute(pathFromRoot)
   ) {
-    throw new Error("Protected runtime source escaped its action root");
+    throw new Error("Protected runtime source escaped its protected root");
   }
   const entry = assertProtectedRuntimeEntry(canonicalPath, {
     directory,
@@ -1184,45 +1192,210 @@ function assertProtectedRuntimeDescendant({
     });
     const nextParent = dirname(parent);
     if (nextParent === parent) {
-      throw new Error("Protected runtime source escaped its action root");
+      throw new Error("Protected runtime source escaped its protected root");
     }
     parent = nextParent;
   }
   return { entry, path: canonicalPath };
 }
 
-function readPnpmVersion(path, run) {
-  const result = run(path, ["--version"], {
-    encoding: "utf8",
-    env: {
-      HOME: "/nonexistent",
-      LANG: "C",
-      LC_ALL: "C",
-      PATH: "/usr/bin:/bin",
-    },
-    timeout: 10_000,
-    windowsHide: true,
-  });
-  if (result.error || result.signal || result.status !== 0) {
-    throw new Error("Pinned pnpm standalone executable did not run");
+function validatePinnedPnpmBootstrapFiles({ packageJsonPath, lockfilePath }) {
+  const packageMetadata = JSON.parse(readFileSync(packageJsonPath, "utf8"));
+  if (
+    !hasExactObjectKeys(packageMetadata, [
+      "dependencies",
+      "description",
+      "name",
+      "private",
+      "version",
+    ]) ||
+    packageMetadata.name !== "@mento-protocol/vercel-pnpm-bootstrap" ||
+    packageMetadata.version !== "0.0.0" ||
+    packageMetadata.private !== true ||
+    packageMetadata.description !==
+      "Integrity-pinned Linux pnpm bootstrap for trusted Vercel builds" ||
+    !hasExactObjectKeys(packageMetadata.dependencies, ["@pnpm/linux-x64"]) ||
+    packageMetadata.dependencies["@pnpm/linux-x64"] !== PINNED_PNPM_VERSION ||
+    packageMetadata.scripts !== undefined ||
+    packageMetadata.workspaces !== undefined ||
+    packageMetadata.overrides !== undefined
+  ) {
+    throw new Error("Trusted pnpm bootstrap manifest is not exact");
   }
-  return result.stdout.trim();
+
+  const lockfileContents = readFileSync(lockfilePath);
+  const lockfileDigest = createHash("sha256")
+    .update(lockfileContents)
+    .digest("hex");
+  if (lockfileDigest !== PINNED_PNPM_BOOTSTRAP_LOCKFILE_SHA256) {
+    throw new Error("Trusted pnpm bootstrap lockfile is not exact");
+  }
+  const lockfile = JSON.parse(lockfileContents.toString("utf8"));
+  const rootPackage = lockfile.packages?.[""];
+  const pnpmPackage = lockfile.packages?.["node_modules/@pnpm/linux-x64"];
+  if (
+    !hasExactObjectKeys(lockfile, [
+      "lockfileVersion",
+      "name",
+      "packages",
+      "requires",
+      "version",
+    ]) ||
+    lockfile.name !== "@mento-protocol/vercel-pnpm-bootstrap" ||
+    lockfile.version !== "0.0.0" ||
+    lockfile.lockfileVersion !== 3 ||
+    lockfile.requires !== true ||
+    !hasExactObjectKeys(lockfile.packages, [
+      "",
+      "node_modules/@pnpm/linux-x64",
+    ]) ||
+    !hasExactObjectKeys(rootPackage, ["dependencies", "name", "version"]) ||
+    rootPackage.name !== "@mento-protocol/vercel-pnpm-bootstrap" ||
+    rootPackage.version !== "0.0.0" ||
+    !hasExactObjectKeys(rootPackage.dependencies, ["@pnpm/linux-x64"]) ||
+    rootPackage.dependencies["@pnpm/linux-x64"] !== PINNED_PNPM_VERSION ||
+    !hasExactObjectKeys(pnpmPackage, [
+      "bin",
+      "cpu",
+      "funding",
+      "integrity",
+      "license",
+      "os",
+      "resolved",
+      "version",
+    ]) ||
+    pnpmPackage.version !== PINNED_PNPM_VERSION ||
+    pnpmPackage.resolved !== PINNED_PNPM_LINUX_X64_RESOLVED ||
+    pnpmPackage.integrity !== PINNED_PNPM_LINUX_X64_INTEGRITY ||
+    pnpmPackage.license !== "MIT" ||
+    !hasExactObjectKeys(pnpmPackage.bin, ["pnpm"]) ||
+    pnpmPackage.bin.pnpm !== "pnpm" ||
+    JSON.stringify(pnpmPackage.os) !== '["linux"]' ||
+    JSON.stringify(pnpmPackage.cpu) !== '["x64"]' ||
+    !hasExactObjectKeys(pnpmPackage.funding, ["url"]) ||
+    pnpmPackage.funding.url !== "https://opencollective.com/pnpm"
+  ) {
+    throw new Error("Trusted pnpm bootstrap lockfile structure is invalid");
+  }
 }
 
-function resolvePinnedPnpmExecutable({
+export function stageTrustedPnpmBootstrapManifest({
+  controllerRoot,
   runnerTemp,
-  pnpmRoot,
-  pnpmSource,
+  bootstrapRoot,
   expectedUid = process.getuid?.(),
   expectedGid = process.getgid?.(),
-  run = spawnSync,
+}) {
+  requiredText(controllerRoot, "Trusted controller path");
+  if (!isAbsolute(controllerRoot)) {
+    throw new Error("Trusted controller path must be absolute");
+  }
+  const uid = numericIdentity(expectedUid, "Expected runner UID");
+  const gid = numericIdentity(expectedGid, "Expected runner GID");
+  const canonicalControllerRoot = realpathSync(controllerRoot);
+  assertProtectedRuntimeEntry(canonicalControllerRoot, {
+    directory: true,
+    expectedUid: uid,
+    expectedGid: gid,
+  });
+  const sourceRoot = join(
+    canonicalControllerRoot,
+    "scripts",
+    "vercel-pnpm-bootstrap",
+  );
+  assertProtectedRuntimeDescendant({
+    root: canonicalControllerRoot,
+    path: sourceRoot,
+    directory: true,
+    expectedUid: uid,
+    expectedGid: gid,
+  });
+  const sourcePackageJson = assertProtectedRuntimeDescendant({
+    root: canonicalControllerRoot,
+    path: join(sourceRoot, "package.json"),
+    directory: false,
+    expectedUid: uid,
+    expectedGid: gid,
+  });
+  const sourceLockfile = assertProtectedRuntimeDescendant({
+    root: canonicalControllerRoot,
+    path: join(sourceRoot, "package-lock.json"),
+    directory: false,
+    expectedUid: uid,
+    expectedGid: gid,
+  });
+  validatePinnedPnpmBootstrapFiles({
+    packageJsonPath: sourcePackageJson.path,
+    lockfilePath: sourceLockfile.path,
+  });
+
+  const canonicalBootstrapRoot = assertRunnerTempChild({
+    runnerTemp,
+    path: bootstrapRoot,
+    expectedName: PNPM_BOOTSTRAP_DIRECTORY,
+    expectedUid: uid,
+    expectedGid: gid,
+  });
+  if (optionalEntry(canonicalBootstrapRoot)) {
+    throw new Error("Trusted pnpm bootstrap destination must be fresh");
+  }
+
+  let created = false;
+  try {
+    mkdirSync(canonicalBootstrapRoot, { mode: 0o700 });
+    created = true;
+    chmodSync(canonicalBootstrapRoot, 0o700);
+    assertProtectedRuntimeEntry(canonicalBootstrapRoot, {
+      directory: true,
+      expectedUid: uid,
+      expectedGid: gid,
+    });
+    for (const [name, source] of [
+      ["package.json", sourcePackageJson],
+      ["package-lock.json", sourceLockfile],
+    ]) {
+      const destination = join(canonicalBootstrapRoot, name);
+      copyFileSync(source.path, destination, fsConstants.COPYFILE_EXCL);
+      chmodSync(destination, 0o444);
+      const destinationEntry = assertProtectedRuntimeEntry(destination, {
+        directory: false,
+        expectedUid: uid,
+        expectedGid: gid,
+      });
+      if (
+        realpathSync(destination) !== destination ||
+        (destinationEntry.dev === source.entry.dev &&
+          destinationEntry.ino === source.entry.ino)
+      ) {
+        throw new Error("Trusted pnpm bootstrap copy is not independent");
+      }
+    }
+    validatePinnedPnpmBootstrapFiles({
+      packageJsonPath: join(canonicalBootstrapRoot, "package.json"),
+      lockfilePath: join(canonicalBootstrapRoot, "package-lock.json"),
+    });
+    return canonicalBootstrapRoot;
+  } catch (error) {
+    if (created) {
+      rmSync(canonicalBootstrapRoot, { force: true, recursive: true });
+    }
+    throw error;
+  }
+}
+
+function resolvePinnedPnpmBootstrapExecutable({
+  runnerTemp,
+  pnpmRoot,
+  expectedUid = process.getuid?.(),
+  expectedGid = process.getgid?.(),
+  expectedPnpmSha256 = PINNED_PNPM_LINUX_X64_SHA256,
 }) {
   const uid = numericIdentity(expectedUid, "Expected runner UID");
   const gid = numericIdentity(expectedGid, "Expected runner GID");
   const canonicalPnpmRoot = assertRunnerTempChild({
     runnerTemp,
     path: pnpmRoot,
-    expectedName: PNPM_ACTION_DIRECTORY,
+    expectedName: PNPM_BOOTSTRAP_DIRECTORY,
     expectedUid: uid,
     expectedGid: gid,
   });
@@ -1231,120 +1404,79 @@ function resolvePinnedPnpmExecutable({
     expectedUid: uid,
     expectedGid: gid,
   });
-
-  requiredText(pnpmSource, "Protected pnpm source");
-  if (!isAbsolute(pnpmSource)) {
-    throw new Error("Protected pnpm source must be absolute");
-  }
-  const canonicalPnpmSource = realpathSync(pnpmSource);
-  const expectedLauncher = join(
-    canonicalPnpmRoot,
-    "node_modules",
-    ".bin",
-    "bin",
-    "pnpm",
-  );
-  if (canonicalPnpmSource !== expectedLauncher) {
-    throw new Error("Pinned pnpm source is not the action launcher");
-  }
-  const launcherEntry = assertProtectedRuntimeDescendant({
+  const stagedPackageJson = assertProtectedRuntimeDescendant({
     root: canonicalPnpmRoot,
-    path: canonicalPnpmSource,
+    path: join(canonicalPnpmRoot, "package.json"),
     directory: false,
     expectedUid: uid,
     expectedGid: gid,
-    requireSingleLink: false,
   });
-  if (
-    (launcherEntry.entry.mode & 0o111) === 0 ||
-    readPnpmVersion(canonicalPnpmSource, run) !== PINNED_PNPM_VERSION
-  ) {
-    throw new Error("Pinned pnpm launcher is not the requested release");
-  }
+  const stagedLockfile = assertProtectedRuntimeDescendant({
+    root: canonicalPnpmRoot,
+    path: join(canonicalPnpmRoot, "package-lock.json"),
+    directory: false,
+    expectedUid: uid,
+    expectedGid: gid,
+  });
+  validatePinnedPnpmBootstrapFiles({
+    packageJsonPath: stagedPackageJson.path,
+    lockfilePath: stagedLockfile.path,
+  });
 
-  const globalRoot = join(
+  const packageRoot = join(
     canonicalPnpmRoot,
     "node_modules",
-    ".bin",
-    "global",
-    "v11",
+    "@pnpm",
+    "linux-x64",
   );
   assertProtectedRuntimeDescendant({
     root: canonicalPnpmRoot,
-    path: globalRoot,
+    path: packageRoot,
     directory: true,
     expectedUid: uid,
     expectedGid: gid,
   });
-
-  const matchingCandidates = new Map();
-  for (const installEntry of readdirSync(globalRoot, {
-    withFileTypes: true,
-  }).sort((left, right) => left.name.localeCompare(right.name))) {
-    if (!installEntry.isDirectory() && !installEntry.isSymbolicLink()) continue;
-    const installRoot = join(globalRoot, installEntry.name);
-    const executableLocator = join(
-      installRoot,
-      "node_modules",
-      "@pnpm",
-      "exe",
-      "pnpm",
-    );
-    const packageJsonLocator = join(
-      installRoot,
-      "node_modules",
-      "@pnpm",
-      "exe",
-      "package.json",
-    );
-    if (!existsSync(executableLocator) || !existsSync(packageJsonLocator)) {
-      continue;
-    }
-    assertProtectedRuntimeDescendant({
-      root: canonicalPnpmRoot,
-      path: installRoot,
-      directory: true,
-      expectedUid: uid,
-      expectedGid: gid,
-    });
-    const packageJson = assertProtectedRuntimeDescendant({
-      root: canonicalPnpmRoot,
-      path: packageJsonLocator,
-      directory: false,
-      expectedUid: uid,
-      expectedGid: gid,
-      requireSingleLink: false,
-    });
-    const executable = assertProtectedRuntimeDescendant({
-      root: canonicalPnpmRoot,
-      path: executableLocator,
-      directory: false,
-      expectedUid: uid,
-      expectedGid: gid,
-      requireSingleLink: false,
-    });
-    const packageMetadata = JSON.parse(readFileSync(packageJson.path, "utf8"));
-    if (packageMetadata.name !== "@pnpm/exe") {
-      throw new Error("Pinned pnpm package identity is invalid");
-    }
-    if (packageMetadata.version !== PINNED_PNPM_VERSION) continue;
-    if (
-      (executable.entry.mode & 0o111) === 0 ||
-      readPnpmVersion(executable.path, run) !== PINNED_PNPM_VERSION
-    ) {
-      throw new Error("Pinned pnpm standalone executable is not exact");
-    }
-    matchingCandidates.set(
-      `${executable.entry.dev}:${executable.entry.ino}`,
-      executable.path,
-    );
+  const packageJson = assertProtectedRuntimeDescendant({
+    root: canonicalPnpmRoot,
+    path: join(packageRoot, "package.json"),
+    directory: false,
+    expectedUid: uid,
+    expectedGid: gid,
+  });
+  const executablePath = join(packageRoot, "pnpm");
+  if (
+    lstatSync(executablePath).isSymbolicLink() ||
+    realpathSync(executablePath) !== executablePath
+  ) {
+    throw new Error("Pinned pnpm bootstrap executable is not a real file");
   }
-  if (matchingCandidates.size !== 1) {
-    throw new Error(
-      "Pinned pnpm standalone executable is missing or ambiguous",
-    );
+  const executable = assertProtectedRuntimeDescendant({
+    root: canonicalPnpmRoot,
+    path: executablePath,
+    directory: false,
+    expectedUid: uid,
+    expectedGid: gid,
+  });
+  const installedMetadata = JSON.parse(readFileSync(packageJson.path, "utf8"));
+  if (
+    installedMetadata.name !== "@pnpm/linux-x64" ||
+    installedMetadata.version !== PINNED_PNPM_VERSION ||
+    !hasExactObjectKeys(installedMetadata.scripts, []) ||
+    !hasExactObjectKeys(installedMetadata.bin, ["pnpm"]) ||
+    installedMetadata.bin.pnpm !== "pnpm" ||
+    JSON.stringify(installedMetadata.os) !== '["linux"]' ||
+    JSON.stringify(installedMetadata.cpu) !== '["x64"]' ||
+    (executable.entry.mode & 0o111) === 0
+  ) {
+    throw new Error("Pinned pnpm bootstrap package is not exact");
   }
-  return matchingCandidates.values().next().value;
+  const executableDigest = createHash("sha256")
+    .update(readFileSync(executable.path))
+    .digest("hex");
+  if (executableDigest !== expectedPnpmSha256) {
+    throw new Error("Pinned pnpm bootstrap executable digest is invalid");
+  }
+  return executable.path;
 }
 
 export function stageTrustedRuntime({
@@ -1352,9 +1484,9 @@ export function stageTrustedRuntime({
   toolsRoot,
   nodeSource,
   pnpmRoot,
-  pnpmSource,
   expectedUid = process.getuid?.(),
   expectedGid = process.getgid?.(),
+  expectedPnpmSha256 = PINNED_PNPM_LINUX_X64_SHA256,
 }) {
   const uid = numericIdentity(expectedUid, "Expected runner UID");
   const gid = numericIdentity(expectedGid, "Expected runner GID");
@@ -1369,17 +1501,27 @@ export function stageTrustedRuntime({
     throw new Error("Protected runtime destination must be fresh");
   }
 
-  const pnpmExecutable = resolvePinnedPnpmExecutable({
+  const pnpmExecutable = resolvePinnedPnpmBootstrapExecutable({
     runnerTemp,
     pnpmRoot,
-    pnpmSource,
     expectedUid: uid,
     expectedGid: gid,
+    expectedPnpmSha256,
   });
   const sources = [
-    ["node", nodeSource],
-    ["pnpm-bootstrap", pnpmExecutable],
-  ].map(([name, source]) => {
+    {
+      destinationDirectory: "bin",
+      destinationName: "node",
+      source: nodeSource,
+    },
+    {
+      destinationDirectory: "bootstrap-bin",
+      destinationName: "pnpm",
+      source: pnpmExecutable,
+    },
+  ].map(({ destinationDirectory, destinationName, source }) => {
+    const name =
+      destinationName === "pnpm" ? "pnpm bootstrap" : destinationName;
     requiredText(source, `Protected ${name} source`);
     if (!isAbsolute(source)) {
       throw new Error(`Protected ${name} source must be absolute`);
@@ -1389,7 +1531,12 @@ export function stageTrustedRuntime({
     if (!sourceEntry.isFile()) {
       throw new Error(`Protected ${name} source must be a regular file`);
     }
-    return { name, source: canonicalSource, sourceEntry };
+    return {
+      destinationDirectory,
+      destinationName,
+      source: canonicalSource,
+      sourceEntry,
+    };
   });
 
   let created = false;
@@ -1398,22 +1545,36 @@ export function stageTrustedRuntime({
     created = true;
     chmodSync(canonicalToolsRoot, 0o755);
     const binDirectory = join(canonicalToolsRoot, "bin");
-    mkdirSync(binDirectory, { mode: 0o755 });
-    chmodSync(binDirectory, 0o755);
+    const bootstrapBinDirectory = join(canonicalToolsRoot, "bootstrap-bin");
+    for (const directory of [binDirectory, bootstrapBinDirectory]) {
+      mkdirSync(directory, { mode: 0o755 });
+      chmodSync(directory, 0o755);
+    }
     assertProtectedRuntimeEntry(canonicalToolsRoot, {
       directory: true,
       expectedUid: uid,
       expectedGid: gid,
     });
-    assertProtectedRuntimeEntry(binDirectory, {
-      directory: true,
-      expectedUid: uid,
-      expectedGid: gid,
-    });
+    for (const directory of [binDirectory, bootstrapBinDirectory]) {
+      assertProtectedRuntimeEntry(directory, {
+        directory: true,
+        expectedUid: uid,
+        expectedGid: gid,
+      });
+    }
 
     const staged = {};
-    for (const { name, source, sourceEntry } of sources) {
-      const destination = join(binDirectory, name);
+    for (const {
+      destinationDirectory,
+      destinationName,
+      source,
+      sourceEntry,
+    } of sources) {
+      const destination = join(
+        canonicalToolsRoot,
+        destinationDirectory,
+        destinationName,
+      );
       copyFileSync(source, destination, fsConstants.COPYFILE_EXCL);
       chmodSync(destination, 0o555);
       const destinationEntry = assertProtectedRuntimeEntry(destination, {
@@ -1428,12 +1589,19 @@ export function stageTrustedRuntime({
       ) {
         throw new Error("Protected runtime copy is not independent");
       }
-      staged[name] = destination;
+      staged[destinationName] = destination;
+    }
+    const stagedPnpmDigest = createHash("sha256")
+      .update(readFileSync(staged.pnpm))
+      .digest("hex");
+    if (stagedPnpmDigest !== expectedPnpmSha256) {
+      throw new Error("Protected pnpm bootstrap copy digest is invalid");
     }
     return {
       binDirectory,
+      bootstrapBinDirectory,
       nodePath: staged.node,
-      pnpmBootstrapPath: staged["pnpm-bootstrap"],
+      pnpmBootstrapPath: staged.pnpm,
     };
   } catch (error) {
     if (created) rmSync(canonicalToolsRoot, { force: true, recursive: true });
@@ -2924,9 +3092,18 @@ function stageTrustedRuntimeFromEnvironment() {
     runnerTemp: process.env.RUNNER_TEMP,
     toolsRoot: process.env.TRUSTED_VERCEL_TOOLS_PATH,
     nodeSource: process.env.NODE_SOURCE_PATH,
-    pnpmRoot: process.env.PNPM_ACTION_DEST,
-    pnpmSource: process.env.PNPM_SOURCE_PATH,
+    pnpmRoot: process.env.PNPM_BOOTSTRAP_PATH,
   });
+}
+
+function stageTrustedPnpmBootstrapManifestFromEnvironment() {
+  process.stdout.write(
+    `${stageTrustedPnpmBootstrapManifest({
+      controllerRoot: process.env.CONTROLLER_PATH,
+      runnerTemp: process.env.RUNNER_TEMP,
+      bootstrapRoot: process.env.PNPM_BOOTSTRAP_PATH,
+    })}\n`,
+  );
 }
 
 function stageTrustedPnpmRuntimeManifestFromEnvironment() {
@@ -2958,6 +3135,8 @@ if (isCliEntrypoint()) {
   if (command === "prepare") prepareFromEnvironment();
   else if (command === "validate-source") validateSourceFromEnvironment();
   else if (command === "materialize-source") materializeSourceFromEnvironment();
+  else if (command === "stage-pnpm-bootstrap")
+    stageTrustedPnpmBootstrapManifestFromEnvironment();
   else if (command === "stage-runtime") stageTrustedRuntimeFromEnvironment();
   else if (command === "stage-pnpm-runtime")
     stageTrustedPnpmRuntimeManifestFromEnvironment();
@@ -2987,7 +3166,7 @@ if (isCliEntrypoint()) {
   else if (command === "total") totalFromEnvironment();
   else {
     throw new Error(
-      "Usage: vercel-prebuilt-workflow.mjs prepare|validate-source|materialize-source|stage-runtime|stage-pnpm-runtime|stage-pnpm-launcher|prepare-link|prepare-pull-staging|pull|validate-pull|validate-pull-staging|stage-pull|validate-candidate-pull|build|assert-output|trusted-install-modules-dir|deploy|verify|smoke|total",
+      "Usage: vercel-prebuilt-workflow.mjs prepare|validate-source|materialize-source|stage-runtime|stage-pnpm-bootstrap|stage-pnpm-runtime|stage-pnpm-launcher|prepare-link|prepare-pull-staging|pull|validate-pull|validate-pull-staging|stage-pull|validate-candidate-pull|build|assert-output|trusted-install-modules-dir|deploy|verify|smoke|total",
     );
   }
 }

--- a/scripts/vercel-prebuilt-workflow.test.mjs
+++ b/scripts/vercel-prebuilt-workflow.test.mjs
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { Buffer } from "node:buffer";
 import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import {
   chmodSync,
   copyFileSync,
@@ -45,6 +46,7 @@ import {
   queryVercelDeployments,
   smokeUiPreview,
   stageVercelPullForCandidate,
+  stageTrustedPnpmBootstrapManifest,
   stageTrustedPnpmLauncher,
   stageTrustedPnpmRuntimeManifest,
   stageTrustedRuntime,
@@ -1270,51 +1272,15 @@ test("candidate staging rejects source components with the wrong owner", () => {
   }
 });
 
-test("trusted runtime copies hosted Node and the exact standalone pnpm target into independent protected files", () => {
+test("trusted runtime copies hosted Node and the authenticated Linux pnpm bootstrap into independent protected files", () => {
   const sourceRoot = mkdtempSync(join(tmpdir(), "vercel-runtime-source-"));
   const runnerTemp = mkdtempSync(join(tmpdir(), "vercel-runtime-runner-"));
   const toolsRoot = join(runnerTemp, "mento-vercel-trusted-tools");
-  const pnpmRoot = join(runnerTemp, "mento-pnpm-tools");
+  const pnpmRoot = join(runnerTemp, "mento-vercel-pnpm-bootstrap");
   const nodeSource = join(sourceRoot, "node");
-  const pnpmSource = join(pnpmRoot, "node_modules", ".bin", "bin", "pnpm");
-  const pnpmGlobalRoot = join(
-    pnpmRoot,
-    "node_modules",
-    ".bin",
-    "global",
-    "v11",
-  );
-  const pnpmInstallRoot = join(pnpmGlobalRoot, "install-12345-1700000000000");
-  const pnpmHashRoot = join(pnpmGlobalRoot, "a2d-19f6b3f78e2");
-  const pnpmPackageRoot = join(
-    pnpmRoot,
-    "node_modules",
-    ".bin",
-    "store",
-    "v11",
-    "links",
-    "a2d-19f6b3f78e2",
-    "node_modules",
-    "@pnpm",
-    "exe",
-  );
-  const pnpmPackageLink = join(pnpmInstallRoot, "node_modules", "@pnpm", "exe");
+  const pnpmPackageRoot = join(pnpmRoot, "node_modules", "@pnpm", "linux-x64");
   const pnpmExecutable = join(pnpmPackageRoot, "pnpm");
-  const pnpmExecutableLocator = join(
-    pnpmHashRoot,
-    "node_modules",
-    "@pnpm",
-    "exe",
-    "pnpm",
-  );
-  const pnpmStoreCopy = join(pnpmRoot, "pnpm-store-copy");
   const nodeContents = "#!/bin/sh\necho node\n";
-  const pnpmSourceContents = [
-    "#!/bin/sh",
-    'basedir=$(dirname "$0")',
-    'exec "$basedir/../global/v11/a2d-19f6b3f78e2/node_modules/@pnpm/exe/pnpm" "$@"',
-    "",
-  ].join("\n");
   const pnpmExecutableContents = [
     "#!/bin/sh",
     'if [ "$1" = "--version" ]; then',
@@ -1324,39 +1290,43 @@ test("trusted runtime copies hosted Node and the exact standalone pnpm target in
     "fi",
     "",
   ].join("\n");
+  const expectedPnpmSha256 = createHash("sha256")
+    .update(pnpmExecutableContents)
+    .digest("hex");
   try {
     chmodSync(sourceRoot, 0o777);
     chmodSync(runnerTemp, 0o711);
     writeFileSync(nodeSource, nodeContents, { mode: 0o777 });
-    mkdirSync(dirname(pnpmSource), { recursive: true });
-    mkdirSync(dirname(pnpmPackageLink), { recursive: true });
     mkdirSync(pnpmPackageRoot, { recursive: true });
-    writeFileSync(pnpmSource, pnpmSourceContents, { mode: 0o555 });
+    for (const file of ["package.json", "package-lock.json"]) {
+      copyFileSync(
+        join(REPOSITORY_ROOT, "scripts", "vercel-pnpm-bootstrap", file),
+        join(pnpmRoot, file),
+      );
+      chmodSync(join(pnpmRoot, file), 0o444);
+    }
     writeFileSync(
       join(pnpmPackageRoot, "package.json"),
-      JSON.stringify({ name: "@pnpm/exe", version: "10.34.4" }),
+      JSON.stringify({
+        name: "@pnpm/linux-x64",
+        version: "10.34.4",
+        scripts: {},
+        bin: { pnpm: "pnpm" },
+        os: ["linux"],
+        cpu: ["x64"],
+      }),
       { mode: 0o444 },
     );
-    writeFileSync(pnpmStoreCopy, pnpmExecutableContents, { mode: 0o555 });
-    linkSync(pnpmStoreCopy, pnpmExecutable);
-    symlinkSync(
-      relative(dirname(pnpmPackageLink), pnpmPackageRoot),
-      pnpmPackageLink,
-    );
-    symlinkSync(relative(dirname(pnpmHashRoot), pnpmInstallRoot), pnpmHashRoot);
+    writeFileSync(pnpmExecutable, pnpmExecutableContents, { mode: 0o555 });
     chmodSync(pnpmRoot, 0o755);
-    assert.equal(lstatSync(pnpmExecutable).nlink, 2);
-    assert.equal(
-      realpathSync(pnpmExecutableLocator),
-      realpathSync(pnpmExecutable),
-    );
+    assert.equal(lstatSync(pnpmExecutable).nlink, 1);
 
     const staged = stageTrustedRuntime({
       runnerTemp,
       toolsRoot,
       nodeSource,
       pnpmRoot,
-      pnpmSource,
+      expectedPnpmSha256,
     });
     const canonicalToolsRoot = join(
       realpathSync(runnerTemp),
@@ -1364,10 +1334,15 @@ test("trusted runtime copies hosted Node and the exact standalone pnpm target in
     );
     assert.deepEqual(staged, {
       binDirectory: join(canonicalToolsRoot, "bin"),
+      bootstrapBinDirectory: join(canonicalToolsRoot, "bootstrap-bin"),
       nodePath: join(canonicalToolsRoot, "bin", "node"),
-      pnpmBootstrapPath: join(canonicalToolsRoot, "bin", "pnpm-bootstrap"),
+      pnpmBootstrapPath: join(canonicalToolsRoot, "bootstrap-bin", "pnpm"),
     });
-    for (const path of [canonicalToolsRoot, staged.binDirectory]) {
+    for (const path of [
+      canonicalToolsRoot,
+      staged.binDirectory,
+      staged.bootstrapBinDirectory,
+    ]) {
       const entry = lstatSync(path);
       assert.equal(entry.isDirectory(), true);
       assert.equal(entry.isSymbolicLink(), false);
@@ -1387,9 +1362,7 @@ test("trusted runtime copies hosted Node and the exact standalone pnpm target in
     }
 
     writeFileSync(nodeSource, "replaced node\n");
-    chmodSync(pnpmSource, 0o755);
     chmodSync(pnpmExecutable, 0o755);
-    writeFileSync(pnpmSource, "replaced pnpm launcher\n");
     writeFileSync(pnpmExecutable, "replaced pnpm executable\n");
     assert.equal(readFileSync(staged.nodePath, "utf8"), nodeContents);
     assert.equal(
@@ -1409,7 +1382,7 @@ test("trusted runtime copies hosted Node and the exact standalone pnpm target in
           toolsRoot,
           nodeSource,
           pnpmRoot,
-          pnpmSource,
+          expectedPnpmSha256,
         }),
       /destination must be fresh/,
     );
@@ -1423,7 +1396,7 @@ test("trusted runtime copies hosted Node and the exact standalone pnpm target in
           toolsRoot,
           nodeSource,
           pnpmRoot,
-          pnpmSource,
+          expectedPnpmSha256,
         }),
       /destination must be fresh/,
     );
@@ -1436,13 +1409,113 @@ test("trusted runtime copies hosted Node and the exact standalone pnpm target in
           toolsRoot,
           nodeSource,
           pnpmRoot,
-          pnpmSource,
+          expectedPnpmSha256,
         }),
       /Runner temporary directory is not protected/,
     );
   } finally {
     rmSync(sourceRoot, { force: true, recursive: true });
     rmSync(runnerTemp, { force: true, recursive: true });
+  }
+});
+
+test("trusted pnpm bootstrap manifest and npm lock are exact before network installation", () => {
+  const fixtureRoot = mkdtempSync(join(tmpdir(), "vercel-pnpm-bootstrap-"));
+  const controllerRoot = join(fixtureRoot, "controller");
+  const sourceRoot = join(controllerRoot, "scripts", "vercel-pnpm-bootstrap");
+  const runnerTemp = join(fixtureRoot, "runner-temp");
+  const bootstrapRoot = join(runnerTemp, "mento-vercel-pnpm-bootstrap");
+  try {
+    mkdirSync(sourceRoot, { recursive: true });
+    mkdirSync(runnerTemp, { mode: 0o711 });
+    for (const file of ["package.json", "package-lock.json"]) {
+      copyFileSync(
+        join(REPOSITORY_ROOT, "scripts", "vercel-pnpm-bootstrap", file),
+        join(sourceRoot, file),
+      );
+      chmodSync(join(sourceRoot, file), 0o444);
+    }
+    for (const path of [
+      controllerRoot,
+      join(controllerRoot, "scripts"),
+      sourceRoot,
+    ]) {
+      chmodSync(path, 0o755);
+    }
+
+    assert.equal(
+      stageTrustedPnpmBootstrapManifest({
+        controllerRoot,
+        runnerTemp,
+        bootstrapRoot,
+      }),
+      join(realpathSync(runnerTemp), "mento-vercel-pnpm-bootstrap"),
+    );
+    assert.equal(lstatSync(bootstrapRoot).mode & 0o777, 0o700);
+    for (const file of ["package.json", "package-lock.json"]) {
+      const source = join(sourceRoot, file);
+      const destination = join(bootstrapRoot, file);
+      assert.equal(lstatSync(destination).mode & 0o777, 0o444);
+      assert.notEqual(lstatSync(source).ino, lstatSync(destination).ino);
+      assert.equal(
+        readFileSync(destination, "utf8"),
+        readFileSync(source, "utf8"),
+      );
+    }
+    assert.throws(
+      () =>
+        stageTrustedPnpmBootstrapManifest({
+          controllerRoot,
+          runnerTemp,
+          bootstrapRoot,
+        }),
+      /destination must be fresh/,
+    );
+
+    rmSync(bootstrapRoot, { force: true, recursive: true });
+    const packagePath = join(sourceRoot, "package.json");
+    chmodSync(packagePath, 0o644);
+    const packageMetadata = JSON.parse(readFileSync(packagePath, "utf8"));
+    packageMetadata.scripts = { prepare: "echo unsafe" };
+    writeFileSync(packagePath, `${JSON.stringify(packageMetadata, null, 2)}\n`);
+    chmodSync(packagePath, 0o444);
+    assert.throws(
+      () =>
+        stageTrustedPnpmBootstrapManifest({
+          controllerRoot,
+          runnerTemp,
+          bootstrapRoot,
+        }),
+      /manifest is not exact/,
+    );
+
+    chmodSync(packagePath, 0o644);
+    copyFileSync(
+      join(REPOSITORY_ROOT, "scripts", "vercel-pnpm-bootstrap", "package.json"),
+      packagePath,
+    );
+    chmodSync(packagePath, 0o444);
+    const lockPath = join(sourceRoot, "package-lock.json");
+    chmodSync(lockPath, 0o644);
+    writeFileSync(
+      lockPath,
+      readFileSync(lockPath, "utf8").replace(
+        "registry.npmjs.org",
+        "registry.example.invalid",
+      ),
+    );
+    chmodSync(lockPath, 0o444);
+    assert.throws(
+      () =>
+        stageTrustedPnpmBootstrapManifest({
+          controllerRoot,
+          runnerTemp,
+          bootstrapRoot,
+        }),
+      /lockfile is not exact/,
+    );
+  } finally {
+    rmSync(fixtureRoot, { force: true, recursive: true });
   }
 });
 
@@ -1697,118 +1770,119 @@ test("trusted candidate pnpm launcher uses the lockfile-pinned JavaScript packag
   }
 });
 
-test("trusted runtime rejects missing, wrong-version, and ambiguous standalone pnpm targets", () => {
+test("trusted runtime rejects missing, malformed, digest-drifted, and hardlinked pnpm bootstrap targets", () => {
   const runnerTemp = mkdtempSync(join(tmpdir(), "vercel-runtime-runner-"));
   const toolsRoot = join(runnerTemp, "mento-vercel-trusted-tools");
-  const pnpmRoot = join(runnerTemp, "mento-pnpm-tools");
+  const pnpmRoot = join(runnerTemp, "mento-vercel-pnpm-bootstrap");
   const nodeSource = join(runnerTemp, "node");
-  const pnpmSource = join(pnpmRoot, "node_modules", ".bin", "bin", "pnpm");
-  const firstExecutable = join(
+  const pnpmExecutable = join(
     pnpmRoot,
     "node_modules",
-    ".bin",
-    "global",
-    "v11",
-    "first",
-    "node_modules",
     "@pnpm",
-    "exe",
+    "linux-x64",
     "pnpm",
   );
-  const firstPackageJson = join(dirname(firstExecutable), "package.json");
-  const secondExecutable = join(
-    pnpmRoot,
-    "node_modules",
-    ".bin",
-    "global",
-    "v11",
-    "second",
-    "node_modules",
-    "@pnpm",
-    "exe",
-    "pnpm",
-  );
-  const secondPackageJson = join(dirname(secondExecutable), "package.json");
-  const stage = () =>
+  const pnpmPackageJson = join(dirname(pnpmExecutable), "package.json");
+  const executableContents = "#!/bin/sh\necho 10.34.4\n";
+  const expectedPnpmSha256 = createHash("sha256")
+    .update(executableContents)
+    .digest("hex");
+  const stage = (digest = expectedPnpmSha256) =>
     stageTrustedRuntime({
       runnerTemp,
       toolsRoot,
       nodeSource,
       pnpmRoot,
-      pnpmSource,
+      expectedPnpmSha256: digest,
     });
   try {
     chmodSync(runnerTemp, 0o711);
     writeFileSync(nodeSource, "#!/bin/sh\necho node\n", { mode: 0o555 });
-    mkdirSync(dirname(pnpmSource), { recursive: true });
-    mkdirSync(dirname(firstExecutable), { recursive: true });
-    writeFileSync(pnpmSource, "#!/bin/sh\necho 10.34.4\n", { mode: 0o555 });
+    mkdirSync(pnpmRoot, { recursive: true });
+    for (const file of ["package.json", "package-lock.json"]) {
+      copyFileSync(
+        join(REPOSITORY_ROOT, "scripts", "vercel-pnpm-bootstrap", file),
+        join(pnpmRoot, file),
+      );
+      chmodSync(join(pnpmRoot, file), 0o444);
+    }
     chmodSync(pnpmRoot, 0o755);
 
-    assert.throws(stage, /missing or ambiguous/);
+    assert.throws(stage);
 
+    mkdirSync(dirname(pnpmExecutable), { recursive: true });
     writeFileSync(
-      firstPackageJson,
-      JSON.stringify({ name: "@pnpm/exe", version: "10.25.0" }),
+      pnpmPackageJson,
+      JSON.stringify({
+        name: "@pnpm/linux-x64",
+        version: "10.25.0",
+        scripts: {},
+        bin: { pnpm: "pnpm" },
+        os: ["linux"],
+        cpu: ["x64"],
+      }),
       { mode: 0o444 },
     );
-    writeFileSync(firstExecutable, "#!/bin/sh\necho 10.25.0\n", {
+    writeFileSync(pnpmExecutable, executableContents, {
       mode: 0o555,
     });
-    assert.throws(stage, /missing or ambiguous/);
+    assert.throws(stage, /package is not exact/);
 
-    chmodSync(firstExecutable, 0o755);
-    writeFileSync(firstExecutable, "#!/bin/sh\necho 10.34.4\n", {
-      mode: 0o555,
-    });
-    chmodSync(firstPackageJson, 0o644);
+    chmodSync(pnpmPackageJson, 0o644);
     writeFileSync(
-      firstPackageJson,
-      JSON.stringify({ name: "@pnpm/exe", version: "10.34.4" }),
+      pnpmPackageJson,
+      JSON.stringify({
+        name: "@pnpm/linux-x64",
+        version: "10.34.4",
+        scripts: {},
+        bin: { pnpm: "pnpm" },
+        os: ["linux"],
+        cpu: ["x64"],
+      }),
     );
-    chmodSync(firstPackageJson, 0o444);
-    mkdirSync(dirname(secondExecutable), { recursive: true });
-    writeFileSync(
-      secondPackageJson,
-      JSON.stringify({ name: "@pnpm/exe", version: "10.34.4" }),
-      { mode: 0o444 },
-    );
-    writeFileSync(secondExecutable, "#!/bin/sh\necho 10.34.4\n", {
-      mode: 0o555,
-    });
-    assert.throws(stage, /missing or ambiguous/);
+    chmodSync(pnpmPackageJson, 0o444);
+    assert.throws(() => stage("0".repeat(64)), /executable digest is invalid/);
+
+    const hardlinkSource = join(runnerTemp, "hardlinked-pnpm");
+    chmodSync(pnpmExecutable, 0o755);
+    rmSync(pnpmExecutable);
+    writeFileSync(hardlinkSource, executableContents, { mode: 0o555 });
+    linkSync(hardlinkSource, pnpmExecutable);
+    assert.equal(lstatSync(pnpmExecutable).nlink, 2);
+    assert.throws(stage, /runner-owned/);
   } finally {
     rmSync(runnerTemp, { force: true, recursive: true });
   }
 });
 
-test("trusted runtime rejects a standalone pnpm package link outside the action root", () => {
+test("trusted runtime rejects a pnpm bootstrap package link outside its fixed root", () => {
   const runnerTemp = mkdtempSync(join(tmpdir(), "vercel-runtime-runner-"));
   const outsideRoot = mkdtempSync(join(tmpdir(), "vercel-runtime-outside-"));
   const toolsRoot = join(runnerTemp, "mento-vercel-trusted-tools");
-  const pnpmRoot = join(runnerTemp, "mento-pnpm-tools");
+  const pnpmRoot = join(runnerTemp, "mento-vercel-pnpm-bootstrap");
   const nodeSource = join(runnerTemp, "node");
-  const pnpmSource = join(pnpmRoot, "node_modules", ".bin", "bin", "pnpm");
-  const packageLink = join(
-    pnpmRoot,
-    "node_modules",
-    ".bin",
-    "global",
-    "v11",
-    "install",
-    "node_modules",
-    "@pnpm",
-    "exe",
-  );
+  const packageLink = join(pnpmRoot, "node_modules", "@pnpm", "linux-x64");
   try {
     chmodSync(runnerTemp, 0o711);
     writeFileSync(nodeSource, "#!/bin/sh\necho node\n", { mode: 0o555 });
-    mkdirSync(dirname(pnpmSource), { recursive: true });
     mkdirSync(dirname(packageLink), { recursive: true });
-    writeFileSync(pnpmSource, "#!/bin/sh\necho 10.34.4\n", { mode: 0o555 });
+    for (const file of ["package.json", "package-lock.json"]) {
+      copyFileSync(
+        join(REPOSITORY_ROOT, "scripts", "vercel-pnpm-bootstrap", file),
+        join(pnpmRoot, file),
+      );
+      chmodSync(join(pnpmRoot, file), 0o444);
+    }
     writeFileSync(
       join(outsideRoot, "package.json"),
-      JSON.stringify({ name: "@pnpm/exe", version: "10.34.4" }),
+      JSON.stringify({
+        name: "@pnpm/linux-x64",
+        version: "10.34.4",
+        scripts: {},
+        bin: { pnpm: "pnpm" },
+        os: ["linux"],
+        cpu: ["x64"],
+      }),
       { mode: 0o444 },
     );
     writeFileSync(join(outsideRoot, "pnpm"), "#!/bin/sh\necho 10.34.4\n", {
@@ -1824,9 +1898,8 @@ test("trusted runtime rejects a standalone pnpm package link outside the action 
           toolsRoot,
           nodeSource,
           pnpmRoot,
-          pnpmSource,
         }),
-      /escaped its action root/,
+      /escaped its protected root/,
     );
   } finally {
     rmSync(outsideRoot, { force: true, recursive: true });
@@ -2154,27 +2227,26 @@ test("candidate execution is UID-isolated and hands upload to runner-owned state
   assert.match(raw, /\/usr\/bin\/pgrep -u "\$BUILD_UID"/g);
   assert.match(raw, /Create immutable runner-owned upload handoff/);
   assert.match(raw, /mento-vercel-upload-source/);
-  assert.match(raw, /dest: \$\{\{ runner\.temp \}\}\/mento-pnpm-tools/);
-  assert.match(raw, /standalone: true/);
+  assert.match(raw, /mento-vercel-pnpm-bootstrap/);
+  assert.doesNotMatch(raw, /standalone: true/);
   assert.match(
     raw,
     /EXPECTED_PNPM_LINUX_X64_SHA256: e02c01738ce850754cf00111fd97bec24de550e1e963690486f02d9dae1a2193/,
   );
-  const pnpmVerificationBlock = raw.slice(
-    raw.indexOf("- name: Verify pinned pnpm target before first execution"),
-    raw.indexOf("- name: Set up pinned Node.js and pnpm cache"),
+  const pnpmBootstrapBlock = raw.slice(
+    raw.indexOf("- name: Stage and authenticate pinned pnpm bootstrap"),
+    raw.indexOf("- name: Prove authenticated pnpm path before cache restore"),
   );
-  assert.match(pnpmVerificationBlock, /uname -s/);
-  assert.match(pnpmVerificationBlock, /uname -m/);
-  assert.match(pnpmVerificationBlock, /path_pnpm="\$\(type -P pnpm\)"/);
-  assert.match(
-    pnpmVerificationBlock,
-    /realpath "\$path_pnpm"\)" != "\$pnpm_target"/,
-  );
-  assert.match(pnpmVerificationBlock, /\/usr\/bin\/sha256sum "\$pnpm_target"/);
+  assert.match(pnpmBootstrapBlock, /uname -s/);
+  assert.match(pnpmBootstrapBlock, /uname -m/);
+  assert.match(pnpmBootstrapBlock, /stage-pnpm-bootstrap/);
+  assert.match(pnpmBootstrapBlock, /npm_cli" ci/);
+  assert.match(pnpmBootstrapBlock, /--ignore-scripts/);
+  assert.match(pnpmBootstrapBlock, /stage-runtime/);
+  assert.match(pnpmBootstrapBlock, /\/usr\/bin\/sha256sum "\$pnpm_bootstrap"/);
   assert.ok(
-    pnpmVerificationBlock.indexOf('/usr/bin/sha256sum "$pnpm_target"') <
-      pnpmVerificationBlock.indexOf('"$pnpm_target" --version'),
+    pnpmBootstrapBlock.indexOf('/usr/bin/sha256sum "$pnpm_bootstrap"') <
+      pnpmBootstrapBlock.indexOf('"$pnpm_bootstrap" --version'),
   );
   assert.match(raw, /userdel mento-vercel-build/);
   assert.match(raw, /node_modules\/vercel\/dist\/index\.js/);
@@ -2186,11 +2258,13 @@ test("candidate execution is UID-isolated and hands upload to runner-owned state
     "SOURCE_PATH/node_modules",
     "SOURCE_PATH/package.json",
     "SOURCE_PATH/pnpm-lock.yaml",
-    "PNPM_ACTION_DEST",
     "TRUSTED_VERCEL_TOOLS_PATH",
     "trusted_bin_dir",
+    "bootstrap_bin_dir",
     "node_bin",
     "pnpm_bootstrap",
+    "trusted_pnpm_store_parent",
+    "trusted_pnpm_store",
     "pnpm_runtime_root",
     "pnpm_bin",
   ]) {
@@ -2211,16 +2285,11 @@ test("candidate execution is UID-isolated and hands upload to runner-owned state
   assert.match(isolationBlock, /--frozen-lockfile/);
   assert.match(isolationBlock, /--ignore-scripts/);
   assert.match(isolationBlock, /--package-import-method copy/);
-  assert.match(
-    isolationBlock,
-    /\/bin\/chmod -R a\+rX,go-w "\$PNPM_ACTION_DEST"/,
-  );
-  assert.match(isolationBlock, /NODE_SOURCE_PATH="\$setup_node_bin" \\/);
-  assert.match(isolationBlock, /PNPM_SOURCE_PATH="\$setup_pnpm_bin" \\/);
-  assert.match(
-    isolationBlock,
-    /vercel-prebuilt-workflow\.mjs" \\\n\s+stage-runtime/,
-  );
+  assert.doesNotMatch(isolationBlock, /PNPM_ACTION_DEST|PNPM_BIN_DEST/);
+  assert.doesNotMatch(isolationBlock, /\bstage-runtime\b/);
+  assert.match(isolationBlock, /pnpm_bootstrap="\$bootstrap_bin_dir\/pnpm"/);
+  assert.match(isolationBlock, /trusted_pnpm_store=.*store path --silent/);
+  assert.match(isolationBlock, /\/usr\/bin\/sha256sum "\$pnpm_bootstrap"/);
   assert.match(
     isolationBlock,
     /vercel-prebuilt-workflow\.mjs" \\\n\s+stage-pnpm-runtime/,
@@ -2236,10 +2305,6 @@ test("candidate execution is UID-isolated and hands upload to runner-owned state
   );
   assert.match(
     isolationBlock,
-    /Pinned pnpm escaped its action-owned directory/,
-  );
-  assert.match(
-    isolationBlock,
     /Protected pnpm copy does not match the pinned release/,
   );
   assert.match(
@@ -2252,18 +2317,16 @@ test("candidate execution is UID-isolated and hands upload to runner-owned state
   );
   assert.match(
     isolationBlock,
-    /Pinned pnpm action directory escaped RUNNER_TEMP/,
+    /Protected runtime root is not the authenticated fixed directory/,
   );
-  assert.match(isolationBlock, /Protected runtime destination already exists/);
   assert.match(isolationBlock, /trusted-install-modules-dir/);
   assert.match(isolationBlock, /--modules-dir "\$trusted_modules_dir"/);
   const runnerTempHardenIndex = isolationBlock.indexOf(
     '/bin/chmod 0711 "$RUNNER_TEMP"',
   );
-  const pnpmActionHardenIndex = isolationBlock.indexOf(
-    '/bin/chmod -R a+rX,go-w "$PNPM_ACTION_DEST"',
+  const protectedStoreIndex = isolationBlock.indexOf(
+    'trusted_pnpm_store="$("$pnpm_bootstrap" store path --silent)"',
   );
-  const protectedRuntimeCopyIndex = isolationBlock.indexOf("stage-runtime");
   const protectedPnpmRuntimeIndex =
     isolationBlock.indexOf("stage-pnpm-runtime");
   const protectedLauncherIndex = isolationBlock.indexOf("stage-pnpm-launcher");
@@ -2279,9 +2342,8 @@ test("candidate execution is UID-isolated and hands upload to runner-owned state
   );
   const materializeIndex = isolationBlock.indexOf("materialize-source");
   assert.notEqual(runnerTempHardenIndex, -1);
-  assert.ok(pnpmActionHardenIndex > runnerTempHardenIndex);
-  assert.ok(protectedRuntimeCopyIndex > pnpmActionHardenIndex);
-  assert.ok(protectedPnpmRuntimeIndex > protectedRuntimeCopyIndex);
+  assert.ok(protectedStoreIndex > runnerTempHardenIndex);
+  assert.ok(protectedPnpmRuntimeIndex > protectedStoreIndex);
   assert.ok(protectedLauncherIndex > protectedPnpmRuntimeIndex);
   assert.ok(protectedPathLoopIndex > protectedLauncherIndex);
   assert.ok(runnerTempProtectionIndex > protectedPathLoopIndex);

--- a/scripts/vercel-prebuilt-workflows.test.mjs
+++ b/scripts/vercel-prebuilt-workflows.test.mjs
@@ -186,25 +186,40 @@ test("exact source, build, and upload remain in one standard-runner job", () => 
   );
 });
 
-test("prebuilt separates trusted standalone bootstrap from candidate JavaScript pnpm", () => {
+test("prebuilt authenticates a locked Linux pnpm binary before cache or candidate execution", () => {
   const reusable = workflow(reusablePath);
   const supplyChain = workflow(".github/workflows/supply-chain.yml");
   const trunk = workflow(".trunk/trunk.yaml");
   const steps = reusable.jobs.prebuilt.steps;
   const names = steps.map(({ name }) => name);
   const manifest = JSON.parse(read("package.json"));
+  const bootstrapManifest = JSON.parse(
+    read("scripts/vercel-pnpm-bootstrap/package.json"),
+  );
+  const bootstrapLock = JSON.parse(
+    read("scripts/vercel-pnpm-bootstrap/package-lock.json"),
+  );
   const runtimeManifest = JSON.parse(
     read("scripts/vercel-pnpm-runtime/package.json"),
   );
   const runtimeLock = parse(read("scripts/vercel-pnpm-runtime/pnpm-lock.yaml"));
   const rootOsvConfig = read("osv-scanner.toml");
   const runtimeOsvConfig = read("scripts/vercel-pnpm-runtime/osv-scanner.toml");
-  const pnpmSetup = steps.find(({ name }) => name === "Set up pinned pnpm");
-  const pnpmTargetVerification = steps.find(
-    ({ name }) => name === "Verify pinned pnpm target before first execution",
-  );
   const nodeSetup = steps.find(
-    ({ name }) => name === "Set up pinned Node.js and pnpm cache",
+    ({ name }) =>
+      name === "Set up pinned Node.js without package-manager cache",
+  );
+  const bootstrap = steps.find(
+    ({ name }) => name === "Stage and authenticate pinned pnpm bootstrap",
+  );
+  const pathProof = steps.find(
+    ({ name }) => name === "Prove authenticated pnpm path before cache restore",
+  );
+  const cacheRestore = steps.find(
+    ({ name }) => name === "Restore trusted pnpm cache",
+  );
+  const cacheReverification = steps.find(
+    ({ name }) => name === "Reverify authenticated pnpm after cache restore",
   );
   const isolation = steps.find(
     ({ name }) =>
@@ -213,12 +228,31 @@ test("prebuilt separates trusted standalone bootstrap from candidate JavaScript 
   const install = steps.find(
     ({ name }) => name === "Install frozen dependencies",
   );
+  const cleanup = steps.find(
+    ({ name }) => name === "Remove isolated build and upload state",
+  );
 
   assert.equal(manifest.devDependencies.pnpm, undefined);
   assert.equal(manifest.packageManager, "pnpm@10.34.4");
   assert.equal(
     manifest.scripts["supply-chain:lockfile-lint"],
     "node scripts/lockfile-lint.mjs && LOCKFILE_LINT_ROOT=scripts/vercel-pnpm-runtime node scripts/lockfile-lint.mjs",
+  );
+  assert.deepEqual(bootstrapManifest.dependencies, {
+    "@pnpm/linux-x64": "10.34.4",
+  });
+  assert.equal(bootstrapManifest.scripts, undefined);
+  assert.deepEqual(Object.keys(bootstrapLock.packages), [
+    "",
+    "node_modules/@pnpm/linux-x64",
+  ]);
+  assert.equal(
+    bootstrapLock.packages["node_modules/@pnpm/linux-x64"].resolved,
+    "https://registry.npmjs.org/@pnpm/linux-x64/-/linux-x64-10.34.4.tgz",
+  );
+  assert.equal(
+    bootstrapLock.packages["node_modules/@pnpm/linux-x64"].integrity,
+    "sha512-6gsJT9HUs1kBsJANC5SEJNRGAMzjGMKgxEtCvPLYd7NIktbh1GH5Ktcu7nLYcbxX8SirCHHzhZiMolW0mvzoqA==",
   );
   assert.deepEqual(runtimeManifest.dependencies, { pnpm: "10.34.4" });
   assert.deepEqual(Object.keys(runtimeLock.packages), ["pnpm@10.34.4"]);
@@ -237,92 +271,115 @@ test("prebuilt separates trusted standalone bootstrap from candidate JavaScript 
     supplyChain.jobs["osv-pnpm-runtime"].with["scan-args"],
     /--config=scripts\/vercel-pnpm-runtime\/osv-scanner\.toml[\s\S]*--lockfile=scripts\/vercel-pnpm-runtime\/pnpm-lock\.yaml/,
   );
+  assert.equal(
+    supplyChain.jobs["osv-pnpm-bootstrap"].with["scan-args"].trim(),
+    "--lockfile=scripts/vercel-pnpm-bootstrap/package-lock.json",
+  );
+  assert.doesNotMatch(
+    supplyChain.jobs["osv-pnpm-bootstrap"].with["scan-args"],
+    /--config/,
+  );
   assert.match(runtimeOsvConfig, /GHSA-gj8w-mvpf-x27x/);
   assert.match(runtimeOsvConfig, /ignoreUntil = 2026-08-16T00:00:00Z/);
   assert.equal(
-    supplyChain.jobs["lockfile-lint"].steps.at(-1).run,
+    supplyChain.jobs["lockfile-lint"].steps.find(
+      ({ name }) => name === "lockfile integrity + registry check",
+    ).run,
     "npm run supply-chain:lockfile-lint",
+  );
+  const bootstrapInstall = supplyChain.jobs["lockfile-lint"].steps.find(
+    ({ name }) => name === "Install and authenticate the Linux pnpm bootstrap",
+  );
+  assert.equal(
+    bootstrapInstall["working-directory"],
+    "scripts/vercel-pnpm-bootstrap",
+  );
+  assert.match(
+    bootstrapInstall.run,
+    /npm ci --ignore-scripts --no-audit --no-fund/,
+  );
+  assert.ok(
+    bootstrapInstall.run.indexOf("sha256sum --check --strict") <
+      bootstrapInstall.run.indexOf('"$pnpm_binary" --version'),
   );
   const trunkOsvIgnore = trunk.lint.ignore.find(({ linters }) =>
     linters.includes("osv-scanner"),
   );
   assert.deepEqual(trunkOsvIgnore.paths, [
     "pnpm-lock.yaml",
+    "scripts/vercel-pnpm-bootstrap/package-lock.json",
     "scripts/vercel-pnpm-runtime/pnpm-lock.yaml",
   ]);
-  assert.equal(pnpmSetup.with.dest, "${{ runner.temp }}/mento-pnpm-tools");
-  assert.equal(pnpmSetup.with.standalone, true);
-  assert.equal(pnpmSetup.with.version, "10.34.4");
-  assert.equal(pnpmSetup.id, "pnpm");
   assert.equal(
-    pnpmTargetVerification.env.EXPECTED_PNPM_LINUX_X64_SHA256,
-    "e02c01738ce850754cf00111fd97bec24de550e1e963690486f02d9dae1a2193",
+    steps.some(({ uses }) => uses?.startsWith("pnpm/action-setup@")),
+    false,
   );
+  assert.equal(nodeSetup.with["node-version"], 22);
+  assert.equal(nodeSetup.with["package-manager-cache"], false);
+  assert.equal(nodeSetup.with.cache, undefined);
   assert.equal(
-    pnpmTargetVerification.env.PNPM_ACTION_DEST,
-    "${{ runner.temp }}/mento-pnpm-tools",
+    bootstrap.env.PNPM_BOOTSTRAP_PATH,
+    "${{ runner.temp }}/mento-vercel-pnpm-bootstrap",
   );
-  assert.equal(
-    pnpmTargetVerification.env.PNPM_BIN_DEST,
-    "${{ steps.pnpm.outputs.bin_dest }}",
-  );
-  assert.match(pnpmTargetVerification.run, /uname -s/);
-  assert.match(pnpmTargetVerification.run, /uname -m/);
+  assert.match(bootstrap.run, /stage-pnpm-bootstrap/);
+  assert.match(bootstrap.run, /"\$setup_node_bin" "\$npm_cli" ci/);
+  assert.match(bootstrap.run, /--ignore-scripts/);
+  assert.match(bootstrap.run, /NPM_CONFIG_IGNORE_SCRIPTS=true/);
   assert.match(
-    pnpmTargetVerification.run,
-    /bin_dest="\$\(\/usr\/bin\/realpath "\$PNPM_BIN_DEST"\)"/,
+    bootstrap.run,
+    /NPM_CONFIG_REGISTRY=https:\/\/registry\.npmjs\.org\//,
   );
+  assert.match(bootstrap.run, /stage-runtime/);
+  assert.match(bootstrap.run, /pnpm_bootstrap="\$bootstrap_bin_dir\/pnpm"/);
+  assert.match(bootstrap.run, /\/usr\/bin\/sha256sum "\$pnpm_bootstrap"/);
   assert.match(
-    pnpmTargetVerification.run,
-    /pnpm_target="\$\(\/usr\/bin\/realpath "\$PNPM_BIN_DEST\/pnpm"\)"/,
-  );
-  assert.match(pnpmTargetVerification.run, /path_pnpm="\$\(type -P pnpm\)"/);
-  assert.match(
-    pnpmTargetVerification.run,
-    /realpath "\$path_pnpm"\)" != "\$pnpm_target"/,
-  );
-  assert.match(
-    pnpmTargetVerification.run,
-    /\/usr\/bin\/sha256sum "\$pnpm_target"/,
-  );
-  assert.match(
-    pnpmTargetVerification.run,
-    /"\$pnpm_target" --version \| \/usr\/bin\/grep -Fxq "10\.34\.4"/,
+    bootstrap.run,
+    /"\$pnpm_bootstrap" --version \| \/usr\/bin\/grep -Fxq "10\.34\.4"/,
   );
   assert.ok(
-    pnpmTargetVerification.run.indexOf('/usr/bin/sha256sum "$pnpm_target"') <
-      pnpmTargetVerification.run.indexOf('"$pnpm_target" --version'),
+    bootstrap.run.indexOf("stage-pnpm-bootstrap") <
+      bootstrap.run.indexOf('"$setup_node_bin" "$npm_cli" ci'),
   );
+  assert.ok(
+    bootstrap.run.indexOf('"$setup_node_bin" "$npm_cli" ci') <
+      bootstrap.run.indexOf("stage-runtime"),
+  );
+  assert.ok(
+    bootstrap.run.indexOf('/usr/bin/sha256sum "$pnpm_bootstrap"') <
+      bootstrap.run.indexOf('"$pnpm_bootstrap" --version'),
+  );
+  assert.ok(
+    bootstrap.run.indexOf('"$pnpm_bootstrap" --version') <
+      bootstrap.run.indexOf(
+        `printf '%s\\n' "$bootstrap_bin_dir" >> "$GITHUB_PATH"`,
+      ),
+  );
+  assert.match(pathProof.run, /path_pnpm="\$\(type -P pnpm\)"/);
+  assert.match(pathProof.run, /realpath "\$path_pnpm"\)" != "\$expected_pnpm"/);
+  assert.ok(
+    pathProof.run.indexOf('/usr/bin/sha256sum "$path_pnpm"') <
+      pathProof.run.indexOf('"$path_pnpm" --version'),
+  );
+  assert.equal(cacheRestore.with["node-version"], undefined);
+  assert.equal(cacheRestore.with["node-version-file"], undefined);
+  assert.equal(cacheRestore.with.architecture, undefined);
+  assert.equal(cacheRestore.with.cache, "pnpm");
   assert.deepEqual(
-    nodeSetup.with["cache-dependency-path"].trim().split(/\s+/),
+    cacheRestore.with["cache-dependency-path"].trim().split(/\s+/),
     [
       "controller/pnpm-lock.yaml",
       "controller/scripts/vercel-pnpm-runtime/pnpm-lock.yaml",
     ],
   );
-  assert.equal(
-    isolation.env.PNPM_ACTION_DEST,
-    "${{ runner.temp }}/mento-pnpm-tools",
-  );
-  assert.equal(
-    isolation.env.PNPM_BIN_DEST,
-    "${{ steps.pnpm.outputs.bin_dest }}",
-  );
   assert.match(
-    isolation.run,
-    /if \[ "\$\(realpath "\$PNPM_BIN_DEST"\)" != "\$PNPM_ACTION_DEST\/node_modules\/\.bin\/bin" \]; then/,
+    cacheReverification.run,
+    /Cache restore changed the authenticated pnpm path/,
   );
-  assert.match(
-    isolation.run,
-    /setup_pnpm_bin="\$\(realpath "\$PNPM_BIN_DEST\/pnpm"\)"/,
-  );
-  assert.doesNotMatch(isolation.run, /command -v pnpm/);
-  assert.match(isolation.run, /NODE_SOURCE_PATH="\$setup_node_bin" \\/);
-  assert.match(isolation.run, /PNPM_SOURCE_PATH="\$setup_pnpm_bin" \\/);
-  assert.match(
-    isolation.run,
-    /controller\/scripts\/vercel-prebuilt-workflow\.mjs" \\\n\s+stage-runtime/,
-  );
+  assert.equal(isolation.env.PNPM_ACTION_DEST, undefined);
+  assert.equal(isolation.env.PNPM_BIN_DEST, undefined);
+  assert.doesNotMatch(isolation.run, /PNPM_ACTION_DEST|PNPM_BIN_DEST/);
+  assert.match(isolation.run, /pnpm_bootstrap="\$bootstrap_bin_dir\/pnpm"/);
+  assert.match(isolation.run, /trusted_pnpm_store=.*store path --silent/);
   assert.match(
     isolation.run,
     /controller\/scripts\/vercel-prebuilt-workflow\.mjs" \\\n\s+stage-pnpm-runtime/,
@@ -336,14 +393,11 @@ test("prebuilt separates trusted standalone bootstrap from candidate JavaScript 
     isolation.run,
     /printf '%s\\n' "\$trusted_bin_dir" >> "\$GITHUB_PATH"/,
   );
-  assert.match(isolation.run, /"\$PNPM_ACTION_DEST" \\/);
   assert.match(isolation.run, /"\$TRUSTED_VERCEL_TOOLS_PATH" \\/);
   assert.match(isolation.run, /"\$trusted_bin_dir" \\/);
+  assert.match(isolation.run, /"\$bootstrap_bin_dir" \\/);
   assert.match(isolation.run, /"\$node_bin" \\/);
-  assert.match(
-    isolation.run,
-    /pnpm_bootstrap="\$trusted_bin_dir\/pnpm-bootstrap"/,
-  );
+  assert.match(isolation.run, /"\$trusted_pnpm_store" \\/);
   assert.match(
     isolation.run,
     /Protected runtime directory is not cross-identity readable/,
@@ -360,16 +414,29 @@ test("prebuilt separates trusted standalone bootstrap from candidate JavaScript 
   assert.match(install.run, /NPM_CONFIG_PACKAGE_MANAGER_STRICT_VERSION=false/);
   assert.match(install.run, /"\$pnpm_bin" --version \|/);
   assert.match(install.run, /\/usr\/bin\/grep -Fxq "10\.34\.4"/);
+  assert.equal(
+    cleanup.env.PNPM_BOOTSTRAP_PATH,
+    "${{ runner.temp }}/mento-vercel-pnpm-bootstrap",
+  );
+  assert.match(cleanup.run, /"\$PNPM_BOOTSTRAP_PATH" \\/);
   assert.ok(
-    names.indexOf("Set up pinned pnpm") <
-      names.indexOf("Verify pinned pnpm target before first execution"),
+    names.indexOf("Set up pinned Node.js without package-manager cache") <
+      names.indexOf("Stage and authenticate pinned pnpm bootstrap"),
   );
   assert.ok(
-    names.indexOf("Verify pinned pnpm target before first execution") <
-      names.indexOf("Set up pinned Node.js and pnpm cache"),
+    names.indexOf("Stage and authenticate pinned pnpm bootstrap") <
+      names.indexOf("Prove authenticated pnpm path before cache restore"),
   );
   assert.ok(
-    names.indexOf("Set up pinned Node.js and pnpm cache") <
+    names.indexOf("Prove authenticated pnpm path before cache restore") <
+      names.indexOf("Restore trusted pnpm cache"),
+  );
+  assert.ok(
+    names.indexOf("Restore trusted pnpm cache") <
+      names.indexOf("Reverify authenticated pnpm after cache restore"),
+  );
+  assert.ok(
+    names.indexOf("Reverify authenticated pnpm after cache restore") <
       names.indexOf(
         "Prepare isolated exact-SHA source and protected Vercel CLI",
       ),


### PR DESCRIPTION
## The Problem

The immutable Vercel prebuilt pilot exposed a trust-boundary flaw in the
runner-privileged pnpm bootstrap. `pnpm/action-setup` installs `@pnpm/exe`
through a lifecycle script before the downloaded target can be authenticated,
so the pinned version was not a content-authenticated first execution.

## The Solution

- replace the privileged action bootstrap with an exact npm lock for
  `@pnpm/linux-x64@10.34.4`, including reviewed registry SRI and executable
  SHA-256
- install with isolated npm state and lifecycle scripts disabled, validate the
  literal binary metadata and digest, then independently copy, re-hash, and
  version-check it before cache restore or candidate execution
- preserve the candidate UID/store isolation and always-run cleanup boundaries
- add dedicated OSV/Linux installation coverage, structural regression tests,
  and the pnpm bump/runbook documentation

This is the security follow-up required before rerunning the immutable pilot
for #518 and continuing epic #515.

## Validation

- `pnpm vercel:workflow:test` — 72 passed
- `pnpm supply-chain:lockfile-lint` — passed
- `pnpm supply-chain:lockfile-lint:test` — 45 passed
- `pnpm ci:action-pins` — all 22 workflow/action files pinned
- `pnpm ci:action-pins:test` — 48 scanner + 11 materializer tests passed
- `pnpm adr:check` and `pnpm adr:check:test` — passed
- `pnpm quality:budgets:test` — 30 passed
- `pnpm check-types` — 8/8 tasks passed
- targeted `trunk check`, `trunk fmt`, and `git diff --check` — clean
- fresh-context autoreview — no findings, 0.91 confidence

## Ship Checklist

- [x] ship skill used
- [x] local review run
- [x] validation run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes the trusted-tool bootstrap for an isolated build pilot (auth boundaries, SHA pinning, PATH/cache ordering); mistakes could weaken supply-chain guarantees or break deployments.
> 
> **Overview**
> Replaces **`pnpm/action-setup`** in the privileged Vercel prebuilt job with a **content-authenticated** Linux pnpm bootstrap so the first privileged execution is not driven by `@pnpm/exe` lifecycle scripts.
> 
> A new **`scripts/vercel-pnpm-bootstrap`** npm lock pins **`@pnpm/linux-x64@10.34.4`** (registry SRI + reviewed executable SHA-256). The workflow stages manifests via **`stage-pnpm-bootstrap`**, runs **`npm ci`** in isolated npm state with scripts disabled, validates the literal binary, copies Node and pnpm into **`mento-vercel-trusted-tools`** (`bootstrap-bin/pnpm`), re-hashes and version-checks, then puts the protected copy on **`PATH`** **before** a cache-only **`setup-node`** step. **Pre- and post-cache** steps prove **`PATH`** still resolves to that binary.
> 
> The isolation step no longer stages runtime from the action; it reuses the authenticated **`bootstrap-bin`** layout, validates the trusted pnpm store, and extends protected-path checks. Cleanup removes bootstrap staging dirs.
> 
> **Supply chain:** new **`osv-pnpm-bootstrap`** job, Linux **`npm ci`** + digest proof in **`lockfile-lint`**, trunk ignore for the bootstrap lockfile, and **`vercel-prebuilt-workflow.mjs`** / test updates for bootstrap validation and **`stage-runtime`** wiring. **`docs/vercel-deployments.md`** documents the bump runbook. Smoke job still uses **`pnpm/action-setup`** (unchanged).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5559b0d064cf216424540727a5e356a4804f8d2. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->