### PR TITLE
fix(ci): run candidate pnpm from isolated cwd

### DIFF
--- a/.github/workflows/_vercel-prebuilt.yml
+++ b/.github/workflows/_vercel-prebuilt.yml
@@ -686,9 +686,16 @@ jobs:
             echo "Candidate can modify canonical node_modules" >&2
             exit 1
           fi
+          sudo --non-interactive /usr/bin/install \
+            -d -o "$build_uid" -g "$build_gid" -m 0700 \
+            "$CANDIDATE_HOME_PATH" \
+            "$CANDIDATE_HOME_PATH/cache" \
+            "$CANDIDATE_HOME_PATH/config" \
+            "$CANDIDATE_HOME_PATH/data" \
+            "$CANDIDATE_HOME_PATH/tmp"
           if ! candidate_pnpm_version="$(
             sudo --non-interactive /usr/bin/env -i \
-              HOME=/nonexistent \
+              HOME="$CANDIDATE_HOME_PATH" \
               LANG=C \
               LC_ALL=C \
               PATH=/usr/bin:/bin \
@@ -698,6 +705,9 @@ jobs:
               --clear-groups \
               --no-new-privs \
               -- \
+              /bin/sh -c 'cd "$1" && shift && exec "$@"' \
+              candidate-pnpm-probe \
+              "$CANDIDATE_HOME_PATH" \
               "$pnpm_bin" --version
           )" ||
             [ "$candidate_pnpm_version" != "10.34.4" ]; then
@@ -720,13 +730,6 @@ jobs:
           sudo --non-interactive /bin/chown \
             -R --no-dereference "$build_uid:$build_gid" \
             "$CANDIDATE_SOURCE_PATH"
-          sudo --non-interactive /usr/bin/install \
-            -d -o "$build_uid" -g "$build_gid" -m 0700 \
-            "$CANDIDATE_HOME_PATH" \
-            "$CANDIDATE_HOME_PATH/cache" \
-            "$CANDIDATE_HOME_PATH/config" \
-            "$CANDIDATE_HOME_PATH/data" \
-            "$CANDIDATE_HOME_PATH/tmp"
           printf '{"commitSha":"%s"}\n' "$DEPLOY_SHA" \
             > "${CANDIDATE_SOURCE_PATH}.provenance.json"
           /bin/chmod 0600 "${CANDIDATE_SOURCE_PATH}.provenance.json"
@@ -776,6 +779,9 @@ jobs:
             --clear-groups \
             --no-new-privs \
             -- \
+            /bin/sh -c 'cd "$1" && shift && exec "$@"' \
+            candidate-pnpm-probe \
+            "$CANDIDATE_HOME_PATH" \
             "$pnpm_bin" --version |
             /usr/bin/grep -Fxq "10.34.4"; then
             echo "Isolated candidate cannot execute the protected pnpm launcher" >&2
@@ -807,6 +813,9 @@ jobs:
             --clear-groups \
             --no-new-privs \
             -- \
+            /bin/sh -c 'cd "$1" && shift && exec "$@"' \
+            candidate-pnpm-install \
+            "$CANDIDATE_HOME_PATH" \
             "$pnpm_bin" --dir "$CANDIDATE_SOURCE_PATH" install --frozen-lockfile --ignore-scripts \
             2>&1
           candidate_status=$?

--- a/docs/vercel-deployments.md
+++ b/docs/vercel-deployments.md
@@ -432,10 +432,12 @@ downgrade the trusted runtime or reject the intentional patched v10 version.
 This removes the standalone executable's own image from the cross-identity
 execution path: the pilot failed when that image was not effectively readable
 after switching to the isolated candidate identity, even though the
-runner-owned executable checks had passed. The root and candidate-runtime pnpm
-locks remain covered by OSV and sha512/registry validation. The bootstrap npm
-lock has a separate OSV job, exact byte/shape validation, npm's SRI
-enforcement, and a Linux CI installation that hashes the executable before
+runner-owned executable checks had passed. Candidate pnpm probes execute from
+the candidate-owned home rather than the runner workspace, which is
+intentionally not readable after the identity switch. The root and
+candidate-runtime pnpm locks remain covered by OSV and sha512/registry
+validation. The bootstrap npm lock has a separate OSV job, exact byte/shape
+validation, npm's SRI enforcement, and a Linux CI installation that hashes the executable before
 running it.
 Before any credentialed command, the worker proves the runtime root, its
 replacement-relevant parents, Node.js, pnpm, and the CLI are not candidate

