### PR TITLE
fix(ci): make Vercel runtime cross-identity accessible

### DIFF
--- a/.github/workflows/_vercel-prebuilt.yml
+++ b/.github/workflows/_vercel-prebuilt.yml
@@ -138,6 +138,10 @@ jobs:
       started_at_ms: ${{ steps.prepare.outputs.started_at_ms }}
       build_duration_ms: ${{ steps.build.outputs.build_duration_ms }}
       deploy_duration_ms: ${{ steps.deploy.outputs.deploy_duration_ms }}
+    env:
+      VERCEL_ISOLATION_ROOT: /var/lib/mento-vercel-runtime-${{ github.run_id }}-${{ github.run_attempt }}/work
+      VERCEL_RUNTIME_MARKER: /var/lib/mento-vercel-runtime-${{ github.run_id }}-${{ github.run_attempt }}/.mento-vercel-runtime
+      VERCEL_RUNTIME_ROOT: /var/lib/mento-vercel-runtime-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - name: Check out trusted workflow controller
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -161,19 +165,108 @@ jobs:
           node-version: 22
           package-manager-cache: false
 
+      - name: Create protected cross-identity runtime root
+        shell: bash
+        run: |
+          set -euo pipefail
+          umask 077
+          if [[ ! "$GITHUB_RUN_ID" =~ ^[1-9][0-9]*$ ]] ||
+            [[ ! "$GITHUB_RUN_ATTEMPT" =~ ^[1-9][0-9]*$ ]]; then
+            echo "GitHub runtime identity is invalid" >&2
+            exit 1
+          fi
+          expected_runtime_root="/var/lib/mento-vercel-runtime-$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT"
+          if [ "$VERCEL_RUNTIME_ROOT" != "$expected_runtime_root" ] ||
+            [ "$VERCEL_ISOLATION_ROOT" != "$expected_runtime_root/work" ] ||
+            [ "$VERCEL_RUNTIME_MARKER" != "$expected_runtime_root/.mento-vercel-runtime" ]; then
+            echo "Vercel runtime paths do not match the trusted run identity" >&2
+            exit 1
+          fi
+          if [ -e "$VERCEL_RUNTIME_ROOT" ] || [ -L "$VERCEL_RUNTIME_ROOT" ]; then
+            echo "Vercel runtime root must be fresh" >&2
+            exit 1
+          fi
+          for protected_ancestor in / /var /var/lib; do
+            if [ ! -d "$protected_ancestor" ] ||
+              [ -L "$protected_ancestor" ] ||
+              [ "$(/usr/bin/realpath "$protected_ancestor")" != "$protected_ancestor" ] ||
+              [ "$(/usr/bin/stat -c %u "$protected_ancestor")" != "0" ] ||
+              [ "$(/usr/bin/stat -c %g "$protected_ancestor")" != "0" ]; then
+              echo "Vercel isolation ancestor is not a real root-owned directory" >&2
+              exit 1
+            fi
+            ancestor_mode="$(
+              /usr/bin/stat -c %a "$protected_ancestor"
+            )"
+            ancestor_mode_value=$((8#$ancestor_mode))
+            if (( (ancestor_mode_value & 07022) != 0 ||
+              (ancestor_mode_value & 0001) == 0 )); then
+              echo "Vercel isolation ancestor has unsafe permissions" >&2
+              exit 1
+            fi
+          done
+          sudo --non-interactive /usr/bin/install \
+            -d \
+            -o root \
+            -g root \
+            -m 0711 \
+            -- \
+            "$VERCEL_RUNTIME_ROOT"
+          sudo --non-interactive /usr/bin/install \
+            -d \
+            -o "$(/usr/bin/id -u)" \
+            -g "$(/usr/bin/id -g)" \
+            -m 0711 \
+            -- \
+            "$VERCEL_ISOLATION_ROOT"
+          /usr/bin/printf '%s\n' "$GITHUB_RUN_ID:$GITHUB_RUN_ATTEMPT" |
+            sudo --non-interactive /usr/bin/tee "$VERCEL_RUNTIME_MARKER" >/dev/null
+          sudo --non-interactive /bin/chown root:root "$VERCEL_RUNTIME_MARKER"
+          sudo --non-interactive /bin/chmod 0400 "$VERCEL_RUNTIME_MARKER"
+          if [ ! -d "$VERCEL_RUNTIME_ROOT" ] ||
+            [ -L "$VERCEL_RUNTIME_ROOT" ] ||
+            [ "$(sudo --non-interactive /usr/bin/realpath "$VERCEL_RUNTIME_ROOT")" != "$VERCEL_RUNTIME_ROOT" ] ||
+            [ "$(sudo --non-interactive /usr/bin/stat -c %u "$VERCEL_RUNTIME_ROOT")" != "0" ] ||
+            [ "$(sudo --non-interactive /usr/bin/stat -c %g "$VERCEL_RUNTIME_ROOT")" != "0" ] ||
+            [ "$(sudo --non-interactive /usr/bin/stat -c %a "$VERCEL_RUNTIME_ROOT")" != "711" ] ||
+            [ ! -d "$VERCEL_ISOLATION_ROOT" ] ||
+            [ -L "$VERCEL_ISOLATION_ROOT" ] ||
+            [ "$(sudo --non-interactive /usr/bin/realpath "$VERCEL_ISOLATION_ROOT")" != "$VERCEL_ISOLATION_ROOT" ] ||
+            [ "$(/usr/bin/stat -c %u "$VERCEL_ISOLATION_ROOT")" != "$(/usr/bin/id -u)" ] ||
+            [ "$(/usr/bin/stat -c %g "$VERCEL_ISOLATION_ROOT")" != "$(/usr/bin/id -g)" ] ||
+            [ "$(/usr/bin/stat -c %a "$VERCEL_ISOLATION_ROOT")" != "711" ] ||
+            [ ! -f "$VERCEL_RUNTIME_MARKER" ] ||
+            [ -L "$VERCEL_RUNTIME_MARKER" ] ||
+            [ "$(sudo --non-interactive /usr/bin/stat -c %u "$VERCEL_RUNTIME_MARKER")" != "0" ] ||
+            [ "$(sudo --non-interactive /usr/bin/stat -c %g "$VERCEL_RUNTIME_MARKER")" != "0" ] ||
+            [ "$(sudo --non-interactive /usr/bin/stat -c %a "$VERCEL_RUNTIME_MARKER")" != "400" ] ||
+            [ "$(sudo --non-interactive /bin/cat "$VERCEL_RUNTIME_MARKER")" != "$GITHUB_RUN_ID:$GITHUB_RUN_ATTEMPT" ]; then
+            echo "Vercel runtime root was not created with the protected contract" >&2
+            exit 1
+          fi
+          printf '%s\n' "VERCEL_RUNTIME_ROOT_READY=1" >> "$GITHUB_ENV"
+
       - name: Stage and authenticate pinned pnpm bootstrap
         shell: bash
         env:
           EXPECTED_PNPM_LINUX_X64_SHA256: e02c01738ce850754cf00111fd97bec24de550e1e963690486f02d9dae1a2193
-          PNPM_BOOTSTRAP_CACHE_PATH: ${{ runner.temp }}/mento-vercel-npm-cache
-          PNPM_BOOTSTRAP_HOME_PATH: ${{ runner.temp }}/mento-vercel-npm-home
-          PNPM_BOOTSTRAP_PATH: ${{ runner.temp }}/mento-vercel-pnpm-bootstrap
-          PNPM_BOOTSTRAP_TMP_PATH: ${{ runner.temp }}/mento-vercel-npm-tmp
-          TRUSTED_VERCEL_TOOLS_PATH: ${{ runner.temp }}/mento-vercel-trusted-tools
+          PNPM_BOOTSTRAP_CACHE_PATH: ${{ env.VERCEL_ISOLATION_ROOT }}/mento-vercel-npm-cache
+          PNPM_BOOTSTRAP_HOME_PATH: ${{ env.VERCEL_ISOLATION_ROOT }}/mento-vercel-npm-home
+          PNPM_BOOTSTRAP_PATH: ${{ env.VERCEL_ISOLATION_ROOT }}/mento-vercel-pnpm-bootstrap
+          PNPM_BOOTSTRAP_TMP_PATH: ${{ env.VERCEL_ISOLATION_ROOT }}/mento-vercel-npm-tmp
+          TRUSTED_VERCEL_TOOLS_PATH: ${{ env.VERCEL_ISOLATION_ROOT }}/mento-vercel-trusted-tools
         run: |
           set -euo pipefail
           umask 077
-          /bin/chmod 0711 "$RUNNER_TEMP"
+          if [ ! -d "$VERCEL_ISOLATION_ROOT" ] ||
+            [ -L "$VERCEL_ISOLATION_ROOT" ] ||
+            [ "$(/usr/bin/realpath "$VERCEL_ISOLATION_ROOT")" != "$VERCEL_ISOLATION_ROOT" ] ||
+            [ "$(/usr/bin/stat -c %u "$VERCEL_ISOLATION_ROOT")" != "$(/usr/bin/id -u)" ] ||
+            [ "$(/usr/bin/stat -c %g "$VERCEL_ISOLATION_ROOT")" != "$(/usr/bin/id -g)" ] ||
+            [ "$(/usr/bin/stat -c %a "$VERCEL_ISOLATION_ROOT")" != "711" ]; then
+            echo "Vercel isolation root changed before pnpm bootstrap" >&2
+            exit 1
+          fi
           if [ "$(/usr/bin/uname -s)" != "Linux" ] ||
             [ "$(/usr/bin/uname -m)" != "x86_64" ]; then
             echo "Pinned pnpm bootstrap supports only the expected Linux x64 runner" >&2
@@ -223,7 +316,7 @@ jobs:
           bootstrap_root="$(
             CONTROLLER_PATH="$GITHUB_WORKSPACE/controller" \
             PNPM_BOOTSTRAP_PATH="$PNPM_BOOTSTRAP_PATH" \
-            RUNNER_TEMP="$RUNNER_TEMP" \
+            VERCEL_ISOLATION_ROOT="$VERCEL_ISOLATION_ROOT" \
               "$setup_node_bin" \
               "$GITHUB_WORKSPACE/controller/scripts/vercel-prebuilt-workflow.mjs" \
               stage-pnpm-bootstrap
@@ -260,7 +353,7 @@ jobs:
           /bin/chmod -R a+rX,go-w "$PNPM_BOOTSTRAP_PATH"
           NODE_SOURCE_PATH="$setup_node_bin" \
           PNPM_BOOTSTRAP_PATH="$PNPM_BOOTSTRAP_PATH" \
-          RUNNER_TEMP="$RUNNER_TEMP" \
+          VERCEL_ISOLATION_ROOT="$VERCEL_ISOLATION_ROOT" \
           TRUSTED_VERCEL_TOOLS_PATH="$TRUSTED_VERCEL_TOOLS_PATH" \
             "$setup_node_bin" \
             "$GITHUB_WORKSPACE/controller/scripts/vercel-prebuilt-workflow.mjs" \
@@ -309,7 +402,7 @@ jobs:
       - name: Prove authenticated pnpm path before cache restore
         env:
           EXPECTED_PNPM_LINUX_X64_SHA256: e02c01738ce850754cf00111fd97bec24de550e1e963690486f02d9dae1a2193
-          TRUSTED_VERCEL_TOOLS_PATH: ${{ runner.temp }}/mento-vercel-trusted-tools
+          TRUSTED_VERCEL_TOOLS_PATH: ${{ env.VERCEL_ISOLATION_ROOT }}/mento-vercel-trusted-tools
         run: |
           set -euo pipefail
           expected_pnpm="$TRUSTED_VERCEL_TOOLS_PATH/bootstrap-bin/pnpm"
@@ -338,7 +431,7 @@ jobs:
       - name: Reverify authenticated pnpm after cache restore
         env:
           EXPECTED_PNPM_LINUX_X64_SHA256: e02c01738ce850754cf00111fd97bec24de550e1e963690486f02d9dae1a2193
-          TRUSTED_VERCEL_TOOLS_PATH: ${{ runner.temp }}/mento-vercel-trusted-tools
+          TRUSTED_VERCEL_TOOLS_PATH: ${{ env.VERCEL_ISOLATION_ROOT }}/mento-vercel-trusted-tools
         run: |
           set -euo pipefail
           expected_pnpm="$TRUSTED_VERCEL_TOOLS_PATH/bootstrap-bin/pnpm"
@@ -390,12 +483,12 @@ jobs:
       - name: Prepare isolated exact-SHA source and protected Vercel CLI
         id: isolation
         env:
-          CANDIDATE_HOME_PATH: ${{ runner.temp }}/mento-vercel-candidate-home
-          CANDIDATE_SOURCE_PATH: ${{ runner.temp }}/mento-vercel-candidate-source
+          CANDIDATE_HOME_PATH: ${{ env.VERCEL_ISOLATION_ROOT }}/mento-vercel-candidate-home
+          CANDIDATE_SOURCE_PATH: ${{ env.VERCEL_ISOLATION_ROOT }}/mento-vercel-candidate-source
           DEPLOY_SHA: ${{ steps.source.outputs.checked_out_sha }}
           EXPECTED_PNPM_LINUX_X64_SHA256: e02c01738ce850754cf00111fd97bec24de550e1e963690486f02d9dae1a2193
           SOURCE_PATH: ${{ github.workspace }}/source
-          TRUSTED_VERCEL_TOOLS_PATH: ${{ runner.temp }}/mento-vercel-trusted-tools
+          TRUSTED_VERCEL_TOOLS_PATH: ${{ env.VERCEL_ISOLATION_ROOT }}/mento-vercel-trusted-tools
         run: |
           set -euo pipefail
           umask 077
@@ -418,11 +511,21 @@ jobs:
             echo "Dedicated candidate identity unexpectedly owns a process" >&2
             exit 1
           fi
+          {
+            printf '%s\n' "CANDIDATE_IDENTITY_GID=$build_gid"
+            printf '%s\n' "CANDIDATE_IDENTITY_UID=$build_uid"
+            printf '%s\n' "CANDIDATE_IDENTITY_READY=1"
+          } >> "$GITHUB_ENV"
 
-          /bin/chmod 0711 "$RUNNER_TEMP"
-          if [ ! -d "$TRUSTED_VERCEL_TOOLS_PATH" ] ||
+          if [ ! -d "$VERCEL_ISOLATION_ROOT" ] ||
+            [ -L "$VERCEL_ISOLATION_ROOT" ] ||
+            [ "$(/usr/bin/realpath "$VERCEL_ISOLATION_ROOT")" != "$VERCEL_ISOLATION_ROOT" ] ||
+            [ "$(/usr/bin/stat -c %u "$VERCEL_ISOLATION_ROOT")" != "$(id -u)" ] ||
+            [ "$(/usr/bin/stat -c %g "$VERCEL_ISOLATION_ROOT")" != "$(id -g)" ] ||
+            [ "$(/usr/bin/stat -c %a "$VERCEL_ISOLATION_ROOT")" != "711" ] ||
+            [ ! -d "$TRUSTED_VERCEL_TOOLS_PATH" ] ||
             [ -L "$TRUSTED_VERCEL_TOOLS_PATH" ] ||
-            [ "$(realpath "$TRUSTED_VERCEL_TOOLS_PATH")" != "$RUNNER_TEMP/mento-vercel-trusted-tools" ]; then
+            [ "$(realpath "$TRUSTED_VERCEL_TOOLS_PATH")" != "$VERCEL_ISOLATION_ROOT/mento-vercel-trusted-tools" ]; then
             echo "Protected runtime root is not the authenticated fixed directory" >&2
             exit 1
           fi
@@ -553,9 +656,12 @@ jobs:
               /usr/bin/test -w "$1"
           }
           for protected_path in \
+            "/var/lib" \
+            "$VERCEL_RUNTIME_ROOT" \
+            "$VERCEL_RUNTIME_MARKER" \
+            "$VERCEL_ISOLATION_ROOT" \
             "$GITHUB_WORKSPACE" \
             "$GITHUB_WORKSPACE/controller" \
-            "$RUNNER_TEMP" \
             "$SOURCE_PATH" \
             "$SOURCE_PATH/.git" \
             "$SOURCE_PATH/package.json" \
@@ -578,6 +684,24 @@ jobs:
           done
           if [ -e "$SOURCE_PATH/node_modules" ] && candidate_can_write "$SOURCE_PATH/node_modules"; then
             echo "Candidate can modify canonical node_modules" >&2
+            exit 1
+          fi
+          if ! candidate_pnpm_version="$(
+            sudo --non-interactive /usr/bin/env -i \
+              HOME=/nonexistent \
+              LANG=C \
+              LC_ALL=C \
+              PATH=/usr/bin:/bin \
+              /usr/bin/setpriv \
+              --reuid="$build_uid" \
+              --regid="$build_gid" \
+              --clear-groups \
+              --no-new-privs \
+              -- \
+              "$pnpm_bin" --version
+          )" ||
+            [ "$candidate_pnpm_version" != "10.34.4" ]; then
+            echo "Candidate cannot execute the protected runtime through its isolation ancestors" >&2
             exit 1
           fi
 
