### PR TITLE
fix(ci): bind Dependabot intake to PR metadata

### DIFF
--- a/docs/vercel-deployments.md
+++ b/docs/vercel-deployments.md
@@ -693,10 +693,17 @@ with only `contents: read`, performs metadata validation without a checkout,
 artifact, secret, or PR-code execution, and encodes the PR number, exact head
 SHA, and action in its strict run name. A completed-intake `workflow_run` then
 starts trusted default-branch controller code with a write-capable token. That
-follow-up validates the intake workflow identity, re-queries the PR, and posts
-the successful preview-disabled status only when the PR is still open, still
-Dependabot-owned/ref-classified, and still on the encoded exact SHA. Stale or
-malformed callbacks write nothing.
+follow-up validates the intake workflow identity and its one immutable PR link:
+the run's candidate head ref/SHA must match the linked PR and encoded receipt,
+while the linked base must remain this repository's `main` branch. GitHub
+reports the candidate branch, not the workflow-definition branch, in a
+`pull_request_target` run's `head_branch` field. The controller then re-queries
+the PR and posts the successful preview-disabled status only when the PR is
+still open, still Dependabot-owned/ref-classified, and still on the encoded
+exact SHA. Stale or malformed callbacks write nothing.
+For a closed event GitHub may omit the run's PR association; that one case
+still binds the strict receipt SHA to the run head and is write-inert by
+definition.
 
 GitHub runs `repository_dispatch` from the last commit and workflow definition
 on the default branch; unlike `workflow_dispatch`, its request cannot select a

--- a/scripts/vercel-preview-controller.mjs
+++ b/scripts/vercel-preview-controller.mjs
@@ -3135,6 +3135,7 @@ export function validateDependabotIntakeWorkflowRun(rawRun) {
     run.display_title,
     "Dependabot intake display title",
   );
