### PR TITLE
fix(ci): make preview reconcile replays idempotent

### DIFF
--- a/docs/vercel-deployments.md
+++ b/docs/vercel-deployments.md
@@ -848,6 +848,24 @@ trust boundary, durably coalesced, failure, or controller error. Detailed
 PR/SHA/key/run/Deployment evidence remains in the canonical journal because
 status descriptions are bounded.
 
+Terminal status targets are durable evidence rather than the URL of whichever
+controller invocation happened to reconcile them. Verified uploads, including
+uploads that later fail smoke, point at the immutable `vercel.app` deployment;
+terminal failures without an upload point at their exact worker run. Outcomes
+that have no more specific artifact, such as no-runtime, coalesced, or
+unsupported events, retain the target already recorded in their terminal
+journal decision.
+
+An exact canonical replay leaves the journal revision, digest, and status
+decision unchanged. Only in that unchanged-state case, the controller reads one
+newest-first, 100-row page of commit statuses and suppresses a write when the
+latest `Vercel Preview` entry was created by `github-actions[bot]` and exactly
+matches state, description, and normalized target URL. A missing, mismatched,
+foreign-authored, malformed, or temporarily unreadable witness never blocks
+reconciliation: the controller conservatively writes the canonical status
+again, so an externally deleted or altered status is repaired while a genuine
+pending-to-terminal or target transition remains visible.
+
 For each open/reopen/base-retarget/bootstrap epoch, the oldest journal event
 entry that actually affects the UI is `first_eligible_sha`. It always runs
 first. An identical bootstrap aliases an existing lifecycle anchor instead of

--- a/scripts/vercel-preview-controller.mjs
+++ b/scripts/vercel-preview-controller.mjs
@@ -279,11 +279,12 @@ function parseJournalBody(body) {
   return JSON.parse(body.slice(prefix.length, -suffix.length));
 }
 