@@ -614,8 +738,8 @@ jobs:
         env:
           BUILD_GID: ${{ steps.isolation.outputs.build_gid }}
           BUILD_UID: ${{ steps.isolation.outputs.build_uid }}
-          CANDIDATE_HOME_PATH: ${{ runner.temp }}/mento-vercel-candidate-home
-          CANDIDATE_SOURCE_PATH: ${{ runner.temp }}/mento-vercel-candidate-source
+          CANDIDATE_HOME_PATH: ${{ env.VERCEL_ISOLATION_ROOT }}/mento-vercel-candidate-home
+          CANDIDATE_SOURCE_PATH: ${{ env.VERCEL_ISOLATION_ROOT }}/mento-vercel-candidate-source
         run: |
           set -euo pipefail
           terminate_candidate() {
@@ -710,7 +834,7 @@ jobs:
       - name: Prepare fresh runner-owned Vercel pull staging
         env:
           EXPECTED_ROOT_DIRECTORY: ${{ inputs.expected_root_directory }}
-          PULL_STAGING_PATH: ${{ runner.temp }}/mento-vercel-pull-staging
+          PULL_STAGING_PATH: ${{ env.VERCEL_ISOLATION_ROOT }}/mento-vercel-pull-staging
           VERCEL_ORG_ID: ${{ inputs.vercel_org_id }}
           VERCEL_PROJECT_ID: ${{ inputs.vercel_project_id }}
         run: |
@@ -751,8 +875,8 @@ jobs:
         id: pull
         env:
           GIT_BRANCH: ${{ inputs.git_branch }}
-          SOURCE_PATH: ${{ runner.temp }}/mento-vercel-pull-staging
-          TRUSTED_VERCEL_TOOLS_PATH: ${{ runner.temp }}/mento-vercel-trusted-tools
+          SOURCE_PATH: ${{ env.VERCEL_ISOLATION_ROOT }}/mento-vercel-pull-staging
+          TRUSTED_VERCEL_TOOLS_PATH: ${{ env.VERCEL_ISOLATION_ROOT }}/mento-vercel-trusted-tools
           VERCEL_ORG_ID: ${{ inputs.vercel_org_id }}
           VERCEL_PROJECT_ID: ${{ inputs.vercel_project_id }}
           VERCEL_TOKEN: ${{ secrets.vercel_token }}
@@ -763,7 +887,7 @@ jobs:
       - name: Assert isolated runner-owned Vercel pull result
         env:
           EXPECTED_ROOT_DIRECTORY: ${{ inputs.expected_root_directory }}
-          PULL_STAGING_PATH: ${{ runner.temp }}/mento-vercel-pull-staging
+          PULL_STAGING_PATH: ${{ env.VERCEL_ISOLATION_ROOT }}/mento-vercel-pull-staging
           VERCEL_ORG_ID: ${{ inputs.vercel_org_id }}
           VERCEL_PROJECT_ID: ${{ inputs.vercel_project_id }}
         run: node "$GITHUB_WORKSPACE/controller/scripts/vercel-prebuilt-workflow.mjs" validate-pull-staging
@@ -772,7 +896,7 @@ jobs:
         env:
           CI: 1
           NEXT_PUBLIC_VERCEL_ENV: preview
-          PULL_STAGING_PATH: ${{ runner.temp }}/mento-vercel-pull-staging
+          PULL_STAGING_PATH: ${{ env.VERCEL_ISOLATION_ROOT }}/mento-vercel-pull-staging
           VERCEL: 1
           VERCEL_ENV: preview
           VERCEL_TARGET_ENV: preview
@@ -785,9 +909,9 @@ jobs:
         env:
           BUILD_GID: ${{ steps.isolation.outputs.build_gid }}
           BUILD_UID: ${{ steps.isolation.outputs.build_uid }}
-          CANDIDATE_SOURCE_PATH: ${{ runner.temp }}/mento-vercel-candidate-source
+          CANDIDATE_SOURCE_PATH: ${{ env.VERCEL_ISOLATION_ROOT }}/mento-vercel-candidate-source
           EXPECTED_ROOT_DIRECTORY: ${{ inputs.expected_root_directory }}
-          PULL_STAGING_PATH: ${{ runner.temp }}/mento-vercel-pull-staging
+          PULL_STAGING_PATH: ${{ env.VERCEL_ISOLATION_ROOT }}/mento-vercel-pull-staging
           VERCEL_ORG_ID: ${{ inputs.vercel_org_id }}
           VERCEL_PROJECT_ID: ${{ inputs.vercel_project_id }}
         run: |
@@ -806,7 +930,7 @@ jobs:
             PULL_STAGING_GID="$(id -g)" \
             PULL_STAGING_PATH="$PULL_STAGING_PATH" \
             PULL_STAGING_UID="$(id -u)" \
-            RUNNER_TEMP="$RUNNER_TEMP" \
+            VERCEL_ISOLATION_ROOT="$VERCEL_ISOLATION_ROOT" \
             VERCEL_ORG_ID="$VERCEL_ORG_ID" \
             VERCEL_PROJECT_ID="$VERCEL_PROJECT_ID" \
             "$node_bin" \
@@ -821,7 +945,7 @@ jobs:
         env:
           BUILD_GID: ${{ steps.isolation.outputs.build_gid }}
           BUILD_UID: ${{ steps.isolation.outputs.build_uid }}
-          CANDIDATE_SOURCE_PATH: ${{ runner.temp }}/mento-vercel-candidate-source
+          CANDIDATE_SOURCE_PATH: ${{ env.VERCEL_ISOLATION_ROOT }}/mento-vercel-candidate-source
           EXPECTED_ROOT_DIRECTORY: ${{ inputs.expected_root_directory }}
           VERCEL_ORG_ID: ${{ inputs.vercel_org_id }}
           VERCEL_PROJECT_ID: ${{ inputs.vercel_project_id }}
@@ -840,7 +964,7 @@ jobs:
             PATH="$(dirname "$node_bin"):/usr/bin:/bin" \
             PULL_STAGING_GID="$(id -g)" \
             PULL_STAGING_UID="$(id -u)" \
-            RUNNER_TEMP="$RUNNER_TEMP" \
+            VERCEL_ISOLATION_ROOT="$VERCEL_ISOLATION_ROOT" \
             VERCEL_ORG_ID="$VERCEL_ORG_ID" \
             VERCEL_PROJECT_ID="$VERCEL_PROJECT_ID" \
             "$node_bin" \
@@ -856,15 +980,15 @@ jobs:
         env:
           BUILD_GID: ${{ steps.isolation.outputs.build_gid }}
           BUILD_UID: ${{ steps.isolation.outputs.build_uid }}
-          CANDIDATE_HOME_PATH: ${{ runner.temp }}/mento-vercel-candidate-home
+          CANDIDATE_HOME_PATH: ${{ env.VERCEL_ISOLATION_ROOT }}/mento-vercel-candidate-home
           CI: 1
           DEPLOY_SHA: ${{ steps.source.outputs.checked_out_sha }}
           EXPECTED_ROOT_DIRECTORY: ${{ inputs.expected_root_directory }}
           GIT_BRANCH: ${{ inputs.git_branch }}
           MENTO_NEXT_DEPLOYMENT_ID: ${{ steps.prepare.outputs.next_deployment_id }}
           NEXT_PUBLIC_VERCEL_ENV: preview
-          SOURCE_PATH: ${{ runner.temp }}/mento-vercel-candidate-source
-          TRUSTED_VERCEL_TOOLS_PATH: ${{ runner.temp }}/mento-vercel-trusted-tools
+          SOURCE_PATH: ${{ env.VERCEL_ISOLATION_ROOT }}/mento-vercel-candidate-source
+          TRUSTED_VERCEL_TOOLS_PATH: ${{ env.VERCEL_ISOLATION_ROOT }}/mento-vercel-trusted-tools
           TURBO_REMOTE_CACHE_SIGNATURE_KEY: ${{ secrets.turbo_remote_cache_signature_key }}
           TURBO_TEAM: ${{ inputs.turbo_team }}
           TURBO_TOKEN: ${{ secrets.turbo_token }}
@@ -917,7 +1041,7 @@ jobs:
             PATH="$(dirname "$node_bin"):/usr/bin:/bin" \
             PULL_STAGING_GID="$(id -g)" \
             PULL_STAGING_UID="$(id -u)" \
-            RUNNER_TEMP="$RUNNER_TEMP" \
+            VERCEL_ISOLATION_ROOT="$VERCEL_ISOLATION_ROOT" \
             SOURCE_PATH="$SOURCE_PATH" \
             TURBO_REMOTE_CACHE_SIGNATURE_KEY="$TURBO_REMOTE_CACHE_SIGNATURE_KEY" \
             TURBO_TEAM="$TURBO_TEAM" \
@@ -998,7 +1122,7 @@ jobs:
           EXPECTED_ROOT_DIRECTORY: ${{ inputs.expected_root_directory }}
           LOGICAL_TARGET: ${{ inputs.logical_target }}
           MENTO_NEXT_DEPLOYMENT_ID: ${{ steps.prepare.outputs.next_deployment_id }}
-          SOURCE_PATH: ${{ runner.temp }}/mento-vercel-candidate-source
+          SOURCE_PATH: ${{ env.VERCEL_ISOLATION_ROOT }}/mento-vercel-candidate-source
           VERCEL_ORG_ID: ${{ inputs.vercel_org_id }}
           VERCEL_PROJECT_ID: ${{ inputs.vercel_project_id }}
         run: |
@@ -1031,7 +1155,7 @@ jobs:
       - name: Revalidate runner-owned pulled UI settings after the build
         env:
           EXPECTED_ROOT_DIRECTORY: ${{ inputs.expected_root_directory }}
-          PULL_STAGING_PATH: ${{ runner.temp }}/mento-vercel-pull-staging
+          PULL_STAGING_PATH: ${{ env.VERCEL_ISOLATION_ROOT }}/mento-vercel-pull-staging
           VERCEL_ORG_ID: ${{ inputs.vercel_org_id }}
           VERCEL_PROJECT_ID: ${{ inputs.vercel_project_id }}
         run: node "$GITHUB_WORKSPACE/controller/scripts/vercel-prebuilt-workflow.mjs" validate-pull-staging
@@ -1040,12 +1164,12 @@ jobs:
         id: handoff
         env:
           BUILD_UID: ${{ steps.isolation.outputs.build_uid }}
-          CANDIDATE_HOME_PATH: ${{ runner.temp }}/mento-vercel-candidate-home
-          CANDIDATE_SOURCE_PATH: ${{ runner.temp }}/mento-vercel-candidate-source
+          CANDIDATE_HOME_PATH: ${{ env.VERCEL_ISOLATION_ROOT }}/mento-vercel-candidate-home
+          CANDIDATE_SOURCE_PATH: ${{ env.VERCEL_ISOLATION_ROOT }}/mento-vercel-candidate-source
           DEPLOY_SHA: ${{ steps.source.outputs.checked_out_sha }}
           EXPECTED_ROOT_DIRECTORY: ${{ inputs.expected_root_directory }}
-          PULL_STAGING_PATH: ${{ runner.temp }}/mento-vercel-pull-staging
-          UPLOAD_SOURCE_PATH: ${{ runner.temp }}/mento-vercel-upload-source
+          PULL_STAGING_PATH: ${{ env.VERCEL_ISOLATION_ROOT }}/mento-vercel-pull-staging
+          UPLOAD_SOURCE_PATH: ${{ env.VERCEL_ISOLATION_ROOT }}/mento-vercel-upload-source
         run: |
           set -euo pipefail
           umask 077
@@ -1077,17 +1201,20 @@ jobs:
           /bin/chmod 0600 "${UPLOAD_SOURCE_PATH}.provenance.json"
 
           assert_candidate_stopped
-          sudo --non-interactive /usr/sbin/userdel mento-vercel-build
-          if getent group mento-vercel-build >/dev/null; then
-            sudo --non-interactive /usr/sbin/groupdel mento-vercel-build
+          if [ "$CANDIDATE_SOURCE_PATH" != "$VERCEL_ISOLATION_ROOT/mento-vercel-candidate-source" ] ||
+            [ "$CANDIDATE_HOME_PATH" != "$VERCEL_ISOLATION_ROOT/mento-vercel-candidate-home" ] ||
+            [ "$PULL_STAGING_PATH" != "$VERCEL_ISOLATION_ROOT/mento-vercel-pull-staging" ] ||
+            [ "$UPLOAD_SOURCE_PATH" != "$VERCEL_ISOLATION_ROOT/mento-vercel-upload-source" ]; then
+            echo "Refusing to remove an unexpected handoff path" >&2
+            exit 1
           fi
-          sudo --non-interactive /bin/rm -rf -- "$CANDIDATE_SOURCE_PATH"
-          sudo --non-interactive /bin/rm -rf -- "$CANDIDATE_HOME_PATH"
+          sudo --non-interactive /bin/rm \
+            -rf \
+            --one-file-system \
+            -- \
+            "$CANDIDATE_SOURCE_PATH" \
+            "$CANDIDATE_HOME_PATH"
           /bin/rm -f -- "${CANDIDATE_SOURCE_PATH}.provenance.json"
-          case "$PULL_STAGING_PATH" in
-            "$RUNNER_TEMP"/mento-vercel-pull-staging) ;;
-            *) echo "Refusing to remove unexpected pull staging" >&2; exit 1 ;;
-          esac
           /bin/rm -rf -- "$PULL_STAGING_PATH"
 
           echo "upload_uid=$(id -u)" >> "$GITHUB_OUTPUT"
