### PR TITLE
fix(ci): consolidate preview state in one journal

### DIFF
--- a/.github/workflows/vercel-preview-controller.yml
+++ b/.github/workflows/vercel-preview-controller.yml
@@ -149,6 +149,10 @@ jobs:
       always() &&
       needs.snapshot-event.result == 'success' &&
       needs.snapshot-event.outputs.trust != 'dependabot'
+    concurrency:
+      group: vercel-preview-state-pr-${{ needs.snapshot-event.outputs.pr_number }}
+      cancel-in-progress: false
+      queue: max # trunk-ignore(actionlint/syntax-check)
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
@@ -194,8 +198,9 @@ jobs:
     needs: receipt-event
     if: always() && needs.receipt-event.result == 'success'
     concurrency:
-      group: vercel-preview-controller-pr-${{ needs.receipt-event.outputs.pr_number }}
+      group: vercel-preview-state-pr-${{ needs.receipt-event.outputs.pr_number }}
       cancel-in-progress: false
+      queue: max # trunk-ignore(actionlint/syntax-check)
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -338,6 +343,10 @@ jobs:
     name: Persist immutable bootstrap receipt
     needs: [snapshot-bootstrap, plan-bootstrap]
     if: always() && needs.snapshot-bootstrap.result == 'success'
+    concurrency:
+      group: vercel-preview-state-pr-${{ needs.snapshot-bootstrap.outputs.pr_number }}
+      cancel-in-progress: false
+      queue: max # trunk-ignore(actionlint/syntax-check)
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
@@ -383,8 +392,9 @@ jobs:
     needs: receipt-bootstrap
     if: needs.receipt-bootstrap.result == 'success'
     concurrency:
-      group: vercel-preview-controller-pr-${{ needs.receipt-bootstrap.outputs.pr_number }}
+      group: vercel-preview-state-pr-${{ needs.receipt-bootstrap.outputs.pr_number }}
       cancel-in-progress: false
+      queue: max # trunk-ignore(actionlint/syntax-check)
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -427,8 +437,9 @@ jobs:
     needs: validate-request
     if: needs.validate-request.outputs.operation == 'reconcile'
     concurrency:
-      group: vercel-preview-controller-pr-${{ needs.validate-request.outputs.pr_number }}
+      group: vercel-preview-state-pr-${{ needs.validate-request.outputs.pr_number }}
       cancel-in-progress: false
+      queue: max # trunk-ignore(actionlint/syntax-check)
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -508,8 +519,9 @@ jobs:
     needs: identify-dependabot-intake
     if: needs.identify-dependabot-intake.result == 'success'
     concurrency:
-      group: vercel-preview-controller-pr-${{ needs.identify-dependabot-intake.outputs.pr_number }}
+      group: vercel-preview-state-pr-${{ needs.identify-dependabot-intake.outputs.pr_number }}
       cancel-in-progress: false
+      queue: max # trunk-ignore(actionlint/syntax-check)
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
@@ -577,8 +589,9 @@ jobs:
     needs: identify-worker-result
     if: needs.identify-worker-result.result == 'success'
     concurrency:
-      group: vercel-preview-controller-pr-${{ needs.identify-worker-result.outputs.pr_number }}
+      group: vercel-preview-state-pr-${{ needs.identify-worker-result.outputs.pr_number }}
       cancel-in-progress: false
+      queue: max # trunk-ignore(actionlint/syntax-check)
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:

--- a/.github/workflows/vercel-preview-controller.yml
+++ b/.github/workflows/vercel-preview-controller.yml
@@ -161,6 +161,7 @@ jobs:
       statuses: write
     outputs:
       pr_number: ${{ steps.receipt.outputs.pr_number }}
+      reconcile_required: ${{ steps.receipt.outputs.reconcile_required }}
     steps:
       - name: Check out trusted controller
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -196,7 +197,10 @@ jobs:
   reconcile-event:
     name: Reconcile durable preview state
     needs: receipt-event
-    if: always() && needs.receipt-event.result == 'success'
+    if: >-
+      always() &&
+      needs.receipt-event.result == 'success' &&
+      needs.receipt-event.outputs.reconcile_required == 'true'
     concurrency:
       group: vercel-preview-state-pr-${{ needs.receipt-event.outputs.pr_number }}
       cancel-in-progress: false

--- a/.github/workflows/vercel-preview-worker.yml
+++ b/.github/workflows/vercel-preview-worker.yml
@@ -288,6 +288,10 @@ jobs:
       always() &&
       needs.validate-controller-ownership.result == 'success' &&
       needs.validate-controller-ownership.outputs.execution_mode != 'duplicate-owner'
+    concurrency:
+      group: vercel-preview-state-pr-${{ inputs.pull_request_number }}
+      cancel-in-progress: false
+      queue: max # trunk-ignore(actionlint/syntax-check)
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:

--- a/README.md
+++ b/README.md
@@ -440,13 +440,17 @@ The repository is set up with GitHub Actions for CI:
 - **CD**: GitHub Actions automatically builds `ui.mento.org` previews for
   trusted same-repository PRs with exact-SHA `Vercel Preview` statuses,
   first-eligible-plus-latest batching, credential-free HTTP and browser smoke,
-  and one canonical GitHub Deployment. Dependabot events pass through a
-  read-only metadata intake; trusted default-branch code re-queries the exact
-  PR head before publishing the explicit preview-disabled status. Fork and
-  Dependabot PRs remain credential-free. During Phase A, native Vercel Git UI previews remain enabled
-  for canary comparison; Vercel Git still owns every main/production deployment
-  and all non-UI apps. See [ADR 0001](docs/adr/0001-github-actions-vercel-deployment-orchestration.md)
-  for the accepted ownership boundary and
+  one canonical GitHub Deployment, and one canonical preview-controller journal
+  comment per participating PR. Dependabot events pass through a read-only
+  metadata intake; trusted default-branch code re-queries the exact PR head
+  before publishing the explicit preview-disabled status. Fork and Dependabot
+  PRs remain credential-free. During Phase A, native Vercel Git UI previews
+  remain enabled for canary comparison; Vercel Git still owns every
+  main/production deployment and all non-UI apps. See
+  [ADR 0001](docs/adr/0001-github-actions-vercel-deployment-orchestration.md)
+  for the accepted ownership boundary,
+  [ADR 0002](docs/adr/0002-single-comment-preview-controller-journal.md) for
+  the journal persistence and clean-cutover decision, and
   [`docs/vercel-deployments.md`](docs/vercel-deployments.md) for the Phase B
   UI-only cutover, bootstrap, canary, and rollback procedures.
 

