### PR TITLE
test(ci): verify automatic preview callbacks

### DIFF
--- a/apps/ui.mento.org/app/layout.tsx
+++ b/apps/ui.mento.org/app/layout.tsx
@@ -29,7 +29,7 @@ export default function RootLayout({
     <html lang="en" suppressHydrationWarning>
       <body
         className={inter.className}
-        data-vercel-preview-auto-callback-canary="v1"
+        data-vercel-preview-auto-callback-canary="v2-cancel"
       >
         <AppShell>{children}</AppShell>
       </body>

--- a/apps/ui.mento.org/app/layout.tsx
+++ b/apps/ui.mento.org/app/layout.tsx
@@ -27,7 +27,10 @@ export default function RootLayout({
 }): React.ReactElement {
   return (
     <html lang="en" suppressHydrationWarning>
-      <body className={inter.className}>
+      <body
+        className={inter.className}
+        data-vercel-preview-auto-callback-canary="v1"
+      >
         <AppShell>{children}</AppShell>
       </body>
     </html>


### PR DESCRIPTION
## The Problem

The preview controller callback-auth change needs live end-to-end proof that a controller-dispatched worker automatically produces a trusted `workflow_run` callback without manual reconciliation.

## The Solution

This temporary canary adds one inert, browser-detectable data attribute to the UI showcase body. Keep this PR open and unmerged while the automatic success, cancellation, and idempotency paths are verified; close it unmerged after the canary is complete.

## Validation

- `pnpm --filter ui.mento.org check-types`
- `trunk check apps/ui.mento.org/app/layout.tsx`
- `pnpm adr:check`
- `git diff --check`
- focused independent diff review: approved, no findings
- normal pre-push typecheck hook passed

## Ship Checklist

- [x] ship skill used
- [x] local review run
- [x] validation run
- [ ] automatic callback observed without manual recovery
- [ ] exact deployed preview browser-verified

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single inert HTML data attribute on the showcase layout; no auth, data, or runtime behavior changes.
> 
> **Overview**
> Adds a temporary **canary marker** on the UI showcase root layout so deployed Vercel previews can be identified in the browser while validating automatic `workflow_run` callbacks (no manual reconciliation).
> 
> The only code change is `data-vercel-preview-auto-callback-canary="v1"` on the `<body>` in `apps/ui.mento.org/app/layout.tsx`. The attribute is inert and intended to stay **open and unmerged** until success, cancellation, and idempotency paths are verified, then removed without merging.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1112c080f164d418764f72afe4ae246d4af48b33. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->