### PR TITLE
fix(ci): restore automatic preview worker callbacks

### DIFF
--- a/.github/workflows/vercel-preview-controller.yml
+++ b/.github/workflows/vercel-preview-controller.yml
@@ -227,6 +227,7 @@ jobs:
         env:
           PR_NUMBER: ${{ needs.receipt-event.outputs.pr_number }}
           WORKFLOW_SHA: ${{ github.workflow_sha }}
+          WORKER_DISPATCH_TOKEN: ${{ secrets.GH_PREVIEW_WORKFLOW_DISPATCH_TOKEN }}
         with:
           script: |
             const { pathToFileURL } = require("node:url");
@@ -234,8 +235,12 @@ jobs:
               `${process.env.GITHUB_WORKSPACE}/controller/scripts/vercel-preview-controller.mjs`,
             );
             const { reconcilePreview } = await import(moduleUrl.href);
+            const workerDispatchGithub = process.env.WORKER_DISPATCH_TOKEN
+              ? getOctokit(process.env.WORKER_DISPATCH_TOKEN)
+              : null;
             await reconcilePreview({
               github,
+              workerDispatchGithub,
               context,
               core,
               prNumber: process.env.PR_NUMBER,
@@ -421,6 +426,7 @@ jobs:
         env:
           PR_NUMBER: ${{ needs.receipt-bootstrap.outputs.pr_number }}
           WORKFLOW_SHA: ${{ github.workflow_sha }}
+          WORKER_DISPATCH_TOKEN: ${{ secrets.GH_PREVIEW_WORKFLOW_DISPATCH_TOKEN }}
         with:
           script: |
             const { pathToFileURL } = require("node:url");
@@ -428,8 +434,12 @@ jobs:
               `${process.env.GITHUB_WORKSPACE}/controller/scripts/vercel-preview-controller.mjs`,
             );
             const { reconcilePreview } = await import(moduleUrl.href);
+            const workerDispatchGithub = process.env.WORKER_DISPATCH_TOKEN
+              ? getOctokit(process.env.WORKER_DISPATCH_TOKEN)
+              : null;
             await reconcilePreview({
               github,
+              workerDispatchGithub,
               context,
               core,
               prNumber: process.env.PR_NUMBER,
@@ -466,6 +476,7 @@ jobs:
         env:
           PR_NUMBER: ${{ needs.validate-request.outputs.pr_number }}
           WORKFLOW_SHA: ${{ github.workflow_sha }}
+          WORKER_DISPATCH_TOKEN: ${{ secrets.GH_PREVIEW_WORKFLOW_DISPATCH_TOKEN }}
         with:
           script: |
             const { pathToFileURL } = require("node:url");
@@ -473,8 +484,12 @@ jobs:
               `${process.env.GITHUB_WORKSPACE}/controller/scripts/vercel-preview-controller.mjs`,
             );
             const { reconcilePreview } = await import(moduleUrl.href);
+            const workerDispatchGithub = process.env.WORKER_DISPATCH_TOKEN
+              ? getOctokit(process.env.WORKER_DISPATCH_TOKEN)
+              : null;
             await reconcilePreview({
               github,
+              workerDispatchGithub,
               context,
               core,
               prNumber: process.env.PR_NUMBER,
@@ -617,6 +632,7 @@ jobs:
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           WORKFLOW_SHA: ${{ github.workflow_sha }}
+          WORKER_DISPATCH_TOKEN: ${{ secrets.GH_PREVIEW_WORKFLOW_DISPATCH_TOKEN }}
         with:
           script: |
             const { pathToFileURL } = require("node:url");
@@ -628,11 +644,15 @@ jobs:
               recoverWorkerResult,
               reconcilePreview,
             } = await import(moduleUrl.href);
+            const workerDispatchGithub = process.env.WORKER_DISPATCH_TOKEN
+              ? getOctokit(process.env.WORKER_DISPATCH_TOKEN)
+              : null;
             try {
               const result = await recoverWorkerResult({ github, context, core });
               if (result?.should_reconcile_current_epoch) {
                 await reconcilePreview({
                   github,
+                  workerDispatchGithub,
                   context,
                   core,
                   prNumber: result.pr,

--- a/README.md
+++ b/README.md
@@ -444,13 +444,18 @@ The repository is set up with GitHub Actions for CI:
   comment per participating PR. Dependabot events pass through a read-only
   metadata intake; trusted default-branch code re-queries the exact PR head
   before publishing the explicit preview-disabled status. Fork and Dependabot
-  PRs remain credential-free. During Phase A, native Vercel Git UI previews
+  PRs remain credential-free. A dedicated repository-scoped GitHub credential
+  performs only the worker-dispatch POST so terminal `workflow_run` callbacks
+  are created; the normal job token still owns all state and recovery calls.
+  During Phase A, native Vercel Git UI previews
   remain enabled for canary comparison; Vercel Git still owns every
   main/production deployment and all non-UI apps. See
   [ADR 0001](docs/adr/0001-github-actions-vercel-deployment-orchestration.md)
   for the accepted ownership boundary,
   [ADR 0002](docs/adr/0002-single-comment-preview-controller-journal.md) for
-  the journal persistence and clean-cutover decision, and
+  the journal persistence and clean-cutover decision,
+  [ADR 0003](docs/adr/0003-preview-worker-dispatch-authentication.md) for the
+  worker-dispatch authentication boundary, and
   [`docs/vercel-deployments.md`](docs/vercel-deployments.md) for the Phase B
   UI-only cutover, bootstrap, canary, and rollback procedures.
 

--- a/docs/adr/0003-preview-worker-dispatch-authentication.md
+++ b/docs/adr/0003-preview-worker-dispatch-authentication.md
@@ -1,0 +1,175 @@
+---
+title: A dedicated repository-scoped credential dispatches preview workers
+status: active
+owner: eng
+canonical: true
+last_verified: 2026-07-17
+scope: ci/deployment/preview-worker-dispatch-authentication
+date: 2026-07
+---
+
+# ADR 0003 — A dedicated repository-scoped credential dispatches preview workers
+
+**Status:** Accepted (Jul 2026)
+**Scope:** ci/deployment/preview-worker-dispatch-authentication
+
+## Context
+
+ADR 0001 made trusted default-branch GitHub Actions code the owner of Vercel
+preview orchestration, and ADR 0002 consolidated its durable coordination state
+into one pull-request journal. The controller dispatches a separate
+`Vercel Preview Worker` and relies on the worker's terminal `workflow_run`
+event to recover its result, advance first-plus-latest scheduling, and publish
+the final status.
+
+The initial controller dispatched that worker with the job's repository
+`GITHUB_TOKEN`. GitHub permits a `GITHUB_TOKEN`-authenticated
+`workflow_dispatch` to create the worker, but suppresses most events caused by
+that token from creating further workflow runs. Consequently the worker ran,
+yet its terminal `workflow_run` callback was not created. A later pull-request
+event or manual repository reconciliation could recover the completed worker,
+but automatic terminalization, cancellation recovery, and latest-push
+advancement were not dependable.
+
+GitHub recommends using a GitHub App installation token or personal access
+token when one workflow must trigger another workflow. This is a credential
+boundary, not a reason to move the controller's journal, status, Deployment,
+run-listing, validation, or recovery authority away from `GITHUB_TOKEN`.
+
+This ADR refines ADR 0001's preview-controller trust boundary. It does not
+supersede ADR 0001 or ADR 0002.
+
+## Decision
+
+### One narrowly used dispatch credential
+
+The repository has one Actions secret named
+`GH_PREVIEW_WORKFLOW_DISPATCH_TOKEN`. Its value is a fine-grained personal
+access token whose resource owner is `mento-protocol`, repository access is
+limited to `frontend-monorepo`, and repository permission is limited to
+`Actions: read and write` plus implicit metadata read.
+
+Only the four trusted reconciliation steps in
+`.github/workflows/vercel-preview-controller.yml` receive that secret. Each
+constructs a secondary Octokit client with the `actions/github-script`
+`getOctokit(token)` helper and passes the client to `reconcilePreview`. The
+secondary client is used for exactly one operation:
+
+```text
+POST /repos/mento-protocol/frontend-monorepo/actions/workflows/
+  vercel-preview-worker.yml/dispatches
+```
+
+There is no `GITHUB_TOKEN` fallback for that POST. The primary Octokit client,
+authenticated by the job's repository `GITHUB_TOKEN`, continues to own every
+pull-request journal mutation, commit status, Deployment and Deployment status,
+pull-request lookup, workflow-run listing and validation, recovery operation,
+and controller-error publication. The workflow does not replace
+`actions/github-script`'s `github-token` input with the personal access token.
+
+The dispatch credential is never sent to the worker, reusable Vercel workflow,
+candidate checkout, Vercel command, artifact, journal, log, output, or summary.
+It is not a Vercel credential and does not replace `VERCEL_TOKEN_PREVIEW`.
+
+### Fail-closed behavior and recovery
+
+Reconciliation first writes and rereads the durable `intended` selection and
+uses the primary client to search for a matching worker. If a valid existing
+worker is found, reconciliation attaches or recovers it without requiring the
+dispatch credential. Only when no existing worker can own the intent does the
+controller require the secondary client. A missing secret then fails closed
+immediately before the new dispatch, leaves the durable intent recoverable,
+and publishes an error status through the primary client.
+
+A worker dispatched with the dedicated credential is expected to produce its
+terminal `workflow_run` callback automatically. The callback still runs only
+trusted default-branch controller code, validates the exact worker identity,
+and uses `GITHUB_TOKEN` for terminal evidence and subsequent reconciliation.
+The dispatch credential grants no authority to the worker itself.
+
+### Provisioning, rotation, and rollback
+
+A maintainer creates the fine-grained token interactively, gives it an explicit
+owner and expiration/rotation date, and stores it only as the repository Actions
+secret. Automation may verify that the secret is configured by observing
+workflow behavior but must never retrieve, print, reconstruct, or export its
+value.
+
+Rotation replaces the repository secret with an equivalently scoped token and
+then proves one automatic worker callback. Revocation is fail-closed for new
+dispatches; already-created workers and their recovery remain operable through
+the primary client.
+
+Rollback removes the secondary dispatch path only in a reviewed change that
+also replaces its callback guarantee. Reintroducing `GITHUB_TOKEN` dispatch is
+not a valid rollback because it recreates the known event-suppression failure.
+
+## Alternatives considered
+
+### GitHub App installation token
+
+Operationally preferable for long-lived organization automation because the
+identity is bot-owned, installation-scoped, and short-lived. Rejected for the
+immediate repair because registering and installing an App and minting its
+token adds operational setup beyond this single repository. Reconsider the App
+when a second repository needs this automation, a personal-token rotation
+causes an incident, or the organization standardizes an Actions-dispatch App.
+
+### Continue dispatching with `GITHUB_TOKEN`
+
+Rejected. The worker starts, but GitHub suppresses the terminal callback on
+which automatic recovery and first-plus-latest advancement depend.
+
+### Have the worker send `repository_dispatch`
+
+Rejected. A final job can emit before the workflow is technically terminal,
+creating a recovery race, and cannot report cancellation, startup failure, or
+termination before the notifier runs. Adding polling or a watchdog would create
+another recovery protocol.
+
+### Poll or schedule reconciliation
+
+Rejected as the primary mechanism. It adds delay, spend, and another state
+machine while remaining weaker than GitHub's terminal event. Manual
+`vercel-preview-reconcile` remains an operator recovery tool, not normal
+completion delivery.
+
+### Let the worker write its terminal result
+
+Rejected. A running workflow cannot reliably observe its own final platform
+conclusion, especially cancellation and startup failure, and this would move
+controller write authority into the credential-bearing worker.
+
+## Consequences
+
+- Successful, failed, cancelled, timed-out, and startup-failed workers can
+  produce the existing automatic terminal callback without manual reconcile.
+- One fine-grained credential becomes an operational prerequisite for new
+  preview work. Its absence is explicit and fail-closed.
+- The personal token remains able to perform other Actions-write operations in
+  the selected repository, so repository-only access, minimal permissions,
+  expiration, rotation ownership, and exact call-site tests are required.
+- Existing-worker recovery remains available during token expiry or rotation.
+- Structural tests must fail if the secret reaches another workflow/job, if a
+  reconciliation step overrides the primary `github-token`, or if the worker
+  receives the secret.
+- Unit tests must prove that the secondary client performs only dispatch while
+  primary-client run validation and missing-secret recovery remain intact.
+
+## Evidence
+
+Repository surfaces:
+
+- [Preview controller workflow](../../.github/workflows/vercel-preview-controller.yml)
+- [Preview controller implementation](../../scripts/vercel-preview-controller.mjs)
+- [Preview controller tests](../../scripts/vercel-preview-controller.test.mjs)
+- [Preview workflow structural tests](../../scripts/vercel-preview-workflows.test.mjs)
+- [Vercel deployment runbook](../vercel-deployments.md)
+
+Primary platform documentation:
+
+- [Events triggered by `GITHUB_TOKEN`](https://docs.github.com/en/actions/concepts/security/github_token#when-github_token-triggers-workflow-runs)
+- [Triggering a workflow from a workflow](https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/trigger-a-workflow)
+- [Create a workflow dispatch event](https://docs.github.com/en/rest/actions/workflows#create-a-workflow-dispatch-event)
+- [Fine-grained personal access token permissions](https://docs.github.com/en/rest/authentication/permissions-required-for-fine-grained-personal-access-tokens)
+- [Keeping API credentials secure](https://docs.github.com/en/rest/authentication/keeping-your-api-credentials-secure)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -43,3 +43,4 @@ adds a high-signal surface without a numbered ADR.
 | -------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
 | [0001](0001-github-actions-vercel-deployment-orchestration.md) | GitHub Actions owns Vercel build/deployment orchestration; Vercel remains hosting/runtime |
 | [0002](0002-single-comment-preview-controller-journal.md)      | One canonical pull-request comment stores the preview controller journal                  |
+| [0003](0003-preview-worker-dispatch-authentication.md)         | A dedicated repository-scoped credential dispatches preview workers                       |

--- a/docs/vercel-deployments.md
+++ b/docs/vercel-deployments.md
@@ -232,7 +232,9 @@ These are pulled when they exist but are not missing-build failures.
 `CHAINALYSIS_API_KEY` is optional in the app schema and is not a prebuilt-build
 prerequisite.
 
-### Required GitHub secret mirrors from issue #517
+### Required GitHub secrets
+
+The following Vercel build-value mirrors come from issue #517:
 
 - Repository secret `ETHERSCAN_API_KEY`: governance trusted previews only.
 - `vercel-cli-production` environment secret `ETHERSCAN_API_KEY`: governance
@@ -241,6 +243,24 @@ prerequisite.
   to the governance or reserve production build step that consumes it. If app
   production is ever migrated separately, scope it to that app step as well.
 - Standard previews and app `v3`: no `SENTRY_AUTH_TOKEN`.
+
+The automatic preview controller additionally requires repository Actions
+secret `GH_PREVIEW_WORKFLOW_DISPATCH_TOKEN`. Create a fine-grained GitHub
+personal access token with resource owner `mento-protocol`, access to only the
+`frontend-monorepo` repository, and repository permission `Actions: read and
+write` (implicit metadata read only otherwise). Store it interactively without
+printing or passing its value as an argument:
+
+```bash
+gh secret set GH_PREVIEW_WORKFLOW_DISPATCH_TOKEN \
+  --repo mento-protocol/frontend-monorepo
+```
+
+The token authorizes only the controller's worker `workflow_dispatch` POST. It
+never replaces the controller step's primary `GITHUB_TOKEN` client and never
+enters the worker, reusable Vercel workflow, candidate checkout, journal, log,
+output, or summary. Record an owner, expiration, and rotation date for the
+credential outside the repository.
 
 `vercel-cli-production` is the dedicated GitHub deployment environment for this
 migration. Do not modify or reuse the generic pre-existing `Production`
@@ -636,6 +656,8 @@ A Deployment or status created with the repository `GITHUB_TOKEN` does not
 trigger another workflow run. Therefore `.github/workflows/preview-smoke.yml`
 will not recurse for this pilot. Direct smoke in the reusable worker is the
 required success gate. Do not add a PAT to force `deployment_status` recursion.
+The dedicated worker-dispatch PAT is not an exception; its sole purpose is the
+automatic controller's worker `workflow_dispatch` POST described below.
 
 ### Evidence and browser verification
 
@@ -874,9 +896,22 @@ exact worker or intake workflow path rather than the presentation name, then
 repeat full source validation before any status or Deployment write.
 
 Zero matches dispatches `.github/workflows/vercel-preview-worker.yml` on `main`
-using the HTTP 200 `return_run_details` API contract only while the executing
-controller's own workflow SHA still equals the persisted intent. The returned
-run is re-queried once per second with a bounded 30-second retry-delay budget
+using a secondary Octokit client authenticated only by repository secret
+`GH_PREVIEW_WORKFLOW_DISPATCH_TOKEN`. The fine-grained token is scoped to this
+repository with `Actions: read and write`; it performs only the HTTP 200
+`return_run_details` dispatch POST. The primary `GITHUB_TOKEN` client continues
+all journal, status, Deployment, PR, run-listing, run-validation, and recovery
+operations. The controller never falls back to `GITHUB_TOKEN` for dispatch,
+because a worker created by that token does not produce the terminal
+`workflow_run` callback required by this protocol.
+
+The dispatch occurs only while the executing controller's own workflow SHA
+still equals the persisted intent. If the dedicated secret is missing, the
+controller fails closed immediately before a new dispatch, retains the durable
+`intended` state, and posts an error status through its primary client. The
+secret is not needed to find, attach, validate, or recover an existing worker.
+The returned run is re-queried through the primary client once per second with
+a bounded 30-second retry-delay budget
 because GitHub may temporarily return the workflow's default title before
 materializing the configured `run-name`. API request latency is additive; the
 workflow timeout remains the outer wall-clock bound. Only that exact transient
@@ -896,6 +931,15 @@ worker's completion callback causes the current controller to reselect the same
 desired event entry under its own workflow SHA. The new key therefore advances
 automatically without ever pretending that new workflow code fulfilled the
 retired intent.
+
+For live acceptance, do not issue a manual reconcile. Verify that the worker's
+actor is the fine-grained token owner rather than `github-actions[bot]`, its
+completion automatically creates a controller run with event `workflow_run`,
+terminal recovery succeeds, the same journal gains the result, active ownership
+clears, and `Vercel Preview` becomes terminal at the immutable URL. Repeat with
+a controlled failure and a cancelled worker before Deployment creation, then
+rerun a callback to prove journal, worker, Deployment, and result idempotency.
+Until that evidence exists after provisioning, Phase A remains blocked.
 
 The canonical Deployment key and environment are:
 

--- a/scripts/vercel-preview-controller.mjs
+++ b/scripts/vercel-preview-controller.mjs
@@ -3764,11 +3764,16 @@ async function getWorkerRun(github, context, runId, selected) {
 
 async function dispatchWorker(
   github,
+  workerDispatchGithub,
   context,
   selected,
   { waitForRunDetails = wait } = {},
 ) {
-  const response = await github.request(
+  invariant(
+    workerDispatchGithub !== null && workerDispatchGithub !== undefined,
+    "Worker dispatch credential is unavailable",
+  );
+  const response = await workerDispatchGithub.request(
     "POST /repos/{owner}/{repo}/actions/workflows/{workflow_id}/dispatches",
     {
       ...ownerRepo(context),
@@ -4030,6 +4035,7 @@ async function recoverCompletedOwnedRuns({
 
 export async function reconcilePreview({
   github,
+  workerDispatchGithub = null,
   context,
   core,
   prNumber: rawPr,
@@ -4178,9 +4184,13 @@ export async function reconcilePreview({
         let runDetails = recoveredRun;
         if (!runDetails) {
           try {
-            runDetails = await dispatchWorker(github, context, selected, {
-              waitForRunDetails: waitForRecovery,
-            });
+            runDetails = await dispatchWorker(
+              github,
+              workerDispatchGithub,
+              context,
+              selected,
+              { waitForRunDetails: waitForRecovery },
+            );
           } catch (error) {
             if (error instanceof WorkerWorkflowShaMismatchError) {
               await recordSupersededIntent({

--- a/scripts/vercel-preview-controller.test.mjs
+++ b/scripts/vercel-preview-controller.test.mjs
@@ -47,11 +47,16 @@ const SHA = Object.fromEntries(
     (index + 1).toString(16).repeat(40),
   ]),
 );
+const workerDispatchClients = new WeakMap();
 
 function reconcilePreview(options) {
+  const workerDispatchGithub = Object.hasOwn(options, "workerDispatchGithub")
+    ? options.workerDispatchGithub
+    : workerDispatchClients.get(options.github);
   return reconcilePreviewImplementation({
     workflowSha: SHA.E,
     now: () => timestamp(0),
+    workerDispatchGithub,
     ...options,
   });
 }
@@ -2496,6 +2501,8 @@ function fakeGitHub({
   const workflowRunAttemptRequests = [];
   const workflowRunListRequests = [];
   const workflowRunRequests = [];
+  const primaryRequests = [];
+  const workerDispatchRequests = [];
   const transientDisplayTitles = [...workflowRunDisplayTitles];
   const transientListDisplayTitles = [...workflowRunListDisplayTitles];
   const transientListRunIds = [...workflowRunListRunIds];
@@ -2659,6 +2666,7 @@ function fakeGitHub({
       throw new Error("Unexpected fixture pagination method");
     },
     request: async (route, request) => {
+      primaryRequests.push({ route, request: structuredClone(request) });
       if (
         route ===
         "GET /repos/{owner}/{repo}/actions/runs/{run_id}/attempts/{attempt_number}"
@@ -2687,6 +2695,15 @@ function fakeGitHub({
         }
         return { status: 200, data: structuredClone(data) };
       }
+      throw new Error(`Unexpected primary-client request: ${route}`);
+    },
+  };
+  const workerDispatchGithub = {
+    request: async (route, request) => {
+      workerDispatchRequests.push({
+        route,
+        request: structuredClone(request),
+      });
       assert.equal(
         route,
         "POST /repos/{owner}/{repo}/actions/workflows/{workflow_id}/dispatches",
@@ -2710,8 +2727,10 @@ function fakeGitHub({
       return { status: 200, data: { workflow_run_id: id } };
     },
   };
+  workerDispatchClients.set(github, workerDispatchGithub);
   return {
     github,
+    workerDispatchGithub,
     comments,
     runs,
     deployments,
@@ -2723,6 +2742,8 @@ function fakeGitHub({
     workflowRunAttemptRequests,
     workflowRunListRequests,
     workflowRunRequests,
+    primaryRequests,
+    workerDispatchRequests,
   };
 }
 
@@ -4011,6 +4032,15 @@ test("durable dispatch persists intent and waits for the exact run title to mate
     waitForRecovery: async (milliseconds) => waits.push(milliseconds),
   });
   assert.equal(fixture.dispatches.length, 1);
+  assert.equal(fixture.workerDispatchRequests.length, 1);
+  assert.equal(
+    fixture.workerDispatchRequests[0].route,
+    "POST /repos/{owner}/{repo}/actions/workflows/{workflow_id}/dispatches",
+  );
+  assert.equal(
+    fixture.primaryRequests.some(({ route }) => route.includes("/dispatches")),
+    false,
+  );
   assert.equal(state.ui.active.dispatch_state, "dispatched");
   assert.equal(state.ui.active.workflow_run_id, 8_000);
   assert.equal(state.ui.active.workflow_sha, SHA.E);
@@ -4029,6 +4059,43 @@ test("durable dispatch persists intent and waits for the exact run title to mate
   assert.deepEqual(journal.receipts.events, [opened]);
   assert.equal(journal.receipts.selections.length, 1);
   assert.equal(journal.state.ui.active.dispatch_state, "dispatched");
+});
+
+test("a missing worker dispatch credential fails closed only when a new dispatch is required", async () => {
+  const opened = event({
+    run: 120,
+    action: "opened",
+    head: SHA.A,
+    updated: timestamp(1),
+  });
+  const fixture = fakeGitHub({
+    pullRequest: pull({ head: SHA.A, updated: timestamp(1) }),
+    comments: [journalComment({ events: [opened] })],
+  });
+
+  await assert.rejects(
+    reconcilePreview({
+      github: fixture.github,
+      workerDispatchGithub: null,
+      context: fakeContext(),
+      core: fakeCore(),
+      prNumber: 519,
+      waitForRecovery: async () => {},
+    }),
+    /Worker dispatch credential is unavailable/,
+  );
+
+  assert.equal(fixture.dispatches.length, 0);
+  assert.equal(fixture.workerDispatchRequests.length, 0);
+  assert.equal(
+    fixture.primaryRequests.some(({ route }) => route.includes("/dispatches")),
+    false,
+  );
+  assert.equal(fixture.commitStatuses.at(-1).state, "error");
+  const journal = journalFromComment(fixture.comments[0]);
+  assert.equal(journal.receipts.selections.length, 1);
+  assert.equal(journal.state.ui.active.dispatch_state, "intended");
+  assert.equal(journal.state.ui.active.workflow_run_id, null);
 });
 
 test("durable dispatch fails closed when the exact run title never materializes", async () => {
@@ -4256,12 +4323,14 @@ test("intended dispatch recovery attaches exactly one run and fails closed on am
   });
   const state = await reconcilePreview({
     github: recovered.github,
+    workerDispatchGithub: null,
     context: fakeContext(),
     core: fakeCore(),
     prNumber: 519,
     waitForRecovery: async () => {},
   });
   assert.equal(recovered.dispatches.length, 0);
+  assert.equal(recovered.workerDispatchRequests.length, 0);
   assert.equal(state.ui.active.workflow_run_id, existingRun.id);
 
   const ambiguous = fakeGitHub({

--- a/scripts/vercel-preview-workflows.test.mjs
+++ b/scripts/vercel-preview-workflows.test.mjs
@@ -361,8 +361,61 @@ test("every controller write-token job checks out only trusted workflow code", (
   }
   assert.doesNotMatch(
     read(controllerPath),
-    /secrets\.|VERCEL_TOKEN|TURBO_TOKEN|TURBO_REMOTE_CACHE_SIGNATURE_KEY/,
+    /VERCEL_TOKEN|TURBO_TOKEN|TURBO_REMOTE_CACHE_SIGNATURE_KEY/,
   );
+});
+
+test("only reconciliation steps receive the dedicated worker dispatch credential", () => {
+  const reconciliationJobs = [
+    "reconcile-event",
+    "reconcile-bootstrap",
+    "reconcile-request",
+    "recover-worker-result",
+  ];
+  const secretExpression = "${{ secrets.GH_PREVIEW_WORKFLOW_DISPATCH_TOKEN }}";
+  const raw = read(controllerPath);
+  const secretNames = [...raw.matchAll(/secrets\.([A-Z0-9_]+)/g)].map(
+    ([, name]) => name,
+  );
+  assert.deepEqual(
+    secretNames,
+    Array(4).fill("GH_PREVIEW_WORKFLOW_DISPATCH_TOKEN"),
+  );
+
+  for (const [jobName, job] of Object.entries(controller.jobs)) {
+    for (const step of job.steps ?? []) {
+      const hasDispatchSecret = Object.values(step.env ?? {}).includes(
+        secretExpression,
+      );
+      if (!hasDispatchSecret) continue;
+      assert.ok(
+        reconciliationJobs.includes(jobName),
+        `${jobName} must not receive the worker dispatch credential`,
+      );
+      assert.equal(step.env.WORKER_DISPATCH_TOKEN, secretExpression);
+      assert.equal(Object.hasOwn(step.with ?? {}, "github-token"), false);
+      assert.match(
+        step.with.script,
+        /getOctokit\(process\.env\.WORKER_DISPATCH_TOKEN\)/,
+      );
+      assert.match(step.with.script, /workerDispatchGithub,/);
+    }
+  }
+
+  for (const jobName of reconciliationJobs) {
+    const step = controller.jobs[jobName].steps.find((candidate) =>
+      String(candidate.with?.script ?? "").includes("reconcilePreview"),
+    );
+    assert.ok(step, `${jobName} must invoke reconciliation`);
+    assert.equal(step.env.WORKER_DISPATCH_TOKEN, secretExpression);
+  }
+
+  for (const path of [workerPath, ".github/workflows/_vercel-prebuilt.yml"]) {
+    assert.doesNotMatch(
+      read(path),
+      /GH_PREVIEW_WORKFLOW_DISPATCH_TOKEN|WORKER_DISPATCH_TOKEN/,
+    );
+  }
 });
 
 test("every controller reconciliation binds selections to its immutable workflow SHA", () => {


### PR DESCRIPTION
## The Problem

Preview workers dispatched by the controller with the repository `GITHUB_TOKEN`
run successfully, but GitHub suppresses their terminal `workflow_run` event.
The controller therefore cannot automatically terminalize the preview, recover
cancellation or failure, or advance first-plus-latest scheduling without a later
PR event or manual reconciliation.

## The Solution

Use repository secret `GH_PREVIEW_WORKFLOW_DISPATCH_TOKEN` to create a secondary
Octokit client in the four trusted reconciliation steps. Only the worker
`workflow_dispatch` POST uses that client. The primary `GITHUB_TOKEN` client
continues to own every journal, status, Deployment, run-listing, validation, and
recovery call, with no legacy or fallback dispatch path.

If the secret is missing, the controller fails closed immediately before a new
dispatch while preserving the durable intended selection and error status.
Existing-worker recovery remains available without the secret. The dispatch
credential never enters the worker, reusable Vercel workflow, candidate code,
logs, outputs, or journal.

ADR 0003 records the trust boundary, alternatives, rollout, rotation, and
reconsideration criteria. The deployment runbook documents exact least-privilege
provisioning and live acceptance. This PR must not merge until the repository
secret is provisioned; after merge, acceptance requires an automatic terminal
callback without a manual reconcile.

## Validation

- `pnpm test`
- `pnpm check-types`
- `pnpm quality:budgets:test`
- `pnpm ci:action-pins`
- `pnpm ci:action-pins:test`
- `pnpm adr:check --include-untracked`
- `pnpm adr:check:test`
- `pnpm pr:description:test`
- `trunk fmt`
- `trunk check`
- `git diff --check`
- Structured autoreview: deterministic pass clean; fresh-context semantic pass
  had no accepted finding. Its sole suggestion contradicted the exact pinned
  `actions/github-script` v9 source, which injects `getOctokit` and no longer
  supports the suggested CommonJS import.

## Ship Checklist

- [x] ship skill used
- [x] local review run
- [x] validation run
- [ ] repository secret provisioned
- [ ] automatic callback proven live

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the critical preview orchestration path and adds a new operational secret; scope is narrow (dispatch-only) with fail-closed behavior and tests, but new previews block until the secret is provisioned and live callbacks are proven.
> 
> **Overview**
> Restores dependable **automatic** preview worker completion by stopping `GITHUB_TOKEN`-authenticated `workflow_dispatch`, which started workers but suppressed their terminal `workflow_run` callbacks.
> 
> The four trusted reconciliation steps in `vercel-preview-controller.yml` now receive `GH_PREVIEW_WORKFLOW_DISPATCH_TOKEN`, build a secondary Octokit client with `getOctokit`, and pass `workerDispatchGithub` into `reconcilePreview`. **`dispatchWorker` uses that client only for the worker dispatch POST**; there is no `GITHUB_TOKEN` fallback. Journal, statuses, Deployments, run listing, validation, and recovery stay on the primary client.
> 
> If the secret is missing when a **new** dispatch is required, reconciliation **fails closed** (error status, durable `intended` state preserved). Attaching or recovering an already-created worker does not need the PAT.
> 
> **ADR 0003**, README, and `docs/vercel-deployments.md` document the boundary, provisioning, and live acceptance. Unit and structural tests assert dispatch isolation, missing-secret behavior, and that the secret never reaches the worker or other workflows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b359ff3c91783019c856221e9977277a6b8b3f89. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->