### PR TITLE
test(ci): run Phase A preview batching canary

### DIFF
--- a/apps/ui.mento.org/app/layout.tsx
+++ b/apps/ui.mento.org/app/layout.tsx
@@ -27,7 +27,7 @@ export default function RootLayout({
 }): React.ReactElement {
   return (
     <html lang="en" suppressHydrationWarning>
-      <body className={inter.className} data-vercel-preview-phase-a="A">
+      <body className={inter.className} data-vercel-preview-phase-a="B">
         <AppShell>{children}</AppShell>
       </body>
     </html>

--- a/apps/ui.mento.org/app/layout.tsx
+++ b/apps/ui.mento.org/app/layout.tsx
@@ -27,7 +27,7 @@ export default function RootLayout({
 }): React.ReactElement {
   return (
     <html lang="en" suppressHydrationWarning>
-      <body className={inter.className} data-vercel-preview-phase-a="C">
+      <body className={inter.className} data-vercel-preview-phase-a="E">
         <AppShell>{children}</AppShell>
       </body>
     </html>

--- a/apps/ui.mento.org/app/layout.tsx
+++ b/apps/ui.mento.org/app/layout.tsx
@@ -27,7 +27,7 @@ export default function RootLayout({
 }): React.ReactElement {
   return (
     <html lang="en" suppressHydrationWarning>
-      <body className={inter.className}>
+      <body className={inter.className} data-vercel-preview-phase-a="A">
         <AppShell>{children}</AppShell>
       </body>
     </html>

--- a/apps/ui.mento.org/app/layout.tsx
+++ b/apps/ui.mento.org/app/layout.tsx
@@ -27,7 +27,7 @@ export default function RootLayout({
 }): React.ReactElement {
   return (
     <html lang="en" suppressHydrationWarning>
-      <body className={inter.className} data-vercel-preview-phase-a="B">
+      <body className={inter.className} data-vercel-preview-phase-a="C">
         <AppShell>{children}</AppShell>
       </body>
     </html>

--- a/docs/vercel-preview-phase-a-canary.md
+++ b/docs/vercel-preview-phase-a-canary.md
@@ -1,0 +1,4 @@
+# Vercel preview Phase A canary
+
+This documentation-only commit is marker D in the temporary A/B/C/D/E live
+preview batching canary for issue #519.


### PR DESCRIPTION
## The Problem

Issue #519 still needs live evidence that the GitHub-driven Vercel preview controller preserves the first runtime build, coalesces an overlapping push burst to only the latest runtime SHA, reuses that preview for a documentation-only push, and deploys a later runtime push after becoming idle.

## The Solution

Start a temporary trusted same-repository canary at marker A. This PR will receive preconstructed B, C, D, and E commits through exact-SHA pushes while its preview automation is observed. It will be closed unmerged after the evidence is collected.

## Validation

- Each A/B/C/D/E parent-to-child transition was run through `scripts/plan-vercel-deployments.mjs` locally.
- A, B, C, and E select only `ui`; D is `non-runtime-only` with no deployment target.
- `git diff --check origin/main..HEAD`
- `pnpm adr:check`
- Repository-wide `Vercel Preview Worker` queue verified idle before A.

## Ship Checklist

- [x] ship skill used
- [x] local review run
- [x] validation run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single data attribute on the app shell for CI canary identification; no auth, data, or production logic touched.
> 
> **Overview**
> Adds a **`data-vercel-preview-phase-a="A"`** attribute on the root `<body>` in `apps/ui.mento.org/app/layout.tsx` so the Phase A canary commit is identifiable during live observation of the GitHub-driven Vercel preview controller (first runtime build, burst coalescing, doc-only reuse, later runtime deploy).
> 
> No behavior, routing, or styling changes beyond that DOM marker for the temporary same-repo canary described in the PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97c48f6967ecd0e1575a1ebe0d15a2f5714eeb20. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->