### PR TITLE
fix(ci): validate safe Vercel function links

### DIFF
--- a/.github/workflows/_vercel-prebuilt.yml
+++ b/.github/workflows/_vercel-prebuilt.yml
@@ -1200,7 +1200,10 @@ jobs:
             "$CANDIDATE_SOURCE_PATH/$EXPECTED_ROOT_DIRECTORY/.vercel/output/." \
             "$UPLOAD_SOURCE_PATH/$EXPECTED_ROOT_DIRECTORY/.vercel/output/"
           assert_candidate_stopped
-          sudo --non-interactive /bin/chown -R "$(id -u):$(id -g)" \
+          sudo --non-interactive /bin/chown \
+            -R \
+            --no-dereference \
+            "$(id -u):$(id -g)" \
             "$UPLOAD_SOURCE_PATH"
           /bin/chmod -R u-s,g-s,o-t "$UPLOAD_SOURCE_PATH"
           /bin/chmod -R u+rwX,go+rX,go-w "$UPLOAD_SOURCE_PATH"

--- a/docs/vercel-deployments.md
+++ b/docs/vercel-deployments.md
@@ -549,7 +549,7 @@ preview --project-directory "$VERCEL_ISOLATION_ROOT/mento-vercel-pull-staging/ap
 8. stop all candidate-UID processes, then use the trusted privileged controller
    to assert the UI project mapping, Build Output API v3 config, custom
    deployment ID, preview target, pinned CLI build record, output ownership,
-   and runner-owned exact-SHA provenance;
+   safe filesystem shape, and runner-owned exact-SHA provenance;
 9. create a runner-owned upload handoff containing only the validated output,
    trusted project settings, repo link, and exact-SHA provenance;
 10. `vercel deploy --prebuilt --target preview --archive=tgz --format=json`;
@@ -569,6 +569,15 @@ The upload command supplies `githubCommitOrg`, `githubCommitRepo`,
 `githubCommitSha`, and `githubCommitRef`. It intentionally omits
 `githubDeployment=1`, so Vercel cannot create a duplicate GitHub Deployment.
 The build output never becomes a GitHub artifact and never crosses jobs.
+
+The Next.js builder can legitimately represent multiple prerender routes with
+relative symbolic links to one generated function directory. Output validation
+permits only bounded, control-character-free `functions/**/*.func` aliases to a
+directly materialized `.func` directory in that same output tree. Absolute,
+broken, chained, cyclic, non-function, file-targeting, ancestor/self, and
+escaping links remain rejected. The trusted handoff preserves accepted links
+without dereferencing them and changes the link ownership explicitly before
+applying the same validation again immediately before upload.
 
 CLI `56.2.0` gates its local Root Directory monorepo defaults behind
 `VERCEL_BUILD_MONOREPO_SUPPORT=1`. The worker supplies that trusted constant to