--- a/scripts/vercel-prebuilt-workflows.test.mjs
+++ b/scripts/vercel-prebuilt-workflows.test.mjs
@@ -433,9 +433,29 @@ test("prebuilt authenticates a locked Linux pnpm binary before cache or candidat
   assert.match(isolation.run, /candidate_pnpm_version/);
   assert.match(
     isolation.run,
+    /candidate_pnpm_version="\$\(\n\s+sudo --non-interactive/,
+  );
+  assert.match(isolation.run, /HOME="\$CANDIDATE_HOME_PATH" \\/);
+  assert.match(
+    isolation.run,
+    /\/bin\/sh -c 'cd "\$1" && shift && exec "\$@"' \\\n\s+candidate-pnpm-probe \\\n\s+"\$CANDIDATE_HOME_PATH" \\\n\s+"\$pnpm_bin" --version/,
+  );
+  assert.ok(
+    isolation.run.indexOf('"$CANDIDATE_HOME_PATH/tmp"') <
+      isolation.run.indexOf('candidate_pnpm_version="$('),
+  );
+  assert.match(
+    isolation.run,
     /Candidate cannot execute the protected runtime through its isolation ancestors/,
   );
   assert.match(install.run, /\/usr\/bin\/setpriv/);
+  assert.equal(
+    (install.run.match(/\/bin\/sh -c 'cd "\$1" && shift && exec "\$@"'/g) ?? [])
+      .length,
+    2,
+  );
+  assert.match(install.run, /candidate-pnpm-probe \\/);
+  assert.match(install.run, /candidate-pnpm-install \\/);
   assert.match(install.run, /NPM_CONFIG_MANAGE_PACKAGE_MANAGER_VERSIONS=false/);
   assert.match(install.run, /NPM_CONFIG_PACKAGE_MANAGER_STRICT_VERSION=false/);
   assert.match(install.run, /"\$pnpm_bin" --version \|/);


### PR DESCRIPTION
## The Problem

The first post-merge immutable UI pilot, run 29528460531, proved that the protected /var/lib runtime root and cross-identity launcher are reachable, but pnpm inherited the runner-owned GitHub workspace as its current directory. The isolated candidate could not scan that directory, so the pilot failed with EACCES before dependency installation.

## The Solution

- Create the candidate-owned home before the first cross-identity pnpm probe.
- Run both candidate pnpm probes and the real frozen install through a candidate-side shell that changes into that home after the UID/GID drop while preserving argv exactly.
- Add structural regression coverage for the protected CWD wrapper and document why candidate pnpm commands never inherit the runner workspace.

## Verification

- pnpm vercel:workflow:test (72/72)
- pnpm quality:budgets:test (30/30)
- pnpm ci:action-pins
- pnpm ci:action-pins:test (48 + 11)
- pnpm adr:check
- pnpm adr:check:test (9/9)
- pnpm check-types (8/8)
- targeted Trunk format/check clean
- full pre-push Trunk, typecheck, and Knip gates passed
- fresh privilege-boundary review found no actionable issues

After merge, rerun the same immutable UI pilot against source SHA 59ee56ee63e45e1290a4ba126f10ba5475298a64.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the Vercel prebuilt privilege-boundary path (setpriv, candidate UID, pnpm isolation); behavior change is narrow but security-relevant CI infrastructure.
> 
> **Overview**
> Fixes the immutable UI prebuilt pilot failing with **EACCES** when the isolated candidate ran pnpm while still inheriting the runner-owned GitHub workspace as the current working directory.
> 
> **Workflow:** Candidate-owned home (`cache`, `config`, `data`, `tmp`) is created **before** the first cross-identity pnpm probe. Probes and the frozen `pnpm install` no longer use `HOME=/nonexistent`; they set `HOME` to the candidate home and run through a small `/bin/sh` wrapper that `cd`s into that home after `setpriv`, then `exec`s pnpm with argv unchanged (`candidate-pnpm-probe` / `candidate-pnpm-install`).
> 
> **Docs & tests:** The runbook now states that candidate pnpm must not inherit the runner workspace after the UID switch. Workflow tests assert home creation ordering, `HOME="$CANDIDATE_HOME_PATH"`, and both install-step wrappers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2715b7d0bffc45532adc953614ae652c014d50f2. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->