### PR TITLE
chore(ci): validate Dependabot-ref preview isolation

### DIFF
--- a/docs/canaries/vercel-preview-dependabot-ref-canary-194620.md
+++ b/docs/canaries/vercel-preview-dependabot-ref-canary-194620.md
@@ -1,0 +1,3 @@
+# Dependabot-ref preview canary
+
+Temporary documentation-only marker for validating the unsupported preview path for a same-repository `dependabot/*` branch.


### PR DESCRIPTION
## The Problem

Issue #519 still needs live evidence that a same-repository branch classified by the `dependabot/*` ref boundary cannot enter the credentialed GitHub-driven Vercel preview path. This is a temporary canary PR and must be closed unmerged after the evidence is collected.

## The Solution

Add one documentation-only marker on a `dependabot/*` branch. The expected result is a successful `Vercel Preview` unsupported status for the exact SHA, with no preview worker, GitHub Deployment, preview journal, credentialed reusable preview job, or native Vercel Git deployment.

This proves the branch-name classifier only; the PR author is a maintainer, not the literal `dependabot[bot]` actor.

## Validation

- `pnpm vercel:preview:test` (112/112)
- `pnpm adr:check`
- `trunk check docs/canaries/vercel-preview-dependabot-ref-canary-194620.md`
- repository pre-push checks (`check-types`, Trunk, Knip)

## Ship Checklist

- [x] ship skill used
- [x] local review run
- [x] validation run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only addition with no runtime, auth, or deployment behavior changes.
>
> **Overview**
> Adds a **temporary, docs-only** marker at `docs/canaries/vercel-preview-dependabot-ref-canary-194620.md` so CI can exercise a same-repo branch on `dependabot/*` and confirm it stays on the **unsupported** Vercel preview path (unsupported `Vercel Preview` status, no credentialed preview worker / deployment / journal).
>
> This PR is meant to be **closed unmerged** after evidence is collected; it does not change preview logic, Vercel config, or workflows—only the canary doc for issue #519 validation.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d87871c8ab877d1ed92cb2fafc7b378a1f56387d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- dependabot-ref-retest:2026-07-17T20:19:07Z -->
