### PR TITLE
fix(ci): harden Vercel browser smoke

### DIFF
--- a/apps/ui.mento.org/e2e/vercel-preview-browser-smoke.mjs
+++ b/apps/ui.mento.org/e2e/vercel-preview-browser-smoke.mjs
@@ -10,6 +10,7 @@ const GITHUB_DEPLOYMENT_ID_PATTERN = /^[1-9][0-9]*$/;
 const VERCEL_DEPLOYMENT_ID_PATTERN = /^dpl_[A-Za-z0-9]+$/;
 const NEXT_DEPLOYMENT_ID_PATTERN = /^m-ui-[0-9a-f]{19}$/;
 const MAX_NEXT_STATIC_ASSET_REQUESTS = 5_000;
+const NEXT_STATIC_ASSET_IDLE_MS = 250;
 const AUTOMATIC_KEY_PATTERN =
   /^vercel-preview:v1:pr:[1-9][0-9]*:target:ui:sha:([0-9a-f]{40})$/;
 const PILOT_KEY_PATTERN =
@@ -217,7 +218,34 @@ export function assertBrowserDeploymentIdentity(
 
 function createBrowserDeploymentIdentityMonitor(page, expectedOrigin) {
   const assetReferences = [];
+  const activeRequests = new Set();
+  const activityWaiters = new Set();
   let overflow = false;
+
+  function signalActivity() {
+    for (const resolve of activityWaiters) {
+      resolve(true);
+    }
+    activityWaiters.clear();
+  }
+
+  function waitForActivity(timeoutMs) {
+    return new Promise((resolve) => {
+      let settled = false;
+      let timer;
+      const finish = (activityObserved) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        activityWaiters.delete(onActivity);
+        resolve(activityObserved);
+      };
+      const onActivity = () => finish(true);
+      activityWaiters.add(onActivity);
+      timer = setTimeout(() => finish(false), timeoutMs);
+    });
+  }
+
   page.on("request", (request) => {
     let url;
     try {
@@ -233,11 +261,59 @@ function createBrowserDeploymentIdentityMonitor(page, expectedOrigin) {
     }
     if (assetReferences.length >= MAX_NEXT_STATIC_ASSET_REQUESTS) {
       overflow = true;
+      signalActivity();
       return;
     }
     assetReferences.push(url.toString());
+    activeRequests.add(request);
+    signalActivity();
   });
+
+  const finishRequest = (request) => {
+    if (activeRequests.delete(request)) {
+      signalActivity();
+    }
+  };
+  page.on("requestfinished", finishRequest);
+  page.on("requestfailed", finishRequest);
+
   return {
+    async waitForIdle(timeoutMs) {
+      const deadline = Date.now() + timeoutMs;
+      while (true) {
+        if (overflow) {
+          throw new Error(
+            "Browser-loaded Next.js asset identity evidence exceeded its limit",
+          );
+        }
+        const remainingMs = deadline - Date.now();
+        if (remainingMs <= 0) {
+          throw new Error(
+            "Browser-loaded Next.js assets did not become idle before timeout",
+          );
+        }
+        if (activeRequests.size > 0) {
+          const activityObserved = await waitForActivity(remainingMs);
+          if (!activityObserved) {
+            throw new Error(
+              "Browser-loaded Next.js assets did not become idle before timeout",
+            );
+          }
+          continue;
+        }
+
+        const quietWindowMs = Math.min(NEXT_STATIC_ASSET_IDLE_MS, remainingMs);
+        const activityObserved = await waitForActivity(quietWindowMs);
+        if (!activityObserved) {
+          if (quietWindowMs < NEXT_STATIC_ASSET_IDLE_MS) {
+            throw new Error(
+              "Browser-loaded Next.js assets did not become idle before timeout",
+            );
+          }
+          return;
+        }
+      }
+    },
     assertExpected(expectedDeploymentId, htmlDeploymentId) {
       if (overflow) {
         throw new Error(
@@ -287,6 +363,7 @@ export async function runBrowserSmoke({ chromium, input, timeoutMs = 30_000 }) {
       .getByRole("heading", { name: "Basic Components", exact: true })
       .waitFor({ state: "visible" });
     await page.waitForLoadState("load");
+    await deploymentIdentityMonitor.waitForIdle(timeoutMs);
     const renderedDeploymentId = await page
       .locator("html")
       .getAttribute("data-dpl-id");
@@ -321,6 +398,7 @@ export async function runBrowserSmoke({ chromium, input, timeoutMs = 30_000 }) {
         "Browser smoke interaction did not remain updated after hydration",
       );
     }
+    await deploymentIdentityMonitor.waitForIdle(timeoutMs);
     deploymentIdentityMonitor.assertExpected(
       validated.nextDeploymentId,
       await page.locator("html").getAttribute("data-dpl-id"),

--- a/apps/ui.mento.org/e2e/vercel-preview-browser-smoke.mjs
+++ b/apps/ui.mento.org/e2e/vercel-preview-browser-smoke.mjs
@@ -398,10 +398,13 @@ export async function runBrowserSmoke({ chromium, input, timeoutMs = 30_000 }) {
         "Browser smoke interaction did not remain updated after hydration",
       );
     }
+    const finalRenderedDeploymentId = await page
+      .locator("html")
+      .getAttribute("data-dpl-id");
     await deploymentIdentityMonitor.waitForIdle(timeoutMs);
     deploymentIdentityMonitor.assertExpected(
       validated.nextDeploymentId,
-      await page.locator("html").getAttribute("data-dpl-id"),
+      finalRenderedDeploymentId,
     );
     monitor.assertClean();
     return {

--- a/apps/ui.mento.org/e2e/vercel-preview-browser-smoke.mjs
+++ b/apps/ui.mento.org/e2e/vercel-preview-browser-smoke.mjs
@@ -215,7 +215,7 @@ export function assertBrowserDeploymentIdentity(
   }
 }
 
-export function createBrowserDeploymentIdentityMonitor(page, expectedOrigin) {
+function createBrowserDeploymentIdentityMonitor(page, expectedOrigin) {
   const assetReferences = [];
   let overflow = false;
   page.on("request", (request) => {

--- a/apps/ui.mento.org/e2e/vercel-preview-browser-smoke.mjs
+++ b/apps/ui.mento.org/e2e/vercel-preview-browser-smoke.mjs
@@ -9,6 +9,7 @@ const SHA_PATTERN = /^[0-9a-f]{40}$/;
 const GITHUB_DEPLOYMENT_ID_PATTERN = /^[1-9][0-9]*$/;
 const VERCEL_DEPLOYMENT_ID_PATTERN = /^dpl_[A-Za-z0-9]+$/;
 const NEXT_DEPLOYMENT_ID_PATTERN = /^m-ui-[0-9a-f]{19}$/;
+const MAX_NEXT_STATIC_ASSET_REQUESTS = 5_000;
 const AUTOMATIC_KEY_PATTERN =
   /^vercel-preview:v1:pr:[1-9][0-9]*:target:ui:sha:([0-9a-f]{40})$/;
 const PILOT_KEY_PATTERN =
@@ -147,6 +148,111 @@ export function createBrowserFailureMonitor(page, expectedOrigin) {
   };
 }
 
+export function assertBrowserDeploymentIdentity(
+  identity,
+  expectedDeploymentId,
+  expectedOrigin,
+) {
+  if (
+    !identity ||
+    typeof identity !== "object" ||
+    (identity.htmlDeploymentId !== null &&
+      identity.htmlDeploymentId !== expectedDeploymentId)
+  ) {
+    throw new Error(
+      "Browser-rendered page carries a conflicting deployment ID",
+    );
+  }
+  if (
+    !Array.isArray(identity.assetReferences) ||
+    identity.assetReferences.length === 0 ||
+    identity.assetReferences.length > MAX_NEXT_STATIC_ASSET_REQUESTS
+  ) {
+    throw new Error(
+      "Browser-loaded Next.js asset identity evidence is missing or invalid",
+    );
+  }
+  let javaScriptAsset = false;
+  let styleAsset = false;
+  let nextStaticAssets = 0;
+  for (const reference of identity.assetReferences) {
+    if (
+      typeof reference !== "string" ||
+      reference.length === 0 ||
+      reference.length > 2_048
+    ) {
+      throw new Error("Browser-loaded Next.js asset reference is invalid");
+    }
+    let url;
+    try {
+      url = new URL(reference);
+    } catch {
+      throw new Error("Browser-loaded Next.js asset reference is invalid");
+    }
+    if (
+      url.origin !== expectedOrigin ||
+      !url.pathname.startsWith("/_next/static/")
+    ) {
+      continue;
+    }
+    nextStaticAssets += 1;
+    const deploymentIds = url.searchParams.getAll("dpl");
+    if (
+      deploymentIds.length !== 1 ||
+      deploymentIds[0] !== expectedDeploymentId
+    ) {
+      throw new Error(
+        "Browser-loaded Next.js assets do not carry only the expected deployment ID",
+      );
+    }
+    javaScriptAsset ||= url.pathname.endsWith(".js");
+    styleAsset ||= url.pathname.endsWith(".css");
+  }
+  if (nextStaticAssets === 0 || !javaScriptAsset || !styleAsset) {
+    throw new Error(
+      "Browser-loaded Next.js asset identity evidence is missing or invalid",
+    );
+  }
+}
+
+export function createBrowserDeploymentIdentityMonitor(page, expectedOrigin) {
+  const assetReferences = [];
+  let overflow = false;
+  page.on("request", (request) => {
+    let url;
+    try {
+      url = new URL(request.url());
+    } catch {
+      return;
+    }
+    if (
+      url.origin !== expectedOrigin ||
+      !url.pathname.startsWith("/_next/static/")
+    ) {
+      return;
+    }
+    if (assetReferences.length >= MAX_NEXT_STATIC_ASSET_REQUESTS) {
+      overflow = true;
+      return;
+    }
+    assetReferences.push(url.toString());
+  });
+  return {
+    assertExpected(expectedDeploymentId, htmlDeploymentId) {
+      if (overflow) {
+        throw new Error(
+          "Browser-loaded Next.js asset identity evidence exceeded its limit",
+        );
+      }
+      assertBrowserDeploymentIdentity(
+        { htmlDeploymentId, assetReferences },
+        expectedDeploymentId,
+        expectedOrigin,
+      );
+    },
+  };
+}
+
 export async function runBrowserSmoke({ chromium, input, timeoutMs = 30_000 }) {
   const validated = validateBrowserSmokeInput(input);
   const baseUrl = new URL(validated.deploymentUrl);
@@ -157,6 +263,10 @@ export async function runBrowserSmoke({ chromium, input, timeoutMs = 30_000 }) {
     page.setDefaultTimeout(timeoutMs);
     page.setDefaultNavigationTimeout(timeoutMs);
     const monitor = createBrowserFailureMonitor(page, baseUrl.origin);
+    const deploymentIdentityMonitor = createBrowserDeploymentIdentityMonitor(
+      page,
+      baseUrl.origin,
+    );
 
     const response = await page.goto(baseUrl.toString(), {
       waitUntil: "domcontentloaded",
@@ -176,14 +286,14 @@ export async function runBrowserSmoke({ chromium, input, timeoutMs = 30_000 }) {
     await page
       .getByRole("heading", { name: "Basic Components", exact: true })
       .waitFor({ state: "visible" });
+    await page.waitForLoadState("load");
     const renderedDeploymentId = await page
       .locator("html")
       .getAttribute("data-dpl-id");
-    if (renderedDeploymentId !== validated.nextDeploymentId) {
-      throw new Error(
-        "Browser-rendered page does not carry the expected deployment ID",
-      );
-    }
+    deploymentIdentityMonitor.assertExpected(
+      validated.nextDeploymentId,
+      renderedDeploymentId,
+    );
 
     await page
       .getByPlaceholder("Search components...", { exact: true })
@@ -206,6 +316,15 @@ export async function runBrowserSmoke({ chromium, input, timeoutMs = 30_000 }) {
 
     // Let errors from hydration and interaction microtasks reach the listeners.
     await page.waitForTimeout(250);
+    if (!(await checkbox.isChecked())) {
+      throw new Error(
+        "Browser smoke interaction did not remain updated after hydration",
+      );
+    }
+    deploymentIdentityMonitor.assertExpected(
+      validated.nextDeploymentId,
+      await page.locator("html").getAttribute("data-dpl-id"),
+    );
     monitor.assertClean();
     return {
       deploymentUrl: validated.deploymentUrl,

--- a/apps/ui.mento.org/e2e/vercel-preview-browser-smoke.test.mjs
+++ b/apps/ui.mento.org/e2e/vercel-preview-browser-smoke.test.mjs
@@ -3,6 +3,7 @@ import { EventEmitter } from "node:events";
 import { test } from "node:test";
 
 import {
+  assertBrowserDeploymentIdentity,
   createBrowserFailureMonitor,
   loadTrustedChromium,
   runBrowserSmoke,
@@ -23,9 +24,20 @@ const INPUT = {
 };
 
 class FakePage extends EventEmitter {
-  constructor({ afterInteraction } = {}) {
+  constructor({
+    afterInteraction,
+    htmlDeploymentId = NEXT_DEPLOYMENT_ID,
+    assetReferences = [
+      `${INPUT.deploymentUrl}/_next/static/app.js?dpl=${NEXT_DEPLOYMENT_ID}`,
+      `${INPUT.deploymentUrl}/_next/static/app.css?dpl=${NEXT_DEPLOYMENT_ID}`,
+    ],
+    navigationAssetReferences = [],
+  } = {}) {
     super();
     this.afterInteraction = afterInteraction;
+    this.htmlDeploymentId = htmlDeploymentId;
+    this.assetReferences = assetReferences;
+    this.navigationAssetReferences = navigationAssetReferences;
     this.currentUrl = INPUT.deploymentUrl;
     this.checkboxChecked = false;
     this.calls = [];
@@ -42,6 +54,9 @@ class FakePage extends EventEmitter {
   async goto(url, options) {
     this.calls.push(["goto", url, options]);
     this.currentUrl = new URL("/basic-components", url).toString();
+    for (const reference of this.assetReferences) {
+      this.emit("request", { url: () => reference });
+    }
     return { ok: () => true, status: () => 200 };
   }
 
@@ -54,7 +69,7 @@ class FakePage extends EventEmitter {
     return {
       getAttribute: async (attribute) => {
         assert.equal(attribute, "data-dpl-id");
-        return NEXT_DEPLOYMENT_ID;
+        return this.htmlDeploymentId;
       },
     };
   }
@@ -82,6 +97,9 @@ class FakePage extends EventEmitter {
       return {
         click: async () => {
           this.calls.push(["click", "Textarea"]);
+          for (const reference of this.navigationAssetReferences) {
+            this.emit("request", { url: () => reference });
+          }
           this.currentUrl = new URL(
             "/form-components",
             INPUT.deploymentUrl,
@@ -109,6 +127,11 @@ class FakePage extends EventEmitter {
     );
     this.calls.push(["wait-for-url", url, options]);
     assert.equal(this.currentUrl, url);
+  }
+
+  async waitForLoadState(state) {
+    assert.equal(state, "load");
+    this.calls.push(["load-state", state]);
   }
 
   async waitForTimeout(timeout) {
@@ -168,6 +191,75 @@ test("browser smoke validates the immutable deployment identity tuple", () => {
   );
 });
 
+test("browser identity accepts exact assets after hydration removes the html marker", () => {
+  const origin = new URL(INPUT.deploymentUrl).origin;
+  assert.doesNotThrow(() =>
+    assertBrowserDeploymentIdentity(
+      {
+        htmlDeploymentId: null,
+        assetReferences: [
+          `${INPUT.deploymentUrl}/_next/static/app.js?dpl=${NEXT_DEPLOYMENT_ID}&cache=1`,
+          `${INPUT.deploymentUrl}/_next/static/app.css?cache=1&dpl=${NEXT_DEPLOYMENT_ID}`,
+        ],
+      },
+      NEXT_DEPLOYMENT_ID,
+      origin,
+    ),
+  );
+});
+
+test("browser identity rejects missing, mixed, duplicate, or cross-origin evidence", () => {
+  const otherDeploymentId = "m-ui-fffffffffffffffffff";
+  const origin = new URL(INPUT.deploymentUrl).origin;
+  assert.throws(
+    () =>
+      assertBrowserDeploymentIdentity(
+        {
+          htmlDeploymentId: otherDeploymentId,
+          assetReferences: [
+            `${INPUT.deploymentUrl}/_next/static/app.js?dpl=${NEXT_DEPLOYMENT_ID}`,
+            `${INPUT.deploymentUrl}/_next/static/app.css?dpl=${NEXT_DEPLOYMENT_ID}`,
+          ],
+        },
+        NEXT_DEPLOYMENT_ID,
+        origin,
+      ),
+    /conflicting deployment ID/,
+  );
+  const invalidReferences = [
+    [],
+    [
+      `${INPUT.deploymentUrl}/_next/static/app.js?dpl=${NEXT_DEPLOYMENT_ID}`,
+      `${INPUT.deploymentUrl}/_next/static/app.css`,
+    ],
+    [
+      `${INPUT.deploymentUrl}/_next/static/app.js?dpl=${NEXT_DEPLOYMENT_ID}`,
+      `${INPUT.deploymentUrl}/_next/static/app.css?dpl=${otherDeploymentId}`,
+    ],
+    [
+      `${INPUT.deploymentUrl}/_next/static/app.js?dpl=${NEXT_DEPLOYMENT_ID}`,
+      `${INPUT.deploymentUrl}/_next/static/app.css?dpl=${NEXT_DEPLOYMENT_ID}&dpl=${otherDeploymentId}`,
+    ],
+    [
+      `https://other.vercel.app/_next/static/app.js?dpl=${NEXT_DEPLOYMENT_ID}`,
+      `https://other.vercel.app/_next/static/app.css?dpl=${NEXT_DEPLOYMENT_ID}`,
+    ],
+    [`${INPUT.deploymentUrl}/_next/static/app.js?dpl=${NEXT_DEPLOYMENT_ID}`],
+  ];
+  for (const assetReferences of invalidReferences) {
+    assert.throws(() =>
+      assertBrowserDeploymentIdentity(
+        {
+          htmlDeploymentId: null,
+          assetReferences,
+        },
+        NEXT_DEPLOYMENT_ID,
+        origin,
+      ),
+    );
+  }
+});
+
 test("trusted checkout resolves its own pinned Playwright package", async () => {
   const chromium = await loadTrustedChromium(repoRoot);
   assert.equal(typeof chromium.launch, "function");
@@ -191,12 +283,41 @@ test("browser smoke renders, navigates through search, and changes a control", a
     "/form-components",
   ]);
   assert.equal(result.interaction, "sidebar-search-and-checkbox");
+  assert.equal(page.calls.filter((call) => call[0] === "load-state").length, 1);
   assert.ok(page.calls.some((call) => call[0] === "fill"));
   assert.ok(
     page.calls.some(
       (call) => call[0] === "click" && call[1] === "Checkbox option",
     ),
   );
+});
+
+test("browser smoke rejects conflicting route-specific asset identity", async () => {
+  const page = new FakePage({
+    navigationAssetReferences: [
+      `${INPUT.deploymentUrl}/_next/static/form.js?dpl=m-ui-fffffffffffffffffff`,
+    ],
+  });
+  const fake = fakeChromium(page);
+  await assert.rejects(
+    runBrowserSmoke({ chromium: fake.chromium, input: INPUT }),
+    /do not carry only the expected deployment ID/,
+  );
+  assert.equal(fake.state.closed, true);
+});
+
+test("browser smoke rejects a control reset during hydration settle", async () => {
+  const page = new FakePage({
+    afterInteraction(currentPage) {
+      currentPage.checkboxChecked = false;
+    },
+  });
+  const fake = fakeChromium(page);
+  await assert.rejects(
+    runBrowserSmoke({ chromium: fake.chromium, input: INPUT }),
+    /did not remain updated after hydration/,
+  );
+  assert.equal(fake.state.closed, true);
 });
 
 test("browser smoke closes Chrome when a captured failure rejects the run", async () => {

--- a/apps/ui.mento.org/e2e/vercel-preview-browser-smoke.test.mjs
+++ b/apps/ui.mento.org/e2e/vercel-preview-browser-smoke.test.mjs
@@ -55,13 +55,28 @@ class FakePage extends EventEmitter {
     this.calls.push(["goto", url, options]);
     this.currentUrl = new URL("/basic-components", url).toString();
     for (const reference of this.assetReferences) {
-      this.emit("request", { url: () => reference });
+      this.emitAssetRequest(reference);
     }
     return { ok: () => true, status: () => 200 };
   }
 
   url() {
     return this.currentUrl;
+  }
+
+  emitAssetRequest(reference) {
+    const request = this.startAssetRequest(reference);
+    this.emit("requestfinished", request);
+  }
+
+  startAssetRequest(reference) {
+    const request = {
+      failure: () => ({ errorText: "net::ERR_FAILED" }),
+      method: () => "GET",
+      url: () => reference,
+    };
+    this.emit("request", request);
+    return request;
   }
 
   locator(selector) {
@@ -98,7 +113,7 @@ class FakePage extends EventEmitter {
         click: async () => {
           this.calls.push(["click", "Textarea"]);
           for (const reference of this.navigationAssetReferences) {
-            this.emit("request", { url: () => reference });
+            this.emitAssetRequest(reference);
           }
           this.currentUrl = new URL(
             "/form-components",
@@ -302,6 +317,43 @@ test("browser smoke rejects conflicting route-specific asset identity", async ()
   await assert.rejects(
     runBrowserSmoke({ chromium: fake.chromium, input: INPUT }),
     /do not carry only the expected deployment ID/,
+  );
+  assert.equal(fake.state.closed, true);
+});
+
+test("browser smoke rejects a late route-specific asset after interaction", async () => {
+  const page = new FakePage({
+    afterInteraction(currentPage) {
+      setTimeout(() => {
+        currentPage.emitAssetRequest(
+          `${INPUT.deploymentUrl}/_next/static/late-form.js?dpl=m-ui-fffffffffffffffffff`,
+        );
+      }, 10);
+    },
+  });
+  const fake = fakeChromium(page);
+  await assert.rejects(
+    runBrowserSmoke({ chromium: fake.chromium, input: INPUT }),
+    /do not carry only the expected deployment ID/,
+  );
+  assert.equal(fake.state.closed, true);
+});
+
+test("browser smoke waits for a late static request to reach a terminal event", async () => {
+  const page = new FakePage({
+    afterInteraction(currentPage) {
+      setTimeout(() => {
+        const request = currentPage.startAssetRequest(
+          `${INPUT.deploymentUrl}/_next/static/late-form.js?dpl=${NEXT_DEPLOYMENT_ID}`,
+        );
+        setTimeout(() => currentPage.emit("requestfailed", request), 300);
+      }, 10);
+    },
+  });
+  const fake = fakeChromium(page);
+  await assert.rejects(
+    runBrowserSmoke({ chromium: fake.chromium, input: INPUT }),
+    /same-origin request failed: GET/,
   );
   assert.equal(fake.state.closed, true);
 });

--- a/apps/ui.mento.org/e2e/vercel-preview-browser-smoke.test.mjs
+++ b/apps/ui.mento.org/e2e/vercel-preview-browser-smoke.test.mjs
@@ -27,6 +27,7 @@ class FakePage extends EventEmitter {
   constructor({
     afterInteraction,
     htmlDeploymentId = NEXT_DEPLOYMENT_ID,
+    onFinalHtmlDeploymentIdRead,
     assetReferences = [
       `${INPUT.deploymentUrl}/_next/static/app.js?dpl=${NEXT_DEPLOYMENT_ID}`,
       `${INPUT.deploymentUrl}/_next/static/app.css?dpl=${NEXT_DEPLOYMENT_ID}`,
@@ -36,6 +37,8 @@ class FakePage extends EventEmitter {
     super();
     this.afterInteraction = afterInteraction;
     this.htmlDeploymentId = htmlDeploymentId;
+    this.onFinalHtmlDeploymentIdRead = onFinalHtmlDeploymentIdRead;
+    this.htmlDeploymentIdReads = 0;
     this.assetReferences = assetReferences;
     this.navigationAssetReferences = navigationAssetReferences;
     this.currentUrl = INPUT.deploymentUrl;
@@ -84,6 +87,10 @@ class FakePage extends EventEmitter {
     return {
       getAttribute: async (attribute) => {
         assert.equal(attribute, "data-dpl-id");
+        this.htmlDeploymentIdReads += 1;
+        if (this.htmlDeploymentIdReads === 2) {
+          this.onFinalHtmlDeploymentIdRead?.(this);
+        }
         return this.htmlDeploymentId;
       },
     };
@@ -348,6 +355,23 @@ test("browser smoke waits for a late static request to reach a terminal event", 
         );
         setTimeout(() => currentPage.emit("requestfailed", request), 300);
       }, 10);
+    },
+  });
+  const fake = fakeChromium(page);
+  await assert.rejects(
+    runBrowserSmoke({ chromium: fake.chromium, input: INPUT }),
+    /same-origin request failed: GET/,
+  );
+  assert.equal(fake.state.closed, true);
+});
+
+test("browser smoke settles requests started by its final DOM read", async () => {
+  const page = new FakePage({
+    onFinalHtmlDeploymentIdRead(currentPage) {
+      const request = currentPage.startAssetRequest(
+        `${INPUT.deploymentUrl}/_next/static/final-read.js?dpl=${NEXT_DEPLOYMENT_ID}`,
+      );
+      setTimeout(() => currentPage.emit("requestfailed", request), 300);
     },
   });
   const fake = fakeChromium(page);

--- a/docs/vercel-deployments.md
+++ b/docs/vercel-deployments.md
@@ -845,7 +845,16 @@ UI smoke. Every initial or resumed credential-free smoke attempt keeps the
 HTTP/header/static-asset checks, then uses the trusted main-branch smoke
 controller with Playwright and the GitHub runner's system Chrome to render the
 showcase, search and navigate to a second route, change a form control, and fail
-on page/console errors or failed same-origin requests and responses. Its
+on page/console errors or failed same-origin requests and responses. The direct
+HTTP phase verifies the server-rendered `data-dpl-id`; after hydration, the
+browser phase requires every loaded same-origin `/_next/static/` asset to carry
+exactly the expected `?dpl=` value and rejects any conflicting retained HTML
+deployment marker. Controller-side request monitoring remains active through
+the second-route interaction, so dynamically loaded chunks cannot escape the
+same identity check. This preserves fail-closed deployment-identity proof when
+React reconciles the server-injected HTML attribute out of the live DOM. Chrome
+also waits for the initial page load before changing controlled inputs, then
+rechecks the changed form control after the hydration/interaction settle. Its
 dependency graph comes from the trusted workflow checkout, candidate lifecycle
 scripts stay disabled, and no Vercel or Turbo credential is present in the
 smoke job. The worker records a durable non-terminal upload evidence receipt;

--- a/docs/vercel-deployments.md
+++ b/docs/vercel-deployments.md
@@ -851,7 +851,9 @@ browser phase requires every loaded same-origin `/_next/static/` asset to carry
 exactly the expected `?dpl=` value and rejects any conflicting retained HTML
 deployment marker. Controller-side request monitoring remains active through
 the second-route interaction, so dynamically loaded chunks cannot escape the
-same identity check. This preserves fail-closed deployment-identity proof when
+same identity check. The controller waits for all observed static requests to
+finish and for a quiet window before its final assertion. This preserves
+fail-closed deployment-identity proof when
 React reconciles the server-injected HTML attribute out of the live DOM. Chrome
 also waits for the initial page load before changing controlled inputs, then
 rechecks the changed form control after the hydration/interaction settle. Its


### PR DESCRIPTION
## The Problem

The first standalone pilot uploaded and verified a valid immutable deployment, but hosted Chrome failed because Next.js intentionally removes its server-injected data-dpl-id before hydration. The smoke also interacted with the SSR search field before initial hydration, allowing React to reset its value.

## The Solution

- keep direct HTTP responsible for verifying the initial server data-dpl-id
- monitor actual Playwright request events through both routes and require every same-origin Next static asset to carry exactly one expected dpl value
- require JavaScript and CSS identity evidence and reject missing, mixed, duplicate, cross-origin, overflow, or late route-chunk evidence
- wait for initial page load before controlled input changes and re-check checkbox state after the hydration settle
- document the split identity and hydration contract

## Verification

- pnpm vercel:workflow:test (78/78)
- pnpm check-types
- pnpm knip
- trunk check --fix
- real system-Chrome smoke against https://uimento-b84ue4xte-mentolabs.vercel.app
- Chrome DevTools: exact asset deployment IDs, interaction works, no console errors

## Ship Checklist

- [x] ship skill used
- [x] local review run
- [x] validation run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to CI smoke scripts, unit tests, and documentation; they tighten verification gates without altering production app or deployment orchestration logic.
> 
> **Overview**
> Hardens **Vercel preview browser smoke** so deployment identity stays verifiable after Next.js hydration and interactions are less flaky.
> 
> **Deployment identity:** HTTP checks still cover the initial server `data-dpl-id`. The browser path now records same-origin `/_next/static/` requests and requires every such asset to carry exactly one expected `?dpl=` value, with both JS and CSS present. Conflicting HTML markers, mixed IDs, cross-origin assets, and route chunks loaded after navigation are rejected. Identity is asserted after the first page load and again after the form interaction.
> 
> **Hydration timing:** Smoke waits for `load` before filling the search field, re-checks the checkbox after the settle window, and fails if hydration resets the control.
> 
> Tests cover the new `assertBrowserDeploymentIdentity` helper and failure modes; `docs/vercel-deployments.md` documents the split HTTP vs browser identity contract.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2eb664af50796a9477dc5eee540f9377f639258. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->