### PR TITLE
fix(ci): migrate legacy preview receipt comments

### DIFF
--- a/docs/vercel-deployments.md
+++ b/docs/vercel-deployments.md
@@ -729,10 +729,16 @@ marker remains the first line, and the JSON remains canonical so receipt
 identity, validation, and recovery semantics do not change. The stored Markdown
 leaves the final `</details>` implicit so its JSON fence remains the literal end
 of the body; GitHub closes the toggle when rendering it, while already-running
-legacy workers can still parse comments created during rollout. Existing
-immutable receipts in the legacy uncollapsed format remain valid and are never
-rewritten; the mutable state comment adopts the current presentation on its
-next update.
+legacy workers can still parse comments created during rollout. Receipt
+immutability applies to the hidden marker and canonical JSON payload, not to its
+Markdown presentation. Reconciliation upgrades an exact canonical legacy body
+in place, preserving its comment ID, marker, and JSON. It defers that migration
+while an active or recoverable retired worker from an older workflow revision
+lacks a terminal result, because that older writer may still require the legacy
+envelope for idempotent retries. Each reconciliation upgrades at most five
+comments; any remaining or temporarily failed presentation updates resume on a
+later reconciliation without blocking preview status publication. The mutable
+state comment continues to adopt the current presentation on its next update.
 
 `Vercel Preview` is reserved for a Statuses API commit status, not a workflow
 job/check name. Every exact receipt SHA gets one truthful result: pending,

--- a/scripts/vercel-preview-controller.mjs
+++ b/scripts/vercel-preview-controller.mjs
@@ -25,6 +25,12 @@ const EVENT_MARKER_PREFIX = "<!-- vercel-preview-event-receipt:v1:run:";
 const EVIDENCE_MARKER_PREFIX = "<!-- vercel-preview-worker-evidence:v1:";
 const RESULT_MARKER_PREFIX = "<!-- vercel-preview-worker-result:v1:";
 const SELECTION_MARKER_PREFIX = "<!-- vercel-preview-selection:v1:key:";
+const IMMUTABLE_RECEIPT_MARKER_PREFIXES = [
+  EVENT_MARKER_PREFIX,
+  EVIDENCE_MARKER_PREFIX,
+  RESULT_MARKER_PREFIX,
+  SELECTION_MARKER_PREFIX,
+];
 const CONTROLLER_MARKER = "<!-- vercel-preview-controller:v1 -->";
 const SHA_PATTERN = /^[0-9a-f]{40}$/;
 const LOGIN_PATTERN =
@@ -53,6 +59,7 @@ const TERMINAL_STATES = new Set(["success", "failure", "error"]);
 const MAX_COMMENTS = 500;
 const MAX_RECEIPTS = 200;
 const MAX_HISTORY = 40;
+const MAX_PRESENTATION_MIGRATIONS_PER_RECONCILE = 5;
 const WORKER_RUN_PAGE_SIZE = 100;
 const MAX_WORKER_RUN_PAGES = 3;
 const WORKER_RUN_VISIBILITY_ATTEMPTS = 3;
@@ -1936,6 +1943,112 @@ function parseControllerComments(comments) {
   };
 }
 