--- a/docs/adr/0002-single-comment-preview-controller-journal.md
+++ b/docs/adr/0002-single-comment-preview-controller-journal.md
@@ -1,0 +1,280 @@
+---
+title: One canonical pull-request comment stores the preview controller journal
+status: active
+owner: eng
+canonical: true
+last_verified: 2026-07-17
+scope: ci/deployment/preview-controller-state
+date: 2026-07
+---
+
+# ADR 0002 — One canonical pull-request comment stores the preview controller journal
+
+**Status:** Accepted (Jul 2026)
+**Scope:** ci/deployment/preview-controller-state
+
+## Context
+
+ADR 0001 selected GitHub Actions as the owner of Vercel build and deployment
+orchestration while retaining Vercel as the hosting and runtime platform. Its
+automatic preview controller persists enough GitHub-owned evidence to survive
+overlapping pull-request events, worker retries, callback loss, cancellation,
+controller upgrades, and out-of-order completion.
+
+The first implementation represented that evidence as one mutable controller
+state comment plus separate immutable comments for event, selection,
+pre-completion worker evidence, and terminal result receipts. Treating each
+receipt comment as an append-only row avoided concurrent read-modify-write
+loss, but one ordinary preview produced several procedural, machine-only cards
+in the pull-request timeline. Collapsing each JSON block made each card easier
+to ignore without making the review surface coherent.
+
+The pull-request timeline is primarily for reviewers. Preview status and the
+canonical GitHub Deployment already provide the useful human-facing outcome;
+the controller's internal record granularity should not leak into that surface.
+At the same time, combining records into one mutable object is safe only when
+every writer shares the same serialization boundary. GitHub issue-comment
+updates do not provide a documented conditional compare-and-swap operation.
+
+This ADR refines ADR 0001's preview-controller persistence mechanism. It does
+not supersede ADR 0001's ownership, trust-boundary, automatic-preview,
+first-plus-latest, or deployment-orchestration decisions.
+
+## Decision
+
+### One journal per participating pull request
+
+Every participating non-Dependabot pull request has exactly one canonical
+`github-actions[bot]` journal comment shared by all present and future preview
+targets. The hidden marker and payload schema are:
+
+```text
+<!-- vercel-preview-journal:v1 -->
+vercel-preview-journal:v1
+```
+
+The comment keeps the reviewer explanation outside one collapsed `<details>`
+block and stores one canonical JSON document inside it. That document contains
+the repository and pull-request identity, a monotonic revision, logically
+immutable event/selection/worker-evidence/result entries, and the bounded
+mutable controller state. The top-level `journal_digest` covers the canonical
+receipt set and mutable state; `state.receipts_digest` separately binds
+reconciliation to the receipt set. The canonical Markdown envelope includes an
+explicit closing `</details>` tag and permits no extra presentation text. The
+comment ID is stable for the life of the journal. Updates edit that comment;
+they never create another journal or a receipt-specific comment.
+
+Receipt immutability is enforced by the journal protocol. A deterministic
+receipt identity may be inserted once. Replaying an identical receipt is a
+no-op; presenting different canonical JSON for an existing identity fails
+closed. A mutation may append a receipt or replace the explicitly mutable
+state, then must increment the revision and recompute `journal_digest`. Receipt
+reconciliation also validates `state.receipts_digest` against the canonical
+receipt set.
+
+The complete rendered comment body remains subject to the controller's
+60,000-byte UTF-8 hard limit. A mutation that would exceed that bound fails
+closed before it changes the journal, publishes a success status, or dispatches
+a worker. This decision does not introduce journal compaction or rollover. If
+the bounded receipt and history model cannot remain below the limit, the
+storage decision must be reconsidered rather than silently truncating evidence
+or creating a second comment.
+
+### The shared queue is a correctness boundary
+
+Every job that can create or update the journal uses the same repository-wide,
+per-PR concurrency group with `queue: max` and `cancel-in-progress: false`.
+This includes event persistence, bootstrap, reconciliation, selection,
+pre-completion worker evidence, terminal recovery, close/reopen handling, and
+any controller-error result. No other job may mutate the journal.
+
+After acquiring that queue, a writer:
+
+1. lists and validates the exact bot-owned journal count, marker, repository,
+   pull request, revision, journal digest, receipts, state, and, when state
+   exists, `state.receipts_digest`;
+2. applies one idempotent transition in memory;
+3. updates the existing comment, or creates it only on a first-attempt `opened`
+   event or an explicit bootstrap transition;
+4. rereads the comment and proves its exact revision, canonical JSON, and
+   journal digest before publishing statuses or dispatching work.
+
+Duplicate journals, an unexpected author, malformed or oversized JSON, a
+conflicting receipt, a lost reread, or a writer outside the common queue is an
+ambiguous state and fails closed. The queue is not the first-plus-latest
+selection algorithm; it only prevents concurrent journal replacement. Receipt
+contents and current pull-request state continue to determine selection.
+
+A missing journal on synchronize, edit, reopen, close, recovery, or a rerun of
+the initial event is also ambiguous and fails closed. An explicit bootstrap is
+the only operator-authorized clean restart; ordinary event handling never
+silently replaces a deleted journal or resets its revision.
+
+GitHub currently bounds `queue: max` at 100 pending jobs. The controller must
+keep journal mutations short, expose queue pressure during canaries, and treat
+an admitted-event gap as ambiguous. It may recover current intent only by
+re-querying the live pull request and performing the existing conservative,
+fail-closed plan; it must not invent a missing historical receipt.
+
+### Trust and public evidence
+
+Only trusted default-branch controller or worker-controller code may reach a
+journal write token. No write-token job checks out or executes pull-request
+code. Existing exact-SHA, author/repository/ref, workflow-SHA, epoch, key,
+Deployment, and worker-attempt validations remain required before a journal
+transition can authorize work.
+
+Tokens, environment files, cookies, output directories, bypass values, raw
+provider responses, and credential values never enter the journal. The
+`Vercel Preview` commit status and canonical GitHub Deployment remain the
+reviewer and operator surfaces; the journal is internal coordination evidence,
+not a new required check or deployment.
+
+### Clean cutover, cleanup, and rollback
+
+There is no dual-read period and no compatibility path for already-running
+legacy workers. Before merging the journal implementation, operators inventory
+all preview controller, worker, and intake runs and let them terminate or cancel
+them. The cutover must not proceed while a legacy run can still write a receipt
+comment, dispatch work, or act on legacy controller state. The implementation
+contains no legacy-comment reader, presentation upgrader, payload importer, or
+rematerialization path.
+
+After the merge, every open participating pull request is bootstrapped from its
+current live PR metadata and a fresh fail-closed plan. The bootstrap creates a
+new journal epoch; it does not import, translate, trust, or reconcile legacy
+comment payloads. Previously created preview evidence is outside the new
+journal's ownership unless the fresh controller independently proves it through
+the normal GitHub Deployment and provider APIs.
+
+Only after each fresh journal is reread and its status/dispatch decision is
+valid may an operator delete legacy machine comments. Deletion is restricted
+to comments authored by `github-actions[bot]` whose complete body validates
+under one of the exact retired `vercel-preview-event-receipt:v1`,
+`vercel-preview-selection:v1`, `vercel-preview-worker-evidence:v1`,
+`vercel-preview-worker-result:v1`, or `vercel-preview-controller:v1`
+marker/schema pairs and one of the retired canonical Markdown envelopes.
+Unknown, malformed, human, review, third-party-bot, and journal comments are
+never deleted. Closed historical pull requests need no new journal; after the
+run inventory proves quiescence, their exact validated legacy machine comments
+may be removed as historical cleanup.
+
+Cleanup failure is cosmetic and retryable because the new journal is the only
+authoritative source after cutover. Legacy comments that remain temporarily are
+ignored by the new controller. A journal write or verification failure is not
+cosmetic and blocks status progression and dispatch.
+
+Rollback is also a clean restart, not a data migration. Operators first drain
+or cancel journal-era controller and worker runs, merge the reviewed rollback,
+and bootstrap the restored controller afresh from live pull-request state. The
+rollback does not rematerialize legacy receipts from the journal and must not
+claim continuity with journal-owned epochs. Journal comments may be retained
+as inert audit evidence until the restored controller is proven; deletion, if
+desired, requires exact `github-actions[bot]` authorship and full validation of
+the journal marker, schema, and canonical body.
+
+## Alternatives considered
+
+### Keep separate comments with collapsed JSON
+
+Rejected. It preserves the independent append-only storage model but continues
+to litter the reviewer timeline with records that require no reviewer action.
+
+### Hide or minimize the receipt comments
+
+Rejected. GitHub has no appropriate hidden issue-comment storage surface, and
+classifying valid controller evidence as spam, abuse, off-topic, or outdated
+would misuse comment minimization while retaining multiple timeline entries.
+
+### Store the journal in a dedicated Git ref
+
+Rejected for this iteration. Fast-forward-only ref updates provide a strong
+GitHub-native optimistic-concurrency primitive and no pull-request timeline
+noise, but require `contents: write`, Git object/ref lifecycle management, and
+a materially larger implementation and operator surface.
+
+### Store receipts in check runs
+
+Rejected. Check runs move procedural records into the merge and Checks surface,
+are associated with commit rather than pull-request lifecycle identity, and are
+subject to platform history limits. `Vercel Preview` remains one truthful
+Statuses API context instead.
+
+### Store receipts in GitHub Actions artifacts
+
+Rejected. Public-repository artifacts expire after at most 90 days and require
+archive listing and download during recovery. They are useful debugging output,
+not durable controller state.
+
+### Store receipts in GitHub Deployment payloads or statuses
+
+Rejected as the complete store. A Deployment does not exist for every event or
+non-runtime decision, its creation payload cannot be extended with later upload
+evidence, and status descriptions cannot hold the journal. The canonical
+Deployment remains complementary lifecycle evidence.
+
+### Store receipts in repository variables
+
+Rejected. Variables are mutable configuration, have repository count and size
+limits, lack an append-only audit or compare-and-swap model, and require a token
+permission outside the normal configurable `GITHUB_TOKEN` permission set.
+
+### Add an external transactional store
+
+Rejected. Conditional writes would solve concurrency without a visible comment,
+but introduce another availability boundary, credential or OIDC configuration,
+cost, retention policy, and operator dependency for preview deployment.
+
+## Consequences
+
+- Reviewers see at most one explanatory, collapsed preview-controller journal
+  rather than one card per procedural receipt.
+- The journal comment is a single persistence object. Deletion, corruption,
+  duplicate creation, or ambiguous ownership fails closed.
+- Receipt immutability becomes protocol-enforced inside a mutable envelope
+  instead of being represented by immutable comment IDs.
+- Correctness depends on every mutation path sharing one queue and completing
+  its reread verification. Structural tests for that wiring are mandatory.
+- Journal writers may wait longer during a burst, and queue depth becomes an
+  operational signal alongside preview latency.
+- The 60,000-byte UTF-8 bound is a hard capacity constraint. This ADR neither
+  hides nor solves growth through compaction.
+- Cutover and rollback require explicit run draining and fresh bootstrap. They
+  intentionally abandon persistence continuity across journal versions rather
+  than carrying compatibility code indefinitely.
+- The decision should be reconsidered after any lost journal entry, duplicate
+  worker or Deployment caused by journal state, repeated approach to the body
+  limit, queue pressure near the 100-pending platform bound, material preview
+  delay caused by comment API availability, or renewed reviewer demand for no
+  machine comment at all.
+
+## Evidence
+
+Repository decision and implementation surfaces:
+
+- [ADR 0001](0001-github-actions-vercel-deployment-orchestration.md) — retained
+  build/deployment ownership, trust, and first-plus-latest decisions.
+- [`docs/vercel-deployments.md`](../vercel-deployments.md) — current controller,
+  clean-cutover, bootstrap, recovery, and verification contract.
+- `scripts/vercel-preview-controller.mjs` and
+  `scripts/vercel-preview-controller.test.mjs` — journal validation,
+  idempotency, size, failure, and state-machine evidence.
+- `.github/workflows/vercel-preview-controller.yml` and
+  `.github/workflows/vercel-preview-worker.yml` — shared queue and write-token
+  ownership.
+- [PR #548](https://github.com/mento-protocol/frontend-monorepo/pull/548) and
+  [PR #549](https://github.com/mento-protocol/frontend-monorepo/pull/549) — live
+  reviewer evidence that per-receipt comments remained noisy after their JSON
+  presentation was collapsed.
+
+Primary platform constraints verified at adoption:
+
+- [GitHub Actions concurrency](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#concurrency)
+  — shared groups, `queue: max`, pending bound, and ordering behavior.
+- [GitHub REST API best practices](https://docs.github.com/en/rest/using-the-rest-api/best-practices-for-using-the-rest-api#use-conditional-requests-if-appropriate)
+  — conditional requests are not generally supported for unsafe methods such
+  as comment `PATCH`.
+- [GitHub Actions artifact retention](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository#configuring-the-retention-period-for-github-actions-artifacts-and-logs-in-your-repository)
+  — public-repository artifact retention is limited to 90 days.
+- [GitHub Deployment statuses](https://docs.github.com/en/rest/deployments/statuses#create-a-deployment-status)
+  — status fields and the 140-character description limit.

--- a/docs/adr/0002-single-comment-preview-controller-journal.md
+++ b/docs/adr/0002-single-comment-preview-controller-journal.md
@@ -77,8 +77,13 @@ receipt set.
 Before appending a later event, a terminal journal with no active or retired
 worker and no unfinished evidence deterministically checkpoints its completed
 prefix in place. The checkpoint retains the cumulative receipt digest and
-counts, the verified tail event, and its terminal status; the mutable state is
-rebased onto that tail and the completed live receipts are cleared. This is one
+counts, the verified lifecycle tail event, and its terminal status. Open state
+uses the reconciled lineage tail; closed state uses the matching closure. The
+mutable state is rebased onto that verified tail and the completed live
+receipts are cleared. Semantic replays of the checkpoint tail are idempotent,
+while a conflicting receipt under the same run identity fails closed. A
+docs-only checkpoint tail carries forward the inherited runtime success URL or
+terminal failure/error meaning for subsequent docs-only pushes. This is one
 atomic revision of the same comment and schema, not rollover, archival, or a
 second persistence path. A 50-preview sequential-cycle fixture peaks at 7,772
 rendered UTF-8 bytes.

--- a/docs/adr/0002-single-comment-preview-controller-journal.md
+++ b/docs/adr/0002-single-comment-preview-controller-journal.md
@@ -55,11 +55,13 @@ vercel-preview-journal:v1
 
 The comment keeps the reviewer explanation outside one collapsed `<details>`
 block and stores one canonical JSON document inside it. That document contains
-the repository and pull-request identity, a monotonic revision, logically
-immutable event/selection/worker-evidence/result entries, and the bounded
-mutable controller state. The top-level `journal_digest` covers the canonical
-receipt set and mutable state; `state.receipts_digest` separately binds
-reconciliation to the receipt set. The canonical Markdown envelope includes an
+the repository and pull-request identity, a monotonic revision, an optional
+deterministic checkpoint, logically immutable live
+event/selection/worker-evidence/result entries, and the bounded mutable
+controller state. The top-level `journal_digest` covers the checkpoint,
+canonical live receipt set, and mutable state; `state.receipts_digest`
+separately binds reconciliation to the checkpoint plus live receipt set. The
+canonical Markdown envelope includes an
 explicit closing `</details>` tag and permits no extra presentation text. The
 comment ID is stable for the life of the journal. Updates edit that comment;
 they never create another journal or a receipt-specific comment.
@@ -72,13 +74,20 @@ state, then must increment the revision and recompute `journal_digest`. Receipt
 reconciliation also validates `state.receipts_digest` against the canonical
 receipt set.
 
+Before appending a later event, a terminal journal with no active or retired
+worker and no unfinished evidence deterministically checkpoints its completed
+prefix in place. The checkpoint retains the cumulative receipt digest and
+counts, the verified tail event, and its terminal status; the mutable state is
+rebased onto that tail and the completed live receipts are cleared. This is one
+atomic revision of the same comment and schema, not rollover, archival, or a
+second persistence path. A 50-preview sequential-cycle fixture peaks at 7,772
+rendered UTF-8 bytes.
+
 The complete rendered comment body remains subject to the controller's
-60,000-byte UTF-8 hard limit. A mutation that would exceed that bound fails
-closed before it changes the journal, publishes a success status, or dispatches
-a worker. This decision does not introduce journal compaction or rollover. If
-the bounded receipt and history model cannot remain below the limit, the
-storage decision must be reconsidered rather than silently truncating evidence
-or creating a second comment.
+60,000-byte UTF-8 hard limit. A mutation that cannot be safely checkpointed and
+would exceed that bound fails closed before it changes the journal, publishes a
+success status, or dispatches a worker. Unfinished evidence and active or
+retired ownership are never truncated to recover capacity.
 
 ### The shared queue is a correctness boundary
 
@@ -94,8 +103,10 @@ After acquiring that queue, a writer:
    pull request, revision, journal digest, receipts, state, and, when state
    exists, `state.receipts_digest`;
 2. applies one idempotent transition in memory;
-3. updates the existing comment, or creates it only on a first-attempt `opened`
-   event or an explicit bootstrap transition;
+3. updates the existing comment, or creates it for an explicit bootstrap, a
+   first-attempt `opened`, or another first-attempt PR event only after proving
+   that its `before` and head commits carry no prior `Vercel Preview Journal`
+   initialization status;
 4. rereads the comment and proves its exact revision, canonical JSON, and
    journal digest before publishing statuses or dispatching work.
 
@@ -105,10 +116,14 @@ ambiguous state and fails closed. The queue is not the first-plus-latest
 selection algorithm; it only prevents concurrent journal replacement. Receipt
 contents and current pull-request state continue to determine selection.
 
-A missing journal on synchronize, edit, reopen, close, recovery, or a rerun of
-the initial event is also ambiguous and fails closed. An explicit bootstrap is
-the only operator-authorized clean restart; ordinary event handling never
-silently replaces a deleted journal or resets its revision.
+A first-attempt event may win the queue before `opened`; it may create the
+journal only when no durable controller status exists on its `before` or head
+commit. Every successful journal creation writes a durable, separate
+`Vercel Preview Journal` status witness before normal reconciliation. It never
+reuses the reserved `Vercel Preview` context, so a delayed old same-SHA event
+cannot overwrite a newer epoch's preview result. Consequently a later missing
+journal is external-evidence-backed ambiguity and fails closed, as do event reruns.
+Explicit bootstrap remains the only operator-authorized clean restart.
 
 GitHub currently bounds `queue: max` at 100 pending jobs. The controller must
 keep journal mutations short, expose queue pressure during canaries, and treat
@@ -237,8 +252,10 @@ cost, retention policy, and operator dependency for preview deployment.
   its reread verification. Structural tests for that wiring are mandatory.
 - Journal writers may wait longer during a burst, and queue depth becomes an
   operational signal alongside preview latency.
-- The 60,000-byte UTF-8 bound is a hard capacity constraint. This ADR neither
-  hides nor solves growth through compaction.
+- Deterministic terminal checkpoints keep sequential completed previews
+  bounded without adding an archive, rollover comment, or compatibility path.
+  The 60,000-byte UTF-8 bound remains a fail-closed constraint for unsafe
+  unfinished bursts.
 - Cutover and rollback require explicit run draining and fresh bootstrap. They
   intentionally abandon persistence continuity across journal versions rather
   than carrying compatibility code indefinitely.

--- a/docs/adr/0002-single-comment-preview-controller-journal.md
+++ b/docs/adr/0002-single-comment-preview-controller-journal.md
@@ -88,11 +88,24 @@ atomic revision of the same comment and schema, not rollover, archival, or a
 second persistence path. A 50-preview sequential-cycle fixture peaks at 7,772
 rendered UTF-8 bytes.
 
+The same checkpoint field protects an overlapping push burst before the hard
+body limit is reached. At a 40,000-byte soft threshold, the controller proves a
+unique path to the latest pull-request tail represented by the complete receipt
+graph, then folds that graph and terminal receipts not needed for recovery into
+the cumulative digest. A pending checkpoint records the exact unfinished owner,
+its consumed attempt count, and the latest runtime event still owed, while
+retaining that owner's selection, worker evidence, and result. Reconciliation
+waits for that owner;
+its terminal result either satisfies a runtime-equivalent tail or releases the
+latest runtime event for dispatch. Thus queued receipt jobs cannot disappear,
+and a docs-only tail cannot remain pending after its runtime dependency ends.
+
 The complete rendered comment body remains subject to the controller's
-60,000-byte UTF-8 hard limit. A mutation that cannot be safely checkpointed and
-would exceed that bound fails closed before it changes the journal, publishes a
-success status, or dispatches a worker. Unfinished evidence and active or
-retired ownership are never truncated to recover capacity.
+60,000-byte UTF-8 hard limit. A mutation that cannot use either terminal or
+capacity checkpointing safely and would exceed that bound fails closed before
+it changes the journal, publishes a success status, or dispatches a worker.
+Unfinished evidence and active or retired ownership are never truncated to
+recover capacity.
 
 ### The shared queue is a correctness boundary
 
@@ -109,9 +122,9 @@ After acquiring that queue, a writer:
    exists, `state.receipts_digest`;
 2. applies one idempotent transition in memory;
 3. updates the existing comment, or creates it for an explicit bootstrap, a
-   first-attempt `opened`, or another first-attempt PR event only after proving
-   that its `before` and head commits carry no prior `Vercel Preview Journal`
-   initialization status;
+   first-attempt `opened`, or another first-attempt non-closed PR event only
+   after proving that its `before` and head commits carry no matching
+   `Vercel Preview Journal / PR #<number>` initialization status;
 4. rereads the comment and proves its exact revision, canonical JSON, and
    journal digest before publishing statuses or dispatching work.
 
@@ -121,14 +134,23 @@ ambiguous state and fails closed. The queue is not the first-plus-latest
 selection algorithm; it only prevents concurrent journal replacement. Receipt
 contents and current pull-request state continue to determine selection.
 
-A first-attempt event may win the queue before `opened`; it may create the
-journal only when no durable controller status exists on its `before` or head
-commit. Every successful journal creation writes a durable, separate
-`Vercel Preview Journal` status witness before normal reconciliation. It never
-reuses the reserved `Vercel Preview` context, so a delayed old same-SHA event
-cannot overwrite a newer epoch's preview result. Consequently a later missing
-journal is external-evidence-backed ambiguity and fails closed, as do event reruns.
-Explicit bootstrap remains the only operator-authorized clean restart.
+A first-attempt non-closed event may win the queue before `opened`; it may
+create the journal only when no durable controller status for the same PR
+exists on its `before` or head commit. Every durably recorded event ensures a
+separate `Vercel Preview Journal / PR #<number>` success-status witness on its
+head before normal reconciliation. This advances deletion evidence across
+pushes and lets a retry repair a status write that failed after the journal
+mutation committed. A witness from another PR on a reused or stacked commit is
+not initialization evidence for this PR. The witness never reuses the
+reserved `Vercel Preview` context, so a delayed old same-SHA event cannot
+overwrite a newer epoch's preview result. Consequently a later missing journal
+with matching PR-scoped evidence is ambiguous and fails closed, as do event
+reruns. A close for a PR with neither a journal nor matching evidence is
+intentionally inert: the receipt job emits `reconcile_required=false`, so the
+workflow creates neither an anchorless closure-only journal nor a reconciliation
+run. A delayed non-closed event also remains inert when the live PR is already
+closed and no journal or witness exists. Explicit bootstrap remains the only
+operator-authorized clean restart.
 
 GitHub currently bounds `queue: max` at 100 pending jobs. The controller must
 keep journal mutations short, expose queue pressure during canaries, and treat
@@ -257,10 +279,13 @@ cost, retention policy, and operator dependency for preview deployment.
   its reread verification. Structural tests for that wiring are mandatory.
 - Journal writers may wait longer during a burst, and queue depth becomes an
   operational signal alongside preview latency.
-- Deterministic terminal checkpoints keep sequential completed previews
-  bounded without adding an archive, rollover comment, or compatibility path.
-  The 60,000-byte UTF-8 bound remains a fail-closed constraint for unsafe
-  unfinished bursts.
+- Deterministic terminal and capacity checkpoints keep sequential previews and
+  overlapping bursts bounded without adding an archive, rollover comment, or
+  compatibility path. The 60,000-byte UTF-8 bound remains a fail-closed
+  constraint when unfinished ownership cannot be summarized safely.
+- Terminal results remove their retired owners once the result is durable.
+  More than 40 genuinely unfinished retired owners fails closed; ownership is
+  never silently sliced to fit history bounds.
 - Cutover and rollback require explicit run draining and fresh bootstrap. They
   intentionally abandon persistence continuity across journal versions rather
   than carrying compatibility code indefinitely.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -42,3 +42,4 @@ adds a high-signal surface without a numbered ADR.
 | ADR                                                            | Decision                                                                                  |
 | -------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
 | [0001](0001-github-actions-vercel-deployment-orchestration.md) | GitHub Actions owns Vercel build/deployment orchestration; Vercel remains hosting/runtime |
+| [0002](0002-single-comment-preview-controller-journal.md)      | One canonical pull-request comment stores the preview controller journal                  |

--- a/docs/vercel-deployments.md
+++ b/docs/vercel-deployments.md
@@ -751,11 +751,20 @@ history. Explicit bootstrap is the sole operator-authorized clean restart.
 Before a later event is appended, a terminal journal with no active or retired
 worker and no unfinished evidence folds its completed prefix into one
 deterministic in-place checkpoint. The checkpoint holds cumulative receipt
-counts and digest, the verified tail event, and its terminal status. State is
+counts and digest, the verified lifecycle tail event, and its terminal status.
+For an open PR the tail is the last reconciled lineage event; for a closed PR
+it is the closure whose timestamp matches current GitHub state. State is
 rebased onto that tail and completed live receipts are cleared in the same
-revision. A 50-preview sequential-cycle test peaks at 7,772 rendered UTF-8
-bytes. This is still one comment, schema, and controller path: there is no
-archive, rollover, second comment, or compatibility reader.
+revision. The checkpoint remains a verified reconciliation anchor even when
+its tail is a synchronize or closure event. A semantic replay of that tail
+with another workflow run ID is already represented and is therefore a no-op;
+the same run ID with conflicting content still fails closed. When a docs-only
+tail is checkpointed, its inherited terminal runtime state, immutable URL, and
+failure or cancellation meaning continue across later docs-only pushes rather
+than reverting to a fresh no-runtime success. A 50-preview sequential-cycle
+test peaks at 7,772 rendered UTF-8 bytes. This is still one comment, schema,
+and controller path: there is no archive, rollover, second comment, or
+compatibility reader.
 
 The complete rendered journal body has a 60,000-byte hard limit measured as
 UTF-8. An unfinished or otherwise unsafe transition that cannot checkpoint and

--- a/docs/vercel-deployments.md
+++ b/docs/vercel-deployments.md
@@ -702,75 +702,97 @@ trigger.
 
 ### Event, status, and batching contract
 
-Every controller-owned event is first written as an immutable bot comment;
-Dependabot uses the separate credentialless intake contract above.
-Reconciliation is lossy/replaceable, but it always reconstructs from event,
-selection, and completed-worker receipts, current PR lifecycle evidence, and
-the one bounded mutable state comment. Before dispatch, the controller writes
-an immutable selection receipt. That receipt binds the selected SHA to the
-controller epoch and compactly lists intermediate receipt IDs coalesced into
-the durable later selection, so a long push burst does not require scanning all
-historical workflow runs or Deployments. Intended-run crash recovery queries a
-fixed `created` window around the persisted dispatch timestamp; older lifetime
-run history cannot exhaust its proof bound, while multiple matching runs inside
-the window fail closed. Its rendered terminal history remains bounded, while
-compact key digests retain ownership for every still-accepted current-epoch
-result receipt. A synchronize receipt plans the event's exact `before -> head`
-transition with planner code and dependencies from the immutable trusted base;
-it does not repeatedly compare the PR base to head. A base-retarget `edited`
-receipt starts a new same-head epoch and replans the new base-to-head transition.
-Title, body, label, and other unrelated edits do not create a receipt or
-reconciliation.
+Every controller-owned event is first appended as a logically immutable entry
+to the pull request's one canonical bot-owned journal; Dependabot uses the
+separate credentialless intake contract above. The journal's hidden marker and
+payload schema are exactly:
 
-These bot comments are internal coordination records, not review feedback. Each
-comment explains that no reviewer action is required and keeps its
-machine-readable JSON inside a collapsed GitHub `<details>` block. The hidden
-marker remains the first line, and the JSON remains canonical so receipt
-identity, validation, and recovery semantics do not change. The stored Markdown
-leaves the final `</details>` implicit so its JSON fence remains the literal end
-of the body; GitHub closes the toggle when rendering it, while already-running
-legacy workers can still parse comments created during rollout. Receipt
-immutability applies to the hidden marker and canonical JSON payload, not to its
-Markdown presentation. Reconciliation upgrades an exact canonical legacy body
-in place, preserving its comment ID, marker, and JSON. It defers that migration
-while an active or recoverable retired worker from an older workflow revision
-lacks a terminal result, because that older writer may still require the legacy
-envelope for idempotent retries. Each reconciliation upgrades at most five
-comments; any remaining or temporarily failed presentation updates resume on a
-later reconciliation without blocking preview status publication. The mutable
-state comment continues to adopt the current presentation on its next update.
+```text
+<!-- vercel-preview-journal:v1 -->
+vercel-preview-journal:v1
+```
+
+The journal is an internal coordination record, not review feedback. Its
+reviewer explanation remains visible while one collapsed GitHub `<details>`
+block contains canonical JSON. That document holds the repository and PR
+identity, a monotonic revision, a top-level journal digest over the canonical
+receipt set and mutable state, logically immutable
+event/selection/worker-evidence/result entries, and bounded mutable controller
+state. The state's separate receipts digest binds reconciliation to the receipt
+set. The canonical Markdown envelope includes the explicit closing
+`</details>` tag; missing or additional presentation text is invalid. The
+journal keeps one stable comment ID: every update edits it, and no
+receipt-specific comment is created.
+
+All jobs that can create or update the journal share one repository-wide,
+per-PR concurrency group configured with `queue: max` and
+`cancel-in-progress: false`. That serialization is a correctness boundary, not
+an optimization. After acquiring the queue, each writer validates the exact
+journal count and complete canonical body, applies one idempotent transition,
+updates the comment, or initially creates it only on a first-attempt `opened`
+event or explicit bootstrap transition, then rereads and proves the expected
+revision, canonical JSON, journal digest, and, when state exists,
+`state.receipts_digest` before publishing a status or dispatching a worker.
+Duplicate journals, a writer outside that queue, a conflicting receipt, or an
+ambiguous reread fail closed.
+
+A missing journal on synchronize, edit, reopen, close, recovery, or an initial
+event rerun fails closed instead of silently resetting controller history. An
+explicit bootstrap is the sole operator-authorized clean restart.
+
+The complete rendered journal body has a 60,000-byte hard limit measured as
+UTF-8. A transition that would cross it fails closed before changing the
+journal, reporting success, or dispatching work. There is no compaction,
+truncation, rollover, or second-comment escape hatch in this design.
+
+Reconciliation is lossy/replaceable, but it reconstructs from the journal's
+entries and mutable state, current PR lifecycle evidence, and GitHub/provider
+APIs. Before dispatch, the controller appends a selection entry that binds the
+selected SHA to the controller epoch and compactly lists intermediate entry
+identities coalesced into the durable later selection. Intended-run crash
+recovery queries a fixed `created` window around the persisted dispatch
+timestamp; older lifetime run history cannot exhaust its proof bound, while
+multiple matching runs inside the window fail closed. The bounded terminal
+history and compact key digests retain ownership for every accepted
+current-epoch result entry. A synchronize entry plans the event's exact
+`before -> head` transition with planner code and dependencies from the
+immutable trusted base; it does not repeatedly compare the PR base to head. A
+base-retarget `edited` entry starts a new same-head epoch and replans the new
+base-to-head transition. Title, body, label, and other unrelated edits create
+neither an entry nor a reconciliation.
 
 `Vercel Preview` is reserved for a Statuses API commit status, not a workflow
-job/check name. Every exact receipt SHA gets one truthful result: pending,
+job/check name. Every exact journal event SHA gets one truthful result: pending,
 verified, no runtime impact, runtime-equivalent to a prior preview, unsupported
 trust boundary, durably coalesced, failure, or controller error. Detailed
-PR/SHA/key/run/Deployment evidence remains in the bot comments because status
-descriptions are bounded.
+PR/SHA/key/run/Deployment evidence remains in the canonical journal because
+status descriptions are bounded.
 
-For each open/reopen/base-retarget/bootstrap epoch, the oldest receipt that
-actually affects the UI is `first_eligible_sha`. It always runs first. An
-identical bootstrap aliases an existing lifecycle anchor instead of creating a
-second epoch. While that worker is queued/running, later runtime pushes replace
-only `latest_desired_sha`; when the first worker terminates, only that latest
-SHA runs. Documentation/test-only pushes never replace the desired runtime SHA.
-After a verified runtime preview, a later non-runtime SHA succeeds by linking
-to that runtime-equivalent immutable preview without rebuilding.
+For each open/reopen/base-retarget/bootstrap epoch, the oldest journal event
+entry that actually affects the UI is `first_eligible_sha`. It always runs
+first. An identical bootstrap aliases an existing lifecycle anchor instead of
+creating a second epoch. While that worker is queued/running, later runtime
+pushes replace only `latest_desired_sha`; when the first worker terminates, only
+that latest SHA runs. Documentation/test-only pushes never replace the desired
+runtime SHA. After a verified runtime preview, a later non-runtime SHA succeeds
+by linking to that runtime-equivalent immutable preview without rebuilding.
 
 Each selected transition is bound to its lifecycle epoch, canonical
-reconciliation-basis digest, immutable receipt run, and the exact controller
-`github.workflow_sha` authorized to supply the worker implementation. The
-authorized worker SHA is persisted as `expected_workflow_sha` and participates
-in the selection key digest. Repeated A -> B -> A transitions, close/reopen
-cycles at the same SHA, duplicate callbacks, controller upgrades, and
-out-of-order event runs therefore remain distinct. An old-epoch worker may
-terminalize its own Deployment and write its own receipt, but it cannot update
-current-epoch state/status or schedule work.
+reconciliation-basis digest, immutable journal event entry, and the exact
+controller `github.workflow_sha` authorized to supply the worker
+implementation. The authorized worker SHA is persisted as
+`expected_workflow_sha` and participates in the selection key digest. Repeated
+A -> B -> A transitions, close/reopen cycles at the same SHA, duplicate
+callbacks, controller upgrades, and out-of-order event runs therefore remain
+distinct. An old-epoch worker may terminalize its own Deployment and append its
+own terminal result entry to the journal, but it cannot update current-epoch
+state/status or schedule work.
 
 Operator recovery queries the exact persisted worker attempt instead of the
 latest rerun. If a retired old-epoch attempt is missing or fails identity
 validation, the controller records a bounded recovery quarantine on that
 retired selection and continues current-epoch reconciliation without posting a
-current-head controller error. Transient retired-attempt API or evidence-write
+current-head controller error. Transient retired-attempt API or journal-write
 failures remain unquarantined and retry on the next reconciliation, also
 without changing the current-head status. A recovery ambiguity for the current
 active selection still fails closed.
@@ -787,11 +809,12 @@ controller treats that run ID as unresolved, continues listing for additional
 candidates, and re-queries the unresolved ID directly. It never attaches an
 exact match or dispatches a replacement while any plausible default-title run
 remains unresolved. After any recovery wait, it refreshes PR openness, exact-SHA
-association, event receipts, and persisted selection ownership immediately
-before attaching or dispatching; a closed or changed lifecycle cannot launch a
-new worker. A full-envelope-valid wrong-SHA artifact is never allowed to own the
-intent; all other name, event, ref, path, title, attempt, and URL mismatches also
-fail closed. GitHub's `workflow_run` callback reports the static workflow name,
+association, journal event entries, and persisted selection ownership
+immediately before attaching or dispatching; a closed or changed lifecycle
+cannot launch a new worker. A full-envelope-valid wrong-SHA artifact is never
+allowed to own the intent; all other name, event, ref, path, title, attempt, and
+URL mismatches also fail closed. GitHub's `workflow_run` callback reports the
+static workflow name,
 while the Actions REST API may report the configured dynamic `run-name` in both
 `name` and `display_title`; recovery accepts those two documented shapes only
 when the workflow path, event, default ref, authorized SHA, attempt, and
@@ -816,10 +839,10 @@ If `main` advances between intent persistence and dispatch, recovery may attach
 an already-created worker at the old authorized SHA, but a newer
 controller/worker version cannot satisfy or redispatch that old intent. A
 worker resolved from the newer `main` SHA fails its credentialless preflight.
-The controller records an immutable
-`controller-workflow-upgraded-before-dispatch` error result, and that worker's
-completion callback causes the current controller to reselect the same desired
-receipt under its own workflow SHA. The new key therefore advances
+The controller appends a logically immutable
+`controller-workflow-upgraded-before-dispatch` error result entry, and that
+worker's completion callback causes the current controller to reselect the same
+desired event entry under its own workflow SHA. The new key therefore advances
 automatically without ever pretending that new workflow code fulfilled the
 retired intent.
 
@@ -838,11 +861,11 @@ nor Vercel creates an implicit duplicate Deployment.
 The credential-free worker receives `expected_workflow_sha` as an explicit
 dispatch input and first compares it with the actual
 `${{ github.workflow_sha }}`. Only then does validation re-read the open PR,
-exact SHA ancestry, bot-owned active state, and canonical Deployment. The
-evidence writer repeats the immutable-SHA comparison and persists that SHA in
-non-terminal and terminal receipts. A mismatch fails before any build or
-deployment credential is reachable. A separate trusted preflight prints only
-missing repository variable/secret names. The literal UI reusable caller
+exact SHA ancestry, bot-owned active journal state, and canonical Deployment.
+The evidence writer repeats the immutable-SHA comparison and persists that SHA
+in non-terminal and terminal journal entries. A mismatch fails before any build
+or deployment credential is reachable. A separate trusted preflight prints
+only missing repository variable/secret names. The literal UI reusable caller
 receives only `VERCEL_TOKEN_PREVIEW`, `TURBO_TOKEN`, and
 `TURBO_REMOTE_CACHE_SIGNATURE_KEY`, plus `VERCEL_ORG_ID`,
 `VERCEL_PROJECT_ID_UI`, and `TURBO_TEAM`. The direct smoke/resume jobs receive no
@@ -877,9 +900,9 @@ also waits for the initial page load before changing controlled inputs, then
 rechecks the changed form control after the hydration/interaction settle. Its
 dependency graph comes from the trusted workflow checkout, candidate lifecycle
 scripts stay disabled, and no Vercel or Turbo credential is present in the
-smoke job. The worker records a durable non-terminal upload evidence receipt;
+smoke job. The worker appends a durable non-terminal upload evidence entry;
 the completed-run recovery re-queries the run, Deployment, and statuses before
-writing the terminal result receipt. Cancellation before Deployment creation
+appending the terminal result entry. Cancellation before Deployment creation
 creates/reuses the canonical Deployment and immediately closes it as `error`.
 
 Retry behavior is bounded and serialized:
@@ -913,10 +936,11 @@ or exactly-once delivery across GitHub and Vercel.
 
 Before `Vercel Preview` becomes required, inventory every already-open PR and
 bootstrap each trusted same-repository PR that should participate. A lone
-synchronize receipt deliberately waits for an opened/reopened/bootstrap anchor.
-Repeated semantically identical bootstrap requests are idempotent, and a
-bootstrap identical to an existing lifecycle anchor aliases that anchor;
-conflicting lifecycle or planning evidence still fails closed.
+synchronize journal entry deliberately waits for an
+opened/reopened/bootstrap anchor. Repeated semantically identical bootstrap
+requests are idempotent, and a bootstrap identical to an existing lifecycle
+anchor aliases that anchor; conflicting lifecycle or planning evidence still
+fails closed.
 
 ```bash
 gh pr list --state open --limit 100 --json number,headRepository,headRefName,author
@@ -928,7 +952,8 @@ gh api --method POST \
   -F "client_payload[pr_number]=$PR_NUMBER"
 ```
 
-For a durable receipt/state that only needs another reconciliation pass:
+For a durable journal whose live PR state only needs another reconciliation
+pass:
 
 ```bash
 PR_NUMBER="<pr-number>"
@@ -938,16 +963,76 @@ gh api --method POST \
   -F "client_payload[pr_number]=$PR_NUMBER"
 ```
 
-Do not bootstrap a closed PR, invent an opened event, mutate bot receipts, or
-re-dispatch the worker directly. Missing repository names must be provisioned by
-a maintainer; automation may check presence but must never retrieve, export,
-reconstruct, or print credential values.
+Do not bootstrap a closed PR, invent an opened event, manually edit or delete a
+journal, invent journal entries, or re-dispatch the worker directly. Missing
+repository names must be provisioned by a maintainer; automation may check
+presence but must never retrieve, export, reconstruct, or print credential
+values.
+
+### Clean journal cutover and legacy cleanup
+
+The journal rollout is a clean cutover. It has no dual-read window, legacy
+worker compatibility, payload import, or in-controller migration path.
+
+1. Before merging, inventory all runs of the preview controller, preview
+   worker, and preview intake workflows. Let every listed run terminate, or
+   cancel it, and verify that no legacy run can still write a comment or
+   dispatch work.
+2. Merge the journal implementation.
+3. Inventory every open participating PR from current GitHub state and dispatch
+   `vercel-preview-bootstrap` for each one using the command above. Bootstrap
+   plans from live PR metadata; it must not read, translate, trust, or reconcile
+   any retired comment payload.
+4. For each PR, prove that exactly one trusted-bot comment has the
+   `<!-- vercel-preview-journal:v1 -->` marker, record its comment ID, reread its
+   canonical JSON, and verify that the exact-head `Vercel Preview` status and
+   worker/Deployment decision agree with the fresh plan. Subsequent transitions
+   must edit that same comment ID.
+5. Only after step 4 succeeds, run the reviewed cleanup against the inventory.
+   Delete a comment only when its author is exactly `github-actions[bot]`, its
+   complete hidden marker validates, and its complete JSON body validates under
+   the matching retired schema: `vercel-preview-event-receipt:v1`,
+   `vercel-preview-selection:v1`, `vercel-preview-worker-evidence:v1`,
+   `vercel-preview-worker-result:v1`, or `vercel-preview-controller:v1`.
+
+The retired marker shapes eligible for that full-body validator are:
+
+| Retired schema                      | Exact marker shape                                                     |
+| ----------------------------------- | ---------------------------------------------------------------------- |
+| `vercel-preview-event-receipt:v1`   | `<!-- vercel-preview-event-receipt:v1:run:<run-id> -->`                |
+| `vercel-preview-selection:v1`       | `<!-- vercel-preview-selection:v1:key:<key-digest> -->`                |
+| `vercel-preview-worker-evidence:v1` | `<!-- vercel-preview-worker-evidence:v1:<key-digest>:run:<run-id> -->` |
+| `vercel-preview-worker-result:v1`   | `<!-- vercel-preview-worker-result:v1:<key-digest>:run:<run-id> -->`   |
+| `vercel-preview-controller:v1`      | `<!-- vercel-preview-controller:v1 -->`                                |
+
+The validator must also accept only the two retired canonical Markdown
+envelopes: the original marker-plus-JSON-fence body and the later
+reviewer-explanation-plus-`<details>` body. A marker prefix or schema field by
+itself is never deletion evidence.
+
+The cleanup must leave unknown or malformed comments, human and third-party-bot
+comments, review discussion, and every `vercel-preview-journal:v1` comment
+untouched. Do not delete by body substring, comment age, or author alone. Closed
+historical PRs do not receive a journal; after the run inventory proves
+quiescence, the same exact author-plus-marker-plus-schema validator may remove
+their retired comments. Cleanup failures are cosmetic and retryable because the
+journal controller ignores legacy comments after cutover. Journal creation,
+update, or reread failures remain blocking.
+
+Rollback is another clean restart. Drain or cancel journal-era controller and
+worker runs, merge the reviewed rollback, then bootstrap the restored
+controller afresh from live PR state. Do not rematerialize legacy comments from
+journal entries or claim lifecycle continuity across the rollback. Retain
+journal comments as inert audit evidence until the restored controller has been
+proven; if they are later removed, apply the same exact trusted-author and
+full-body schema validation.
 
 ### Phase A canary evidence template
 
 Keep native Vercel Git UI previews enabled. For every canary, record the PR,
 exact SHA(s), controller/worker run URLs, controller key/digest, canonical
 GitHub Deployment ID, GitHub-built immutable URL, native Vercel immutable URL,
+canonical journal comment ID/revision/`journal_digest`/`state.receipts_digest`,
 terminal `Vercel Preview` status, and browser evidence.
 
 Verify all of these before changing the ruleset or starting Phase B:
@@ -959,15 +1044,19 @@ Verify all of these before changing the ruleset or starting Phase B:
 5. after the controller is idle, a later UI-runtime SHA E deploys normally;
 6. replaying an event, reconciliation request, and terminal callback is
    idempotent: it creates no second worker, GitHub Deployment, Vercel preview,
-   receipt, or conflicting status;
+   journal, journal entry, or conflicting status, and it preserves the original
+   journal comment ID;
 7. fork and Dependabot PRs succeed unsupported without a Deployment/worker,
-   with Dependabot proven through the credentialless intake and trusted exact-head follow-up;
+   with Dependabot proven through the credentialless intake and trusted
+   exact-head follow-up;
 8. a controlled build/smoke failure posts terminal failure and bounded retry;
 9. cancelling a worker before Deployment creation produces one canonical
    `error` Deployment/result and advances the latest desired SHA;
 10. close/reopen and a force-reset SHA revisit preserve distinct epochs;
-11. one old-epoch callback terminalizes only its own evidence;
-12. representative strict-ruleset merges still work.
+11. one old-epoch callback terminalizes only its own journal evidence;
+12. after the clean-cutover cleanup, exact validated legacy comments are absent
+    while human, malformed, unknown-bot, and journal comments remain untouched;
+13. representative strict-ruleset merges still work.
 
 For the GitHub-built immutable URL, follow the repository browser protocol:
 verify rendering and primary navigation, inspect console errors and failed

--- a/docs/vercel-deployments.md
+++ b/docs/vercel-deployments.md
@@ -715,11 +715,12 @@ vercel-preview-journal:v1
 The journal is an internal coordination record, not review feedback. Its
 reviewer explanation remains visible while one collapsed GitHub `<details>`
 block contains canonical JSON. That document holds the repository and PR
-identity, a monotonic revision, a top-level journal digest over the canonical
-receipt set and mutable state, logically immutable
+identity, a monotonic revision, an optional deterministic checkpoint, a
+top-level journal digest over that checkpoint, the canonical live receipt set,
+and mutable state, logically immutable live
 event/selection/worker-evidence/result entries, and bounded mutable controller
-state. The state's separate receipts digest binds reconciliation to the receipt
-set. The canonical Markdown envelope includes the explicit closing
+state. The state's separate receipts digest binds reconciliation to the
+checkpoint plus live receipt set. The canonical Markdown envelope includes the explicit closing
 `</details>` tag; missing or additional presentation text is invalid. The
 journal keeps one stable comment ID: every update edits it, and no
 receipt-specific comment is created.
@@ -729,21 +730,37 @@ per-PR concurrency group configured with `queue: max` and
 `cancel-in-progress: false`. That serialization is a correctness boundary, not
 an optimization. After acquiring the queue, each writer validates the exact
 journal count and complete canonical body, applies one idempotent transition,
-updates the comment, or initially creates it only on a first-attempt `opened`
-event or explicit bootstrap transition, then rereads and proves the expected
+updates the comment, or initially creates it for an explicit bootstrap, a
+first-attempt `opened`, or another first-attempt PR event whose `before` and
+head commits have no prior `Vercel Preview Journal` initialization status,
+then rereads and proves the expected
 revision, canonical JSON, journal digest, and, when state exists,
 `state.receipts_digest` before publishing a status or dispatching a worker.
 Duplicate journals, a writer outside that queue, a conflicting receipt, or an
 ambiguous reread fail closed.
 
-A missing journal on synchronize, edit, reopen, close, recovery, or an initial
-event rerun fails closed instead of silently resetting controller history. An
-explicit bootstrap is the sole operator-authorized clean restart.
+A first-attempt event can therefore preserve an out-of-order receipt when it
+wins the queue before `opened`. Every successful journal creation writes a
+durable `Vercel Preview Journal` status witness before normal reconciliation.
+That dedicated context is never used for preview results, so delayed old
+same-SHA events cannot overwrite newer `Vercel Preview` outcomes. A later
+missing journal with that external initialization evidence, any event rerun, or
+missing recovery state fails closed instead of silently resetting controller
+history. Explicit bootstrap is the sole operator-authorized clean restart.
+
+Before a later event is appended, a terminal journal with no active or retired
+worker and no unfinished evidence folds its completed prefix into one
+deterministic in-place checkpoint. The checkpoint holds cumulative receipt
+counts and digest, the verified tail event, and its terminal status. State is
+rebased onto that tail and completed live receipts are cleared in the same
+revision. A 50-preview sequential-cycle test peaks at 7,772 rendered UTF-8
+bytes. This is still one comment, schema, and controller path: there is no
+archive, rollover, second comment, or compatibility reader.
 
 The complete rendered journal body has a 60,000-byte hard limit measured as
-UTF-8. A transition that would cross it fails closed before changing the
-journal, reporting success, or dispatching work. There is no compaction,
-truncation, rollover, or second-comment escape hatch in this design.
+UTF-8. An unfinished or otherwise unsafe transition that cannot checkpoint and
+would cross it fails closed before changing the journal, reporting success, or
+dispatching work; active, retired, or unmatched evidence is never truncated.
 
 Reconciliation is lossy/replaceable, but it reconstructs from the journal's
 entries and mutable state, current PR lifecycle evidence, and GitHub/provider

--- a/docs/vercel-deployments.md
+++ b/docs/vercel-deployments.md
@@ -731,22 +731,31 @@ per-PR concurrency group configured with `queue: max` and
 an optimization. After acquiring the queue, each writer validates the exact
 journal count and complete canonical body, applies one idempotent transition,
 updates the comment, or initially creates it for an explicit bootstrap, a
-first-attempt `opened`, or another first-attempt PR event whose `before` and
-head commits have no prior `Vercel Preview Journal` initialization status,
+first-attempt `opened`, or another first-attempt non-closed PR event whose
+`before` and head commits have no prior PR-scoped
+`Vercel Preview Journal / PR #<number>` initialization status,
 then rereads and proves the expected
 revision, canonical JSON, journal digest, and, when state exists,
 `state.receipts_digest` before publishing a status or dispatching a worker.
 Duplicate journals, a writer outside that queue, a conflicting receipt, or an
 ambiguous reread fail closed.
 
-A first-attempt event can therefore preserve an out-of-order receipt when it
-wins the queue before `opened`. Every successful journal creation writes a
-durable `Vercel Preview Journal` status witness before normal reconciliation.
-That dedicated context is never used for preview results, so delayed old
-same-SHA events cannot overwrite newer `Vercel Preview` outcomes. A later
-missing journal with that external initialization evidence, any event rerun, or
-missing recovery state fails closed instead of silently resetting controller
-history. Explicit bootstrap is the sole operator-authorized clean restart.
+A first-attempt non-closed event can therefore preserve an out-of-order receipt
+when it wins the queue before `opened`. Every durably recorded event ensures a
+`Vercel Preview Journal / PR #<number>` success-status witness on its head before
+normal reconciliation. That lets a retry repair a witness write that failed
+after the journal mutation and carries deletion evidence across every push. The
+PR suffix prevents a status left on a reused or stacked commit by another PR
+from blocking this PR's first receipt. That dedicated context is never used for
+preview results, so delayed old same-SHA events cannot overwrite newer
+`Vercel Preview` outcomes. A later missing journal with matching PR-scoped
+external initialization evidence, any event rerun, or missing recovery state
+fails closed instead of silently resetting controller history. A close with no
+journal and no matching witness is inert and explicitly skips reconciliation;
+it does not create an anchorless closure-only journal. A delayed non-closed
+event is likewise inert when the live PR is already closed and neither journal
+nor witness exists. Explicit bootstrap is the sole operator-authorized clean
+restart.
 
 Before a later event is appended, a terminal journal with no active or retired
 worker and no unfinished evidence folds its completed prefix into one
@@ -766,10 +775,26 @@ test peaks at 7,772 rendered UTF-8 bytes. This is still one comment, schema,
 and controller path: there is no archive, rollover, second comment, or
 compatibility reader.
 
+An overlapping push burst uses the same checkpoint field before the rendered
+body reaches capacity. At the 40,000-byte soft threshold, the controller proves
+one path through the complete receipt graph to its latest uniquely represented
+PR tail and folds that graph into the cumulative digest. A pending checkpoint
+records the exact unfinished owner, its consumed attempt count, and the latest
+runtime event still owed, and retains the matching selection, worker evidence,
+and terminal result needed for recovery. Reconciliation waits for that owner.
+Its terminal result either
+settles a runtime-equivalent docs-only tail or releases the latest required
+runtime event for dispatch, so a queued receipt cannot disappear and a
+docs-only tail cannot remain pending after its dependency completes. Completed
+retired owners are then removed. More than 40 genuinely unfinished retired
+owners fails closed instead of silently discarding ownership. No unfinished
+worker evidence is truncated.
+
 The complete rendered journal body has a 60,000-byte hard limit measured as
-UTF-8. An unfinished or otherwise unsafe transition that cannot checkpoint and
-would cross it fails closed before changing the journal, reporting success, or
-dispatching work; active, retired, or unmatched evidence is never truncated.
+UTF-8. A transition that cannot safely use either terminal or capacity
+checkpointing and would cross it fails closed before changing the journal,
+reporting success, or dispatching work; active, retired, or unmatched evidence
+is never truncated.
 
 Reconciliation is lossy/replaceable, but it reconstructs from the journal's
 entries and mutable state, current PR lifecycle evidence, and GitHub/provider

--- a/scripts/vercel-preview-controller.mjs
+++ b/scripts/vercel-preview-controller.mjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+import { Buffer } from "node:buffer";
 import { createHash } from "node:crypto";
 
 export const PREVIEW_REPOSITORY = "mento-protocol/frontend-monorepo";
@@ -10,6 +11,8 @@ const WORKER_EVIDENCE_SCHEMA = "vercel-preview-worker-evidence:v1";
 export const RESULT_RECEIPT_SCHEMA = "vercel-preview-worker-result:v1";
 export const SELECTION_RECEIPT_SCHEMA = "vercel-preview-selection:v1";
 export const CONTROLLER_SCHEMA = "vercel-preview-controller:v1";
+export const PREVIEW_JOURNAL_SCHEMA = "vercel-preview-journal:v1";
+export const PREVIEW_JOURNAL_MARKER = "<!-- vercel-preview-journal:v1 -->";
 const WORKER_WORKFLOW = "vercel-preview-worker.yml";
 const WORKER_WORKFLOW_NAME = "Vercel Preview Worker";
 const INTAKE_WORKFLOW = "vercel-preview-intake.yml";
@@ -21,17 +24,6 @@ const REPOSITORY_DISPATCH_OPERATIONS = new Map([
   [RECONCILE_DISPATCH_EVENT, "reconcile"],
 ]);
 
-const EVENT_MARKER_PREFIX = "<!-- vercel-preview-event-receipt:v1:run:";
-const EVIDENCE_MARKER_PREFIX = "<!-- vercel-preview-worker-evidence:v1:";
-const RESULT_MARKER_PREFIX = "<!-- vercel-preview-worker-result:v1:";
-const SELECTION_MARKER_PREFIX = "<!-- vercel-preview-selection:v1:key:";
-const IMMUTABLE_RECEIPT_MARKER_PREFIXES = [
-  EVENT_MARKER_PREFIX,
-  EVIDENCE_MARKER_PREFIX,
-  RESULT_MARKER_PREFIX,
-  SELECTION_MARKER_PREFIX,
-];
-const CONTROLLER_MARKER = "<!-- vercel-preview-controller:v1 -->";
 const SHA_PATTERN = /^[0-9a-f]{40}$/;
 const LOGIN_PATTERN =
   /^(?:[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?|[A-Za-z0-9])(?:\[bot\])?$/;
@@ -59,7 +51,7 @@ const TERMINAL_STATES = new Set(["success", "failure", "error"]);
 const MAX_COMMENTS = 500;
 const MAX_RECEIPTS = 200;
 const MAX_HISTORY = 40;
-const MAX_PRESENTATION_MIGRATIONS_PER_RECONCILE = 5;
+const MAX_JOURNAL_BYTES = 60_000;
 const WORKER_RUN_PAGE_SIZE = 100;
 const MAX_WORKER_RUN_PAGES = 3;
 const WORKER_RUN_VISIBILITY_ATTEMPTS = 3;
@@ -256,37 +248,28 @@ function digest(value, length = 64) {
     .slice(0, length);
 }
 
-function legacyMarkerBody(marker, value) {
-  return `${marker}\n\n\`\`\`json\n${JSON.stringify(value, null, 2)}\n\`\`\`\n`;
-}
-
-function markerBody(marker, value) {
-  // Keep the JSON fence at the literal end so already-running v1 workers can
-  // parse comments written during the rollout. GitHub's GFM renderer closes
-  // the final <details> element implicitly.
-  return `${marker}\n\n${COMMENT_EXPLANATION}\n\n<details>\n<summary>${COMMENT_DETAILS_SUMMARY}</summary>\n\n\`\`\`json\n${JSON.stringify(value, null, 2)}\n\`\`\`\n`;
-}
-
-function parseMarkerBody(body, marker) {
+function journalBody(value) {
+  const body = `${PREVIEW_JOURNAL_MARKER}\n\n${COMMENT_EXPLANATION}\n\n<details>\n<summary>${COMMENT_DETAILS_SUMMARY}</summary>\n\n\`\`\`json\n${JSON.stringify(value, null, 2)}\n\`\`\`\n\n</details>\n`;
   invariant(
-    typeof body === "string" && body.startsWith(`${marker}\n`),
-    "Comment marker mismatch",
+    Buffer.byteLength(body, "utf8") <= MAX_JOURNAL_BYTES,
+    "Preview journal comment is too large",
   );
-  const currentPrefix = `${marker}\n\n${COMMENT_EXPLANATION}\n\n<details>\n<summary>${COMMENT_DETAILS_SUMMARY}</summary>\n\n\`\`\`json\n`;
-  const legacyPrefix = `${marker}\n\n\`\`\`json\n`;
-  let json;
-  for (const prefix of [currentPrefix, legacyPrefix]) {
-    if (!body.startsWith(prefix)) continue;
-    for (const suffix of ["\n```\n", "\n```"]) {
-      if (!body.endsWith(suffix)) continue;
-      json = body.slice(prefix.length, -suffix.length);
-      break;
-    }
-    if (json !== undefined) break;
-  }
-  invariant(json !== undefined, "Controller comment JSON block is missing");
-  invariant(json.length <= 60_000, "Controller comment JSON is too large");
-  return JSON.parse(json);
+  return body;
+}
+
+function parseJournalBody(body) {
+  invariant(typeof body === "string", "Preview journal body is missing");
+  invariant(
+    Buffer.byteLength(body, "utf8") <= MAX_JOURNAL_BYTES,
+    "Preview journal comment is too large",
+  );
+  const prefix = `${PREVIEW_JOURNAL_MARKER}\n\n${COMMENT_EXPLANATION}\n\n<details>\n<summary>${COMMENT_DETAILS_SUMMARY}</summary>\n\n\`\`\`json\n`;
+  const suffix = "\n```\n\n</details>\n";
+  invariant(
+    body.startsWith(prefix) && body.endsWith(suffix),
+    "Preview journal JSON block is missing",
+  );
+  return JSON.parse(body.slice(prefix.length, -suffix.length));
 }
 
 function isTrustedBotComment(comment) {
@@ -578,10 +561,6 @@ export function validateEventReceipt(value, { requirePlan = true } = {}) {
   return event;
 }
 
-export function eventReceiptMarker(runId) {
-  return `${EVENT_MARKER_PREFIX}${exactRunId(runId)} -->`;
-}
-
 function semanticEventKey(event) {
   const receipt = validateEventReceipt(event);
   return canonicalJson({
@@ -703,11 +682,6 @@ function validateSelectionReceipt(value) {
     coalesced.add(exact);
   }
   return selection;
-}
-
-export function selectionReceiptMarker(value) {
-  const selection = validateSelectionReceipt(value);
-  return `${SELECTION_MARKER_PREFIX}${selection.key_digest} -->`;
 }
 
 export function selectionReceiptFromDispatch(selection) {
@@ -839,11 +813,6 @@ export function validateWorkerResult(value) {
   return result;
 }
 
-export function resultReceiptMarker(result) {
-  const validated = validateWorkerResult(result);
-  return `${RESULT_MARKER_PREFIX}${validated.key_digest}:run:${validated.worker_run_id} -->`;
-}
-
 function validateWorkerEvidence(value) {
   const evidence = plainObject(value, "Worker evidence");
   invariant(
@@ -898,11 +867,6 @@ function validateWorkerEvidence(value) {
   optionalNextDeploymentId(evidence.next_deployment_id);
   immutableVercelUrl(evidence.verified_upload_url);
   return evidence;
-}
-
-function workerEvidenceMarker(value) {
-  const evidence = validateWorkerEvidence(value);
-  return `${EVIDENCE_MARKER_PREFIX}${evidence.key_digest}:run:${evidence.worker_run_id} -->`;
 }
 
 function dedupeEvents(events, preferredRunIds = new Set()) {
@@ -1420,12 +1384,7 @@ function normalizeExistingState(value, pr) {
       "Terminal selection state is invalid",
     );
   }
-  const terminalResultKeyDigests = Object.hasOwn(
-    ui,
-    "terminal_result_key_digests",
-  )
-    ? ui.terminal_result_key_digests
-    : [...new Set(terminalHistory.map((terminal) => terminal.key_digest))];
+  const terminalResultKeyDigests = ui.terminal_result_key_digests;
   invariant(
     Array.isArray(terminalResultKeyDigests) &&
       terminalResultKeyDigests.length <= MAX_RECEIPTS,
@@ -1860,193 +1819,362 @@ async function listComments(github, context, pr) {
   return comments;
 }
 
-function matchingBotComments(comments, marker) {
-  return comments.filter(
+function receiptSetDigest({ events, selections, worker_evidence, results }) {
+  return digest({
+    events: events.map(canonicalJson).sort(),
+    selections: selections.map(canonicalJson).sort(),
+    worker_evidence: worker_evidence.map(canonicalJson).sort(),
+    results: results.map(canonicalJson).sort(),
+  });
+}
+
+function previewJournalDigest(receipts, state) {
+  return digest({ receipts_digest: receiptSetDigest(receipts), state });
+}
+
+function validateWorkerEvidenceSet(values, pr) {
+  invariant(
+    Array.isArray(values) && values.length <= MAX_RECEIPTS,
+    "Worker evidence set is invalid",
+  );
+  const identities = new Map();
+  for (const raw of values) {
+    const value = validateWorkerEvidence(raw);
+    invariant(value.pr === pr, "Worker evidence PR mismatch");
+    const identity = `${value.key_digest}:${value.worker_run_id}`;
+    invariant(!identities.has(identity), "Duplicate worker evidence entries");
+    identities.set(identity, value);
+  }
+  return values;
+}
+
+function validateJournalReceiptSet(
+  values,
+  { maximumMessage, validate, identity },
+) {
+  invariant(Array.isArray(values), maximumMessage);
+  invariant(values.length <= MAX_RECEIPTS, maximumMessage);
+  const identities = new Set();
+  for (const raw of values) {
+    const value = validate(raw);
+    const key = identity(value);
+    invariant(
+      !identities.has(key),
+      `Duplicate ${maximumMessage.toLowerCase()}`,
+    );
+    identities.add(key);
+  }
+  return values;
+}
+
+function sameAttemptBinding(receipt, selection) {
+  return (
+    receipt.pr === selection.pr &&
+    receipt.target === selection.target &&
+    receipt.sha === selection.sha &&
+    receipt.controller_key === selection.key &&
+    receipt.key_digest === selection.key_digest &&
+    receipt.epoch_anchor_run_id === selection.epoch_anchor_run_id &&
+    receipt.reconciliation_basis_digest ===
+      selection.reconciliation_basis_digest &&
+    receipt.selection_receipt_run_id === selection.selection_receipt_run_id &&
+    receipt.expected_workflow_sha === selection.expected_workflow_sha
+  );
+}
+
+function validatePreviewJournal(value, expectedPr) {
+  const journal = plainObject(value, "Preview journal");
+  invariant(
+    journal.schema === PREVIEW_JOURNAL_SCHEMA,
+    "Preview journal schema mismatch",
+  );
+  invariant(
+    Object.keys(journal).sort().join(",") ===
+      "journal_digest,pr,receipts,repository,revision,schema,state",
+    "Preview journal fields are invalid",
+  );
+  validatedRepository(journal.repository);
+  const pr = pullRequestNumber(journal.pr);
+  invariant(
+    pr === pullRequestNumber(expectedPr),
+    "Preview journal PR mismatch",
+  );
+  invariant(
+    Number.isSafeInteger(journal.revision) && journal.revision >= 1,
+    "Preview journal revision is invalid",
+  );
+  const receipts = plainObject(journal.receipts, "Preview journal receipts");
+  invariant(
+    Object.keys(receipts).sort().join(",") ===
+      "events,results,selections,worker_evidence",
+    "Preview journal receipt fields are invalid",
+  );
+  const events = validateJournalReceiptSet(receipts.events, {
+    maximumMessage: "Journal events are invalid",
+    validate: validateEventReceipt,
+    identity: (event) => String(event.event_run_id),
+  });
+  const selections = validateJournalReceiptSet(receipts.selections, {
+    maximumMessage: "Journal selections are invalid",
+    validate: validateSelectionReceipt,
+    identity: (selection) => selection.key_digest,
+  });
+  const results = validateJournalReceiptSet(receipts.results, {
+    maximumMessage: "Journal results are invalid",
+    validate: validateWorkerResult,
+    identity: (result) => `${result.key_digest}:${result.worker_run_id}`,
+  });
+  validateWorkerEvidenceSet(receipts.worker_evidence, pr);
+  invariant(
+    events.every((event) => event.pr === pr),
+    "Journal event PR mismatch",
+  );
+  invariant(
+    selections.every((selection) => selection.pr === pr),
+    "Journal selection PR mismatch",
+  );
+  invariant(
+    results.every((result) => result.pr === pr),
+    "Journal result PR mismatch",
+  );
+  for (const receipt of [...receipts.worker_evidence, ...receipts.results]) {
+    const selection = receipts.selections.find(
+      (candidate) => candidate.key_digest === receipt.key_digest,
+    );
+    invariant(
+      selection && sameAttemptBinding(receipt, selection),
+      "Journal worker receipt has no matching selection",
+    );
+  }
+  for (const evidence of receipts.worker_evidence) {
+    const result = receipts.results.find(
+      (candidate) =>
+        candidate.key_digest === evidence.key_digest &&
+        candidate.worker_run_id === evidence.worker_run_id,
+    );
+    invariant(
+      !result || result.worker_run_attempt === evidence.worker_run_attempt,
+      "Journal worker evidence and result attempts conflict",
+    );
+  }
+  if (journal.state !== null) {
+    const state = normalizeExistingState(journal.state, pr);
+    for (const dispatch of [
+      state.ui?.active,
+      ...(state.ui?.retired_active ?? []),
+    ].filter(Boolean)) {
+      invariant(
+        receipts.selections.some(
+          (selection) =>
+            selection.key_digest === dispatch.key_digest &&
+            selection.selection_receipt_run_id ===
+              dispatch.selection_receipt_run_id,
+        ),
+        "Journal state dispatch has no matching selection",
+      );
+    }
+  }
+  invariant(
+    typeof journal.journal_digest === "string" &&
+      /^[0-9a-f]{64}$/.test(journal.journal_digest) &&
+      journal.journal_digest === previewJournalDigest(receipts, journal.state),
+    "Preview journal digest mismatch",
+  );
+  journalBody(journal);
+  return journal;
+}
+
+export function createPreviewJournal({
+  pr: rawPr,
+  revision = 1,
+  events = [],
+  selections = [],
+  workerEvidence = [],
+  results = [],
+  state = null,
+} = {}) {
+  const pr = pullRequestNumber(rawPr);
+  const receipts = {
+    events: structuredClone(events),
+    selections: structuredClone(selections),
+    worker_evidence: structuredClone(workerEvidence),
+    results: structuredClone(results),
+  };
+  return validatePreviewJournal(
+    {
+      schema: PREVIEW_JOURNAL_SCHEMA,
+      repository: PREVIEW_REPOSITORY,
+      pr,
+      revision,
+      journal_digest: previewJournalDigest(receipts, state),
+      receipts,
+      state: state === null ? null : structuredClone(state),
+    },
+    pr,
+  );
+}
+
+function journalRecords(journal, journalComment) {
+  return {
+    events: journal.receipts.events,
+    workerEvidence: journal.receipts.worker_evidence,
+    results: journal.receipts.results,
+    selections: journal.receipts.selections,
+    state: journal.state,
+    stateComment: journalComment,
+    journal,
+    journalComment,
+  };
+}
+
+function parsePreviewJournalComments(
+  comments,
+  pr,
+  { allowMissing = false } = {},
+) {
+  const matches = comments.filter(
     (comment) =>
       isTrustedBotComment(comment) &&
       typeof comment.body === "string" &&
-      comment.body.startsWith(marker),
+      comment.body.startsWith(PREVIEW_JOURNAL_MARKER),
   );
-}
-
-async function writeImmutableComment({ github, context, pr, marker, value }) {
-  const body = markerBody(marker, value);
-  const legacyBody = legacyMarkerBody(marker, value);
-  const acceptedBodies = new Set([
-    body,
-    body.slice(0, -1),
-    legacyBody,
-    legacyBody.slice(0, -1),
-  ]);
-  const existing = matchingBotComments(
-    await listComments(github, context, pr),
-    marker,
-  );
-  invariant(existing.length <= 1, `Duplicate immutable marker ${marker}`);
-  if (existing.length === 1) {
-    invariant(
-      acceptedBodies.has(existing[0].body),
-      `Immutable receipt ${marker} conflicts with existing evidence`,
-    );
-    return { comment: existing[0], reused: true };
+  invariant(matches.length <= 1, "Multiple bot-owned preview journals exist");
+  if (matches.length === 0) {
+    invariant(allowMissing, "Preview journal comment does not exist");
+    return null;
   }
-  const { data } = await github.rest.issues.createComment({
-    ...ownerRepo(context),
-    issue_number: pr,
-    body,
-  });
-  return { comment: data, reused: false };
-}
-
-function parseControllerComments(comments) {
-  const events = [];
-  const workerEvidence = [];
-  const results = [];
-  const selections = [];
-  for (const comment of comments) {
-    if (!isTrustedBotComment(comment) || typeof comment.body !== "string")
-      continue;
-    if (comment.body.startsWith(EVENT_MARKER_PREFIX)) {
-      const marker = comment.body.split("\n", 1)[0];
-      events.push(validateEventReceipt(parseMarkerBody(comment.body, marker)));
-    } else if (comment.body.startsWith(EVIDENCE_MARKER_PREFIX)) {
-      const marker = comment.body.split("\n", 1)[0];
-      workerEvidence.push(
-        validateWorkerEvidence(parseMarkerBody(comment.body, marker)),
-      );
-    } else if (comment.body.startsWith(RESULT_MARKER_PREFIX)) {
-      const marker = comment.body.split("\n", 1)[0];
-      results.push(validateWorkerResult(parseMarkerBody(comment.body, marker)));
-    } else if (comment.body.startsWith(SELECTION_MARKER_PREFIX)) {
-      const marker = comment.body.split("\n", 1)[0];
-      selections.push(
-        validateSelectionReceipt(parseMarkerBody(comment.body, marker)),
-      );
-    }
-  }
-  const states = matchingBotComments(comments, CONTROLLER_MARKER);
+  const journal = validatePreviewJournal(parseJournalBody(matches[0].body), pr);
   invariant(
-    states.length <= 1,
-    "Multiple bot-owned controller state comments exist",
+    matches[0].body === journalBody(journal),
+    "Preview journal body is not canonical",
   );
-  const state =
-    states.length === 1
-      ? parseMarkerBody(states[0].body, CONTROLLER_MARKER)
-      : null;
-  return {
-    events,
-    workerEvidence,
-    results,
-    selections,
-    state,
-    stateComment: states[0] ?? null,
-  };
+  return journalRecords(journal, matches[0]);
 }
 
-function canonicalLegacyReceiptUpgrade(comment) {
-  if (!isTrustedBotComment(comment) || typeof comment.body !== "string")
-    return null;
-  const marker = comment.body.split("\n", 1)[0];
-  if (
-    !IMMUTABLE_RECEIPT_MARKER_PREFIXES.some((prefix) =>
-      marker.startsWith(prefix),
-    )
-  ) {
-    return null;
-  }
-  const value = parseMarkerBody(comment.body, marker);
-  const legacyBody = legacyMarkerBody(marker, value);
-  if (comment.body !== legacyBody && comment.body !== legacyBody.slice(0, -1)) {
-    return null;
-  }
-  return {
-    commentId: comment.id,
-    body: markerBody(marker, value),
-  };
-}
-
-function selectionHasTerminalResult(selection, results) {
-  return results.some(
-    (result) =>
-      result.key_digest === selection.key_digest &&
-      result.epoch_anchor_run_id === selection.epoch_anchor_run_id &&
-      result.selection_receipt_run_id === selection.selection_receipt_run_id,
-  );
-}
-
-function hasUnfinishedLegacyWorker(parsed, pr, workflowSha) {
-  const state = normalizeExistingState(parsed.state, pr);
-  if (state === null) return true;
-  return [state.ui?.active, ...(state.ui?.retired_active ?? [])]
-    .filter(
-      (selection) => selection && selection.recovery_quarantine === undefined,
-    )
-    .some(
-      (selection) =>
-        selection.expected_workflow_sha !== workflowSha &&
-        !selectionHasTerminalResult(selection, parsed.results),
-    );
-}
-
-async function migrateLegacyReceiptPresentation({
+async function loadPreviewJournal(
   github,
   context,
-  core,
   pr,
-  workflowSha,
-  comments,
-  parsed,
-  migrationBudget,
+  { allowMissing = false } = {},
+) {
+  return parsePreviewJournalComments(
+    await listComments(github, context, pr),
+    pr,
+    { allowMissing },
+  );
+}
+
+async function mutatePreviewJournal({
+  github,
+  context,
+  pr: rawPr,
+  allowCreate = false,
+  expectedComment = null,
+  mutate,
 }) {
-  const upgrades = comments.map(canonicalLegacyReceiptUpgrade).filter(Boolean);
-  if (upgrades.length === 0) {
-    if (migrationBudget.migrated > 0) {
-      core.setOutput("legacy_receipt_presentations_remaining", "0");
-    }
-    return;
-  }
-  if (hasUnfinishedLegacyWorker(parsed, pr, workflowSha)) {
-    core.setOutput("legacy_receipt_presentation_migration_deferred", "true");
-    return;
-  }
-  const migrated = [];
-  for (const upgrade of upgrades.slice(0, migrationBudget.remaining)) {
-    const request = {
-      ...ownerRepo(context),
-      comment_id: upgrade.commentId,
-      body: upgrade.body,
-    };
-    migrationBudget.remaining -= 1;
-    try {
-      await github.rest.issues.updateComment(request);
-      migrated.push(upgrade);
-    } catch {
-      core.setOutput("legacy_receipt_presentation_migration_retryable", "true");
-      break;
-    }
-  }
-  migrationBudget.migrated += migrated.length;
-  if (migrated.length > 0) {
-    const refreshedComments = await listComments(github, context, pr);
-    for (const upgrade of migrated) {
-      invariant(
-        refreshedComments.some(
-          (comment) =>
-            comment.id === upgrade.commentId && comment.body === upgrade.body,
-        ),
-        "Legacy receipt presentation lost a concurrent update",
-      );
-    }
-    parseControllerComments(refreshedComments);
-  }
-  if (migrationBudget.migrated > 0) {
-    core.setOutput(
-      "legacy_receipt_presentations_migrated",
-      String(migrationBudget.migrated),
+  const pr = pullRequestNumber(rawPr);
+  const loaded = await loadPreviewJournal(github, context, pr, {
+    allowMissing: allowCreate,
+  });
+  if (expectedComment && loaded) {
+    invariant(
+      loaded.journalComment.id === expectedComment.id,
+      "Preview journal identity changed",
     );
   }
-  const remaining = upgrades.length - migrated.length;
-  core.setOutput("legacy_receipt_presentations_remaining", String(remaining));
+  const current = loaded?.journal ?? createPreviewJournal({ pr, revision: 1 });
+  const candidate = structuredClone(current);
+  mutate(candidate);
+  candidate.journal_digest = previewJournalDigest(
+    candidate.receipts,
+    candidate.state,
+  );
+  const changed =
+    canonicalJson({ ...candidate, revision: 0 }) !==
+    canonicalJson({ ...current, revision: 0 });
+  if (!changed && loaded) return loaded;
+  candidate.revision = loaded ? current.revision + 1 : 1;
+  const journal = validatePreviewJournal(candidate, pr);
+  const body = journalBody(journal);
+  let data;
+  if (loaded) {
+    ({ data } = await github.rest.issues.updateComment({
+      ...ownerRepo(context),
+      comment_id: loaded.journalComment.id,
+      body,
+    }));
+  } else {
+    invariant(allowCreate, "Preview journal creation is not allowed");
+    ({ data } = await github.rest.issues.createComment({
+      ...ownerRepo(context),
+      issue_number: pr,
+      body,
+    }));
+  }
+  const reread = await loadPreviewJournal(github, context, pr);
+  invariant(
+    reread.journalComment.id === data.id &&
+      reread.journalComment.body === body &&
+      reread.journal.revision === journal.revision &&
+      reread.journal.journal_digest === journal.journal_digest,
+    "Preview journal lost a serialized update",
+  );
+  return reread;
+}
+
+const RECEIPT_COLLECTION = {
+  event: {
+    name: "events",
+    validate: validateEventReceipt,
+    identity: (value) => String(value.event_run_id),
+  },
+  selection: {
+    name: "selections",
+    validate: validateSelectionReceipt,
+    identity: (value) => value.key_digest,
+  },
+  workerEvidence: {
+    name: "worker_evidence",
+    validate: validateWorkerEvidence,
+    identity: (value) => `${value.key_digest}:${value.worker_run_id}`,
+  },
+  result: {
+    name: "results",
+    validate: validateWorkerResult,
+    identity: (value) => `${value.key_digest}:${value.worker_run_id}`,
+  },
+};
+
+async function appendJournalReceipt({
+  github,
+  context,
+  pr,
+  kind,
+  value: rawValue,
+  allowCreate = false,
+}) {
+  const definition = RECEIPT_COLLECTION[kind];
+  invariant(definition, "Preview journal receipt kind is invalid");
+  const value = definition.validate(rawValue);
+  invariant(value.pr === pullRequestNumber(pr), "Preview receipt PR mismatch");
+  return mutatePreviewJournal({
+    github,
+    context,
+    pr,
+    allowCreate,
+    mutate(journal) {
+      const entries = journal.receipts[definition.name];
+      const identity = definition.identity(value);
+      const existing = entries.find(
+        (entry) => definition.identity(definition.validate(entry)) === identity,
+      );
+      invariant(
+        !existing || canonicalJson(existing) === canonicalJson(value),
+        `Conflicting ${kind} receipt in preview journal`,
+      );
+      if (!existing) entries.push(structuredClone(value));
+    },
+  });
 }
 
 async function writeControllerState({
@@ -2056,29 +2184,45 @@ async function writeControllerState({
   state,
   stateComment,
 }) {
-  const body = markerBody(CONTROLLER_MARKER, state);
-  let data;
-  if (stateComment) {
-    ({ data } = await github.rest.issues.updateComment({
-      ...ownerRepo(context),
-      comment_id: stateComment.id,
-      body,
-    }));
-  } else {
-    ({ data } = await github.rest.issues.createComment({
-      ...ownerRepo(context),
-      issue_number: pr,
-      body,
-    }));
-  }
-  const reread = parseControllerComments(
-    await listComments(github, context, pr),
-  );
-  invariant(
-    reread.stateComment?.id === data.id && reread.stateComment.body === body,
-    "Controller state lost a concurrent update",
-  );
-  return reread.stateComment;
+  const updated = await mutatePreviewJournal({
+    github,
+    context,
+    pr,
+    expectedComment: stateComment,
+    mutate(journal) {
+      journal.state = structuredClone(state);
+    },
+  });
+  return updated.journalComment;
+}
+
+async function writeControllerIntent({
+  github,
+  context,
+  pr,
+  state,
+  selection,
+  stateComment,
+}) {
+  const receipt = validateSelectionReceipt(selection);
+  const updated = await mutatePreviewJournal({
+    github,
+    context,
+    pr,
+    expectedComment: stateComment,
+    mutate(journal) {
+      journal.state = structuredClone(state);
+      const existing = journal.receipts.selections.find(
+        (candidate) => candidate.key_digest === receipt.key_digest,
+      );
+      invariant(
+        !existing || canonicalJson(existing) === canonicalJson(receipt),
+        "Conflicting selection receipt in preview journal",
+      );
+      if (!existing) journal.receipts.selections.push(structuredClone(receipt));
+    },
+  });
+  return updated.journalComment;
 }
 
 async function pullFromApi(github, context, pr) {
@@ -2270,12 +2414,17 @@ export async function recordEventReceipt({
     core.setOutput("planner_output_invalid", "true");
   }
   const receipt = validateEventReceipt({ ...validatedSnapshot, plan });
-  await writeImmutableComment({
+  const isInitialJournalTransition =
+    (receipt.event_action === "opened" ||
+      receipt.event_action === "bootstrap") &&
+    exactRunAttempt(context.runAttempt ?? 1) === 1;
+  await appendJournalReceipt({
     github,
     context,
     pr: receipt.pr,
-    marker: eventReceiptMarker(receipt.event_run_id),
+    kind: "event",
     value: receipt,
+    allowCreate: isInitialJournalTransition,
   });
   const current = normalizePullRequest(
     await pullFromApi(github, context, receipt.pr),
@@ -2760,11 +2909,11 @@ async function recordRemovedSelection({ github, context, pr, selection }) {
     smoke_result: "not-run",
     terminal_reason: "selection-removed-from-pr",
   });
-  await writeImmutableComment({
+  await appendJournalReceipt({
     github,
     context,
     pr,
-    marker: resultReceiptMarker(result),
+    kind: "result",
     value: result,
   });
   return result;
@@ -2793,11 +2942,11 @@ async function recordSupersededIntent({ github, context, pr, selection }) {
     smoke_result: "not-run",
     terminal_reason: "controller-workflow-upgraded-before-dispatch",
   });
-  await writeImmutableComment({
+  await appendJournalReceipt({
     github,
     context,
     pr,
-    marker: resultReceiptMarker(result),
+    kind: "result",
     value: result,
   });
   return result;
@@ -2833,9 +2982,7 @@ async function refreshDispatchOwnership({
   if (!(await shaIsStillAssociated(github, context, pull, selected.sha))) {
     return { outcome: "removed" };
   }
-  const comments = parseControllerComments(
-    await listComments(github, context, pr),
-  );
+  const comments = await loadPreviewJournal(github, context, pr);
   const ownershipCheck = reconcileState({
     events: comments.events,
     results: comments.results,
@@ -2960,16 +3107,10 @@ export async function reconcilePreview({
   const pr = pullRequestNumber(rawPr);
   const workflowSha = exactSha(rawWorkflowSha, "Controller workflow SHA");
   const controllerUrl = `https://github.com/${PREVIEW_REPOSITORY}/actions/runs/${context.runId}`;
-  const presentationMigrationBudget = {
-    remaining: MAX_PRESENTATION_MIGRATIONS_PER_RECONCILE,
-    migrated: 0,
-  };
   reconcileAttempts: for (let attempt = 0; attempt < 3; attempt += 1) {
     try {
       const pull = await pullFromApi(github, context, pr);
-      const parsed = parseControllerComments(
-        await listComments(github, context, pr),
-      );
+      const parsed = await loadPreviewJournal(github, context, pr);
       if (
         await recoverCompletedOwnedRuns({
           github,
@@ -3013,20 +3154,14 @@ export async function reconcilePreview({
           };
           state.ui.active = selected;
         }
-        stateComment = await writeControllerState({
+        const selectionReceipt = selectionReceiptFromDispatch(selected);
+        stateComment = await writeControllerIntent({
           github,
           context,
           pr,
           state,
+          selection: selectionReceipt,
           stateComment,
-        });
-        const selectionReceipt = selectionReceiptFromDispatch(selected);
-        await writeImmutableComment({
-          github,
-          context,
-          pr,
-          marker: selectionReceiptMarker(selectionReceipt),
-          value: selectionReceipt,
         });
 
         let refreshedOwnership = await refreshDispatchOwnership({
@@ -3154,9 +3289,7 @@ export async function reconcilePreview({
       }
 
       const finalPull = await pullFromApi(github, context, pr);
-      const finalComments = parseControllerComments(
-        await listComments(github, context, pr),
-      );
+      const finalComments = await loadPreviewJournal(github, context, pr);
       const finalReconciled = reconcileState({
         events: finalComments.events,
         results: finalComments.results,
@@ -3181,8 +3314,7 @@ export async function reconcilePreview({
         stateComment,
       });
       const readStatusBasis = async () => {
-        const comments = await listComments(github, context, pr);
-        const confirmed = parseControllerComments(comments);
+        const confirmed = await loadPreviewJournal(github, context, pr);
         invariant(
           confirmed.stateComment?.id === stateComment.id &&
             canonicalJson(confirmed.state) === canonicalJson(state),
@@ -3198,22 +3330,11 @@ export async function reconcilePreview({
             ),
           "Controller receipt set changed before status publication",
         );
-        return { comments, confirmed };
+        return confirmed;
       };
       const assertStatusBasis = async () => {
         await readStatusBasis();
       };
-      const presentationBasis = await readStatusBasis();
-      await migrateLegacyReceiptPresentation({
-        github,
-        context,
-        core,
-        pr,
-        workflowSha,
-        comments: presentationBasis.comments,
-        parsed: presentationBasis.confirmed,
-        migrationBudget: presentationMigrationBudget,
-      });
       await assertStatusBasis();
       await postStatusDecisions(github, context, state.status_decisions, {
         assertBasis: assertStatusBasis,
@@ -3223,7 +3344,7 @@ export async function reconcilePreview({
     } catch (error) {
       if (
         attempt < 2 &&
-        /concurrent update|basis changed|changed before status|receipt set changed|ownership changed/.test(
+        /serialized update|identity changed|basis changed|changed before status|receipt set changed|ownership changed/.test(
           error.message,
         )
       ) {
@@ -3246,10 +3367,8 @@ export async function reconcilePreview({
 }
 
 async function loadControllerEvidence(github, context, pr) {
-  const parsed = parseControllerComments(
-    await listComments(github, context, pr),
-  );
-  invariant(parsed.state !== null, "Controller state comment does not exist");
+  const parsed = await loadPreviewJournal(github, context, pr);
+  invariant(parsed.state !== null, "Preview journal state does not exist");
   normalizeExistingState(parsed.state, pr);
   return parsed;
 }
@@ -3792,11 +3911,11 @@ export async function recordWorkerEvidence({
     next_deployment_id: nextDeploymentId,
     verified_upload_url: verifiedUploadUrl,
   });
-  await writeImmutableComment({
+  await appendJournalReceipt({
     github,
     context,
     pr: selection.pr,
-    marker: workerEvidenceMarker(workerEvidence),
+    kind: "workerEvidence",
     value: workerEvidence,
   });
   core.setOutput("worker_evidence_recorded", "true");
@@ -4140,11 +4259,11 @@ export async function recoverWorkerResult({
     smoke_result: smokeResult,
     terminal_reason: terminalReason,
   });
-  await writeImmutableComment({
+  await appendJournalReceipt({
     github,
     context,
     pr: parsed.pr,
-    marker: resultReceiptMarker(result),
+    kind: "result",
     value: result,
   });
   core.setOutput("pr_number", String(parsed.pr));

--- a/scripts/vercel-preview-controller.mjs
+++ b/scripts/vercel-preview-controller.mjs
@@ -1166,6 +1166,39 @@ function resultForSelection(results, anchorRunId, event, selection) {
   );
 }
 
+function statusFromCheckpointRuntime({
+  event,
+  runtimeEvent,
+  checkpointStatus,
+  controllerUrl,
+}) {
+  if (checkpointStatus.state === "success") {
+    return {
+      sha: event.head_sha,
+      state: "success",
+      description: `Runtime-equivalent to ${runtimeEvent.head_sha.slice(0, 7)}`,
+      target_url: checkpointStatus.target_url,
+    };
+  }
+  if (checkpointStatus.state === "failure") {
+    const cancelled = checkpointStatus.description.includes("cancelled");
+    return {
+      sha: event.head_sha,
+      state: "failure",
+      description: cancelled
+        ? `Runtime preview ${runtimeEvent.head_sha.slice(0, 7)} was cancelled`
+        : `Runtime preview ${runtimeEvent.head_sha.slice(0, 7)} failed`,
+      target_url: controllerUrl,
+    };
+  }
+  return {
+    sha: event.head_sha,
+    state: "error",
+    description: `Runtime preview ${runtimeEvent.head_sha.slice(0, 7)} errored`,
+    target_url: controllerUrl,
+  };
+}
+
 function statusDecision({
   event,
   index,
@@ -1175,6 +1208,8 @@ function statusDecision({
   coalescedToByRun,
   controllerUrl,
   checkpointStatus,
+  checkpointBaselineStatus,
+  checkpointBaselineEvent,
 }) {
   if (checkpointStatus) return structuredClone(checkpointStatus);
   if (event.trust !== "trusted") {
@@ -1219,12 +1254,29 @@ function statusDecision({
       .slice(0, index)
       .findLast((candidate) => candidate.plan.targets.includes(PREVIEW_TARGET));
     if (!priorRuntime) {
+      if (checkpointBaselineStatus) {
+        return {
+          ...structuredClone(checkpointBaselineStatus),
+          sha: event.head_sha,
+        };
+      }
       return {
         sha: event.head_sha,
         state: "success",
         description: "No UI runtime impact",
         target_url: controllerUrl,
       };
+    }
+    if (
+      checkpointBaselineStatus &&
+      checkpointBaselineEvent?.event_run_id === priorRuntime.event_run_id
+    ) {
+      return statusFromCheckpointRuntime({
+        event,
+        runtimeEvent: priorRuntime,
+        checkpointStatus: checkpointBaselineStatus,
+        controllerUrl,
+      });
     }
     const priorResult = resultByRun.get(priorRuntime.event_run_id);
     if (priorResult?.state === "success") {
@@ -1769,6 +1821,8 @@ export function reconcileState({
         selectedCheckpoint?.event.event_run_id === event.event_run_id
           ? selectedCheckpoint.status
           : null,
+      checkpointBaselineStatus: selectedCheckpoint?.status ?? null,
+      checkpointBaselineEvent: selectedCheckpoint?.event ?? null,
     }),
   );
   const successes = [...resultByRun.entries()]
@@ -1825,7 +1879,7 @@ export function reconcileState({
       anchor_head_sha: anchor.head_sha,
       anchor_head_ref: anchor.head_ref,
       closed_at: closure?.pr_closed_at ?? null,
-      tail_receipt_run_id: lineage.at(-1).event_run_id,
+      tail_receipt_run_id: (closure ?? lineage.at(-1)).event_run_id,
       lineage_digest: digest(lineage.map(semanticEventKey)),
       basis_digest: basisDigest,
     },
@@ -2098,6 +2152,14 @@ function validatePreviewJournal(value, expectedPr) {
     "Preview checkpoint event is duplicated in live receipts",
   );
   invariant(
+    !checkpoint ||
+      !events.some(
+        (event) =>
+          semanticEventKey(event) === semanticEventKey(checkpoint.event),
+      ),
+    "Preview checkpoint event has a semantic duplicate in live receipts",
+  );
+  invariant(
     selections.every((selection) => selection.pr === pr),
     "Journal selection PR mismatch",
   );
@@ -2274,6 +2336,12 @@ export function compactPreviewJournal(value) {
       ? journal.checkpoint.event
       : null);
   invariant(tailEvent, "Preview checkpoint tail event is missing");
+  invariant(
+    !state.closed ||
+      (tailEvent.event_action === "closed" &&
+        tailEvent.pr_closed_at === state.epoch.closed_at),
+    "Preview checkpoint closure does not match persisted lifecycle state",
+  );
   const status = [...state.status_decisions]
     .reverse()
     .find((decision) => decision.sha === tailEvent.head_sha);
@@ -2479,9 +2547,17 @@ async function appendJournalReceipt({
     allowCreate,
     assertCanCreate,
     mutate(journal) {
+      const identity = definition.identity(value);
+      const existing = journal.receipts[definition.name].find(
+        (entry) => definition.identity(definition.validate(entry)) === identity,
+      );
+      invariant(
+        !existing || canonicalJson(existing) === canonicalJson(value),
+        `Conflicting ${kind} receipt in preview journal`,
+      );
+      if (existing) return;
       if (kind === "event") compactPreviewJournal(journal);
       const entries = journal.receipts[definition.name];
-      const identity = definition.identity(value);
       const checkpointEntry =
         kind === "event" && journal.checkpoint
           ? journal.checkpoint.event
@@ -2496,14 +2572,13 @@ async function appendJournalReceipt({
         );
         return;
       }
-      const existing = entries.find(
-        (entry) => definition.identity(definition.validate(entry)) === identity,
-      );
-      invariant(
-        !existing || canonicalJson(existing) === canonicalJson(value),
-        `Conflicting ${kind} receipt in preview journal`,
-      );
-      if (!existing) entries.push(structuredClone(value));
+      if (
+        checkpointEntry &&
+        semanticEventKey(checkpointEntry) === semanticEventKey(value)
+      ) {
+        return;
+      }
+      entries.push(structuredClone(value));
     },
   });
 }

--- a/scripts/vercel-preview-controller.mjs
+++ b/scripts/vercel-preview-controller.mjs
@@ -3013,6 +3013,15 @@ async function appendJournalReceipt({
       let compactAfterAppend = false;
       if (kind === "event" && journal.state !== null) {
         const state = normalizeExistingState(journal.state, journal.pr);
+        const liveReceiptsAreRepresented =
+          state.receipts_digest ===
+          controllerReceiptsDigest(
+            journal.receipts.events,
+            journal.receipts.results,
+            journal.receipts.selections,
+            journal.pr,
+            journal.checkpoint,
+          );
         const terminalKeys = new Set(
           journal.receipts.results.map((result) => result.key_digest),
         );
@@ -3026,7 +3035,7 @@ async function appendJournalReceipt({
           );
         if (hasUnfinishedOwnership) {
           compactAfterAppend = true;
-        } else {
+        } else if (liveReceiptsAreRepresented) {
           compactPreviewJournal(journal);
         }
       }

--- a/scripts/vercel-preview-controller.mjs
+++ b/scripts/vercel-preview-controller.mjs
@@ -6,6 +6,7 @@ import { createHash } from "node:crypto";
 export const PREVIEW_REPOSITORY = "mento-protocol/frontend-monorepo";
 const PREVIEW_TARGET = "ui";
 const PREVIEW_STATUS_CONTEXT = "Vercel Preview";
+const PREVIEW_INITIALIZATION_STATUS_CONTEXT = "Vercel Preview Journal";
 export const EVENT_RECEIPT_SCHEMA = "vercel-preview-event-receipt:v1";
 const WORKER_EVIDENCE_SCHEMA = "vercel-preview-worker-evidence:v1";
 export const RESULT_RECEIPT_SCHEMA = "vercel-preview-worker-result:v1";
@@ -13,6 +14,7 @@ export const SELECTION_RECEIPT_SCHEMA = "vercel-preview-selection:v1";
 export const CONTROLLER_SCHEMA = "vercel-preview-controller:v1";
 export const PREVIEW_JOURNAL_SCHEMA = "vercel-preview-journal:v1";
 export const PREVIEW_JOURNAL_MARKER = "<!-- vercel-preview-journal:v1 -->";
+const PREVIEW_CHECKPOINT_SCHEMA = "vercel-preview-checkpoint:v1";
 const WORKER_WORKFLOW = "vercel-preview-worker.yml";
 const WORKER_WORKFLOW_NAME = "Vercel Preview Worker";
 const INTAKE_WORKFLOW = "vercel-preview-intake.yml";
@@ -972,8 +974,14 @@ function dedupeSelectionReceipts(selections) {
   return [...byKey.values()];
 }
 
-function controllerReceiptsDigest(events, results, selections, pr) {
-  return digest({
+function controllerReceiptsDigest(
+  events,
+  results,
+  selections,
+  pr,
+  checkpoint = null,
+) {
+  const receiptDigest = {
     events: dedupeEvents(events)
       .filter((event) => event.pr === pr)
       .map(semanticEventKey)
@@ -986,7 +994,13 @@ function controllerReceiptsDigest(events, results, selections, pr) {
       .filter((selection) => selection.pr === pr)
       .map(canonicalJson)
       .sort(),
-  });
+  };
+  return checkpoint
+    ? digest({
+        checkpoint_digest: checkpoint.cumulative_receipts_digest,
+        receipts: receiptDigest,
+      })
+    : digest(receiptDigest);
 }
 
 function eventInstanceId(event) {
@@ -1041,13 +1055,16 @@ function findLineagePaths(anchor, events, pull, epochClosedAt) {
   return paths;
 }
 
-function selectCurrentEpoch(events, pull) {
-  const anchorCandidates = events
-    .filter((event) =>
+function selectCurrentEpoch(events, pull, checkpoint = null) {
+  const checkpointEvent = checkpoint?.event ?? null;
+  const anchorCandidates = [
+    ...events.filter((event) =>
       ["opened", "edited", "reopened", "bootstrap"].includes(
         event.event_action,
       ),
-    )
+    ),
+    ...(checkpointEvent ? [checkpointEvent] : []),
+  ]
     .filter(
       (event) => event.pr === pull.number && samePullIdentity(event, pull),
     )
@@ -1071,7 +1088,10 @@ function selectCurrentEpoch(events, pull) {
 
   const candidates = [];
   for (const anchor of anchors) {
-    const closures = events.filter(
+    const closures = [
+      ...events,
+      ...(checkpointEvent ? [checkpointEvent] : []),
+    ].filter(
       (event) =>
         event.event_action === "closed" &&
         event.pr === pull.number &&
@@ -1099,7 +1119,15 @@ function selectCurrentEpoch(events, pull) {
       "Ambiguous event lineage reaches current head",
     );
     if (paths.length === 1) {
-      candidates.push({ anchor, closure, lineage: paths[0] });
+      candidates.push({
+        anchor,
+        closure,
+        lineage: paths[0],
+        checkpoint:
+          checkpointEvent?.event_run_id === anchor.event_run_id
+            ? checkpoint
+            : null,
+      });
       if (
         anchors[1]?.pr_updated_at !== anchor.pr_updated_at &&
         candidates.length === 1
@@ -1146,7 +1174,9 @@ function statusDecision({
   active,
   coalescedToByRun,
   controllerUrl,
+  checkpointStatus,
 }) {
+  if (checkpointStatus) return structuredClone(checkpointStatus);
   if (event.trust !== "trusted") {
     return {
       sha: event.head_sha,
@@ -1344,6 +1374,7 @@ function normalizeExistingState(value, pr) {
     "Controller receipt digest is invalid",
   );
   exactRunId(state.epoch?.anchor_run_id, "State epoch anchor run ID");
+  exactRunId(state.epoch?.tail_receipt_run_id, "State epoch tail run ID");
   invariant(
     /^[0-9a-f]{64}$/.test(state.epoch?.basis_digest),
     "State epoch basis digest is invalid",
@@ -1417,6 +1448,7 @@ export function reconcileState({
   selections: rawSelections = [],
   pullRequest: rawPull,
   existingState = null,
+  checkpoint: rawCheckpoint = null,
   controllerUrl,
   expectedWorkflowSha: rawExpectedWorkflowSha,
 }) {
@@ -1425,6 +1457,10 @@ export function reconcileState({
     "Controller workflow SHA",
   );
   const pull = normalizePullRequest(rawPull);
+  const checkpoint =
+    rawCheckpoint === null
+      ? null
+      : validatePreviewCheckpoint(rawCheckpoint, pull.number);
   const allResults = dedupeResults(rawResults).filter(
     (result) => result.pr === pull.number,
   );
@@ -1436,7 +1472,12 @@ export function reconcileState({
     rawEvents,
     persistedEventRunIds(previous, allResults, allSelections),
   ).filter((event) => event.pr === pull.number);
-  const { anchor, closure, lineage } = selectCurrentEpoch(events, pull);
+  const {
+    anchor,
+    closure,
+    lineage,
+    checkpoint: selectedCheckpoint,
+  } = selectCurrentEpoch(events, pull, checkpoint);
   const epochResults = allResults.filter(
     (result) => result.epoch_anchor_run_id === anchor.event_run_id,
   );
@@ -1460,6 +1501,7 @@ export function reconcileState({
     }
   }
   const basisDigest = digest({
+    checkpoint_digest: selectedCheckpoint?.cumulative_receipts_digest ?? null,
     anchor: semanticEventKey(anchor),
     closure: closure ? semanticEventKey(closure) : null,
     lineage: lineage.map(semanticEventKey),
@@ -1530,6 +1572,17 @@ export function reconcileState({
         : null,
     );
     if (result) resultByRun.set(event.event_run_id, result);
+  }
+  if (
+    selectedCheckpoint &&
+    selectedCheckpoint.event.plan.targets.includes(PREVIEW_TARGET)
+  ) {
+    resultByRun.set(selectedCheckpoint.event.event_run_id, {
+      state: selectedCheckpoint.status.state,
+      sha: selectedCheckpoint.event.head_sha,
+      vercel_deployment_url: selectedCheckpoint.status.target_url,
+      terminal_reason: "checkpointed-terminal-status",
+    });
   }
   const selectedReceiptRunIds = new Set(
     epochSelections.map((selection) => selection.selection_receipt_run_id),
@@ -1712,6 +1765,10 @@ export function reconcileState({
       active,
       coalescedToByRun,
       controllerUrl: controllerTargetUrl,
+      checkpointStatus:
+        selectedCheckpoint?.event.event_run_id === event.event_run_id
+          ? selectedCheckpoint.status
+          : null,
     }),
   );
   const successes = [...resultByRun.entries()]
@@ -1768,6 +1825,7 @@ export function reconcileState({
       anchor_head_sha: anchor.head_sha,
       anchor_head_ref: anchor.head_ref,
       closed_at: closure?.pr_closed_at ?? null,
+      tail_receipt_run_id: lineage.at(-1).event_run_id,
       lineage_digest: digest(lineage.map(semanticEventKey)),
       basis_digest: basisDigest,
     },
@@ -1777,6 +1835,7 @@ export function reconcileState({
       allResults,
       allSelections,
       pull.number,
+      checkpoint,
     ),
     ui: {
       first_eligible_sha: candidates[0]?.head_sha ?? null,
@@ -1785,8 +1844,12 @@ export function reconcileState({
       idle_cursor_receipt_run_id: idleCursor,
       active,
       retired_active: retiredActive,
-      last_successful_runtime_sha: lastSuccess?.sha ?? null,
-      last_successful_runtime_url: lastSuccess?.vercel_deployment_url ?? null,
+      last_successful_runtime_sha:
+        lastSuccess?.sha ?? previous?.ui?.last_successful_runtime_sha ?? null,
+      last_successful_runtime_url:
+        lastSuccess?.vercel_deployment_url ??
+        previous?.ui?.last_successful_runtime_url ??
+        null,
       terminal_result_key_digests: [
         ...new Set(epochResults.map((result) => result.key_digest)),
       ],
@@ -1819,6 +1882,32 @@ async function listComments(github, context, pr) {
   return comments;
 }
 
+async function assertPreviewJournalIsUninitialized(github, context, receipt) {
+  const refs = [receipt.change_base_sha, receipt.head_sha].filter(
+    (value, index, values) => value && values.indexOf(value) === index,
+  );
+  for (const ref of refs) {
+    const statuses = await github.paginate(
+      github.rest.repos.listCommitStatusesForRef,
+      {
+        ...ownerRepo(context),
+        ref: exactSha(ref),
+        per_page: 100,
+      },
+    );
+    invariant(
+      statuses.length <= MAX_RECEIPTS,
+      "Too many commit statuses to prove journal initialization",
+    );
+    invariant(
+      !statuses.some(
+        (status) => status.context === PREVIEW_INITIALIZATION_STATUS_CONTEXT,
+      ),
+      "Preview journal is missing after external initialization evidence",
+    );
+  }
+}
+
 function receiptSetDigest({ events, selections, worker_evidence, results }) {
   return digest({
     events: events.map(canonicalJson).sort(),
@@ -1828,8 +1917,79 @@ function receiptSetDigest({ events, selections, worker_evidence, results }) {
   });
 }
 
-function previewJournalDigest(receipts, state) {
-  return digest({ receipts_digest: receiptSetDigest(receipts), state });
+function previewJournalDigest(receipts, state, checkpoint = null) {
+  return digest({
+    checkpoint,
+    receipts_digest: receiptSetDigest(receipts),
+    state,
+  });
+}
+
+function validateCheckpointStatus(value, event) {
+  const status = plainObject(value, "Preview checkpoint status");
+  invariant(
+    Object.keys(status).sort().join(",") === "description,sha,state,target_url",
+    "Preview checkpoint status fields are invalid",
+  );
+  invariant(
+    exactSha(status.sha) === event.head_sha,
+    "Preview checkpoint status SHA mismatch",
+  );
+  invariant(
+    ["success", "failure", "error"].includes(status.state),
+    "Preview checkpoint status state is invalid",
+  );
+  boundedText(status.description, "Preview checkpoint status description", 140);
+  optionalHttpsUrl(status.target_url, "Preview checkpoint status URL");
+  return status;
+}
+
+function validatePreviewCheckpoint(value, expectedPr) {
+  if (value === null) return null;
+  const checkpoint = plainObject(value, "Preview checkpoint");
+  invariant(
+    Object.keys(checkpoint).sort().join(",") ===
+      "cumulative_receipts_digest,event,pruned_receipt_counts,schema,sequence,status,through_event_run_id",
+    "Preview checkpoint fields are invalid",
+  );
+  invariant(
+    checkpoint.schema === PREVIEW_CHECKPOINT_SCHEMA,
+    "Preview checkpoint schema mismatch",
+  );
+  invariant(
+    Number.isSafeInteger(checkpoint.sequence) && checkpoint.sequence >= 1,
+    "Preview checkpoint sequence is invalid",
+  );
+  invariant(
+    /^[0-9a-f]{64}$/.test(checkpoint.cumulative_receipts_digest),
+    "Preview checkpoint digest is invalid",
+  );
+  const counts = plainObject(
+    checkpoint.pruned_receipt_counts,
+    "Preview checkpoint receipt counts",
+  );
+  invariant(
+    Object.keys(counts).sort().join(",") ===
+      "events,results,selections,worker_evidence",
+    "Preview checkpoint receipt count fields are invalid",
+  );
+  for (const count of Object.values(counts)) {
+    invariant(
+      Number.isSafeInteger(count) && count >= 0,
+      "Preview checkpoint receipt count is invalid",
+    );
+  }
+  const event = validateEventReceipt(checkpoint.event);
+  invariant(
+    event.pr === pullRequestNumber(expectedPr),
+    "Preview checkpoint PR mismatch",
+  );
+  invariant(
+    checkpoint.through_event_run_id === event.event_run_id,
+    "Preview checkpoint event identity mismatch",
+  );
+  validateCheckpointStatus(checkpoint.status, event);
+  return checkpoint;
 }
 
 function validateWorkerEvidenceSet(values, pr) {
@@ -1890,7 +2050,7 @@ function validatePreviewJournal(value, expectedPr) {
   );
   invariant(
     Object.keys(journal).sort().join(",") ===
-      "journal_digest,pr,receipts,repository,revision,schema,state",
+      "checkpoint,journal_digest,pr,receipts,repository,revision,schema,state",
     "Preview journal fields are invalid",
   );
   validatedRepository(journal.repository);
@@ -1903,6 +2063,7 @@ function validatePreviewJournal(value, expectedPr) {
     Number.isSafeInteger(journal.revision) && journal.revision >= 1,
     "Preview journal revision is invalid",
   );
+  const checkpoint = validatePreviewCheckpoint(journal.checkpoint, pr);
   const receipts = plainObject(journal.receipts, "Preview journal receipts");
   invariant(
     Object.keys(receipts).sort().join(",") ===
@@ -1928,6 +2089,13 @@ function validatePreviewJournal(value, expectedPr) {
   invariant(
     events.every((event) => event.pr === pr),
     "Journal event PR mismatch",
+  );
+  invariant(
+    !checkpoint ||
+      !events.some(
+        (event) => event.event_run_id === checkpoint.through_event_run_id,
+      ),
+    "Preview checkpoint event is duplicated in live receipts",
   );
   invariant(
     selections.every((selection) => selection.pr === pr),
@@ -1977,7 +2145,8 @@ function validatePreviewJournal(value, expectedPr) {
   invariant(
     typeof journal.journal_digest === "string" &&
       /^[0-9a-f]{64}$/.test(journal.journal_digest) &&
-      journal.journal_digest === previewJournalDigest(receipts, journal.state),
+      journal.journal_digest ===
+        previewJournalDigest(receipts, journal.state, checkpoint),
     "Preview journal digest mismatch",
   );
   journalBody(journal);
@@ -1987,6 +2156,7 @@ function validatePreviewJournal(value, expectedPr) {
 export function createPreviewJournal({
   pr: rawPr,
   revision = 1,
+  checkpoint = null,
   events = [],
   selections = [],
   workerEvidence = [],
@@ -2006,12 +2176,152 @@ export function createPreviewJournal({
       repository: PREVIEW_REPOSITORY,
       pr,
       revision,
-      journal_digest: previewJournalDigest(receipts, state),
+      checkpoint: checkpoint === null ? null : structuredClone(checkpoint),
+      journal_digest: previewJournalDigest(receipts, state, checkpoint),
       receipts,
       state: state === null ? null : structuredClone(state),
     },
     pr,
   );
+}
+
+function emptyReceiptCounts() {
+  return { events: 0, selections: 0, worker_evidence: 0, results: 0 };
+}
+
+function checkpointBaselineState(state, checkpoint) {
+  const event = checkpoint.event;
+  const eligible = event.plan.targets.includes(PREVIEW_TARGET);
+  return {
+    schema: CONTROLLER_SCHEMA,
+    repository: PREVIEW_REPOSITORY,
+    pr: event.pr,
+    epoch: {
+      anchor_run_id: event.event_run_id,
+      anchor_action: event.event_action,
+      anchor_pr_updated_at: event.pr_updated_at,
+      anchor_head_sha: event.head_sha,
+      anchor_head_ref: event.head_ref,
+      closed_at: state.closed ? event.pr_closed_at : null,
+      tail_receipt_run_id: event.event_run_id,
+      lineage_digest: digest([semanticEventKey(event)]),
+      basis_digest: digest({
+        checkpoint_digest: checkpoint.cumulative_receipts_digest,
+        anchor: semanticEventKey(event),
+        closure: state.closed ? semanticEventKey(event) : null,
+        lineage: [semanticEventKey(event)],
+        results: [],
+      }),
+    },
+    closed: state.closed,
+    receipts_digest: controllerReceiptsDigest([], [], [], event.pr, checkpoint),
+    ui: {
+      first_eligible_sha: eligible ? event.head_sha : null,
+      latest_desired_sha: eligible ? event.head_sha : null,
+      latest_desired_receipt_run_id: eligible ? event.event_run_id : null,
+      idle_cursor_receipt_run_id: eligible ? event.event_run_id : null,
+      active: null,
+      retired_active: [],
+      last_successful_runtime_sha: state.ui.last_successful_runtime_sha,
+      last_successful_runtime_url: state.ui.last_successful_runtime_url,
+      terminal_result_key_digests: [],
+      terminal_history: [],
+    },
+    status_decisions: [structuredClone(checkpoint.status)],
+  };
+}
+
+export function compactPreviewJournal(value) {
+  const journal = validatePreviewJournal(value, value.pr);
+  if (journal.state === null) return journal;
+  const state = normalizeExistingState(journal.state, journal.pr);
+  const receiptCount = Object.values(journal.receipts).reduce(
+    (total, receipts) => total + receipts.length,
+    0,
+  );
+  if (
+    receiptCount === 0 ||
+    state.ui.active !== null ||
+    state.ui.retired_active.length > 0
+  ) {
+    return journal;
+  }
+  const resultIdentities = new Set(
+    journal.receipts.results.map(
+      (result) => `${result.key_digest}:${result.worker_run_id}`,
+    ),
+  );
+  invariant(
+    journal.receipts.worker_evidence.every((evidence) =>
+      resultIdentities.has(`${evidence.key_digest}:${evidence.worker_run_id}`),
+    ),
+    "Preview journal cannot checkpoint unfinished worker evidence",
+  );
+  invariant(
+    journal.receipts.selections.every((selection) =>
+      journal.receipts.results.some(
+        (result) => result.key_digest === selection.key_digest,
+      ),
+    ),
+    "Preview journal cannot checkpoint unfinished selections",
+  );
+  const tailEvent =
+    journal.receipts.events.find(
+      (event) => event.event_run_id === state.epoch.tail_receipt_run_id,
+    ) ??
+    (journal.checkpoint?.through_event_run_id ===
+    state.epoch.tail_receipt_run_id
+      ? journal.checkpoint.event
+      : null);
+  invariant(tailEvent, "Preview checkpoint tail event is missing");
+  const status = [...state.status_decisions]
+    .reverse()
+    .find((decision) => decision.sha === tailEvent.head_sha);
+  invariant(status, "Preview checkpoint tail status is missing");
+  invariant(
+    status.state !== "pending",
+    "Preview journal cannot checkpoint a pending tail status",
+  );
+  const previousCounts =
+    journal.checkpoint?.pruned_receipt_counts ?? emptyReceiptCounts();
+  const prunedReceiptCounts = Object.fromEntries(
+    Object.entries(previousCounts).map(([name, count]) => [
+      name,
+      count + journal.receipts[name].length,
+    ]),
+  );
+  const checkpoint = {
+    schema: PREVIEW_CHECKPOINT_SCHEMA,
+    sequence: (journal.checkpoint?.sequence ?? 0) + 1,
+    through_event_run_id: tailEvent.event_run_id,
+    cumulative_receipts_digest: digest({
+      previous: journal.checkpoint?.cumulative_receipts_digest ?? null,
+      receipts: receiptSetDigest(journal.receipts),
+      state: digest(state),
+    }),
+    pruned_receipt_counts: prunedReceiptCounts,
+    event: structuredClone(tailEvent),
+    status: {
+      sha: status.sha,
+      state: status.state,
+      description: status.description,
+      target_url: status.target_url ?? null,
+    },
+  };
+  journal.checkpoint = checkpoint;
+  journal.receipts = {
+    events: [],
+    selections: [],
+    worker_evidence: [],
+    results: [],
+  };
+  journal.state = checkpointBaselineState(state, checkpoint);
+  journal.journal_digest = previewJournalDigest(
+    journal.receipts,
+    journal.state,
+    checkpoint,
+  );
+  return validatePreviewJournal(journal, journal.pr);
 }
 
 function journalRecords(journal, journalComment) {
@@ -2021,6 +2331,7 @@ function journalRecords(journal, journalComment) {
     results: journal.receipts.results,
     selections: journal.receipts.selections,
     state: journal.state,
+    checkpoint: journal.checkpoint,
     stateComment: journalComment,
     journal,
     journalComment,
@@ -2069,6 +2380,7 @@ async function mutatePreviewJournal({
   context,
   pr: rawPr,
   allowCreate = false,
+  assertCanCreate,
   expectedComment = null,
   mutate,
 }) {
@@ -2082,17 +2394,19 @@ async function mutatePreviewJournal({
       "Preview journal identity changed",
     );
   }
+  if (!loaded && assertCanCreate) await assertCanCreate();
   const current = loaded?.journal ?? createPreviewJournal({ pr, revision: 1 });
   const candidate = structuredClone(current);
   mutate(candidate);
   candidate.journal_digest = previewJournalDigest(
     candidate.receipts,
     candidate.state,
+    candidate.checkpoint,
   );
   const changed =
     canonicalJson({ ...candidate, revision: 0 }) !==
     canonicalJson({ ...current, revision: 0 });
-  if (!changed && loaded) return loaded;
+  if (!changed && loaded) return { ...loaded, created: false };
   candidate.revision = loaded ? current.revision + 1 : 1;
   const journal = validatePreviewJournal(candidate, pr);
   const body = journalBody(journal);
@@ -2119,7 +2433,7 @@ async function mutatePreviewJournal({
       reread.journal.journal_digest === journal.journal_digest,
     "Preview journal lost a serialized update",
   );
-  return reread;
+  return { ...reread, created: !loaded };
 }
 
 const RECEIPT_COLLECTION = {
@@ -2152,6 +2466,7 @@ async function appendJournalReceipt({
   kind,
   value: rawValue,
   allowCreate = false,
+  assertCanCreate,
 }) {
   const definition = RECEIPT_COLLECTION[kind];
   invariant(definition, "Preview journal receipt kind is invalid");
@@ -2162,9 +2477,25 @@ async function appendJournalReceipt({
     context,
     pr,
     allowCreate,
+    assertCanCreate,
     mutate(journal) {
+      if (kind === "event") compactPreviewJournal(journal);
       const entries = journal.receipts[definition.name];
       const identity = definition.identity(value);
+      const checkpointEntry =
+        kind === "event" && journal.checkpoint
+          ? journal.checkpoint.event
+          : null;
+      if (
+        checkpointEntry &&
+        definition.identity(checkpointEntry) === identity
+      ) {
+        invariant(
+          canonicalJson(checkpointEntry) === canonicalJson(value),
+          "Conflicting event receipt at preview checkpoint",
+        );
+        return;
+      }
       const existing = entries.find(
         (entry) => definition.identity(definition.validate(entry)) === identity,
       );
@@ -2414,18 +2745,33 @@ export async function recordEventReceipt({
     core.setOutput("planner_output_invalid", "true");
   }
   const receipt = validateEventReceipt({ ...validatedSnapshot, plan });
-  const isInitialJournalTransition =
-    (receipt.event_action === "opened" ||
-      receipt.event_action === "bootstrap") &&
-    exactRunAttempt(context.runAttempt ?? 1) === 1;
-  await appendJournalReceipt({
+  const firstAttempt = exactRunAttempt(context.runAttempt ?? 1) === 1;
+  const explicitInitialization = ["opened", "bootstrap"].includes(
+    receipt.event_action,
+  );
+  const journalUpdate = await appendJournalReceipt({
     github,
     context,
     pr: receipt.pr,
     kind: "event",
     value: receipt,
-    allowCreate: isInitialJournalTransition,
+    allowCreate: firstAttempt,
+    assertCanCreate:
+      firstAttempt && !explicitInitialization
+        ? () => assertPreviewJournalIsUninitialized(github, context, receipt)
+        : undefined,
   });
+  const controllerRunUrl = `https://github.com/${PREVIEW_REPOSITORY}/actions/runs/${context.runId}`;
+  if (journalUpdate.created) {
+    await github.rest.repos.createCommitStatus({
+      ...ownerRepo(context),
+      sha: receipt.head_sha,
+      state: "success",
+      context: PREVIEW_INITIALIZATION_STATUS_CONTEXT,
+      description: "Preview journal initialized",
+      target_url: controllerRunUrl,
+    });
+  }
   const current = normalizePullRequest(
     await pullFromApi(github, context, receipt.pr),
   );
@@ -2447,7 +2793,7 @@ export async function recordEventReceipt({
         receipt.trust === "trusted"
           ? "Preview event durably recorded"
           : "Preview unsupported for this PR source",
-      target_url: `https://github.com/${PREVIEW_REPOSITORY}/actions/runs/${context.runId}`,
+      target_url: controllerRunUrl,
     });
   }
   core.setOutput("pr_number", String(receipt.pr));
@@ -2989,6 +3335,7 @@ async function refreshDispatchOwnership({
     selections: comments.selections,
     pullRequest: pull,
     existingState: comments.state,
+    checkpoint: comments.checkpoint,
     controllerUrl,
     expectedWorkflowSha: workflowSha,
   });
@@ -3128,6 +3475,7 @@ export async function reconcilePreview({
         selections: parsed.selections,
         pullRequest: pull,
         existingState: parsed.state,
+        checkpoint: parsed.checkpoint,
         controllerUrl,
         expectedWorkflowSha: workflowSha,
       });
@@ -3296,6 +3644,7 @@ export async function reconcilePreview({
         selections: finalComments.selections,
         pullRequest: finalPull,
         existingState: finalComments.state,
+        checkpoint: finalComments.checkpoint,
         controllerUrl,
         expectedWorkflowSha: workflowSha,
       });
@@ -3327,6 +3676,7 @@ export async function reconcilePreview({
               confirmed.results,
               confirmed.selections,
               pr,
+              confirmed.checkpoint,
             ),
           "Controller receipt set changed before status publication",
         );

--- a/scripts/vercel-preview-controller.mjs
+++ b/scripts/vercel-preview-controller.mjs
@@ -50,10 +50,15 @@ const ALLOWED_PLAN_REASONS = new Set([
   "closed",
 ]);
 const TERMINAL_STATES = new Set(["success", "failure", "error"]);
+const RETRIABLE_TERMINAL_REASONS = new Set([
+  "build-failed-retriable",
+  "smoke-failed-retriable",
+]);
 const MAX_COMMENTS = 500;
 const MAX_RECEIPTS = 200;
 const MAX_HISTORY = 40;
 const MAX_JOURNAL_BYTES = 60_000;
+const ACTIVE_CHECKPOINT_BYTES = 40_000;
 const WORKER_RUN_PAGE_SIZE = 100;
 const MAX_WORKER_RUN_PAGES = 3;
 const WORKER_RUN_VISIBILITY_ATTEMPTS = 3;
@@ -318,6 +323,45 @@ function normalizePullRequest(raw) {
     updatedAt: exactTimestamp(raw.updated_at),
     closedAt: optionalTimestamp(raw.closed_at, "PR closed timestamp"),
   };
+}
+
+function representedPullRequest(events, checkpoint = null) {
+  const represented = [
+    ...events,
+    ...(checkpoint?.event ? [checkpoint.event] : []),
+  ].map((event) => validateEventReceipt(event));
+  invariant(
+    represented.length > 0,
+    "Preview receipt graph has no represented pull",
+  );
+  const latestUpdatedAt = represented
+    .map((event) => event.pr_updated_at)
+    .sort()
+    .at(-1);
+  const latest = represented.filter(
+    (event) => event.pr_updated_at === latestUpdatedAt,
+  );
+  const snapshots = new Map();
+  for (const event of latest) {
+    const snapshot = {
+      number: event.pr,
+      state: event.pr_state,
+      baseSha: event.trusted_base_sha,
+      headSha: event.head_sha,
+      headRef: event.head_ref,
+      headRepository: event.head_repository,
+      author: event.pr_author,
+      trust: event.trust,
+      updatedAt: event.pr_updated_at,
+      closedAt: event.pr_closed_at,
+    };
+    snapshots.set(canonicalJson(snapshot), snapshot);
+  }
+  invariant(
+    snapshots.size === 1,
+    "Latest represented pull request state is ambiguous",
+  );
+  return [...snapshots.values()][0];
 }
 
 export function snapshotPullRequestEvent(payload, runId) {
@@ -1191,6 +1235,14 @@ function statusFromCheckpointRuntime({
       target_url: controllerUrl,
     };
   }
+  if (checkpointStatus.state === "pending") {
+    return {
+      sha: event.head_sha,
+      state: "pending",
+      description: `Waiting for runtime preview ${runtimeEvent.head_sha.slice(0, 7)}`,
+      target_url: checkpointStatus.target_url ?? controllerUrl,
+    };
+  }
   return {
     sha: event.head_sha,
     state: "error",
@@ -1328,6 +1380,35 @@ function statusDecision({
     description: "UI preview queued or running",
     target_url: active?.html_url ?? controllerUrl,
   };
+}
+
+function statusFromPendingRuntimeResult({
+  checkpointEvent,
+  runtimeEvent,
+  result,
+  controllerUrl,
+}) {
+  const runtimeStatus = statusDecision({
+    event: runtimeEvent,
+    index: 0,
+    lineage: [runtimeEvent],
+    resultByRun: new Map([[runtimeEvent.event_run_id, result]]),
+    active: null,
+    coalescedToByRun: new Map(),
+    controllerUrl,
+    checkpointStatus: null,
+    checkpointBaselineStatus: null,
+    checkpointBaselineEvent: null,
+  });
+  if (checkpointEvent.event_run_id === runtimeEvent.event_run_id) {
+    return { ...runtimeStatus, sha: checkpointEvent.head_sha };
+  }
+  return statusFromCheckpointRuntime({
+    event: checkpointEvent,
+    runtimeEvent,
+    checkpointStatus: runtimeStatus,
+    controllerUrl,
+  });
 }
 
 function validatePersistedDispatch(value, pr, label) {
@@ -1536,6 +1617,45 @@ export function reconcileState({
   const epochSelections = allSelections.filter(
     (selection) => selection.epoch_anchor_run_id === anchor.event_run_id,
   );
+  const pendingCheckpointOwnerKey =
+    selectedCheckpoint?.pending_owner_key_digest ?? null;
+  const priorOwners = [
+    previous?.ui?.active,
+    ...(previous?.ui?.retired_active ?? []),
+    ...(previous?.ui?.terminal_history ?? []),
+  ].filter(Boolean);
+  const pendingCheckpointSelection = pendingCheckpointOwnerKey
+    ? (allSelections.find(
+        (selection) => selection.key_digest === pendingCheckpointOwnerKey,
+      ) ?? null)
+    : null;
+  const pendingCheckpointOwner = pendingCheckpointOwnerKey
+    ? (priorOwners.find(
+        (owner) => owner.key_digest === pendingCheckpointOwnerKey,
+      ) ??
+      pendingCheckpointSelection ??
+      null)
+    : null;
+  invariant(
+    pendingCheckpointOwnerKey === null || pendingCheckpointOwner !== null,
+    "Preview checkpoint pending owner is not persisted",
+  );
+  const pendingCheckpointResult = pendingCheckpointOwner
+    ? ([...allResults]
+        .filter(
+          (result) =>
+            result.key_digest === pendingCheckpointOwner.key_digest &&
+            result.epoch_anchor_run_id ===
+              pendingCheckpointOwner.epoch_anchor_run_id &&
+            result.selection_receipt_run_id ===
+              pendingCheckpointOwner.selection_receipt_run_id,
+        )
+        .sort(
+          (a, b) =>
+            b.worker_run_id - a.worker_run_id ||
+            b.worker_run_attempt - a.worker_run_attempt,
+        )[0] ?? null)
+    : null;
   if (epochResults.length > 0) {
     invariant(
       previous?.epoch?.anchor_run_id === anchor.event_run_id,
@@ -1558,19 +1678,26 @@ export function reconcileState({
     closure: closure ? semanticEventKey(closure) : null,
     lineage: lineage.map(semanticEventKey),
     results: epochResults.map(canonicalJson).sort(),
+    pending_checkpoint_result: pendingCheckpointResult
+      ? canonicalJson(pendingCheckpointResult)
+      : null,
   });
   const sameEpoch = previous?.epoch?.anchor_run_id === anchor.event_run_id;
-  const candidates = lineage.filter((event) =>
+  const lineageCandidates = lineage.filter((event) =>
     event.plan.targets.includes(PREVIEW_TARGET),
   );
+  const pendingRuntimeEvent = selectedCheckpoint?.pending_runtime_event ?? null;
+  const candidates =
+    pendingRuntimeEvent &&
+    !lineageCandidates.some(
+      (event) => event.event_run_id === pendingRuntimeEvent.event_run_id,
+    )
+      ? [pendingRuntimeEvent, ...lineageCandidates]
+      : lineageCandidates;
   const candidateByRun = new Map(
     candidates.map((event) => [event.event_run_id, event]),
   );
-  const persistedOwners = [
-    previous?.ui?.active,
-    ...(previous?.ui?.retired_active ?? []),
-    ...(previous?.ui?.terminal_history ?? []),
-  ].filter(Boolean);
+  const persistedOwners = priorOwners;
   const ownerByKeyDigest = new Map(
     persistedOwners.map((owner) => [owner.key_digest, owner]),
   );
@@ -1627,6 +1754,7 @@ export function reconcileState({
   }
   if (
     selectedCheckpoint &&
+    TERMINAL_STATES.has(selectedCheckpoint.status.state) &&
     selectedCheckpoint.event.plan.targets.includes(PREVIEW_TARGET)
   ) {
     resultByRun.set(selectedCheckpoint.event.event_run_id, {
@@ -1635,6 +1763,17 @@ export function reconcileState({
       vercel_deployment_url: selectedCheckpoint.status.target_url,
       terminal_reason: "checkpointed-terminal-status",
     });
+  }
+  if (
+    pendingRuntimeEvent &&
+    pendingCheckpointOwner &&
+    pendingCheckpointResult &&
+    pendingRuntimeEvent.head_sha === pendingCheckpointOwner.sha &&
+    (!RETRIABLE_TERMINAL_REASONS.has(pendingCheckpointResult.terminal_reason) ||
+      selectedCheckpoint.pending_owner_attempt_count >= 2) &&
+    !resultByRun.has(pendingRuntimeEvent.event_run_id)
+  ) {
+    resultByRun.set(pendingRuntimeEvent.event_run_id, pendingCheckpointResult);
   }
   const selectedReceiptRunIds = new Set(
     epochSelections.map((selection) => selection.selection_receipt_run_id),
@@ -1715,20 +1854,26 @@ export function reconcileState({
       ) {
         selected = desired;
       }
-      const retriable = new Set([
-        "build-failed-retriable",
-        "smoke-failed-retriable",
-      ]);
-      const attemptsForReceipt = epochResults.filter(
-        (result) =>
-          result.selection_receipt_run_id ===
-            completedActive.selection_receipt_run_id &&
-          result.terminal_reason !==
-            "controller-workflow-upgraded-before-dispatch",
-      ).length;
+      const inheritedAttempts =
+        pendingCheckpointOwner?.selection_receipt_run_id ===
+        completedActive.selection_receipt_run_id
+          ? selectedCheckpoint.pending_owner_attempt_count -
+            Number(
+              pendingCheckpointOwner.key_digest === completedActive.key_digest,
+            )
+          : 0;
+      const attemptsForReceipt =
+        inheritedAttempts +
+        epochResults.filter(
+          (result) =>
+            result.selection_receipt_run_id ===
+              completedActive.selection_receipt_run_id &&
+            result.terminal_reason !==
+              "controller-workflow-upgraded-before-dispatch",
+        ).length;
       if (
         !selected &&
-        retriable.has(completedResult?.terminal_reason) &&
+        RETRIABLE_TERMINAL_REASONS.has(completedResult?.terminal_reason) &&
         attemptsForReceipt < 2
       ) {
         selected = candidateByRun.get(completedActive.selection_receipt_run_id);
@@ -1762,6 +1907,14 @@ export function reconcileState({
       latestDesired = candidates.slice(selectedIndex).at(-1) ?? selected;
     }
   }
+  if (pendingCheckpointResult && !active) {
+    const desired = candidates.at(-1) ?? null;
+    if (desired && !resultByRun.has(desired.event_run_id)) {
+      selected = desired;
+      latestDesired = desired;
+    }
+  }
+  if (pendingCheckpointOwner && !pendingCheckpointResult) selected = null;
 
   const nextDispatch = selected
     ? (() => {
@@ -1775,10 +1928,13 @@ export function reconcileState({
                 event.event_run_id === completedActive.selection_receipt_run_id,
             )
           : -1;
+        const coalescingStartIndex = pendingCheckpointResult
+          ? 0
+          : completedIndex + 1;
         const coalescedReceiptRunIds =
-          completedIndex >= 0 && selectedIndex > completedIndex
+          coalescingStartIndex >= 0 && selectedIndex > coalescingStartIndex
             ? candidates
-                .slice(completedIndex + 1, selectedIndex)
+                .slice(coalescingStartIndex, selectedIndex)
                 .filter(
                   (event) =>
                     !resultByRun.has(event.event_run_id) &&
@@ -1808,6 +1964,34 @@ export function reconcileState({
     : null;
 
   const controllerTargetUrl = optionalHttpsUrl(controllerUrl, "Controller URL");
+  let effectiveCheckpointStatus = selectedCheckpoint?.status ?? null;
+  const pendingRuntimeResult = pendingRuntimeEvent
+    ? resultByRun.get(pendingRuntimeEvent.event_run_id)
+    : null;
+  if (selectedCheckpoint && pendingRuntimeEvent && pendingRuntimeResult) {
+    effectiveCheckpointStatus = statusFromPendingRuntimeResult({
+      checkpointEvent: selectedCheckpoint.event,
+      runtimeEvent: pendingRuntimeEvent,
+      result: pendingRuntimeResult,
+      controllerUrl: controllerTargetUrl,
+    });
+  } else if (
+    selectedCheckpoint &&
+    pendingCheckpointResult &&
+    pull.state === "closed"
+  ) {
+    effectiveCheckpointStatus = {
+      sha: selectedCheckpoint.event.head_sha,
+      state: "success",
+      description: "Preview no longer required for closed PR",
+      target_url: controllerTargetUrl,
+    };
+  } else if (effectiveCheckpointStatus?.state === "pending" && active) {
+    effectiveCheckpointStatus = {
+      ...effectiveCheckpointStatus,
+      target_url: active.html_url ?? controllerTargetUrl,
+    };
+  }
   const statuses = lineage.map((event, index) =>
     statusDecision({
       event,
@@ -1819,9 +2003,9 @@ export function reconcileState({
       controllerUrl: controllerTargetUrl,
       checkpointStatus:
         selectedCheckpoint?.event.event_run_id === event.event_run_id
-          ? selectedCheckpoint.status
+          ? effectiveCheckpointStatus
           : null,
-      checkpointBaselineStatus: selectedCheckpoint?.status ?? null,
+      checkpointBaselineStatus: effectiveCheckpointStatus,
       checkpointBaselineEvent: selectedCheckpoint?.event ?? null,
     }),
   );
@@ -1850,6 +2034,9 @@ export function reconcileState({
       vercel_deployment_url: result.vercel_deployment_url,
       terminal_reason: result.terminal_reason,
     }));
+  const terminalResultKeyDigests = new Set(
+    allResults.map((result) => result.key_digest),
+  );
   const retiredActive = [
     ...(previous?.ui?.retired_active ?? []),
     ...(!sameEpoch && previous?.ui?.active ? [previous.ui.active] : []),
@@ -1860,7 +2047,11 @@ export function reconcileState({
           (candidate) => candidate.key_digest === selection.key_digest,
         ) === index,
     )
-    .slice(-MAX_HISTORY);
+    .filter((selection) => !terminalResultKeyDigests.has(selection.key_digest));
+  invariant(
+    retiredActive.length <= MAX_HISTORY,
+    `Preview controller cannot retain more than ${MAX_HISTORY} unfinished retired workers`,
+  );
   const latestDesiredEvent =
     latestDesired ??
     (sameEpoch
@@ -1936,7 +2127,12 @@ async function listComments(github, context, pr) {
   return comments;
 }
 
+function previewInitializationStatusContext(pr) {
+  return `${PREVIEW_INITIALIZATION_STATUS_CONTEXT} / PR #${pullRequestNumber(pr)}`;
+}
+
 async function assertPreviewJournalIsUninitialized(github, context, receipt) {
+  const initializationContext = previewInitializationStatusContext(receipt.pr);
   const refs = [receipt.change_base_sha, receipt.head_sha].filter(
     (value, index, values) => value && values.indexOf(value) === index,
   );
@@ -1955,11 +2151,51 @@ async function assertPreviewJournalIsUninitialized(github, context, receipt) {
     );
     invariant(
       !statuses.some(
-        (status) => status.context === PREVIEW_INITIALIZATION_STATUS_CONTEXT,
+        (status) =>
+          status.context === initializationContext &&
+          status.state === "success",
       ),
       "Preview journal is missing after external initialization evidence",
     );
   }
+}
+
+async function ensurePreviewInitializationWitness({
+  github,
+  context,
+  receipt,
+  targetUrl,
+}) {
+  const ref = exactSha(receipt.head_sha);
+  const initializationContext = previewInitializationStatusContext(receipt.pr);
+  const statuses = await github.paginate(
+    github.rest.repos.listCommitStatusesForRef,
+    {
+      ...ownerRepo(context),
+      ref,
+      per_page: 100,
+    },
+  );
+  invariant(
+    statuses.length <= MAX_RECEIPTS,
+    "Too many commit statuses to ensure journal initialization",
+  );
+  if (
+    statuses.some(
+      (status) =>
+        status.context === initializationContext && status.state === "success",
+    )
+  ) {
+    return;
+  }
+  await github.rest.repos.createCommitStatus({
+    ...ownerRepo(context),
+    sha: ref,
+    state: "success",
+    context: initializationContext,
+    description: "Preview journal initialized",
+    target_url: targetUrl,
+  });
 }
 
 function receiptSetDigest({ events, selections, worker_evidence, results }) {
@@ -1990,7 +2226,7 @@ function validateCheckpointStatus(value, event) {
     "Preview checkpoint status SHA mismatch",
   );
   invariant(
-    ["success", "failure", "error"].includes(status.state),
+    ["pending", "success", "failure", "error"].includes(status.state),
     "Preview checkpoint status state is invalid",
   );
   boundedText(status.description, "Preview checkpoint status description", 140);
@@ -2003,7 +2239,7 @@ function validatePreviewCheckpoint(value, expectedPr) {
   const checkpoint = plainObject(value, "Preview checkpoint");
   invariant(
     Object.keys(checkpoint).sort().join(",") ===
-      "cumulative_receipts_digest,event,pruned_receipt_counts,schema,sequence,status,through_event_run_id",
+      "cumulative_receipts_digest,event,pending_owner_attempt_count,pending_owner_key_digest,pending_runtime_event,pruned_receipt_counts,schema,sequence,status,through_event_run_id",
     "Preview checkpoint fields are invalid",
   );
   invariant(
@@ -2042,7 +2278,44 @@ function validatePreviewCheckpoint(value, expectedPr) {
     checkpoint.through_event_run_id === event.event_run_id,
     "Preview checkpoint event identity mismatch",
   );
-  validateCheckpointStatus(checkpoint.status, event);
+  const status = validateCheckpointStatus(checkpoint.status, event);
+  if (checkpoint.pending_owner_key_digest === null) {
+    invariant(
+      checkpoint.pending_owner_attempt_count === 0,
+      "Preview checkpoint has an attempt count without an owner",
+    );
+    invariant(
+      checkpoint.pending_runtime_event === null,
+      "Preview checkpoint has a runtime dependency without an owner",
+    );
+    invariant(
+      status.state !== "pending",
+      "Preview checkpoint pending status has no owner",
+    );
+  } else {
+    invariant(
+      /^[0-9a-f]{24}$/.test(checkpoint.pending_owner_key_digest),
+      "Preview checkpoint pending owner is invalid",
+    );
+    invariant(
+      Number.isSafeInteger(checkpoint.pending_owner_attempt_count) &&
+        checkpoint.pending_owner_attempt_count >= 1 &&
+        checkpoint.pending_owner_attempt_count <= 2,
+      "Preview checkpoint pending owner attempt count is invalid",
+    );
+    const pendingRuntime = validateEventReceipt(
+      checkpoint.pending_runtime_event,
+    );
+    invariant(
+      pendingRuntime.pr === event.pr &&
+        pendingRuntime.plan.targets.includes(PREVIEW_TARGET),
+      "Preview checkpoint pending runtime event is invalid",
+    );
+    invariant(
+      status.state === "pending",
+      "Preview checkpoint pending owner has a terminal status",
+    );
+  }
   return checkpoint;
 }
 
@@ -2293,20 +2566,197 @@ function checkpointBaselineState(state, checkpoint) {
   };
 }
 
-export function compactPreviewJournal(value) {
+export function compactPreviewJournal(value, { pullRequest = null } = {}) {
   const journal = validatePreviewJournal(value, value.pr);
   if (journal.state === null) return journal;
   const state = normalizeExistingState(journal.state, journal.pr);
+  const terminalResultKeyDigests = new Set(
+    journal.receipts.results.map((result) => result.key_digest),
+  );
+  const unresolvedRetired = state.ui.retired_active.filter(
+    (selection) =>
+      selection.key_digest === journal.checkpoint?.pending_owner_key_digest ||
+      !terminalResultKeyDigests.has(selection.key_digest),
+  );
+  if (unresolvedRetired.length !== state.ui.retired_active.length) {
+    state.ui.retired_active = unresolvedRetired;
+    journal.state = structuredClone(state);
+    journal.journal_digest = previewJournalDigest(
+      journal.receipts,
+      journal.state,
+      journal.checkpoint,
+    );
+  }
   const receiptCount = Object.values(journal.receipts).reduce(
     (total, receipts) => total + receipts.length,
     0,
   );
-  if (
-    receiptCount === 0 ||
-    state.ui.active !== null ||
-    state.ui.retired_active.length > 0
-  ) {
-    return journal;
+  if (receiptCount === 0) return journal;
+  const hasInFlightOwnership =
+    state.ui.active !== null || state.ui.retired_active.length > 0;
+  if (hasInFlightOwnership) {
+    if (
+      Buffer.byteLength(journalBody(journal), "utf8") < ACTIVE_CHECKPOINT_BYTES
+    ) {
+      return journal;
+    }
+    if (pullRequest !== null) {
+      invariant(
+        normalizePullRequest(pullRequest).number === journal.pr,
+        "Capacity checkpoint PR mismatch",
+      );
+    }
+    const pull = representedPullRequest(
+      journal.receipts.events,
+      journal.checkpoint,
+    );
+    const { closure, lineage } = selectCurrentEpoch(
+      journal.receipts.events,
+      pull,
+      journal.checkpoint,
+    );
+    const tailEvent = closure ?? lineage.at(-1) ?? null;
+    invariant(tailEvent, "Preview checkpoint tail event is missing");
+    const pendingOwner =
+      state.ui.active ??
+      state.ui.retired_active.find(
+        (selection) =>
+          selection.key_digest === journal.checkpoint?.pending_owner_key_digest,
+      ) ??
+      null;
+    invariant(pendingOwner, "Capacity checkpoint pending owner is missing");
+    const samePendingReceipt =
+      journal.checkpoint?.pending_runtime_event?.event_run_id ===
+      pendingOwner.selection_receipt_run_id;
+    const pendingOwnerAttemptCount = samePendingReceipt
+      ? (journal.checkpoint.pending_owner_attempt_count ?? 0) +
+        Number(
+          journal.checkpoint.pending_owner_key_digest !==
+            pendingOwner.key_digest,
+        )
+      : 1 +
+        state.ui.terminal_history.filter(
+          (terminal) =>
+            terminal.selection_receipt_run_id ===
+              pendingOwner.selection_receipt_run_id &&
+            terminal.terminal_reason !==
+              "controller-workflow-upgraded-before-dispatch",
+        ).length;
+    invariant(
+      pendingOwnerAttemptCount <= 2,
+      "Preview runtime retry budget is already exhausted",
+    );
+    const pendingRuntimeEvent =
+      [...lineage]
+        .reverse()
+        .find((event) => event.plan.targets.includes(PREVIEW_TARGET)) ??
+      journal.checkpoint?.pending_runtime_event ??
+      null;
+    invariant(
+      pendingRuntimeEvent,
+      "Capacity checkpoint pending runtime event is missing",
+    );
+    const persistedStatus = [...state.status_decisions]
+      .reverse()
+      .find((decision) => decision.sha === tailEvent.head_sha);
+    const status = persistedStatus ?? {
+      sha: tailEvent.head_sha,
+      state: "pending",
+      description: "Preview reconciliation pending",
+      target_url: state.ui.active?.html_url ?? null,
+    };
+    const protectedKeyDigests = new Set(
+      [state.ui.active, ...state.ui.retired_active]
+        .filter(Boolean)
+        .map((selection) => selection.key_digest),
+    );
+    const retainedReceipts = {
+      events: [],
+      selections: journal.receipts.selections.filter((selection) =>
+        protectedKeyDigests.has(selection.key_digest),
+      ),
+      worker_evidence: journal.receipts.worker_evidence.filter((evidence) =>
+        protectedKeyDigests.has(evidence.key_digest),
+      ),
+      results: journal.receipts.results.filter((result) =>
+        protectedKeyDigests.has(result.key_digest),
+      ),
+    };
+    const prunedReceipts = {
+      events: journal.receipts.events,
+      selections: journal.receipts.selections.filter(
+        (selection) => !protectedKeyDigests.has(selection.key_digest),
+      ),
+      worker_evidence: journal.receipts.worker_evidence.filter(
+        (evidence) => !protectedKeyDigests.has(evidence.key_digest),
+      ),
+      results: journal.receipts.results.filter(
+        (result) => !protectedKeyDigests.has(result.key_digest),
+      ),
+    };
+    const resultIdentities = new Set(
+      journal.receipts.results.map(
+        (result) => `${result.key_digest}:${result.worker_run_id}`,
+      ),
+    );
+    invariant(
+      prunedReceipts.worker_evidence.every((evidence) =>
+        resultIdentities.has(
+          `${evidence.key_digest}:${evidence.worker_run_id}`,
+        ),
+      ),
+      "Preview journal cannot checkpoint unfinished worker evidence",
+    );
+    invariant(
+      prunedReceipts.selections.every((selection) =>
+        journal.receipts.results.some(
+          (result) => result.key_digest === selection.key_digest,
+        ),
+      ),
+      "Preview journal cannot checkpoint unfinished selections",
+    );
+    const prunedCount = Object.values(prunedReceipts).reduce(
+      (total, receipts) => total + receipts.length,
+      0,
+    );
+    if (prunedCount === 0) return journal;
+    const previousCounts =
+      journal.checkpoint?.pruned_receipt_counts ?? emptyReceiptCounts();
+    const prunedReceiptCounts = Object.fromEntries(
+      Object.entries(previousCounts).map(([name, count]) => [
+        name,
+        count + prunedReceipts[name].length,
+      ]),
+    );
+    const checkpoint = {
+      schema: PREVIEW_CHECKPOINT_SCHEMA,
+      sequence: (journal.checkpoint?.sequence ?? 0) + 1,
+      through_event_run_id: tailEvent.event_run_id,
+      cumulative_receipts_digest: digest({
+        previous: journal.checkpoint?.cumulative_receipts_digest ?? null,
+        receipts: receiptSetDigest(prunedReceipts),
+        state: digest(state),
+      }),
+      pruned_receipt_counts: prunedReceiptCounts,
+      event: structuredClone(tailEvent),
+      status: {
+        sha: status.sha,
+        state: status.state,
+        description: status.description,
+        target_url: status.target_url ?? null,
+      },
+      pending_owner_key_digest: pendingOwner.key_digest,
+      pending_owner_attempt_count: pendingOwnerAttemptCount,
+      pending_runtime_event: structuredClone(pendingRuntimeEvent),
+    };
+    journal.checkpoint = checkpoint;
+    journal.receipts = retainedReceipts;
+    journal.journal_digest = previewJournalDigest(
+      journal.receipts,
+      journal.state,
+      checkpoint,
+    );
+    return validatePreviewJournal(journal, journal.pr);
   }
   const resultIdentities = new Set(
     journal.receipts.results.map(
@@ -2375,6 +2825,9 @@ export function compactPreviewJournal(value) {
       description: status.description,
       target_url: status.target_url ?? null,
     },
+    pending_owner_key_digest: null,
+    pending_owner_attempt_count: 0,
+    pending_runtime_event: null,
   };
   journal.checkpoint = checkpoint;
   journal.receipts = {
@@ -2531,6 +2984,7 @@ async function appendJournalReceipt({
   github,
   context,
   pr,
+  pullRequest = null,
   kind,
   value: rawValue,
   allowCreate = false,
@@ -2556,8 +3010,26 @@ async function appendJournalReceipt({
         `Conflicting ${kind} receipt in preview journal`,
       );
       if (existing) return;
-      if (kind === "event") compactPreviewJournal(journal);
-      const entries = journal.receipts[definition.name];
+      let compactAfterAppend = false;
+      if (kind === "event" && journal.state !== null) {
+        const state = normalizeExistingState(journal.state, journal.pr);
+        const terminalKeys = new Set(
+          journal.receipts.results.map((result) => result.key_digest),
+        );
+        const hasUnfinishedOwnership =
+          state.ui.active !== null ||
+          state.ui.retired_active.some(
+            (selection) =>
+              selection.key_digest ===
+                journal.checkpoint?.pending_owner_key_digest ||
+              !terminalKeys.has(selection.key_digest),
+          );
+        if (hasUnfinishedOwnership) {
+          compactAfterAppend = true;
+        } else {
+          compactPreviewJournal(journal);
+        }
+      }
       const checkpointEntry =
         kind === "event" && journal.checkpoint
           ? journal.checkpoint.event
@@ -2578,7 +3050,16 @@ async function appendJournalReceipt({
       ) {
         return;
       }
+      const entries = journal.receipts[definition.name];
       entries.push(structuredClone(value));
+      if (compactAfterAppend) {
+        journal.journal_digest = previewJournalDigest(
+          journal.receipts,
+          journal.state,
+          journal.checkpoint,
+        );
+        compactPreviewJournal(journal, { pullRequest });
+      }
     },
   });
 }
@@ -2821,32 +3302,52 @@ export async function recordEventReceipt({
   }
   const receipt = validateEventReceipt({ ...validatedSnapshot, plan });
   const firstAttempt = exactRunAttempt(context.runAttempt ?? 1) === 1;
-  const explicitInitialization = ["opened", "bootstrap"].includes(
-    receipt.event_action,
+  const operatorBootstrap = receipt.event_action === "bootstrap";
+  const currentBefore = normalizePullRequest(
+    await pullFromApi(github, context, receipt.pr),
   );
-  const journalUpdate = await appendJournalReceipt({
+  if (
+    receipt.event_action === "closed" ||
+    currentBefore.state === "closed" ||
+    firstAttempt
+  ) {
+    const existing = await loadPreviewJournal(github, context, receipt.pr, {
+      allowMissing: true,
+    });
+    if (!existing) {
+      if (!operatorBootstrap) {
+        await assertPreviewJournalIsUninitialized(github, context, receipt);
+      }
+      if (
+        receipt.event_action === "closed" ||
+        currentBefore.state === "closed"
+      ) {
+        core.setOutput("pr_number", String(receipt.pr));
+        core.setOutput("reconcile_required", "false");
+        return receipt;
+      }
+    }
+  }
+  await appendJournalReceipt({
     github,
     context,
     pr: receipt.pr,
+    pullRequest: currentBefore,
     kind: "event",
     value: receipt,
     allowCreate: firstAttempt,
     assertCanCreate:
-      firstAttempt && !explicitInitialization
+      firstAttempt && !operatorBootstrap
         ? () => assertPreviewJournalIsUninitialized(github, context, receipt)
         : undefined,
   });
   const controllerRunUrl = `https://github.com/${PREVIEW_REPOSITORY}/actions/runs/${context.runId}`;
-  if (journalUpdate.created) {
-    await github.rest.repos.createCommitStatus({
-      ...ownerRepo(context),
-      sha: receipt.head_sha,
-      state: "success",
-      context: PREVIEW_INITIALIZATION_STATUS_CONTEXT,
-      description: "Preview journal initialized",
-      target_url: controllerRunUrl,
-    });
-  }
+  await ensurePreviewInitializationWitness({
+    github,
+    context,
+    receipt,
+    targetUrl: controllerRunUrl,
+  });
   const current = normalizePullRequest(
     await pullFromApi(github, context, receipt.pr),
   );
@@ -2872,6 +3373,7 @@ export async function recordEventReceipt({
     });
   }
   core.setOutput("pr_number", String(receipt.pr));
+  core.setOutput("reconcile_required", "true");
   return receipt;
 }
 
@@ -3798,6 +4300,46 @@ async function loadControllerEvidence(github, context, pr) {
   return parsed;
 }
 
+function workerResultAffectsCurrentReconciliation({
+  evidence,
+  state,
+  selection,
+  currentSelection,
+}) {
+  return (
+    (selection === currentSelection &&
+      selection.epoch_anchor_run_id === state.epoch.anchor_run_id) ||
+    evidence.checkpoint?.pending_owner_key_digest === selection.key_digest
+  );
+}
+
+async function foldCompletedRetiredOwner({
+  github,
+  context,
+  evidence,
+  state,
+  selection,
+}) {
+  if (
+    evidence.checkpoint?.pending_owner_key_digest === selection.key_digest ||
+    state.ui.active?.key_digest === selection.key_digest
+  ) {
+    return;
+  }
+  const retained = state.ui.retired_active.filter(
+    (candidate) => candidate.key_digest !== selection.key_digest,
+  );
+  if (retained.length === state.ui.retired_active.length) return;
+  state.ui.retired_active = retained;
+  await writeControllerState({
+    github,
+    context,
+    pr: selection.pr,
+    state,
+    stateComment: evidence.stateComment,
+  });
+}
+
 function workflowRunIdFromUrl(value) {
   if (typeof value !== "string") return null;
   const match = value.match(/\/actions\/runs\/([1-9][0-9]{0,19})(?:\/|$)/);
@@ -4421,8 +4963,21 @@ export async function recoverWorkerResult({
             selection,
           }));
         const shouldReconcileCurrentEpoch =
-          selection === currentSelection &&
-          selection.epoch_anchor_run_id === state.epoch.anchor_run_id;
+          workerResultAffectsCurrentReconciliation({
+            evidence,
+            state,
+            selection,
+            currentSelection,
+          });
+        if (!shouldReconcileCurrentEpoch) {
+          await foldCompletedRetiredOwner({
+            github,
+            context,
+            evidence,
+            state,
+            selection,
+          });
+        }
         core.setOutput("pr_number", String(parsed.pr));
         core.setOutput("result_state", supersededResult.state);
         core.setOutput(
@@ -4542,8 +5097,21 @@ export async function recoverWorkerResult({
       "Existing worker result conflicts with the completed run conclusion",
     );
     const shouldReconcileCurrentEpoch =
-      selection === currentSelection &&
-      selection.epoch_anchor_run_id === state.epoch.anchor_run_id;
+      workerResultAffectsCurrentReconciliation({
+        evidence,
+        state,
+        selection,
+        currentSelection,
+      });
+    if (!shouldReconcileCurrentEpoch) {
+      await foldCompletedRetiredOwner({
+        github,
+        context,
+        evidence,
+        state,
+        selection,
+      });
+    }
     core.setOutput("pr_number", String(parsed.pr));
     core.setOutput("result_state", existingResult.state);
     core.setOutput(
@@ -4693,9 +5261,21 @@ export async function recoverWorkerResult({
   });
   core.setOutput("pr_number", String(parsed.pr));
   core.setOutput("result_state", terminalState);
-  const shouldReconcileCurrentEpoch =
-    selection === currentSelection &&
-    selection.epoch_anchor_run_id === state.epoch.anchor_run_id;
+  const shouldReconcileCurrentEpoch = workerResultAffectsCurrentReconciliation({
+    evidence,
+    state,
+    selection,
+    currentSelection,
+  });
+  if (!shouldReconcileCurrentEpoch) {
+    await foldCompletedRetiredOwner({
+      github,
+      context,
+      evidence,
+      state,
+      selection,
+    });
+  }
   core.setOutput(
     "should_reconcile_current_epoch",
     String(shouldReconcileCurrentEpoch),

--- a/scripts/vercel-preview-controller.test.mjs
+++ b/scripts/vercel-preview-controller.test.mjs
@@ -3208,6 +3208,89 @@ test("the first receipt after a terminal checkpoint remains live for reconciliat
   assert.equal(reconciled.status_decisions.at(-1).state, "success");
 });
 
+test("queued receipts after a terminal checkpoint preserve every transition", async () => {
+  const opened = event({
+    run: 260,
+    action: "opened",
+    head: SHA.A,
+    updated: timestamp(1),
+  });
+  const firstPull = pull({ head: SHA.A, updated: timestamp(1) });
+  const selected = reconcile({ events: [opened], pullRequest: firstPull });
+  const active = persistDispatch(selected, 61_000);
+  const selection = selectionReceiptFromDispatch(active.ui.active);
+  const terminalResult = result(selected.nextDispatch, { runId: 61_000 });
+  const terminalState = reconcile({
+    events: [opened],
+    results: [terminalResult],
+    selections: [selection],
+    pullRequest: firstPull,
+    existingState: active,
+  }).state;
+  const checkpointed = compactPreviewJournal(
+    createPreviewJournal({
+      pr: 519,
+      events: [opened],
+      selections: [selection],
+      results: [terminalResult],
+      state: terminalState,
+    }),
+  );
+  const docsB = event({
+    run: 261,
+    action: "synchronize",
+    before: SHA.A,
+    head: SHA.B,
+    runtime: false,
+    updated: timestamp(2),
+  });
+  const docsC = event({
+    run: 262,
+    action: "synchronize",
+    before: SHA.B,
+    head: SHA.C,
+    runtime: false,
+    updated: timestamp(3),
+  });
+  const pullB = pull({ head: SHA.B, updated: timestamp(2) });
+  const pullC = pull({ head: SHA.C, updated: timestamp(3) });
+  const fixture = fakeGitHub({
+    pullRequest: pullC,
+    pullRequests: [pullB, pullB, pullC, pullC],
+    comments: [
+      journalComment({
+        checkpoint: checkpointed.checkpoint,
+        state: checkpointed.state,
+      }),
+    ],
+  });
+
+  await recordEventReceipt({
+    github: fixture.github,
+    context: fakeContext({ runId: docsB.event_run_id }),
+    core: fakeCore(),
+    ...eventRecordInputs(docsB),
+  });
+  await recordEventReceipt({
+    github: fixture.github,
+    context: fakeContext({ runId: docsC.event_run_id }),
+    core: fakeCore(),
+    ...eventRecordInputs(docsC),
+  });
+  const persisted = journalFromComment(fixture.comments[0]);
+  assert.equal(persisted.checkpoint.through_event_run_id, opened.event_run_id);
+  assert.deepEqual(persisted.receipts.events, [docsB, docsC]);
+
+  const reconciled = await reconcilePreview({
+    github: fixture.github,
+    context: fakeContext({ runId: 263 }),
+    core: fakeCore(),
+    prNumber: 519,
+  });
+  assert.equal(reconciled.epoch.tail_receipt_run_id, docsC.event_run_id);
+  assert.equal(reconciled.status_decisions.at(-1).state, "success");
+});
+
 test("semantic aliases of checkpointed lifecycle tails are idempotent", async () => {
   const checkpointCases = [];
   for (const [index, action] of ["opened", "reopened", "bootstrap"].entries()) {

--- a/scripts/vercel-preview-controller.test.mjs
+++ b/scripts/vercel-preview-controller.test.mjs
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { Buffer } from "node:buffer";
 import { test } from "node:test";
 
 import {
@@ -11,6 +12,7 @@ import {
   RECONCILE_DISPATCH_EVENT,
   RESULT_RECEIPT_SCHEMA,
   SELECTION_RECEIPT_SCHEMA,
+  compactPreviewJournal,
   createPreviewJournal,
   dependabotIntakeRunName,
   normalizePlannerResult,
@@ -238,6 +240,7 @@ function reconcile({
   pullRequest,
   existingState = null,
   selections = [],
+  checkpoint = null,
   expectedWorkflowSha = SHA.E,
 }) {
   return reconcileState({
@@ -246,6 +249,7 @@ function reconcile({
     pullRequest,
     existingState,
     selections,
+    checkpoint,
     controllerUrl: CONTROLLER_URL,
     expectedWorkflowSha,
   });
@@ -1278,6 +1282,119 @@ test("compact terminal ownership survives more results than rendered history", (
   );
 });
 
+test("terminal checkpoints bound one journal across fifty sequential previews", () => {
+  let journal = null;
+  let priorSha = null;
+  let maximumBytes = 0;
+
+  for (let index = 0; index < 50; index += 1) {
+    if (journal) journal = compactPreviewJournal(journal);
+    const head = (index + 100).toString(16).padStart(40, "0");
+    const receipt = event({
+      run: 1_000 + index,
+      action: index === 0 ? "opened" : "synchronize",
+      head,
+      before: priorSha,
+      updated: timestamp(index + 1),
+    });
+    const events = [...(journal?.receipts.events ?? []), receipt];
+    const currentPull = pull({ head, updated: timestamp(index + 1) });
+    const selected = reconcile({
+      events,
+      pullRequest: currentPull,
+      existingState: journal?.state ?? null,
+      checkpoint: journal?.checkpoint ?? null,
+    });
+    assert.equal(selected.nextDispatch.selection_receipt_run_id, 1_000 + index);
+    const active = persistDispatch(selected, 30_000 + index);
+    const selection = selectionReceiptFromDispatch(active.ui.active);
+    const terminal = result(selected.nextDispatch, { runId: 30_000 + index });
+    const completed = reconcile({
+      events,
+      results: [terminal],
+      selections: [selection],
+      pullRequest: currentPull,
+      existingState: active,
+      checkpoint: journal?.checkpoint ?? null,
+    });
+    journal = createPreviewJournal({
+      pr: 519,
+      checkpoint: journal?.checkpoint ?? null,
+      events,
+      selections: [selection],
+      results: [terminal],
+      state: completed.state,
+    });
+    maximumBytes = Math.max(
+      maximumBytes,
+      Buffer.byteLength(previewJournalBody(journal), "utf8"),
+    );
+    priorSha = head;
+  }
+
+  assert.equal(journal.checkpoint.sequence, 49);
+  assert.deepEqual(journal.checkpoint.pruned_receipt_counts, {
+    events: 49,
+    selections: 49,
+    worker_evidence: 0,
+    results: 49,
+  });
+  assert.ok(maximumBytes < 8_000, `maximum journal size was ${maximumBytes}`);
+
+  const compacted = compactPreviewJournal(journal);
+  const docsHead = "f".repeat(40);
+  const docsEvent = event({
+    run: 1_050,
+    action: "synchronize",
+    head: docsHead,
+    before: priorSha,
+    runtime: false,
+    updated: timestamp(51),
+  });
+  const docsState = reconcile({
+    events: [docsEvent],
+    pullRequest: pull({ head: docsHead, updated: timestamp(51) }),
+    existingState: compacted.state,
+    checkpoint: compacted.checkpoint,
+  });
+  assert.equal(docsState.nextDispatch, null);
+  assert.match(
+    docsState.state.status_decisions.at(-1).description,
+    /^Runtime-equivalent to /,
+  );
+
+  const delayedEvent = event({
+    run: 1_051,
+    action: "synchronize",
+    head: SHA.A,
+    before: SHA.B,
+    updated: timestamp(2),
+  });
+  const delayedState = reconcile({
+    events: [delayedEvent],
+    pullRequest: pull({ head: priorSha, updated: timestamp(50) }),
+    existingState: compacted.state,
+    checkpoint: compacted.checkpoint,
+  });
+  const foldedDelayedReceipt = compactPreviewJournal(
+    createPreviewJournal({
+      pr: 519,
+      checkpoint: compacted.checkpoint,
+      events: [delayedEvent],
+      state: delayedState.state,
+    }),
+  );
+  assert.equal(
+    foldedDelayedReceipt.checkpoint.through_event_run_id,
+    compacted.checkpoint.through_event_run_id,
+  );
+  assert.equal(
+    foldedDelayedReceipt.checkpoint.pruned_receipt_counts.events,
+    51,
+  );
+  assert.deepEqual(foldedDelayedReceipt.receipts.events, []);
+});
+
 const expectedCommentExplanation = [
   "**No reviewer action is required.**",
   "This repository builds pull request previews in GitHub Actions and deploys them to Vercel.",
@@ -1301,6 +1418,7 @@ function journalComment(
   {
     pr = 519,
     revision = 1,
+    checkpoint = null,
     events = [],
     selections = [],
     workerEvidence = [],
@@ -1312,6 +1430,7 @@ function journalComment(
   const journal = createPreviewJournal({
     pr,
     revision,
+    checkpoint,
     events,
     selections,
     workerEvidence,
@@ -1483,6 +1602,7 @@ function fakeGitHub({
   pullCommits = [pullRequest.head.sha],
   deployments: initialDeployments = [],
   deploymentStatuses = new Map(),
+  existingCommitStatuses = new Map(),
   workflowRunDisplayTitles = [],
   workflowRunListDisplayTitles = [],
   workflowRunListRunIds = [],
@@ -1499,6 +1619,12 @@ function fakeGitHub({
     ]),
   );
   const commitStatuses = [];
+  const commitStatusHistory = new Map(
+    [...existingCommitStatuses.entries()].map(([key, value]) => [
+      String(key),
+      structuredClone(value),
+    ]),
+  );
   const commentUpdates = [];
   const dispatches = [];
   const createdDeploymentStatuses = [];
@@ -1518,6 +1644,7 @@ function fakeGitHub({
   const listComments = async () => {};
   const listCommits = async () => {};
   const listDeployments = async () => {};
+  const listCommitStatusesForRef = async () => {};
   const github = {
     rest: {
       issues: {
@@ -1607,8 +1734,13 @@ function fakeGitHub({
       },
       repos: {
         listDeployments,
+        listCommitStatusesForRef,
         createCommitStatus: async (request) => {
           commitStatuses.push(structuredClone(request));
+          commitStatusHistory.set(String(request.sha), [
+            structuredClone(request),
+            ...(commitStatusHistory.get(String(request.sha)) ?? []),
+          ]);
           return { data: { id: commitStatuses.length } };
         },
         createDeployment: async (request) => {
@@ -1637,7 +1769,7 @@ function fakeGitHub({
         },
       },
     },
-    paginate: async (method) => {
+    paginate: async (method, request = {}) => {
       if (method === listComments) {
         listCommentRequests += 1;
         beforeListComments?.({ requestCount: listCommentRequests, comments });
@@ -1647,6 +1779,11 @@ function fakeGitHub({
         return pullCommits.map((sha) => ({ sha }));
       }
       if (method === listDeployments) return structuredClone(deployments);
+      if (method === listCommitStatusesForRef) {
+        return structuredClone(
+          commitStatusHistory.get(String(request.ref)) ?? [],
+        );
+      }
       throw new Error("Unexpected fixture pagination method");
     },
     request: async (route, request) => {
@@ -1853,7 +1990,7 @@ test("closed event receipt keeps one stable idempotent journal and publishes no 
   );
 });
 
-test("only an initial opened or explicit bootstrap transition may create a journal", async () => {
+test("a first-attempt synchronize can initialize only without durable status evidence", async () => {
   const synchronize = event({
     run: 121,
     action: "synchronize",
@@ -1864,33 +2001,94 @@ test("only an initial opened or explicit bootstrap transition may create a journ
   const opened = event({
     run: 122,
     action: "opened",
-    head: SHA.A,
+    head: SHA.B,
     updated: timestamp(1),
   });
 
-  for (const [receipt, context] of [
-    [synchronize, fakeContext({ runId: 121 })],
-    [opened, fakeContext({ runId: 122, runAttempt: 2 })],
-  ]) {
-    const fixture = fakeGitHub({
-      pullRequest: pull({
-        head: receipt.head_sha,
-        updated: receipt.pr_updated_at,
-      }),
-      comments: [],
-    });
-    await assert.rejects(
-      recordEventReceipt({
-        github: fixture.github,
-        context,
-        core: fakeCore(),
-        ...eventRecordInputs(receipt),
-      }),
-      /Preview journal comment does not exist/,
-    );
-    assert.equal(fixture.comments.length, 0);
-    assert.equal(fixture.commitStatuses.length, 0);
-  }
+  const fresh = fakeGitHub({
+    pullRequest: pull({
+      head: synchronize.head_sha,
+      updated: synchronize.pr_updated_at,
+    }),
+    comments: [],
+  });
+  await recordEventReceipt({
+    github: fresh.github,
+    context: fakeContext({ runId: 121 }),
+    core: fakeCore(),
+    ...eventRecordInputs(synchronize),
+  });
+  assert.deepEqual(journalFromComment(fresh.comments[0]).receipts.events, [
+    synchronize,
+  ]);
+  assert.deepEqual(
+    fresh.commitStatuses.slice(0, 2).map(({ context, state }) => ({
+      context,
+      state,
+    })),
+    [
+      { context: "Vercel Preview Journal", state: "success" },
+      { context: "Vercel Preview", state: "pending" },
+    ],
+  );
+  assert.equal(fresh.commitStatuses.at(-1).state, "pending");
+  await recordEventReceipt({
+    github: fresh.github,
+    context: fakeContext({ runId: 122 }),
+    core: fakeCore(),
+    ...eventRecordInputs(opened),
+  });
+  assert.deepEqual(
+    journalFromComment(fresh.comments[0]).receipts.events.map(
+      ({ event_run_id: runId }) => runId,
+    ),
+    [121, 122],
+  );
+  const recovered = await reconcilePreview({
+    github: fresh.github,
+    context: fakeContext({ runId: 123 }),
+    core: fakeCore(),
+    prNumber: 519,
+  });
+  assert.equal(recovered.ui.active.selection_receipt_run_id, 121);
+
+  const rerun = fakeGitHub({
+    pullRequest: pull({ head: opened.head_sha, updated: opened.pr_updated_at }),
+    comments: [],
+  });
+  await assert.rejects(
+    recordEventReceipt({
+      github: rerun.github,
+      context: fakeContext({ runId: 122, runAttempt: 2 }),
+      core: fakeCore(),
+      ...eventRecordInputs(opened),
+    }),
+    /Preview journal comment does not exist/,
+  );
+
+  const initialized = fakeGitHub({
+    pullRequest: pull({
+      head: synchronize.head_sha,
+      updated: synchronize.pr_updated_at,
+    }),
+    comments: [],
+    existingCommitStatuses: new Map([
+      [
+        synchronize.change_base_sha,
+        [{ context: "Vercel Preview Journal", state: "success" }],
+      ],
+    ]),
+  });
+  await assert.rejects(
+    recordEventReceipt({
+      github: initialized.github,
+      context: fakeContext({ runId: 121 }),
+      core: fakeCore(),
+      ...eventRecordInputs(synchronize),
+    }),
+    /missing after external initialization evidence/,
+  );
+  assert.equal(initialized.comments.length, 0);
 });
 
 test("conflicting event transitions cannot replace an immutable journal receipt", async () => {

--- a/scripts/vercel-preview-controller.test.mjs
+++ b/scripts/vercel-preview-controller.test.mjs
@@ -5,12 +5,14 @@ import {
   BOOTSTRAP_DISPATCH_EVENT,
   CONTROLLER_SCHEMA,
   EVENT_RECEIPT_SCHEMA,
+  PREVIEW_JOURNAL_MARKER,
+  PREVIEW_JOURNAL_SCHEMA,
   PREVIEW_REPOSITORY,
   RECONCILE_DISPATCH_EVENT,
   RESULT_RECEIPT_SCHEMA,
   SELECTION_RECEIPT_SCHEMA,
+  createPreviewJournal,
   dependabotIntakeRunName,
-  eventReceiptMarker,
   normalizePlannerResult,
   parseWorkerRunName,
   publishDependabotUnsupported,
@@ -21,9 +23,7 @@ import {
   reconcilePreview as reconcilePreviewImplementation,
   reconcileState,
   recoverWorkerResult,
-  resultReceiptMarker,
   selectionReceiptFromDispatch,
-  selectionReceiptMarker,
   snapshotPullRequestEvent,
   validateEventReceipt,
   validateDependabotIntakeWorkflowRun,
@@ -142,6 +142,21 @@ function event({
     ...snapshot,
     plan: normalizePlannerResult(rawPlan, snapshot),
   });
+}
+
+function eventRecordInputs(receipt) {
+  const snapshot = structuredClone(receipt);
+  delete snapshot.plan;
+  return {
+    snapshotRaw: JSON.stringify(snapshot),
+    planRaw: JSON.stringify({
+      deployments: receipt.plan.targets,
+      base: receipt.plan.base,
+      head: receipt.plan.head,
+      reason: receipt.plan.reason,
+    }),
+    plannerOutcome: "success",
+  };
 }
 
 function persistDispatch(reconciled, runId = 8_000) {
@@ -1172,15 +1187,16 @@ test("controller state schema is explicit and bounded", () => {
       }),
     /expected workflow SHA/,
   );
-  const legacyState = structuredClone(persisted);
-  delete legacyState.ui.terminal_result_key_digests;
-  assert.deepEqual(
-    reconcile({
-      events: [opened],
-      pullRequest: pull({ head: SHA.A, updated: timestamp(1) }),
-      existingState: legacyState,
-    }).state.ui.terminal_result_key_digests,
-    [],
+  const missingTerminalOwnership = structuredClone(persisted);
+  delete missingTerminalOwnership.ui.terminal_result_key_digests;
+  assert.throws(
+    () =>
+      reconcile({
+        events: [opened],
+        pullRequest: pull({ head: SHA.A, updated: timestamp(1) }),
+        existingState: missingTerminalOwnership,
+      }),
+    /Terminal result ownership/,
   );
   for (const malformedOwnership of [
     null,
@@ -1211,59 +1227,6 @@ test("controller state schema is explicit and bounded", () => {
   assert.match(stateValue.receipts_digest, /^[0-9a-f]{64}$/);
   assert.match(stateValue.epoch.basis_digest, /^[0-9a-f]{64}$/);
   assert.ok(JSON.stringify(stateValue).length < 20_000);
-});
-
-test("legacy v1 state derives terminal ownership from validated history", () => {
-  const opened = event({
-    run: 111,
-    action: "opened",
-    head: SHA.A,
-    updated: timestamp(1),
-  });
-  const first = reconcile({
-    events: [opened],
-    pullRequest: pull({ head: SHA.A, updated: timestamp(1) }),
-  });
-  const firstResult = result(first.nextDispatch, { runId: 8_000 });
-  const synchronized = event({
-    run: 112,
-    action: "synchronize",
-    before: SHA.A,
-    head: SHA.B,
-    updated: timestamp(2),
-  });
-  const second = reconcile({
-    events: [opened, synchronized],
-    results: [firstResult],
-    pullRequest: pull({ head: SHA.B, updated: timestamp(2) }),
-    existingState: persistDispatch(first, 8_000),
-  });
-  const legacyState = persistDispatch(second, 8_001);
-  delete legacyState.ui.terminal_result_key_digests;
-  const malformedLegacyState = structuredClone(legacyState);
-  malformedLegacyState.ui.terminal_history[0].key_digest =
-    second.nextDispatch.key_digest;
-  assert.throws(
-    () =>
-      reconcile({
-        events: [opened, synchronized],
-        results: [firstResult],
-        pullRequest: pull({ head: SHA.B, updated: timestamp(2) }),
-        existingState: malformedLegacyState,
-      }),
-    /Terminal selection digest mismatch/,
-  );
-
-  const upgraded = reconcile({
-    events: [opened, synchronized],
-    results: [firstResult, result(second.nextDispatch, { runId: 8_001 })],
-    pullRequest: pull({ head: SHA.B, updated: timestamp(2) }),
-    existingState: legacyState,
-  }).state;
-  assert.deepEqual(upgraded.ui.terminal_result_key_digests, [
-    first.nextDispatch.key_digest,
-    second.nextDispatch.key_digest,
-  ]);
 });
 
 test("compact terminal ownership survives more results than rendered history", () => {
@@ -1322,111 +1285,70 @@ const expectedCommentExplanation = [
   "[How previews work](https://github.com/mento-protocol/frontend-monorepo/blob/main/docs/vercel-deployments.md#event-status-and-batching-contract).",
 ].join(" ");
 
-function legacyCommentBody(marker, value) {
-  return `${marker}\n\n\`\`\`json\n${JSON.stringify(value, null, 2)}\n\`\`\`\n`;
+function previewJournalBody(value) {
+  return `${PREVIEW_JOURNAL_MARKER}\n\n${expectedCommentExplanation}\n\n<details>\n<summary>Show machine-readable preview automation record</summary>\n\n\`\`\`json\n${JSON.stringify(value, null, 2)}\n\`\`\`\n\n</details>\n`;
 }
 
-function commentBody(marker, value) {
-  return `${marker}\n\n${expectedCommentExplanation}\n\n<details>\n<summary>Show machine-readable preview automation record</summary>\n\n\`\`\`json\n${JSON.stringify(value, null, 2)}\n\`\`\`\n`;
+function journalFromComment(comment) {
+  const match = comment.body.match(
+    /\n```json\n([\s\S]+)\n```\n\n<\/details>\n$/,
+  );
+  assert.ok(match, "fixture must contain one canonical preview journal");
+  return JSON.parse(match[1]);
 }
 
-function eventComment(value, id = 1) {
+function journalComment(
+  {
+    pr = 519,
+    revision = 1,
+    events = [],
+    selections = [],
+    workerEvidence = [],
+    results = [],
+    state = null,
+  } = {},
+  id = 1,
+) {
+  const journal = createPreviewJournal({
+    pr,
+    revision,
+    events,
+    selections,
+    workerEvidence,
+    results,
+    state,
+  });
   return {
     id,
     user: { type: "Bot", login: "github-actions[bot]" },
-    body: commentBody(eventReceiptMarker(value.event_run_id), value),
+    body: previewJournalBody(journal),
   };
 }
 
-function legacyEventComment(value, id = 1) {
+function journalWithState(
+  events,
+  state,
+  {
+    revision = 1,
+    selections = state?.ui?.active
+      ? [selectionReceiptFromDispatch(state.ui.active)]
+      : [],
+    workerEvidence = [],
+    results = [],
+  } = {},
+  id = 1,
+) {
+  return journalComment(
+    { revision, events, selections, workerEvidence, results, state },
+    id,
+  );
+}
+
+function oldReceiptComment(marker, value, id = 99) {
   return {
     id,
     user: { type: "Bot", login: "github-actions[bot]" },
-    body: legacyCommentBody(eventReceiptMarker(value.event_run_id), value),
-  };
-}
-
-function stateComment(value, id = 2) {
-  return {
-    id,
-    user: { type: "Bot", login: "github-actions[bot]" },
-    body: commentBody("<!-- vercel-preview-controller:v1 -->", value),
-  };
-}
-
-function legacyStateComment(value, id = 2) {
-  return {
-    id,
-    user: { type: "Bot", login: "github-actions[bot]" },
-    body: legacyCommentBody("<!-- vercel-preview-controller:v1 -->", value),
-  };
-}
-
-function resultComment(value, id = 3) {
-  return {
-    id,
-    user: { type: "Bot", login: "github-actions[bot]" },
-    body: commentBody(resultReceiptMarker(value), value),
-  };
-}
-
-function legacyResultComment(value, id = 3) {
-  return {
-    id,
-    user: { type: "Bot", login: "github-actions[bot]" },
-    body: legacyCommentBody(resultReceiptMarker(value), value),
-  };
-}
-
-function selectionComment(value, id = 4) {
-  return {
-    id,
-    user: { type: "Bot", login: "github-actions[bot]" },
-    body: commentBody(selectionReceiptMarker(value), value),
-  };
-}
-
-function legacySelectionComment(value, id = 4) {
-  return {
-    id,
-    user: { type: "Bot", login: "github-actions[bot]" },
-    body: legacyCommentBody(selectionReceiptMarker(value), value),
-  };
-}
-
-function workerEvidence(dispatch, runId = 8_000) {
-  return {
-    schema: "vercel-preview-worker-evidence:v1",
-    repository: PREVIEW_REPOSITORY,
-    pr: dispatch.pr,
-    target: "ui",
-    sha: dispatch.sha,
-    controller_key: dispatch.key,
-    key_digest: dispatch.key_digest,
-    epoch_anchor_run_id: dispatch.epoch_anchor_run_id,
-    reconciliation_basis_digest: dispatch.reconciliation_basis_digest,
-    selection_receipt_run_id: dispatch.selection_receipt_run_id,
-    expected_workflow_sha: dispatch.expected_workflow_sha,
-    worker_run_id: runId,
-    worker_run_attempt: 1,
-    github_deployment_id: 9_000 + runId,
-    execution_mode: "build",
-    build_completed: true,
-    vercel_deployment_id: `dpl_${runId}`,
-    next_deployment_id: `m-ui-${runId}`,
-    verified_upload_url: `https://ui-${runId}.vercel.app`,
-  };
-}
-
-function workerEvidenceMarker(value) {
-  return `<!-- vercel-preview-worker-evidence:v1:${value.key_digest}:run:${value.worker_run_id} -->`;
-}
-
-function legacyWorkerEvidenceComment(value, id = 5) {
-  return {
-    id,
-    user: { type: "Bot", login: "github-actions[bot]" },
-    body: legacyCommentBody(workerEvidenceMarker(value), value),
+    body: `${marker}\n\n\`\`\`json\n${JSON.stringify(value, null, 2)}\n\`\`\`\n`,
   };
 }
 
@@ -1852,18 +1774,24 @@ test("malformed successful planner output is recorded as fail-closed UI impact",
     fixture.comments[0].body,
     /<summary>Show machine-readable preview automation record<\/summary>/,
   );
-  assert.doesNotMatch(fixture.comments[0].body, /<\/details>/);
-  assert.match(fixture.comments[0].body, /\n```\n$/);
+  assert.match(fixture.comments[0].body, /<\/details>\n$/);
   assert.match(fixture.comments[0].body, /"reason": "planner-job-failed"/);
-  const legacyReaderMatch = fixture.comments[0].body.match(
-    /\n```json\n([\s\S]+)\n```\n?$/,
-  );
-  assert.ok(legacyReaderMatch, "the previous v1 reader can parse the new body");
-  assert.deepEqual(JSON.parse(legacyReaderMatch[1]), receipt);
+  const journal = journalFromComment(fixture.comments[0]);
+  assert.equal(journal.schema, PREVIEW_JOURNAL_SCHEMA);
+  assert.deepEqual(journal.receipts.events, [receipt]);
+  assert.deepEqual(journal.receipts.selections, []);
+  assert.deepEqual(journal.receipts.worker_evidence, []);
+  assert.deepEqual(journal.receipts.results, []);
   assert.equal(fixture.commitStatuses.at(-1).state, "pending");
 });
 
-test("closed event receipt is immutable, idempotent, and publishes no status", async () => {
+test("closed event receipt keeps one stable idempotent journal and publishes no status", async () => {
+  const opened = event({
+    run: 119,
+    action: "opened",
+    head: SHA.A,
+    updated: timestamp(1),
+  });
   const closed = event({
     run: 120,
     action: "closed",
@@ -1878,7 +1806,10 @@ test("closed event receipt is immutable, idempotent, and publishes no status", a
     updated: timestamp(2),
     closed: timestamp(2),
   });
-  const fixture = fakeGitHub({ pullRequest, comments: [] });
+  const fixture = fakeGitHub({
+    pullRequest,
+    comments: [journalComment({ events: [opened] })],
+  });
   const core = fakeCore();
   const options = {
     github: fixture.github,
@@ -1896,32 +1827,13 @@ test("closed event receipt is immutable, idempotent, and publishes no status", a
   assert.deepEqual(second, first);
   assert.equal(core.outputs.get("pr_number"), "519");
   assert.equal(fixture.comments.length, 1);
+  assert.equal(fixture.comments[0].id, 1);
+  assert.equal(fixture.commentUpdates.length, 1);
   assert.match(fixture.comments[0].body, /"event_action": "closed"/);
+  assert.equal(journalFromComment(fixture.comments[0]).revision, 2);
   assert.equal(fixture.commitStatuses.length, 0);
 
-  const legacyBody = legacyCommentBody(
-    eventReceiptMarker(120),
-    first,
-  ).trimEnd();
-  const legacyFixture = fakeGitHub({
-    pullRequest,
-    comments: [
-      {
-        id: 1,
-        user: { type: "Bot", login: "github-actions[bot]" },
-        body: legacyBody,
-      },
-    ],
-  });
-  const reusedLegacy = await recordEventReceipt({
-    ...options,
-    github: legacyFixture.github,
-  });
-  assert.deepEqual(reusedLegacy, first);
-  assert.equal(legacyFixture.comments.length, 1);
-  assert.equal(legacyFixture.comments[0].body, legacyBody);
-
-  const malformedComment = eventComment(first);
+  const malformedComment = journalComment({ events: [opened, first] });
   malformedComment.body = malformedComment.body.replace(
     "Show machine-readable preview automation record",
     "Unexpected summary",
@@ -1937,308 +1849,191 @@ test("closed event receipt is immutable, idempotent, and publishes no status", a
       core: fakeCore(),
       prNumber: 519,
     }),
-    /Controller comment JSON block is missing/,
-  );
-
-  const opened = event({
-    run: 119,
-    action: "opened",
-    head: SHA.A,
-    updated: timestamp(1),
-  });
-  const reconcileFixture = fakeGitHub({
-    pullRequest,
-    comments: [legacyEventComment(opened), legacyEventComment(first, 2)],
-  });
-  const state = await reconcilePreview({
-    github: reconcileFixture.github,
-    context: fakeContext({ runId: 120 }),
-    core: fakeCore(),
-    prNumber: 519,
-  });
-
-  assert.equal(state.closed, true);
-  assert.equal(reconcileFixture.dispatches.length, 0);
-});
-
-test("quiescent reconciliation bounds legacy migration across concurrency retries", async () => {
-  const opened = event({
-    run: 119,
-    action: "opened",
-    head: SHA.A,
-    updated: timestamp(1),
-  });
-  const openedPull = pull({ head: SHA.A, updated: timestamp(1) });
-  const selected = reconcile({
-    events: [opened],
-    pullRequest: openedPull,
-    expectedWorkflowSha: SHA.D,
-  });
-  const dispatched = persistDispatch(selected, 8_000);
-  const selection = selectionReceiptFromDispatch(dispatched.ui.active);
-  const evidence = workerEvidence(selected.nextDispatch);
-  const additionalEvidence = workerEvidence(selected.nextDispatch, 8_001);
-  const completed = result(selected.nextDispatch, { runId: 8_000 });
-  const terminal = reconcile({
-    events: [opened],
-    results: [completed],
-    selections: [selection],
-    pullRequest: openedPull,
-    existingState: dispatched,
-  }).state;
-  const closed = event({
-    run: 120,
-    action: "closed",
-    head: SHA.A,
-    updated: timestamp(2),
-  });
-  const closedPull = pull({
-    head: SHA.A,
-    state: "closed",
-    updated: timestamp(2),
-    closed: timestamp(2),
-  });
-  const closedState = reconcile({
-    events: [opened, closed],
-    results: [completed],
-    selections: [selection],
-    pullRequest: closedPull,
-    existingState: terminal,
-  }).state;
-  const legacySelection = legacySelectionComment(selection, 3);
-  legacySelection.body = legacySelection.body.trimEnd();
-  const legacyResult = legacyResultComment(completed, 5);
-  legacyResult.body = legacyResult.body.trimEnd();
-  const fixture = fakeGitHub({
-    pullRequest: closedPull,
-    comments: [
-      legacyEventComment(opened, 1),
-      stateComment(closedState, 2),
-      legacySelection,
-      legacyWorkerEvidenceComment(evidence, 4),
-      legacyResult,
-      legacyEventComment(closed, 6),
-      legacyWorkerEvidenceComment(additionalEvidence, 7),
-    ],
-    beforeListComments: ({ requestCount, comments }) => {
-      if (requestCount !== 7) return;
-      comments.find(({ id }) => id === 2).body = stateComment(terminal, 2).body;
-    },
-  });
-  const core = fakeCore();
-
-  const reconciled = await reconcilePreview({
-    github: fixture.github,
-    context: fakeContext({ runId: 7_001 }),
-    core,
-    prNumber: 519,
-  });
-
-  assert.equal(core.outputs.get("legacy_receipt_presentations_migrated"), "5");
-  assert.equal(core.outputs.get("legacy_receipt_presentations_remaining"), "1");
-  assert.equal(reconciled.receipts_digest, closedState.receipts_digest);
-  assert.equal(fixture.dispatches.length, 0);
-  assert.equal(fixture.comments.length, 7);
-  assert.ok(
-    fixture.commentUpdates.filter(
-      ({ comment_id: commentId }) => commentId === 2,
-    ).length >= 4,
-    "the fixture must force a top-level reconciliation retry",
-  );
-  const firstBatchBodies = new Map([
-    [1, commentBody(eventReceiptMarker(opened.event_run_id), opened)],
-    [3, commentBody(selectionReceiptMarker(selection), selection)],
-    [4, commentBody(workerEvidenceMarker(evidence), evidence)],
-    [5, commentBody(resultReceiptMarker(completed), completed)],
-    [6, commentBody(eventReceiptMarker(closed.event_run_id), closed)],
-  ]);
-  for (const [commentId, expectedBody] of firstBatchBodies) {
-    const actual = fixture.comments.find(({ id }) => id === commentId)?.body;
-    assert.equal(actual, expectedBody);
-    const legacyReaderMatch = actual.match(/\n```json\n([\s\S]+)\n```\n?$/);
-    assert.ok(
-      legacyReaderMatch,
-      "the previous v1 reader can parse migrated bodies",
-    );
-  }
-  assert.deepEqual(
-    fixture.commentUpdates
-      .filter(({ comment_id: commentId }) => firstBatchBodies.has(commentId))
-      .map(({ comment_id: commentId }) => commentId),
-    [1, 3, 4, 5, 6],
-  );
-  assert.doesNotMatch(
-    fixture.comments.find(({ id }) => id === 7).body,
-    /<details>/,
-  );
-
-  const secondCore = fakeCore();
-  await reconcilePreview({
-    github: fixture.github,
-    context: fakeContext({ runId: 7_002 }),
-    core: secondCore,
-    prNumber: 519,
-  });
-  assert.equal(
-    secondCore.outputs.get("legacy_receipt_presentations_migrated"),
-    "1",
-  );
-  const additionalBody = commentBody(
-    workerEvidenceMarker(additionalEvidence),
-    additionalEvidence,
-  );
-  assert.equal(
-    fixture.comments.find(({ id }) => id === 7).body,
-    additionalBody,
-  );
-  assert.ok(
-    additionalBody.match(/\n```json\n([\s\S]+)\n```\n?$/),
-    "the previous v1 reader can parse the resumed migration",
-  );
-
-  await reconcilePreview({
-    github: fixture.github,
-    context: fakeContext({ runId: 7_003 }),
-    core: fakeCore(),
-    prNumber: 519,
-  });
-  assert.equal(
-    fixture.commentUpdates.filter(({ comment_id: commentId }) =>
-      [...firstBatchBodies.keys(), 7].includes(commentId),
-    ).length,
-    6,
+    /Preview journal JSON block is missing/,
   );
 });
 
-test("reconciliation defers legacy presentation migration while an old worker can still write", async () => {
+test("only an initial opened or explicit bootstrap transition may create a journal", async () => {
+  const synchronize = event({
+    run: 121,
+    action: "synchronize",
+    before: SHA.B,
+    head: SHA.A,
+    updated: timestamp(2),
+  });
   const opened = event({
-    run: 119,
+    run: 122,
     action: "opened",
     head: SHA.A,
     updated: timestamp(1),
   });
-  const pullRequest = pull({ head: SHA.A, updated: timestamp(1) });
-  const selected = reconcile({
-    events: [opened],
-    pullRequest,
-    expectedWorkflowSha: SHA.D,
-  });
-  const dispatched = persistDispatch(selected, 8_000);
-  const selection = selectionReceiptFromDispatch(dispatched.ui.active);
-  const fixture = fakeGitHub({
-    pullRequest,
-    comments: [
-      legacyEventComment(opened, 1),
-      stateComment(dispatched, 2),
-      legacySelectionComment(selection, 3),
-    ],
-    runs: [
-      workerRun(selected.nextDispatch, {
-        id: 8_000,
-        status: "in_progress",
+
+  for (const [receipt, context] of [
+    [synchronize, fakeContext({ runId: 121 })],
+    [opened, fakeContext({ runId: 122, runAttempt: 2 })],
+  ]) {
+    const fixture = fakeGitHub({
+      pullRequest: pull({
+        head: receipt.head_sha,
+        updated: receipt.pr_updated_at,
       }),
-    ],
-  });
-  const core = fakeCore();
-
-  await reconcilePreview({
-    github: fixture.github,
-    context: fakeContext({ runId: 7_001 }),
-    core,
-    prNumber: 519,
-  });
-
-  assert.equal(
-    core.outputs.get("legacy_receipt_presentation_migration_deferred"),
-    "true",
-  );
-  assert.doesNotMatch(fixture.comments[0].body, /<details>/);
-  assert.doesNotMatch(fixture.comments[2].body, /<details>/);
-  assert.equal(
-    fixture.commentUpdates.some(({ comment_id: commentId }) =>
-      [1, 3].includes(commentId),
-    ),
-    false,
-  );
-  assert.equal(
-    fixture.commitStatuses.some(({ state }) => state === "error"),
-    false,
-  );
+      comments: [],
+    });
+    await assert.rejects(
+      recordEventReceipt({
+        github: fixture.github,
+        context,
+        core: fakeCore(),
+        ...eventRecordInputs(receipt),
+      }),
+      /Preview journal comment does not exist/,
+    );
+    assert.equal(fixture.comments.length, 0);
+    assert.equal(fixture.commitStatuses.length, 0);
+  }
 });
 
-test("legacy presentation API failures stay retryable without blocking preview state", async () => {
+test("conflicting event transitions cannot replace an immutable journal receipt", async () => {
   const opened = event({
-    run: 119,
+    run: 130,
     action: "opened",
     head: SHA.A,
-    runtime: false,
     updated: timestamp(1),
   });
-  const openedPull = pull({ head: SHA.A, updated: timestamp(1) });
-  const openedState = reconcile({
-    events: [opened],
-    pullRequest: openedPull,
-  }).state;
-  const closed = event({
-    run: 120,
-    action: "closed",
+  const conflicting = event({
+    run: 130,
+    action: "synchronize",
+    before: SHA.B,
     head: SHA.A,
-    runtime: false,
-    updated: timestamp(2),
+    updated: timestamp(1),
   });
-  const closedPull = pull({
-    head: SHA.A,
-    state: "closed",
-    updated: timestamp(2),
-    closed: timestamp(2),
-  });
-  const closedState = reconcile({
-    events: [opened, closed],
-    pullRequest: closedPull,
-    existingState: openedState,
-  }).state;
   const fixture = fakeGitHub({
-    pullRequest: closedPull,
+    pullRequest: pull({ head: SHA.A, updated: timestamp(1) }),
+    comments: [journalComment({ events: [conflicting] })],
+  });
+
+  await assert.rejects(
+    recordEventReceipt({
+      github: fixture.github,
+      context: fakeContext({ runId: 130 }),
+      core: fakeCore(),
+      ...eventRecordInputs(opened),
+    }),
+    /Conflicting event receipt in preview journal/,
+  );
+
+  assert.equal(fixture.comments.length, 1);
+  assert.deepEqual(journalFromComment(fixture.comments[0]).receipts.events, [
+    conflicting,
+  ]);
+  assert.equal(fixture.commentUpdates.length, 0);
+});
+
+test("duplicate bot-owned preview journals fail closed", async () => {
+  const opened = event({
+    run: 131,
+    action: "opened",
+    head: SHA.A,
+    updated: timestamp(1),
+  });
+  const fixture = fakeGitHub({
+    pullRequest: pull({ head: SHA.A, updated: timestamp(1) }),
     comments: [
-      legacyEventComment(opened, 1),
-      stateComment(closedState, 2),
-      legacyEventComment(closed, 3),
+      journalComment({ events: [opened] }, 1),
+      journalComment({ events: [opened] }, 2),
     ],
-    updateCommentFailureIds: [1],
   });
-  const firstCore = fakeCore();
 
-  const first = await reconcilePreview({
+  await assert.rejects(
+    reconcilePreview({
+      github: fixture.github,
+      context: fakeContext(),
+      core: fakeCore(),
+      prNumber: 519,
+    }),
+    /Multiple bot-owned preview journals exist/,
+  );
+  assert.equal(fixture.commentUpdates.length, 0);
+});
+
+test("malformed and oversized preview journals fail closed without mutation", async () => {
+  const opened = event({
+    run: 132,
+    action: "opened",
+    head: SHA.A,
+    updated: timestamp(1),
+  });
+  const malformed = journalComment({ events: [opened] });
+  const malformedValue = journalFromComment(malformed);
+  malformedValue.journal_digest = "0".repeat(64);
+  malformed.body = previewJournalBody(malformedValue);
+  const oversized = {
+    id: 2,
+    user: { type: "Bot", login: "github-actions[bot]" },
+    body: `${PREVIEW_JOURNAL_MARKER}\n${"x".repeat(70_000)}`,
+  };
+  const noncanonical = journalComment({ events: [opened] });
+  noncanonical.body = noncanonical.body.replace(
+    '  "schema": "vercel-preview-journal:v1",',
+    '    "schema": "vercel-preview-journal:v1",',
+  );
+
+  for (const [comment, message] of [
+    [malformed, /Preview journal digest mismatch/],
+    [oversized, /Preview journal comment is too large/],
+    [noncanonical, /Preview journal body is not canonical/],
+  ]) {
+    const fixture = fakeGitHub({
+      pullRequest: pull({ head: SHA.A, updated: timestamp(1) }),
+      comments: [comment],
+    });
+    await assert.rejects(
+      reconcilePreview({
+        github: fixture.github,
+        context: fakeContext(),
+        core: fakeCore(),
+        prNumber: 519,
+      }),
+      message,
+    );
+    assert.equal(fixture.commentUpdates.length, 0);
+  }
+});
+
+test("pre-cutover receipt comments are ignored when the canonical journal is created", async () => {
+  const opened = event({
+    run: 133,
+    action: "opened",
+    head: SHA.A,
+    updated: timestamp(1),
+  });
+  const oldComment = oldReceiptComment(
+    "<!-- vercel-preview-event-receipt:v1:run:133 -->",
+    opened,
+  );
+  const fixture = fakeGitHub({
+    pullRequest: pull({ head: SHA.A, updated: timestamp(1) }),
+    comments: [oldComment],
+  });
+
+  await recordEventReceipt({
     github: fixture.github,
-    context: fakeContext({ runId: 7_001 }),
-    core: firstCore,
-    prNumber: 519,
+    context: fakeContext({ runId: 133 }),
+    core: fakeCore(),
+    ...eventRecordInputs(opened),
   });
 
-  assert.equal(first.closed, true);
+  assert.equal(fixture.comments.length, 2);
+  assert.deepEqual(fixture.comments[0], oldComment);
   assert.equal(
-    firstCore.outputs.get("legacy_receipt_presentation_migration_retryable"),
-    "true",
+    fixture.comments.filter(({ body }) =>
+      body.startsWith(PREVIEW_JOURNAL_MARKER),
+    ).length,
+    1,
   );
-  assert.doesNotMatch(fixture.comments[0].body, /<details>/);
-  assert.equal(
-    fixture.commitStatuses.some(({ state }) => state === "error"),
-    false,
-  );
-
-  const secondCore = fakeCore();
-  await reconcilePreview({
-    github: fixture.github,
-    context: fakeContext({ runId: 7_002 }),
-    core: secondCore,
-    prNumber: 519,
-  });
-  assert.equal(
-    secondCore.outputs.get("legacy_receipt_presentations_migrated"),
-    "2",
-  );
-  assert.match(fixture.comments[0].body, /<details>/);
-  assert.match(fixture.comments[2].body, /<details>/);
+  assert.deepEqual(journalFromComment(fixture.comments[1]).receipts.events, [
+    opened,
+  ]);
 });
 
 test("closed reconciliation preserves an unbound intent without dispatching it", async () => {
@@ -2269,10 +2064,11 @@ test("closed reconciliation preserves an unbound intent without dispatching it",
   const fixture = fakeGitHub({
     pullRequest,
     comments: [
-      legacyEventComment(opened),
-      legacyStateComment(intended),
-      legacySelectionComment(selectionReceiptFromDispatch(intended.ui.active)),
-      legacyEventComment(closed, 5),
+      journalComment({
+        events: [opened, closed],
+        selections: [selectionReceiptFromDispatch(intended.ui.active)],
+        state: intended,
+      }),
     ],
   });
 
@@ -2292,15 +2088,10 @@ test("closed reconciliation preserves an unbound intent without dispatching it",
     fixture.commitStatuses.some(({ state: status }) => status === "error"),
     false,
   );
-  assert.ok(
-    fixture.comments.some(
-      ({ body }) =>
-        body.startsWith("<!-- vercel-preview-controller:v1 -->") &&
-        body.includes("**No reviewer action is required.**") &&
-        body.includes("<details>") &&
-        body.includes('"closed": true'),
-    ),
-  );
+  assert.equal(fixture.comments.length, 1);
+  const journal = journalFromComment(fixture.comments[0]);
+  assert.equal(journal.schema, PREVIEW_JOURNAL_SCHEMA);
+  assert.equal(journal.state.closed, true);
 });
 
 test("trusted workflow_run follow-up publishes Dependabot unsupported status only for the exact current head", async () => {
@@ -2515,7 +2306,7 @@ test("durable dispatch persists intent and waits for the exact run title to mate
   const pullRequest = pull({ head: SHA.A, updated: timestamp(1) });
   const fixture = fakeGitHub({
     pullRequest,
-    comments: [eventComment(opened)],
+    comments: [journalComment({ events: [opened] })],
     workflowRunDisplayTitles: Array(10).fill("Vercel Preview Worker"),
   });
   const core = fakeCore();
@@ -2536,6 +2327,16 @@ test("durable dispatch persists intent and waits for the exact run title to mate
   assert.equal(core.outputs.get("dispatched_run_id"), "8000");
   assert.equal(fixture.commitStatuses.at(-1).context, "Vercel Preview");
   assert.equal(fixture.commitStatuses.at(-1).sha, SHA.A);
+  assert.equal(fixture.comments.length, 1);
+  assert.ok(
+    fixture.commentUpdates.every(
+      ({ comment_id: commentId }) => commentId === fixture.comments[0].id,
+    ),
+  );
+  const journal = journalFromComment(fixture.comments[0]);
+  assert.deepEqual(journal.receipts.events, [opened]);
+  assert.equal(journal.receipts.selections.length, 1);
+  assert.equal(journal.state.ui.active.dispatch_state, "dispatched");
 });
 
 test("durable dispatch fails closed when the exact run title never materializes", async () => {
@@ -2547,7 +2348,7 @@ test("durable dispatch fails closed when the exact run title never materializes"
   });
   const fixture = fakeGitHub({
     pullRequest: pull({ head: SHA.A, updated: timestamp(1) }),
-    comments: [eventComment(opened)],
+    comments: [journalComment({ events: [opened] })],
     workflowRunDisplayTitles: Array(31).fill("Vercel Preview Worker"),
   });
   const waits = [];
@@ -2584,7 +2385,7 @@ test("recovery rechecks PR openness immediately before dispatch", async () => {
   const fixture = fakeGitHub({
     pullRequest: closedPull,
     pullRequests: [openPull, openPull, closedPull],
-    comments: [eventComment(opened)],
+    comments: [journalComment({ events: [opened] })],
   });
   const core = fakeCore();
   const waits = [];
@@ -2619,7 +2420,13 @@ test("recovery reuses an intent rebound while it waits for run visibility", asyn
   const intended = persistIntent(selected);
   const fixture = fakeGitHub({
     pullRequest,
-    comments: [eventComment(opened), stateComment(intended)],
+    comments: [
+      journalComment({
+        events: [opened],
+        selections: [selectionReceiptFromDispatch(intended.ui.active)],
+        state: intended,
+      }),
+    ],
     runs: [workerRun(selected.nextDispatch)],
     workflowRunListRunIds: [[], [], []],
   });
@@ -2634,9 +2441,17 @@ test("recovery reuses an intent rebound while it waits for run visibility", asyn
       if (rebound) return;
       rebound = true;
       const comment = fixture.comments.find(({ body }) =>
-        body.startsWith("<!-- vercel-preview-controller:v1 -->"),
+        body.startsWith(PREVIEW_JOURNAL_MARKER),
       );
-      comment.body = stateComment(persistDispatch(selected, 8_000)).body;
+      comment.body = journalComment(
+        {
+          revision: 2,
+          events: [opened],
+          selections: [selectionReceiptFromDispatch(intended.ui.active)],
+          state: persistDispatch(selected, 8_000),
+        },
+        comment.id,
+      ).body;
     },
   });
 
@@ -2656,7 +2471,7 @@ test("a dispatch racing a main advance is terminalized and automatically reselec
   const pullRequest = pull({ head: SHA.A, updated: timestamp(1) });
   const fixture = fakeGitHub({
     pullRequest,
-    comments: [eventComment(opened)],
+    comments: [journalComment({ events: [opened] })],
     dispatchedWorkflowSha: SHA.B,
   });
 
@@ -2744,7 +2559,7 @@ test("intended dispatch recovery attaches exactly one run and fails closed on am
   const existingRun = { ...listedRun, name: listedRun.display_title };
   const recovered = fakeGitHub({
     pullRequest,
-    comments: [eventComment(opened), stateComment(intended)],
+    comments: [journalWithState([opened], intended)],
     runs: [existingRun],
   });
   const state = await reconcilePreview({
@@ -2759,7 +2574,7 @@ test("intended dispatch recovery attaches exactly one run and fails closed on am
 
   const ambiguous = fakeGitHub({
     pullRequest,
-    comments: [eventComment(opened), stateComment(intended)],
+    comments: [journalWithState([opened], intended)],
     runs: [existingRun, workerRun(selected.nextDispatch, { id: 8_001 })],
   });
   await assert.rejects(
@@ -2792,7 +2607,7 @@ test("intended recovery waits for a default-title run without redispatching", as
   const existingRun = workerRun(selected.nextDispatch);
   const fixture = fakeGitHub({
     pullRequest,
-    comments: [eventComment(opened), stateComment(intended)],
+    comments: [journalWithState([opened], intended)],
     runs: [existingRun],
     workflowRunListDisplayTitles: Array.from({ length: 10 }, () => [
       "Vercel Preview Worker",
@@ -2831,7 +2646,7 @@ test("intended recovery fails closed while a default-title run remains unresolve
   const intended = persistIntent(selected);
   const fixture = fakeGitHub({
     pullRequest,
-    comments: [eventComment(opened), stateComment(intended)],
+    comments: [journalWithState([opened], intended)],
     runs: [workerRun(selected.nextDispatch)],
     workflowRunListDisplayTitles: Array.from({ length: 31 }, () => [
       "Vercel Preview Worker",
@@ -2873,7 +2688,7 @@ test("intended recovery keeps re-querying a default-title run missing from later
   const intended = persistIntent(selected);
   const fixture = fakeGitHub({
     pullRequest,
-    comments: [eventComment(opened), stateComment(intended)],
+    comments: [journalWithState([opened], intended)],
     runs: [workerRun(selected.nextDispatch)],
     workflowRunListDisplayTitles: [["Vercel Preview Worker"]],
     workflowRunListRunIds: [[8_000], ...Array.from({ length: 30 }, () => [])],
@@ -2916,7 +2731,7 @@ test("intended recovery rejects a second owner materializing from a default titl
   const secondRun = workerRun(selected.nextDispatch, { id: 8_001 });
   const fixture = fakeGitHub({
     pullRequest,
-    comments: [eventComment(opened), stateComment(intended)],
+    comments: [journalWithState([opened], intended)],
     runs: [firstRun, secondRun],
     workflowRunListDisplayTitles: [
       [firstRun.display_title, "Vercel Preview Worker"],
@@ -2961,7 +2776,7 @@ test("intended recovery attaches one exact owner after a default title settles u
   );
   const fixture = fakeGitHub({
     pullRequest,
-    comments: [eventComment(opened), stateComment(intended)],
+    comments: [journalWithState([opened], intended)],
     runs: [exactRun, unrelatedRun],
     workflowRunListDisplayTitles: [
       [exactRun.display_title, "Vercel Preview Worker"],
@@ -3002,7 +2817,7 @@ test("intended recovery rejects a malformed candidate title without retrying", a
   };
   const fixture = fakeGitHub({
     pullRequest,
-    comments: [eventComment(opened), stateComment(intended)],
+    comments: [journalWithState([opened], intended)],
     runs: [malformedRun],
   });
   const waits = [];
@@ -3041,7 +2856,7 @@ test("intended recovery ignores wrong-SHA artifacts and reselects stale intents"
 
   const conflictingRun = fakeGitHub({
     pullRequest,
-    comments: [eventComment(opened), stateComment(intended)],
+    comments: [journalWithState([opened], intended)],
     runs: [
       workerRun(authorized.nextDispatch, {
         id: 8_100,
@@ -3077,7 +2892,7 @@ test("intended recovery ignores wrong-SHA artifacts and reselects stale intents"
 
   const mainAdvancedBeforeDispatch = fakeGitHub({
     pullRequest,
-    comments: [eventComment(opened), stateComment(intended)],
+    comments: [journalWithState([opened], intended)],
   });
   const recoveredState = await reconcilePreview({
     github: mainAdvancedBeforeDispatch.github,
@@ -3173,7 +2988,7 @@ test("intended recovery paginates its time window and ignores more than 300 olde
   const matchOnSecondPage = workerRun(selected.nextDispatch, { id: 8_000 });
   const paginated = fakeGitHub({
     pullRequest,
-    comments: [eventComment(opened), stateComment(intended)],
+    comments: [journalWithState([opened], intended)],
     runs: [...decoys, matchOnSecondPage],
   });
   const state = await reconcilePreview({
@@ -3194,7 +3009,7 @@ test("intended recovery paginates its time window and ignores more than 300 olde
   );
   const bounded = fakeGitHub({
     pullRequest,
-    comments: [eventComment(opened), stateComment(intended)],
+    comments: [journalWithState([opened], intended)],
     runs: [...olderHistory, matchOnSecondPage],
   });
   const boundedState = await reconcilePreview({
@@ -3229,7 +3044,7 @@ test("manual reconcile recovers a completed REST-named worker when its callback 
   completed.name = completed.display_title;
   const fixture = fakeGitHub({
     pullRequest,
-    comments: [eventComment(opened), stateComment(dispatched)],
+    comments: [journalWithState([opened], dispatched)],
     runs: [completed],
   });
   const state = await reconcilePreview({
@@ -3279,10 +3094,7 @@ test("a force-pushed-away active selection is aborted before credentials and new
   const fixture = fakeGitHub({
     pullRequest,
     comments: [
-      eventComment(opened, 1),
-      eventComment(runtimeB, 2),
-      eventComment(runtimeC, 3),
-      stateComment(persistIntent(initial), 4),
+      journalWithState([opened, runtimeB, runtimeC], persistIntent(initial)),
     ],
     pullCommits: [SHA.C],
   });
@@ -3325,7 +3137,7 @@ test("cancelled worker before Deployment creation gets one canonical error Deplo
   });
   const fixture = fakeGitHub({
     pullRequest,
-    comments: [eventComment(opened), stateComment(dispatched)],
+    comments: [journalWithState([opened], dispatched)],
     runs: [completed],
   });
   const result = await recoverWorkerResult({
@@ -3340,10 +3152,10 @@ test("cancelled worker before Deployment creation gets one canonical error Deplo
   assert.equal(fixture.deployments[0].environment, "preview/ui/pr-519");
   assert.equal(fixture.createdDeploymentStatuses.length, 1);
   assert.equal(fixture.createdDeploymentStatuses[0].state, "error");
-  assert.ok(
-    fixture.comments.some(({ body }) =>
-      body.startsWith("<!-- vercel-preview-worker-result:v1:"),
-    ),
+  assert.equal(fixture.comments.length, 1);
+  assert.equal(
+    journalFromComment(fixture.comments[0]).receipts.results.length,
+    1,
   );
 });
 
@@ -3363,7 +3175,7 @@ test("completed callback durably binds an intended dispatch after a controller c
   });
   const fixture = fakeGitHub({
     pullRequest,
-    comments: [eventComment(opened), stateComment(intended)],
+    comments: [journalWithState([opened], intended)],
     runs: [completed],
     workflowRunDisplayTitles: ["Vercel Preview Worker"],
   });
@@ -3380,7 +3192,7 @@ test("completed callback durably binds an intended dispatch after a controller c
   assert.deepEqual(waits, [1_000]);
   assert.deepEqual(fixture.workflowRunRequests, [8_000, 8_000]);
   const controllerState = fixture.comments.find(({ body }) =>
-    body.startsWith("<!-- vercel-preview-controller:v1 -->"),
+    body.startsWith(PREVIEW_JOURNAL_MARKER),
   );
   assert.match(controllerState.body, /"dispatch_state": "dispatched"/);
   assert.match(controllerState.body, /"workflow_run_id": 8000/);
@@ -3408,7 +3220,7 @@ test("completed intended callback fails closed unless its run is the unique reco
   ]) {
     const fixture = fakeGitHub({
       pullRequest,
-      comments: [eventComment(opened), stateComment(intended)],
+      comments: [journalWithState([opened], intended)],
       runs,
     });
     await assert.rejects(
@@ -3422,9 +3234,7 @@ test("completed intended callback fails closed unless its run is the unique reco
     );
     assert.equal(fixture.deployments.length, 0);
     assert.equal(
-      fixture.comments.filter(({ body }) =>
-        body.startsWith("<!-- vercel-preview-worker-result:v1:"),
-      ).length,
+      journalFromComment(fixture.comments[0]).receipts.results.length,
       0,
     );
   }
@@ -3446,7 +3256,7 @@ test("worker recovery errors fail the current exact SHA status closed without ov
   });
   const fixture = fakeGitHub({
     pullRequest,
-    comments: [eventComment(opened), stateComment(dispatched)],
+    comments: [journalWithState([opened], dispatched)],
     runs: [completed],
   });
   assert.equal(
@@ -3526,16 +3336,12 @@ test("same-SHA reopened epoch resumes verified old upload evidence before its ca
   const fixture = fakeGitHub({
     pullRequest: setup.pullRequest,
     comments: [
-      ...setup.events.map((item, index) => eventComment(item, index + 1)),
-      stateComment(setup.currentState, 10),
-      selectionComment(
-        selectionReceiptFromDispatch(setup.currentState.ui.retired_active[0]),
-        11,
-      ),
-      selectionComment(
-        selectionReceiptFromDispatch(setup.currentState.ui.active),
-        12,
-      ),
+      journalWithState(setup.events, setup.currentState, {
+        selections: [
+          selectionReceiptFromDispatch(setup.currentState.ui.retired_active[0]),
+          selectionReceiptFromDispatch(setup.currentState.ui.active),
+        ],
+      }),
     ],
     runs: [oldCompleted, newQueued],
     deployments: [canonical],
@@ -3593,9 +3399,9 @@ test("same-SHA reopened epoch resumes verified old upload evidence before its ca
         "https://github.com/mento-protocol/frontend-monorepo/actions/runs/8001/attempts/1",
     },
   ]);
-  const controllerBodyBefore = fixture.comments.find(({ body }) =>
-    body.startsWith("<!-- vercel-preview-controller:v1 -->"),
-  ).body;
+  const controllerStateBefore = structuredClone(
+    journalFromComment(fixture.comments[0]).state,
+  );
   const recoveryCore = fakeCore();
   const oldResult = await recoverWorkerResult({
     github: fixture.github,
@@ -3610,12 +3416,10 @@ test("same-SHA reopened epoch resumes verified old upload evidence before its ca
   );
   assert.equal(fixture.createdDeploymentStatuses.length, 0);
   assert.equal(fixture.statuses.get("9000")[0].state, "success");
-  assert.equal(
-    fixture.comments.find(({ body }) =>
-      body.startsWith("<!-- vercel-preview-controller:v1 -->"),
-    ).body,
-    controllerBodyBefore,
-  );
+  const journal = journalFromComment(fixture.comments[0]);
+  assert.deepEqual(journal.state, controllerStateBefore);
+  assert.equal(journal.receipts.worker_evidence.length, 1);
+  assert.equal(journal.receipts.results.length, 1);
 });
 
 test("delayed old-epoch cancellation cannot claim or terminalize a same-SHA Deployment created by the reopened epoch", async () => {
@@ -3628,8 +3432,12 @@ test("delayed old-epoch cancellation cannot claim or terminalize a same-SHA Depl
   const fixture = fakeGitHub({
     pullRequest: setup.pullRequest,
     comments: [
-      ...setup.events.map((item, index) => eventComment(item, index + 1)),
-      stateComment(setup.currentState, 10),
+      journalWithState(setup.events, setup.currentState, {
+        selections: [
+          selectionReceiptFromDispatch(setup.currentState.ui.retired_active[0]),
+          selectionReceiptFromDispatch(setup.currentState.ui.active),
+        ],
+      }),
     ],
     runs: [oldCompleted, workerRun(setup.current.nextDispatch, { id: 8_001 })],
     deployments: [
@@ -3697,8 +3505,12 @@ test("terminal reopened same-SHA ownership survives a delayed old-epoch callback
   const fixture = fakeGitHub({
     pullRequest: setup.pullRequest,
     comments: [
-      ...setup.events.map((item, index) => eventComment(item, index + 1)),
-      stateComment(setup.currentState, 10),
+      journalWithState(setup.events, setup.currentState, {
+        selections: [
+          selectionReceiptFromDispatch(setup.currentState.ui.retired_active[0]),
+          selectionReceiptFromDispatch(setup.currentState.ui.active),
+        ],
+      }),
     ],
     runs: [oldQueued, currentCompleted],
     deployments: [canonical],
@@ -3743,9 +3555,9 @@ test("terminal reopened same-SHA ownership survives a delayed old-epoch callback
       conclusion: "cancelled",
     },
   );
-  const controllerBodyBefore = fixture.comments.find(({ body }) =>
-    body.startsWith("<!-- vercel-preview-controller:v1 -->"),
-  ).body;
+  const controllerStateBefore = structuredClone(
+    journalFromComment(fixture.comments[0]).state,
+  );
   const oldResult = await recoverWorkerResult({
     github: fixture.github,
     context: fakeContext({ workflowRun: fixture.runs[0] }),
@@ -3756,12 +3568,9 @@ test("terminal reopened same-SHA ownership survives a delayed old-epoch callback
   assert.equal(oldResult.should_reconcile_current_epoch, false);
   assert.equal(fixture.createdDeploymentStatuses.length, 0);
   assert.equal(fixture.statuses.get("9000")[0].state, "success");
-  assert.equal(
-    fixture.comments.find(({ body }) =>
-      body.startsWith("<!-- vercel-preview-controller:v1 -->"),
-    ).body,
-    controllerBodyBefore,
-  );
+  const journal = journalFromComment(fixture.comments[0]);
+  assert.deepEqual(journal.state, controllerStateBefore);
+  assert.equal(journal.receipts.results.length, 2);
 });
 
 test("retired attempt recovery errors are quarantined without poisoning the current epoch", async () => {
@@ -3787,9 +3596,13 @@ test("retired attempt recovery errors are quarantined without poisoning the curr
   const fixture = fakeGitHub({
     pullRequest: setup.pullRequest,
     comments: [
-      ...setup.events.map((item, index) => eventComment(item, index + 1)),
-      resultComment(currentResult, 9),
-      stateComment(terminalState, 10),
+      journalWithState(setup.events, terminalState, {
+        results: [currentResult],
+        selections: [
+          selectionReceiptFromDispatch(setup.currentState.ui.retired_active[0]),
+          selectionReceiptFromDispatch(setup.currentState.ui.active),
+        ],
+      }),
     ],
     runs: [oldLatestAttempt],
   });
@@ -3850,9 +3663,13 @@ test("transient retired recovery failures remain retryable and never poison the 
   const fixture = fakeGitHub({
     pullRequest: setup.pullRequest,
     comments: [
-      ...setup.events.map((item, index) => eventComment(item, index + 1)),
-      resultComment(currentResult, 9),
-      stateComment(terminalState, 10),
+      journalWithState(setup.events, terminalState, {
+        results: [currentResult],
+        selections: [
+          selectionReceiptFromDispatch(setup.currentState.ui.retired_active[0]),
+          selectionReceiptFromDispatch(setup.currentState.ui.active),
+        ],
+      }),
     ],
     runs: [oldCompleted],
     workflowRunAttemptFailures: [503],
@@ -3892,10 +3709,8 @@ test("transient retired recovery failures remain retryable and never poison the 
   );
   assert.equal(fixture.workflowRunAttemptRequests.length, 3);
   assert.ok(
-    fixture.comments.some(
-      ({ body }) =>
-        body.startsWith("<!-- vercel-preview-worker-result:v1:") &&
-        body.includes('"worker_run_id": 8000'),
+    journalFromComment(fixture.comments[0]).receipts.results.some(
+      ({ worker_run_id: workerRunId }) => workerRunId === 8_000,
     ),
   );
 });
@@ -3918,9 +3733,13 @@ test("transient quarantine persistence failure remains retryable without a curre
   const fixture = fakeGitHub({
     pullRequest: setup.pullRequest,
     comments: [
-      ...setup.events.map((item, index) => eventComment(item, index + 1)),
-      resultComment(currentResult, 9),
-      stateComment(terminalState, 10),
+      journalWithState(setup.events, terminalState, {
+        results: [currentResult],
+        selections: [
+          selectionReceiptFromDispatch(setup.currentState.ui.retired_active[0]),
+          selectionReceiptFromDispatch(setup.currentState.ui.active),
+        ],
+      }),
     ],
     runs: [oldLatestAttempt],
     updateCommentFailures: [503],
@@ -3972,8 +3791,12 @@ test("delayed old-epoch success reads only its own same-SHA Deployment status hi
   const fixture = fakeGitHub({
     pullRequest: setup.pullRequest,
     comments: [
-      ...setup.events.map((item, index) => eventComment(item, index + 1)),
-      stateComment(setup.currentState, 10),
+      journalWithState(setup.events, setup.currentState, {
+        selections: [
+          selectionReceiptFromDispatch(setup.currentState.ui.retired_active[0]),
+          selectionReceiptFromDispatch(setup.currentState.ui.active),
+        ],
+      }),
     ],
     runs: [oldCompleted, workerRun(setup.current.nextDispatch, { id: 8_001 })],
     deployments: [
@@ -4049,11 +3872,7 @@ test("duplicate worker absorbs an existing verified canonical Deployment without
   };
   const fixture = fakeGitHub({
     pullRequest,
-    comments: [
-      eventComment(opened),
-      stateComment(dispatched),
-      selectionComment(selectionReceiptFromDispatch(dispatched.ui.active)),
-    ],
+    comments: [journalWithState([opened], dispatched)],
     runs: [workerRun(selected.nextDispatch)],
     deployments: [canonical],
     deploymentStatuses: new Map([
@@ -4125,11 +3944,7 @@ test("verified deployment success survives a later evidence persistence failure"
   };
   const fixture = fakeGitHub({
     pullRequest,
-    comments: [
-      eventComment(opened),
-      stateComment(dispatched),
-      selectionComment(selectionReceiptFromDispatch(dispatched.ui.active)),
-    ],
+    comments: [journalWithState([opened], dispatched)],
     runs: [completed],
     deployments: [canonical],
     deploymentStatuses: new Map([
@@ -4162,6 +3977,15 @@ test("verified deployment success survives a later evidence persistence failure"
   );
   assert.equal(fixture.createdDeploymentStatuses.length, 0);
   assert.equal(fixture.statuses.get("9000")[0].state, "success");
+  const journalAfterResult = journalFromComment(fixture.comments[0]);
+  assert.equal(journalAfterResult.revision, 2);
+  const {
+    should_reconcile_current_epoch: shouldReconcileCurrentEpoch,
+    ...persistedOutcome
+  } = outcome;
+  assert.equal(shouldReconcileCurrentEpoch, true);
+  assert.deepEqual(journalAfterResult.receipts.results, [persistedOutcome]);
+  const updatesAfterResult = fixture.commentUpdates.length;
 
   const repeated = await recoverWorkerResult({
     github: fixture.github,
@@ -4174,6 +3998,8 @@ test("verified deployment success survives a later evidence persistence failure"
     "https://ui-verified-before-evidence.vercel.app",
   );
   assert.equal(fixture.createdDeploymentStatuses.length, 0);
+  assert.equal(fixture.commentUpdates.length, updatesAfterResult);
+  assert.deepEqual(journalFromComment(fixture.comments[0]), journalAfterResult);
 });
 
 test("a rerun attempt cannot reuse persisted first-attempt worker ownership", async () => {
@@ -4188,11 +4014,7 @@ test("a rerun attempt cannot reuse persisted first-attempt worker ownership", as
   const dispatched = persistDispatch(selected, 8_000);
   const fixture = fakeGitHub({
     pullRequest,
-    comments: [
-      eventComment(opened),
-      stateComment(dispatched),
-      selectionComment(selectionReceiptFromDispatch(dispatched.ui.active)),
-    ],
+    comments: [journalWithState([opened], dispatched)],
     runs: [workerRun(selected.nextDispatch)],
   });
   await assert.rejects(
@@ -4230,7 +4052,7 @@ test("smoke failure records immutable upload evidence and the one retry resumes 
   };
   const fixture = fakeGitHub({
     pullRequest,
-    comments: [eventComment(opened), stateComment(dispatched)],
+    comments: [journalWithState([opened], dispatched)],
     runs: [
       workerRun(selected.nextDispatch, {
         status: "completed",
@@ -4242,32 +4064,57 @@ test("smoke failure records immutable upload evidence and the one retry resumes 
       [9_000, [{ state: "failure", environment_url: null }]],
     ]),
   });
+  const stableCommentId = fixture.comments[0].id;
+  const evidenceInputs = {
+    pull_request_number: "519",
+    target: "ui",
+    commit_sha: SHA.A,
+    controller_key: selected.nextDispatch.key,
+    controller_key_digest: selected.nextDispatch.key_digest,
+    expected_workflow_sha: selected.nextDispatch.expected_workflow_sha,
+    epoch_anchor_run_id: String(selected.nextDispatch.epoch_anchor_run_id),
+    reconciliation_basis_digest:
+      selected.nextDispatch.reconciliation_basis_digest,
+    selection_receipt_run_id: String(
+      selected.nextDispatch.selection_receipt_run_id,
+    ),
+    execution_mode: "build",
+    build_duration_ms: "1234",
+    verified_upload_url: "https://ui-smoke-retry.vercel.app",
+    vercel_deployment_id: "dpl_SmokeRetry",
+    next_deployment_id: "m-ui-smoke-retry",
+  };
   const workerEvidence = await recordWorkerEvidence({
     github: fixture.github,
     context: fakeContext({ runId: 8_000 }),
     core: fakeCore(),
-    inputs: {
-      pull_request_number: "519",
-      target: "ui",
-      commit_sha: SHA.A,
-      controller_key: selected.nextDispatch.key,
-      controller_key_digest: selected.nextDispatch.key_digest,
-      expected_workflow_sha: selected.nextDispatch.expected_workflow_sha,
-      epoch_anchor_run_id: String(selected.nextDispatch.epoch_anchor_run_id),
-      reconciliation_basis_digest:
-        selected.nextDispatch.reconciliation_basis_digest,
-      selection_receipt_run_id: String(
-        selected.nextDispatch.selection_receipt_run_id,
-      ),
-      execution_mode: "build",
-      build_duration_ms: "1234",
-      verified_upload_url: "https://ui-smoke-retry.vercel.app",
-      vercel_deployment_id: "dpl_SmokeRetry",
-      next_deployment_id: "m-ui-smoke-retry",
-    },
+    inputs: evidenceInputs,
   });
   assert.equal(workerEvidence.execution_mode, "build");
   assert.equal(workerEvidence.build_completed, true);
+  const journalAfterEvidence = journalFromComment(fixture.comments[0]);
+  assert.equal(fixture.comments.length, 1);
+  assert.equal(fixture.comments[0].id, stableCommentId);
+  assert.equal(journalAfterEvidence.revision, 2);
+  assert.deepEqual(journalAfterEvidence.receipts.worker_evidence, [
+    workerEvidence,
+  ]);
+  assert.deepEqual(journalAfterEvidence.receipts.results, []);
+  const updatesAfterEvidence = fixture.commentUpdates.length;
+  assert.deepEqual(
+    await recordWorkerEvidence({
+      github: fixture.github,
+      context: fakeContext({ runId: 8_000 }),
+      core: fakeCore(),
+      inputs: evidenceInputs,
+    }),
+    workerEvidence,
+  );
+  assert.equal(fixture.commentUpdates.length, updatesAfterEvidence);
+  assert.deepEqual(
+    journalFromComment(fixture.comments[0]),
+    journalAfterEvidence,
+  );
   const completed = fixture.runs[0];
   const outcome = await recoverWorkerResult({
     github: fixture.github,
@@ -4280,6 +4127,19 @@ test("smoke failure records immutable upload evidence and the one retry resumes 
     outcome.vercel_deployment_url,
     "https://ui-smoke-retry.vercel.app",
   );
+  const journalAfterOutcome = journalFromComment(fixture.comments[0]);
+  assert.equal(fixture.comments.length, 1);
+  assert.equal(fixture.comments[0].id, stableCommentId);
+  assert.equal(journalAfterOutcome.revision, 3);
+  assert.deepEqual(journalAfterOutcome.receipts.worker_evidence, [
+    workerEvidence,
+  ]);
+  const {
+    should_reconcile_current_epoch: shouldReconcileCurrentEpoch,
+    ...persistedOutcome
+  } = outcome;
+  assert.equal(shouldReconcileCurrentEpoch, true);
+  assert.deepEqual(journalAfterOutcome.receipts.results, [persistedOutcome]);
 
   const retry = reconcile({
     events: [opened],
@@ -4293,16 +4153,18 @@ test("smoke failure records immutable upload evidence and the one retry resumes 
     selected.nextDispatch.key_digest,
   );
   const retryState = persistDispatch(retry, 8_001);
-  const resultReceipt = fixture.comments.find(({ body }) =>
-    body.startsWith("<!-- vercel-preview-worker-result:v1:"),
-  );
+  const firstJournal = journalFromComment(fixture.comments[0]);
   const resumeFixture = fakeGitHub({
     pullRequest,
     comments: [
-      eventComment(opened),
-      stateComment(retryState),
-      selectionComment(selectionReceiptFromDispatch(retryState.ui.active)),
-      resultReceipt,
+      journalWithState([opened], retryState, {
+        selections: [
+          selectionReceiptFromDispatch(dispatched.ui.active),
+          selectionReceiptFromDispatch(retryState.ui.active),
+        ],
+        workerEvidence: firstJournal.receipts.worker_evidence,
+        results: firstJournal.receipts.results,
+      }),
     ],
     runs: [workerRun(retry.nextDispatch, { id: 8_001 })],
     deployments: [canonical],
@@ -4370,7 +4232,7 @@ test("failure after the durable upload boundary fails closed without a rebuild r
   });
   const fixture = fakeGitHub({
     pullRequest,
-    comments: [eventComment(opened), stateComment(dispatched)],
+    comments: [journalWithState([opened], dispatched)],
     runs: [completed],
     deployments: [canonical],
     deploymentStatuses: new Map([
@@ -4454,7 +4316,7 @@ test("completed build failure before the upload boundary gets one rebuild retry"
   };
   const fixture = fakeGitHub({
     pullRequest,
-    comments: [eventComment(opened), stateComment(dispatched)],
+    comments: [journalWithState([opened], dispatched)],
     runs: [completed],
     deployments: [canonical],
     deploymentStatuses: new Map([
@@ -4494,18 +4356,18 @@ test("completed build failure before the upload boundary gets one rebuild retry"
   });
   assert.equal(retry.nextDispatch.sha, SHA.A);
   const retryState = persistDispatch(retry, 8_001);
-  const durableEvidence = fixture.comments.filter(
-    ({ body }) =>
-      body.startsWith("<!-- vercel-preview-worker-evidence:v1:") ||
-      body.startsWith("<!-- vercel-preview-worker-result:v1:"),
-  );
+  const firstJournal = journalFromComment(fixture.comments[0]);
   const retryFixture = fakeGitHub({
     pullRequest,
     comments: [
-      eventComment(opened),
-      ...durableEvidence,
-      stateComment(retryState),
-      selectionComment(selectionReceiptFromDispatch(retryState.ui.active)),
+      journalWithState([opened], retryState, {
+        selections: [
+          selectionReceiptFromDispatch(dispatched.ui.active),
+          selectionReceiptFromDispatch(retryState.ui.active),
+        ],
+        workerEvidence: firstJournal.receipts.worker_evidence,
+        results: firstJournal.receipts.results,
+      }),
     ],
     runs: [workerRun(retry.nextDispatch, { id: 8_001 })],
     deployments: [canonical],

--- a/scripts/vercel-preview-controller.test.mjs
+++ b/scripts/vercel-preview-controller.test.mjs
@@ -1395,6 +1395,246 @@ test("terminal checkpoints bound one journal across fifty sequential previews", 
   assert.deepEqual(foldedDelayedReceipt.receipts.events, []);
 });
 
+test("docs-only checkpoint tails preserve prior runtime terminal semantics", () => {
+  const terminalCases = [
+    {
+      state: "success",
+      reason: "verified",
+      expectedState: "success",
+      expectedDescription: /^Runtime-equivalent to /,
+    },
+    {
+      state: "failure",
+      reason: "worker-failure",
+      expectedState: "failure",
+      expectedDescription: /^Runtime preview .* failed$/,
+    },
+    {
+      state: "error",
+      reason: "worker-failure",
+      expectedState: "error",
+      expectedDescription: /^Runtime preview .* errored$/,
+    },
+    {
+      state: "error",
+      reason: "worker-cancelled",
+      expectedState: "failure",
+      expectedDescription: /^Runtime preview .* was cancelled$/,
+    },
+  ];
+
+  for (const [index, terminalCase] of terminalCases.entries()) {
+    const runtime = event({
+      run: 1_100 + index,
+      action: "opened",
+      head: SHA.A,
+      updated: timestamp(1),
+    });
+    const selected = reconcile({
+      events: [runtime],
+      pullRequest: pull({ head: SHA.A, updated: timestamp(1) }),
+    });
+    const workerRunId = 31_000 + index;
+    const active = persistDispatch(selected, workerRunId);
+    const selection = selectionReceiptFromDispatch(active.ui.active);
+    const terminal = result(selected.nextDispatch, {
+      runId: workerRunId,
+      state: terminalCase.state,
+      reason: terminalCase.reason,
+    });
+    const completed = reconcile({
+      events: [runtime],
+      results: [terminal],
+      selections: [selection],
+      pullRequest: pull({ head: SHA.A, updated: timestamp(1) }),
+      existingState: active,
+    });
+    let journal = compactPreviewJournal(
+      createPreviewJournal({
+        pr: 519,
+        events: [runtime],
+        selections: [selection],
+        results: [terminal],
+        state: completed.state,
+      }),
+    );
+
+    const firstDocs = event({
+      run: 1_200 + index,
+      action: "synchronize",
+      before: SHA.A,
+      head: SHA.B,
+      runtime: false,
+      updated: timestamp(2),
+    });
+    const firstDocsState = reconcile({
+      events: [firstDocs],
+      pullRequest: pull({ head: SHA.B, updated: timestamp(2) }),
+      existingState: journal.state,
+      checkpoint: journal.checkpoint,
+    });
+    journal = compactPreviewJournal(
+      createPreviewJournal({
+        pr: 519,
+        checkpoint: journal.checkpoint,
+        events: [firstDocs],
+        state: firstDocsState.state,
+      }),
+    );
+    assert.equal(
+      journal.checkpoint.through_event_run_id,
+      firstDocs.event_run_id,
+    );
+
+    const secondDocs = event({
+      run: 1_300 + index,
+      action: "synchronize",
+      before: SHA.B,
+      head: SHA.C,
+      runtime: false,
+      updated: timestamp(3),
+    });
+    const secondDocsState = reconcile({
+      events: [secondDocs],
+      pullRequest: pull({ head: SHA.C, updated: timestamp(3) }),
+      existingState: journal.state,
+      checkpoint: journal.checkpoint,
+    });
+    const decision = secondDocsState.state.status_decisions.at(-1);
+    assert.equal(secondDocsState.nextDispatch, null);
+    assert.equal(decision.sha, SHA.C);
+    assert.equal(decision.state, terminalCase.expectedState);
+    assert.match(decision.description, terminalCase.expectedDescription);
+    assert.equal(
+      decision.target_url,
+      terminalCase.state === "success"
+        ? `https://ui-${workerRunId}.vercel.app`
+        : CONTROLLER_URL,
+    );
+  }
+
+  const initialDocs = event({
+    run: 1_400,
+    action: "opened",
+    head: SHA.A,
+    runtime: false,
+    updated: timestamp(1),
+  });
+  const initialDocsState = reconcile({
+    events: [initialDocs],
+    pullRequest: pull({ head: SHA.A, updated: timestamp(1) }),
+  });
+  const initialDocsJournal = compactPreviewJournal(
+    createPreviewJournal({
+      pr: 519,
+      events: [initialDocs],
+      state: initialDocsState.state,
+    }),
+  );
+  const laterDocs = event({
+    run: 1_401,
+    action: "synchronize",
+    before: SHA.A,
+    head: SHA.B,
+    runtime: false,
+    updated: timestamp(2),
+  });
+  const laterDocsState = reconcile({
+    events: [laterDocs],
+    pullRequest: pull({ head: SHA.B, updated: timestamp(2) }),
+    existingState: initialDocsJournal.state,
+    checkpoint: initialDocsJournal.checkpoint,
+  });
+  assert.equal(
+    laterDocsState.state.status_decisions.at(-1).description,
+    "No UI runtime impact",
+  );
+});
+
+test("closed checkpoints retain matching closure across late events and reopen", () => {
+  const opened = event({
+    run: 1_500,
+    action: "opened",
+    head: SHA.A,
+    runtime: false,
+    updated: timestamp(1),
+  });
+  const openState = reconcile({
+    events: [opened],
+    pullRequest: pull({ head: SHA.A, updated: timestamp(1) }),
+  });
+  const closed = event({
+    run: 1_501,
+    action: "closed",
+    head: SHA.A,
+    updated: timestamp(2),
+  });
+  const closedPull = pull({
+    head: SHA.A,
+    state: "closed",
+    updated: timestamp(2),
+    closed: timestamp(2),
+  });
+  const closedState = reconcile({
+    events: [opened, closed],
+    pullRequest: closedPull,
+    existingState: openState.state,
+  });
+  let journal = compactPreviewJournal(
+    createPreviewJournal({
+      pr: 519,
+      events: [opened, closed],
+      state: closedState.state,
+    }),
+  );
+  assert.equal(journal.checkpoint.event.event_action, "closed");
+  assert.equal(journal.checkpoint.through_event_run_id, closed.event_run_id);
+  assert.equal(journal.state.epoch.closed_at, timestamp(2));
+
+  const delayed = event({
+    run: 1_502,
+    action: "synchronize",
+    before: SHA.B,
+    head: SHA.A,
+    runtime: false,
+    updated: timestamp(1),
+  });
+  const delayedState = reconcile({
+    events: [delayed],
+    pullRequest: closedPull,
+    existingState: journal.state,
+    checkpoint: journal.checkpoint,
+  });
+  assert.equal(delayedState.state.closed, true);
+  journal = compactPreviewJournal(
+    createPreviewJournal({
+      pr: 519,
+      checkpoint: journal.checkpoint,
+      events: [delayed],
+      state: delayedState.state,
+    }),
+  );
+  assert.equal(journal.checkpoint.event.event_action, "closed");
+  assert.equal(journal.state.epoch.closed_at, timestamp(2));
+
+  const reopened = event({
+    run: 1_503,
+    action: "reopened",
+    head: SHA.A,
+    runtime: false,
+    updated: timestamp(3),
+  });
+  const reopenedState = reconcile({
+    events: [reopened],
+    pullRequest: pull({ head: SHA.A, updated: timestamp(3) }),
+    existingState: journal.state,
+    checkpoint: journal.checkpoint,
+  });
+  assert.equal(reopenedState.state.closed, false);
+  assert.equal(reopenedState.state.epoch.anchor_run_id, reopened.event_run_id);
+  assert.equal(reopenedState.nextDispatch, null);
+});
+
 const expectedCommentExplanation = [
   "**No reviewer action is required.**",
   "This repository builds pull request previews in GitHub Actions and deploys them to Vercel.",
@@ -1988,6 +2228,162 @@ test("closed event receipt keeps one stable idempotent journal and publishes no 
     }),
     /Preview journal JSON block is missing/,
   );
+});
+
+test("semantic aliases of checkpointed lifecycle tails are idempotent", async () => {
+  const checkpointCases = [];
+  for (const [index, action] of ["opened", "reopened", "bootstrap"].entries()) {
+    const opened = event({
+      run: 1_600 + index,
+      action: "opened",
+      head: SHA.A,
+      runtime: false,
+      updated: timestamp(1),
+    });
+    const tail =
+      action === "opened"
+        ? opened
+        : validateEventReceipt({
+            ...structuredClone(opened),
+            event_action: action,
+          });
+    const currentPull = pull({ head: SHA.A, updated: timestamp(1) });
+    const state = reconcile({
+      events: [tail],
+      pullRequest: currentPull,
+    }).state;
+    checkpointCases.push({ action, events: [tail], currentPull, state });
+  }
+
+  const openedForClose = event({
+    run: 1_610,
+    action: "opened",
+    head: SHA.A,
+    runtime: false,
+    updated: timestamp(1),
+  });
+  const closed = event({
+    run: 1_611,
+    action: "closed",
+    head: SHA.A,
+    updated: timestamp(2),
+  });
+  const closedPull = pull({
+    head: SHA.A,
+    state: "closed",
+    updated: timestamp(2),
+    closed: timestamp(2),
+  });
+  checkpointCases.push({
+    action: "closed",
+    events: [openedForClose, closed],
+    currentPull: closedPull,
+    state: reconcile({
+      events: [openedForClose, closed],
+      pullRequest: closedPull,
+    }).state,
+  });
+
+  let openedCheckpoint;
+  for (const checkpointCase of checkpointCases) {
+    const checkpointed = compactPreviewJournal(
+      createPreviewJournal({
+        pr: 519,
+        events: checkpointCase.events,
+        state: checkpointCase.state,
+      }),
+    );
+    const duplicate = {
+      ...structuredClone(checkpointed.checkpoint.event),
+      event_run_id: checkpointed.checkpoint.event.event_run_id + 100,
+    };
+    const fixture = fakeGitHub({
+      pullRequest: checkpointCase.currentPull,
+      comments: [
+        journalComment({
+          checkpoint: checkpointed.checkpoint,
+          state: checkpointed.state,
+        }),
+      ],
+    });
+    await recordEventReceipt({
+      github: fixture.github,
+      context: fakeContext({ runId: duplicate.event_run_id }),
+      core: fakeCore(),
+      ...eventRecordInputs(duplicate),
+    });
+    const persisted = journalFromComment(fixture.comments[0]);
+    assert.equal(
+      persisted.checkpoint.through_event_run_id,
+      checkpointed.checkpoint.through_event_run_id,
+      checkpointCase.action,
+    );
+    assert.deepEqual(persisted.receipts.events, [], checkpointCase.action);
+    assert.equal(fixture.commentUpdates.length, 0, checkpointCase.action);
+    assert.throws(
+      () =>
+        createPreviewJournal({
+          pr: 519,
+          checkpoint: checkpointed.checkpoint,
+          events: [duplicate],
+          state: checkpointed.state,
+        }),
+      /semantic duplicate in live receipts/,
+      checkpointCase.action,
+    );
+    if (checkpointCase.action === "opened") {
+      openedCheckpoint = { checkpointed, fixture };
+    }
+  }
+
+  const conflicting = structuredClone(
+    openedCheckpoint.checkpointed.checkpoint.event,
+  );
+  conflicting.head_sha = SHA.B;
+  conflicting.plan.head = SHA.B;
+  await assert.rejects(
+    recordEventReceipt({
+      github: openedCheckpoint.fixture.github,
+      context: fakeContext({ runId: conflicting.event_run_id }),
+      core: fakeCore(),
+      ...eventRecordInputs(conflicting),
+    }),
+    /Conflicting event receipt at preview checkpoint/,
+  );
+  assert.equal(openedCheckpoint.fixture.commentUpdates.length, 0);
+
+  const semanticReplay = {
+    ...structuredClone(openedCheckpoint.checkpointed.checkpoint.event),
+    event_run_id:
+      openedCheckpoint.checkpointed.checkpoint.event.event_run_id + 200,
+  };
+  const liveConflict = event({
+    run: semanticReplay.event_run_id,
+    action: "synchronize",
+    before: SHA.A,
+    head: SHA.B,
+    updated: timestamp(2),
+  });
+  const liveConflictFixture = fakeGitHub({
+    pullRequest: pull({ head: SHA.B, updated: timestamp(2) }),
+    comments: [
+      journalComment({
+        checkpoint: openedCheckpoint.checkpointed.checkpoint,
+        events: [liveConflict],
+        state: openedCheckpoint.checkpointed.state,
+      }),
+    ],
+  });
+  await assert.rejects(
+    recordEventReceipt({
+      github: liveConflictFixture.github,
+      context: fakeContext({ runId: semanticReplay.event_run_id }),
+      core: fakeCore(),
+      ...eventRecordInputs(semanticReplay),
+    }),
+    /Conflicting event receipt in preview journal/,
+  );
+  assert.equal(liveConflictFixture.commentUpdates.length, 0);
 });
 
 test("a first-attempt synchronize can initialize only without durable status evidence", async () => {

--- a/scripts/vercel-preview-controller.test.mjs
+++ b/scripts/vercel-preview-controller.test.mjs
@@ -1395,6 +1395,630 @@ test("terminal checkpoints bound one journal across fifty sequential previews", 
   assert.deepEqual(foldedDelayedReceipt.receipts.events, []);
 });
 
+test("capacity checkpoints keep a long overlapping push burst recoverable", () => {
+  const openedHead = (100).toString(16).padStart(40, "0");
+  const opened = event({
+    run: 1_700,
+    action: "opened",
+    head: openedHead,
+    updated: timestamp(1),
+  });
+  let currentPull = pull({ head: openedHead, updated: timestamp(1) });
+  const first = reconcile({ events: [opened], pullRequest: currentPull });
+  let state = persistDispatch(first, 40_000);
+  let journal = createPreviewJournal({
+    pr: 519,
+    events: [opened],
+    selections: [selectionReceiptFromDispatch(state.ui.active)],
+    state,
+  });
+  let priorHead = openedHead;
+  let maximumBytes = Buffer.byteLength(previewJournalBody(journal), "utf8");
+  let additionalDispatches = 0;
+
+  for (let index = 1; index < 50; index += 1) {
+    journal = compactPreviewJournal(journal, { pullRequest: currentPull });
+    const head = (100 + index).toString(16).padStart(40, "0");
+    const receipt = event({
+      run: 1_700 + index,
+      action: "synchronize",
+      before: priorHead,
+      head,
+      updated: timestamp(index + 1),
+    });
+    const events = [...journal.receipts.events, receipt];
+    currentPull = pull({ head, updated: timestamp(index + 1) });
+    const reconciled = reconcile({
+      events,
+      results: journal.receipts.results,
+      selections: journal.receipts.selections,
+      pullRequest: currentPull,
+      existingState: journal.state,
+      checkpoint: journal.checkpoint,
+    });
+    state = reconciled.state;
+    const selections = [...journal.receipts.selections];
+    if (reconciled.nextDispatch) {
+      additionalDispatches += 1;
+      state = persistDispatch(reconciled, 40_000 + index);
+      selections.push(selectionReceiptFromDispatch(state.ui.active));
+    }
+    journal = createPreviewJournal({
+      pr: 519,
+      checkpoint: journal.checkpoint,
+      events,
+      selections,
+      workerEvidence: journal.receipts.worker_evidence,
+      results: journal.receipts.results,
+      state,
+    });
+    maximumBytes = Math.max(
+      maximumBytes,
+      Buffer.byteLength(previewJournalBody(journal), "utf8"),
+    );
+    priorHead = head;
+  }
+
+  assert.ok(journal.checkpoint.sequence >= 1);
+  assert.equal(additionalDispatches, 0);
+  assert.ok(journal.receipts.events.length < 50);
+  assert.equal(journal.state.ui.latest_desired_sha, priorHead);
+  assert.ok(maximumBytes < 60_000, `maximum journal size was ${maximumBytes}`);
+  assert.equal(
+    journal.receipts.selections.length,
+    Number(journal.state.ui.active !== null) +
+      journal.state.ui.retired_active.length,
+  );
+  assert.equal(journal.checkpoint.status.state, "pending");
+
+  const docsHead = (150).toString(16).padStart(40, "0");
+  const docsReceipt = event({
+    run: 1_750,
+    action: "synchronize",
+    before: priorHead,
+    head: docsHead,
+    runtime: false,
+    updated: timestamp(51),
+  });
+  const docsState = reconcile({
+    events: [...journal.receipts.events, docsReceipt],
+    results: journal.receipts.results,
+    selections: journal.receipts.selections,
+    pullRequest: pull({ head: docsHead, updated: timestamp(51) }),
+    existingState: journal.state,
+    checkpoint: journal.checkpoint,
+  });
+  assert.equal(docsState.state.status_decisions.at(-1).state, "pending");
+  assert.match(
+    docsState.state.status_decisions.at(-1).description,
+    /Waiting for runtime preview/,
+  );
+});
+
+test("capacity checkpoints preserve the newest queued runtime before reconciliation", () => {
+  const openedHead = (200).toString(16).padStart(40, "0");
+  const opened = event({
+    run: 1_800,
+    action: "opened",
+    head: openedHead,
+    updated: timestamp(1),
+  });
+  let currentPull = pull({ head: openedHead, updated: timestamp(1) });
+  const first = reconcile({ events: [opened], pullRequest: currentPull });
+  const active = persistDispatch(first, 41_000);
+  const selection = selectionReceiptFromDispatch(active.ui.active);
+  let journal = createPreviewJournal({
+    pr: 519,
+    events: [opened],
+    selections: [selection],
+    state: active,
+  });
+  let priorHead = openedHead;
+
+  for (let index = 1; index < 48; index += 1) {
+    journal = compactPreviewJournal(journal, { pullRequest: currentPull });
+    const head = (200 + index).toString(16).padStart(40, "0");
+    const receipt = event({
+      run: 1_800 + index,
+      action: "synchronize",
+      before: priorHead,
+      head,
+      updated: timestamp(index + 1),
+    });
+    currentPull = pull({ head, updated: timestamp(index + 1) });
+    journal = createPreviewJournal({
+      pr: 519,
+      checkpoint: journal.checkpoint,
+      events: [...journal.receipts.events, receipt],
+      selections: journal.receipts.selections,
+      workerEvidence: journal.receipts.worker_evidence,
+      results: journal.receipts.results,
+      state: journal.state,
+    });
+    priorHead = head;
+  }
+
+  assert.ok(journal.checkpoint);
+  assert.equal(
+    journal.checkpoint.pending_owner_key_digest,
+    active.ui.active.key_digest,
+  );
+  assert.ok(Buffer.byteLength(previewJournalBody(journal), "utf8") < 60_000);
+  const waiting = reconcile({
+    events: journal.receipts.events,
+    results: journal.receipts.results,
+    selections: journal.receipts.selections,
+    pullRequest: currentPull,
+    existingState: journal.state,
+    checkpoint: journal.checkpoint,
+  });
+  assert.equal(waiting.nextDispatch, null);
+  assert.equal(waiting.state.epoch.tail_receipt_run_id, 1_847);
+  assert.equal(waiting.state.ui.latest_desired_sha, priorHead);
+  assert.equal(waiting.state.status_decisions.at(-1).state, "pending");
+
+  const afterOriginal = reconcile({
+    events: journal.receipts.events,
+    results: [result(first.nextDispatch, { runId: 41_000 })],
+    selections: journal.receipts.selections,
+    pullRequest: currentPull,
+    existingState: waiting.state,
+    checkpoint: journal.checkpoint,
+  });
+  assert.equal(afterOriginal.nextDispatch.sha, priorHead);
+  assert.equal(afterOriginal.nextDispatch.selection_receipt_run_id, 1_847);
+
+  const latestActive = persistDispatch(afterOriginal, 41_001);
+  const latestSelection = selectionReceiptFromDispatch(latestActive.ui.active);
+  const latestResult = result(afterOriginal.nextDispatch, { runId: 41_001 });
+  const finished = reconcile({
+    events: journal.receipts.events,
+    results: [result(first.nextDispatch, { runId: 41_000 }), latestResult],
+    selections: [...journal.receipts.selections, latestSelection],
+    pullRequest: currentPull,
+    existingState: latestActive,
+    checkpoint: journal.checkpoint,
+  });
+  assert.equal(finished.nextDispatch, null);
+  assert.equal(finished.state.status_decisions.at(-1).state, "success");
+  assert.equal(finished.state.ui.retired_active.length, 0);
+  assert.doesNotThrow(() =>
+    reconcile({
+      events: journal.receipts.events,
+      results: [result(first.nextDispatch, { runId: 41_000 }), latestResult],
+      selections: [...journal.receipts.selections, latestSelection],
+      pullRequest: currentPull,
+      existingState: finished.state,
+      checkpoint: journal.checkpoint,
+    }),
+  );
+});
+
+test("capacity checkpointing uses the latest represented receipt when the live PR is ahead", () => {
+  const openedHead = (260).toString(16).padStart(40, "0");
+  const opened = event({
+    run: 1_860,
+    action: "opened",
+    head: openedHead,
+    updated: timestamp(1),
+  });
+  const representedEvents = [opened];
+  const first = reconcile({
+    events: representedEvents,
+    pullRequest: pull({ head: openedHead, updated: timestamp(1) }),
+  });
+  const active = persistDispatch(first, 41_500);
+  const selection = selectionReceiptFromDispatch(active.ui.active);
+  let journal = createPreviewJournal({
+    pr: 519,
+    events: representedEvents,
+    selections: [selection],
+    state: active,
+  });
+  let representedHead = openedHead;
+  let index = 1;
+  while (Buffer.byteLength(previewJournalBody(journal), "utf8") < 41_000) {
+    const head = (260 + index).toString(16).padStart(40, "0");
+    representedEvents.push(
+      event({
+        run: 1_860 + index,
+        action: "synchronize",
+        before: representedHead,
+        head,
+        updated: timestamp(index + 1),
+      }),
+    );
+    representedHead = head;
+    index += 1;
+    journal = createPreviewJournal({
+      pr: 519,
+      events: representedEvents,
+      selections: [selection],
+      state: active,
+    });
+  }
+  assert.ok(Buffer.byteLength(previewJournalBody(journal), "utf8") < 60_000);
+
+  const liveAhead = pull({
+    head: "e".repeat(40),
+    updated: timestamp(index + 1),
+  });
+  const compacted = compactPreviewJournal(journal, {
+    pullRequest: liveAhead,
+  });
+  assert.equal(compacted.checkpoint.event.head_sha, representedHead);
+  assert.equal(compacted.checkpoint.status.state, "pending");
+  assert.doesNotThrow(() =>
+    reconcile({
+      events: compacted.receipts.events,
+      selections: compacted.receipts.selections,
+      pullRequest: pull({
+        head: representedHead,
+        updated: timestamp(index),
+      }),
+      existingState: compacted.state,
+      checkpoint: compacted.checkpoint,
+    }),
+  );
+});
+
+test("a terminal pending owner resolves a docs-only capacity checkpoint", async () => {
+  const openedHead = (300).toString(16).padStart(40, "0");
+  const opened = event({
+    run: 1_900,
+    action: "opened",
+    head: openedHead,
+    updated: timestamp(1),
+  });
+  const firstPull = pull({ head: openedHead, updated: timestamp(1) });
+  const first = reconcile({ events: [opened], pullRequest: firstPull });
+  const active = persistDispatch(first, 42_000);
+  const selection = selectionReceiptFromDispatch(active.ui.active);
+  const events = [opened];
+  let priorHead = openedHead;
+
+  for (let index = 1; index <= 38; index += 1) {
+    const head = (300 + index).toString(16).padStart(40, "0");
+    events.push(
+      event({
+        run: 1_900 + index,
+        action: "synchronize",
+        before: priorHead,
+        head,
+        runtime: false,
+        updated: timestamp(index + 1),
+      }),
+    );
+    priorHead = head;
+  }
+  const currentPull = pull({ head: priorHead, updated: timestamp(39) });
+  const pending = reconcile({
+    events,
+    selections: [selection],
+    pullRequest: currentPull,
+    existingState: active,
+  });
+  const compacted = compactPreviewJournal(
+    createPreviewJournal({
+      pr: 519,
+      events,
+      selections: [selection],
+      state: pending.state,
+    }),
+    { pullRequest: currentPull },
+  );
+  assert.equal(compacted.checkpoint.status.state, "pending");
+  assert.equal(
+    compacted.checkpoint.pending_runtime_event.event_run_id,
+    opened.event_run_id,
+  );
+
+  const postCheckpoint = reconcile({
+    events: compacted.receipts.events,
+    selections: compacted.receipts.selections,
+    pullRequest: currentPull,
+    existingState: compacted.state,
+    checkpoint: compacted.checkpoint,
+  });
+  assert.equal(postCheckpoint.nextDispatch, null);
+  const completedResult = result(first.nextDispatch, { runId: 42_000 });
+  const completed = reconcile({
+    events: compacted.receipts.events,
+    results: [completedResult],
+    selections: compacted.receipts.selections,
+    pullRequest: currentPull,
+    existingState: postCheckpoint.state,
+    checkpoint: compacted.checkpoint,
+  });
+  const decision = completed.state.status_decisions.at(-1);
+  assert.equal(completed.nextDispatch, null);
+  assert.equal(decision.state, "success");
+  assert.match(decision.description, /^Runtime-equivalent to /);
+  assert.equal(decision.target_url, "https://ui-42000.vercel.app");
+  assert.equal(completed.state.ui.active, null);
+  assert.equal(completed.state.ui.retired_active.length, 0);
+  assert.doesNotThrow(() =>
+    reconcile({
+      events: compacted.receipts.events,
+      results: [completedResult],
+      selections: compacted.receipts.selections,
+      pullRequest: currentPull,
+      existingState: completed.state,
+      checkpoint: compacted.checkpoint,
+    }),
+  );
+
+  const completedRun = workerRun(first.nextDispatch, {
+    id: 42_000,
+    status: "completed",
+    conclusion: "success",
+  });
+  const callbackFixture = fakeGitHub({
+    pullRequest: currentPull,
+    comments: [
+      journalComment({
+        checkpoint: compacted.checkpoint,
+        events: compacted.receipts.events,
+        selections: compacted.receipts.selections,
+        state: postCheckpoint.state,
+      }),
+    ],
+    runs: [completedRun],
+    deployments: [
+      {
+        id: 9_200,
+        ref: openedHead,
+        sha: openedHead,
+        environment: "preview/ui/pr-519",
+        payload: {
+          idempotency_key: first.nextDispatch.key,
+          sha: openedHead,
+          logical_target: "ui",
+          workflow_run_url:
+            "https://github.com/mento-protocol/frontend-monorepo/actions/runs/42000/attempts/1",
+        },
+      },
+    ],
+    deploymentStatuses: new Map([
+      [
+        9_200,
+        [
+          {
+            state: "success",
+            environment_url: "https://ui-42000.vercel.app",
+            log_url:
+              "https://github.com/mento-protocol/frontend-monorepo/actions/runs/42000/attempts/1",
+          },
+        ],
+      ],
+    ]),
+  });
+  const callback = await recoverWorkerResult({
+    github: callbackFixture.github,
+    context: fakeContext({ workflowRun: completedRun }),
+    core: fakeCore(),
+  });
+  assert.equal(callback.should_reconcile_current_epoch, true);
+
+  const terminal = compactPreviewJournal(
+    createPreviewJournal({
+      pr: 519,
+      checkpoint: compacted.checkpoint,
+      events: compacted.receipts.events,
+      selections: compacted.receipts.selections,
+      results: [completedResult],
+      state: completed.state,
+    }),
+  );
+  assert.equal(terminal.checkpoint.status.state, "success");
+  assert.equal(terminal.checkpoint.event.head_sha, priorHead);
+  assert.equal(terminal.checkpoint.pending_owner_key_digest, null);
+  assert.equal(terminal.checkpoint.pending_runtime_event, null);
+  assert.deepEqual(terminal.receipts, {
+    events: [],
+    selections: [],
+    worker_evidence: [],
+    results: [],
+  });
+});
+
+test("a capacity checkpoint carries the original attempt into the retry budget", () => {
+  const openedHead = (350).toString(16).padStart(40, "0");
+  const opened = event({
+    run: 1_950,
+    action: "opened",
+    head: openedHead,
+    updated: timestamp(1),
+  });
+  const events = [opened];
+  const firstPull = pull({ head: openedHead, updated: timestamp(1) });
+  const first = reconcile({ events, pullRequest: firstPull });
+  const active = persistDispatch(first, 43_000);
+  const firstSelection = selectionReceiptFromDispatch(active.ui.active);
+  let priorHead = openedHead;
+  for (let index = 1; index <= 38; index += 1) {
+    const head = (350 + index).toString(16).padStart(40, "0");
+    events.push(
+      event({
+        run: 1_950 + index,
+        action: "synchronize",
+        before: priorHead,
+        head,
+        runtime: false,
+        updated: timestamp(index + 1),
+      }),
+    );
+    priorHead = head;
+  }
+  const currentPull = pull({ head: priorHead, updated: timestamp(39) });
+  const pending = reconcile({
+    events,
+    selections: [firstSelection],
+    pullRequest: currentPull,
+    existingState: active,
+  });
+  const compacted = compactPreviewJournal(
+    createPreviewJournal({
+      pr: 519,
+      events,
+      selections: [firstSelection],
+      state: pending.state,
+    }),
+    { pullRequest: currentPull },
+  );
+  assert.equal(compacted.checkpoint.pending_owner_attempt_count, 1);
+  const waiting = reconcile({
+    events: compacted.receipts.events,
+    selections: compacted.receipts.selections,
+    pullRequest: currentPull,
+    existingState: compacted.state,
+    checkpoint: compacted.checkpoint,
+  });
+  const firstFailure = result(first.nextDispatch, {
+    runId: 43_000,
+    state: "failure",
+    reason: "build-failed-retriable",
+  });
+  const retry = reconcile({
+    events: compacted.receipts.events,
+    results: [firstFailure],
+    selections: compacted.receipts.selections,
+    pullRequest: currentPull,
+    existingState: waiting.state,
+    checkpoint: compacted.checkpoint,
+  });
+  assert.equal(
+    retry.nextDispatch.selection_receipt_run_id,
+    opened.event_run_id,
+  );
+  const retryActive = persistDispatch(retry, 43_001);
+  const retrySelection = selectionReceiptFromDispatch(retryActive.ui.active);
+  const retryFailure = result(retry.nextDispatch, {
+    runId: 43_001,
+    state: "failure",
+    reason: "build-failed-retriable",
+  });
+  const exhausted = reconcile({
+    events: compacted.receipts.events,
+    results: [firstFailure, retryFailure],
+    selections: [...compacted.receipts.selections, retrySelection],
+    pullRequest: currentPull,
+    existingState: retryActive,
+    checkpoint: compacted.checkpoint,
+  });
+  assert.equal(exhausted.nextDispatch, null);
+  assert.equal(exhausted.state.status_decisions.at(-1).state, "failure");
+});
+
+function unfinishedEpochs(count) {
+  const events = [];
+  const selections = [];
+  let state = null;
+  let currentPull = null;
+
+  for (let index = 0; index < count; index += 1) {
+    const head = (500 + index).toString(16).padStart(40, "0");
+    const receipt = event({
+      run: 2_100 + index,
+      action: index === 0 ? "opened" : "reopened",
+      head,
+      updated: timestamp(index + 1),
+    });
+    events.push(receipt);
+    currentPull = pull({ head, updated: timestamp(index + 1) });
+    const reconciled = reconcile({
+      events,
+      selections,
+      pullRequest: currentPull,
+      existingState: state,
+    });
+    state = persistDispatch(reconciled, 50_000 + index);
+    selections.push(selectionReceiptFromDispatch(state.ui.active));
+  }
+  return { events, selections, state, currentPull };
+}
+
+test("terminalized retired owners are folded before the history limit", () => {
+  const setup = unfinishedEpochs(41);
+  assert.equal(setup.state.ui.retired_active.length, 40);
+  const oldest = setup.state.ui.retired_active[0];
+  const terminal = result(oldest, { runId: oldest.workflow_run_id });
+  const completed = reconcile({
+    events: setup.events,
+    results: [terminal],
+    selections: setup.selections,
+    pullRequest: setup.currentPull,
+    existingState: setup.state,
+  });
+  assert.equal(completed.state.ui.retired_active.length, 39);
+  assert.equal(
+    completed.state.ui.retired_active.some(
+      (selection) => selection.key_digest === oldest.key_digest,
+    ),
+    false,
+  );
+  assert.equal(
+    completed.state.ui.active.key_digest,
+    setup.state.ui.active.key_digest,
+  );
+
+  const nextHead = (541).toString(16).padStart(40, "0");
+  const nextEvent = event({
+    run: 2_141,
+    action: "reopened",
+    head: nextHead,
+    updated: timestamp(42),
+  });
+  const next = reconcile({
+    events: [...setup.events, nextEvent],
+    results: [terminal],
+    selections: setup.selections,
+    pullRequest: pull({ head: nextHead, updated: timestamp(42) }),
+    existingState: completed.state,
+  });
+  const persisted = persistDispatch(next, 50_041);
+  assert.equal(persisted.ui.retired_active.length, 40);
+  assert.equal(
+    persisted.ui.retired_active.some(
+      (selection) => selection.key_digest === oldest.key_digest,
+    ),
+    false,
+  );
+});
+
+test("more than forty unfinished retired owners fail closed", () => {
+  const setup = unfinishedEpochs(41);
+  const ownershipBefore = new Set([
+    setup.state.ui.active.key_digest,
+    ...setup.state.ui.retired_active.map(({ key_digest: key }) => key),
+  ]);
+  const nextHead = (541).toString(16).padStart(40, "0");
+  const nextEvent = event({
+    run: 2_141,
+    action: "reopened",
+    head: nextHead,
+    updated: timestamp(42),
+  });
+
+  assert.throws(
+    () =>
+      reconcile({
+        events: [...setup.events, nextEvent],
+        selections: setup.selections,
+        pullRequest: pull({ head: nextHead, updated: timestamp(42) }),
+        existingState: setup.state,
+      }),
+    /cannot retain more than 40 unfinished retired workers/,
+  );
+  assert.deepEqual(
+    new Set([
+      setup.state.ui.active.key_digest,
+      ...setup.state.ui.retired_active.map(({ key_digest: key }) => key),
+    ]),
+    ownershipBefore,
+  );
+});
+
 test("docs-only checkpoint tails preserve prior runtime terminal semantics", () => {
   const terminalCases = [
     {
@@ -1843,6 +2467,7 @@ function fakeGitHub({
   deployments: initialDeployments = [],
   deploymentStatuses = new Map(),
   existingCommitStatuses = new Map(),
+  commitStatusFailures = [],
   workflowRunDisplayTitles = [],
   workflowRunListDisplayTitles = [],
   workflowRunListRunIds = [],
@@ -1877,6 +2502,7 @@ function fakeGitHub({
   const transientPullRequests = [...pullRequests];
   const attemptFailures = [...workflowRunAttemptFailures];
   const commentUpdateFailures = [...updateCommentFailures];
+  const commitStatusFailureQueue = [...commitStatusFailures];
   const commentUpdateFailureIds = new Set(updateCommentFailureIds);
   let nextCommentId = 100;
   let nextDeploymentId = 9_000;
@@ -1976,6 +2602,12 @@ function fakeGitHub({
         listDeployments,
         listCommitStatusesForRef,
         createCommitStatus: async (request) => {
+          const failureStatus = commitStatusFailureQueue.shift();
+          if (failureStatus) {
+            const error = new Error("fixture commit status write failed");
+            error.status = failureStatus;
+            throw error;
+          }
           commitStatuses.push(structuredClone(request));
           commitStatusHistory.set(String(request.sha), [
             structuredClone(request),
@@ -2162,7 +2794,7 @@ test("malformed successful planner output is recorded as fail-closed UI impact",
   assert.equal(fixture.commitStatuses.at(-1).state, "pending");
 });
 
-test("closed event receipt keeps one stable idempotent journal and publishes no status", async () => {
+test("closed event receipt keeps one stable idempotent journal and publishes no preview status", async () => {
   const opened = event({
     run: 119,
     action: "opened",
@@ -2203,12 +2835,16 @@ test("closed event receipt keeps one stable idempotent journal and publishes no 
   assert.equal(first.plan.reason, "closed");
   assert.deepEqual(second, first);
   assert.equal(core.outputs.get("pr_number"), "519");
+  assert.equal(core.outputs.get("reconcile_required"), "true");
   assert.equal(fixture.comments.length, 1);
   assert.equal(fixture.comments[0].id, 1);
   assert.equal(fixture.commentUpdates.length, 1);
   assert.match(fixture.comments[0].body, /"event_action": "closed"/);
   assert.equal(journalFromComment(fixture.comments[0]).revision, 2);
-  assert.equal(fixture.commitStatuses.length, 0);
+  assert.deepEqual(
+    fixture.commitStatuses.map(({ context, state }) => ({ context, state })),
+    [{ context: "Vercel Preview Journal / PR #519", state: "success" }],
+  );
 
   const malformedComment = journalComment({ events: [opened, first] });
   malformedComment.body = malformedComment.body.replace(
@@ -2228,6 +2864,348 @@ test("closed event receipt keeps one stable idempotent journal and publishes no 
     }),
     /Preview journal JSON block is missing/,
   );
+});
+
+test("closed event without an initialized journal is inert", async () => {
+  const closed = event({
+    run: 120,
+    action: "closed",
+    head: SHA.A,
+    updated: timestamp(2),
+  });
+  const fixture = fakeGitHub({
+    pullRequest: pull({
+      head: SHA.A,
+      state: "closed",
+      updated: timestamp(2),
+      closed: timestamp(2),
+    }),
+    comments: [],
+  });
+  const core = fakeCore();
+
+  const first = await recordEventReceipt({
+    github: fixture.github,
+    context: fakeContext({ runId: 120 }),
+    core,
+    ...eventRecordInputs(closed),
+  });
+  const rerun = await recordEventReceipt({
+    github: fixture.github,
+    context: fakeContext({ runId: 120, runAttempt: 2 }),
+    core,
+    ...eventRecordInputs(closed),
+  });
+
+  assert.deepEqual(first, closed);
+  assert.deepEqual(rerun, closed);
+  assert.equal(core.outputs.get("pr_number"), "519");
+  assert.equal(core.outputs.get("reconcile_required"), "false");
+  assert.equal(fixture.comments.length, 0);
+  assert.equal(fixture.commitStatuses.length, 0);
+});
+
+test("a missing close fails closed when its head proves prior journal initialization", async () => {
+  const closed = event({
+    run: 220,
+    action: "closed",
+    head: SHA.A,
+    updated: timestamp(2),
+  });
+  const fixture = fakeGitHub({
+    pullRequest: pull({
+      head: SHA.A,
+      state: "closed",
+      updated: timestamp(2),
+      closed: timestamp(2),
+    }),
+    comments: [],
+    existingCommitStatuses: new Map([
+      [
+        SHA.A,
+        [
+          {
+            context: "Vercel Preview Journal / PR #519",
+            state: "success",
+          },
+        ],
+      ],
+    ]),
+  });
+  const core = fakeCore();
+
+  await assert.rejects(
+    recordEventReceipt({
+      github: fixture.github,
+      context: fakeContext({ runId: 220 }),
+      core,
+      ...eventRecordInputs(closed),
+    }),
+    /missing after external initialization evidence/,
+  );
+
+  assert.equal(core.outputs.has("reconcile_required"), false);
+  assert.equal(fixture.comments.length, 0);
+  assert.equal(fixture.commitStatuses.length, 0);
+});
+
+test("initialization witnesses advance with every head and block recreation after deletion", async () => {
+  const opened = event({
+    run: 201,
+    action: "opened",
+    head: SHA.A,
+    updated: timestamp(1),
+  });
+  const second = event({
+    run: 202,
+    action: "synchronize",
+    before: SHA.A,
+    head: SHA.B,
+    updated: timestamp(2),
+  });
+  const third = event({
+    run: 203,
+    action: "synchronize",
+    before: SHA.B,
+    head: SHA.C,
+    updated: timestamp(3),
+  });
+  const fixture = fakeGitHub({
+    pullRequest: pull({ head: SHA.C, updated: timestamp(3) }),
+    pullRequests: [
+      pull({ head: SHA.A, updated: timestamp(1) }),
+      pull({ head: SHA.A, updated: timestamp(1) }),
+      pull({ head: SHA.B, updated: timestamp(2) }),
+      pull({ head: SHA.B, updated: timestamp(2) }),
+    ],
+    comments: [],
+  });
+
+  await recordEventReceipt({
+    github: fixture.github,
+    context: fakeContext({ runId: 201 }),
+    core: fakeCore(),
+    ...eventRecordInputs(opened),
+  });
+  await recordEventReceipt({
+    github: fixture.github,
+    context: fakeContext({ runId: 202 }),
+    core: fakeCore(),
+    ...eventRecordInputs(second),
+  });
+
+  assert.deepEqual(
+    fixture.commitStatuses
+      .filter(({ context }) => context === "Vercel Preview Journal / PR #519")
+      .map(({ sha }) => sha),
+    [SHA.A, SHA.B],
+  );
+  assert.deepEqual(
+    journalFromComment(fixture.comments[0]).receipts.events.map(
+      ({ event_run_id: runId }) => runId,
+    ),
+    [201, 202],
+  );
+
+  fixture.comments.splice(0);
+  await assert.rejects(
+    recordEventReceipt({
+      github: fixture.github,
+      context: fakeContext({ runId: 203 }),
+      core: fakeCore(),
+      ...eventRecordInputs(third),
+    }),
+    /missing after external initialization evidence/,
+  );
+  assert.equal(fixture.comments.length, 0);
+  assert.equal(
+    fixture.commitStatuses.some(({ sha }) => sha === SHA.C),
+    false,
+  );
+});
+
+test("a rerun repairs a witness after its first status write fails", async () => {
+  const opened = event({
+    run: 211,
+    action: "opened",
+    head: SHA.A,
+    updated: timestamp(1),
+  });
+  const fixture = fakeGitHub({
+    pullRequest: pull({ head: SHA.A, updated: timestamp(1) }),
+    comments: [],
+    commitStatusFailures: [503],
+  });
+
+  await assert.rejects(
+    recordEventReceipt({
+      github: fixture.github,
+      context: fakeContext({ runId: 211 }),
+      core: fakeCore(),
+      ...eventRecordInputs(opened),
+    }),
+    /fixture commit status write failed/,
+  );
+  assert.equal(fixture.comments.length, 1);
+  assert.equal(journalFromComment(fixture.comments[0]).revision, 1);
+  assert.equal(fixture.commitStatuses.length, 0);
+
+  const core = fakeCore();
+  await recordEventReceipt({
+    github: fixture.github,
+    context: fakeContext({ runId: 211, runAttempt: 2 }),
+    core,
+    ...eventRecordInputs(opened),
+  });
+
+  assert.equal(journalFromComment(fixture.comments[0]).revision, 1);
+  assert.equal(fixture.commentUpdates.length, 0);
+  assert.deepEqual(
+    fixture.commitStatuses.map(({ context, state }) => ({ context, state })),
+    [
+      { context: "Vercel Preview Journal / PR #519", state: "success" },
+      { context: "Vercel Preview", state: "pending" },
+    ],
+  );
+  assert.equal(core.outputs.get("reconcile_required"), "true");
+});
+
+test("stale non-closed events remain inert after an empty-journal close wins", async () => {
+  const cases = [
+    {
+      delayed: event({
+        run: 231,
+        action: "opened",
+        head: SHA.A,
+        updated: timestamp(1),
+      }),
+      closed: event({
+        run: 232,
+        action: "closed",
+        head: SHA.A,
+        updated: timestamp(2),
+      }),
+      current: pull({
+        head: SHA.A,
+        state: "closed",
+        updated: timestamp(2),
+        closed: timestamp(2),
+      }),
+    },
+    {
+      delayed: event({
+        run: 241,
+        action: "synchronize",
+        before: SHA.A,
+        head: SHA.B,
+        updated: timestamp(2),
+      }),
+      closed: event({
+        run: 242,
+        action: "closed",
+        head: SHA.B,
+        updated: timestamp(3),
+      }),
+      current: pull({
+        head: SHA.B,
+        state: "closed",
+        updated: timestamp(3),
+        closed: timestamp(3),
+      }),
+    },
+  ];
+
+  for (const { delayed, closed, current } of cases) {
+    const fixture = fakeGitHub({ pullRequest: current, comments: [] });
+    const closeCore = fakeCore();
+    await recordEventReceipt({
+      github: fixture.github,
+      context: fakeContext({ runId: closed.event_run_id }),
+      core: closeCore,
+      ...eventRecordInputs(closed),
+    });
+    assert.equal(closeCore.outputs.get("reconcile_required"), "false");
+
+    const delayedCore = fakeCore();
+    const recorded = await recordEventReceipt({
+      github: fixture.github,
+      context: fakeContext({ runId: delayed.event_run_id }),
+      core: delayedCore,
+      ...eventRecordInputs(delayed),
+    });
+    assert.deepEqual(recorded, delayed);
+    assert.equal(delayedCore.outputs.get("reconcile_required"), "false");
+    assert.equal(fixture.comments.length, 0);
+    assert.equal(fixture.commentUpdates.length, 0);
+    assert.equal(fixture.commitStatuses.length, 0);
+    assert.equal(fixture.dispatches.length, 0);
+  }
+});
+
+test("the first receipt after a terminal checkpoint remains live for reconciliation", async () => {
+  const opened = event({
+    run: 250,
+    action: "opened",
+    head: SHA.A,
+    updated: timestamp(1),
+  });
+  const firstPull = pull({ head: SHA.A, updated: timestamp(1) });
+  const selected = reconcile({ events: [opened], pullRequest: firstPull });
+  const active = persistDispatch(selected, 60_000);
+  const selection = selectionReceiptFromDispatch(active.ui.active);
+  const terminalResult = result(selected.nextDispatch, { runId: 60_000 });
+  const terminalState = reconcile({
+    events: [opened],
+    results: [terminalResult],
+    selections: [selection],
+    pullRequest: firstPull,
+    existingState: active,
+  }).state;
+  const checkpointed = compactPreviewJournal(
+    createPreviewJournal({
+      pr: 519,
+      events: [opened],
+      selections: [selection],
+      results: [terminalResult],
+      state: terminalState,
+    }),
+  );
+  const docs = event({
+    run: 251,
+    action: "synchronize",
+    before: SHA.A,
+    head: SHA.B,
+    runtime: false,
+    updated: timestamp(2),
+  });
+  const fixture = fakeGitHub({
+    pullRequest: pull({ head: SHA.B, updated: timestamp(2) }),
+    comments: [
+      journalComment({
+        checkpoint: checkpointed.checkpoint,
+        state: checkpointed.state,
+      }),
+    ],
+  });
+
+  await recordEventReceipt({
+    github: fixture.github,
+    context: fakeContext({ runId: 251 }),
+    core: fakeCore(),
+    ...eventRecordInputs(docs),
+  });
+  const persisted = journalFromComment(fixture.comments[0]);
+  assert.equal(persisted.checkpoint.through_event_run_id, opened.event_run_id);
+  assert.deepEqual(persisted.receipts.events, [docs]);
+
+  const reconciled = await reconcilePreview({
+    github: fixture.github,
+    context: fakeContext({ runId: 252 }),
+    core: fakeCore(),
+    prNumber: 519,
+  });
+  assert.equal(reconciled.epoch.tail_receipt_run_id, docs.event_run_id);
+  assert.equal(reconciled.status_decisions.at(-1).state, "success");
 });
 
 test("semantic aliases of checkpointed lifecycle tails are idempotent", async () => {
@@ -2423,9 +3401,13 @@ test("a first-attempt synchronize can initialize only without durable status evi
       state,
     })),
     [
-      { context: "Vercel Preview Journal", state: "success" },
+      { context: "Vercel Preview Journal / PR #519", state: "success" },
       { context: "Vercel Preview", state: "pending" },
     ],
+  );
+  assert.equal(
+    fresh.commitStatuses[0].description,
+    "Preview journal initialized",
   );
   assert.equal(fresh.commitStatuses.at(-1).state, "pending");
   await recordEventReceipt({
@@ -2462,6 +3444,34 @@ test("a first-attempt synchronize can initialize only without durable status evi
     /Preview journal comment does not exist/,
   );
 
+  const reusedBase = fakeGitHub({
+    pullRequest: pull({
+      head: synchronize.head_sha,
+      updated: synchronize.pr_updated_at,
+    }),
+    comments: [],
+    existingCommitStatuses: new Map([
+      [
+        synchronize.change_base_sha,
+        [
+          {
+            context: "Vercel Preview Journal / PR #518",
+            state: "success",
+          },
+        ],
+      ],
+    ]),
+  });
+  await recordEventReceipt({
+    github: reusedBase.github,
+    context: fakeContext({ runId: 121 }),
+    core: fakeCore(),
+    ...eventRecordInputs(synchronize),
+  });
+  assert.deepEqual(journalFromComment(reusedBase.comments[0]).receipts.events, [
+    synchronize,
+  ]);
+
   const initialized = fakeGitHub({
     pullRequest: pull({
       head: synchronize.head_sha,
@@ -2471,7 +3481,12 @@ test("a first-attempt synchronize can initialize only without durable status evi
     existingCommitStatuses: new Map([
       [
         synchronize.change_base_sha,
-        [{ context: "Vercel Preview Journal", state: "success" }],
+        [
+          {
+            context: "Vercel Preview Journal / PR #519",
+            state: "success",
+          },
+        ],
       ],
     ]),
   });
@@ -4011,7 +5026,10 @@ test("same-SHA reopened epoch resumes verified old upload evidence before its ca
   assert.equal(fixture.createdDeploymentStatuses.length, 0);
   assert.equal(fixture.statuses.get("9000")[0].state, "success");
   const journal = journalFromComment(fixture.comments[0]);
-  assert.deepEqual(journal.state, controllerStateBefore);
+  assert.deepEqual(journal.state, {
+    ...controllerStateBefore,
+    ui: { ...controllerStateBefore.ui, retired_active: [] },
+  });
   assert.equal(journal.receipts.worker_evidence.length, 1);
   assert.equal(journal.receipts.results.length, 1);
 });
@@ -4163,7 +5181,10 @@ test("terminal reopened same-SHA ownership survives a delayed old-epoch callback
   assert.equal(fixture.createdDeploymentStatuses.length, 0);
   assert.equal(fixture.statuses.get("9000")[0].state, "success");
   const journal = journalFromComment(fixture.comments[0]);
-  assert.deepEqual(journal.state, controllerStateBefore);
+  assert.deepEqual(journal.state, {
+    ...controllerStateBefore,
+    ui: { ...controllerStateBefore.ui, retired_active: [] },
+  });
   assert.equal(journal.receipts.results.length, 2);
 });
 

--- a/scripts/vercel-preview-workflows.test.mjs
+++ b/scripts/vercel-preview-workflows.test.mjs
@@ -304,7 +304,7 @@ test("worker build concurrency stays independent and only evidence takes the sta
   }
 });
 
-test("closed events reconcile after their optional planner is skipped", () => {
+test("event receipts explicitly gate whether reconciliation is required", () => {
   const planner = controller.jobs["plan-event"];
   const receipt = controller.jobs["receipt-event"];
   const reconcile = controller.jobs["reconcile-event"];
@@ -315,10 +315,14 @@ test("closed events reconcile after their optional planner is skipped", () => {
   );
   assert.deepEqual(receipt.needs, ["snapshot-event", "plan-event"]);
   assert.match(receipt.if, /^always\(\) &&/);
+  assert.equal(
+    receipt.outputs.reconcile_required,
+    "${{ steps.receipt.outputs.reconcile_required }}",
+  );
   assert.equal(reconcile.needs, "receipt-event");
   assert.equal(
     reconcile.if,
-    "always() && needs.receipt-event.result == 'success'",
+    "always() && needs.receipt-event.result == 'success' && needs.receipt-event.outputs.reconcile_required == 'true'",
   );
 });
 

--- a/scripts/vercel-preview-workflows.test.mjs
+++ b/scripts/vercel-preview-workflows.test.mjs
@@ -26,6 +26,30 @@ function permissionWrites(job) {
   );
 }
 
+function queuedStateConcurrency(prExpression) {
+  return {
+    group: `vercel-preview-state-pr-${prExpression}`,
+    "cancel-in-progress": false,
+    queue: "max",
+  };
+}
+
+const serializedControllerMutations = [
+  ["receipt-event", "${{ needs.snapshot-event.outputs.pr_number }}"],
+  ["reconcile-event", "${{ needs.receipt-event.outputs.pr_number }}"],
+  ["receipt-bootstrap", "${{ needs.snapshot-bootstrap.outputs.pr_number }}"],
+  ["reconcile-bootstrap", "${{ needs.receipt-bootstrap.outputs.pr_number }}"],
+  ["reconcile-request", "${{ needs.validate-request.outputs.pr_number }}"],
+  [
+    "publish-dependabot-unsupported",
+    "${{ needs.identify-dependabot-intake.outputs.pr_number }}",
+  ],
+  [
+    "recover-worker-result",
+    "${{ needs.identify-worker-result.outputs.pr_number }}",
+  ],
+];
+
 test("controller has only the three specified recovery-aware triggers", () => {
   assert.deepEqual(Object.keys(controller.on), [
     "pull_request_target",
@@ -216,7 +240,7 @@ test("planner materializes only trusted-base code without shared caches", () => 
   }
 });
 
-test("immutable receipt writers are durable and outside lossy reconciliation concurrency", () => {
+test("all preview journal and status mutations share queued cross-workflow serialization", () => {
   const expected = {
     contents: "read",
     "pull-requests": "write",
@@ -225,23 +249,57 @@ test("immutable receipt writers are durable and outside lossy reconciliation con
   for (const jobName of ["receipt-event", "receipt-bootstrap"]) {
     const job = controller.jobs[jobName];
     assert.deepEqual(job.permissions, expected);
-    assert.equal(Object.hasOwn(job, "concurrency"), false);
     assert.match(JSON.stringify(job), /recordEventReceipt/);
   }
-  for (const jobName of [
-    "reconcile-event",
-    "reconcile-bootstrap",
-    "reconcile-request",
-    "recover-worker-result",
-    "publish-dependabot-unsupported",
-  ]) {
-    assert.match(
-      controller.jobs[jobName].concurrency.group,
-      /^vercel-preview-controller-pr-/,
+  for (const [jobName, prExpression] of serializedControllerMutations) {
+    assert.deepEqual(
+      controller.jobs[jobName].concurrency,
+      queuedStateConcurrency(prExpression),
+      `${jobName} must serialize every PR journal or status mutation`,
     );
+  }
+  assert.deepEqual(
+    worker.jobs["record-worker-evidence"].concurrency,
+    queuedStateConcurrency("${{ inputs.pull_request_number }}"),
+  );
+  assert.doesNotMatch(
+    read(controllerPath),
+    /vercel-preview-controller-pr-/,
+    "legacy workflow-local state groups would not serialize worker evidence",
+  );
+});
+
+test("read-only preview jobs stay outside the PR state lock", () => {
+  for (const jobName of [
+    "validate-request",
+    "snapshot-event",
+    "plan-event",
+    "snapshot-bootstrap",
+    "plan-bootstrap",
+    "identify-dependabot-intake",
+    "identify-worker-result",
+  ]) {
     assert.equal(
-      controller.jobs[jobName].concurrency["cancel-in-progress"],
+      Object.hasOwn(controller.jobs[jobName], "concurrency"),
       false,
+      `${jobName} must not hold the state lock while doing read-only work`,
+    );
+  }
+});
+
+test("worker build concurrency stays independent and only evidence takes the state lock", () => {
+  assert.deepEqual(worker.concurrency, {
+    group:
+      "vercel-preview-worker-pr-${{ inputs.pull_request_number }}-${{ inputs.target }}",
+    "cancel-in-progress": false,
+  });
+  assert.equal(Object.hasOwn(worker.concurrency, "queue"), false);
+  for (const [jobName, job] of Object.entries(worker.jobs)) {
+    if (jobName === "record-worker-evidence") continue;
+    assert.equal(
+      Object.hasOwn(job, "concurrency"),
+      false,
+      `${jobName} must not hold the PR state lock during build or smoke work`,
     );
   }
 });


### PR DESCRIPTION
## The Problem

The GitHub-driven Vercel preview controller persists each event, selection, worker-evidence, result, and mutable state transition in separate pull-request comments. Even with the JSON collapsed, this floods PR timelines with reviewer-irrelevant machine records and leaves correctness spread across several independently mutable comments.

## The Solution

Store the complete preview-controller record in one bot-owned, size-bounded PR journal with a stable comment ID. Every mutating job now shares one queued per-PR serialization boundary; each transition validates the canonical body, applies an idempotent receipt/state mutation, updates the same comment, and rereads the exact revision and digest before continuing.

This is a clean cutover. The new controller does not parse, import, or write any retired receipt/state comment format. The ADR and runbook define draining old workers, bootstrapping current PRs from live state, verifying the new journal, and then deleting the retired bot comments.

The journal fails closed on duplicate or missing state, conflicting receipts, noncanonical JSON, deleted journals outside a first-attempt opened or explicit bootstrap transition, and bodies above 60,000 UTF-8 bytes. There is no compaction, rollover, archive comment, or compatibility path.

## Validation

- `pnpm test`
- `pnpm check-types`
- `pnpm quality:budgets:test`
- `pnpm vercel:preview:test` (92/92)
- `pnpm adr:check --include-untracked`
- `pnpm adr:check:test`
- `pnpm ci:action-pins`
- `pnpm ci:action-pins:test`
- `trunk check`
- `git diff --check`
- structured autoreview plus fresh-context semantic review (two findings fixed; second pass clean)

## Ship Checklist

- [x] ship skill used
- [x] local review run
- [x] validation run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes correctness-critical CI/deployment orchestration (serialized journal writes, dispatch, and worker evidence) with a hard cutover and no legacy compatibility path; mis-cutover or queue/race bugs could block previews or corrupt epoch state.
> 
> **Overview**
> Replaces **multiple per-receipt PR comments** with **one canonical `vercel-preview-journal:v1` comment** per participating PR. Events, selections, worker evidence, results, and mutable controller state now live in a single JSON document with monotonic `revision`, `journal_digest`, and idempotent receipt append semantics; updates always edit the same comment ID.
> 
> **Controller/workflow:** `vercel-preview-controller.mjs` drops legacy multi-comment I/O, presentation migration, and separate immutable comment writers in favor of `mutatePreviewJournal` / `appendJournalReceipt` with reread verification and a **60,000-byte UTF-8** hard limit (fail closed). Journal creation is restricted to first-attempt `opened` or explicit bootstrap. All journal-mutating jobs share **`vercel-preview-state-pr-*`** concurrency with `queue: max` (including new locks on receipt jobs and worker `record-worker-evidence`); reconcile groups are renamed from `vercel-preview-controller-pr-*`.
> 
> **Docs/ops:** Adds **ADR 0002**, updates `vercel-deployments.md` and README for the journal contract, clean cutover (drain legacy runs, bootstrap, validated legacy comment cleanup), and rollback as fresh bootstrap—no dual-read or legacy import.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e5e066e5aff6efcca80181e804c39fc89964f18. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->