### PR TITLE
fix(ui): legible ProposalCardHeader on its always-dark surface

### DIFF
--- a/packages/ui/src/components/ui/proposal-card.tsx
+++ b/packages/ui/src/components/ui/proposal-card.tsx
@@ -5,7 +5,12 @@ import { cn } from "@/lib/utils.js";
 import { cva, type VariantProps } from "class-variance-authority";
 
 const proposalCardHeaderVariants = cva(
-  "flex w-full flex-col items-start justify-start px-6 py-5 gap-6 lg:flex-row lg:!justify-between",
+  // The card surface (--another-card-color) is always dark in both themes, so the
+  // header text must be light regardless of the app theme. primary-foreground is
+  // theme-independent (oklch 0.98 in :root and .dark); without it, plain-text header
+  // children inherit --foreground and render dark-on-dark in light mode. Consumers
+  // can still override (e.g. text-white/70).
+  "flex w-full flex-col items-start justify-start px-6 py-5 gap-6 lg:flex-row lg:!justify-between text-primary-foreground",
   {
     variants: {
       variant: {


### PR DESCRIPTION
## The Problem

- `ProposalCard`'s root uses `bg-[var(--another-card-color)]!` — a dark colour defined **identically** in `:root` and `.dark`, so the card surface is always dark.
- `ProposalCardHeader` set no text colour, so plain-text header children (the proposal title) inherited `--foreground`, which is near-black in the light theme → **dark-on-dark, illegible** unless the whole app runs under `.dark`. The governance list's own `<h2>Proposals</h2>` had the same latent bug.

## The Solution

Add `text-primary-foreground` to the `proposalCardHeaderVariants` base (both `default` and `highlighted` variants). `--primary-foreground` is theme-independent (`oklch(0.98)` in both `:root` and `.dark`), so the header title is light on the always-dark surface regardless of app theme. Consumer overrides (e.g. the governance list's `text-white/70` label) still win. Fixes #566.

## Details

One-line change (plus a comment) in `packages/ui/src/components/ui/proposal-card.tsx`. `text-primary-foreground` is the idiomatic theme utility, consistent with the component's existing `text-*-foreground` usage, and compiles to `color: var(--primary-foreground)`. No API/type change.

## Validation

- Rendered `ProposalCardHeader` in a **light** context (no `.dark` wrapper, plain-text title) via the DS preview harness against the rebuilt `dist` — the title is now legible white on the dark card (both `default` and `highlighted`).
- `pnpm --filter @mento-protocol/ui test` — 28/28 pass (no proposal-card snapshot to update).
- `pnpm exec turbo run check-types --filter @mento-protocol/ui` — pass; `trunk check` — clean; whole-monorepo pre-push hooks — pass.
- Non-regression confirmed for both consumers (governance `proposal-list.tsx`, `ui.mento.org` showcase): dark mode was already `0.98` light and stays so; light mode goes illegible→legible; child `text-*` overrides still win.
- **Expected VRT diff:** the `ui.mento.org` Argos visual check will show an intended diff on the specialized-components ProposalCard (the header title becomes visible) — approve it in Argos.

## Deferrals

None.

## Ship Checklist
- [x] ship skill used
- [x] local review run
- [x] validation run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 038aafac63c96d46444f07329037ee272c2dfa9e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->