@@ -1096,7 +1223,7 @@ jobs:
       - name: Materialize runner-owned upload UI project mapping
         env:
           EXPECTED_ROOT_DIRECTORY: ${{ inputs.expected_root_directory }}
-          SOURCE_PATH: ${{ runner.temp }}/mento-vercel-upload-source
+          SOURCE_PATH: ${{ env.VERCEL_ISOLATION_ROOT }}/mento-vercel-upload-source
           VERCEL_ORG_ID: ${{ inputs.vercel_org_id }}
           VERCEL_PROJECT_ID: ${{ inputs.vercel_project_id }}
         run: node "$GITHUB_WORKSPACE/controller/scripts/vercel-prebuilt-workflow.mjs" prepare-link
@@ -1109,7 +1236,7 @@ jobs:
           EXPECTED_ROOT_DIRECTORY: ${{ inputs.expected_root_directory }}
           LOGICAL_TARGET: ${{ inputs.logical_target }}
           MENTO_NEXT_DEPLOYMENT_ID: ${{ steps.prepare.outputs.next_deployment_id }}
-          SOURCE_PATH: ${{ runner.temp }}/mento-vercel-upload-source
+          SOURCE_PATH: ${{ env.VERCEL_ISOLATION_ROOT }}/mento-vercel-upload-source
           VERCEL_ORG_ID: ${{ inputs.vercel_org_id }}
           VERCEL_PROJECT_ID: ${{ inputs.vercel_project_id }}
         run: node "$GITHUB_WORKSPACE/controller/scripts/vercel-prebuilt-workflow.mjs" assert-output
@@ -1131,9 +1258,9 @@ jobs:
           GIT_BRANCH: ${{ inputs.git_branch }}
           LOGICAL_TARGET: ${{ inputs.logical_target }}
           MENTO_NEXT_DEPLOYMENT_ID: ${{ steps.prepare.outputs.next_deployment_id }}
-          SOURCE_PATH: ${{ runner.temp }}/mento-vercel-upload-source
+          SOURCE_PATH: ${{ env.VERCEL_ISOLATION_ROOT }}/mento-vercel-upload-source
           STARTED_AT_MS: ${{ steps.prepare.outputs.started_at_ms }}
-          TRUSTED_VERCEL_TOOLS_PATH: ${{ runner.temp }}/mento-vercel-trusted-tools
+          TRUSTED_VERCEL_TOOLS_PATH: ${{ env.VERCEL_ISOLATION_ROOT }}/mento-vercel-trusted-tools
           VERCEL_ORG_ID: ${{ inputs.vercel_org_id }}
           VERCEL_PROJECT_ID: ${{ inputs.vercel_project_id }}
           VERCEL_TOKEN: ${{ secrets.vercel_token }}
@@ -1142,8 +1269,8 @@ jobs:
       - name: Verify immutable Vercel deployment metadata
         id: verify
         env:
-          SOURCE_PATH: ${{ runner.temp }}/mento-vercel-upload-source
-          TRUSTED_VERCEL_TOOLS_PATH: ${{ runner.temp }}/mento-vercel-trusted-tools
+          SOURCE_PATH: ${{ env.VERCEL_ISOLATION_ROOT }}/mento-vercel-upload-source
+          TRUSTED_VERCEL_TOOLS_PATH: ${{ env.VERCEL_ISOLATION_ROOT }}/mento-vercel-trusted-tools
           VERCEL_DEPLOYMENT_ID: ${{ steps.deploy.outputs.vercel_deployment_id }}
           VERCEL_DEPLOYMENT_URL: ${{ steps.deploy.outputs.vercel_deployment_url }}
           VERCEL_ORG_ID: ${{ inputs.vercel_org_id }}
@@ -1154,36 +1281,163 @@ jobs:
       - name: Remove isolated build and upload state
         if: always()
         env:
-          CANDIDATE_HOME_PATH: ${{ runner.temp }}/mento-vercel-candidate-home
-          CANDIDATE_SOURCE_PATH: ${{ runner.temp }}/mento-vercel-candidate-source
-          PNPM_BOOTSTRAP_CACHE_PATH: ${{ runner.temp }}/mento-vercel-npm-cache
-          PNPM_BOOTSTRAP_HOME_PATH: ${{ runner.temp }}/mento-vercel-npm-home
-          PNPM_BOOTSTRAP_PATH: ${{ runner.temp }}/mento-vercel-pnpm-bootstrap
-          PNPM_BOOTSTRAP_TMP_PATH: ${{ runner.temp }}/mento-vercel-npm-tmp
-          PULL_STAGING_PATH: ${{ runner.temp }}/mento-vercel-pull-staging
-          TRUSTED_VERCEL_TOOLS_PATH: ${{ runner.temp }}/mento-vercel-trusted-tools
-          UPLOAD_SOURCE_PATH: ${{ runner.temp }}/mento-vercel-upload-source
+          CANDIDATE_HOME_PATH: ${{ env.VERCEL_ISOLATION_ROOT }}/mento-vercel-candidate-home
+          CANDIDATE_SOURCE_PATH: ${{ env.VERCEL_ISOLATION_ROOT }}/mento-vercel-candidate-source
+          PNPM_BOOTSTRAP_CACHE_PATH: ${{ env.VERCEL_ISOLATION_ROOT }}/mento-vercel-npm-cache
+          PNPM_BOOTSTRAP_HOME_PATH: ${{ env.VERCEL_ISOLATION_ROOT }}/mento-vercel-npm-home
+          PNPM_BOOTSTRAP_PATH: ${{ env.VERCEL_ISOLATION_ROOT }}/mento-vercel-pnpm-bootstrap
+          PNPM_BOOTSTRAP_TMP_PATH: ${{ env.VERCEL_ISOLATION_ROOT }}/mento-vercel-npm-tmp
+          PULL_STAGING_PATH: ${{ env.VERCEL_ISOLATION_ROOT }}/mento-vercel-pull-staging
+          TRUSTED_VERCEL_TOOLS_PATH: ${{ env.VERCEL_ISOLATION_ROOT }}/mento-vercel-trusted-tools
+          UPLOAD_SOURCE_PATH: ${{ env.VERCEL_ISOLATION_ROOT }}/mento-vercel-upload-source
         run: |
           set -euo pipefail
