### PR TITLE
fix(ci): inline Vercel prebuilt dependencies

### DIFF
--- a/.github/workflows/_vercel-prebuilt.yml
+++ b/.github/workflows/_vercel-prebuilt.yml
@@ -1102,7 +1102,7 @@ jobs:
             --clear-groups \
             --no-new-privs \
             -- \
-            "$node_bin" "$vercel_cli" build --yes --target preview --project "$VERCEL_PROJECT_ID" \
+            "$node_bin" "$vercel_cli" build --yes --standalone --target preview --project "$VERCEL_PROJECT_ID" \
             2>&1
           candidate_status=$?
           set -e

--- a/docs/vercel-deployments.md
+++ b/docs/vercel-deployments.md
@@ -543,7 +543,7 @@ preview --project-directory "$VERCEL_ISOLATION_ROOT/mento-vercel-pull-staging/ap
    UID has no process;
 6. immediately before build, repeat the trusted privileged exact-SHA
    provenance, candidate-tree, and project-mapping checks;
-7. `vercel build --yes --target preview` as the isolated candidate UID with
+7. `vercel build --yes --standalone --target preview` as the isolated candidate UID with
    `VERCEL_BUILD_MONOREPO_SUPPORT=1`, the signed Turbo remote cache, immutable
    Git metadata, and generated `MENTO_NEXT_DEPLOYMENT_ID`;
 8. stop all candidate-UID processes, then use the trusted privileged controller
@@ -556,6 +556,21 @@ preview --project-directory "$VERCEL_ISOLATION_ROOT/mento-vercel-pull-staging/ap
 11. `vercel inspect --wait --timeout 5m --format=json --scope <org-id>`. The
     explicit scope prevents inspection from falling back to the token owner's
     default Vercel team.
+
+The standalone build flag is mandatory for the narrow upload handoff. Without
+it, Vercel function configs can retain repo-root `filePathMap` references into
+the build tree (including `node_modules`) that no longer exists after the
+candidate source is removed. Standalone mode inlines those dependencies into
+the function output; the trusted output validator rejects every non-empty
+`filePathMap` before the handoff or upload can proceed. Standalone function
+bundles may retain package-manager symlinks, but validation permits only direct,
+relative file or directory links whose lexical and canonical targets remain
+inside the same physical `.func` directory. A bounded relative link to a
+missing in-function target is allowed because dependency tracing can preserve
+unused package-manager links; absolute links, escaping links, and link chains
+remain rejected. Before reading or copying the handoff, the validator also caps
+each `.vc-config.json` at 1 MiB, each regular file at 250 MiB, and the complete
+output at 1 GiB.
 
 Only after that job emits the verified immutable URL does a second trusted job
 perform direct HTTP smoke of the URL, navigation, custom build identity,

