### PR TITLE
test(ci): verify preview journal cutover

### DIFF
--- a/apps/ui.mento.org/app/layout.tsx
+++ b/apps/ui.mento.org/app/layout.tsx
@@ -27,7 +27,7 @@ export default function RootLayout({
 }): React.ReactElement {
   return (
     <html lang="en" suppressHydrationWarning>
-      <body className={inter.className}>
+      <body className={inter.className} data-preview-journal-canary="v1">
         <AppShell>{children}</AppShell>
       </body>
     </html>


### PR DESCRIPTION
## The Problem

The merged single-comment preview journal cutover needs one disposable, runtime-affecting pull request to prove the complete GitHub Actions build, Vercel upload, browser smoke, exact-SHA status, and journal transition on the live default-branch controller.

## The Solution

Add a temporary `data-preview-journal-canary="v1"` attribute to the UI showcase body. This PR is verification-only: it must remain unmerged and will be closed after the immutable preview and journal are verified.

## Validation

- `trunk fmt apps/ui.mento.org/app/layout.tsx`
- `trunk check apps/ui.mento.org/app/layout.tsx`
- `pnpm exec turbo run check-types --filter ui.mento.org`
- full repository pre-push hook

## Ship Checklist

- [x] ship skill used
- [x] local review run
- [x] validation run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single inert HTML data attribute on the showcase app with no auth, data, or product logic changes; PR is explicitly not for merge.
> 
> **Overview**
> Adds a temporary **`data-preview-journal-canary="v1"`** attribute on the root `<body>` in `apps/ui.mento.org/app/layout.tsx` so a disposable PR can exercise the full preview pipeline (build, Vercel deploy, browser smoke, exact-SHA status, and journal transition) against a real runtime DOM change.
> 
> This is **verification-only** and is intended to stay **unmerged**; the attribute should be removed after cutover is confirmed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9445508dffdb1f97836ba2ff723924af2fcf3127. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->