### PR TITLE
test(ci): run current Phase A preview canary

### DIFF
--- a/apps/ui.mento.org/app/layout.tsx
+++ b/apps/ui.mento.org/app/layout.tsx
@@ -27,7 +27,7 @@ export default function RootLayout({
 }): React.ReactElement {
   return (
     <html lang="en" suppressHydrationWarning>
-      <body className={inter.className}>
+      <body className={inter.className} data-vercel-phase-a-current="A">
         <AppShell>{children}</AppShell>
       </body>
     </html>

--- a/apps/ui.mento.org/app/layout.tsx
+++ b/apps/ui.mento.org/app/layout.tsx
@@ -27,7 +27,7 @@ export default function RootLayout({
 }): React.ReactElement {
   return (
     <html lang="en" suppressHydrationWarning>
-      <body className={inter.className} data-vercel-phase-a-current="C">
+      <body className={inter.className} data-vercel-phase-a-current="E">
         <AppShell>{children}</AppShell>
       </body>
     </html>

--- a/apps/ui.mento.org/app/layout.tsx
+++ b/apps/ui.mento.org/app/layout.tsx
@@ -27,7 +27,7 @@ export default function RootLayout({
 }): React.ReactElement {
   return (
     <html lang="en" suppressHydrationWarning>
-      <body className={inter.className} data-vercel-phase-a-current="A">
+      <body className={inter.className} data-vercel-phase-a-current="B">
         <AppShell>{children}</AppShell>
       </body>
     </html>

--- a/apps/ui.mento.org/app/layout.tsx
+++ b/apps/ui.mento.org/app/layout.tsx
@@ -27,7 +27,7 @@ export default function RootLayout({
 }): React.ReactElement {
   return (
     <html lang="en" suppressHydrationWarning>
-      <body className={inter.className} data-vercel-phase-a-current="B">
+      <body className={inter.className} data-vercel-phase-a-current="C">
         <AppShell>{children}</AppShell>
       </body>
     </html>

--- a/docs/vercel-phase-a-current-canary.md
+++ b/docs/vercel-phase-a-current-canary.md
@@ -1,0 +1,5 @@
+# Temporary Phase A canary
+
+This documentation-only marker is commit D in the disposable current-main
+preview batching canary for issue #519. The pull request is closed unmerged
+after evidence collection.


### PR DESCRIPTION
## The Problem

Issue #519 needs current live proof that the GitHub-driven Vercel preview controller preserves the first runtime build, coalesces an overlapping push burst to only the latest runtime SHA, reuses that preview for a documentation-only push, deploys a later runtime push after idle, and remains idempotent under bounded replay.

## The Solution

Run a temporary trusted same-repository canary using an inert browser-detectable body marker. Exact runtime SHAs A, B, and C will be pushed as an overlapping sequence; docs-only D and after-idle runtime E follow. The PR will be closed unmerged and its remote branch deleted after evidence collection.

## Validation

- A, B, C, and E each plan only `ui`.
- D plans `non-runtime-only` with no deployment target.
- Commit hooks passed for every canary commit.
- `git diff --check origin/main..HEAD`
- Repository-wide `Vercel Preview Worker` queue was idle immediately before A.

## Safety

- No credentials, rulesets, production domains, or main-branch files are changed.
- The temporary branch is never merged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single temporary HTML data attribute on the UI shell for canary detection; no auth, deployment config, or production behavior changes.
> 
> **Overview**
> Introduces an **inert, browser-detectable marker** on the UI app root layout: `data-vercel-phase-a-current="A"` on the `<body>` in `layout.tsx`.
> 
> This supports the **temporary same-repo Phase A canary** described in the PR (overlapping runtime pushes A/B/C, docs-only D, after-idle E) so evidence collection can confirm which runtime build is live on the preview without changing credentials, rulesets, or production domains. The branch is intended to be **closed unmerged** after validation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bbe600493b8e237ac1618bd0dc76b483ea0b6b1f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->