--- a/scripts/vercel-prebuilt-workflow.mjs
+++ b/scripts/vercel-prebuilt-workflow.mjs
@@ -54,6 +54,9 @@ export const PILOT_TARGET = {
 
 const SHA_PATTERN = /^[0-9a-f]{40}$/;
 const VERCEL_DEPLOYMENT_ID_PATTERN = /^dpl_[A-Za-z0-9]+$/;
+const MAX_PREBUILT_CONFIG_BYTES = 1024 * 1024;
+const MAX_PREBUILT_FILE_BYTES = 250 * 1024 * 1024;
+const MAX_PREBUILT_TOTAL_BYTES = 1024 * 1024 * 1024;
 const VERCEL_CLI_BASE_ENVIRONMENT = [
   "CI",
   "FORCE_COLOR",
@@ -328,6 +331,7 @@ export function buildVercelBuildArguments({ projectId }) {
   return [
     "build",
     "--yes",
+    "--standalone",
     "--target",
     "preview",
     "--project",
@@ -2507,14 +2511,104 @@ function isStrictDescendant(root, path) {
   );
 }
 
+function findPhysicalFunctionDirectory(outputDirectory, sourceParts) {
+  for (let index = sourceParts.length - 2; index > 0; index -= 1) {
+    if (!sourceParts[index].endsWith(".func")) continue;
+    const functionDirectory = join(
+      outputDirectory,
+      ...sourceParts.slice(0, index + 1),
+    );
+    try {
+      const functionEntry = lstatSync(functionDirectory);
+      const configEntry = lstatSync(join(functionDirectory, ".vc-config.json"));
+      if (
+        !functionEntry.isSymbolicLink() &&
+        functionEntry.isDirectory() &&
+        !configEntry.isSymbolicLink() &&
+        configEntry.isFile()
+      ) {
+        return functionDirectory;
+      }
+    } catch {
+      // A route directory may itself end in .func without being a function.
+    }
+  }
+  return undefined;
+}
+
+function assertContainedFunctionDependencyLink(
+  physicalFunctionDirectory,
+  path,
+  lexicalTarget,
+) {
+  let canonicalFunctionDirectory;
+  try {
+    canonicalFunctionDirectory = realpathSync(physicalFunctionDirectory);
+  } catch {
+    throw new Error("Prebuilt function symbolic link target is invalid");
+  }
+  const lexicalTargetFromFunction = relative(
+    physicalFunctionDirectory,
+    lexicalTarget,
+  );
+  if (
+    !isStrictDescendant(physicalFunctionDirectory, lexicalTarget) ||
+    isStrictDescendant(lexicalTarget, path) ||
+    isStrictDescendant(path, lexicalTarget)
+  ) {
+    throw new Error("Prebuilt function symbolic link escaped its scope");
+  }
+  const targetParts = lexicalTargetFromFunction.split(sep);
+  let current = physicalFunctionDirectory;
+  let targetEntry;
+  for (const [index, part] of targetParts.entries()) {
+    current = join(current, part);
+    try {
+      targetEntry = lstatSync(current);
+    } catch (error) {
+      if (error?.code === "ENOENT") return;
+      throw new Error("Prebuilt function symbolic link target is invalid");
+    }
+    const final = index === targetParts.length - 1;
+    if (
+      targetEntry.isSymbolicLink() ||
+      (final
+        ? !targetEntry.isDirectory() && !targetEntry.isFile()
+        : !targetEntry.isDirectory())
+    ) {
+      throw new Error("Prebuilt function symbolic link escaped its scope");
+    }
+  }
+  let canonicalTarget;
+  try {
+    canonicalTarget = realpathSync(lexicalTarget);
+  } catch {
+    throw new Error("Prebuilt function symbolic link target is invalid");
+  }
+  if (
+    relative(canonicalFunctionDirectory, canonicalTarget) !==
+    lexicalTargetFromFunction
+  ) {
+    throw new Error("Prebuilt function symbolic link escaped its scope");
+  }
+}
+
 function assertSafeOutputSymlink(
   outputDirectory,
   canonicalOutputDirectory,
   path,
 ) {
+  if (basename(path) === ".vc-config.json") {
+    throw new Error("Prebuilt output contains a linked Vercel function config");
+  }
   const target = readlinkSync(path);
   const functionsDirectory = join(outputDirectory, "functions");
   const sourceFromRoot = relative(outputDirectory, path);
+  const sourceParts = sourceFromRoot.split(sep);
+  const physicalFunctionDirectory = findPhysicalFunctionDirectory(
+    outputDirectory,
+    sourceParts,
+  );
   if (
     target.length === 0 ||
     Buffer.byteLength(target, "utf8") > 4_096 ||
@@ -2522,11 +2616,19 @@ function assertSafeOutputSymlink(
     isAbsolute(target) ||
     !isStrictDescendant(outputDirectory, path) ||
     !sourceFromRoot.startsWith(`functions${sep}`) ||
-    !sourceFromRoot.endsWith(".func")
+    (!physicalFunctionDirectory && !sourceFromRoot.endsWith(".func"))
   ) {
     throw new Error("Prebuilt output contains an unsupported symbolic link");
   }
   const lexicalTarget = resolve(dirname(path), target);
+  if (physicalFunctionDirectory) {
+    assertContainedFunctionDependencyLink(
+      physicalFunctionDirectory,
+      path,
+      lexicalTarget,
+    );
+    return;
+  }
   const lexicalTargetFromRoot = relative(outputDirectory, lexicalTarget);
   if (
     !isStrictDescendant(functionsDirectory, lexicalTarget) ||
@@ -2536,14 +2638,20 @@ function assertSafeOutputSymlink(
     throw new Error("Prebuilt output symbolic link target escaped its scope");
   }
   let canonicalTarget;
+  let targetConfigEntry;
   let targetEntry;
   try {
     canonicalTarget = realpathSync(lexicalTarget);
     targetEntry = lstatSync(lexicalTarget);
+    targetConfigEntry = lstatSync(join(lexicalTarget, ".vc-config.json"));
   } catch {
     throw new Error("Prebuilt output symbolic link target is invalid");
   }
-  if (!targetEntry.isDirectory()) {
+  if (
+    !targetEntry.isDirectory() ||
+    targetConfigEntry.isSymbolicLink() ||
+    !targetConfigEntry.isFile()
+  ) {
     throw new Error(
       "Prebuilt output symbolic link target is not a function directory",
     );
@@ -2556,6 +2664,34 @@ function assertSafeOutputSymlink(
   }
 }
 
+function assertStandaloneVercelConfig(path, entry) {
+  if (basename(path) !== ".vc-config.json") return;
+  if (entry.size > MAX_PREBUILT_CONFIG_BYTES) {
+    throw new Error("Prebuilt output contains an oversized function config");
+  }
+  let config;
+  try {
+    config = JSON.parse(readFileSync(path, "utf8"));
+  } catch {
+    throw new Error("Prebuilt output contains an invalid function config");
+  }
+  if (!config || typeof config !== "object" || Array.isArray(config)) {
+    throw new Error("Prebuilt output contains an invalid function config");
+  }
+  if (!Object.hasOwn(config, "filePathMap")) return;
+  const { filePathMap } = config;
+  if (
+    !filePathMap ||
+    typeof filePathMap !== "object" ||
+    Array.isArray(filePathMap) ||
+    Object.keys(filePathMap).length > 0
+  ) {
+    throw new Error(
+      "Prebuilt output contains external function file references",
+    );
+  }
+}
+
 function assertSafeOutputTree(
   outputDirectory,
   { expectedUid = process.getuid?.(), expectedGid = process.getgid?.() } = {},
@@ -2565,6 +2701,7 @@ function assertSafeOutputTree(
   const canonicalOutputDirectory = realpathSync(outputDirectory);
   const pending = [outputDirectory];
   let entries = 0;
+  let totalBytes = 0;
   while (pending.length > 0) {
     const path = pending.pop();
     const entry = lstatSync(path);
@@ -2578,6 +2715,24 @@ function assertSafeOutputTree(
       );
     }
     const symbolicLink = entry.isSymbolicLink();
+    if (
+      basename(path) === ".vc-config.json" &&
+      (symbolicLink || !entry.isFile())
+    ) {
+      throw new Error("Prebuilt output contains an invalid function config");
+    }
+    if (!entry.isDirectory()) {
+      if (!Number.isSafeInteger(entry.size) || entry.size < 0) {
+        throw new Error("Prebuilt output contains an invalid entry size");
+      }
+      totalBytes += entry.size;
+      if (
+        !Number.isSafeInteger(totalBytes) ||
+        totalBytes > MAX_PREBUILT_TOTAL_BYTES
+      ) {
+        throw new Error("Prebuilt output exceeds its total size limit");
+      }
+    }
     if (
       uid === process.getuid?.() &&
       !symbolicLink &&
@@ -2596,9 +2751,13 @@ function assertSafeOutputTree(
     if (!entry.isFile()) {
       throw new Error("Prebuilt output contains a special filesystem node");
     }
+    if (entry.size > MAX_PREBUILT_FILE_BYTES) {
+      throw new Error("Prebuilt output contains an oversized file");
+    }
     if (uid === process.getuid?.() && entry.nlink !== 1) {
       throw new Error("Prebuilt output contains a hard-linked file");
     }
+    assertStandaloneVercelConfig(path, entry);
   }
   return outputDirectory;
 }

--- a/scripts/vercel-prebuilt-workflow.test.mjs
+++ b/scripts/vercel-prebuilt-workflow.test.mjs
@@ -15,6 +15,7 @@ import {
   realpathSync,
   rmSync,
   symlinkSync,
+  truncateSync,
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
@@ -153,6 +154,18 @@ function uploadFixture() {
       rmSync(`${repoRoot}.provenance.json`, { force: true });
     },
   };
+}
+
+function writeFunctionConfig(functionDirectory, extra = {}) {
+  mkdirSync(functionDirectory, { recursive: true });
+  writeFileSync(
+    join(functionDirectory, ".vc-config.json"),
+    JSON.stringify({
+      runtime: "nodejs22.x",
+      handler: "index.js",
+      ...extra,
+    }),
+  );
 }
 const CONTROLLER_KEY = `vercel-preview:v1:pr:519:target:ui:sha:${SHA}`;
 const LOOKUP_STARTED_AT = 1_720_000_000_000;
@@ -396,6 +409,7 @@ test("pinned CLI arguments preserve preview branch and exact commit metadata", (
   assert.deepEqual(buildVercelBuildArguments({ projectId: "prj_example" }), [
     "build",
     "--yes",
+    "--standalone",
     "--target",
     "preview",
     "--project",
@@ -2481,6 +2495,10 @@ test("candidate execution is UID-isolated and hands upload to runner-owned state
     buildBlock.indexOf("set +e"),
     buildBlock.indexOf("candidate_status=$?"),
   );
+  assert.match(
+    buildCandidateBlock,
+    /"\$node_bin" "\$vercel_cli" build --yes --standalone --target preview --project "\$VERCEL_PROJECT_ID"/,
+  );
   const handoffBlock = raw.slice(
     raw.indexOf("- name: Create immutable runner-owned upload handoff"),
     raw.indexOf("- name: Materialize runner-owned upload UI project mapping"),
@@ -2913,12 +2931,53 @@ test("UI upload guard accepts contained relative Vercel function symlinks", () =
     const functionsDirectory = join(fixture.outputDirectory, "functions");
     const parentFunction = join(functionsDirectory, "parent.func");
     const nestedFunctionsDirectory = join(functionsDirectory, "nested");
-    mkdirSync(parentFunction, { recursive: true });
+    writeFunctionConfig(parentFunction);
     mkdirSync(nestedFunctionsDirectory, { recursive: true });
     writeFileSync(join(parentFunction, "index.js"), "export {};\n");
     symlinkSync(
       "../parent.func",
       join(nestedFunctionsDirectory, "prerender.func"),
+    );
+    assert.equal(
+      assertPrebuiltReadyForUpload(fixture.options),
+      fixture.outputDirectory,
+    );
+  } finally {
+    fixture.cleanup();
+  }
+});
+
+test("UI upload guard accepts contained standalone dependency symlinks", () => {
+  const fixture = uploadFixture();
+  try {
+    const functionDirectory = join(
+      fixture.outputDirectory,
+      "functions",
+      "api.func",
+    );
+    const packageDirectory = join(
+      functionDirectory,
+      "node_modules",
+      ".pnpm",
+      "package@1.0.0",
+      "node_modules",
+      "package",
+    );
+    const packageLink = join(functionDirectory, "node_modules", "package");
+    writeFunctionConfig(functionDirectory);
+    mkdirSync(packageDirectory, { recursive: true });
+    writeFileSync(join(packageDirectory, "index.js"), "export {};\n");
+    symlinkSync(relative(dirname(packageLink), packageDirectory), packageLink);
+    const unusedPackageLinkDirectory = join(
+      functionDirectory,
+      "node_modules",
+      ".pnpm",
+      "node_modules",
+    );
+    mkdirSync(unusedPackageLinkDirectory, { recursive: true });
+    symlinkSync(
+      "../semver@6.3.1/node_modules/semver",
+      join(unusedPackageLinkDirectory, "semver"),
     );
     assert.equal(
       assertPrebuiltReadyForUpload(fixture.options),
@@ -3037,6 +3096,183 @@ test("UI upload guard rejects unsafe links, special nodes, and runner-writable s
           join(outputDirectory, "config.json"),
           join(outputDirectory, "static", "hardlink"),
         ),
+    },
+    {
+      name: "external function file map",
+      mutate: ({ outputDirectory }) => {
+        const functionDirectory = join(
+          outputDirectory,
+          "functions",
+          "api.func",
+        );
+        writeFunctionConfig(functionDirectory, {
+          filePathMap: {
+            "node_modules/@opentelemetry/api/context.js":
+              "node_modules/.pnpm/@opentelemetry+api@1.9.0/context.js",
+          },
+        });
+      },
+    },
+    {
+      name: "external file map outside functions",
+      mutate: ({ outputDirectory }) => {
+        writeFileSync(
+          join(outputDirectory, "static", ".vc-config.json"),
+          JSON.stringify({
+            filePathMap: {
+              "private.txt": "../../private.txt",
+            },
+          }),
+        );
+      },
+    },
+    {
+      name: "linked Vercel config",
+      mutate: ({ outputDirectory }) => {
+        const staticDirectory = join(outputDirectory, "static");
+        writeFileSync(
+          join(staticDirectory, "config-target.json"),
+          JSON.stringify({ runtime: "nodejs22.x", handler: "index.js" }),
+        );
+        symlinkSync(
+          "config-target.json",
+          join(staticDirectory, ".vc-config.json"),
+        );
+      },
+    },
+    {
+      name: "directory-shaped Vercel config",
+      mutate: ({ outputDirectory }) =>
+        mkdirSync(join(outputDirectory, "static", ".vc-config.json")),
+    },
+    {
+      name: "oversized Vercel config",
+      mutate: ({ outputDirectory }) => {
+        const functionDirectory = join(
+          outputDirectory,
+          "functions",
+          "api.func",
+        );
+        writeFunctionConfig(functionDirectory);
+        truncateSync(
+          join(functionDirectory, ".vc-config.json"),
+          1024 * 1024 + 1,
+        );
+      },
+    },
+    {
+      name: "oversized output file",
+      mutate: ({ outputDirectory }) => {
+        const path = join(outputDirectory, "static", "oversized.bin");
+        writeFileSync(path, "");
+        truncateSync(path, 250 * 1024 * 1024 + 1);
+      },
+    },
+    {
+      name: "oversized aggregate output",
+      mutate: ({ outputDirectory }) => {
+        for (let index = 0; index < 5; index += 1) {
+          const path = join(
+            outputDirectory,
+            "static",
+            `aggregate-${index}.bin`,
+          );
+          writeFileSync(path, "");
+          truncateSync(path, 220 * 1024 * 1024);
+        }
+      },
+    },
+    {
+      name: "absolute standalone dependency symbolic link",
+      mutate: ({ outputDirectory }) => {
+        const functionDirectory = join(
+          outputDirectory,
+          "functions",
+          "api.func",
+        );
+        writeFunctionConfig(functionDirectory);
+        mkdirSync(join(functionDirectory, "node_modules"), { recursive: true });
+        symlinkSync(
+          "/etc/passwd",
+          join(functionDirectory, "node_modules", "package"),
+        );
+      },
+    },
+    {
+      name: "escaping standalone dependency symbolic link",
+      mutate: ({ outputDirectory }) => {
+        const functionDirectory = join(
+          outputDirectory,
+          "functions",
+          "api.func",
+        );
+        writeFunctionConfig(functionDirectory);
+        const packageLink = join(functionDirectory, "node_modules", "package");
+        mkdirSync(dirname(packageLink), { recursive: true });
+        symlinkSync(
+          relative(dirname(packageLink), outputDirectory),
+          packageLink,
+        );
+      },
+    },
+    {
+      name: "chained standalone dependency symbolic link",
+      mutate: ({ outputDirectory }) => {
+        const packageDirectory = join(
+          outputDirectory,
+          "functions",
+          "api.func",
+          "node_modules",
+        );
+        writeFunctionConfig(dirname(packageDirectory));
+        mkdirSync(join(packageDirectory, "target"), { recursive: true });
+        symlinkSync("target", join(packageDirectory, "first"));
+        symlinkSync("first", join(packageDirectory, "second"));
+      },
+    },
+    {
+      name: "broken standalone dependency symbolic link chain",
+      mutate: ({ outputDirectory }) => {
+        const functionDirectory = join(
+          outputDirectory,
+          "functions",
+          "api.func",
+        );
+        const packageDirectory = join(functionDirectory, "node_modules");
+        writeFunctionConfig(functionDirectory);
+        mkdirSync(packageDirectory, { recursive: true });
+        symlinkSync("missing", join(packageDirectory, "first"));
+        symlinkSync("first/child", join(packageDirectory, "second"));
+      },
+    },
+    {
+      name: "existing standalone dependency symbolic link chain",
+      mutate: ({ outputDirectory }) => {
+        const functionDirectory = join(
+          outputDirectory,
+          "functions",
+          "api.func",
+        );
+        const packageDirectory = join(functionDirectory, "node_modules");
+        writeFunctionConfig(functionDirectory);
+        mkdirSync(join(packageDirectory, "target"), { recursive: true });
+        symlinkSync("target", join(packageDirectory, "first"));
+        symlinkSync("first/missing", join(packageDirectory, "second"));
+      },
+    },
+    {
+      name: "standalone dependency symbolic link escapes nearest function",
+      mutate: ({ outputDirectory }) => {
+        const outerFunction = join(outputDirectory, "functions", "outer.func");
+        const innerFunction = join(outerFunction, "inner.func");
+        const outerTarget = join(outerFunction, "node_modules", "target");
+        const innerLink = join(innerFunction, "node_modules", "package");
+        writeFunctionConfig(outerFunction);
+        writeFunctionConfig(innerFunction);
+        mkdirSync(outerTarget, { recursive: true });
+        mkdirSync(dirname(innerLink), { recursive: true });
+        symlinkSync(relative(dirname(innerLink), outerTarget), innerLink);
+      },
     },
     {
       name: "FIFO",


### PR DESCRIPTION
## The Problem

GitHub-built UI prebuilt output retained repo-relative `filePathMap` dependency references. The hardened output-only handoff deletes the candidate source tree before credentialed upload, so Vercel CLI could not stat those references and the pilot failed before creating a deployment.

## The Solution

- build with pinned Vercel CLI `--standalone` so function dependencies are self-contained
- reject external file maps, unsafe config shapes, escaping or chained links, and oversized output before handoff or upload
- cover the real unused broken pnpm symlink while keeping the validator fail-closed
- document the self-contained prebuilt handoff invariant and limits

## Verification

- `pnpm vercel:workflow:test` (74/74)
- `pnpm check-types`
- `trunk check --fix`
- `pnpm ci:action-pins`
- `pnpm adr:check`
- `pnpm quality:budgets:test`
- deterministic autoreview: clean
- fresh-context semantic autoreview: 0 findings, 0.93 confidence

## Ship Checklist

- [x] ship skill used
- [x] local review run
- [x] validation run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the production UI prebuilt build mode and tightens upload validation on the deployment path; mis-tuned limits or symlink rules could block legitimate builds, but scope is CI/security hardening rather than app runtime behavior.
> 
> **Overview**
> Fixes GitHub-built UI prebuilt uploads failing after the candidate source tree is removed, when function configs still pointed at repo-relative **`filePathMap`** paths (e.g. **`node_modules`**) that no longer exist on disk.
> 
> **Build:** Preview prebuilt jobs now run **`vercel build --yes --standalone --target preview`** (workflow shell and **`buildVercelBuildArguments`**), so dependencies are inlined into function output for the narrow upload handoff.
> 
> **Validation:** The trusted output guard enforces self-contained artifacts before handoff/upload: any non-empty **`filePathMap`** in **`.vc-config.json`** is rejected; configs must be regular files (not symlinks/directories); caps apply at **1 MiB** per config, **250 MiB** per file, and **1 GiB** total output. Symlink rules are extended so standalone **`.func`** bundles may keep contained relative package-manager links inside the same physical function directory (including bounded broken unused links), while absolute, escaping, and chained links remain blocked.
> 
> **Docs/tests:** **`vercel-deployments.md`** documents the standalone invariant and limits; workflow tests assert the new CLI flag and cover accept/reject cases for the expanded guards.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02dcb1522bbe91eefbeaee73d83df745506117a2. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->