### PR TITLE
fix(ci): make preview receipts reviewer-friendly

### DIFF
--- a/docs/vercel-deployments.md
+++ b/docs/vercel-deployments.md
@@ -722,6 +722,18 @@ receipt starts a new same-head epoch and replans the new base-to-head transition
 Title, body, label, and other unrelated edits do not create a receipt or
 reconciliation.
 
+These bot comments are internal coordination records, not review feedback. Each
+comment explains that no reviewer action is required and keeps its
+machine-readable JSON inside a collapsed GitHub `<details>` block. The hidden
+marker remains the first line, and the JSON remains canonical so receipt
+identity, validation, and recovery semantics do not change. The stored Markdown
+leaves the final `</details>` implicit so its JSON fence remains the literal end
+of the body; GitHub closes the toggle when rendering it, while already-running
+legacy workers can still parse comments created during rollout. Existing
+immutable receipts in the legacy uncollapsed format remain valid and are never
+rewritten; the mutable state comment adopts the current presentation on its
+next update.
+
 `Vercel Preview` is reserved for a Statuses API commit status, not a workflow
 job/check name. Every exact receipt SHA gets one truthful result: pending,
 verified, no runtime impact, runtime-equivalent to a prior preview, unsupported

--- a/scripts/vercel-preview-controller.mjs
+++ b/scripts/vercel-preview-controller.mjs
@@ -66,6 +66,14 @@ const WORKER_RECOVERY_BEFORE_MS = 2 * 60 * 1_000;
 const WORKER_RECOVERY_AFTER_MS = 15 * 60 * 1_000;
 const UPLOAD_STARTED_DESCRIPTION = "Prebuilt preview upload starting";
 const RETIRED_RECOVERY_QUARANTINE = "persisted-attempt-invalid-or-unavailable";