+function canonicalLegacyReceiptUpgrade(comment) {
+  if (!isTrustedBotComment(comment) || typeof comment.body !== "string")
+    return null;
+  const marker = comment.body.split("\n", 1)[0];
+  if (
+    !IMMUTABLE_RECEIPT_MARKER_PREFIXES.some((prefix) =>
+      marker.startsWith(prefix),
+    )
+  ) {
+    return null;
+  }
+  const value = parseMarkerBody(comment.body, marker);
+  const legacyBody = legacyMarkerBody(marker, value);
+  if (comment.body !== legacyBody && comment.body !== legacyBody.slice(0, -1)) {
+    return null;
+  }
+  return {
+    commentId: comment.id,
+    body: markerBody(marker, value),
+  };
+}
+
+function selectionHasTerminalResult(selection, results) {
+  return results.some(
+    (result) =>
+      result.key_digest === selection.key_digest &&
+      result.epoch_anchor_run_id === selection.epoch_anchor_run_id &&
+      result.selection_receipt_run_id === selection.selection_receipt_run_id,
+  );
+}
+
+function hasUnfinishedLegacyWorker(parsed, pr, workflowSha) {
+  const state = normalizeExistingState(parsed.state, pr);
+  if (state === null) return true;
+  return [state.ui?.active, ...(state.ui?.retired_active ?? [])]
+    .filter(
+      (selection) => selection && selection.recovery_quarantine === undefined,
+    )
+    .some(
+      (selection) =>
+        selection.expected_workflow_sha !== workflowSha &&
+        !selectionHasTerminalResult(selection, parsed.results),
+    );
+}
+
+async function migrateLegacyReceiptPresentation({
+  github,
+  context,
+  core,
+  pr,
+  workflowSha,
+  comments,
+  parsed,
+  migrationBudget,
+}) {
+  const upgrades = comments.map(canonicalLegacyReceiptUpgrade).filter(Boolean);
+  if (upgrades.length === 0) {
+    if (migrationBudget.migrated > 0) {
+      core.setOutput("legacy_receipt_presentations_remaining", "0");
+    }
+    return;
+  }
+  if (hasUnfinishedLegacyWorker(parsed, pr, workflowSha)) {
+    core.setOutput("legacy_receipt_presentation_migration_deferred", "true");
+    return;
+  }
+  const migrated = [];
+  for (const upgrade of upgrades.slice(0, migrationBudget.remaining)) {
+    const request = {
+      ...ownerRepo(context),
+      comment_id: upgrade.commentId,
+      body: upgrade.body,
+    };
+    migrationBudget.remaining -= 1;
+    try {
+      await github.rest.issues.updateComment(request);
+      migrated.push(upgrade);
+    } catch {
+      core.setOutput("legacy_receipt_presentation_migration_retryable", "true");
+      break;
+    }
+  }
+  migrationBudget.migrated += migrated.length;
+  if (migrated.length > 0) {
+    const refreshedComments = await listComments(github, context, pr);
+    for (const upgrade of migrated) {
+      invariant(
+        refreshedComments.some(
+          (comment) =>
+            comment.id === upgrade.commentId && comment.body === upgrade.body,
+        ),
+        "Legacy receipt presentation lost a concurrent update",
+      );
+    }
+    parseControllerComments(refreshedComments);
+  }
+  if (migrationBudget.migrated > 0) {
+    core.setOutput(
+      "legacy_receipt_presentations_migrated",
+      String(migrationBudget.migrated),
+    );
+  }
+  const remaining = upgrades.length - migrated.length;
+  core.setOutput("legacy_receipt_presentations_remaining", String(remaining));
+}
+
 async function writeControllerState({
   github,
   context,
@@ -2847,6 +2960,10 @@ export async function reconcilePreview({
   const pr = pullRequestNumber(rawPr);
   const workflowSha = exactSha(rawWorkflowSha, "Controller workflow SHA");
   const controllerUrl = `https://github.com/${PREVIEW_REPOSITORY}/actions/runs/${context.runId}`;
+  const presentationMigrationBudget = {
+    remaining: MAX_PRESENTATION_MIGRATIONS_PER_RECONCILE,
+    migrated: 0,
+  };
   reconcileAttempts: for (let attempt = 0; attempt < 3; attempt += 1) {
     try {
       const pull = await pullFromApi(github, context, pr);
@@ -3063,10 +3180,9 @@ export async function reconcilePreview({
         state,
         stateComment,
       });
-      const assertStatusBasis = async () => {
-        const confirmed = parseControllerComments(
-          await listComments(github, context, pr),
-        );
+      const readStatusBasis = async () => {
+        const comments = await listComments(github, context, pr);
+        const confirmed = parseControllerComments(comments);
         invariant(
           confirmed.stateComment?.id === stateComment.id &&
             canonicalJson(confirmed.state) === canonicalJson(state),
@@ -3082,7 +3198,22 @@ export async function reconcilePreview({
             ),
           "Controller receipt set changed before status publication",
         );
+        return { comments, confirmed };
       };
+      const assertStatusBasis = async () => {
+        await readStatusBasis();
+      };
+      const presentationBasis = await readStatusBasis();
+      await migrateLegacyReceiptPresentation({
+        github,
+        context,
+        core,
+        pr,
+        workflowSha,
+        comments: presentationBasis.comments,
+        parsed: presentationBasis.confirmed,
+        migrationBudget: presentationMigrationBudget,
+      });
       await assertStatusBasis();
       await postStatusDecisions(github, context, state.status_decisions, {
         assertBasis: assertStatusBasis,

--- a/scripts/vercel-preview-controller.test.mjs
+++ b/scripts/vercel-preview-controller.test.mjs
@@ -1370,6 +1370,14 @@ function resultComment(value, id = 3) {
   };
 }
 
+function legacyResultComment(value, id = 3) {
+  return {
+    id,
+    user: { type: "Bot", login: "github-actions[bot]" },
+    body: legacyCommentBody(resultReceiptMarker(value), value),
+  };
+}
+
 function selectionComment(value, id = 4) {
   return {
     id,
@@ -1383,6 +1391,42 @@ function legacySelectionComment(value, id = 4) {
     id,
     user: { type: "Bot", login: "github-actions[bot]" },
     body: legacyCommentBody(selectionReceiptMarker(value), value),
+  };
+}
+
+function workerEvidence(dispatch, runId = 8_000) {
+  return {
+    schema: "vercel-preview-worker-evidence:v1",
+    repository: PREVIEW_REPOSITORY,
+    pr: dispatch.pr,
+    target: "ui",
+    sha: dispatch.sha,
+    controller_key: dispatch.key,
+    key_digest: dispatch.key_digest,
+    epoch_anchor_run_id: dispatch.epoch_anchor_run_id,
+    reconciliation_basis_digest: dispatch.reconciliation_basis_digest,
+    selection_receipt_run_id: dispatch.selection_receipt_run_id,
+    expected_workflow_sha: dispatch.expected_workflow_sha,
+    worker_run_id: runId,
+    worker_run_attempt: 1,
+    github_deployment_id: 9_000 + runId,
+    execution_mode: "build",
+    build_completed: true,
+    vercel_deployment_id: `dpl_${runId}`,
+    next_deployment_id: `m-ui-${runId}`,
+    verified_upload_url: `https://ui-${runId}.vercel.app`,
+  };
+}
+
+function workerEvidenceMarker(value) {
+  return `<!-- vercel-preview-worker-evidence:v1:${value.key_digest}:run:${value.worker_run_id} -->`;
+}
+
+function legacyWorkerEvidenceComment(value, id = 5) {
+  return {
+    id,
+    user: { type: "Bot", login: "github-actions[bot]" },
+    body: legacyCommentBody(workerEvidenceMarker(value), value),
   };
 }
 
@@ -1513,6 +1557,7 @@ function fakeGitHub({
   workerRunTotalCount,
   workflowRunAttemptFailures = [],
   updateCommentFailures = [],
+  updateCommentFailureIds = [],
   pullCommits = [pullRequest.head.sha],
   deployments: initialDeployments = [],
   deploymentStatuses = new Map(),
@@ -1520,6 +1565,7 @@ function fakeGitHub({
   workflowRunListDisplayTitles = [],
   workflowRunListRunIds = [],
   pullRequests = [],
+  beforeListComments,
 } = {}) {
   const comments = structuredClone(initialComments);
   const runs = structuredClone(initialRuns);
@@ -1531,6 +1577,7 @@ function fakeGitHub({
     ]),
   );
   const commitStatuses = [];
+  const commentUpdates = [];
   const dispatches = [];
   const createdDeploymentStatuses = [];
   const workflowRunAttemptRequests = [];
@@ -1542,8 +1589,10 @@ function fakeGitHub({
   const transientPullRequests = [...pullRequests];
   const attemptFailures = [...workflowRunAttemptFailures];
   const commentUpdateFailures = [...updateCommentFailures];
+  const commentUpdateFailureIds = new Set(updateCommentFailureIds);
   let nextCommentId = 100;
   let nextDeploymentId = 9_000;
+  let listCommentRequests = 0;
   const listComments = async () => {};
   const listCommits = async () => {};
   const listDeployments = async () => {};
@@ -1561,6 +1610,11 @@ function fakeGitHub({
           return { data };
         },
         updateComment: async ({ comment_id, body }) => {
+          if (commentUpdateFailureIds.delete(comment_id)) {
+            const error = new Error("fixture targeted comment update failed");
+            error.status = 503;
+            throw error;
+          }
           const failureStatus = commentUpdateFailures.shift();
           if (failureStatus) {
             const error = new Error("fixture comment update failed");
@@ -1569,6 +1623,7 @@ function fakeGitHub({
           }
           const comment = comments.find(({ id }) => id === comment_id);
           assert.ok(comment, "fixture update must target an existing comment");
+          commentUpdates.push({ comment_id, body });
           comment.body = body;
           return { data: comment };
         },
@@ -1661,7 +1716,11 @@ function fakeGitHub({
       },
     },
     paginate: async (method) => {
-      if (method === listComments) return structuredClone(comments);
+      if (method === listComments) {
+        listCommentRequests += 1;
+        beforeListComments?.({ requestCount: listCommentRequests, comments });
+        return structuredClone(comments);
+      }
       if (method === listCommits) {
         return pullCommits.map((sha) => ({ sha }));
       }
@@ -1727,6 +1786,7 @@ function fakeGitHub({
     deployments,
     statuses,
     commitStatuses,
+    commentUpdates,
     dispatches,
     createdDeploymentStatuses,
     workflowRunAttemptRequests,
@@ -1899,6 +1959,286 @@ test("closed event receipt is immutable, idempotent, and publishes no status", a
 
   assert.equal(state.closed, true);
   assert.equal(reconcileFixture.dispatches.length, 0);
+});
+
+test("quiescent reconciliation bounds legacy migration across concurrency retries", async () => {
+  const opened = event({
+    run: 119,
+    action: "opened",
+    head: SHA.A,
+    updated: timestamp(1),
+  });
+  const openedPull = pull({ head: SHA.A, updated: timestamp(1) });
+  const selected = reconcile({
+    events: [opened],
+    pullRequest: openedPull,
+    expectedWorkflowSha: SHA.D,
+  });
+  const dispatched = persistDispatch(selected, 8_000);
+  const selection = selectionReceiptFromDispatch(dispatched.ui.active);
+  const evidence = workerEvidence(selected.nextDispatch);
+  const additionalEvidence = workerEvidence(selected.nextDispatch, 8_001);
+  const completed = result(selected.nextDispatch, { runId: 8_000 });
+  const terminal = reconcile({
+    events: [opened],
+    results: [completed],
+    selections: [selection],
+    pullRequest: openedPull,
+    existingState: dispatched,
+  }).state;
+  const closed = event({
+    run: 120,
+    action: "closed",
+    head: SHA.A,
+    updated: timestamp(2),
+  });
+  const closedPull = pull({
+    head: SHA.A,
+    state: "closed",
+    updated: timestamp(2),
+    closed: timestamp(2),
+  });
+  const closedState = reconcile({
+    events: [opened, closed],
+    results: [completed],
+    selections: [selection],
+    pullRequest: closedPull,
+    existingState: terminal,
+  }).state;
+  const legacySelection = legacySelectionComment(selection, 3);
+  legacySelection.body = legacySelection.body.trimEnd();
+  const legacyResult = legacyResultComment(completed, 5);
+  legacyResult.body = legacyResult.body.trimEnd();
+  const fixture = fakeGitHub({
+    pullRequest: closedPull,
+    comments: [
+      legacyEventComment(opened, 1),
+      stateComment(closedState, 2),
+      legacySelection,
+      legacyWorkerEvidenceComment(evidence, 4),
+      legacyResult,
+      legacyEventComment(closed, 6),
+      legacyWorkerEvidenceComment(additionalEvidence, 7),
+    ],
+    beforeListComments: ({ requestCount, comments }) => {
+      if (requestCount !== 7) return;
+      comments.find(({ id }) => id === 2).body = stateComment(terminal, 2).body;
+    },
+  });
+  const core = fakeCore();
+
+  const reconciled = await reconcilePreview({
+    github: fixture.github,
+    context: fakeContext({ runId: 7_001 }),
+    core,
+    prNumber: 519,
+  });
+
+  assert.equal(core.outputs.get("legacy_receipt_presentations_migrated"), "5");
+  assert.equal(core.outputs.get("legacy_receipt_presentations_remaining"), "1");
+  assert.equal(reconciled.receipts_digest, closedState.receipts_digest);
+  assert.equal(fixture.dispatches.length, 0);
+  assert.equal(fixture.comments.length, 7);
+  assert.ok(
+    fixture.commentUpdates.filter(
+      ({ comment_id: commentId }) => commentId === 2,
+    ).length >= 4,
+    "the fixture must force a top-level reconciliation retry",
+  );
+  const firstBatchBodies = new Map([
+    [1, commentBody(eventReceiptMarker(opened.event_run_id), opened)],
+    [3, commentBody(selectionReceiptMarker(selection), selection)],
+    [4, commentBody(workerEvidenceMarker(evidence), evidence)],
+    [5, commentBody(resultReceiptMarker(completed), completed)],
+    [6, commentBody(eventReceiptMarker(closed.event_run_id), closed)],
+  ]);
+  for (const [commentId, expectedBody] of firstBatchBodies) {
+    const actual = fixture.comments.find(({ id }) => id === commentId)?.body;
+    assert.equal(actual, expectedBody);
+    const legacyReaderMatch = actual.match(/\n```json\n([\s\S]+)\n```\n?$/);
+    assert.ok(
+      legacyReaderMatch,
+      "the previous v1 reader can parse migrated bodies",
+    );
+  }
+  assert.deepEqual(
+    fixture.commentUpdates
+      .filter(({ comment_id: commentId }) => firstBatchBodies.has(commentId))
+      .map(({ comment_id: commentId }) => commentId),
+    [1, 3, 4, 5, 6],
+  );
+  assert.doesNotMatch(
+    fixture.comments.find(({ id }) => id === 7).body,
+    /<details>/,
+  );
+
+  const secondCore = fakeCore();
+  await reconcilePreview({
+    github: fixture.github,
+    context: fakeContext({ runId: 7_002 }),
+    core: secondCore,
+    prNumber: 519,
+  });
+  assert.equal(
+    secondCore.outputs.get("legacy_receipt_presentations_migrated"),
+    "1",
+  );
+  const additionalBody = commentBody(
+    workerEvidenceMarker(additionalEvidence),
+    additionalEvidence,
+  );
+  assert.equal(
+    fixture.comments.find(({ id }) => id === 7).body,
+    additionalBody,
+  );
+  assert.ok(
+    additionalBody.match(/\n```json\n([\s\S]+)\n```\n?$/),
+    "the previous v1 reader can parse the resumed migration",
+  );
+
+  await reconcilePreview({
+    github: fixture.github,
+    context: fakeContext({ runId: 7_003 }),
+    core: fakeCore(),
+    prNumber: 519,
+  });
+  assert.equal(
+    fixture.commentUpdates.filter(({ comment_id: commentId }) =>
+      [...firstBatchBodies.keys(), 7].includes(commentId),
+    ).length,
+    6,
+  );
+});
+
+test("reconciliation defers legacy presentation migration while an old worker can still write", async () => {
+  const opened = event({
+    run: 119,
+    action: "opened",
+    head: SHA.A,
+    updated: timestamp(1),
+  });
+  const pullRequest = pull({ head: SHA.A, updated: timestamp(1) });
+  const selected = reconcile({
+    events: [opened],
+    pullRequest,
+    expectedWorkflowSha: SHA.D,
+  });
+  const dispatched = persistDispatch(selected, 8_000);
+  const selection = selectionReceiptFromDispatch(dispatched.ui.active);
+  const fixture = fakeGitHub({
+    pullRequest,
+    comments: [
+      legacyEventComment(opened, 1),
+      stateComment(dispatched, 2),
+      legacySelectionComment(selection, 3),
+    ],
+    runs: [
+      workerRun(selected.nextDispatch, {
+        id: 8_000,
+        status: "in_progress",
+      }),
+    ],
+  });
+  const core = fakeCore();
+
+  await reconcilePreview({
+    github: fixture.github,
+    context: fakeContext({ runId: 7_001 }),
+    core,
+    prNumber: 519,
+  });
+
+  assert.equal(
+    core.outputs.get("legacy_receipt_presentation_migration_deferred"),
+    "true",
+  );
+  assert.doesNotMatch(fixture.comments[0].body, /<details>/);
+  assert.doesNotMatch(fixture.comments[2].body, /<details>/);
+  assert.equal(
+    fixture.commentUpdates.some(({ comment_id: commentId }) =>
+      [1, 3].includes(commentId),
+    ),
+    false,
+  );
+  assert.equal(
+    fixture.commitStatuses.some(({ state }) => state === "error"),
+    false,
+  );
+});
+
+test("legacy presentation API failures stay retryable without blocking preview state", async () => {
+  const opened = event({
+    run: 119,
+    action: "opened",
+    head: SHA.A,
+    runtime: false,
+    updated: timestamp(1),
+  });
+  const openedPull = pull({ head: SHA.A, updated: timestamp(1) });
+  const openedState = reconcile({
+    events: [opened],
+    pullRequest: openedPull,
+  }).state;
+  const closed = event({
+    run: 120,
+    action: "closed",
+    head: SHA.A,
+    runtime: false,
+    updated: timestamp(2),
+  });
+  const closedPull = pull({
+    head: SHA.A,
+    state: "closed",
+    updated: timestamp(2),
+    closed: timestamp(2),
+  });
+  const closedState = reconcile({
+    events: [opened, closed],
+    pullRequest: closedPull,
+    existingState: openedState,
+  }).state;
+  const fixture = fakeGitHub({
+    pullRequest: closedPull,
+    comments: [
+      legacyEventComment(opened, 1),
+      stateComment(closedState, 2),
+      legacyEventComment(closed, 3),
+    ],
+    updateCommentFailureIds: [1],
+  });
+  const firstCore = fakeCore();
+
+  const first = await reconcilePreview({
+    github: fixture.github,
+    context: fakeContext({ runId: 7_001 }),
+    core: firstCore,
+    prNumber: 519,
+  });
+
+  assert.equal(first.closed, true);
+  assert.equal(
+    firstCore.outputs.get("legacy_receipt_presentation_migration_retryable"),
+    "true",
+  );
+  assert.doesNotMatch(fixture.comments[0].body, /<details>/);
+  assert.equal(
+    fixture.commitStatuses.some(({ state }) => state === "error"),
+    false,
+  );
+
+  const secondCore = fakeCore();
+  await reconcilePreview({
+    github: fixture.github,
+    context: fakeContext({ runId: 7_002 }),
+    core: secondCore,
+    prNumber: 519,
+  });
+  assert.equal(
+    secondCore.outputs.get("legacy_receipt_presentations_migrated"),
+    "2",
+  );
+  assert.match(fixture.comments[0].body, /<details>/);
+  assert.match(fixture.comments[2].body, /<details>/);
 });
 
 test("closed reconciliation preserves an unbound intent without dispatching it", async () => {


### PR DESCRIPTION
## The Problem

Preview-controller comments created before #548 merged still expose raw machine-readable JSON, so the same PR timeline mixes reviewer-friendly toggles with large uncollapsed receipts.

## The Solution

Migrate canonical legacy receipt envelopes in place after their older worker is terminal. The migration preserves the comment ID, hidden marker, and JSON payload; limits each top-level reconciliation to five update attempts; and treats presentation API failures as retryable rather than blocking preview status publication.

## Validation

- pnpm vercel:preview:test (89/89)
- pnpm test
- pnpm check-types
- pnpm quality:budgets:test (30/30)
- trunk check on all changed files
- Fresh-context autoreview findings fixed: bounded content updates and retry-loop-stable budget

## Ship Checklist

- [x] ship skill used
- [x] local and fresh-context review run
- [x] validation run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches automatic preview reconciliation and mutates existing bot comments on live PRs, but only presentation is rewritten after strict legacy-body checks and worker-terminal gating; preview status publication is explicitly decoupled from migration success.
> 
> **Overview**
> Reconciliation now **upgrades pre-rollout preview receipt comments** from uncollapsed JSON to the reviewer-friendly `<details>` layout **in place** (same comment ID, marker, and canonical JSON), instead of treating those bodies as permanently frozen.
> 
> Migration runs **after** controller state is written and **before** `Vercel Preview` statuses are posted, with a **cap of five comment updates per reconcile** and a **budget that survives top-level reconcile retries**. It is **skipped** while an active or recoverable retired worker on an older `expected_workflow_sha` still lacks a terminal result, so legacy envelopes stay available for idempotent retries. **GitHub API update failures** are marked retryable and do not block status publication; remaining legacy comments are counted via workflow outputs.
> 
> Docs now state that immutability applies to the hidden marker and JSON payload, not Markdown presentation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8694c3cca8ae83ea3810179c2be6f02dffbe93c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->