+function isTrustedGitHubActionsBot(actor) {
+  return actor?.type === "Bot" && actor?.login === "github-actions[bot]";
+}
+
 function isTrustedBotComment(comment) {
-  return (
-    comment?.user?.type === "Bot" &&
-    comment?.user?.login === "github-actions[bot]"
-  );
+  return isTrustedGitHubActionsBot(comment?.user);
 }
 
 function classifyTrust({ headRepository, headRef, author }) {
@@ -1232,7 +1233,7 @@ function statusFromCheckpointRuntime({
       description: cancelled
         ? `Runtime preview ${runtimeEvent.head_sha.slice(0, 7)} was cancelled`
         : `Runtime preview ${runtimeEvent.head_sha.slice(0, 7)} failed`,
-      target_url: controllerUrl,
+      target_url: checkpointStatus.target_url ?? controllerUrl,
     };
   }
   if (checkpointStatus.state === "pending") {
@@ -1247,7 +1248,7 @@ function statusFromCheckpointRuntime({
     sha: event.head_sha,
     state: "error",
     description: `Runtime preview ${runtimeEvent.head_sha.slice(0, 7)} errored`,
-    target_url: controllerUrl,
+    target_url: checkpointStatus.target_url ?? controllerUrl,
   };
 }
 
@@ -1287,7 +1288,7 @@ function statusDecision({
       sha: event.head_sha,
       state: "failure",
       description: "UI preview build, deploy, or smoke failed",
-      target_url: controllerUrl,
+      target_url: terminalResultUrl(result, controllerUrl),
     };
   }
   if (eligible && result?.state === "error") {
@@ -1298,7 +1299,7 @@ function statusDecision({
       description: cancelled
         ? "UI preview worker was cancelled"
         : "UI preview controller or infrastructure error",
-      target_url: controllerUrl,
+      target_url: terminalResultUrl(result, controllerUrl),
     };
   }
   if (!eligible) {
@@ -1344,7 +1345,7 @@ function statusDecision({
         sha: event.head_sha,
         state: "failure",
         description: `Runtime preview ${priorRuntime.head_sha.slice(0, 7)} failed`,
-        target_url: controllerUrl,
+        target_url: terminalResultUrl(priorResult, controllerUrl),
       };
     }
     if (priorResult?.state === "error") {
@@ -1355,7 +1356,7 @@ function statusDecision({
         description: cancelled
           ? `Runtime preview ${priorRuntime.head_sha.slice(0, 7)} was cancelled`
           : `Runtime preview ${priorRuntime.head_sha.slice(0, 7)} errored`,
-        target_url: controllerUrl,
+        target_url: terminalResultUrl(priorResult, controllerUrl),
       };
     }
     return {
@@ -1380,6 +1381,39 @@ function statusDecision({
     description: "UI preview queued or running",
     target_url: active?.html_url ?? controllerUrl,
   };
+}
+
+function terminalResultUrl(result, controllerUrl) {
+  if (result?.vercel_deployment_url) {
+    return immutableVercelUrl(result.vercel_deployment_url);
+  }
+  if (result?.worker_run_id) {
+    return `https://github.com/${PREVIEW_REPOSITORY}/actions/runs/${exactRunId(
+      result.worker_run_id,
+      "Terminal worker run ID",
+    )}`;
+  }
+  return controllerUrl;
+}
+
+function preserveSettledControllerTarget(
+  decision,
+  previousBySha,
+  controllerUrl,
+) {
+  const previous = previousBySha.get(decision.sha);
+  if (
+    TERMINAL_STATES.has(decision.state) &&
+    decision.target_url === controllerUrl &&
+    previous?.state === decision.state &&
+    previous.description === decision.description
+  ) {
+    return {
+      ...decision,
+      target_url: previous.target_url,
+    };
+  }
+  return decision;
 }
 
 function statusFromPendingRuntimeResult({
@@ -1992,22 +2026,32 @@ export function reconcileState({
       target_url: active.html_url ?? controllerTargetUrl,
     };
   }
+  const previousStatusBySha = new Map(
+    (previous?.status_decisions ?? []).map((decision) => [
+      decision.sha,
+      decision,
+    ]),
+  );
   const statuses = lineage.map((event, index) =>
-    statusDecision({
-      event,
-      index,
-      lineage,
-      resultByRun,
-      active,
-      coalescedToByRun,
-      controllerUrl: controllerTargetUrl,
-      checkpointStatus:
-        selectedCheckpoint?.event.event_run_id === event.event_run_id
-          ? effectiveCheckpointStatus
-          : null,
-      checkpointBaselineStatus: effectiveCheckpointStatus,
-      checkpointBaselineEvent: selectedCheckpoint?.event ?? null,
-    }),
+    preserveSettledControllerTarget(
+      statusDecision({
+        event,
+        index,
+        lineage,
+        resultByRun,
+        active,
+        coalescedToByRun,
+        controllerUrl: controllerTargetUrl,
+        checkpointStatus:
+          selectedCheckpoint?.event.event_run_id === event.event_run_id
+            ? effectiveCheckpointStatus
+            : null,
+        checkpointBaselineStatus: effectiveCheckpointStatus,
+        checkpointBaselineEvent: selectedCheckpoint?.event ?? null,
+      }),
+      previousStatusBySha,
+      controllerTargetUrl,
+    ),
   );
   const successes = [...resultByRun.entries()]
     .filter(([, result]) => result.state === "success")
@@ -3472,7 +3516,7 @@ async function postStatusDecisions(
   github,
   context,
   decisions,
-  { assertBasis } = {},
+  { assertBasis, suppressExactReplay = false } = {},
 ) {
   const latestBySha = new Map(
     decisions.map((decision) => [decision.sha, decision]),
@@ -3491,6 +3535,38 @@ async function postStatusDecisions(
         decision.target_url,
         "Status target URL",
       );
+    if (suppressExactReplay) {
+      let latest = null;
+      try {
+        const { data: statuses } =
+          await github.rest.repos.listCommitStatusesForRef({
+            ...ownerRepo(context),
+            ref: request.sha,
+            per_page: 100,
+          });
+        // GitHub returns commit statuses newest first. Only an exact latest
+        // witness may suppress a replay; a missing first-page match writes
+        // conservatively instead of relying on an unbounded history scan.
+        if (Array.isArray(statuses)) {
+          latest = statuses.find(
+            (status) => status.context === PREVIEW_STATUS_CONTEXT,
+          );
+        }
+      } catch {
+        // This lookup is only a duplicate-write optimization. A transient read
+        // failure must not replace settled preview truth with a controller error.
+      }
+      if (
+        isTrustedGitHubActionsBot(latest?.creator) &&
+        latest?.state === request.state &&
+        latest.description === request.description &&
+        (latest.target_url ?? null) === (request.target_url ?? null)
+      ) {
+        if (assertBasis) await assertBasis();
+        continue;
+      }
+    }
+    if (assertBasis) await assertBasis();
     await github.rest.repos.createCommitStatus(request);
     if (assertBasis) await assertBasis();
   }
@@ -4132,6 +4208,8 @@ export async function reconcilePreview({
     try {
       const pull = await pullFromApi(github, context, pr);
       const parsed = await loadPreviewJournal(github, context, pr);
+      const stateBeforeReconciliation =
+        parsed.state === null ? null : canonicalJson(parsed.state);
       if (
         await recoverCompletedOwnedRuns({
           github,
@@ -4366,6 +4444,9 @@ export async function reconcilePreview({
       await assertStatusBasis();
       await postStatusDecisions(github, context, state.status_decisions, {
         assertBasis: assertStatusBasis,
+        suppressExactReplay:
+          stateBeforeReconciliation !== null &&
+          stateBeforeReconciliation === canonicalJson(state),
       });
       core.setOutput("pr_number", String(pr));
       return state;

--- a/scripts/vercel-preview-controller.test.mjs
+++ b/scripts/vercel-preview-controller.test.mjs
@@ -212,6 +212,9 @@ function result(
     runId = 8_000,
     state = "success",
     reason = state === "success" ? "verified" : "worker-failure",
+    vercelDeploymentUrl = state === "success"
+      ? `https://ui-${runId}.vercel.app`
+      : null,
   } = {},
 ) {
   return validateWorkerResult({
@@ -232,8 +235,7 @@ function result(
     state,
     vercel_deployment_id: state === "success" ? `dpl_${runId}` : null,
     next_deployment_id: state === "success" ? `m-ui-${runId}` : null,
-    vercel_deployment_url:
-      state === "success" ? `https://ui-${runId}.vercel.app` : null,
+    vercel_deployment_url: vercelDeploymentUrl,
     smoke_result: state === "success" ? "passed" : "failed",
     terminal_reason: reason,
   });
@@ -2138,7 +2140,7 @@ test("docs-only checkpoint tails preserve prior runtime terminal semantics", () 
       decision.target_url,
       terminalCase.state === "success"
         ? `https://ui-${workerRunId}.vercel.app`
-        : CONTROLLER_URL,
+        : `https://github.com/${PREVIEW_REPOSITORY}/actions/runs/${workerRunId}`,
     );
   }
 
@@ -2504,12 +2506,14 @@ function fakeGitHub({
   deployments: initialDeployments = [],
   deploymentStatuses = new Map(),
   existingCommitStatuses = new Map(),
+  commitStatusListFailures = [],
   commitStatusFailures = [],
   workflowRunDisplayTitles = [],
   workflowRunListDisplayTitles = [],
   workflowRunListRunIds = [],
   pullRequests = [],
   beforeListComments,
+  beforeListCommitStatuses,
 } = {}) {
   const comments = structuredClone(initialComments);
   const runs = structuredClone(initialRuns);
@@ -2541,15 +2545,34 @@ function fakeGitHub({
   const transientPullRequests = [...pullRequests];
   const attemptFailures = [...workflowRunAttemptFailures];
   const commentUpdateFailures = [...updateCommentFailures];
+  const commitStatusListFailureQueue = [...commitStatusListFailures];
   const commitStatusFailureQueue = [...commitStatusFailures];
   const commentUpdateFailureIds = new Set(updateCommentFailureIds);
   let nextCommentId = 100;
   let nextDeploymentId = 9_000;
   let listCommentRequests = 0;
+  let listCommitStatusRequests = 0;
   const listComments = async () => {};
   const listCommits = async () => {};
   const listDeployments = async () => {};
-  const listCommitStatusesForRef = async () => {};
+  const listCommitStatusesForRef = async ({ ref, per_page = 100 }) => {
+    listCommitStatusRequests += 1;
+    beforeListCommitStatuses?.({
+      requestCount: listCommitStatusRequests,
+      comments,
+    });
+    const failureStatus = commitStatusListFailureQueue.shift();
+    if (failureStatus) {
+      const error = new Error("fixture commit status read failed");
+      error.status = failureStatus;
+      throw error;
+    }
+    return {
+      data: structuredClone(
+        (commitStatusHistory.get(String(ref)) ?? []).slice(0, per_page),
+      ),
+    };
+  };
   const github = {
     rest: {
       issues: {
@@ -2801,6 +2824,484 @@ function fakeCore() {
     },
   };
 }
+
+function previewCommitStatuses(decisions) {
+  const statuses = new Map();
+  for (const decision of decisions) {
+    statuses.set(decision.sha, [
+      {
+        context: "Vercel Preview",
+        state: decision.state,
+        description: decision.description,
+        target_url: new URL(decision.target_url).toString(),
+        creator: { type: "Bot", login: "github-actions[bot]" },
+      },
+    ]);
+  }
+  return statuses;
+}
+
+async function assertSettledReplayIsIdempotent({
+  events,
+  pullRequest,
+  state,
+  selections = [],
+  results = [],
+  runId,
+}) {
+  const comment = journalComment({
+    revision: 7,
+    events,
+    selections,
+    results,
+    state,
+  });
+  const before = journalFromComment(comment);
+  const fixture = fakeGitHub({
+    pullRequest,
+    comments: [comment],
+    existingCommitStatuses: previewCommitStatuses(state.status_decisions),
+  });
+
+  await reconcilePreview({
+    github: fixture.github,
+    context: fakeContext({ runId }),
+    core: fakeCore(),
+    prNumber: pullRequest.number,
+  });
+
+  assert.deepEqual(journalFromComment(fixture.comments[0]), before);
+  assert.equal(fixture.commentUpdates.length, 0);
+  assert.equal(
+    fixture.commitStatuses.length,
+    0,
+    JSON.stringify(fixture.commitStatuses),
+  );
+  assert.equal(fixture.dispatches.length, 0);
+}
+
+test("settled reconcile replays preserve journal and status intent across terminal outcomes", async () => {
+  const runtimeCases = [
+    {
+      state: "success",
+      reason: "verified",
+      expectedTarget: (workerRunId) => `https://ui-${workerRunId}.vercel.app`,
+    },
+    {
+      state: "failure",
+      reason: "build-failed-final",
+      expectedTarget: (workerRunId) =>
+        `https://github.com/${PREVIEW_REPOSITORY}/actions/runs/${workerRunId}`,
+    },
+    {
+      state: "failure",
+      reason: "smoke-failed-final",
+      vercelDeploymentUrl: "https://smoke-failure.vercel.app",
+      expectedTarget: () => "https://smoke-failure.vercel.app",
+    },
+    {
+      state: "error",
+      reason: "worker_timed_out",
+      expectedTarget: (workerRunId) =>
+        `https://github.com/${PREVIEW_REPOSITORY}/actions/runs/${workerRunId}`,
+    },
+  ];
+  let runId = 7_100;
+  for (const terminal of runtimeCases) {
+    const opened = event({
+      run: runId,
+      action: "opened",
+      head: SHA.A,
+      updated: timestamp(1),
+    });
+    const pullRequest = pull({ head: SHA.A, updated: timestamp(1) });
+    const selected = reconcile({ events: [opened], pullRequest });
+    const active = persistDispatch(selected, runId + 1);
+    const selection = selectionReceiptFromDispatch(active.ui.active);
+    const terminalResult = result(selected.nextDispatch, {
+      runId: runId + 1,
+      ...terminal,
+    });
+    const state = reconcile({
+      events: [opened],
+      results: [terminalResult],
+      selections: [selection],
+      pullRequest,
+      existingState: active,
+    }).state;
+    assert.equal(
+      state.status_decisions[0].target_url,
+      terminal.expectedTarget(runId + 1),
+    );
+
+    await assertSettledReplayIsIdempotent({
+      events: [opened],
+      pullRequest,
+      state,
+      selections: [selection],
+      results: [terminalResult],
+      runId: runId + 2,
+    });
+    runId += 10;
+  }
+
+  const docs = event({
+    run: 7_200,
+    action: "opened",
+    head: SHA.B,
+    runtime: false,
+    updated: timestamp(1),
+  });
+  const docsPull = pull({ head: SHA.B, updated: timestamp(1) });
+  await assertSettledReplayIsIdempotent({
+    events: [docs],
+    pullRequest: docsPull,
+    state: reconcile({ events: [docs], pullRequest: docsPull }).state,
+    runId: 7_201,
+  });
+
+  const unsupported = event({
+    run: 7_210,
+    action: "opened",
+    head: SHA.C,
+    repository: "fork/frontend-monorepo",
+    author: "fork-author",
+    updated: timestamp(1),
+  });
+  const unsupportedPull = pull({
+    head: SHA.C,
+    repository: "fork/frontend-monorepo",
+    author: "fork-author",
+    updated: timestamp(1),
+  });
+  await assertSettledReplayIsIdempotent({
+    events: [unsupported],
+    pullRequest: unsupportedPull,
+    state: reconcile({
+      events: [unsupported],
+      pullRequest: unsupportedPull,
+    }).state,
+    runId: 7_211,
+  });
+
+  const burst = [
+    event({ run: 7_220, action: "opened", head: SHA.A, updated: timestamp(1) }),
+    event({
+      run: 7_221,
+      action: "synchronize",
+      before: SHA.A,
+      head: SHA.B,
+      updated: timestamp(2),
+    }),
+    event({
+      run: 7_222,
+      action: "synchronize",
+      before: SHA.B,
+      head: SHA.C,
+      updated: timestamp(3),
+    }),
+  ];
+  const burstPull = pull({ head: SHA.C, updated: timestamp(3) });
+  const selectedA = reconcile({ events: burst, pullRequest: burstPull });
+  const activeA = persistDispatch(selectedA, 7_223);
+  const selectionA = selectionReceiptFromDispatch(activeA.ui.active);
+  const resultA = result(selectedA.nextDispatch, { runId: 7_223 });
+  const selectedC = reconcile({
+    events: burst,
+    results: [resultA],
+    selections: [selectionA],
+    pullRequest: burstPull,
+    existingState: activeA,
+  });
+  const activeC = persistDispatch(selectedC, 7_224);
+  const selectionC = selectionReceiptFromDispatch(activeC.ui.active);
+  const resultC = result(selectedC.nextDispatch, { runId: 7_224 });
+  const burstState = reconcile({
+    events: burst,
+    results: [resultA, resultC],
+    selections: [selectionA, selectionC],
+    pullRequest: burstPull,
+    existingState: activeC,
+  }).state;
+  assert.match(burstState.status_decisions[1].description, /Coalesced/);
+  await assertSettledReplayIsIdempotent({
+    events: burst,
+    pullRequest: burstPull,
+    state: burstState,
+    selections: [selectionA, selectionC],
+    results: [resultA, resultC],
+    runId: 7_225,
+  });
+});
+
+test("settled replay suppression uses only the latest bounded status witness", async () => {
+  const docs = event({
+    run: 7_260,
+    action: "opened",
+    head: SHA.D,
+    runtime: false,
+    updated: timestamp(1),
+  });
+  const pullRequest = pull({ head: SHA.D, updated: timestamp(1) });
+  const state = reconcile({ events: [docs], pullRequest }).state;
+  const comment = journalComment({ events: [docs], state });
+  const exactStatus = previewCommitStatuses(state.status_decisions).get(
+    SHA.D,
+  )[0];
+  const noise = Array.from({ length: 100 }, (_, index) => ({
+    context: `Unrelated check ${index}`,
+    state: "success",
+    description: "Unrelated status",
+    target_url: null,
+  }));
+
+  const lastRealisticStatusFixture = fakeGitHub({
+    pullRequest,
+    comments: [comment],
+    existingCommitStatuses: new Map([
+      [SHA.D, [...noise.slice(0, 99), exactStatus]],
+    ]),
+  });
+  await reconcilePreview({
+    github: lastRealisticStatusFixture.github,
+    context: fakeContext({ runId: 7_261 }),
+    core: fakeCore(),
+    prNumber: 519,
+  });
+  assert.equal(lastRealisticStatusFixture.commentUpdates.length, 0);
+  assert.equal(lastRealisticStatusFixture.commitStatuses.length, 0);
+
+  const newerMismatchFixture = fakeGitHub({
+    pullRequest,
+    comments: [comment],
+    existingCommitStatuses: new Map([
+      [
+        SHA.D,
+        [
+          { ...exactStatus, description: "Stale external description" },
+          exactStatus,
+        ],
+      ],
+    ]),
+  });
+  await reconcilePreview({
+    github: newerMismatchFixture.github,
+    context: fakeContext({ runId: 7_262 }),
+    core: fakeCore(),
+    prNumber: 519,
+  });
+  assert.equal(newerMismatchFixture.commentUpdates.length, 0);
+  assert.equal(newerMismatchFixture.commitStatuses.length, 1);
+
+  const foreignCreatorFixture = fakeGitHub({
+    pullRequest,
+    comments: [comment],
+    existingCommitStatuses: new Map([
+      [
+        SHA.D,
+        [
+          {
+            ...exactStatus,
+            creator: { type: "User", login: "foreign-maintainer" },
+          },
+        ],
+      ],
+    ]),
+  });
+  await reconcilePreview({
+    github: foreignCreatorFixture.github,
+    context: fakeContext({ runId: 7_263 }),
+    core: fakeCore(),
+    prNumber: 519,
+  });
+  assert.equal(foreignCreatorFixture.commentUpdates.length, 0);
+  assert.equal(foreignCreatorFixture.commitStatuses.length, 1);
+
+  const beyondBoundFixture = fakeGitHub({
+    pullRequest,
+    comments: [comment],
+    existingCommitStatuses: new Map([[SHA.D, [...noise, exactStatus]]]),
+  });
+  await reconcilePreview({
+    github: beyondBoundFixture.github,
+    context: fakeContext({ runId: 7_264 }),
+    core: fakeCore(),
+    prNumber: 519,
+  });
+  assert.equal(beyondBoundFixture.commentUpdates.length, 0);
+  assert.equal(beyondBoundFixture.commitStatuses.length, 1);
+
+  const racedState = structuredClone(state);
+  racedState.status_decisions[0].target_url =
+    "https://github.com/mento-protocol/frontend-monorepo/actions/runs/7265";
+  const racedComment = journalComment({
+    revision: 8,
+    events: [docs],
+    state: racedState,
+  });
+  const basisRaceFixture = fakeGitHub({
+    pullRequest,
+    comments: [comment],
+    existingCommitStatuses: new Map([
+      [SHA.D, [{ ...exactStatus, description: "Stale external description" }]],
+    ]),
+    beforeListCommitStatuses: ({ requestCount, comments }) => {
+      if (requestCount === 1) comments[0].body = racedComment.body;
+    },
+  });
+  const stateAfterRace = await reconcilePreview({
+    github: basisRaceFixture.github,
+    context: fakeContext({ runId: 7_265 }),
+    core: fakeCore(),
+    prNumber: 519,
+  });
+  assert.equal(basisRaceFixture.commitStatuses.length, 1);
+  assert.equal(
+    basisRaceFixture.commitStatuses[0].target_url,
+    racedState.status_decisions[0].target_url,
+  );
+  assert.deepEqual(stateAfterRace, racedState);
+});
+
+test("reconcile still publishes genuine terminal changes and repairs a missing status witness", async () => {
+  const opened = event({
+    run: 7_300,
+    action: "opened",
+    head: SHA.A,
+    updated: timestamp(1),
+  });
+  const pullRequest = pull({ head: SHA.A, updated: timestamp(1) });
+  const selected = reconcile({ events: [opened], pullRequest });
+  const active = persistDispatch(selected, 7_301);
+  const selection = selectionReceiptFromDispatch(active.ui.active);
+  const terminalResult = result(selected.nextDispatch, {
+    runId: 7_301,
+    state: "failure",
+    reason: "build-failed-final",
+  });
+  const pendingComment = journalWithState([opened], active, {
+    selections: [selection],
+    results: [terminalResult],
+  });
+  const pendingFixture = fakeGitHub({
+    pullRequest,
+    comments: [pendingComment],
+    existingCommitStatuses: previewCommitStatuses(active.status_decisions),
+  });
+
+  const terminalState = await reconcilePreview({
+    github: pendingFixture.github,
+    context: fakeContext({ runId: 7_302 }),
+    core: fakeCore(),
+    prNumber: 519,
+  });
+  assert.equal(terminalState.status_decisions[0].state, "failure");
+  assert.equal(pendingFixture.commentUpdates.length, 1);
+  assert.equal(pendingFixture.commitStatuses.length, 1);
+  assert.equal(pendingFixture.commitStatuses[0].state, "failure");
+
+  const controllerTargetState = structuredClone(terminalState);
+  controllerTargetState.status_decisions[0].target_url = CONTROLLER_URL;
+  const controllerTargetComment = journalComment({
+    events: [opened],
+    selections: [selection],
+    results: [terminalResult],
+    state: controllerTargetState,
+  });
+  const changedCanonicalTargetFixture = fakeGitHub({
+    pullRequest,
+    comments: [controllerTargetComment],
+    existingCommitStatuses: previewCommitStatuses(
+      controllerTargetState.status_decisions,
+    ),
+  });
+  const migratedTargetState = await reconcilePreview({
+    github: changedCanonicalTargetFixture.github,
+    context: fakeContext({ runId: 7_303 }),
+    core: fakeCore(),
+    prNumber: 519,
+  });
+  assert.equal(changedCanonicalTargetFixture.commentUpdates.length, 1);
+  assert.equal(changedCanonicalTargetFixture.commitStatuses.length, 1);
+  assert.equal(
+    migratedTargetState.status_decisions[0].target_url,
+    `https://github.com/${PREVIEW_REPOSITORY}/actions/runs/7301`,
+  );
+  assert.equal(
+    changedCanonicalTargetFixture.commitStatuses[0].target_url,
+    migratedTargetState.status_decisions[0].target_url,
+  );
+
+  const settledComment = journalComment({
+    events: [opened],
+    selections: [selection],
+    results: [terminalResult],
+    state: terminalState,
+  });
+  const readFailureFixture = fakeGitHub({
+    pullRequest,
+    comments: [settledComment],
+    existingCommitStatuses: previewCommitStatuses(
+      terminalState.status_decisions,
+    ),
+    commitStatusListFailures: [503],
+  });
+  const stateAfterReadFailure = await reconcilePreview({
+    github: readFailureFixture.github,
+    context: fakeContext({ runId: 7_304 }),
+    core: fakeCore(),
+    prNumber: 519,
+  });
+  assert.deepEqual(stateAfterReadFailure, terminalState);
+  assert.equal(readFailureFixture.commentUpdates.length, 0);
+  assert.equal(readFailureFixture.commitStatuses.length, 1);
+  assert.equal(readFailureFixture.commitStatuses[0].state, "failure");
+  assert.equal(
+    readFailureFixture.commitStatuses[0].description,
+    terminalState.status_decisions[0].description,
+  );
+  assert.equal(
+    readFailureFixture.commitStatuses[0].target_url,
+    terminalState.status_decisions[0].target_url,
+  );
+
+  const missingWitnessFixture = fakeGitHub({
+    pullRequest,
+    comments: [settledComment],
+  });
+  await reconcilePreview({
+    github: missingWitnessFixture.github,
+    context: fakeContext({ runId: 7_305 }),
+    core: fakeCore(),
+    prNumber: 519,
+  });
+  assert.equal(missingWitnessFixture.commentUpdates.length, 0);
+  assert.equal(missingWitnessFixture.commitStatuses.length, 1);
+  assert.equal(missingWitnessFixture.commitStatuses[0].state, "failure");
+
+  const changedTargetStatuses = previewCommitStatuses(
+    terminalState.status_decisions,
+  );
+  changedTargetStatuses.get(SHA.A)[0].target_url =
+    "https://github.com/mento-protocol/frontend-monorepo/actions/runs/999";
+  const changedTargetFixture = fakeGitHub({
+    pullRequest,
+    comments: [settledComment],
+    existingCommitStatuses: changedTargetStatuses,
+  });
+  await reconcilePreview({
+    github: changedTargetFixture.github,
+    context: fakeContext({ runId: 7_306 }),
+    core: fakeCore(),
+    prNumber: 519,
+  });
+  assert.equal(changedTargetFixture.commentUpdates.length, 0);
+  assert.equal(changedTargetFixture.commitStatuses.length, 1);
+  assert.equal(
+    changedTargetFixture.commitStatuses[0].target_url,
+    terminalState.status_decisions[0].target_url,
+  );
+});
 
 test("malformed successful planner output is recorded as fail-closed UI impact", async () => {
   const opened = event({


### PR DESCRIPTION
## The Problem

A terminal Vercel preview reconciliation was not replay-idempotent. The controller recomputed terminal status targets from the current controller run, so replaying an already-settled journal could increment its revision and append a duplicate `Vercel Preview` commit status. The controlled failure canary in #562 exposed this after the terminal smoke-failure result had already settled.

The status-history read used for deduplication also must remain an optimization: a transient read failure, a foreign field-identical status, or a concurrent journal update must never suppress or replace canonical preview truth.

## The Solution

- use immutable Vercel deployment URLs for post-upload terminal outcomes and exact worker-run URLs for terminal failures without an upload
- retain the prior terminal target only for outcomes whose only candidate is the current controller URL
- snapshot canonical state before reconciliation and enable write suppression only when the complete state remains byte-for-byte canonical-equivalent
- inspect one newest-first bounded commit-status page and suppress only an exact latest `github-actions[bot]` witness
- treat status-history lookup failures or malformed responses conservatively by re-posting canonical truth
- revalidate the journal basis after lookup and immediately before every status write
- add deterministic coverage for success, failure, error, no-runtime, coalesced, unsupported, pending-to-terminal, target repair, creator provenance, bounded history, transient API failure, and a concurrent journal mutation
- document the durable status-target and exact-replay contract

## Verification

- `pnpm vercel:preview:test`
- `pnpm vercel:workflow:test`
- `pnpm vercel:primitives:test`
- `pnpm ci:action-pins:test`
- `pnpm quality:budgets:test`
- `pnpm adr:check:test`
- `pnpm adr:check`
- `trunk check scripts/vercel-preview-controller.mjs scripts/vercel-preview-controller.test.mjs docs/vercel-deployments.md`
- pre-push type checks, Knip, Trunk, and ADR checks

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches automatic PR preview status publication and journal reconciliation in CI; behavior is heavily tested and fails closed on ambiguous witness reads, but incorrect suppression could hide real status transitions.
> 
> **Overview**
> Re-running the Vercel preview controller on an already-settled journal no longer bumps the journal revision or posts duplicate **`Vercel Preview`** commit statuses when nothing canonical changed.
> 
> **Durable terminal links:** Terminal decisions now prefer immutable **`vercel.app`** URLs when an upload exists (including smoke failures) and exact GitHub Actions worker-run URLs when a terminal failure has no deployment. **`preserveSettledControllerTarget`** keeps the prior journal target for outcomes that would otherwise fall back to the current controller run (no-runtime, coalesced, unsupported).
> 
> **Exact-replay write suppression:** Before reconciliation, canonical state is snapshotted; if the recomputed state is byte-for-byte equivalent, **`postStatusDecisions`** skips **`createCommitStatus`** when the newest **`Vercel Preview`** on a bounded first page was authored by **`github-actions[bot]`** and matches state, description, and target URL. Missing, foreign, mismatched, or unreadable witnesses still trigger a conservative rewrite so deleted or stale statuses get repaired.
> 
> Docs in **`vercel-deployments.md`** describe the durable-target and replay contract; tests cover terminal outcomes, suppression edge cases, repairs, and concurrent journal races.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 288412eb2c0d22ef6220f39d5acce33900fb9566. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->