+const COMMENT_EXPLANATION = [
+  "**No reviewer action is required.**",
+  "This repository builds pull request previews in GitHub Actions and deploys them to Vercel.",
+  "This record lets the preview automation handle overlapping pushes and recover safely from retries.",
+  "[How previews work](https://github.com/mento-protocol/frontend-monorepo/blob/main/docs/vercel-deployments.md#event-status-and-batching-contract).",
+].join(" ");
+const COMMENT_DETAILS_SUMMARY =
+  "Show machine-readable preview automation record";
 
 class WorkerWorkflowShaMismatchError extends Error {
   constructor({ runId, actualWorkflowSha, expectedWorkflowSha }) {
@@ -241,8 +249,15 @@ function digest(value, length = 64) {
     .slice(0, length);
 }
 
-function markerBody(marker, value) {
+function legacyMarkerBody(marker, value) {
   return `${marker}\n\n\`\`\`json\n${JSON.stringify(value, null, 2)}\n\`\`\`\n`;
+}
+
+function markerBody(marker, value) {
+  // Keep the JSON fence at the literal end so already-running v1 workers can
+  // parse comments written during the rollout. GitHub's GFM renderer closes
+  // the final <details> element implicitly.
+  return `${marker}\n\n${COMMENT_EXPLANATION}\n\n<details>\n<summary>${COMMENT_DETAILS_SUMMARY}</summary>\n\n\`\`\`json\n${JSON.stringify(value, null, 2)}\n\`\`\`\n`;
 }
 
 function parseMarkerBody(body, marker) {
@@ -250,10 +265,21 @@ function parseMarkerBody(body, marker) {
     typeof body === "string" && body.startsWith(`${marker}\n`),
     "Comment marker mismatch",
   );
-  const match = body.match(/\n```json\n([\s\S]+)\n```\n?$/);
-  invariant(match, "Controller comment JSON block is missing");
-  invariant(match[1].length <= 60_000, "Controller comment JSON is too large");
-  return JSON.parse(match[1]);
+  const currentPrefix = `${marker}\n\n${COMMENT_EXPLANATION}\n\n<details>\n<summary>${COMMENT_DETAILS_SUMMARY}</summary>\n\n\`\`\`json\n`;
+  const legacyPrefix = `${marker}\n\n\`\`\`json\n`;
+  let json;
+  for (const prefix of [currentPrefix, legacyPrefix]) {
+    if (!body.startsWith(prefix)) continue;
+    for (const suffix of ["\n```\n", "\n```"]) {
+      if (!body.endsWith(suffix)) continue;
+      json = body.slice(prefix.length, -suffix.length);
+      break;
+    }
+    if (json !== undefined) break;
+  }
+  invariant(json !== undefined, "Controller comment JSON block is missing");
+  invariant(json.length <= 60_000, "Controller comment JSON is too large");
+  return JSON.parse(json);
 }
 
 function isTrustedBotComment(comment) {
@@ -1838,6 +1864,13 @@ function matchingBotComments(comments, marker) {
 
 async function writeImmutableComment({ github, context, pr, marker, value }) {
   const body = markerBody(marker, value);
+  const legacyBody = legacyMarkerBody(marker, value);
+  const acceptedBodies = new Set([
+    body,
+    body.slice(0, -1),
+    legacyBody,
+    legacyBody.slice(0, -1),
+  ]);
   const existing = matchingBotComments(
     await listComments(github, context, pr),
     marker,
@@ -1845,7 +1878,7 @@ async function writeImmutableComment({ github, context, pr, marker, value }) {
   invariant(existing.length <= 1, `Duplicate immutable marker ${marker}`);
   if (existing.length === 1) {
     invariant(
-      existing[0].body === body,
+      acceptedBodies.has(existing[0].body),
       `Immutable receipt ${marker} conflicts with existing evidence`,
     );
     return { comment: existing[0], reused: true };

--- a/scripts/vercel-preview-controller.test.mjs
+++ b/scripts/vercel-preview-controller.test.mjs
@@ -1315,8 +1315,19 @@ test("compact terminal ownership survives more results than rendered history", (
   );
 });
 
-function commentBody(marker, value) {
+const expectedCommentExplanation = [
+  "**No reviewer action is required.**",
+  "This repository builds pull request previews in GitHub Actions and deploys them to Vercel.",
+  "This record lets the preview automation handle overlapping pushes and recover safely from retries.",
+  "[How previews work](https://github.com/mento-protocol/frontend-monorepo/blob/main/docs/vercel-deployments.md#event-status-and-batching-contract).",
+].join(" ");
+
+function legacyCommentBody(marker, value) {
   return `${marker}\n\n\`\`\`json\n${JSON.stringify(value, null, 2)}\n\`\`\`\n`;
+}
+
+function commentBody(marker, value) {
+  return `${marker}\n\n${expectedCommentExplanation}\n\n<details>\n<summary>Show machine-readable preview automation record</summary>\n\n\`\`\`json\n${JSON.stringify(value, null, 2)}\n\`\`\`\n`;
 }
 
 function eventComment(value, id = 1) {
@@ -1327,11 +1338,27 @@ function eventComment(value, id = 1) {
   };
 }
 
+function legacyEventComment(value, id = 1) {
+  return {
+    id,
+    user: { type: "Bot", login: "github-actions[bot]" },
+    body: legacyCommentBody(eventReceiptMarker(value.event_run_id), value),
+  };
+}
+
 function stateComment(value, id = 2) {
   return {
     id,
     user: { type: "Bot", login: "github-actions[bot]" },
     body: commentBody("<!-- vercel-preview-controller:v1 -->", value),
+  };
+}
+
+function legacyStateComment(value, id = 2) {
+  return {
+    id,
+    user: { type: "Bot", login: "github-actions[bot]" },
+    body: legacyCommentBody("<!-- vercel-preview-controller:v1 -->", value),
   };
 }
 
@@ -1348,6 +1375,14 @@ function selectionComment(value, id = 4) {
     id,
     user: { type: "Bot", login: "github-actions[bot]" },
     body: commentBody(selectionReceiptMarker(value), value),
+  };
+}
+
+function legacySelectionComment(value, id = 4) {
+  return {
+    id,
+    user: { type: "Bot", login: "github-actions[bot]" },
+    body: legacyCommentBody(selectionReceiptMarker(value), value),
   };
 }
 
@@ -1748,7 +1783,23 @@ test("malformed successful planner output is recorded as fail-closed UI impact",
   assert.equal(receipt.plan.base, SHA.E);
   assert.equal(receipt.plan.head, SHA.A);
   assert.equal(core.outputs.get("planner_output_invalid"), "true");
+  assert.match(
+    fixture.comments[0].body,
+    /\*\*No reviewer action is required\.\*\*/,
+  );
+  assert.match(fixture.comments[0].body, /<details>/);
+  assert.match(
+    fixture.comments[0].body,
+    /<summary>Show machine-readable preview automation record<\/summary>/,
+  );
+  assert.doesNotMatch(fixture.comments[0].body, /<\/details>/);
+  assert.match(fixture.comments[0].body, /\n```\n$/);
   assert.match(fixture.comments[0].body, /"reason": "planner-job-failed"/);
+  const legacyReaderMatch = fixture.comments[0].body.match(
+    /\n```json\n([\s\S]+)\n```\n?$/,
+  );
+  assert.ok(legacyReaderMatch, "the previous v1 reader can parse the new body");
+  assert.deepEqual(JSON.parse(legacyReaderMatch[1]), receipt);
   assert.equal(fixture.commitStatuses.at(-1).state, "pending");
 });
 
@@ -1788,6 +1839,47 @@ test("closed event receipt is immutable, idempotent, and publishes no status", a
   assert.match(fixture.comments[0].body, /"event_action": "closed"/);
   assert.equal(fixture.commitStatuses.length, 0);
 
+  const legacyBody = legacyCommentBody(
+    eventReceiptMarker(120),
+    first,
+  ).trimEnd();
+  const legacyFixture = fakeGitHub({
+    pullRequest,
+    comments: [
+      {
+        id: 1,
+        user: { type: "Bot", login: "github-actions[bot]" },
+        body: legacyBody,
+      },
+    ],
+  });
+  const reusedLegacy = await recordEventReceipt({
+    ...options,
+    github: legacyFixture.github,
+  });
+  assert.deepEqual(reusedLegacy, first);
+  assert.equal(legacyFixture.comments.length, 1);
+  assert.equal(legacyFixture.comments[0].body, legacyBody);
+
+  const malformedComment = eventComment(first);
+  malformedComment.body = malformedComment.body.replace(
+    "Show machine-readable preview automation record",
+    "Unexpected summary",
+  );
+  const malformedFixture = fakeGitHub({
+    pullRequest,
+    comments: [malformedComment],
+  });
+  await assert.rejects(
+    reconcilePreview({
+      github: malformedFixture.github,
+      context: fakeContext({ runId: 120 }),
+      core: fakeCore(),
+      prNumber: 519,
+    }),
+    /Controller comment JSON block is missing/,
+  );
+
   const opened = event({
     run: 119,
     action: "opened",
@@ -1796,7 +1888,7 @@ test("closed event receipt is immutable, idempotent, and publishes no status", a
   });
   const reconcileFixture = fakeGitHub({
     pullRequest,
-    comments: [eventComment(opened), eventComment(first, 2)],
+    comments: [legacyEventComment(opened), legacyEventComment(first, 2)],
   });
   const state = await reconcilePreview({
     github: reconcileFixture.github,
@@ -1837,10 +1929,10 @@ test("closed reconciliation preserves an unbound intent without dispatching it",
   const fixture = fakeGitHub({
     pullRequest,
     comments: [
-      eventComment(opened),
-      stateComment(intended),
-      selectionComment(selectionReceiptFromDispatch(intended.ui.active)),
-      eventComment(closed, 5),
+      legacyEventComment(opened),
+      legacyStateComment(intended),
+      legacySelectionComment(selectionReceiptFromDispatch(intended.ui.active)),
+      legacyEventComment(closed, 5),
     ],
   });
 
@@ -1864,6 +1956,8 @@ test("closed reconciliation preserves an unbound intent without dispatching it",
     fixture.comments.some(
       ({ body }) =>
         body.startsWith("<!-- vercel-preview-controller:v1 -->") &&
+        body.includes("**No reviewer action is required.**") &&
+        body.includes("<details>") &&
         body.includes('"closed": true'),
     ),
   );


### PR DESCRIPTION
## The Problem

The Vercel preview controller uses durable bot-authored pull-request comments as its event and recovery journal. Those comments currently expose raw JSON without context, so they look like unexplained automation noise to reviewers.

A presentation fix must preserve immutable receipt identity and remain readable by both existing comments and already-running workers authorized by an older controller SHA.

## The Solution

- Add a plain-English explanation that no reviewer action is required and link to the preview-controller runbook.
- Put machine-readable JSON behind a collapsed GitHub `<details>` toggle.
- Keep the JSON fence at the literal end of the stored body so the previous v1 reader remains forward-compatible during rollout; GitHub closes the toggle when rendering.
- Accept current and legacy comment envelopes with or without a terminal newline, without rewriting immutable legacy receipts.
- Cover new rendering, old-reader compatibility, legacy reconciliation, idempotency, and malformed-envelope rejection.
- Document the reviewer-facing comment contract and migration behavior.

Architecture decision: Not applicable — comment presentation changes while the existing durable controller architecture and schemas remain unchanged.

Refs #519.

## Validation

- `pnpm test` — passed
- `pnpm check-types` — passed
- `pnpm vercel:preview:test` — 86/86 passed after the compatibility fix
- `pnpm quality:budgets:test` — 30/30 passed
- `pnpm ci:action-pins` — passed
- `trunk check scripts/vercel-preview-controller.mjs scripts/vercel-preview-controller.test.mjs docs/vercel-deployments.md` — passed
- `git diff --check` — passed
- GitHub Markdown API rendered the exact final source as visible explanatory prose plus a closed `<details>` toggle; no test comment was posted
- Interactive Chrome DevTools was unavailable in this session
- Fresh-context semantic autoreview — initial rolling-upgrade and terminal-newline findings fixed; final review clean at 0.97 confidence
- Deterministic local autoreview — clean
- Commit and pre-push hooks — passed

## Ship Checklist

- [x] ship skill used
- [x] local review run
- [x] validation run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches durable comment parsing and idempotency for preview automation evidence; rollout is mitigated by legacy acceptance but a parsing bug could break reconciliation.
> 
> **Overview**
> Vercel preview controller **bot PR comments** now read as internal automation notes instead of raw JSON: each body starts with a short “no reviewer action required” explanation (with a link to the runbook) and puts the canonical receipt JSON inside a collapsed `<details>` block.
> 
> **Parsing and rollout safety** change in tandem: `parseMarkerBody` accepts both the new envelope and the previous marker-plus-JSON layout (with or without a trailing newline), and immutable receipt writes treat existing legacy bodies as valid so nothing is rewritten. New comments omit an explicit closing `</details>` so the JSON fence stays at the literal end of the body—keeping older v1 workers able to read comments posted mid-rollout while GitHub still renders the toggle closed.
> 
> `docs/vercel-deployments.md` documents this reviewer-facing contract and migration behavior; tests cover the new markup, legacy reconciliation/idempotency, and rejection of malformed envelopes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b939c5383bd89ca38d211c9a656fe138ee9c6d42. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->