--- a/scripts/vercel-prebuilt-workflow.mjs
+++ b/scripts/vercel-prebuilt-workflow.mjs
@@ -18,6 +18,7 @@ import {
   mkdirSync,
   openSync,
   readFileSync,
+  readlinkSync,
   readdirSync,
   realpathSync,
   rmSync,
@@ -2496,12 +2497,72 @@ function numericIdentity(value, label) {
   return numeric;
 }
 
+function isStrictDescendant(root, path) {
+  const pathFromRoot = relative(root, path);
+  return (
+    pathFromRoot !== "" &&
+    pathFromRoot !== ".." &&
+    !pathFromRoot.startsWith(`..${sep}`) &&
+    !isAbsolute(pathFromRoot)
+  );
+}
+
+function assertSafeOutputSymlink(
+  outputDirectory,
+  canonicalOutputDirectory,
+  path,
+) {
+  const target = readlinkSync(path);
+  const functionsDirectory = join(outputDirectory, "functions");
+  const sourceFromRoot = relative(outputDirectory, path);
+  if (
+    target.length === 0 ||
+    Buffer.byteLength(target, "utf8") > 4_096 ||
+    hasControlCharacters(target) ||
+    isAbsolute(target) ||
+    !isStrictDescendant(outputDirectory, path) ||
+    !sourceFromRoot.startsWith(`functions${sep}`) ||
+    !sourceFromRoot.endsWith(".func")
+  ) {
+    throw new Error("Prebuilt output contains an unsupported symbolic link");
+  }
+  const lexicalTarget = resolve(dirname(path), target);
+  const lexicalTargetFromRoot = relative(outputDirectory, lexicalTarget);
+  if (
+    !isStrictDescendant(functionsDirectory, lexicalTarget) ||
+    !lexicalTargetFromRoot.endsWith(".func") ||
+    isStrictDescendant(lexicalTarget, path)
+  ) {
+    throw new Error("Prebuilt output symbolic link target escaped its scope");
+  }
+  let canonicalTarget;
+  let targetEntry;
+  try {
+    canonicalTarget = realpathSync(lexicalTarget);
+    targetEntry = lstatSync(lexicalTarget);
+  } catch {
+    throw new Error("Prebuilt output symbolic link target is invalid");
+  }
+  if (!targetEntry.isDirectory()) {
+    throw new Error(
+      "Prebuilt output symbolic link target is not a function directory",
+    );
+  }
+  if (
+    relative(canonicalOutputDirectory, canonicalTarget) !==
+    lexicalTargetFromRoot
+  ) {
+    throw new Error("Prebuilt output symbolic link target escaped its root");
+  }
+}
+
 function assertSafeOutputTree(
   outputDirectory,
   { expectedUid = process.getuid?.(), expectedGid = process.getgid?.() } = {},
 ) {
   const uid = numericIdentity(expectedUid, "Expected output UID");
   const gid = numericIdentity(expectedGid, "Expected output GID");
+  const canonicalOutputDirectory = realpathSync(outputDirectory);
   const pending = [outputDirectory];
   let entries = 0;
   while (pending.length > 0) {
@@ -2516,14 +2577,17 @@ function assertSafeOutputTree(
         "Prebuilt output contains an entry with unsafe ownership",
       );
     }
+    const symbolicLink = entry.isSymbolicLink();
     if (
       uid === process.getuid?.() &&
+      !symbolicLink &&
       ((entry.mode & 0o022) !== 0 || (entry.mode & 0o7000) !== 0)
     ) {
       throw new Error("Runner-owned prebuilt output has unsafe permissions");
     }
-    if (entry.isSymbolicLink()) {
-      throw new Error("Prebuilt output contains a symbolic link");
+    if (symbolicLink) {
+      assertSafeOutputSymlink(outputDirectory, canonicalOutputDirectory, path);
+      continue;
     }
     if (entry.isDirectory()) {
       for (const child of readdirSync(path)) pending.push(join(path, child));

--- a/scripts/vercel-prebuilt-workflow.test.mjs
+++ b/scripts/vercel-prebuilt-workflow.test.mjs
@@ -2642,6 +2642,7 @@ test("candidate execution is UID-isolated and hands upload to runner-owned state
     handoffBlock,
     /\/bin\/cp -R \\\n\s+--no-dereference \\\n\s+--preserve=mode,timestamps/,
   );
+  assert.match(handoffBlock, /\/bin\/chown \\\n\s+-R \\\n\s+--no-dereference/);
   for (const block of [installBlock, buildBlock]) {
     assert.match(block, /\/usr\/bin\/env -i/);
     assert.match(block, /::stop-commands::\$command_token/);
@@ -2906,12 +2907,128 @@ test("UI upload revalidates exact provenance and project mapping immediately", a
   }
 });
 
-test("UI upload guard rejects links, special nodes, and runner-writable state", () => {
+test("UI upload guard accepts contained relative Vercel function symlinks", () => {
+  const fixture = uploadFixture();
+  try {
+    const functionsDirectory = join(fixture.outputDirectory, "functions");
+    const parentFunction = join(functionsDirectory, "parent.func");
+    const nestedFunctionsDirectory = join(functionsDirectory, "nested");
+    mkdirSync(parentFunction, { recursive: true });
+    mkdirSync(nestedFunctionsDirectory, { recursive: true });
+    writeFileSync(join(parentFunction, "index.js"), "export {};\n");
+    symlinkSync(
+      "../parent.func",
+      join(nestedFunctionsDirectory, "prerender.func"),
+    );
+    assert.equal(
+      assertPrebuiltReadyForUpload(fixture.options),
+      fixture.outputDirectory,
+    );
+  } finally {
+    fixture.cleanup();
+  }
+});
+
+test("UI upload guard rejects unsafe links, special nodes, and runner-writable state", () => {
   const mutateCases = [
     {
-      name: "symbolic link",
+      name: "absolute symbolic link",
+      mutate: ({ outputDirectory }) => {
+        const functionsDirectory = join(outputDirectory, "functions");
+        mkdirSync(functionsDirectory);
+        symlinkSync(
+          join(outputDirectory, "static", "nested", "asset.js"),
+          join(functionsDirectory, "absolute.func"),
+        );
+      },
+    },
+    {
+      name: "contained non-function symbolic link",
       mutate: ({ outputDirectory }) =>
-        symlinkSync("/etc/passwd", join(outputDirectory, "static", "escape")),
+        symlinkSync(
+          "nested/asset.js",
+          join(outputDirectory, "static", "contained"),
+        ),
+    },
+    {
+      name: "function symbolic link outside functions",
+      mutate: ({ outputDirectory }) => {
+        const functionsDirectory = join(outputDirectory, "functions");
+        mkdirSync(functionsDirectory);
+        mkdirSync(join(outputDirectory, "static", "outside.func"));
+        symlinkSync(
+          "../static/outside.func",
+          join(functionsDirectory, "outside.func"),
+        );
+      },
+    },
+    {
+      name: "escaping relative symbolic link",
+      mutate: ({ outputDirectory }) => {
+        const functionsDirectory = join(outputDirectory, "functions");
+        mkdirSync(functionsDirectory);
+        const path = join(functionsDirectory, "escape.func");
+        symlinkSync(relative(dirname(path), "/etc/passwd"), path);
+      },
+    },
+    {
+      name: "broken symbolic link",
+      mutate: ({ outputDirectory }) => {
+        const functionsDirectory = join(outputDirectory, "functions");
+        mkdirSync(functionsDirectory);
+        symlinkSync("missing.func", join(functionsDirectory, "broken.func"));
+      },
+    },
+    {
+      name: "cyclic symbolic link",
+      mutate: ({ outputDirectory }) => {
+        const functionsDirectory = join(outputDirectory, "functions");
+        mkdirSync(functionsDirectory);
+        symlinkSync("cycle-b.func", join(functionsDirectory, "cycle-a.func"));
+        symlinkSync("cycle-a.func", join(functionsDirectory, "cycle-b.func"));
+      },
+    },
+    {
+      name: "function symbolic link to a file",
+      mutate: ({ outputDirectory }) => {
+        const functionsDirectory = join(outputDirectory, "functions");
+        mkdirSync(functionsDirectory);
+        writeFileSync(
+          join(functionsDirectory, "target.func"),
+          "not a directory",
+        );
+        symlinkSync("target.func", join(functionsDirectory, "file-alias.func"));
+      },
+    },
+    {
+      name: "function symbolic link chain",
+      mutate: ({ outputDirectory }) => {
+        const functionsDirectory = join(outputDirectory, "functions");
+        mkdirSync(join(functionsDirectory, "target.func"), { recursive: true });
+        symlinkSync("target.func", join(functionsDirectory, "first.func"));
+        symlinkSync("first.func", join(functionsDirectory, "second.func"));
+      },
+    },
+    {
+      name: "function symbolic link to an ancestor",
+      mutate: ({ outputDirectory }) => {
+        const nestedDirectory = join(
+          outputDirectory,
+          "functions",
+          "parent.func",
+          "nested",
+        );
+        mkdirSync(nestedDirectory, { recursive: true });
+        symlinkSync("..", join(nestedDirectory, "ancestor.func"));
+      },
+    },
+    {
+      name: "output-root symbolic link",
+      mutate: ({ outputDirectory }) => {
+        const functionsDirectory = join(outputDirectory, "functions");
+        mkdirSync(functionsDirectory);
+        symlinkSync("..", join(functionsDirectory, "root.func"));
+      },
     },
     {
       name: "hard link",


### PR DESCRIPTION
## The Problem

The immutable UI prebuilt pilot reached a successful Turbo and Next build, then failed before upload because the trusted output guard rejected every symbolic link. A faithful rebuild of source SHA `59ee56ee63e45e1290a4ba126f10ba5475298a64` with the pinned Vercel CLI found 69 intentional aliases, all relative `functions/**/*.func` links to one real internal `.func` directory.

The pilot must admit that builder-owned shape without allowing arbitrary links, escape paths, chains, files, or unsafe handoff behavior.

## The Solution

Narrow the output contract to relative `functions/**/*.func` aliases whose immediate target is a directly materialized `.func` directory at the same lexical and canonical path inside the output tree. Reject absolute, escaping, broken, cyclic, chained, non-function, file-targeting, ancestor/self, and outside-functions links.

Preserve accepted links during the trusted upload handoff with `cp --no-dereference`, normalize link ownership with recursive `chown --no-dereference`, retain ownership checks on link entries, and revalidate the runner-owned handoff immediately before upload. The deployment runbook now records the exact contract.

## Validation

- `pnpm vercel:workflow:test` — 73/73
- `pnpm quality:budgets:test` — 30/30
- `pnpm ci:action-pins:test` — 48/48 plus 11/11 materializer tests
- `pnpm ci:action-pins`
- `pnpm vercel:preview:test` — 86/86
- `pnpm adr:check:test` — 9/9
- `pnpm adr:check`
- `pnpm vercel:versions:check`
- `pnpm check-types` — 8/8
- focused Trunk checks and `git diff --check`
- two independent security/correctness reviews: all clear

## Pilot evidence

The failed hosted pilot is [run 29531000262](https://github.com/mento-protocol/frontend-monorepo/actions/runs/29531000262). It proved the monorepo build fix by completing `turbo run build` and both UI tasks before stopping at the old blanket symlink rejection. After this PR merges, the same immutable source SHA and branch will be rerun through upload, direct smoke, hosted browser smoke, cleanup, and final GitHub Deployment finalization.

No production domain, alias, Vercel Git setting, or automatic PR cutover changes here.

Relates #518
Parent: #515

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes security-sensitive prebuilt output and upload handoff logic; symlink rules are strict but mistakes could admit unsafe paths or break legitimate builds.
> 
> **Overview**
> Unblocks the UI prebuilt pilot after builds failed because the output guard rejected **all** symlinks, while Next.js legitimately emits many relative `functions/**/*.func` aliases to one real function directory.
> 
> **Output validation** in `vercel-prebuilt-workflow.mjs` no longer fails on every symlink. It allows only bounded, relative links under `functions/**/*.func` whose target is a **direct** materialized `.func` directory inside the same output tree (lexical and canonical paths must agree). Absolute, escaping, broken, cyclic, chained, non-function, file, and ancestor/self links still fail.
> 
> **Upload handoff** in `_vercel-prebuilt.yml` already copies with `cp --no-dereference`; it now runs recursive `chown --no-dereference` on the handoff tree so link entries get runner ownership without following links, then re-validates before upload.
> 
> **Docs** (`vercel-deployments.md`) document the symlink contract. **Tests** add acceptance of a valid function alias and many rejection cases for unsafe links.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3aa2c4dfc8e26595f71dc42a28456300d84d7f9f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->