+  const parsed = parseDependabotIntakeRunName(displayTitle);
   const workflowName = boundedText(run.name, "Dependabot intake workflow name");
   invariant(
     workflowName === INTAKE_WORKFLOW_NAME || workflowName === displayTitle,
@@ -3149,8 +3150,89 @@ export function validateDependabotIntakeWorkflowRun(rawRun) {
     run.event === "pull_request_target",
     "Dependabot intake event mismatch",
   );
-  invariant(run.head_branch === "main", "Dependabot intake ref mismatch");
-  exactSha(run.head_sha, "Dependabot intake workflow SHA");
+  const runHeadRef = validatedHeadRef(run.head_branch);
+  const runHeadSha = exactSha(run.head_sha, "Dependabot intake head SHA");
+  invariant(runHeadSha === parsed.sha, "Dependabot intake head SHA mismatch");
+  const runHeadRepository = plainObject(
+    run.head_repository,
+    "Dependabot intake head repository",
+  );
+  const runHeadRepositoryName = boundedText(
+    runHeadRepository.full_name,
+    "Dependabot intake head repository name",
+  );
+  const runHeadRepositoryUrl = optionalHttpsUrl(
+    runHeadRepository.url,
+    "Dependabot intake head repository URL",
+  );
+  invariant(
+    runHeadRepositoryUrl ===
+      `https://api.github.com/repos/${runHeadRepositoryName}`,
+    "Dependabot intake head repository mismatch",
+  );
+  invariant(
+    Array.isArray(run.pull_requests) &&
+      run.pull_requests.length <= 1 &&
+      (run.pull_requests.length === 1 || parsed.action === "closed"),
+    "Dependabot intake PR linkage mismatch",
+  );
+  if (run.pull_requests.length === 1) {
+    const linkedPull = plainObject(
+      run.pull_requests[0],
+      "Dependabot intake linked PR",
+    );
+    const linkedHead = plainObject(
+      linkedPull.head,
+      "Dependabot intake linked PR head",
+    );
+    const linkedHeadRepository = plainObject(
+      linkedHead.repo,
+      "Dependabot intake linked PR head repository",
+    );
+    const linkedBase = plainObject(
+      linkedPull.base,
+      "Dependabot intake linked PR base",
+    );
+    const linkedBaseRepository = plainObject(
+      linkedBase.repo,
+      "Dependabot intake linked PR base repository",
+    );
+    const linkedHeadRef = validatedHeadRef(linkedHead.ref);
+    const linkedHeadSha = exactSha(
+      linkedHead.sha,
+      "Dependabot intake linked PR head SHA",
+    );
+    invariant(
+      pullRequestNumber(linkedPull.number) === parsed.pr &&
+        optionalHttpsUrl(linkedPull.url, "Dependabot intake linked PR URL") ===
+          `https://api.github.com/repos/${PREVIEW_REPOSITORY}/pulls/${parsed.pr}`,
+      "Dependabot intake linked PR identity mismatch",
+    );
+    invariant(
+      runHeadRef === linkedHeadRef,
+      "Dependabot intake head ref mismatch",
+    );
+    invariant(
+      runHeadSha === linkedHeadSha,
+      "Dependabot intake head SHA mismatch",
+    );
+    invariant(
+      optionalHttpsUrl(
+        linkedHeadRepository.url,
+        "Dependabot intake linked PR head repository URL",
+      ) === runHeadRepositoryUrl,
+      "Dependabot intake linked PR head repository mismatch",
+    );
+    invariant(
+      linkedBase.ref === "main" &&
+        optionalHttpsUrl(
+          linkedBaseRepository.url,
+          "Dependabot intake linked PR base repository URL",
+        ) === `https://api.github.com/repos/${PREVIEW_REPOSITORY}`,
+      "Dependabot intake default-branch trust mismatch",
+    );
+    exactSha(linkedBase.sha, "Dependabot intake trusted base SHA");
+  }
   exactRunId(run.id, "Dependabot intake workflow run ID");
   invariant(
     run.status === "completed" && run.conclusion === "success",
@@ -3160,7 +3242,7 @@ export function validateDependabotIntakeWorkflowRun(rawRun) {
     run.repository?.full_name,
     "Dependabot intake workflow repository",
   );
-  return parseDependabotIntakeRunName(displayTitle);
+  return parsed;
 }
 
 export async function publishDependabotUnsupported({

--- a/scripts/vercel-preview-controller.test.mjs
+++ b/scripts/vercel-preview-controller.test.mjs
@@ -2377,18 +2377,50 @@ function dependabotIntakeRun({
   pr = 519,
   sha = SHA.A,
   action = "opened",
+  headRef = "dependabot/npm/pnpm",
+  headRepository = PREVIEW_REPOSITORY,
+  baseRef = "main",
+  baseRepository = PREVIEW_REPOSITORY,
   ...overrides
 } = {}) {
+  const [, headRepositoryName] = headRepository.split("/");
+  const [, baseRepositoryName] = baseRepository.split("/");
   return {
     id: 7_500,
     name: "Vercel Preview Intake",
     path: ".github/workflows/vercel-preview-intake.yml@main",
     event: "pull_request_target",
-    head_branch: "main",
-    head_sha: SHA.E,
+    head_branch: headRef,
+    head_sha: sha,
+    head_repository: {
+      full_name: headRepository,
+      url: `https://api.github.com/repos/${headRepository}`,
+    },
     status: "completed",
     conclusion: "success",
     repository: { full_name: PREVIEW_REPOSITORY },
+    pull_requests: [
+      {
+        number: pr,
+        url: `https://api.github.com/repos/${PREVIEW_REPOSITORY}/pulls/${pr}`,
+        head: {
+          ref: headRef,
+          sha,
+          repo: {
+            name: headRepositoryName,
+            url: `https://api.github.com/repos/${headRepository}`,
+          },
+        },
+        base: {
+          ref: baseRef,
+          sha: SHA.E,
+          repo: {
+            name: baseRepositoryName,
+            url: `https://api.github.com/repos/${baseRepository}`,
+          },
+        },
+      },
+    ],
     display_title: dependabotIntakeRunName({ pr, sha, action }),
     html_url:
       "https://github.com/mento-protocol/frontend-monorepo/actions/runs/7500",
@@ -3807,8 +3839,11 @@ test("closed reconciliation preserves an unbound intent without dispatching it",
   assert.equal(journal.state.closed, true);
 });
 
-test("trusted workflow_run follow-up publishes Dependabot unsupported status only for the exact current head", async () => {
+test("trusted workflow_run follow-up binds the candidate PR ref and publishes Dependabot unsupported status only for the exact current head", async () => {
   const workflowRun = dependabotIntakeRun();
+  assert.equal(workflowRun.head_branch, "dependabot/npm/pnpm");
+  assert.equal(workflowRun.head_sha, SHA.A);
+  assert.equal(workflowRun.pull_requests[0].base.ref, "main");
   assert.deepEqual(validateDependabotIntakeWorkflowRun(workflowRun), {
     pr: 519,
     sha: SHA.A,
@@ -3880,7 +3915,58 @@ test("trusted workflow_run follow-up publishes Dependabot unsupported status onl
   }
 });
 
+test("closed Dependabot intake without a GitHub PR association stays write-inert", async () => {
+  const workflowRun = dependabotIntakeRun({
+    action: "closed",
+    pull_requests: [],
+  });
+  assert.deepEqual(validateDependabotIntakeWorkflowRun(workflowRun), {
+    pr: 519,
+    sha: SHA.A,
+    action: "closed",
+  });
+  const fixture = fakeGitHub({
+    pullRequest: pull({
+      head: SHA.A,
+      state: "closed",
+      author: "dependabot[bot]",
+      ref: "dependabot/npm/pnpm",
+      updated: timestamp(2),
+    }),
+    comments: [],
+  });
+  const core = fakeCore();
+  assert.equal(
+    await publishDependabotUnsupported({
+      github: fixture.github,
+      context: fakeContext({ workflowRun }),
+      core,
+    }),
+    null,
+  );
+  assert.equal(fixture.commitStatuses.length, 0);
+  assert.equal(core.outputs.get("status_published"), "false");
+});
+
 test("malformed Dependabot intake identity fails before any status write", async () => {
+  const mismatchedHeadRef = dependabotIntakeRun();
+  mismatchedHeadRef.pull_requests[0].head.ref = "dependabot/npm/other";
+  const mismatchedLinkedHeadSha = dependabotIntakeRun();
+  mismatchedLinkedHeadSha.pull_requests[0].head.sha = SHA.B;
+  const mismatchedLinkedPull = dependabotIntakeRun();
+  mismatchedLinkedPull.pull_requests[0].number = 520;
+  const mismatchedLinkedPullUrl = dependabotIntakeRun();
+  mismatchedLinkedPullUrl.pull_requests[0].url =
+    "https://api.github.com/repos/attacker/example/pulls/519";
+  const mismatchedLinkedHeadRepository = dependabotIntakeRun();
+  mismatchedLinkedHeadRepository.pull_requests[0].head.repo.url =
+    "https://api.github.com/repos/attacker/example";
+  const multipleLinkedPulls = dependabotIntakeRun();
+  multipleLinkedPulls.pull_requests.push(
+    structuredClone(multipleLinkedPulls.pull_requests[0]),
+  );
+  const closedWithConflictingLink = dependabotIntakeRun({ action: "closed" });
+  closedWithConflictingLink.pull_requests[0].head.sha = SHA.B;
   for (const workflowRun of [
     dependabotIntakeRun({ name: "Vercel Preview Worker" }),
     dependabotIntakeRun({
@@ -3892,6 +3978,17 @@ test("malformed Dependabot intake identity fails before any status write", async
     dependabotIntakeRun({
       repository: { full_name: "attacker/example" },
     }),
+    dependabotIntakeRun({ head_sha: SHA.B }),
+    dependabotIntakeRun({ pull_requests: [] }),
+    mismatchedHeadRef,
+    mismatchedLinkedHeadSha,
+    mismatchedLinkedPull,
+    mismatchedLinkedPullUrl,
+    mismatchedLinkedHeadRepository,
+    multipleLinkedPulls,
+    dependabotIntakeRun({ baseRef: "feature/untrusted-base" }),
+    dependabotIntakeRun({ baseRepository: "attacker/example" }),
+    closedWithConflictingLink,
   ]) {
     const fixture = fakeGitHub({
       pullRequest: pull({


### PR DESCRIPTION
## The Problem

The credentialless Dependabot preview intake succeeds, but its trusted `workflow_run` follow-up rejects live `pull_request_target` metadata with `Dependabot intake ref mismatch`. GitHub reports the candidate PR branch in the triggering run's `head_branch`, not `main`; canary PR #560 demonstrated the failure in intake run `29609105971` and controller run `29609114571`.

That leaves the exact canary SHA without the explicit successful unsupported `Vercel Preview` status even though no credentialed worker or Deployment is created.

## The Solution

Bind the strict intake run-name receipt to GitHub's immutable workflow-run PR metadata instead of requiring a literal `main` head ref:

- match the run head SHA/ref to the encoded receipt and linked PR;
- require one exact PR association, the expected `main` base, and the expected base repository before a write-eligible follow-up;
- bind the linked head repository to the run head repository without assuming the head is the base repository;
- allow GitHub's missing closed-PR association only for the already write-inert `closed` action;
- document the platform distinction and add positive, mismatch, cross-repository, and closed-event regression coverage.

This is a routine correction inside the existing preview trust boundary, so no new architecture decision is introduced.

Refs #519 and #560.

## Validation

- `pnpm vercel:preview:test` (113/113)
- `pnpm ci:action-pins` (22 workflow/composite files)
- `pnpm ci:action-pins:test` (48 + 11)
- `pnpm adr:check`
- `pnpm adr:check:test` (9/9)
- `trunk check scripts/vercel-preview-controller.mjs scripts/vercel-preview-controller.test.mjs docs/vercel-deployments.md`
- `git diff --check`
- repository pre-push checks (`check-types`, Trunk, Knip)
- structured autoreview: fresh-context semantic review clean; deterministic review clean

## Ship Checklist

- [x] ship skill used
- [x] local review run
- [x] validation run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes trust-boundary validation for Dependabot preview status publishing; incorrect rules could block legitimate statuses or weaken checks, but scope is limited to existing intake follow-up logic with expanded regression tests.
> 
> **Overview**
> Fixes Dependabot preview intake where the trusted `workflow_run` follow-up failed with **Dependabot intake ref mismatch** because validation required `head_branch === "main"` while GitHub sets `head_branch` to the **candidate PR branch** on `pull_request_target` runs.
> 
> **`validateDependabotIntakeWorkflowRun`** now ties the strict intake run-name receipt to immutable workflow-run PR metadata: run head ref/SHA must match the encoded receipt and (when present) the single linked PR; linked base must be **`main`** on the expected repo; head repository URLs must align without assuming head equals base repo. **`closed`** may omit `pull_requests` (GitHub quirk) and still validates receipt SHA against run head—writes stay inert when the PR is already closed.
> 
> Docs in **`vercel-deployments.md`** describe this platform behavior. Tests use realistic Dependabot branch/SHA/`pull_requests` payloads plus mismatch, cross-repo, multi-link, and closed-without-association cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6304da2696213082b564876dd680d9b78ba8a108. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->