-          if getent passwd mento-vercel-build >/dev/null; then
-            build_uid="$(id -u mento-vercel-build)"
-            sudo --non-interactive /usr/bin/pkill -KILL -u "$build_uid" >/dev/null 2>&1 || true
+          if [ "${VERCEL_RUNTIME_ROOT_READY:-}" != "1" ]; then
+            if [ -e "$VERCEL_RUNTIME_ROOT" ] || [ -L "$VERCEL_RUNTIME_ROOT" ]; then
+              echo "Unproven protected runtime root exists; refusing cleanup" >&2
+              exit 1
+            fi
+            echo "Protected runtime root was not created by this run; skipping cleanup"
+            exit 0
+          fi
+          if [[ ! "$GITHUB_RUN_ID" =~ ^[1-9][0-9]*$ ]] ||
+            [[ ! "$GITHUB_RUN_ATTEMPT" =~ ^[1-9][0-9]*$ ]]; then
+            echo "GitHub runtime identity is invalid during cleanup" >&2
+            exit 1
+          fi
+          expected_runtime_root="/var/lib/mento-vercel-runtime-$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT"
+          if [ "$VERCEL_RUNTIME_ROOT" != "$expected_runtime_root" ] ||
+            [ "$VERCEL_ISOLATION_ROOT" != "$expected_runtime_root/work" ] ||
+            [ "$VERCEL_RUNTIME_MARKER" != "$expected_runtime_root/.mento-vercel-runtime" ]; then
+            echo "Refusing to clean unexpected runtime paths" >&2
+            exit 1
+          fi
+          for protected_ancestor in / /var /var/lib; do
+            if [ ! -d "$protected_ancestor" ] ||
+              [ -L "$protected_ancestor" ] ||
+              [ "$(/usr/bin/realpath "$protected_ancestor")" != "$protected_ancestor" ] ||
+              [ "$(/usr/bin/stat -c %u "$protected_ancestor")" != "0" ] ||
+              [ "$(/usr/bin/stat -c %g "$protected_ancestor")" != "0" ]; then
+              echo "Vercel runtime ancestor changed before cleanup" >&2
+              exit 1
+            fi
+            ancestor_mode="$(
+              /usr/bin/stat -c %a "$protected_ancestor"
+            )"
+            ancestor_mode_value=$((8#$ancestor_mode))
+            if (( (ancestor_mode_value & 07022) != 0 ||
+              (ancestor_mode_value & 0001) == 0 )); then
+              echo "Vercel runtime ancestor permissions changed before cleanup" >&2
+              exit 1
+            fi
+          done
+          if [ ! -d "$VERCEL_RUNTIME_ROOT" ] ||
+            [ -L "$VERCEL_RUNTIME_ROOT" ] ||
+            [ "$(sudo --non-interactive /usr/bin/realpath "$VERCEL_RUNTIME_ROOT")" != "$VERCEL_RUNTIME_ROOT" ] ||
+            [ "$(sudo --non-interactive /usr/bin/stat -c %u "$VERCEL_RUNTIME_ROOT")" != "0" ] ||
+            [ "$(sudo --non-interactive /usr/bin/stat -c %g "$VERCEL_RUNTIME_ROOT")" != "0" ] ||
+            [ "$(sudo --non-interactive /usr/bin/stat -c %a "$VERCEL_RUNTIME_ROOT")" != "711" ] ||
+            [ ! -d "$VERCEL_ISOLATION_ROOT" ] ||
+            [ -L "$VERCEL_ISOLATION_ROOT" ] ||
+            [ "$(sudo --non-interactive /usr/bin/realpath "$VERCEL_ISOLATION_ROOT")" != "$VERCEL_ISOLATION_ROOT" ] ||
+            [ "$(/usr/bin/stat -c %u "$VERCEL_ISOLATION_ROOT")" != "$(/usr/bin/id -u)" ] ||
+            [ "$(/usr/bin/stat -c %g "$VERCEL_ISOLATION_ROOT")" != "$(/usr/bin/id -g)" ] ||
+            [ "$(/usr/bin/stat -c %a "$VERCEL_ISOLATION_ROOT")" != "711" ] ||
+            [ ! -f "$VERCEL_RUNTIME_MARKER" ] ||
+            [ -L "$VERCEL_RUNTIME_MARKER" ] ||
+            [ "$(sudo --non-interactive /usr/bin/stat -c %u "$VERCEL_RUNTIME_MARKER")" != "0" ] ||
+            [ "$(sudo --non-interactive /usr/bin/stat -c %g "$VERCEL_RUNTIME_MARKER")" != "0" ] ||
+            [ "$(sudo --non-interactive /usr/bin/stat -c %a "$VERCEL_RUNTIME_MARKER")" != "400" ] ||
+            [ "$(sudo --non-interactive /bin/cat "$VERCEL_RUNTIME_MARKER")" != "$GITHUB_RUN_ID:$GITHUB_RUN_ATTEMPT" ]; then
+            echo "Protected runtime root failed cleanup validation" >&2
+            exit 1
+          fi
+          runtime_entries="$(
+            sudo --non-interactive /usr/bin/find "$VERCEL_RUNTIME_ROOT" \
+              -mindepth 1 \
+              -maxdepth 1 \
+              -printf '%f\n' |
+              LC_ALL=C /usr/bin/sort
+          )"
+          if [ "$runtime_entries" != $'.mento-vercel-runtime\nwork' ]; then
+            echo "Protected runtime root contains unexpected top-level state" >&2
+            exit 1
+          fi
+          assert_expected_path() {
+            if [ "$1" != "$2" ]; then
+              echo "Refusing to clean an unexpected path: $1" >&2
+              exit 1
+            fi
+          }
+          assert_expected_path \
+            "$CANDIDATE_HOME_PATH" \
+            "$VERCEL_ISOLATION_ROOT/mento-vercel-candidate-home"
+          assert_expected_path \
+            "$CANDIDATE_SOURCE_PATH" \
+            "$VERCEL_ISOLATION_ROOT/mento-vercel-candidate-source"
+          assert_expected_path \
+            "$PNPM_BOOTSTRAP_CACHE_PATH" \
+            "$VERCEL_ISOLATION_ROOT/mento-vercel-npm-cache"
+          assert_expected_path \
+            "$PNPM_BOOTSTRAP_HOME_PATH" \
+            "$VERCEL_ISOLATION_ROOT/mento-vercel-npm-home"
+          assert_expected_path \
+            "$PNPM_BOOTSTRAP_PATH" \
+            "$VERCEL_ISOLATION_ROOT/mento-vercel-pnpm-bootstrap"
+          assert_expected_path \
+            "$PNPM_BOOTSTRAP_TMP_PATH" \
+            "$VERCEL_ISOLATION_ROOT/mento-vercel-npm-tmp"
+          assert_expected_path \
+            "$PULL_STAGING_PATH" \
+            "$VERCEL_ISOLATION_ROOT/mento-vercel-pull-staging"
+          assert_expected_path \
+            "$TRUSTED_VERCEL_TOOLS_PATH" \
+            "$VERCEL_ISOLATION_ROOT/mento-vercel-trusted-tools"
+          assert_expected_path \
+            "$UPLOAD_SOURCE_PATH" \
+            "$VERCEL_ISOLATION_ROOT/mento-vercel-upload-source"
+
+          unmanaged_candidate_identity=0
+          if [ "${CANDIDATE_IDENTITY_READY:-}" = "1" ]; then
+            if [[ ! "${CANDIDATE_IDENTITY_UID:-}" =~ ^[1-9][0-9]*$ ]] ||
+              [[ ! "${CANDIDATE_IDENTITY_GID:-}" =~ ^[1-9][0-9]*$ ]]; then
+              echo "Candidate identity record is invalid" >&2
+              exit 1
+            fi
+            if ! getent passwd mento-vercel-build >/dev/null ||
+              ! getent group mento-vercel-build >/dev/null ||
+              [ "$(id -u mento-vercel-build)" != "$CANDIDATE_IDENTITY_UID" ] ||
+              [ "$(id -g mento-vercel-build)" != "$CANDIDATE_IDENTITY_GID" ] ||
+              [ "$(
+                getent group mento-vercel-build | /usr/bin/cut -d: -f3
+              )" != "$CANDIDATE_IDENTITY_GID" ]; then
+              echo "Candidate identity changed before cleanup" >&2
+              exit 1
+            fi
+            sudo --non-interactive /usr/bin/pkill \
+              -KILL \
+              -u "$CANDIDATE_IDENTITY_UID" >/dev/null 2>&1 || true
             for _ in $(seq 1 50); do
-              if ! sudo --non-interactive /usr/bin/pgrep -u "$build_uid" >/dev/null 2>&1; then
+              if ! sudo --non-interactive /usr/bin/pgrep \
+                -u "$CANDIDATE_IDENTITY_UID" >/dev/null 2>&1; then
                 break
               fi
               /bin/sleep 0.1
             done
-            if sudo --non-interactive /usr/bin/pgrep -u "$build_uid" >/dev/null 2>&1; then
+            if sudo --non-interactive /usr/bin/pgrep \
+              -u "$CANDIDATE_IDENTITY_UID" >/dev/null 2>&1; then
               echo "Candidate processes survived final cleanup" >&2
               exit 1
             fi
-            sudo --non-interactive /usr/sbin/userdel mento-vercel-build
+          elif getent passwd mento-vercel-build >/dev/null ||
+            getent group mento-vercel-build >/dev/null; then
+            unmanaged_candidate_identity=1
           fi
-          if getent group mento-vercel-build >/dev/null; then
-            sudo --non-interactive /usr/sbin/groupdel mento-vercel-build
-          fi
-          for path in \
+
+          sudo --non-interactive /bin/rm \
+            -rf \
+            --one-file-system \
+            -- \
             "$CANDIDATE_HOME_PATH" \
             "$CANDIDATE_SOURCE_PATH" \
             "$PNPM_BOOTSTRAP_CACHE_PATH" \
@@ -1192,25 +1446,43 @@ jobs:
             "$PNPM_BOOTSTRAP_TMP_PATH" \
             "$PULL_STAGING_PATH" \
             "$TRUSTED_VERCEL_TOOLS_PATH" \
-            "$UPLOAD_SOURCE_PATH"; do
-            case "$path" in
-              "$RUNNER_TEMP"/mento-vercel-*) ;;
-              *) echo "Refusing to clean an unexpected path" >&2; exit 1 ;;
-            esac
-          done
-          sudo --non-interactive /bin/rm -rf -- \
-            "$CANDIDATE_HOME_PATH" \
-            "$CANDIDATE_SOURCE_PATH" \
-            "$PNPM_BOOTSTRAP_CACHE_PATH" \
-            "$PNPM_BOOTSTRAP_HOME_PATH" \
-            "$PNPM_BOOTSTRAP_PATH" \
-            "$PNPM_BOOTSTRAP_TMP_PATH" \
-            "$PULL_STAGING_PATH" \
             "$UPLOAD_SOURCE_PATH"
-          /bin/rm -rf -- "$TRUSTED_VERCEL_TOOLS_PATH"
-          /bin/rm -f -- \
+          sudo --non-interactive /bin/rm -f -- \
             "${CANDIDATE_SOURCE_PATH}.provenance.json" \
             "${UPLOAD_SOURCE_PATH}.provenance.json"
+          sudo --non-interactive /bin/rmdir "$VERCEL_ISOLATION_ROOT"
+          sudo --non-interactive /bin/rm -f -- "$VERCEL_RUNTIME_MARKER"
+          sudo --non-interactive /bin/rmdir "$VERCEL_RUNTIME_ROOT"
+          if sudo --non-interactive /usr/bin/test -e "$VERCEL_RUNTIME_ROOT" ||
+            sudo --non-interactive /usr/bin/test -L "$VERCEL_RUNTIME_ROOT"; then
+            echo "Protected runtime root survived cleanup" >&2
+            exit 1
+          fi
+
+          if [ "${CANDIDATE_IDENTITY_READY:-}" = "1" ]; then
+            if getent passwd mento-vercel-build >/dev/null; then
+              sudo --non-interactive /usr/sbin/userdel mento-vercel-build
+            fi
+            if getent group mento-vercel-build >/dev/null; then
+              candidate_group_gid="$(
+                getent group mento-vercel-build | /usr/bin/cut -d: -f3
+              )"
+              if [ "$candidate_group_gid" != "$CANDIDATE_IDENTITY_GID" ]; then
+                echo "Candidate group changed before cleanup" >&2
+                exit 1
+              fi
+              sudo --non-interactive /usr/sbin/groupdel mento-vercel-build
+            fi
+            if getent passwd mento-vercel-build >/dev/null ||
+              getent group mento-vercel-build >/dev/null; then
+              echo "Candidate identity survived cleanup" >&2
+              exit 1
+            fi
+          fi
+          if [ "$unmanaged_candidate_identity" = "1" ]; then
+            echo "Unmanaged candidate identity exists; left untouched" >&2
+            exit 1
+          fi
 
   smoke:
     name: Smoke verified ${{ inputs.logical_target }} preview

--- a/docs/vercel-deployments.md
+++ b/docs/vercel-deployments.md
@@ -371,7 +371,19 @@ Instead, pinned setup-node first provides Node.js and its bundled npm with
 package-manager caching explicitly disabled. Trusted controller code validates
 the exact manifest and complete npm lockfile under
 `scripts/vercel-pnpm-bootstrap`, then copies them into a fresh fixed directory
-under `RUNNER_TEMP`.
+under the job-scoped Vercel isolation work root.
+
+Each build job derives that boundary from the immutable Actions run identity:
+`/var/lib/mento-vercel-runtime-<run-id>-<run-attempt>` is a fresh root-owned
+`0711` directory, its `.mento-vercel-runtime` marker is a root-owned `0400`
+file containing the exact run ID and attempt, and `work/` is a runner-owned
+`0711` directory. Before creating it, the worker proves `/`, `/var`, and
+`/var/lib` are real root-owned directories with no group or other write bit.
+The root-owned outer directory prevents the isolated candidate from replacing
+the runner-owned work entry through a writable parent; the work directory
+allows traversal to reviewed fixed children without allowing the candidate to
+list, create, rename, or remove those children. The workflow does not grant
+ACLs or loosen permissions on runner home or workspace ancestors.
 
 That lock has one dependency only: `@pnpm/linux-x64@10.34.4` from the official
 npm registry with its reviewed sha512 SRI. The worker runs `npm ci` outside the
@@ -429,9 +441,12 @@ Before any credentialed command, the worker proves the runtime root, its
 replacement-relevant parents, Node.js, pnpm, and the CLI are not candidate
 writable; it also proves the CLI resolves inside the protected directory, its
 package version is exactly `56.2.0`, and protected `node <cli> --version`
-executes successfully. The workflow test suite repeats the CLI install with
-the actual pinned pnpm version in a temporary checkout while retaining a
-frozen-lockfile failure boundary.
+executes successfully. It then switches to the dedicated candidate UID and
+executes the protected pnpm launcher once before materializing or running the
+selected source, proving that every isolation ancestor is searchable by that
+identity. The workflow test suite repeats the CLI install with the actual
+pinned pnpm version in a temporary checkout while retaining a frozen-lockfile
+failure boundary.
 
 The candidate dependency install intentionally does **not** reuse setup-node's
 runner-owned pnpm store, even though the candidate is proven unable to write it.
@@ -444,23 +459,34 @@ its duration separately from `vercel build`. The signed Turbo remote build
 cache remains enabled and its hit/miss evidence remains part of the comparison.
 
 Before candidate installation, the worker proves the checked-out index tree is
-the exact selected commit tree. Before any candidate process starts, it
-normalizes `RUNNER_TEMP` to runner-owned `0711` permissions and proves the
-candidate UID cannot write that parent. A trusted, bounded materializer then
-lists the exact commit with `git ls-tree`, reads every raw blob with
-`git cat-file`, and writes only supported regular files and symbolic links into
-a fresh fixed child path that is subsequently handed to the candidate UID. It
-rejects unsafe paths, unsupported modes (including gitlinks), oversized trees,
-and filesystem collisions. Reading raw objects deliberately bypasses both
-archive attributes (`export-ignore` and `export-subst`) and checkout filters
-(`eol`, `ident`, and custom filters), so the candidate always receives the
-selected commit's stored bytes.
+the exact selected commit tree. The candidate UID cannot write `/var/lib`, the
+run-scoped root, its marker, or the runner-owned work directory. A trusted,
+bounded materializer then lists the exact commit with `git ls-tree`, reads every
+raw blob with `git cat-file`, and writes only supported regular files and
+symbolic links into the fixed candidate-source child that is subsequently
+handed to the candidate UID. It rejects unsafe paths, unsupported modes
+(including gitlinks), oversized trees, and filesystem collisions. Reading raw
+objects deliberately bypasses both archive attributes (`export-ignore` and
+`export-subst`) and checkout filters (`eol`, `ident`, and custom filters), so
+the candidate always receives the selected commit's stored bytes.
+
+The always-run cleanup is authorized separately from normal job success. A
+readiness flag is written only after the root, work directory, and run marker
+pass their exact ownership, mode, path, and content checks. The candidate
+identity similarly records its UID and GID before its readiness flag. Cleanup
+does nothing when no proven root exists, but fails closed if an unproven root
+does exist. For a proven root it revalidates the protected ancestors and marker,
+matches every removable child to its fixed path, kills and verifies all
+candidate-UID processes, removes the known state without crossing filesystems,
+removes the empty work and outer directories, and proves the outer root is
+absent before deleting the recorded candidate user and group. Unexpected
+top-level state or a pre-existing/unmatched candidate identity is never deleted.
 
 ### Root Directory and command sequence
 
 The pinned Vercel CLI commands execute from monorepo-shaped roots. Before
 `vercel pull`, the worker creates a fresh runner-owned staging tree at a fixed
