### PR TITLE
test(ci): exercise preview failure and cancellation canary

### DIFF
--- a/apps/ui.mento.org/app/layout.tsx
+++ b/apps/ui.mento.org/app/layout.tsx
@@ -29,7 +29,7 @@ export default function RootLayout({
     <html lang="en" suppressHydrationWarning>
       <body
         className={inter.className}
-        data-vercel-preview-cancel-canary="candidate-x"
+        data-vercel-preview-cancel-canary="latest-y"
       >
         <AppShell>{children}</AppShell>
       </body>

--- a/apps/ui.mento.org/app/layout.tsx
+++ b/apps/ui.mento.org/app/layout.tsx
@@ -27,7 +27,10 @@ export default function RootLayout({
 }): React.ReactElement {
   return (
     <html lang="en" suppressHydrationWarning>
-      <body className={inter.className}>
+      <body
+        className={inter.className}
+        data-vercel-preview-cancel-canary="candidate-x"
+      >
         <AppShell>{children}</AppShell>
       </body>
     </html>

--- a/apps/ui.mento.org/app/layout.tsx
+++ b/apps/ui.mento.org/app/layout.tsx
@@ -29,7 +29,7 @@ export default function RootLayout({
     <html lang="en" suppressHydrationWarning>
       <body
         className={inter.className}
-        data-vercel-preview-cancel-canary="latest-y"
+        data-vercel-preview-cancel-canary="candidate-x2"
       >
         <AppShell>{children}</AppShell>
       </body>

--- a/apps/ui.mento.org/app/layout.tsx
+++ b/apps/ui.mento.org/app/layout.tsx
@@ -29,7 +29,7 @@ export default function RootLayout({
     <html lang="en" suppressHydrationWarning>
       <body
         className={inter.className}
-        data-vercel-preview-cancel-canary="candidate-x2"
+        data-vercel-preview-cancel-canary="latest-y2"
       >
         <AppShell>{children}</AppShell>
       </body>

--- a/apps/ui.mento.org/app/page.tsx
+++ b/apps/ui.mento.org/app/page.tsx
@@ -1,5 +1,5 @@
 import { redirect } from "next/navigation";
 
 export default function Home() {
-  redirect("/interactive-components");
+  redirect("/basic-components");
 }

--- a/apps/ui.mento.org/app/page.tsx
+++ b/apps/ui.mento.org/app/page.tsx
@@ -1,5 +1,5 @@
 import { redirect } from "next/navigation";
 
 export default function Home() {
-  redirect("/basic-components");
+  redirect("/interactive-components");
 }


### PR DESCRIPTION
## The Problem

Phase A still needs current-main live evidence for the bounded smoke-failure retry and cancellation-before-Deployment recovery paths.

## The Solution

This disposable trusted same-repository PR first redirects the UI showcase root to a route that deliberately fails the trusted preview smoke after one successful upload. After that retry contract is proven, follow-up inert UI commits will restore the route and exercise a deliberately cancelled worker while a newer desired SHA is durably queued. The PR will be closed unmerged and its branch deleted after exact controller, worker, Deployment, Vercel, journal, and status evidence is captured.

## Validation

- pnpm check-types
- trunk check apps/ui.mento.org/app/page.tsx
- pnpm adr:check
- git diff --check

## Safety

- No production, main, ruleset, environment, or credential mutation
- Cancel only the exact worker run dispatched for this PR and recorded SHA
- Close unmerged and delete the remote branch after proof

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single redirect change in a non-production showcase app, intended as a temporary unmerged canary with no credential or environment changes.
> 
> **Overview**
> **Changes the UI showcase home redirect** from `/basic-components` to `/interactive-components` in `apps/ui.mento.org/app/page.tsx`.
> 
> That mismatch is intentional: trusted preview browser smoke asserts the root lands on **Basic Components** (`/basic-components`). This disposable PR uses the one-line redirect so the first successful upload is followed by a bounded smoke failure, to validate retry and cancellation recovery in CI. The branch is meant to be closed unmerged after evidence is captured.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96633edfe35efe6972967ca2c2b030bdbde92cf6. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->