### PR TITLE
docs(ci): verify no-runtime preview on current main

### DIFF
--- a/docs/vercel-preview-no-runtime-current-canary-20260719.md
+++ b/docs/vercel-preview-no-runtime-current-canary-20260719.md
@@ -1,0 +1,5 @@
+# Vercel preview no-runtime canary
+
+This temporary documentation-only marker verifies that the trusted preview
+planner classifies a pull request with no runtime changes as `non-runtime-only`.
+It will be closed without merging after the evidence is recorded for #519.


### PR DESCRIPTION
## The Problem

Issue #519 needs current-main Phase A evidence that a trusted same-repository pull request containing only documentation changes does not dispatch a GitHub-built Vercel preview.

## The Solution

Add one temporary documentation-only marker from exact base `3b0406315405272490703e3521f7b27a15dbbcea`. The local trusted planner classifies the exact transition as `non-runtime-only` with no targets.

This PR is an evidence canary. It will be closed unmerged and its remote branch deleted after the close-event controller settles.

## Validation

- `node scripts/plan-vercel-deployments.mjs --base 3b0406315405272490703e3521f7b27a15dbbcea --head 315461aa17679c0cbf86ed9e29535e726b4bfc96` -> `deployments=[]`, `reason=non-runtime-only`
- `trunk check docs/vercel-preview-no-runtime-current-canary-20260719.md`
- `git diff --check 3b0406315405272490703e3521f7b27a15dbbcea..315461aa17679c0cbf86ed9e29535e726b4bfc96`
- repository pre-push checks (`adr:check`, Trunk, check-types, Knip)

No reviewer action is needed; this PR must not be merged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime, CI logic, or deployment behavior in the diff; intended to be closed unmerged.
> 
> **Overview**
> Adds a **temporary documentation-only marker** (`docs/vercel-preview-no-runtime-current-canary-20260719.md`) to capture Phase A evidence for #519: a trusted same-repo PR with no runtime changes should be classified as `non-runtime-only` and must not dispatch a GitHub-built Vercel preview.
> 
> The file states the canary purpose and that the PR will be **closed without merging** after the close-event controller records evidence. No application, workflow, or planner code is modified in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 315461aa17679c0cbf86ed9e29535e726b4bfc96. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->