-path under `RUNNER_TEMP`. That tree contains only real
+path under `$VERCEL_ISOLATION_ROOT`. That tree contains only real
 `apps/ui.mento.org` directory components and an ephemeral repo-level link built
 from trusted repository variables; it contains no checked-out candidate file.
 This lets CLI `56.2.0` resolve the configured UI Root Directory without giving
@@ -506,7 +532,7 @@ job:
 <validated-branch>` only inside that staging tree;
 3. recursively validate the pulled tree;
 4. run the equivalent of `pnpm vercel:env:check --target ui --environment
-preview --project-directory "$RUNNER_TEMP/mento-vercel-pull-staging/apps/ui.mento.org"`
+preview --project-directory "$VERCEL_ISOLATION_ROOT/mento-vercel-pull-staging/apps/ui.mento.org"`
    against that runner-owned tree, with explicit preview system constants
    overriding pulled values;
 5. copy only the three required files into freshly created candidate `.vercel`

--- a/scripts/vercel-prebuilt-workflow.mjs
+++ b/scripts/vercel-prebuilt-workflow.mjs
@@ -449,38 +449,39 @@ function pilotRootDirectory(value) {
   return value;
 }
 
-function assertRunnerTempChild({
-  runnerTemp,
+function assertIsolationRootChild({
+  isolationRoot,
   path,
   expectedName,
   expectedUid = process.getuid?.(),
   expectedGid = process.getgid?.(),
 }) {
-  requiredText(runnerTemp, "Runner temporary directory");
+  requiredText(isolationRoot, "Vercel isolation root");
   requiredText(path, "Isolated path");
-  if (!isAbsolute(runnerTemp) || !isAbsolute(path)) {
-    throw new Error("Runner isolation paths must be absolute");
+  if (!isAbsolute(isolationRoot) || !isAbsolute(path)) {
+    throw new Error("Vercel isolation paths must be absolute");
   }
   const uid = numericIdentity(expectedUid, "Expected runner UID");
   const gid = numericIdentity(expectedGid, "Expected runner GID");
-  const realRunnerTemp = realpathSync(runnerTemp);
-  const runnerEntry = lstatSync(realRunnerTemp);
+  const realIsolationRoot = realpathSync(isolationRoot);
+  const isolationEntry = lstatSync(isolationRoot);
   if (
-    runnerEntry.isSymbolicLink() ||
-    !runnerEntry.isDirectory() ||
-    runnerEntry.uid !== uid ||
-    runnerEntry.gid !== gid ||
-    (runnerEntry.mode & 0o7022) !== 0
+    realIsolationRoot !== isolationRoot ||
+    isolationEntry.isSymbolicLink() ||
+    !isolationEntry.isDirectory() ||
+    isolationEntry.uid !== uid ||
+    isolationEntry.gid !== gid ||
+    (isolationEntry.mode & 0o7777) !== 0o711
   ) {
-    throw new Error("Runner temporary directory is not protected");
+    throw new Error("Vercel isolation root is not protected");
   }
   if (
     basename(path) !== expectedName ||
-    realpathSync(dirname(path)) !== realRunnerTemp
+    realpathSync(dirname(path)) !== realIsolationRoot
   ) {
-    throw new Error("Isolated path is not the expected RUNNER_TEMP child");
+    throw new Error("Isolated path is not the expected isolation-root child");
   }
-  return join(realRunnerTemp, expectedName);
+  return join(realIsolationRoot, expectedName);
 }
 
 function rawGitEnvironment() {
@@ -682,7 +683,7 @@ function ensureMaterializedParent(root, components) {
 }
 
 export function materializeExactGitTree({
-  runnerTemp,
+  isolationRoot,
   sourceRoot,
   candidateRoot,
   commitSha,
@@ -699,8 +700,8 @@ export function materializeExactGitTree({
   if (!sourceEntry.isDirectory()) {
     throw new Error("Exact Git source must be a real directory");
   }
-  const canonicalCandidateRoot = assertRunnerTempChild({
-    runnerTemp,
+  const canonicalCandidateRoot = assertIsolationRootChild({
+    isolationRoot,
     path: candidateRoot,
     expectedName: CANDIDATE_SOURCE_DIRECTORY,
     expectedUid,
@@ -894,15 +895,15 @@ function assertExactPulledConfiguration({
 }
 
 export function prepareVercelPullStaging({
-  runnerTemp,
+  isolationRoot,
   stagingRoot,
   expectedRootDirectory,
   vercelOrgId,
   vercelProjectId,
 }) {
   pilotRootDirectory(expectedRootDirectory);
-  const canonicalStagingRoot = assertRunnerTempChild({
-    runnerTemp,
+  const canonicalStagingRoot = assertIsolationRootChild({
+    isolationRoot,
     path: stagingRoot,
     expectedName: PULL_STAGING_DIRECTORY,
   });
@@ -927,7 +928,7 @@ export function prepareVercelPullStaging({
 }
 
 export function assertVercelPullStaging({
-  runnerTemp,
+  isolationRoot,
   stagingRoot,
   expectedRootDirectory,
   vercelOrgId,
@@ -936,15 +937,15 @@ export function assertVercelPullStaging({
   expectedGid = process.getgid?.(),
 }) {
   pilotRootDirectory(expectedRootDirectory);
-  const canonicalStagingRoot = assertRunnerTempChild({
-    runnerTemp,
+  const canonicalStagingRoot = assertIsolationRootChild({
+    isolationRoot,
     path: stagingRoot,
     expectedName: PULL_STAGING_DIRECTORY,
     expectedUid,
     expectedGid,
   });
   if (realpathSync(stagingRoot) !== canonicalStagingRoot) {
-    throw new Error("Vercel pull staging resolves outside RUNNER_TEMP");
+    throw new Error("Vercel pull staging resolves outside the isolation root");
   }
   assertExactFilesystemTree(
     canonicalStagingRoot,
@@ -964,7 +965,7 @@ export function assertVercelPullStaging({
 }
 
 function assertCandidateRootComponents({
-  runnerTemp,
+  isolationRoot,
   candidateRoot,
   expectedRootDirectory,
   buildUid,
@@ -972,15 +973,15 @@ function assertCandidateRootComponents({
   runnerUid,
   runnerGid,
 }) {
-  const canonicalCandidateRoot = assertRunnerTempChild({
-    runnerTemp,
+  const canonicalCandidateRoot = assertIsolationRootChild({
+    isolationRoot,
     path: candidateRoot,
     expectedName: CANDIDATE_SOURCE_DIRECTORY,
     expectedUid: runnerUid,
     expectedGid: runnerGid,
   });
   if (realpathSync(candidateRoot) !== canonicalCandidateRoot) {
-    throw new Error("Candidate source resolves outside RUNNER_TEMP");
+    throw new Error("Candidate source resolves outside the isolation root");
   }
   let current = canonicalCandidateRoot;
   for (const [path, label] of [
@@ -1004,7 +1005,7 @@ function assertCandidateRootComponents({
 }
 
 function assertCandidateVercelPull({
-  runnerTemp,
+  isolationRoot,
   candidateRoot,
   expectedRootDirectory,
   vercelOrgId,
@@ -1019,7 +1020,7 @@ function assertCandidateVercelPull({
   const trustedUid = numericIdentity(runnerUid, "Runner UID");
   const trustedGid = numericIdentity(runnerGid, "Runner GID");
   const canonicalCandidateRoot = assertCandidateRootComponents({
-    runnerTemp,
+    isolationRoot,
     candidateRoot,
     expectedRootDirectory,
     buildUid: candidateUid,
@@ -1043,7 +1044,7 @@ function assertCandidateVercelPull({
 }
 
 export function stageVercelPullForCandidate({
-  runnerTemp,
+  isolationRoot,
   stagingRoot,
   candidateRoot,
   expectedRootDirectory,
@@ -1059,7 +1060,7 @@ export function stageVercelPullForCandidate({
   const trustedUid = numericIdentity(runnerUid, "Runner UID");
   const trustedGid = numericIdentity(runnerGid, "Runner GID");
   assertVercelPullStaging({
-    runnerTemp,
+    isolationRoot,
     stagingRoot,
     expectedRootDirectory,
     vercelOrgId,
@@ -1068,7 +1069,7 @@ export function stageVercelPullForCandidate({
     expectedGid: trustedGid,
   });
   const canonicalCandidateRoot = assertCandidateRootComponents({
-    runnerTemp,
+    isolationRoot,
     candidateRoot,
     expectedRootDirectory,
     buildUid: candidateUid,
@@ -1110,7 +1111,7 @@ export function stageVercelPullForCandidate({
     chmodSync(destination, 0o600);
   }
   return assertCandidateVercelPull({
-    runnerTemp,
+    isolationRoot,
     candidateRoot: canonicalCandidateRoot,
     expectedRootDirectory,
     vercelOrgId,
@@ -1281,7 +1282,7 @@ function validatePinnedPnpmBootstrapFiles({ packageJsonPath, lockfilePath }) {
 
 export function stageTrustedPnpmBootstrapManifest({
   controllerRoot,
-  runnerTemp,
+  isolationRoot,
   bootstrapRoot,
   expectedUid = process.getuid?.(),
   expectedGid = process.getgid?.(),
@@ -1329,8 +1330,8 @@ export function stageTrustedPnpmBootstrapManifest({
     lockfilePath: sourceLockfile.path,
   });
 
-  const canonicalBootstrapRoot = assertRunnerTempChild({
-    runnerTemp,
+  const canonicalBootstrapRoot = assertIsolationRootChild({
+    isolationRoot,
     path: bootstrapRoot,
     expectedName: PNPM_BOOTSTRAP_DIRECTORY,
     expectedUid: uid,
@@ -1384,7 +1385,7 @@ export function stageTrustedPnpmBootstrapManifest({
 }
 
 function resolvePinnedPnpmBootstrapExecutable({
-  runnerTemp,
+  isolationRoot,
   pnpmRoot,
   expectedUid = process.getuid?.(),
   expectedGid = process.getgid?.(),
@@ -1392,8 +1393,8 @@ function resolvePinnedPnpmBootstrapExecutable({
 }) {
   const uid = numericIdentity(expectedUid, "Expected runner UID");
   const gid = numericIdentity(expectedGid, "Expected runner GID");
-  const canonicalPnpmRoot = assertRunnerTempChild({
-    runnerTemp,
+  const canonicalPnpmRoot = assertIsolationRootChild({
+    isolationRoot,
     path: pnpmRoot,
     expectedName: PNPM_BOOTSTRAP_DIRECTORY,
     expectedUid: uid,
@@ -1480,7 +1481,7 @@ function resolvePinnedPnpmBootstrapExecutable({
 }
 
 export function stageTrustedRuntime({
-  runnerTemp,
+  isolationRoot,
   toolsRoot,
   nodeSource,
   pnpmRoot,
@@ -1490,8 +1491,8 @@ export function stageTrustedRuntime({
 }) {
   const uid = numericIdentity(expectedUid, "Expected runner UID");
   const gid = numericIdentity(expectedGid, "Expected runner GID");
-  const canonicalToolsRoot = assertRunnerTempChild({
-    runnerTemp,
+  const canonicalToolsRoot = assertIsolationRootChild({
+    isolationRoot,
     path: toolsRoot,
     expectedName: TRUSTED_TOOLS_DIRECTORY,
     expectedUid: uid,
@@ -1502,7 +1503,7 @@ export function stageTrustedRuntime({
   }
 
   const pnpmExecutable = resolvePinnedPnpmBootstrapExecutable({
-    runnerTemp,
+    isolationRoot,
     pnpmRoot,
     expectedUid: uid,
     expectedGid: gid,
@@ -2853,7 +2854,7 @@ function validateSourceFromEnvironment() {
 
 function materializeSourceFromEnvironment() {
   materializeExactGitTree({
-    runnerTemp: process.env.RUNNER_TEMP,
+    isolationRoot: process.env.VERCEL_ISOLATION_ROOT,
     sourceRoot: process.env.SOURCE_PATH,
     candidateRoot: process.env.CANDIDATE_SOURCE_PATH,
     commitSha: process.env.DEPLOY_SHA,
@@ -2880,7 +2881,7 @@ function prepareLinkFromEnvironment() {
 
 function preparePullStagingFromEnvironment() {
   prepareVercelPullStaging({
-    runnerTemp: process.env.RUNNER_TEMP,
+    isolationRoot: process.env.VERCEL_ISOLATION_ROOT,
     stagingRoot: process.env.PULL_STAGING_PATH,
     expectedRootDirectory: process.env.EXPECTED_ROOT_DIRECTORY,
     vercelOrgId: process.env.VERCEL_ORG_ID,
@@ -2890,7 +2891,7 @@ function preparePullStagingFromEnvironment() {
 
 function validatePullStagingFromEnvironment() {
   assertVercelPullStaging({
-    runnerTemp: process.env.RUNNER_TEMP,
+    isolationRoot: process.env.VERCEL_ISOLATION_ROOT,
     stagingRoot: process.env.PULL_STAGING_PATH,
     expectedRootDirectory: process.env.EXPECTED_ROOT_DIRECTORY,
     vercelOrgId: process.env.VERCEL_ORG_ID,
@@ -2902,7 +2903,7 @@ function validatePullStagingFromEnvironment() {
 
 function stagePullFromEnvironment() {
   stageVercelPullForCandidate({
-    runnerTemp: process.env.RUNNER_TEMP,
+    isolationRoot: process.env.VERCEL_ISOLATION_ROOT,
     stagingRoot: process.env.PULL_STAGING_PATH,
     candidateRoot: process.env.CANDIDATE_SOURCE_PATH,
     expectedRootDirectory: process.env.EXPECTED_ROOT_DIRECTORY,
@@ -2917,7 +2918,7 @@ function stagePullFromEnvironment() {
 
 function validateCandidatePullFromEnvironment() {
   assertCandidateVercelPull({
-    runnerTemp: process.env.RUNNER_TEMP,
+    isolationRoot: process.env.VERCEL_ISOLATION_ROOT,
     candidateRoot: process.env.CANDIDATE_SOURCE_PATH,
     expectedRootDirectory: process.env.EXPECTED_ROOT_DIRECTORY,
     vercelOrgId: process.env.VERCEL_ORG_ID,
@@ -2946,7 +2947,7 @@ function buildFromEnvironment() {
     "EXPECTED_ROOT_DIRECTORY",
     "PULL_STAGING_GID",
     "PULL_STAGING_UID",
-    "RUNNER_TEMP",
+    "VERCEL_ISOLATION_ROOT",
     "SOURCE_PATH",
     "TURBO_TEAM",
     "TURBO_TOKEN",
@@ -2965,7 +2966,7 @@ function buildFromEnvironment() {
     process.env.PULL_STAGING_UID,
   );
   assertCandidateVercelPull({
-    runnerTemp: process.env.RUNNER_TEMP,
+    isolationRoot: process.env.VERCEL_ISOLATION_ROOT,
     candidateRoot: process.env.SOURCE_PATH,
     expectedRootDirectory: process.env.EXPECTED_ROOT_DIRECTORY,
     vercelOrgId: process.env.VERCEL_ORG_ID,
@@ -3089,7 +3090,7 @@ function totalFromEnvironment() {
 
 function stageTrustedRuntimeFromEnvironment() {
   stageTrustedRuntime({
-    runnerTemp: process.env.RUNNER_TEMP,
+    isolationRoot: process.env.VERCEL_ISOLATION_ROOT,
     toolsRoot: process.env.TRUSTED_VERCEL_TOOLS_PATH,
     nodeSource: process.env.NODE_SOURCE_PATH,
     pnpmRoot: process.env.PNPM_BOOTSTRAP_PATH,
@@ -3100,7 +3101,7 @@ function stageTrustedPnpmBootstrapManifestFromEnvironment() {
   process.stdout.write(
     `${stageTrustedPnpmBootstrapManifest({
       controllerRoot: process.env.CONTROLLER_PATH,
-      runnerTemp: process.env.RUNNER_TEMP,
+      isolationRoot: process.env.VERCEL_ISOLATION_ROOT,
       bootstrapRoot: process.env.PNPM_BOOTSTRAP_PATH,
     })}\n`,
   );

--- a/scripts/vercel-prebuilt-workflow.test.mjs
+++ b/scripts/vercel-prebuilt-workflow.test.mjs
@@ -180,14 +180,17 @@ function pilotContract(overrides = {}) {
 }
 
 function pulledStagingFixture() {
-  const runnerTemp = mkdtempSync(join(tmpdir(), "vercel-pull-runner-"));
-  const stagingRoot = join(runnerTemp, "mento-vercel-pull-staging");
-  const candidateRoot = join(runnerTemp, "mento-vercel-candidate-source");
+  const isolationRoot = realpathSync(
+    mkdtempSync(join(tmpdir(), "vercel-pull-runner-")),
+  );
+  const stagingRoot = join(isolationRoot, "mento-vercel-pull-staging");
+  const candidateRoot = join(isolationRoot, "mento-vercel-candidate-source");
   const vercelOrgId = "team_example";
   const vercelProjectId = "prj_ui";
   const expectedRootDirectory = PILOT_TARGET.expectedRootDirectory;
+  chmodSync(isolationRoot, 0o711);
   prepareVercelPullStaging({
-    runnerTemp,
+    isolationRoot,
     stagingRoot,
     expectedRootDirectory,
     vercelOrgId,
@@ -206,7 +209,7 @@ function pulledStagingFixture() {
     { mode: 0o600 },
   );
   return {
-    runnerTemp,
+    isolationRoot,
     stagingRoot,
     candidateRoot,
     appState,
@@ -214,14 +217,14 @@ function pulledStagingFixture() {
     vercelOrgId,
     vercelProjectId,
     options: {
-      runnerTemp,
+      isolationRoot,
       stagingRoot,
       expectedRootDirectory,
       vercelOrgId,
       vercelProjectId,
     },
     cleanup() {
-      rmSync(runnerTemp, { force: true, recursive: true });
+      rmSync(isolationRoot, { force: true, recursive: true });
     },
   };
 }
@@ -988,7 +991,7 @@ test("Vercel CLI receives the repo link instead of ID variables that override it
   );
 });
 
-test("Vercel pull staging is a fresh exact runner-temp tree", () => {
+test("Vercel pull staging is a fresh exact isolation-root tree", () => {
   const fixture = pulledStagingFixture();
   try {
     assert.equal(
@@ -1008,9 +1011,9 @@ test("Vercel pull staging is a fresh exact runner-temp tree", () => {
       () =>
         prepareVercelPullStaging({
           ...fixture.options,
-          stagingRoot: join(fixture.runnerTemp, "candidate-selected"),
+          stagingRoot: join(fixture.isolationRoot, "candidate-selected"),
         }),
-      /expected RUNNER_TEMP child/,
+      /expected isolation-root child/,
     );
   } finally {
     fixture.cleanup();
@@ -1021,7 +1024,7 @@ test("UI preview environment validation reads only trusted pull staging", () => 
   const fixture = pulledStagingFixture();
   try {
     const canonicalProject = join(
-      fixture.runnerTemp,
+      fixture.isolationRoot,
       "source",
       fixture.expectedRootDirectory,
     );
@@ -1077,7 +1080,7 @@ test("Vercel pull staging rejects links, hardlinks, special files, and unsafe st
       name: "repo link symlink",
       mutate: (fixture) => {
         const path = join(fixture.stagingRoot, ".vercel", "repo.json");
-        const outside = join(fixture.runnerTemp, "outside-repo.json");
+        const outside = join(fixture.isolationRoot, "outside-repo.json");
         writeFileSync(outside, "untouched");
         rmSync(path);
         symlinkSync(outside, path);
@@ -1086,7 +1089,7 @@ test("Vercel pull staging rejects links, hardlinks, special files, and unsafe st
     {
       name: "app Vercel directory symlink",
       mutate: (fixture) => {
-        const outside = join(fixture.runnerTemp, "outside-state");
+        const outside = join(fixture.isolationRoot, "outside-state");
         mkdirSync(outside);
         rmSync(fixture.appState, { recursive: true });
         symlinkSync(outside, fixture.appState);
@@ -1096,7 +1099,7 @@ test("Vercel pull staging rejects links, hardlinks, special files, and unsafe st
       name: `${name} symlink`,
       mutate: (fixture) => {
         const path = join(fixture.appState, name);
-        const outside = join(fixture.runnerTemp, `outside-${name}`);
+        const outside = join(fixture.isolationRoot, `outside-${name}`);
         writeFileSync(outside, "untouched");
         rmSync(path);
         symlinkSync(outside, path);
@@ -1188,7 +1191,10 @@ test("candidate Vercel links cannot redirect trusted pulled-state copies", () =>
         fixture.expectedRootDirectory,
       );
       mkdirSync(appRoot, { recursive: true });
-      const outsideDirectory = join(fixture.runnerTemp, "trusted-controller");
+      const outsideDirectory = join(
+        fixture.isolationRoot,
+        "trusted-controller",
+      );
       const sentinelPath = join(outsideDirectory, "sentinel.txt");
       mkdirSync(outsideDirectory);
       writeFileSync(sentinelPath, "untouched", { mode: 0o600 });
@@ -1227,7 +1233,7 @@ test("candidate Vercel links cannot redirect trusted pulled-state copies", () =>
   }
 });
 
-test("candidate staging rejects a source root that escapes RUNNER_TEMP", () => {
+test("candidate staging rejects a source root that escapes the isolation root", () => {
   const fixture = pulledStagingFixture();
   const outside = mkdtempSync(join(tmpdir(), "vercel-candidate-outside-"));
   try {
@@ -1274,9 +1280,11 @@ test("candidate staging rejects source components with the wrong owner", () => {
 
 test("trusted runtime copies hosted Node and the authenticated Linux pnpm bootstrap into independent protected files", () => {
   const sourceRoot = mkdtempSync(join(tmpdir(), "vercel-runtime-source-"));
-  const runnerTemp = mkdtempSync(join(tmpdir(), "vercel-runtime-runner-"));
-  const toolsRoot = join(runnerTemp, "mento-vercel-trusted-tools");
-  const pnpmRoot = join(runnerTemp, "mento-vercel-pnpm-bootstrap");
+  const isolationRoot = realpathSync(
+    mkdtempSync(join(tmpdir(), "vercel-runtime-runner-")),
+  );
+  const toolsRoot = join(isolationRoot, "mento-vercel-trusted-tools");
+  const pnpmRoot = join(isolationRoot, "mento-vercel-pnpm-bootstrap");
   const nodeSource = join(sourceRoot, "node");
   const pnpmPackageRoot = join(pnpmRoot, "node_modules", "@pnpm", "linux-x64");
   const pnpmExecutable = join(pnpmPackageRoot, "pnpm");
@@ -1295,7 +1303,7 @@ test("trusted runtime copies hosted Node and the authenticated Linux pnpm bootst
     .digest("hex");
   try {
     chmodSync(sourceRoot, 0o777);
-    chmodSync(runnerTemp, 0o711);
+    chmodSync(isolationRoot, 0o711);
     writeFileSync(nodeSource, nodeContents, { mode: 0o777 });
     mkdirSync(pnpmPackageRoot, { recursive: true });
     for (const file of ["package.json", "package-lock.json"]) {
@@ -1322,14 +1330,14 @@ test("trusted runtime copies hosted Node and the authenticated Linux pnpm bootst
     assert.equal(lstatSync(pnpmExecutable).nlink, 1);
 
     const staged = stageTrustedRuntime({
-      runnerTemp,
+      isolationRoot,
       toolsRoot,
       nodeSource,
       pnpmRoot,
       expectedPnpmSha256,
     });
     const canonicalToolsRoot = join(
-      realpathSync(runnerTemp),
+      realpathSync(isolationRoot),
       "mento-vercel-trusted-tools",
     );
     assert.deepEqual(staged, {
@@ -1378,7 +1386,7 @@ test("trusted runtime copies hosted Node and the authenticated Linux pnpm bootst
     assert.throws(
       () =>
         stageTrustedRuntime({
-          runnerTemp,
+          isolationRoot,
           toolsRoot,
           nodeSource,
           pnpmRoot,
@@ -1392,7 +1400,7 @@ test("trusted runtime copies hosted Node and the authenticated Linux pnpm bootst
     assert.throws(
       () =>
         stageTrustedRuntime({
-          runnerTemp,
+          isolationRoot,
           toolsRoot,
           nodeSource,
           pnpmRoot,
@@ -1401,33 +1409,35 @@ test("trusted runtime copies hosted Node and the authenticated Linux pnpm bootst
       /destination must be fresh/,
     );
     rmSync(toolsRoot, { force: true });
-    chmodSync(runnerTemp, 0o777);
+    chmodSync(isolationRoot, 0o777);
     assert.throws(
       () =>
         stageTrustedRuntime({
-          runnerTemp,
+          isolationRoot,
           toolsRoot,
           nodeSource,
           pnpmRoot,
           expectedPnpmSha256,
         }),
-      /Runner temporary directory is not protected/,
+      /Vercel isolation root is not protected/,
     );
   } finally {
     rmSync(sourceRoot, { force: true, recursive: true });
-    rmSync(runnerTemp, { force: true, recursive: true });
+    rmSync(isolationRoot, { force: true, recursive: true });
   }
 });
 
 test("trusted pnpm bootstrap manifest and npm lock are exact before network installation", () => {
-  const fixtureRoot = mkdtempSync(join(tmpdir(), "vercel-pnpm-bootstrap-"));
+  const fixtureRoot = realpathSync(
+    mkdtempSync(join(tmpdir(), "vercel-pnpm-bootstrap-")),
+  );
   const controllerRoot = join(fixtureRoot, "controller");
   const sourceRoot = join(controllerRoot, "scripts", "vercel-pnpm-bootstrap");
-  const runnerTemp = join(fixtureRoot, "runner-temp");
-  const bootstrapRoot = join(runnerTemp, "mento-vercel-pnpm-bootstrap");
+  const isolationRoot = join(fixtureRoot, "isolation-root");
+  const bootstrapRoot = join(isolationRoot, "mento-vercel-pnpm-bootstrap");
   try {
     mkdirSync(sourceRoot, { recursive: true });
-    mkdirSync(runnerTemp, { mode: 0o711 });
+    mkdirSync(isolationRoot, { mode: 0o711 });
     for (const file of ["package.json", "package-lock.json"]) {
       copyFileSync(
         join(REPOSITORY_ROOT, "scripts", "vercel-pnpm-bootstrap", file),
@@ -1446,10 +1456,10 @@ test("trusted pnpm bootstrap manifest and npm lock are exact before network inst
     assert.equal(
       stageTrustedPnpmBootstrapManifest({
         controllerRoot,
-        runnerTemp,
+        isolationRoot,
         bootstrapRoot,
       }),
-      join(realpathSync(runnerTemp), "mento-vercel-pnpm-bootstrap"),
+      join(realpathSync(isolationRoot), "mento-vercel-pnpm-bootstrap"),
     );
     assert.equal(lstatSync(bootstrapRoot).mode & 0o777, 0o700);
     for (const file of ["package.json", "package-lock.json"]) {
@@ -1466,7 +1476,7 @@ test("trusted pnpm bootstrap manifest and npm lock are exact before network inst
       () =>
         stageTrustedPnpmBootstrapManifest({
           controllerRoot,
-          runnerTemp,
+          isolationRoot,
           bootstrapRoot,
         }),
       /destination must be fresh/,
@@ -1483,7 +1493,7 @@ test("trusted pnpm bootstrap manifest and npm lock are exact before network inst
       () =>
         stageTrustedPnpmBootstrapManifest({
           controllerRoot,
-          runnerTemp,
+          isolationRoot,
           bootstrapRoot,
         }),
       /manifest is not exact/,
@@ -1509,7 +1519,7 @@ test("trusted pnpm bootstrap manifest and npm lock are exact before network inst
       () =>
         stageTrustedPnpmBootstrapManifest({
           controllerRoot,
-          runnerTemp,
+          isolationRoot,
           bootstrapRoot,
         }),
       /lockfile is not exact/,
@@ -1771,10 +1781,12 @@ test("trusted candidate pnpm launcher uses the lockfile-pinned JavaScript packag
 });
 
 test("trusted runtime rejects missing, malformed, digest-drifted, and hardlinked pnpm bootstrap targets", () => {
-  const runnerTemp = mkdtempSync(join(tmpdir(), "vercel-runtime-runner-"));
-  const toolsRoot = join(runnerTemp, "mento-vercel-trusted-tools");
-  const pnpmRoot = join(runnerTemp, "mento-vercel-pnpm-bootstrap");
-  const nodeSource = join(runnerTemp, "node");
+  const isolationRoot = realpathSync(
+    mkdtempSync(join(tmpdir(), "vercel-runtime-runner-")),
+  );
+  const toolsRoot = join(isolationRoot, "mento-vercel-trusted-tools");
+  const pnpmRoot = join(isolationRoot, "mento-vercel-pnpm-bootstrap");
+  const nodeSource = join(isolationRoot, "node");
   const pnpmExecutable = join(
     pnpmRoot,
     "node_modules",
@@ -1789,14 +1801,14 @@ test("trusted runtime rejects missing, malformed, digest-drifted, and hardlinked
     .digest("hex");
   const stage = (digest = expectedPnpmSha256) =>
     stageTrustedRuntime({
-      runnerTemp,
+      isolationRoot,
       toolsRoot,
       nodeSource,
       pnpmRoot,
       expectedPnpmSha256: digest,
     });
   try {
-    chmodSync(runnerTemp, 0o711);
+    chmodSync(isolationRoot, 0o711);
     writeFileSync(nodeSource, "#!/bin/sh\necho node\n", { mode: 0o555 });
     mkdirSync(pnpmRoot, { recursive: true });
     for (const file of ["package.json", "package-lock.json"]) {
@@ -1843,7 +1855,7 @@ test("trusted runtime rejects missing, malformed, digest-drifted, and hardlinked
     chmodSync(pnpmPackageJson, 0o444);
     assert.throws(() => stage("0".repeat(64)), /executable digest is invalid/);
 
-    const hardlinkSource = join(runnerTemp, "hardlinked-pnpm");
+    const hardlinkSource = join(isolationRoot, "hardlinked-pnpm");
     chmodSync(pnpmExecutable, 0o755);
     rmSync(pnpmExecutable);
     writeFileSync(hardlinkSource, executableContents, { mode: 0o555 });
@@ -1851,19 +1863,21 @@ test("trusted runtime rejects missing, malformed, digest-drifted, and hardlinked
     assert.equal(lstatSync(pnpmExecutable).nlink, 2);
     assert.throws(stage, /runner-owned/);
   } finally {
-    rmSync(runnerTemp, { force: true, recursive: true });
+    rmSync(isolationRoot, { force: true, recursive: true });
   }
 });
 
 test("trusted runtime rejects a pnpm bootstrap package link outside its fixed root", () => {
-  const runnerTemp = mkdtempSync(join(tmpdir(), "vercel-runtime-runner-"));
+  const isolationRoot = realpathSync(
+    mkdtempSync(join(tmpdir(), "vercel-runtime-runner-")),
+  );
   const outsideRoot = mkdtempSync(join(tmpdir(), "vercel-runtime-outside-"));
-  const toolsRoot = join(runnerTemp, "mento-vercel-trusted-tools");
-  const pnpmRoot = join(runnerTemp, "mento-vercel-pnpm-bootstrap");
-  const nodeSource = join(runnerTemp, "node");
+  const toolsRoot = join(isolationRoot, "mento-vercel-trusted-tools");
+  const pnpmRoot = join(isolationRoot, "mento-vercel-pnpm-bootstrap");
+  const nodeSource = join(isolationRoot, "node");
   const packageLink = join(pnpmRoot, "node_modules", "@pnpm", "linux-x64");
   try {
-    chmodSync(runnerTemp, 0o711);
+    chmodSync(isolationRoot, 0o711);
     writeFileSync(nodeSource, "#!/bin/sh\necho node\n", { mode: 0o555 });
     mkdirSync(dirname(packageLink), { recursive: true });
     for (const file of ["package.json", "package-lock.json"]) {
@@ -1894,7 +1908,7 @@ test("trusted runtime rejects a pnpm bootstrap package link outside its fixed ro
     assert.throws(
       () =>
         stageTrustedRuntime({
-          runnerTemp,
+          isolationRoot,
           toolsRoot,
           nodeSource,
           pnpmRoot,
@@ -1903,7 +1917,7 @@ test("trusted runtime rejects a pnpm bootstrap package link outside its fixed ro
     );
   } finally {
     rmSync(outsideRoot, { force: true, recursive: true });
-    rmSync(runnerTemp, { force: true, recursive: true });
+    rmSync(isolationRoot, { force: true, recursive: true });
   }
 });
 
@@ -2027,13 +2041,15 @@ test(
 
 test("raw Git-object materialization bypasses archive and checkout filters", () => {
   const repository = mkdtempSync(join(tmpdir(), "vercel-raw-source-"));
-  const runnerTemp = mkdtempSync(join(tmpdir(), "vercel-raw-runner-"));
-  const candidate = join(runnerTemp, "mento-vercel-candidate-source");
+  const isolationRoot = realpathSync(
+    mkdtempSync(join(tmpdir(), "vercel-raw-runner-")),
+  );
+  const candidate = join(isolationRoot, "mento-vercel-candidate-source");
   const checkoutCandidate = mkdtempSync(
     join(tmpdir(), "vercel-filtered-candidate-"),
   );
   try {
-    chmodSync(runnerTemp, 0o700);
+    chmodSync(isolationRoot, 0o711);
     execFileSync("git", ["init", "--quiet"], { cwd: repository });
     writeFileSync(
       join(repository, ".gitattributes"),
@@ -2074,7 +2090,7 @@ test("raw Git-object materialization bypasses archive and checkout filters", () 
     }).trim();
 
     const result = materializeExactGitTree({
-      runnerTemp,
+      isolationRoot,
       sourceRoot: repository,
       candidateRoot: candidate,
       commitSha,
@@ -2127,7 +2143,7 @@ test("raw Git-object materialization bypasses archive and checkout filters", () 
     assert.throws(
       () =>
         materializeExactGitTree({
-          runnerTemp,
+          isolationRoot,
           sourceRoot: repository,
           candidateRoot: candidate,
           commitSha,
@@ -2136,17 +2152,19 @@ test("raw Git-object materialization bypasses archive and checkout filters", () 
     );
   } finally {
     rmSync(repository, { force: true, recursive: true });
-    rmSync(runnerTemp, { force: true, recursive: true });
+    rmSync(isolationRoot, { force: true, recursive: true });
     rmSync(checkoutCandidate, { force: true, recursive: true });
   }
 });
 
 test("raw Git-object materialization rejects gitlinks before writing", () => {
   const repository = mkdtempSync(join(tmpdir(), "vercel-gitlink-source-"));
-  const runnerTemp = mkdtempSync(join(tmpdir(), "vercel-gitlink-runner-"));
-  const candidate = join(runnerTemp, "mento-vercel-candidate-source");
+  const isolationRoot = realpathSync(
+    mkdtempSync(join(tmpdir(), "vercel-gitlink-runner-")),
+  );
+  const candidate = join(isolationRoot, "mento-vercel-candidate-source");
   try {
-    chmodSync(runnerTemp, 0o700);
+    chmodSync(isolationRoot, 0o711);
     execFileSync("git", ["init", "--quiet"], { cwd: repository });
     writeFileSync(join(repository, "plain.txt"), "plain\n");
     execFileSync("git", ["add", "."], { cwd: repository });
@@ -2197,7 +2215,7 @@ test("raw Git-object materialization rejects gitlinks before writing", () => {
     assert.throws(
       () =>
         materializeExactGitTree({
-          runnerTemp,
+          isolationRoot,
           sourceRoot: repository,
           candidateRoot: candidate,
           commitSha: gitlinkCommit,
@@ -2210,7 +2228,7 @@ test("raw Git-object materialization rejects gitlinks before writing", () => {
     );
   } finally {
     rmSync(repository, { force: true, recursive: true });
-    rmSync(runnerTemp, { force: true, recursive: true });
+    rmSync(isolationRoot, { force: true, recursive: true });
   }
 });
 
@@ -2228,6 +2246,10 @@ test("candidate execution is UID-isolated and hands upload to runner-owned state
   assert.match(raw, /Create immutable runner-owned upload handoff/);
   assert.match(raw, /mento-vercel-upload-source/);
   assert.match(raw, /mento-vercel-pnpm-bootstrap/);
+  assert.doesNotMatch(raw, /\$\{\{ runner\.temp \}\}\/mento-vercel-/);
+  assert.doesNotMatch(raw, /\$RUNNER_TEMP/);
+  assert.doesNotMatch(raw, /\bsetfacl\b/);
+  assert.doesNotMatch(raw, /chmod[^\n]*(?:\$HOME|\/home\/runner)/);
   assert.doesNotMatch(raw, /standalone: true/);
   assert.match(
     raw,
@@ -2251,9 +2273,38 @@ test("candidate execution is UID-isolated and hands upload to runner-owned state
   assert.match(raw, /userdel mento-vercel-build/);
   assert.match(raw, /node_modules\/vercel\/dist\/index\.js/);
   assert.match(raw, /candidate_can_write/);
+  const runtimeRootBlock = raw.slice(
+    raw.indexOf("- name: Create protected cross-identity runtime root"),
+    raw.indexOf("- name: Stage and authenticate pinned pnpm bootstrap"),
+  );
+  assert.match(
+    raw,
+    /VERCEL_RUNTIME_ROOT: \/var\/lib\/mento-vercel-runtime-\$\{\{ github\.run_id \}\}-\$\{\{ github\.run_attempt \}\}/,
+  );
+  assert.match(
+    raw,
+    /VERCEL_ISOLATION_ROOT: \/var\/lib\/mento-vercel-runtime-\$\{\{ github\.run_id \}\}-\$\{\{ github\.run_attempt \}\}\/work/,
+  );
+  assert.match(
+    runtimeRootBlock,
+    /for protected_ancestor in \/ \/var \/var\/lib/,
+  );
+  assert.match(runtimeRootBlock, /-o root \\\n\s+-g root \\\n\s+-m 0711/);
+  assert.match(
+    runtimeRootBlock,
+    /-o "\$\(\/usr\/bin\/id -u\)" \\\n\s+-g "\$\(\/usr\/bin\/id -g\)" \\\n\s+-m 0711/,
+  );
+  assert.match(runtimeRootBlock, /\/bin\/chmod 0400 "\$VERCEL_RUNTIME_MARKER"/);
+  assert.ok(
+    runtimeRootBlock.indexOf('/bin/chmod 0400 "$VERCEL_RUNTIME_MARKER"') <
+      runtimeRootBlock.indexOf("VERCEL_RUNTIME_ROOT_READY=1"),
+  );
   for (const protectedPath of [
+    "/var/lib",
+    "VERCEL_RUNTIME_ROOT",
+    "VERCEL_RUNTIME_MARKER",
+    "VERCEL_ISOLATION_ROOT",
     "GITHUB_WORKSPACE/controller",
-    "RUNNER_TEMP",
     "SOURCE_PATH/.git",
     "SOURCE_PATH/node_modules",
     "SOURCE_PATH/package.json",
@@ -2321,8 +2372,8 @@ test("candidate execution is UID-isolated and hands upload to runner-owned state
   );
   assert.match(isolationBlock, /trusted-install-modules-dir/);
   assert.match(isolationBlock, /--modules-dir "\$trusted_modules_dir"/);
-  const runnerTempHardenIndex = isolationBlock.indexOf(
-    '/bin/chmod 0711 "$RUNNER_TEMP"',
+  const isolationRootValidationIndex = isolationBlock.indexOf(
+    'stat -c %a "$VERCEL_ISOLATION_ROOT"',
   );
   const protectedStoreIndex = isolationBlock.indexOf(
     'trusted_pnpm_store="$("$pnpm_bootstrap" store path --silent)"',
@@ -2333,21 +2384,25 @@ test("candidate execution is UID-isolated and hands upload to runner-owned state
   const protectedPathLoopIndex = isolationBlock.indexOf(
     "for protected_path in \\",
   );
-  const runnerTempProtectionIndex = isolationBlock.indexOf(
-    '"$RUNNER_TEMP" \\',
+  const isolationRootProtectionIndex = isolationBlock.indexOf(
+    '"$VERCEL_ISOLATION_ROOT" \\',
     protectedPathLoopIndex,
+  );
+  const candidateRuntimeProbeIndex = isolationBlock.indexOf(
+    "candidate_pnpm_version",
   );
   const trustedPathIndex = isolationBlock.indexOf(
     `printf '%s\\n' "$trusted_bin_dir" >> "$GITHUB_PATH"`,
   );
   const materializeIndex = isolationBlock.indexOf("materialize-source");
-  assert.notEqual(runnerTempHardenIndex, -1);
-  assert.ok(protectedStoreIndex > runnerTempHardenIndex);
+  assert.notEqual(isolationRootValidationIndex, -1);
+  assert.ok(protectedStoreIndex > isolationRootValidationIndex);
   assert.ok(protectedPnpmRuntimeIndex > protectedStoreIndex);
   assert.ok(protectedLauncherIndex > protectedPnpmRuntimeIndex);
   assert.ok(protectedPathLoopIndex > protectedLauncherIndex);
-  assert.ok(runnerTempProtectionIndex > protectedPathLoopIndex);
-  assert.ok(trustedPathIndex > runnerTempProtectionIndex);
+  assert.ok(isolationRootProtectionIndex > protectedPathLoopIndex);
+  assert.ok(candidateRuntimeProbeIndex > isolationRootProtectionIndex);
+  assert.ok(trustedPathIndex > candidateRuntimeProbeIndex);
   assert.ok(materializeIndex > trustedPathIndex);
   assert.match(
     isolationBlock,
@@ -2497,7 +2552,7 @@ test("candidate execution is UID-isolated and hands upload to runner-owned state
   };
   assert.match(
     pullBlock,
-    /SOURCE_PATH: \$\{\{ runner\.temp \}\}\/mento-vercel-pull-staging/,
+    /SOURCE_PATH: \$\{\{ env\.VERCEL_ISOLATION_ROOT \}\}\/mento-vercel-pull-staging/,
   );
   assert.doesNotMatch(pullBlock, /github\.workspace.*source/);
   assertSinglePrivilegedControllerInvocation(stagePullBlock, "stage-pull");
@@ -2572,7 +2627,7 @@ test("candidate execution is UID-isolated and hands upload to runner-owned state
   assert.equal(raw.match(/vercel-build-environment\.mjs/g)?.length, 1);
   assert.match(
     environmentValidationBlock,
-    /PULL_STAGING_PATH: \$\{\{ runner\.temp \}\}\/mento-vercel-pull-staging/,
+    /PULL_STAGING_PATH: \$\{\{ env\.VERCEL_ISOLATION_ROOT \}\}\/mento-vercel-pull-staging/,
   );
   assert.match(
     environmentValidationBlock,
@@ -2607,6 +2662,10 @@ test("candidate execution is UID-isolated and hands upload to runner-owned state
       "GITHUB_STEP_SUMMARY",
       "NODE_OPTIONS",
       "RUNNER_TEMP",
+      "VERCEL_ISOLATION_ROOT",
+      "VERCEL_RUNTIME_MARKER",
+      "VERCEL_RUNTIME_ROOT",
+      "VERCEL_RUNTIME_ROOT_READY",
     ]) {
       assert.doesNotMatch(block, new RegExp(`\\n\\s+${name}=`));
     }
@@ -2615,6 +2674,34 @@ test("candidate execution is UID-isolated and hands upload to runner-owned state
   assert.doesNotMatch(installBlock, /--store-dir|PNPM_STORE/);
   assert.doesNotMatch(buildBlock, /\n\s+VERCEL_TOKEN:/);
   assert.doesNotMatch(buildBlock, /\n\s+VERCEL_TOKEN=/);
+  assert.doesNotMatch(handoffBlock, /userdel|groupdel/);
+  assert.match(handoffBlock, /--one-file-system/);
+  const cleanupBlock = raw.slice(
+    raw.indexOf("- name: Remove isolated build and upload state"),
+    raw.indexOf("\n  smoke:"),
+  );
+  assert.match(cleanupBlock, /VERCEL_RUNTIME_ROOT_READY:-/);
+  assert.match(cleanupBlock, /Unproven protected runtime root exists/);
+  assert.match(cleanupBlock, /CANDIDATE_IDENTITY_READY:-/);
+  assert.match(cleanupBlock, /CANDIDATE_IDENTITY_UID/);
+  assert.match(cleanupBlock, /CANDIDATE_IDENTITY_GID/);
+  assert.match(cleanupBlock, /assert_expected_path/g);
+  assert.doesNotMatch(cleanupBlock, /mento-vercel-\*\)/);
+  assert.match(cleanupBlock, /-rf \\\n\s+--one-file-system \\\n\s+--/);
+  assert.match(
+    cleanupBlock,
+    /sudo --non-interactive \/bin\/rmdir "\$VERCEL_ISOLATION_ROOT"/,
+  );
+  assert.match(
+    cleanupBlock,
+    /sudo --non-interactive \/bin\/rmdir "\$VERCEL_RUNTIME_ROOT"/,
+  );
+  assert.match(cleanupBlock, /Protected runtime root survived cleanup/);
+  assert.match(cleanupBlock, /Candidate identity survived cleanup/);
+  assert.ok(
+    cleanupBlock.indexOf('/bin/rmdir "$VERCEL_RUNTIME_ROOT"') <
+      cleanupBlock.indexOf("userdel mento-vercel-build"),
+  );
   assert.ok(
     buildBlock.indexOf("pkill -KILL -u") <
       buildBlock.indexOf("build_duration_ms="),

--- a/scripts/vercel-prebuilt-workflows.test.mjs
+++ b/scripts/vercel-prebuilt-workflows.test.mjs
@@ -188,9 +188,10 @@ test("exact source, build, and upload remain in one standard-runner job", () => 
 
 test("prebuilt authenticates a locked Linux pnpm binary before cache or candidate execution", () => {
   const reusable = workflow(reusablePath);
+  const prebuilt = reusable.jobs.prebuilt;
   const supplyChain = workflow(".github/workflows/supply-chain.yml");
   const trunk = workflow(".trunk/trunk.yaml");
-  const steps = reusable.jobs.prebuilt.steps;
+  const steps = prebuilt.steps;
   const names = steps.map(({ name }) => name);
   const manifest = JSON.parse(read("package.json"));
   const bootstrapManifest = JSON.parse(
@@ -208,6 +209,9 @@ test("prebuilt authenticates a locked Linux pnpm binary before cache or candidat
   const nodeSetup = steps.find(
     ({ name }) =>
       name === "Set up pinned Node.js without package-manager cache",
+  );
+  const runtimeRootSetup = steps.find(
+    ({ name }) => name === "Create protected cross-identity runtime root",
   );
   const bootstrap = steps.find(
     ({ name }) => name === "Stage and authenticate pinned pnpm bootstrap",
@@ -318,8 +322,25 @@ test("prebuilt authenticates a locked Linux pnpm binary before cache or candidat
   assert.equal(nodeSetup.with["package-manager-cache"], false);
   assert.equal(nodeSetup.with.cache, undefined);
   assert.equal(
+    prebuilt.env.VERCEL_RUNTIME_ROOT,
+    "/var/lib/mento-vercel-runtime-${{ github.run_id }}-${{ github.run_attempt }}",
+  );
+  assert.equal(
+    prebuilt.env.VERCEL_ISOLATION_ROOT,
+    "/var/lib/mento-vercel-runtime-${{ github.run_id }}-${{ github.run_attempt }}/work",
+  );
+  assert.equal(
+    prebuilt.env.VERCEL_RUNTIME_MARKER,
+    "/var/lib/mento-vercel-runtime-${{ github.run_id }}-${{ github.run_attempt }}/.mento-vercel-runtime",
+  );
+  assert.match(
+    runtimeRootSetup.run,
+    /for protected_ancestor in \/ \/var \/var\/lib/,
+  );
+  assert.match(runtimeRootSetup.run, /VERCEL_RUNTIME_ROOT_READY=1/);
+  assert.equal(
     bootstrap.env.PNPM_BOOTSTRAP_PATH,
-    "${{ runner.temp }}/mento-vercel-pnpm-bootstrap",
+    "${{ env.VERCEL_ISOLATION_ROOT }}/mento-vercel-pnpm-bootstrap",
   );
   assert.match(bootstrap.run, /stage-pnpm-bootstrap/);
   assert.match(bootstrap.run, /"\$setup_node_bin" "\$npm_cli" ci/);
@@ -409,6 +430,11 @@ test("prebuilt authenticates a locked Linux pnpm binary before cache or candidat
   );
   assert.match(isolation.run, /"\$pnpm_bootstrap" \\/);
   assert.match(isolation.run, /"\$pnpm_bin"; do/);
+  assert.match(isolation.run, /candidate_pnpm_version/);
+  assert.match(
+    isolation.run,
+    /Candidate cannot execute the protected runtime through its isolation ancestors/,
+  );
   assert.match(install.run, /\/usr\/bin\/setpriv/);
   assert.match(install.run, /NPM_CONFIG_MANAGE_PACKAGE_MANAGER_VERSIONS=false/);
   assert.match(install.run, /NPM_CONFIG_PACKAGE_MANAGER_STRICT_VERSION=false/);
@@ -416,11 +442,15 @@ test("prebuilt authenticates a locked Linux pnpm binary before cache or candidat
   assert.match(install.run, /\/usr\/bin\/grep -Fxq "10\.34\.4"/);
   assert.equal(
     cleanup.env.PNPM_BOOTSTRAP_PATH,
-    "${{ runner.temp }}/mento-vercel-pnpm-bootstrap",
+    "${{ env.VERCEL_ISOLATION_ROOT }}/mento-vercel-pnpm-bootstrap",
   );
   assert.match(cleanup.run, /"\$PNPM_BOOTSTRAP_PATH" \\/);
   assert.ok(
     names.indexOf("Set up pinned Node.js without package-manager cache") <
+      names.indexOf("Create protected cross-identity runtime root"),
+  );
+  assert.ok(
+    names.indexOf("Create protected cross-identity runtime root") <
       names.indexOf("Stage and authenticate pinned pnpm bootstrap"),
   );
   assert.ok(
@@ -528,7 +558,7 @@ test("monorepo CLI and trusted env validation use their exact roots", () => {
   assert.equal(environmentValidation["working-directory"], undefined);
   assert.equal(
     environmentValidation.env.PULL_STAGING_PATH,
-    "${{ runner.temp }}/mento-vercel-pull-staging",
+    "${{ env.VERCEL_ISOLATION_ROOT }}/mento-vercel-pull-staging",
   );
   assert.match(
     environmentValidation.run,


### PR DESCRIPTION
## The Problem

The immutable UI pilot authenticated and staged the pinned pnpm launcher correctly, but the dedicated candidate UID could not traverse the runner-home ancestors above `RUNNER_TEMP`. The hosted install therefore failed before candidate dependencies with `cannot open .../bin/pnpm: Permission denied`.

The credentialed pilot is intentionally hard-pinned to `main`, so this repair must preserve that trust boundary and be validated with an immediate post-merge hosted pilot before any preview ownership cutover.

## The Solution

- create a run-scoped root-owned runtime boundary under `/var/lib`, with an exact root-owned run marker and a runner-owned `0711` work directory
- place every trusted, candidate, pull, and upload staging path beneath that non-replaceable boundary
- prove the candidate UID cannot write the protected ancestors or runtime state and can execute the protected pnpm launcher before selected source is materialized
- make cleanup readiness- and identity-gated, validate exact paths/ownership/modes, kill candidate processes, remove only known state without crossing filesystems, and prove the runtime root and candidate identity are gone
- rename the controller contract from `RUNNER_TEMP` semantics to the explicit Vercel isolation root and update structural tests and the deployment runbook

## Validation

- `pnpm vercel:workflow:test` — 72/72
- `pnpm quality:budgets:test` — 30/30
- `pnpm ci:action-pins`
- `pnpm ci:action-pins:test` — 48 + 11
- `pnpm adr:check` and `pnpm adr:check:test` — 9/9
- `pnpm check-types` — 8/8
- `trunk check` — clean
- two fresh-context reviews — no actionable implementation or security findings

## Rollout

After this exact reviewed head merges, immediately dispatch the `main`-pinned UI pilot against the existing immutable candidate SHA. Do not begin preview ownership cutover until hosted dependency install, build, upload, HTTP smoke, browser interaction, console checks, and cleanup all pass.

Refs #519

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes the CI isolation boundary, sudo-created `/var/lib` runtime roots, candidate identity lifecycle, and fail-closed cleanup for the credentialed Vercel prebuilt pilot—security-critical deployment infrastructure.
> 
> **Overview**
> Fixes the isolated **candidate UID** failing to traverse runner-home ancestors to the pinned **pnpm** launcher by moving all trusted/candidate/pull/upload staging off **`runner.temp`** into a **run-scoped** boundary under **`/var/lib/mento-vercel-runtime-<run-id>-<run-attempt>`**.
> 
> The workflow now **creates** a fresh **root-owned** `0711` outer directory, a **root-owned** `0400` run marker, and a **runner-owned** `0711` **`work/`** directory (with ancestor permission checks), sets **`VERCEL_ISOLATION_ROOT`** / related env vars, and routes bootstrap, trusted tools, candidate source/home, pull staging, and upload handoff through fixed children under **`work/`**. **Isolation** adds **`/var/lib`**, runtime root/marker, and **`VERCEL_ISOLATION_ROOT`** to protected paths, records **candidate UID/GID** for cleanup, and **probes** candidate execution of protected **pnpm** before materializing source. **Handoff** drops early **userdel** and uses **`--one-file-system`** removals with exact-path guards. **Always-run cleanup** is **readiness-gated** (`VERCEL_RUNTIME_ROOT_READY`), revalidates marker/paths, kills recorded candidate processes, removes only known state, and tears down the runtime root.
> 
> **`vercel-prebuilt-workflow.mjs`** renames **`assertRunnerTempChild`** → **`assertIsolationRootChild`** and threads **`VERCEL_ISOLATION_ROOT`** through staging/materialize/build env. **Docs** and **structural tests** document and assert the new contract (no **`runner.temp`** / **`RUNNER_TEMP`** for mento-vercel paths).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f3f7c1c8e5fcf0c9d7470140d32f21bbef9ac3d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->