### PR TITLE
fix(ci): enable Vercel monorepo builds

### DIFF
--- a/.github/workflows/_vercel-prebuilt.yml
+++ b/.github/workflows/_vercel-prebuilt.yml
@@ -1002,6 +1002,7 @@ jobs:
           TURBO_TEAM: ${{ inputs.turbo_team }}
           TURBO_TOKEN: ${{ secrets.turbo_token }}
           VERCEL: 1
+          VERCEL_BUILD_MONOREPO_SUPPORT: "1"
           VERCEL_ENV: preview
           VERCEL_GIT_COMMIT_REF: ${{ inputs.git_branch }}
           VERCEL_GIT_COMMIT_SHA: ${{ steps.source.outputs.checked_out_sha }}
@@ -1084,6 +1085,7 @@ jobs:
             TURBO_TEAM="$TURBO_TEAM" \
             TURBO_TOKEN="$TURBO_TOKEN" \
             VERCEL="$VERCEL" \
+            VERCEL_BUILD_MONOREPO_SUPPORT="$VERCEL_BUILD_MONOREPO_SUPPORT" \
             VERCEL_ENV="$VERCEL_ENV" \
             VERCEL_GIT_COMMIT_REF="$VERCEL_GIT_COMMIT_REF" \
             VERCEL_GIT_COMMIT_SHA="$VERCEL_GIT_COMMIT_SHA" \

--- a/docs/vercel-deployments.md
+++ b/docs/vercel-deployments.md
@@ -543,9 +543,9 @@ preview --project-directory "$VERCEL_ISOLATION_ROOT/mento-vercel-pull-staging/ap
    UID has no process;
 6. immediately before build, repeat the trusted privileged exact-SHA
    provenance, candidate-tree, and project-mapping checks;
-7. `vercel build --yes --target preview` as the isolated candidate UID with the
-   signed Turbo remote cache, immutable Git metadata, and generated
-   `MENTO_NEXT_DEPLOYMENT_ID`;
+7. `vercel build --yes --target preview` as the isolated candidate UID with
+   `VERCEL_BUILD_MONOREPO_SUPPORT=1`, the signed Turbo remote cache, immutable
+   Git metadata, and generated `MENTO_NEXT_DEPLOYMENT_ID`;
 8. stop all candidate-UID processes, then use the trusted privileged controller
    to assert the UI project mapping, Build Output API v3 config, custom
    deployment ID, preview target, pinned CLI build record, output ownership,
@@ -569,6 +569,16 @@ The upload command supplies `githubCommitOrg`, `githubCommitRepo`,
 `githubCommitSha`, and `githubCommitRef`. It intentionally omits
 `githubDeployment=1`, so Vercel cannot create a duplicate GitHub Deployment.
 The build output never becomes a GitHub artifact and never crosses jobs.
+
+CLI `56.2.0` gates its local Root Directory monorepo defaults behind
+`VERCEL_BUILD_MONOREPO_SUPPORT=1`. The worker supplies that trusted constant to
+the clean candidate environment so the CLI activates its Turborepo default,
+`turbo run build`, for the Root Directory project. Turbo then includes upstream
+workspace packages such as `@mento-protocol/ui` before the selected Next.js
+app. Re-audit this internal, version-coupled flag whenever the pinned CLI
+changes. Do not replace it with a separate app dependency prebuild: that would
+duplicate work before the CLI's own build and could diverge from Vercel's
+project settings.
 
 ### Canonical GitHub Deployment
 

--- a/scripts/vercel-prebuilt-workflows.test.mjs
+++ b/scripts/vercel-prebuilt-workflows.test.mjs
@@ -729,10 +729,19 @@ test("workflow restores signed Turbo cache and immutable Vercel build metadata",
     "VERCEL_GIT_REPO_OWNER",
     "VERCEL_GIT_REPO_SLUG",
     "NEXT_PUBLIC_VERCEL_ENV",
+    "VERCEL_BUILD_MONOREPO_SUPPORT",
     "VERCEL_TARGET_ENV",
   ]) {
     assert.match(raw, new RegExp(`${value}:`), `${value} must be explicit`);
   }
+  const build = workflow(reusablePath).jobs.prebuilt.steps.find(
+    ({ name }) => name === "Build the UI prebuilt output",
+  );
+  assert.equal(build.env.VERCEL_BUILD_MONOREPO_SUPPORT, "1");
+  assert.match(
+    build.run,
+    /VERCEL_BUILD_MONOREPO_SUPPORT="\$VERCEL_BUILD_MONOREPO_SUPPORT"/,
+  );
   assert.doesNotMatch(raw, /githubDeployment=1/);
   assert.doesNotMatch(raw, /--token/);
 });


### PR DESCRIPTION
## The Problem

The immutable `ui.mento.org` prebuilt pilot reached `vercel build`, but Vercel CLI 56.2.0 launched the app-local Next.js build without first building `@mento-protocol/ui`. The missing `packages/ui/dist` output caused ten module-resolution failures and prevented issue #518 from completing its live proof.

## The Solution

Enable the pinned CLI monorepo mode with the trusted constant `VERCEL_BUILD_MONOREPO_SUPPORT=1` and explicitly carry it through the candidate `env -i` boundary. For this Root Directory project, CLI 56.2.0 detects Turborepo and selects `turbo run build`, which schedules upstream workspace builds before the app without adding a redundant manual prebuild.

The workflow contract test now locks the exact value and clean-environment propagation. The deployment runbook documents the behavior, its version coupling, and the required re-audit when the CLI pin changes.

Relates to #518 and #515.

## Verification

- `pnpm vercel:workflow:test` (72/72)
- `pnpm quality:budgets:test` (30/30)
- `pnpm ci:action-pins`
- `pnpm ci:action-pins:test` (48 + 11)
- `pnpm adr:check`
- `pnpm adr:check:test` (9/9)
- `pnpm vercel:versions:check`
- `pnpm check-types`
- focused Trunk formatting and lint checks
- pinned CLI detector returns `buildCommand: turbo run build`
- independent review: ALL CLEAR (96% confidence)

The final acceptance gate is rerunning the same immutable `ui.mento.org` pilot after merge and confirming upstream UI build, upload, HTTP smoke, and browser smoke all succeed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the trusted CI build command path for UI prebuilt previews; incorrect behavior would break deployments but the change is a single documented env constant with contract tests.
> 
> **Overview**
> Fixes **ui.mento.org** prebuilt `vercel build` failures where the pinned CLI ran only the app-local Next.js build and skipped upstream **`@mento-protocol/ui`**.
> 
> The reusable prebuilt workflow now sets **`VERCEL_BUILD_MONOREPO_SUPPORT=1`** on the build step and forwards it through the isolated candidate **`env -i`** boundary so CLI **56.2.0** uses its Turborepo default (**`turbo run build`**) for the Root Directory project.
> 
> **`vercel-prebuilt-workflows.test.mjs`** locks the value and propagation; **`docs/vercel-deployments.md`** documents version coupling and warns against a separate manual prebuild.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b9e1f25fd932d48591b2714a66bd775fd2eeaafe. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->