### PR TITLE
chore(ci): cut UI branch previews over to GitHub Actions

### DIFF
--- a/.github/workflows/vercel-preview-controller.yml
+++ b/.github/workflows/vercel-preview-controller.yml
@@ -11,6 +11,9 @@ on:
 
 permissions: {}
 
+env:
+  VERCEL_PREVIEW_CONTROLLER_MODE: active
+
 jobs:
   validate-request:
     name: Validate default-branch repository request
@@ -225,9 +228,10 @@ jobs:
       - name: Persist intent, recover or dispatch one worker, and publish statuses
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
+          CONTROLLER_MODE: ${{ env.VERCEL_PREVIEW_CONTROLLER_MODE }}
           PR_NUMBER: ${{ needs.receipt-event.outputs.pr_number }}
           WORKFLOW_SHA: ${{ github.workflow_sha }}
-          WORKER_DISPATCH_TOKEN: ${{ secrets.GH_PREVIEW_WORKFLOW_DISPATCH_TOKEN }}
+          WORKER_DISPATCH_TOKEN: ${{ env.VERCEL_PREVIEW_CONTROLLER_MODE == 'active' && secrets.GH_PREVIEW_WORKFLOW_DISPATCH_TOKEN || '' }}
         with:
           script: |
             const { pathToFileURL } = require("node:url");
@@ -243,6 +247,7 @@ jobs:
               workerDispatchGithub,
               context,
               core,
+              controllerMode: process.env.CONTROLLER_MODE,
               prNumber: process.env.PR_NUMBER,
               workflowSha: process.env.WORKFLOW_SHA,
             });
@@ -424,9 +429,10 @@ jobs:
       - name: Reconcile bootstrapped PR
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
+          CONTROLLER_MODE: ${{ env.VERCEL_PREVIEW_CONTROLLER_MODE }}
           PR_NUMBER: ${{ needs.receipt-bootstrap.outputs.pr_number }}
           WORKFLOW_SHA: ${{ github.workflow_sha }}
-          WORKER_DISPATCH_TOKEN: ${{ secrets.GH_PREVIEW_WORKFLOW_DISPATCH_TOKEN }}
+          WORKER_DISPATCH_TOKEN: ${{ env.VERCEL_PREVIEW_CONTROLLER_MODE == 'active' && secrets.GH_PREVIEW_WORKFLOW_DISPATCH_TOKEN || '' }}
         with:
           script: |
             const { pathToFileURL } = require("node:url");
@@ -442,6 +448,7 @@ jobs:
               workerDispatchGithub,
               context,
               core,
+              controllerMode: process.env.CONTROLLER_MODE,
               prNumber: process.env.PR_NUMBER,
               workflowSha: process.env.WORKFLOW_SHA,
             });
@@ -474,9 +481,10 @@ jobs:
       - name: Reconcile requested PR
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
+          CONTROLLER_MODE: ${{ env.VERCEL_PREVIEW_CONTROLLER_MODE }}
           PR_NUMBER: ${{ needs.validate-request.outputs.pr_number }}
           WORKFLOW_SHA: ${{ github.workflow_sha }}
-          WORKER_DISPATCH_TOKEN: ${{ secrets.GH_PREVIEW_WORKFLOW_DISPATCH_TOKEN }}
+          WORKER_DISPATCH_TOKEN: ${{ env.VERCEL_PREVIEW_CONTROLLER_MODE == 'active' && secrets.GH_PREVIEW_WORKFLOW_DISPATCH_TOKEN || '' }}
         with:
           script: |
             const { pathToFileURL } = require("node:url");
@@ -492,6 +500,7 @@ jobs:
               workerDispatchGithub,
               context,
               core,
+              controllerMode: process.env.CONTROLLER_MODE,
               prNumber: process.env.PR_NUMBER,
               workflowSha: process.env.WORKFLOW_SHA,
             });
@@ -631,8 +640,9 @@ jobs:
       - name: Terminalize or recover Deployment and persist immutable result
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
+          CONTROLLER_MODE: ${{ env.VERCEL_PREVIEW_CONTROLLER_MODE }}
           WORKFLOW_SHA: ${{ github.workflow_sha }}
-          WORKER_DISPATCH_TOKEN: ${{ secrets.GH_PREVIEW_WORKFLOW_DISPATCH_TOKEN }}
+          WORKER_DISPATCH_TOKEN: ${{ env.VERCEL_PREVIEW_CONTROLLER_MODE == 'active' && secrets.GH_PREVIEW_WORKFLOW_DISPATCH_TOKEN || '' }}
         with:
           script: |
             const { pathToFileURL } = require("node:url");
@@ -655,6 +665,7 @@ jobs:
                   workerDispatchGithub,
                   context,
                   core,
+                  controllerMode: process.env.CONTROLLER_MODE,
                   prNumber: result.pr,
                   workflowSha: process.env.WORKFLOW_SHA,
                 });

--- a/README.md
+++ b/README.md
@@ -449,6 +449,10 @@ The repository is set up with GitHub Actions for CI:
   are created; the normal job token still owns all state and recovery calls.
   After the Phase A-canary-gated Phase B cutover, GitHub Actions owns UI branch
   previews and native Vercel Git branch previews are disabled only for UI.
+  The version-controlled controller mode is `active` in that state; the
+  executable ownership test permits rollback only when the same PR switches it
+  to `observe-only` and restores native UI branch previews, preventing duplicate
+  automatic owners.
   Vercel Git still owns every main/production deployment and all non-UI apps. See
   [ADR 0001](docs/adr/0001-github-actions-vercel-deployment-orchestration.md)
   for the accepted ownership boundary,

--- a/README.md
+++ b/README.md
@@ -452,7 +452,13 @@ The repository is set up with GitHub Actions for CI:
   The version-controlled controller mode is `active` in that state; the
   executable ownership test permits rollback only when the same PR switches it
   to `observe-only` and restores native UI branch previews, preventing duplicate
-  automatic owners.
+  automatic owners. The trusted controller also reads the candidate's bounded
+  exact-head UI Vercel configuration and rechecks it before dispatch: an exact
+  native rollback head suppresses GitHub dispatch even before merge, while an
+  unknown configuration or an `observe-only`/GitHub-owned head fails closed.
+  During rollback, `Vercel Preview` proves owner selection and journal drain
+  only; native Vercel deployment status and browser evidence separately prove
+  that the preview works.
   Vercel Git still owns every main/production deployment and all non-UI apps. See
   [ADR 0001](docs/adr/0001-github-actions-vercel-deployment-orchestration.md)
   for the accepted ownership boundary,

--- a/README.md
+++ b/README.md
@@ -447,9 +447,9 @@ The repository is set up with GitHub Actions for CI:
   PRs remain credential-free. A dedicated repository-scoped GitHub credential
   performs only the worker-dispatch POST so terminal `workflow_run` callbacks
   are created; the normal job token still owns all state and recovery calls.
-  During Phase A, native Vercel Git UI previews
-  remain enabled for canary comparison; Vercel Git still owns every
-  main/production deployment and all non-UI apps. See
+  After the Phase A-canary-gated Phase B cutover, GitHub Actions owns UI branch
+  previews and native Vercel Git branch previews are disabled only for UI.
+  Vercel Git still owns every main/production deployment and all non-UI apps. See
   [ADR 0001](docs/adr/0001-github-actions-vercel-deployment-orchestration.md)
   for the accepted ownership boundary,
   [ADR 0002](docs/adr/0002-single-comment-preview-controller-journal.md) for

--- a/apps/ui.mento.org/app/layout.tsx
+++ b/apps/ui.mento.org/app/layout.tsx
@@ -20,7 +20,6 @@ export const metadata: Metadata = {
   description: "Mento UI Components",
 };
 
-// Phase B single-owner canary for #519: force one exact-SHA UI preview.
 export default function RootLayout({
   children,
 }: {

--- a/apps/ui.mento.org/app/layout.tsx
+++ b/apps/ui.mento.org/app/layout.tsx
@@ -20,6 +20,7 @@ export const metadata: Metadata = {
   description: "Mento UI Components",
 };
 
+// Phase B single-owner canary for #519: force one exact-SHA UI preview.
 export default function RootLayout({
   children,
 }: {

--- a/apps/ui.mento.org/vercel.json
+++ b/apps/ui.mento.org/vercel.json
@@ -2,7 +2,8 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "git": {
     "deploymentEnabled": {
-      "dependabot/**": false
+      "**": false,
+      "main": true
     }
   }
 }

--- a/docs/adr/0001-github-actions-vercel-deployment-orchestration.md
+++ b/docs/adr/0001-github-actions-vercel-deployment-orchestration.md
@@ -3,7 +3,7 @@ title: GitHub Actions owns Vercel build and deployment orchestration; Vercel rem
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-07-15
+last_verified: 2026-07-21
 scope: ci/deployment
 date: 2026-07
 ---
@@ -211,9 +211,17 @@ before the final reviewed ownership change.
 `git.deploymentEnabled` branch rules disable only replaced native paths. The app
 configuration always retains `v2: true`. There is no permanent state in which
 native Vercel Git and GitHub Actions both automatically activate the same
-target/SHA. Recovery restores GitHub's controller to shadow mode and restores
+target/SHA. Recovery sets GitHub's controller to `observe-only` mode and restores
 the prior Vercel Git branch rules in the same reviewed change, then proves the
 native canary path before treating Vercel Git as owner again.
+
+For UI branch previews, that boundary is executable:
+`.github/workflows/vercel-preview-controller.yml` carries a
+version-controlled `active` or `observe-only` mode, and
+`scripts/vercel-git-ownership.test.mjs` accepts only `active` paired with native
+branch previews disabled or `observe-only` paired with native ownership
+restored. `observe-only` retains receipts, terminal recovery, and status
+evidence but cannot dispatch a new worker.
 
 Ordinary targets recover with exact captured deployment IDs and verify every
 domain after rollback. App `v3` recovers each reviewed alias independently to

--- a/docs/adr/0003-preview-worker-dispatch-authentication.md
+++ b/docs/adr/0003-preview-worker-dispatch-authentication.md
@@ -3,7 +3,7 @@ title: A dedicated repository-scoped credential dispatches preview workers
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-07-17
+last_verified: 2026-07-21
 scope: ci/deployment/preview-worker-dispatch-authentication
 date: 2026-07
 ---
@@ -100,9 +100,12 @@ then proves one automatic worker callback. Revocation is fail-closed for new
 dispatches; already-created workers and their recovery remain operable through
 the primary client.
 
-Rollback removes the secondary dispatch path only in a reviewed change that
-also replaces its callback guarantee. Reintroducing `GITHUB_TOKEN` dispatch is
-not a valid rollback because it recreates the known event-suppression failure.
+Rollback sets the version-controlled controller mode to `observe-only` in the
+same reviewed change that restores native Vercel Git ownership. That mode does
+not expose the secondary credential to reconciliation and the dispatch
+implementation rejects a new worker POST. Reintroducing `GITHUB_TOKEN` dispatch
+is not a valid rollback because it recreates the known event-suppression
+failure.
 
 ## Alternatives considered
 

--- a/docs/vercel-deployments.md
+++ b/docs/vercel-deployments.md
@@ -941,6 +941,9 @@ retired selection and continues current-epoch reconciliation without posting a
 current-head controller error. The quarantined selection remains in the journal
 as audit evidence, but it no longer counts as live GitHub deployment ownership
 and therefore cannot hold a native-Vercel ownership handoff pending forever.
+When no live GitHub owner remains, terminal journal compaction folds the
+quarantine marker and its unfinished receipts into the checkpoint's cumulative
+digest and bounded receipt counts before dropping them from the baseline state.
 Transient retired-attempt API or journal-write failures remain unquarantined
 and retry on the next reconciliation, also without changing the current-head
 status. A recovery ambiguity for the current active selection still fails

--- a/docs/vercel-deployments.md
+++ b/docs/vercel-deployments.md
@@ -696,7 +696,7 @@ The cost go/no-go record in issue #518 and the Phase A live-canary evidence
 below were prerequisites for the final UI Git-ownership cutover. The current
 Phase B ownership model reflects that gate having completed.
 
-## Automatic trusted UI previews (Phase A)
+## Automatic trusted UI previews (current; introduced in Phase A)
 
 `.github/workflows/vercel-preview-controller.yml` is the only automatic event
 controller. It runs trusted default-branch code for `pull_request_target`

--- a/docs/vercel-deployments.md
+++ b/docs/vercel-deployments.md
@@ -5,11 +5,12 @@ preview controller used by the GitHub Actions deployment migration tracked in
 [issue #515](https://github.com/mento-protocol/frontend-monorepo/issues/515).
 The ownership boundary and its trade-offs are recorded in
 [ADR 0001](adr/0001-github-actions-vercel-deployment-orchestration.md).
-Phase A enables GitHub-built previews for trusted same-repository UI pull
-requests while native Vercel Git UI previews remain enabled for canary
-comparison. Production/main and every non-UI application remain owned by Vercel
-Git. Phase B changes only UI branch-preview ownership after the live canaries in
-this runbook pass.
+Phase A enabled GitHub-built previews for trusted same-repository UI pull
+requests while native Vercel Git UI previews remained enabled for canary
+comparison. After that evidence gate, Phase B transferred only UI branch-preview
+ownership to GitHub Actions. Native Vercel Git previews are now disabled for UI
+branches other than `main`; production/main and every non-UI application remain
+owned by Vercel Git.
 
 ## Pinned prerequisites
 
@@ -1191,8 +1192,11 @@ old-epoch evidence is recent may the ruleset require the Statuses API
 
 ## UI Vercel Git cutover (Phase B)
 
-Phase B must be a separate merge after Phase A canaries pass. Change only
-`apps/ui.mento.org/vercel.json`, preserving its schema and unrelated keys:
+Phase B becomes the current ownership model when this change merges. Merge it
+only after every Phase A dual-path canary above has passed and its
+GitHub-built/native-preview evidence has been recorded. This separate merge
+changes only `apps/ui.mento.org/vercel.json`, preserving its schema and unrelated
+keys:
 
 ```json
 {
@@ -1206,14 +1210,18 @@ Phase B must be a separate merge after Phase A canaries pass. Change only
 }
 ```
 
-Vercel treats any matching `true` as enabled, so `main` remains native even
-though it also matches `**`. Use a fresh/main-rebased UI canary containing this
-configuration. Prove one canonical GitHub Deployment, one Vercel preview, no
-native branch preview, a truthful required status, and an unchanged native
-merge/main deployment. Inventory pre-cutover open branches and require them to
-rebase/merge `main` before using them as duplicate-prevention evidence.
+Vercel treats any matching `true` as enabled, so `main` remains natively
+deployed even though it also matches `**`. If this Phase B branch waited while
+Phase A changed, rebase it onto the final Phase A `main` before merge. After the
+merge, use a fresh UI canary or rebase an existing UI canary onto the resulting
+`main` so it contains this configuration. Prove one canonical GitHub
+Deployment, one Vercel preview, no native branch preview, a truthful required
+status, and an unchanged native merge/main deployment. Stale pre-cutover
+branches still carry their old static `vercel.json` and are not valid
+duplicate-prevention evidence.
 
-Rollback changes that same file exactly to:
+Rollback is mutually exclusive with the Phase B configuration and changes that
+same file exactly to:
 
 ```json
 {

--- a/docs/vercel-deployments.md
+++ b/docs/vercel-deployments.md
@@ -1288,6 +1288,8 @@ Immediately before merging the rollback, establish a coordinated no-push window
 and drain or cancel every non-completed run of all three workflows:
 
 ```bash
+set -euo pipefail
+
 list_nonterminal_preview_runs() {
   local workflow status
   local -a workflows=(
@@ -1317,14 +1319,15 @@ list_nonterminal_preview_runs |
 
 `gh api --paginate` follows every response page separately for every workflow
 and every GitHub nonterminal status; do not replace it with a bounded
-`gh run list --limit ...` query. Repeat the inventory and cancellation pipeline
-until the inventory prints no rows. After that first empty result, wait for
-cancellations to settle because worker and intake completion can start a final
-controller callback, then require a second empty exhaustive sweep immediately
-before merge. Do not merge while any queued, requested, waiting, pending, or
-in-progress controller, worker, or intake run remains. This quiescence proof
-prevents a run loaded from the old `active` workflow SHA from dispatching after
-native ownership is restored.
+`gh run list --limit ...` query. Any query or cancellation error aborts the
+shell; correct the cause and rerun the full inventory from the start. Repeat the
+inventory and cancellation pipeline until the inventory prints no rows. After
+that first empty result, wait for cancellations to settle because worker and
+intake completion can start a final controller callback, then require a second
+empty exhaustive sweep immediately before merge. Do not merge while any queued,
+requested, waiting, pending, or in-progress controller, worker, or intake run
+remains. This quiescence proof prevents a run loaded from the old `active`
+workflow SHA from dispatching after native ownership is restored.
 
 Before merging the rollback, inventory every active UI-runtime PR and branch
 that carries the Phase B `"**": false` rule. After the restored configuration

--- a/docs/vercel-deployments.md
+++ b/docs/vercel-deployments.md
@@ -938,10 +938,15 @@ Operator recovery queries the exact persisted worker attempt instead of the
 latest rerun. If a retired old-epoch attempt is missing or fails identity
 validation, the controller records a bounded recovery quarantine on that
 retired selection and continues current-epoch reconciliation without posting a
-current-head controller error. Transient retired-attempt API or journal-write
-failures remain unquarantined and retry on the next reconciliation, also
-without changing the current-head status. A recovery ambiguity for the current
-active selection still fails closed.
+current-head controller error. The quarantined selection remains in the journal
+as audit evidence, but it no longer counts as live GitHub deployment ownership
+and therefore cannot hold a native-Vercel ownership handoff pending forever.
+Transient retired-attempt API or journal-write failures remain unquarantined
+and retry on the next reconciliation, also without changing the current-head
+status. A recovery ambiguity for the current active selection still fails
+closed. Durable recovery, ownership-flip, and no-dispatch mutations may require
+multiple local reconciliation passes; those bounded progress passes are
+separate from the three-attempt budget reserved for serialized journal races.
 
 ### Durable dispatch and exact Deployment identity
 

--- a/docs/vercel-deployments.md
+++ b/docs/vercel-deployments.md
@@ -725,13 +725,15 @@ rechecks that exact-head ownership immediately before the dispatch credential
 can make its only POST. The exact native configuration suppresses dispatch even
 when the default-branch workflow is still `active`, which protects a rollback
 PR before it merges. `observe-only` never creates a dispatch intent or worker.
-It does, however, reconcile a previously persisted `intended` entry: one unique
-existing worker is attached without the secondary credential, a completed
-worker is terminalized normally, an in-progress worker remains durably attached
-for its callback, and no match after bounded observation is retired as
-`dispatch-disabled-intent-without-worker`. Multiple matches fail closed. An
-`observe-only` controller paired with the GitHub-owned candidate configuration
-also fails closed because neither automatic preview path would own that head.
+It does, however, reconcile every previously persisted `intended` entry in both
+the current and epoch-retired ownership slots: one unique existing worker is
+attached without the secondary credential, a completed worker is terminalized
+in the same reconciliation attempt, an in-progress worker remains durably
+attached in its original slot for its callback, and no match after bounded
+observation is retired as `dispatch-disabled-intent-without-worker`. Multiple
+matches fail closed. An `observe-only` controller paired with the GitHub-owned
+candidate configuration also fails closed because neither automatic preview
+path would own that head.
 
 Dependabot is intentionally split out before any write boundary.
 `.github/workflows/vercel-preview-intake.yml` receives the same PR activities
@@ -1311,8 +1313,9 @@ not make a split rollback acceptable.
 On the rollback PR, `Vercel Preview` reports `pending` with
 `Draining GitHub preview before native ownership` while any journal-owned
 GitHub intent or worker remains. The controller attaches a uniquely matching
-crash-window worker without dispatching; completion is recovered normally, and
-an intent with no worker is durably retired after bounded observation. Only
+crash-window worker without dispatching, including ownership retired by a close
+or reopen epoch; completion is recovered in that same reconciliation attempt,
+and an intent with no worker is durably retired after bounded observation. Only
 after no active or retired GitHub ownership remains does the context become
 `success` with `Native Vercel owns this UI preview`. Missing, malformed, or
 unknown candidate configuration, multiple matching workers, and an

--- a/docs/vercel-deployments.md
+++ b/docs/vercel-deployments.md
@@ -727,12 +727,15 @@ ownership inputs immediately before the dispatch credential can make its only
 POST. A selected native-owned receipt is persisted as an intent and routed
 through the same bounded no-dispatch recovery path: one already-created worker
 is attached and drained, while no matching worker produces the durable
-`dispatch-disabled-intent-without-worker` result and advances reconciliation to
-the next receipt. That terminal reason is ownership-success, not GitHub build
-evidence; it creates no GitHub Deployment. The exact native configuration also
-suppresses dispatch when the default-branch workflow is still `active`, which
-protects a rollback PR before it merges. `observe-only` never creates a new
-dispatch intent or worker.
+`native-owned-selection-without-github-worker` result and advances
+reconciliation to the next receipt. That dedicated terminal reason is
+ownership-success, not GitHub build evidence; it creates no GitHub Deployment.
+The generic `dispatch-disabled-intent-without-worker` result remains an error
+for the SHA whose GitHub-owned intent was retired, so a later ownership flip
+cannot falsely relabel that historical SHA as native-owned. The exact native
+configuration also suppresses dispatch when the default-branch workflow is
+still `active`, which protects a rollback PR before it merges. `observe-only`
+never creates a new dispatch intent or worker.
 It does, however, reconcile every previously persisted `intended` entry in both
 the current and epoch-retired ownership slots: one unique existing worker is
 attached without the secondary credential, a completed worker is terminalized
@@ -1342,11 +1345,13 @@ or reopen epoch; completion is recovered in that same reconciliation attempt,
 and an intent with no worker is durably retired after bounded observation. A
 native-owned historical receipt encountered after a later switch back to
 GitHub ownership follows that same durable retirement path instead of being
-dispatched by the later head's configuration. The synthetic no-dispatch result
-is reported as ownership-success and never claims a native build or smoke.
-Only after no active or retired GitHub ownership remains does the context
-become `success` with `Native Vercel owns this UI preview`. Missing, malformed,
-or unknown candidate configuration, multiple matching workers, and an
+dispatched by the later head's configuration. Its dedicated
+`native-owned-selection-without-github-worker` result is reported as
+ownership-success and never claims a native build or smoke. Generic retirement
+of a GitHub-owned intent keeps its error semantics. Only after no active or
+retired GitHub ownership remains does the current native-owned context become
+`success` with `Native Vercel owns this UI preview`. Missing, malformed, or
+unknown candidate configuration, multiple matching workers, and an
 `observe-only`/GitHub-owned combination remain `error`.
 
 That green context proves only the controller's owner selection and drained

--- a/docs/vercel-deployments.md
+++ b/docs/vercel-deployments.md
@@ -14,11 +14,14 @@ owned by Vercel Git.
 
 The automatic controller's version-controlled
 `VERCEL_PREVIEW_CONTROLLER_MODE` is `active` in this ownership state. The only
-other accepted value is `observe-only`, which records receipts and publishes a
-truthful no-dispatch status but cannot create a worker. The executable ownership
-test requires `active` to be paired with disabled native UI branch previews and
-`observe-only` to be paired with restored native previews, so a reviewed change
-cannot leave both automatic owners enabled or leave the UI branch path ownerless.
+other accepted value is `observe-only`, which records receipts, recovers or
+retires already-persisted dispatch ownership, and publishes a truthful
+no-dispatch status but cannot create a worker. The executable ownership test
+requires `active` to be paired with disabled native UI branch previews and
+`observe-only` to be paired with restored native previews. The runtime
+controller separately validates the candidate's exact-head UI Vercel
+configuration, covering the pull-request window in which the trusted workflow
+still comes from `main` while Vercel already reads the candidate branch.
 
 ## Pinned prerequisites
 
@@ -708,13 +711,27 @@ one validated PR number. The controller has no Vercel/Turbo credential and no
 write-token job checks out or executes PR code.
 
 The workflow-level `VERCEL_PREVIEW_CONTROLLER_MODE` is an executable ownership
-switch, not a secret or an operator-set repository variable. Every reconciliation
-passes it to the trusted controller implementation. `active` permits the one
-worker-dispatch path; `observe-only` returns before intent selection, writes no
-new dispatch entry, and publishes `GitHub preview dispatch is observe-only` for
-the current open head. The dedicated dispatch secret is exposed to the step only
-when the version-controlled mode is `active`, and the dispatch implementation
-rechecks that mode immediately before its only worker-dispatch POST.
+switch, not a secret or an operator-set repository variable. Every
+reconciliation passes it to the trusted controller implementation. For each
+open trusted PR, the controller also reads
+`apps/ui.mento.org/vercel.json` from the candidate's exact 40-character head
+SHA through the Contents API. It accepts only the bounded, valid UTF-8 JSON
+representation of the two exact reviewed ownership configurations in this
+runbook; missing, oversized, malformed, or unknown content fails closed before
+journal mutation or any worker-dispatch request.
+
+`active` can create a worker only for the exact GitHub-owned configuration and
+rechecks that exact-head ownership immediately before the dispatch credential
+can make its only POST. The exact native configuration suppresses dispatch even
+when the default-branch workflow is still `active`, which protects a rollback
+PR before it merges. `observe-only` never creates a dispatch intent or worker.
+It does, however, reconcile a previously persisted `intended` entry: one unique
+existing worker is attached without the secondary credential, a completed
+worker is terminalized normally, an in-progress worker remains durably attached
+for its callback, and no match after bounded observation is retired as
+`dispatch-disabled-intent-without-worker`. Multiple matches fail closed. An
+`observe-only` controller paired with the GitHub-owned candidate configuration
+also fails closed because neither automatic preview path would own that head.
 
 Dependabot is intentionally split out before any write boundary.
 `.github/workflows/vercel-preview-intake.yml` receives the same PR activities
@@ -961,9 +978,13 @@ because a worker created by that token does not produce the terminal
 
 This dispatch description applies only while
 `VERCEL_PREVIEW_CONTROLLER_MODE: active`. In `observe-only` mode, event planning,
-journal receipts, completed-worker recovery, and the explicit no-dispatch status
-remain available, but the secondary client is not populated and the dispatch
-guard rejects the POST even if a caller reaches it unexpectedly.
+journal receipts, completed-worker recovery, crash-window intent discovery or
+retirement, and the explicit no-dispatch status remain available, but the
+secondary client is not populated and the dispatch guard rejects the POST even
+if a caller reaches it unexpectedly. Exact native candidate ownership also
+disables dispatch while an `active` default-branch controller handles the
+rollback PR; candidate configuration errors and ownership ambiguity never make
+a secondary-client request.
 
 The dispatch occurs only while the executing controller's own workflow SHA
 still equals the persisted intent. If the dedicated secret is missing, the
@@ -1279,10 +1300,33 @@ restore `apps/ui.mento.org/vercel.json` exactly to:
 ```
 
 Do not split those two edits across merges. A configuration-only rollback would
-restore native previews while the active controller could still dispatch a
-duplicate GitHub-built preview. A mode-only rollback would leave the UI branch
-path with no automatic preview owner. `pnpm vercel:preview:test` rejects both
-invalid ownership pairs.
+not be a supported steady state, and a mode-only rollback would leave every
+still-Phase-B UI branch without an automatic preview owner.
+`pnpm vercel:preview:test` rejects both invalid repository ownership pairs. The
+exact-head runtime guard is additional pre-merge protection: as soon as the
+rollback PR contains the exact native configuration, the still-`active`
+controller from `main` refuses to dispatch for it. This cross-ref safeguard does
+not make a split rollback acceptable.
+
+On the rollback PR, `Vercel Preview` reports `pending` with
+`Draining GitHub preview before native ownership` while any journal-owned
+GitHub intent or worker remains. The controller attaches a uniquely matching
+crash-window worker without dispatching; completion is recovered normally, and
+an intent with no worker is durably retired after bounded observation. Only
+after no active or retired GitHub ownership remains does the context become
+`success` with `Native Vercel owns this UI preview`. Missing, malformed, or
+unknown candidate configuration, multiple matching workers, and an
+`observe-only`/GitHub-owned combination remain `error`.
+
+That green context proves only the controller's owner selection and drained
+journal state. Its target is the controller run as audit evidence; it does not
+prove that native Vercel built, deployed, or smoke-tested the candidate. Before
+merging the rollback, separately require the native Vercel deployment/status
+for the rollback PR's exact head SHA, open its immutable preview URL, and run the
+repository browser protocol: verify rendering and primary navigation, inspect
+console errors and failed network requests, confirm assets and fonts, and check
+the expected security headers. Record the native deployment and browser
+evidence on the PR. Never treat the ownership-only status as this evidence.
 
 Immediately before merging the rollback, establish a coordinated no-push window
 and drain or cancel every non-completed run of all three workflows:
@@ -1333,7 +1377,10 @@ Before merging the rollback, inventory every active UI-runtime PR and branch
 that carries the Phase B `"**": false` rule. After the restored configuration
 reaches `main`, each inventoried branch must rebase or merge that `main`, or
 receive an explicitly reviewed equivalent branch update containing the exact
-rollback configuration, before native preview restoration can be claimed.
+rollback configuration, before native preview restoration can be claimed. A
+stale Phase B branch still carrying the GitHub-owned configuration is
+deliberately ownerless under the restored `observe-only` controller and receives
+an error status until it takes the rollback configuration.
 
 The rollback PR must update the current-state ownership text in `README.md` and
 this runbook. Do not weaken or remove the executable pairing assertion in
@@ -1342,8 +1389,9 @@ mode/configuration change mandatory.
 
 Use a fresh or restored-main-rebased UI canary to prove native previews return.
 A fresh canary proves only its own branch and is not evidence that every active
-Phase B branch was restored. Remove or leave non-required the `Vercel Preview`
-ruleset context until the controller is repaired. Do not change production
+Phase B branch was restored. The `Vercel Preview` context remains
+ownership-only in `observe-only`; require separate native Vercel and browser
+evidence anywhere preview readiness gates a merge. Do not change production
 domains, other apps, or recreate Governance QA.
 
 ### Historical Phase A pilot cleanup

--- a/docs/vercel-deployments.md
+++ b/docs/vercel-deployments.md
@@ -659,12 +659,12 @@ failure could not overwrite a verified deployment's lifecycle truth. The
 reusable workflow published `deployment_url` only from the smoke-backed success
 step; it never fell back to the unverified upload output.
 
-A Deployment or status created with the repository `GITHUB_TOKEN` did not
+A Deployment or status created with the repository `GITHUB_TOKEN` does not
 trigger another workflow run. Therefore `.github/workflows/preview-smoke.yml`
 did not recurse for the pilot. Direct smoke in the reusable worker was the
-required success gate. The pilot did not add a PAT to force
-`deployment_status` recursion. The dedicated worker-dispatch PAT was not an
-exception; its sole purpose was the automatic controller's worker
+required success gate. Do not add a PAT to force `deployment_status` recursion;
+the Phase A pilot did not need one. The dedicated worker-dispatch PAT was not
+an exception; its sole purpose was the automatic controller's worker
 `workflow_dispatch` POST described below.
 
 ### Historical Phase A evidence and browser verification

--- a/docs/vercel-deployments.md
+++ b/docs/vercel-deployments.md
@@ -1356,7 +1356,12 @@ unknown candidate configuration, multiple matching workers, and an
 
 That green context proves only the controller's owner selection and drained
 journal state. Its target is the controller run as audit evidence; it does not
-prove that native Vercel built, deployed, or smoke-tested the candidate. Before
+prove that native Vercel built, deployed, or smoke-tested the candidate. The
+same current-head ownership decision is persisted in the
+journal and posted as the external status. A native-ownership checkpoint keeps
+that meaning across later docs-only pushes but never updates
+`last_successful_runtime_*`; only validated live worker evidence can replace
+that build-and-smoke provenance. Before
 merging the rollback, separately require the native Vercel deployment/status
 for the rollback PR's exact head SHA, open its immutable preview URL, and run the
 repository browser protocol: verify rendering and primary navigation, inspect

--- a/docs/vercel-deployments.md
+++ b/docs/vercel-deployments.md
@@ -1288,17 +1288,43 @@ Immediately before merging the rollback, establish a coordinated no-push window
 and drain or cancel every non-completed run of all three workflows:
 
 ```bash
-gh run list --workflow vercel-preview-controller.yml --limit 100 --json databaseId,status,url
-gh run list --workflow vercel-preview-worker.yml --limit 100 --json databaseId,status,url
-gh run list --workflow vercel-preview-intake.yml --limit 100 --json databaseId,status,url
-gh run cancel <run-id>
+list_nonterminal_preview_runs() {
+  local workflow status
+  local -a workflows=(
+    vercel-preview-controller.yml
+    vercel-preview-worker.yml
+    vercel-preview-intake.yml
+  )
+  local -a statuses=(queued requested waiting pending in_progress)
+
+  for workflow in "${workflows[@]}"; do
+    for status in "${statuses[@]}"; do
+      gh api --paginate --method GET \
+        "repos/mento-protocol/frontend-monorepo/actions/workflows/${workflow}/runs" \
+        -f status="$status" \
+        -f per_page=100 \
+        --jq '.workflow_runs[] | [.id, .status, .path, .html_url] | @tsv'
+    done
+  done | sort -u
+}
+
+list_nonterminal_preview_runs
+list_nonterminal_preview_runs |
+  cut -f1 |
+  sort -u |
+  while read -r run_id; do gh run cancel "$run_id"; done
 ```
 
-Repeat the inventory after cancellations settle because worker and intake
-completion can start a final controller callback. Do not merge until repeated
-sweeps show no queued, requested, waiting, pending, or in-progress controller,
-worker, or intake run. This quiescence proof prevents a run loaded from the old
-`active` workflow SHA from dispatching after native ownership is restored.
+`gh api --paginate` follows every response page separately for every workflow
+and every GitHub nonterminal status; do not replace it with a bounded
+`gh run list --limit ...` query. Repeat the inventory and cancellation pipeline
+until the inventory prints no rows. After that first empty result, wait for
+cancellations to settle because worker and intake completion can start a final
+controller callback, then require a second empty exhaustive sweep immediately
+before merge. Do not merge while any queued, requested, waiting, pending, or
+in-progress controller, worker, or intake run remains. This quiescence proof
+prevents a run loaded from the old `active` workflow SHA from dispatching after
+native ownership is restored.
 
 Before merging the rollback, inventory every active UI-runtime PR and branch
 that carries the Phase B `"**": false` rule. After the restored configuration

--- a/docs/vercel-deployments.md
+++ b/docs/vercel-deployments.md
@@ -12,6 +12,14 @@ ownership to GitHub Actions. Native Vercel Git previews are now disabled for UI
 branches other than `main`; production/main and every non-UI application remain
 owned by Vercel Git.
 
+The automatic controller's version-controlled
+`VERCEL_PREVIEW_CONTROLLER_MODE` is `active` in this ownership state. The only
+other accepted value is `observe-only`, which records receipts and publishes a
+truthful no-dispatch status but cannot create a worker. The executable ownership
+test requires `active` to be paired with disabled native UI branch previews and
+`observe-only` to be paired with restored native previews, so a reviewed change
+cannot leave both automatic owners enabled or leave the UI branch path ownerless.
+
 ## Pinned prerequisites
 
 - Vercel CLI: exactly `56.2.0` in the root `devDependencies`. The project owner
@@ -699,6 +707,15 @@ completed `Vercel Preview Worker` callbacks; and accepts the default-branch-boun
 one validated PR number. The controller has no Vercel/Turbo credential and no
 write-token job checks out or executes PR code.
 
+The workflow-level `VERCEL_PREVIEW_CONTROLLER_MODE` is an executable ownership
+switch, not a secret or an operator-set repository variable. Every reconciliation
+passes it to the trusted controller implementation. `active` permits the one
+worker-dispatch path; `observe-only` returns before intent selection, writes no
+new dispatch entry, and publishes `GitHub preview dispatch is observe-only` for
+the current open head. The dedicated dispatch secret is exposed to the step only
+when the version-controlled mode is `active`, and the dispatch implementation
+rechecks that mode immediately before its only worker-dispatch POST.
+
 Dependabot is intentionally split out before any write boundary.
 `.github/workflows/vercel-preview-intake.yml` receives the same PR activities
 with only `contents: read`, performs metadata validation without a checkout,
@@ -941,6 +958,12 @@ all journal, status, Deployment, PR, run-listing, run-validation, and recovery
 operations. The controller never falls back to `GITHUB_TOKEN` for dispatch,
 because a worker created by that token does not produce the terminal
 `workflow_run` callback required by this protocol.
+
+This dispatch description applies only while
+`VERCEL_PREVIEW_CONTROLLER_MODE: active`. In `observe-only` mode, event planning,
+journal receipts, completed-worker recovery, and the explicit no-dispatch status
+remain available, but the secondary client is not populated and the dispatch
+guard rejects the POST even if a caller reaches it unexpectedly.
 
 The dispatch occurs only while the executing controller's own workflow SHA
 still equals the persisted intent. If the dedicated secret is missing, the
@@ -1208,8 +1231,10 @@ unsupported-trust, failure, cancellation, and old-epoch evidence.
 
 Phase B is the current ownership model after this change merges. Its completed
 precondition was that every Phase A dual-path canary above passed and its
-GitHub-built/native-preview evidence was recorded. This separate merge changes
-only `apps/ui.mento.org/vercel.json`, preserving its schema and unrelated keys:
+GitHub-built/native-preview evidence was recorded. This separate merge pairs
+`VERCEL_PREVIEW_CONTROLLER_MODE: active` in
+`.github/workflows/vercel-preview-controller.yml` with the following exact
+`apps/ui.mento.org/vercel.json`, preserving its schema and unrelated keys:
 
 ```json
 {
@@ -1238,8 +1263,9 @@ unchanged native merge/main deployment. A fresh canary proves only its own
 branch; stale pre-cutover branches still carry their old static `vercel.json`
 and are not valid repository-wide duplicate-prevention evidence.
 
-Rollback is mutually exclusive with the Phase B configuration and changes that
-same file exactly to:
+Rollback is mutually exclusive with the Phase B configuration. One reviewed PR
+must atomically change `VERCEL_PREVIEW_CONTROLLER_MODE` to `observe-only` and
+restore `apps/ui.mento.org/vercel.json` exactly to:
 
 ```json
 {
@@ -1252,17 +1278,38 @@ same file exactly to:
 }
 ```
 
+Do not split those two edits across merges. A configuration-only rollback would
+restore native previews while the active controller could still dispatch a
+duplicate GitHub-built preview. A mode-only rollback would leave the UI branch
+path with no automatic preview owner. `pnpm vercel:preview:test` rejects both
+invalid ownership pairs.
+
+Immediately before merging the rollback, establish a coordinated no-push window
+and drain or cancel every non-completed run of all three workflows:
+
+```bash
+gh run list --workflow vercel-preview-controller.yml --limit 100 --json databaseId,status,url
+gh run list --workflow vercel-preview-worker.yml --limit 100 --json databaseId,status,url
+gh run list --workflow vercel-preview-intake.yml --limit 100 --json databaseId,status,url
+gh run cancel <run-id>
+```
+
+Repeat the inventory after cancellations settle because worker and intake
+completion can start a final controller callback. Do not merge until repeated
+sweeps show no queued, requested, waiting, pending, or in-progress controller,
+worker, or intake run. This quiescence proof prevents a run loaded from the old
+`active` workflow SHA from dispatching after native ownership is restored.
+
 Before merging the rollback, inventory every active UI-runtime PR and branch
 that carries the Phase B `"**": false` rule. After the restored configuration
 reaches `main`, each inventoried branch must rebase or merge that `main`, or
 receive an explicitly reviewed equivalent branch update containing the exact
 rollback configuration, before native preview restoration can be claimed.
 
-The rollback PR must also update the executable ownership assertion in
-`scripts/vercel-git-ownership.test.mjs` and the current-state ownership text in
-`README.md` and this runbook. Do not merge a configuration-only rollback that
-leaves repository tests or operator documentation claiming that GitHub Actions
-still owns UI branch previews.
+The rollback PR must update the current-state ownership text in `README.md` and
+this runbook. Do not weaken or remove the executable pairing assertion in
+`scripts/vercel-git-ownership.test.mjs`; it is the guard that makes the atomic
+mode/configuration change mandatory.
 
 Use a fresh or restored-main-rebased UI canary to prove native previews return.
 A fresh canary proves only its own branch and is not evidence that every active

--- a/docs/vercel-deployments.md
+++ b/docs/vercel-deployments.md
@@ -674,8 +674,9 @@ navigation, inspect console errors and failed network requests, confirm static
 assets/fonts, and compare security headers plus the Vercel toolbar/CSP behavior
 with the native preview. Attach the URL and concise evidence to the PR or issue.
 
-The final UI Git-ownership cutover remains blocked on the cost go/no-go evidence
-in issue #518 and the Phase A live canaries below.
+The cost go/no-go record in issue #518 and the Phase A live-canary evidence
+below were prerequisites for the final UI Git-ownership cutover. The current
+Phase B ownership model reflects that gate having completed.
 
 ## Automatic trusted UI previews (Phase A)
 
@@ -965,7 +966,9 @@ terminal recovery succeeds, the same journal gains the result, active ownership
 clears, and `Vercel Preview` becomes terminal at the immutable URL. Repeat with
 a controlled failure and a cancelled worker before Deployment creation, then
 rerun a callback to prove journal, worker, Deployment, and result idempotency.
-Until that evidence exists after provisioning, Phase A remains blocked.
+That automatic-callback, failure, cancellation, and replay evidence was a Phase
+A acceptance gate after credential provisioning and had to pass before the UI
+Git-ownership cutover.
 
 The canonical Deployment key and environment are:
 
@@ -1055,8 +1058,9 @@ or exactly-once delivery across GitHub and Vercel.
 
 ### Bootstrap and operator recovery
 
-Before `Vercel Preview` becomes required, inventory every already-open PR and
-bootstrap each trusted same-repository PR that should participate. A lone
+Before `Vercel Preview` became required during Phase A, maintainers had to
+inventory every already-open PR and bootstrap each trusted same-repository PR
+that should participate. A lone
 synchronize journal entry deliberately waits for an
 opened/reopened/bootstrap anchor. Repeated semantically identical bootstrap
 requests are idempotent, and a bootstrap identical to an existing lifecycle
@@ -1150,13 +1154,14 @@ full-body schema validation.
 
 ### Phase A canary evidence template
 
-Keep native Vercel Git UI previews enabled. For every canary, record the PR,
-exact SHA(s), controller/worker run URLs, controller key/digest, canonical
+Phase A kept native Vercel Git UI previews enabled. For every canary, record the
+PR, exact SHA(s), controller/worker run URLs, controller key/digest, canonical
 GitHub Deployment ID, GitHub-built immutable URL, native Vercel immutable URL,
 canonical journal comment ID/revision/`journal_digest`/`state.receipts_digest`,
 terminal `Vercel Preview` status, and browser evidence.
 
-Verify all of these before changing the ruleset or starting Phase B:
+The Phase A gate required all of these before changing the ruleset or starting
+Phase B:
 
 1. trusted UI-affecting A produces both native and GitHub previews;
 2. rapid UI pushes A -> B -> C deploy A then C, with B durably coalesced;
@@ -1185,18 +1190,16 @@ network requests, confirm JS/CSS/font assets, and compare security headers plus
 Vercel toolbar/CSP behavior with the native preview. A canary is not accepted
 from workflow logs alone.
 
-Only after successful deploy, no-runtime, runtime-reuse, coalesced, after-idle,
-idempotent replay/reconcile, unsupported-trust, failure, cancellation, and
-old-epoch evidence is recent may the ruleset require the Statuses API
-`Vercel Preview` context.
+The Phase A ruleset change was gated on recent successful-deploy, no-runtime,
+runtime-reuse, coalesced, after-idle, idempotent replay/reconcile,
+unsupported-trust, failure, cancellation, and old-epoch evidence.
 
 ## UI Vercel Git cutover (Phase B)
 
-Phase B becomes the current ownership model when this change merges. Merge it
-only after every Phase A dual-path canary above has passed and its
-GitHub-built/native-preview evidence has been recorded. This separate merge
-changes only `apps/ui.mento.org/vercel.json`, preserving its schema and unrelated
-keys:
+Phase B is the current ownership model after this change merges. Its completed
+precondition was that every Phase A dual-path canary above passed and its
+GitHub-built/native-preview evidence was recorded. This separate merge changes
+only `apps/ui.mento.org/vercel.json`, preserving its schema and unrelated keys:
 
 ```json
 {
@@ -1212,13 +1215,18 @@ keys:
 
 Vercel treats any matching `true` as enabled, so `main` remains natively
 deployed even though it also matches `**`. If this Phase B branch waited while
-Phase A changed, rebase it onto the final Phase A `main` before merge. After the
-merge, use a fresh UI canary or rebase an existing UI canary onto the resulting
-`main` so it contains this configuration. Prove one canonical GitHub
-Deployment, one Vercel preview, no native branch preview, a truthful required
-status, and an unchanged native merge/main deployment. Stale pre-cutover
-branches still carry their old static `vercel.json` and are not valid
-duplicate-prevention evidence.
+Phase A changed, rebase it onto the final Phase A `main` before merge. Before
+the Phase B merge, inventory every active UI-runtime PR and branch. After the
+cutover reaches `main`, each active branch must rebase or merge that `main`, or
+receive an explicitly reviewed equivalent branch update containing this Phase B
+configuration, before repository-wide duplicate prevention can be claimed.
+
+Use a fresh UI canary or rebase an existing UI canary onto the resulting `main`
+so it contains this configuration. Prove one canonical GitHub Deployment, one
+Vercel preview, no native branch preview, a truthful required status, and an
+unchanged native merge/main deployment. A fresh canary proves only its own
+branch; stale pre-cutover branches still carry their old static `vercel.json`
+and are not valid repository-wide duplicate-prevention evidence.
 
 Rollback is mutually exclusive with the Phase B configuration and changes that
 same file exactly to:
@@ -1234,10 +1242,17 @@ same file exactly to:
 }
 ```
 
-Merge the rollback normally, use a fresh UI canary to prove native previews
-return, and remove/leave non-required the `Vercel Preview` ruleset context until
-the controller is repaired. Do not change production domains, other apps, or
-recreate Governance QA.
+Before merging the rollback, inventory every active UI-runtime PR and branch
+that carries the Phase B `"**": false` rule. After the restored configuration
+reaches `main`, each inventoried branch must rebase or merge that `main`, or
+receive an explicitly reviewed equivalent branch update containing the exact
+rollback configuration, before native preview restoration can be claimed.
+
+Use a fresh or restored-main-rebased UI canary to prove native previews return.
+A fresh canary proves only its own branch and is not evidence that every active
+Phase B branch was restored. Remove or leave non-required the `Vercel Preview`
+ruleset context until the controller is repaired. Do not change production
+domains, other apps, or recreate Governance QA.
 
 ### Cleanup
 

--- a/docs/vercel-deployments.md
+++ b/docs/vercel-deployments.md
@@ -713,18 +713,26 @@ write-token job checks out or executes PR code.
 The workflow-level `VERCEL_PREVIEW_CONTROLLER_MODE` is an executable ownership
 switch, not a secret or an operator-set repository variable. Every
 reconciliation passes it to the trusted controller implementation. For each
-open trusted PR, the controller also reads
-`apps/ui.mento.org/vercel.json` from the candidate's exact 40-character head
-SHA through the Contents API. It accepts only the bounded, valid UTF-8 JSON
-representation of the two exact reviewed ownership configurations in this
-runbook; missing, oversized, malformed, or unknown content fails closed before
-journal mutation or any worker-dispatch request.
+open trusted PR, the controller reads `apps/ui.mento.org/vercel.json` through
+the Contents API at immutable 40-character SHAs. The current PR head selects
+the controller's overall mode, but every historical event selected for dispatch
+is checked again at that event's own SHA after its PR-lineage association is
+proven. It accepts only the bounded, valid UTF-8 JSON representation of the two
+exact reviewed ownership configurations in this runbook; missing, oversized,
+malformed, or unknown content fails closed before any worker-dispatch request.
 
-`active` can create a worker only for the exact GitHub-owned configuration and
-rechecks that exact-head ownership immediately before the dispatch credential
-can make its only POST. The exact native configuration suppresses dispatch even
-when the default-branch workflow is still `active`, which protects a rollback
-PR before it merges. `observe-only` never creates a dispatch intent or worker.
+`active` can create a worker only while both the current head and the selected
+event SHA have the exact GitHub-owned configuration, and rechecks both immutable
+ownership inputs immediately before the dispatch credential can make its only
+POST. A selected native-owned receipt is persisted as an intent and routed
+through the same bounded no-dispatch recovery path: one already-created worker
+is attached and drained, while no matching worker produces the durable
+`dispatch-disabled-intent-without-worker` result and advances reconciliation to
+the next receipt. That terminal reason is ownership-success, not GitHub build
+evidence; it creates no GitHub Deployment. The exact native configuration also
+suppresses dispatch when the default-branch workflow is still `active`, which
+protects a rollback PR before it merges. `observe-only` never creates a new
+dispatch intent or worker.
 It does, however, reconcile every previously persisted `intended` entry in both
 the current and epoch-retired ownership slots: one unique existing worker is
 attached without the secondary credential, a completed worker is terminalized
@@ -975,6 +983,14 @@ when the workflow path, event, default ref, authorized SHA, attempt, and
 epoch-bound title identity also validate. Completion follow-ups route by the
 exact worker or intake workflow path rather than the presentation name, then
 repeat full source validation before any status or Deployment write.
+
+The worker independently repeats the immutable ownership check before emitting
+`should_deploy`, inspecting deployment state, or reaching any Vercel secret. It
+requires both the then-current PR head and its controller-authorized
+`commit_sha` to remain GitHub-owned. This is defense in depth for a worker that
+was queued while ownership changed; controller journal ownership alone cannot
+authorize code whose own `vercel.json` assigns preview deployment to native
+Vercel.
 
 Zero matches dispatches `.github/workflows/vercel-preview-worker.yml` on `main`
 using a secondary Octokit client authenticated only by repository secret
@@ -1323,10 +1339,14 @@ On the rollback PR, `Vercel Preview` reports `pending` with
 GitHub intent or worker remains. The controller attaches a uniquely matching
 crash-window worker without dispatching, including ownership retired by a close
 or reopen epoch; completion is recovered in that same reconciliation attempt,
-and an intent with no worker is durably retired after bounded observation. Only
-after no active or retired GitHub ownership remains does the context become
-`success` with `Native Vercel owns this UI preview`. Missing, malformed, or
-unknown candidate configuration, multiple matching workers, and an
+and an intent with no worker is durably retired after bounded observation. A
+native-owned historical receipt encountered after a later switch back to
+GitHub ownership follows that same durable retirement path instead of being
+dispatched by the later head's configuration. The synthetic no-dispatch result
+is reported as ownership-success and never claims a native build or smoke.
+Only after no active or retired GitHub ownership remains does the context
+become `success` with `Native Vercel owns this UI preview`. Missing, malformed,
+or unknown candidate configuration, multiple matching workers, and an
 `observe-only`/GitHub-owned combination remain `error`.
 
 That green context proves only the controller's owner selection and drained

--- a/docs/vercel-deployments.md
+++ b/docs/vercel-deployments.md
@@ -301,53 +301,59 @@ build-minute observation are documented in
 tool does not start the observation window; collection begins only after the
 four-target cutover is complete.
 
-## Manual UI prebuilt pilot
+## Historical Phase A manual UI prebuilt pilot (audit record)
 
-`.github/workflows/vercel-prebuilt-pilot.yml` is the only entry point for the
-first prebuilt preview. It has only a manual `workflow_dispatch` trigger and
-accepts exactly three selectors: the fixed `ui` target, an immutable lowercase
-40-character commit SHA, and the same-repository branch that contains that SHA.
-It does not replace or disable the Vercel Git integration. Native Vercel Git
-previews remain the source of truth while this pilot gathers functional and
-timing evidence.
+> **Historical evidence only.** This section preserves the Phase A pilot's
+> controls and native-preview comparison procedure for audit. It is not a
+> current operator entry point: under Phase B, do not dispatch the manual pilot
+> or expect a same-SHA native UI branch preview. Current operators must use the
+> [Phase B canary and rollback procedures](#ui-vercel-git-cutover-phase-b).
+> The commands and implementation details below are retained only as audited
+> Phase A evidence and must not be treated as a supported Phase B procedure.
 
-The caller maps only the UI preview configuration:
+During Phase A, `.github/workflows/vercel-prebuilt-pilot.yml` was the only entry
+point for the first prebuilt preview. It had only a manual `workflow_dispatch`
+trigger and accepted exactly three selectors: the fixed `ui` target, an
+immutable lowercase 40-character commit SHA, and the same-repository branch
+that contained that SHA. It did not replace or disable the Vercel Git
+integration. Native Vercel Git previews remained the source of truth while the
+pilot gathered functional and timing evidence.
+
+The Phase A caller mapped only the UI preview configuration:
 
 - repository variables `VERCEL_ORG_ID`, `VERCEL_PROJECT_ID_UI`, and
   `TURBO_TEAM`;
 - repository secrets `VERCEL_TOKEN_PREVIEW`, `TURBO_TOKEN`, and
   `TURBO_REMOTE_CACHE_SIGNATURE_KEY`.
 
-The reusable worker declares each secret separately. It never inherits all
-caller secrets, never receives a production Vercel token, never selects a
-production GitHub environment, and never passes a token on a command line. The
-separate smoke job receives no Vercel or Turbo credential and has only
-`contents: read` permission; the immutable preview must therefore be publicly
-reachable for this pilot.
+The reusable worker declared each secret separately. It never inherited all
+caller secrets, received a production Vercel token, selected a production
+GitHub environment, or passed a token on a command line. The separate smoke job
+received no Vercel or Turbo credential and had only `contents: read` permission;
+the immutable preview therefore had to be publicly reachable for the pilot.
 
-The reusable contract accepts only `refs/heads/main` and the exact main-branch
-pilot caller identity. A dispatch that selects another branch, tag, or caller is
-rejected before candidate dependency or build code executes.
+The reusable contract accepted only `refs/heads/main` and the exact main-branch
+pilot caller identity. A dispatch selecting another branch, tag, or caller was
+rejected before candidate dependency or build code executed.
 
-### Dispatch
+### Historical Phase A dispatch procedure
 
-This is a privileged maintainer action, not an automatic PR trigger. Dispatch
-only after reviewing the selected SHA and accepting its same-repository author
-as trusted: dependency installation and the UI build execute that source with
-the pulled UI preview variables and signed Turbo cache credentials. The
-candidate process never receives the Vercel token, but it can read its own
-build inputs and execute arbitrary build code. Fork sources cannot be selected,
-and the workflow rejects Dependabot branches. If the source is not trusted, do
-not dispatch the pilot.
+This was a privileged maintainer action, not an automatic PR trigger. Phase A
+maintainers dispatched only after reviewing the selected SHA and accepting its
+same-repository author as trusted: dependency installation and the UI build
+executed that source with the pulled UI preview variables and signed Turbo cache
+credentials. The candidate process never received the Vercel token, but it
+could read its own build inputs and execute arbitrary build code. Fork sources
+could not be selected, and the workflow rejected Dependabot branches.
 
-The dispatch is accepted only from `refs/heads/main`. The caller invokes the
-reusable worker from the same main commit, and the worker validates the caller
-workflow identity again before any candidate code or credentialed step runs. A
-dispatch that selects another branch or tag is rejected before the reusable
-job receives its preview credentials.
+The dispatch was accepted only from `refs/heads/main`. The caller invoked the
+reusable worker from the same main commit, and the worker validated the caller
+workflow identity again before any candidate code or credentialed step ran. A
+dispatch selecting another branch or tag was rejected before the reusable job
+received its preview credentials.
 
-Choose a SHA that already has a native Vercel Git UI preview and a branch that
-contains it. Verify both locally before dispatching:
+Phase A maintainers chose a SHA that already had a native Vercel Git UI preview
+and a branch that contained it. They verified both locally before dispatching:
 
 ```bash
 SHA="<lowercase-40-character-sha>"
@@ -362,22 +368,22 @@ gh workflow run vercel-prebuilt-pilot.yml \
   -f git_branch="$BRANCH"
 ```
 
-The workflow independently rejects malformed, option-like, newline-bearing,
-missing, or unreachable refs. It checks out the exact SHA with full history and
-uses the recorded `HEAD` for the custom Next deployment ID, Vercel metadata,
+The workflow independently rejected malformed, option-like, newline-bearing,
+missing, or unreachable refs. It checked out the exact SHA with full history
+and used the recorded `HEAD` for the custom Next deployment ID, Vercel metadata,
 GitHub Deployment ref, smoke evidence, and outputs.
 
-Do not dispatch from a pull-request ref. After the main-only guard, the workflow
-controller is checked out from the trusted `github.workflow_sha`; the requested
-source is checked out separately and is never executed automatically with
-preview credentials. Candidate dependency lifecycle scripts are disabled. The
-worker also restores the controller from its trusted workflow SHA after
-dependency installation and again after the candidate build, before output
-assertion, upload, and inspection.
+The Phase A pilot did not dispatch from a pull-request ref. After the main-only
+guard, the workflow controller was checked out from the trusted
+`github.workflow_sha`; the requested source was checked out separately and was
+never executed automatically with preview credentials. Candidate dependency
+lifecycle scripts were disabled. The worker also restored the controller from
+its trusted workflow SHA after dependency installation and again after the
+candidate build, before output assertion, upload, and inspection.
 
-The Vercel CLI is a separate trusted tool install. Pinned pnpm `10.34.4` reads
-the main controller's exact `package.json` and frozen `pnpm-lock.yaml`, disables
-lifecycle scripts, and copies packages into a runner-owned directory outside
+The Vercel CLI was a separate trusted tool install. Pinned pnpm `10.34.4` read
+the main controller's exact `package.json` and frozen `pnpm-lock.yaml`, disabled
+lifecycle scripts, and copied packages into a runner-owned directory outside
 the checkout. Its `--modules-dir` and `--virtual-store-dir` values are validated
 relative paths from the controller to that directory; pnpm treats an absolute
 `--modules-dir` as project-relative and would otherwise materialize the CLI at
@@ -440,12 +446,12 @@ Before staging, the controller requires the manifest to match its exact allowed
 fields and binds the complete one-importer lockfile bytes to
 `PINNED_PNPM_RUNTIME_LOCKFILE_SHA256`; this rejects extra dependency/config
 sections, custom tarballs, changed integrity, or extra importers/packages before
-the bootstrap install. A pnpm bump must update the bootstrap npm manifest and
-lockfile, reviewed registry SRI and Linux x64 executable digest, isolated
-JavaScript-runtime manifest and pnpm lockfile, `PINNED_PNPM_VERSION`, and both
-complete-lockfile digests together. On a non-Linux development host,
-`npm install --package-lock-only --force` may be used only to regenerate this
-Linux-specific lock; the CI installation must never use `--force`.
+the bootstrap install. Any Phase A pnpm bump had to update the bootstrap npm
+manifest and lockfile, reviewed registry SRI and Linux x64 executable digest,
+isolated JavaScript-runtime manifest and pnpm lockfile, `PINNED_PNPM_VERSION`,
+and both complete-lockfile digests together. On a non-Linux development host,
+`npm install --package-lock-only --force` could be used only to regenerate this
+Linux-specific lock; the CI installation was never allowed to use `--force`.
 The protected launcher always uses protected Node plus that runtime's
 `pnpm.cjs`; it disables pnpm's package-manager self-switch and strict patch
 version check so an older candidate `packageManager` field cannot silently
@@ -477,9 +483,10 @@ Its isolated `HOME` and XDG directories place that store under the disposable
 candidate home, which is deleted before upload. Sharing a runner store here
 would let selected source code mutate cache state that an Actions post-step
 could save from the trusted `main` run if an isolation boundary regressed.
-Treat candidate dependency installation as a cold, measured pilot cost; record
-its duration separately from `vercel build`. The signed Turbo remote build
-cache remains enabled and its hit/miss evidence remains part of the comparison.
+Phase A treated candidate dependency installation as a cold, measured pilot
+cost and recorded its duration separately from `vercel build`. The signed Turbo
+remote build cache remained enabled, and its hit/miss evidence remained part of
+the historical comparison.
 
 Before candidate installation, the worker proves the checked-out index tree is
 the exact selected commit tree. The candidate UID cannot write `/var/lib`, the
@@ -505,10 +512,10 @@ removes the empty work and outer directories, and proves the outer root is
 absent before deleting the recorded candidate user and group. Unexpected
 top-level state or a pre-existing/unmatched candidate identity is never deleted.
 
-### Root Directory and command sequence
+### Historical Phase A Root Directory and command sequence
 
-The pinned Vercel CLI commands execute from monorepo-shaped roots. Before
-`vercel pull`, the worker creates a fresh runner-owned staging tree at a fixed
+The pinned Vercel CLI commands executed from monorepo-shaped roots. Before
+`vercel pull`, the worker created a fresh runner-owned staging tree at a fixed
 path under `$VERCEL_ISOLATION_ROOT`. That tree contains only real
 `apps/ui.mento.org` directory components and an ephemeral repo-level link built
 from trusted repository variables; it contains no checked-out candidate file.
@@ -547,8 +554,7 @@ controller validates the ID variables but deliberately withholds them from the
 Vercel CLI child process: CLI `56.2.0` otherwise gives those variables
 precedence over `repo.json` and loses the monorepo Root Directory mapping.
 
-The credentialed worker runs this sequence in one standard `ubuntu-latest`
-job:
+The credentialed worker ran this sequence in one standard `ubuntu-latest` job:
 
 1. create the fresh runner-owned pull staging and exact repo-level UI link;
 2. run `vercel pull --yes --environment preview --git-branch
@@ -593,7 +599,7 @@ remain rejected. Before reading or copying the handoff, the validator also caps
 each `.vc-config.json` at 1 MiB, each regular file at 250 MiB, and the complete
 output at 1 GiB.
 
-Only after that job emits the verified immutable URL does a second trusted job
+Only after that job emitted the verified immutable URL did a second trusted job
 perform direct HTTP smoke of the URL, navigation, custom build identity,
 representative JS/CSS/font assets, and preview security headers. That smoke job
 checks out only `github.workflow_sha`; it never checks out or executes the
@@ -618,19 +624,19 @@ applying the same validation again immediately before upload.
 CLI `56.2.0` gates its local Root Directory monorepo defaults behind
 `VERCEL_BUILD_MONOREPO_SUPPORT=1`. The worker supplies that trusted constant to
 the clean candidate environment so the CLI activates its Turborepo default,
-`turbo run build`, for the Root Directory project. Turbo then includes upstream
+`turbo run build`, for the Root Directory project. Turbo then included upstream
 workspace packages such as `@mento-protocol/ui` before the selected Next.js
-app. Re-audit this internal, version-coupled flag whenever the pinned CLI
-changes. Do not replace it with a separate app dependency prebuild: that would
-duplicate work before the CLI's own build and could diverge from Vercel's
-project settings.
+app. The Phase A design required this internal, version-coupled flag to be
+re-audited whenever the pinned CLI changed and forbade replacing it with a
+separate app dependency prebuild, which would have duplicated work before the
+CLI's own build and could have diverged from Vercel's project settings.
 
-### Canonical GitHub Deployment
+### Historical Phase A canonical GitHub Deployment
 
-The worker owns one explicit REST Deployment for the exact SHA. It uses only
-`contents: read` and `deployments: write`; no job-level Actions environment is
-declared, so GitHub does not create an implicit event-SHA Deployment. The create
-request uses `auto_merge: false`, empty required contexts, the deterministic
+The worker owned one explicit REST Deployment for the exact SHA. It used only
+`contents: read` and `deployments: write`; no job-level Actions environment was
+declared, so GitHub did not create an implicit event-SHA Deployment. The create
+request used `auto_merge: false`, empty required contexts, the deterministic
 `vercel-preview-ui` environment, and transient/non-production flags.
 
 The run-scoped pilot key is:
@@ -639,40 +645,44 @@ The run-scoped pilot key is:
 vercel-pilot:v1:ui:sha:<sha>:run:<run_id>:attempt:<run_attempt>
 ```
 
-Retries with that exact key reuse the existing record. A deliberate workflow
-rerun has a different attempt key and creates a new pilot attempt. Only
-non-secret provenance is stored in the payload.
+Retries with that exact key reused the existing record. A deliberate workflow
+rerun had a different attempt key and created a new pilot attempt. Only
+non-secret provenance was stored in the payload.
 
-Statuses progress through `queued` and `in_progress`. `success` is posted with
-the immutable Vercel `environment_url` and Actions `log_url` only after direct
-smoke passes. Build, deploy, or smoke failures post `failure`; cancellation or
-controller/infrastructure failures post `error`. The `if: always()` lifecycle
-job closes any record that did not reach success. It is independent of
-best-effort timing and run-summary steps, so a metrics failure cannot overwrite
-a verified deployment's lifecycle truth. The reusable workflow publishes
-`deployment_url` only from the smoke-backed success step; it never falls back
-to the unverified upload output.
+Statuses progressed through `queued` and `in_progress`. `success` was posted
+with the immutable Vercel `environment_url` and Actions `log_url` only after
+direct smoke passed. Build, deploy, or smoke failures posted `failure`;
+cancellation or controller/infrastructure failures posted `error`. The
+`if: always()` lifecycle job closed any record that did not reach success. It
+was independent of best-effort timing and run-summary steps, so a metrics
+failure could not overwrite a verified deployment's lifecycle truth. The
+reusable workflow published `deployment_url` only from the smoke-backed success
+step; it never fell back to the unverified upload output.
 
-A Deployment or status created with the repository `GITHUB_TOKEN` does not
+A Deployment or status created with the repository `GITHUB_TOKEN` did not
 trigger another workflow run. Therefore `.github/workflows/preview-smoke.yml`
-will not recurse for this pilot. Direct smoke in the reusable worker is the
-required success gate. Do not add a PAT to force `deployment_status` recursion.
-The dedicated worker-dispatch PAT is not an exception; its sole purpose is the
-automatic controller's worker `workflow_dispatch` POST described below.
+did not recurse for the pilot. Direct smoke in the reusable worker was the
+required success gate. The pilot did not add a PAT to force
+`deployment_status` recursion. The dedicated worker-dispatch PAT was not an
+exception; its sole purpose was the automatic controller's worker
+`workflow_dispatch` POST described below.
 
-### Evidence and browser verification
+### Historical Phase A evidence and browser verification
 
-The run summary records the exact SHA, immutable URL, Vercel Deployment ID,
-GitHub Deployment ID, build duration, upload duration, and total controller
-duration. Turbo prints remote-cache hit/miss evidence in the build log. Compare
-those values with the same-SHA native Vercel Git preview, but do not infer
-billing savings from elapsed time alone.
+The Phase A run summary recorded the exact SHA, immutable URL, Vercel Deployment
+ID, GitHub Deployment ID, build duration, upload duration, and total controller
+duration. Turbo printed remote-cache hit/miss evidence in the build log. Phase A
+reviewers compared those values with the same-SHA native Vercel Git preview but
+did not infer billing savings from elapsed time alone.
 
-Before treating the pilot as accepted, follow the repository browser protocol
-on the immutable GitHub-built URL: verify page rendering and primary
-navigation, inspect console errors and failed network requests, confirm static
-assets/fonts, and compare security headers plus the Vercel toolbar/CSP behavior
-with the native preview. Attach the URL and concise evidence to the PR or issue.
+Phase A acceptance also required the repository browser protocol on the
+immutable GitHub-built URL: reviewers verified page rendering and primary
+navigation, inspected console errors and failed network requests, confirmed
+static assets/fonts, and compared security headers plus Vercel toolbar/CSP
+behavior with the native preview. They attached the URL and concise evidence to
+the PR or issue. This same-SHA native comparison is intentionally unavailable
+after Phase B disables native UI branch previews; current validation uses the
+[Phase B canary and rollback procedures](#ui-vercel-git-cutover-phase-b).
 
 The cost go/no-go record in issue #518 and the Phase A live-canary evidence
 below were prerequisites for the final UI Git-ownership cutover. The current

--- a/docs/vercel-deployments.md
+++ b/docs/vercel-deployments.md
@@ -1258,16 +1258,23 @@ reaches `main`, each inventoried branch must rebase or merge that `main`, or
 receive an explicitly reviewed equivalent branch update containing the exact
 rollback configuration, before native preview restoration can be claimed.
 
+The rollback PR must also update the executable ownership assertion in
+`scripts/vercel-git-ownership.test.mjs` and the current-state ownership text in
+`README.md` and this runbook. Do not merge a configuration-only rollback that
+leaves repository tests or operator documentation claiming that GitHub Actions
+still owns UI branch previews.
+
 Use a fresh or restored-main-rebased UI canary to prove native previews return.
 A fresh canary proves only its own branch and is not evidence that every active
 Phase B branch was restored. Remove or leave non-required the `Vercel Preview`
 ruleset context until the controller is repaired. Do not change production
 domains, other apps, or recreate Governance QA.
 
-### Cleanup
+### Historical Phase A pilot cleanup
 
-After evidence is saved, a maintainer may remove only the pilot's immutable
-preview using the preview-scoped CLI credential:
+This is historical Phase A evidence, not a current Phase B operation. After the
+Phase A pilot evidence was saved, a maintainer could remove only that pilot's
+immutable preview using the preview-scoped CLI credential:
 
 ```bash
 export VERCEL_TOKEN="<preview-scoped-token>"
@@ -1276,6 +1283,8 @@ pnpm exec vercel remove "<immutable-vercel-deployment-url-or-id>" --yes
 
 Confirm the value is the unique pilot URL or `dpl_` ID from the run summary.
 Never pass a production domain or alias, and do not change Vercel Git settings.
+Do not use this retired pilot command to remove current controller-managed
+previews.
 
 The complete zero-network pilot and automatic-preview suites are:
 

--- a/scripts/vercel-git-ownership.test.mjs
+++ b/scripts/vercel-git-ownership.test.mjs
@@ -87,7 +87,7 @@ test("repository has exactly one canonical UI branch-preview owner", () => {
   );
 });
 
-test("cutover and rollback pair controller and native ownership atomically", () => {
+test("cutover and rollback permit only the two reviewed steady-state ownership pairs", () => {
   assert.notDeepEqual(CUTOVER_CONFIGURATION, ROLLBACK_CONFIGURATION);
   assertExactOwnership(
     structuredClone(CUTOVER_CONFIGURATION),

--- a/scripts/vercel-git-ownership.test.mjs
+++ b/scripts/vercel-git-ownership.test.mjs
@@ -1,6 +1,9 @@
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { test } from "node:test";
+import { isDeepStrictEqual } from "node:util";
+
+import { parse } from "yaml";
 
 const SCHEMA = "https://openapi.vercel.sh/vercel.json";
 
@@ -23,6 +26,19 @@ const CUTOVER_CONFIGURATION = {
   },
 };
 
+const ACTIVE_CONTROLLER_MODE = "active";
+const OBSERVE_ONLY_CONTROLLER_MODE = "observe-only";
+
+const controller = parse(
+  readFileSync(
+    new URL(
+      "../.github/workflows/vercel-preview-controller.yml",
+      import.meta.url,
+    ),
+    "utf8",
+  ),
+);
+
 function configuration(app) {
   return JSON.parse(
     readFileSync(
@@ -38,11 +54,45 @@ function assertExactOwnership(value, expected) {
   assert.deepEqual(Object.keys(value.git), ["deploymentEnabled"]);
 }
 
+function assertSinglePreviewOwner(value, controllerMode) {
+  assert.ok(
+    isDeepStrictEqual(value, CUTOVER_CONFIGURATION) ||
+      isDeepStrictEqual(value, ROLLBACK_CONFIGURATION),
+    "UI Vercel Git ownership must match a reviewed exact state",
+  );
+  assert.ok(
+    [ACTIVE_CONTROLLER_MODE, OBSERVE_ONLY_CONTROLLER_MODE].includes(
+      controllerMode,
+    ),
+    "Preview controller mode must match a reviewed exact state",
+  );
+  const githubActionsOwnsBranchPreviews =
+    controllerMode === ACTIVE_CONTROLLER_MODE;
+  const nativeVercelOwnsBranchPreviews = isDeepStrictEqual(
+    value,
+    ROLLBACK_CONFIGURATION,
+  );
+  assert.notEqual(
+    githubActionsOwnsBranchPreviews,
+    nativeVercelOwnsBranchPreviews,
+    "Exactly one of GitHub Actions or native Vercel must own UI branch previews",
+  );
+}
+
 test("Phase B gives GitHub Actions exact UI branch-preview ownership", () => {
-  assertExactOwnership(configuration("ui.mento.org"), CUTOVER_CONFIGURATION);
+  const uiConfiguration = configuration("ui.mento.org");
+  assert.equal(
+    controller.env.VERCEL_PREVIEW_CONTROLLER_MODE,
+    ACTIVE_CONTROLLER_MODE,
+  );
+  assertExactOwnership(uiConfiguration, CUTOVER_CONFIGURATION);
+  assertSinglePreviewOwner(
+    uiConfiguration,
+    controller.env.VERCEL_PREVIEW_CONTROLLER_MODE,
+  );
 });
 
-test("cutover and rollback ownership fixtures are exact and mutually exclusive", () => {
+test("cutover and rollback pair controller and native ownership atomically", () => {
   assert.notDeepEqual(CUTOVER_CONFIGURATION, ROLLBACK_CONFIGURATION);
   assertExactOwnership(
     structuredClone(CUTOVER_CONFIGURATION),
@@ -57,6 +107,24 @@ test("cutover and rollback ownership fixtures are exact and mutually exclusive",
   assert.equal(
     ROLLBACK_CONFIGURATION.git.deploymentEnabled["dependabot/**"],
     false,
+  );
+  assertSinglePreviewOwner(CUTOVER_CONFIGURATION, ACTIVE_CONTROLLER_MODE);
+  assertSinglePreviewOwner(
+    ROLLBACK_CONFIGURATION,
+    OBSERVE_ONLY_CONTROLLER_MODE,
+  );
+  assert.throws(
+    () =>
+      assertSinglePreviewOwner(ROLLBACK_CONFIGURATION, ACTIVE_CONTROLLER_MODE),
+    /Exactly one/,
+  );
+  assert.throws(
+    () =>
+      assertSinglePreviewOwner(
+        CUTOVER_CONFIGURATION,
+        OBSERVE_ONLY_CONTROLLER_MODE,
+      ),
+    /Exactly one/,
   );
 });
 

--- a/scripts/vercel-git-ownership.test.mjs
+++ b/scripts/vercel-git-ownership.test.mjs
@@ -38,8 +38,8 @@ function assertExactOwnership(value, expected) {
   assert.deepEqual(Object.keys(value.git), ["deploymentEnabled"]);
 }
 
-test("Phase A preserves the exact rollback-safe native UI ownership", () => {
-  assertExactOwnership(configuration("ui.mento.org"), ROLLBACK_CONFIGURATION);
+test("Phase B gives GitHub Actions exact UI branch-preview ownership", () => {
+  assertExactOwnership(configuration("ui.mento.org"), CUTOVER_CONFIGURATION);
 });
 
 test("cutover and rollback ownership fixtures are exact and mutually exclusive", () => {
@@ -60,7 +60,7 @@ test("cutover and rollback ownership fixtures are exact and mutually exclusive",
   );
 });
 
-test("Phase A and Phase B never change another application's Vercel Git ownership", () => {
+test("Phase B does not change another application's Vercel Git ownership", () => {
   for (const app of [
     "app.mento.org",
     "governance.mento.org",

--- a/scripts/vercel-git-ownership.test.mjs
+++ b/scripts/vercel-git-ownership.test.mjs
@@ -79,13 +79,8 @@ function assertSinglePreviewOwner(value, controllerMode) {
   );
 }
 
-test("Phase B gives GitHub Actions exact UI branch-preview ownership", () => {
+test("repository has exactly one canonical UI branch-preview owner", () => {
   const uiConfiguration = configuration("ui.mento.org");
-  assert.equal(
-    controller.env.VERCEL_PREVIEW_CONTROLLER_MODE,
-    ACTIVE_CONTROLLER_MODE,
-  );
-  assertExactOwnership(uiConfiguration, CUTOVER_CONFIGURATION);
   assertSinglePreviewOwner(
     uiConfiguration,
     controller.env.VERCEL_PREVIEW_CONTROLLER_MODE,
@@ -125,6 +120,10 @@ test("cutover and rollback pair controller and native ownership atomically", () 
         OBSERVE_ONLY_CONTROLLER_MODE,
       ),
     /Exactly one/,
+  );
+  assert.throws(
+    () => assertSinglePreviewOwner(CUTOVER_CONFIGURATION, "disabled"),
+    /Preview controller mode must match a reviewed exact state/,
   );
 });
 

--- a/scripts/vercel-preview-controller.mjs
+++ b/scripts/vercel-preview-controller.mjs
@@ -4236,7 +4236,26 @@ export async function reconcilePreview({
       ) {
         continue reconcileAttempts;
       }
+      const reconciled = reconcileState({
+        events: parsed.events,
+        results: parsed.results,
+        selections: parsed.selections,
+        pullRequest: pull,
+        existingState: parsed.state,
+        checkpoint: parsed.checkpoint,
+        controllerUrl,
+        expectedWorkflowSha: workflowSha,
+      });
+      let state = reconciled.state;
+      let stateComment = parsed.stateComment;
       if (controllerMode === "observe-only") {
+        stateComment = await writeControllerState({
+          github,
+          context,
+          pr,
+          state,
+          stateComment,
+        });
         const currentPull = normalizePullRequest(pull);
         if (currentPull.state === "open") {
           await github.rest.repos.createCommitStatus({
@@ -4251,20 +4270,8 @@ export async function reconcilePreview({
         core.setOutput("controller_mode", controllerMode);
         core.setOutput("dispatch_skipped", "true");
         core.setOutput("pr_number", String(pr));
-        return parsed.state;
+        return state;
       }
-      const reconciled = reconcileState({
-        events: parsed.events,
-        results: parsed.results,
-        selections: parsed.selections,
-        pullRequest: pull,
-        existingState: parsed.state,
-        checkpoint: parsed.checkpoint,
-        controllerUrl,
-        expectedWorkflowSha: workflowSha,
-      });
-      let state = reconciled.state;
-      let stateComment = parsed.stateComment;
       let selected = state.closed
         ? null
         : (reconciled.nextDispatch ??

--- a/scripts/vercel-preview-controller.mjs
+++ b/scripts/vercel-preview-controller.mjs
@@ -1308,6 +1308,14 @@ function statusDecision({
   }
   const eligible = event.plan.targets.includes(PREVIEW_TARGET);
   const result = resultByRun.get(event.event_run_id);
+  if (eligible && result?.terminal_reason === NO_DISPATCH_ORPHAN_REASON) {
+    return {
+      sha: event.head_sha,
+      state: "success",
+      description: "Native Vercel owns this UI preview",
+      target_url: controllerUrl,
+    };
+  }
   if (eligible && result?.state === "success") {
     return {
       sha: event.head_sha,
@@ -2191,15 +2199,12 @@ function ownerRepo(context) {
   return context.repo;
 }
 
-async function candidateUiPreviewOwner(github, context, pull) {
-  const normalized = normalizePullRequest(pull);
-  if (normalized.state !== "open" || normalized.trust !== "trusted") {
-    return null;
-  }
+async function uiPreviewOwnerAtSha(github, context, sha) {
+  const immutableSha = exactSha(sha, "Candidate UI Vercel configuration SHA");
   const { data } = await github.rest.repos.getContent({
     ...ownerRepo(context),
     path: UI_VERCEL_CONFIGURATION_PATH,
-    ref: normalized.headSha,
+    ref: immutableSha,
   });
   const file = plainObject(data, "Candidate UI Vercel configuration");
   invariant(
@@ -2247,6 +2252,14 @@ async function candidateUiPreviewOwner(github, context, pull) {
     return UI_PREVIEW_OWNER_NATIVE;
   }
   throw new Error("Candidate UI Vercel configuration is not recognized");
+}
+
+async function candidateUiPreviewOwner(github, context, pull) {
+  const normalized = normalizePullRequest(pull);
+  if (normalized.state !== "open" || normalized.trust !== "trusted") {
+    return null;
+  }
+  return uiPreviewOwnerAtSha(github, context, normalized.headSha);
 }
 
 async function listComments(github, context, pr) {
@@ -4307,18 +4320,33 @@ async function refreshDispatchOwnership({
   if (normalizePullRequest(pull).state !== "open") {
     return { outcome: "closed" };
   }
-  assertDispatchTrust(pull, selected);
-  const previewOwner = await candidateUiPreviewOwner(github, context, pull);
-  if (previewOwner === UI_PREVIEW_OWNER_NATIVE) {
-    return { outcome: UI_PREVIEW_OWNER_NATIVE };
+  const normalized = assertDispatchTrust(pull, selected);
+  const currentPreviewOwner = await uiPreviewOwnerAtSha(
+    github,
+    context,
+    normalized.headSha,
+  );
+  if (currentPreviewOwner === UI_PREVIEW_OWNER_NATIVE) {
+    return { outcome: "current-head-native" };
   }
   invariant(
-    previewOwner === UI_PREVIEW_OWNER_GITHUB,
-    "GitHub preview dispatch does not own the candidate UI configuration",
+    currentPreviewOwner === UI_PREVIEW_OWNER_GITHUB,
+    "GitHub preview dispatch does not own the current UI configuration",
   );
   if (!(await shaIsStillAssociated(github, context, pull, selected.sha))) {
     return { outcome: "removed" };
   }
+  const selectedPreviewOwner =
+    selected.sha === normalized.headSha
+      ? currentPreviewOwner
+      : await uiPreviewOwnerAtSha(github, context, selected.sha);
+  if (selectedPreviewOwner === UI_PREVIEW_OWNER_NATIVE) {
+    return { outcome: "selected-native" };
+  }
+  invariant(
+    selectedPreviewOwner === UI_PREVIEW_OWNER_GITHUB,
+    "GitHub preview dispatch does not own the selected UI configuration",
+  );
   const comments = await loadPreviewJournal(github, context, pr);
   const ownershipCheck = reconcileState({
     events: comments.events,
@@ -4633,7 +4661,22 @@ export async function reconcilePreview({
           recordDeterministicProgress();
           continue reconcileAttempts;
         }
-        if (refreshedOwnership.outcome === UI_PREVIEW_OWNER_NATIVE) {
+        if (
+          refreshedOwnership.outcome === "current-head-native" ||
+          refreshedOwnership.outcome === "selected-native"
+        ) {
+          invariant(
+            await reconcileNoDispatchIntents({
+              github,
+              context,
+              core,
+              pr,
+              state,
+              stateComment,
+              waitForRecovery,
+            }),
+            "Native-owned selection did not retain its durable intent",
+          );
           recordDeterministicProgress();
           continue reconcileAttempts;
         }
@@ -4684,7 +4727,22 @@ export async function reconcilePreview({
           recordDeterministicProgress();
           continue reconcileAttempts;
         }
-        if (refreshedOwnership.outcome === UI_PREVIEW_OWNER_NATIVE) {
+        if (
+          refreshedOwnership.outcome === "current-head-native" ||
+          refreshedOwnership.outcome === "selected-native"
+        ) {
+          invariant(
+            await reconcileNoDispatchIntents({
+              github,
+              context,
+              core,
+              pr,
+              state,
+              stateComment,
+              waitForRecovery,
+            }),
+            "Native-owned selection did not retain its durable intent",
+          );
           recordDeterministicProgress();
           continue reconcileAttempts;
         }
@@ -5037,10 +5095,27 @@ export async function validateWorkerDispatch({
     "Worker controller key digest is invalid",
   );
   const pull = await pullFromApi(github, context, pr);
-  assertDispatchTrust(pull, { git_ref: gitRef });
+  const normalizedPull = assertDispatchTrust(pull, { git_ref: gitRef });
   invariant(
     await shaIsStillAssociated(github, context, pull, sha),
     "Selected SHA is no longer associated with the PR lineage",
+  );
+  const currentPreviewOwner = await uiPreviewOwnerAtSha(
+    github,
+    context,
+    normalizedPull.headSha,
+  );
+  invariant(
+    currentPreviewOwner === UI_PREVIEW_OWNER_GITHUB,
+    "GitHub preview worker does not own the current UI configuration",
+  );
+  const selectedPreviewOwner =
+    sha === normalizedPull.headSha
+      ? currentPreviewOwner
+      : await uiPreviewOwnerAtSha(github, context, sha);
+  invariant(
+    selectedPreviewOwner === UI_PREVIEW_OWNER_GITHUB,
+    "GitHub preview worker does not own the selected UI configuration",
   );
   const evidence = await loadControllerEvidence(github, context, pr);
   const state = evidence.state;

--- a/scripts/vercel-preview-controller.mjs
+++ b/scripts/vercel-preview-controller.mjs
@@ -7,6 +7,18 @@ export const PREVIEW_REPOSITORY = "mento-protocol/frontend-monorepo";
 const PREVIEW_TARGET = "ui";
 const PREVIEW_STATUS_CONTEXT = "Vercel Preview";
 const PREVIEW_INITIALIZATION_STATUS_CONTEXT = "Vercel Preview Journal";
+const UI_VERCEL_CONFIGURATION_PATH = "apps/ui.mento.org/vercel.json";
+const UI_VERCEL_CONFIGURATION_MAX_BYTES = 2_048;
+const UI_PREVIEW_OWNER_GITHUB = "github-actions";
+const UI_PREVIEW_OWNER_NATIVE = "native-vercel";
+const UI_VERCEL_GITHUB_CONFIGURATION = {
+  $schema: "https://openapi.vercel.sh/vercel.json",
+  git: { deploymentEnabled: { "**": false, main: true } },
+};
+const UI_VERCEL_NATIVE_CONFIGURATION = {
+  $schema: "https://openapi.vercel.sh/vercel.json",
+  git: { deploymentEnabled: { "dependabot/**": false } },
+};
 export const EVENT_RECEIPT_SCHEMA = "vercel-preview-event-receipt:v1";
 const WORKER_EVIDENCE_SCHEMA = "vercel-preview-worker-evidence:v1";
 export const RESULT_RECEIPT_SCHEMA = "vercel-preview-worker-result:v1";
@@ -73,6 +85,7 @@ const WORKER_RECOVERY_BEFORE_MS = 2 * 60 * 1_000;
 const WORKER_RECOVERY_AFTER_MS = 15 * 60 * 1_000;
 const UPLOAD_STARTED_DESCRIPTION = "Prebuilt preview upload starting";
 const RETIRED_RECOVERY_QUARANTINE = "persisted-attempt-invalid-or-unavailable";
+const NO_DISPATCH_ORPHAN_REASON = "dispatch-disabled-intent-without-worker";
 const COMMENT_EXPLANATION = [
   "**No reviewer action is required.**",
   "This repository builds pull request previews in GitHub Actions and deploys them to Vercel.",
@@ -2167,6 +2180,64 @@ function ownerRepo(context) {
   return context.repo;
 }
 
+async function candidateUiPreviewOwner(github, context, pull) {
+  const normalized = normalizePullRequest(pull);
+  if (normalized.state !== "open" || normalized.trust !== "trusted") {
+    return null;
+  }
+  const { data } = await github.rest.repos.getContent({
+    ...ownerRepo(context),
+    path: UI_VERCEL_CONFIGURATION_PATH,
+    ref: normalized.headSha,
+  });
+  const file = plainObject(data, "Candidate UI Vercel configuration");
+  invariant(
+    file.type === "file" && file.path === UI_VERCEL_CONFIGURATION_PATH,
+    "Candidate UI Vercel configuration is not the expected file",
+  );
+  invariant(
+    file.encoding === "base64" &&
+      Number.isSafeInteger(file.size) &&
+      file.size > 0 &&
+      file.size <= UI_VERCEL_CONFIGURATION_MAX_BYTES,
+    "Candidate UI Vercel configuration metadata is invalid",
+  );
+  invariant(
+    typeof file.content === "string" &&
+      file.content.length > 0 &&
+      file.content.length <=
+        Math.ceil(UI_VERCEL_CONFIGURATION_MAX_BYTES / 3) * 4 + 128 &&
+      /^[A-Za-z0-9+/=\r\n]+$/.test(file.content),
+    "Candidate UI Vercel configuration encoding is invalid",
+  );
+  const encoded = file.content.replace(/[\r\n]/g, "");
+  const bytes = Buffer.from(encoded, "base64");
+  invariant(
+    bytes.length === file.size && bytes.toString("base64") === encoded,
+    "Candidate UI Vercel configuration encoding is invalid",
+  );
+  const text = bytes.toString("utf8");
+  invariant(
+    Buffer.from(text, "utf8").equals(bytes),
+    "Candidate UI Vercel configuration is not valid UTF-8",
+  );
+  let configuration;
+  try {
+    configuration = JSON.parse(text);
+  } catch {
+    throw new Error("Candidate UI Vercel configuration is malformed");
+  }
+  plainObject(configuration, "Candidate UI Vercel configuration");
+  const candidate = canonicalJson(configuration);
+  if (candidate === canonicalJson(UI_VERCEL_GITHUB_CONFIGURATION)) {
+    return UI_PREVIEW_OWNER_GITHUB;
+  }
+  if (candidate === canonicalJson(UI_VERCEL_NATIVE_CONFIGURATION)) {
+    return UI_PREVIEW_OWNER_NATIVE;
+  }
+  throw new Error("Candidate UI Vercel configuration is not recognized");
+}
+
 async function listComments(github, context, pr) {
   const comments = await github.paginate(github.rest.issues.listComments, {
     ...ownerRepo(context),
@@ -3994,7 +4065,15 @@ async function shaIsStillAssociated(github, context, pull, sha) {
   return commits.some((commit) => commit.sha === sha);
 }
 
-async function recordRemovedSelection({ github, context, pr, selection }) {
+async function recordControllerTerminalResult({
+  github,
+  context,
+  pr,
+  selection,
+  state,
+  terminalReason,
+  runIdLabel,
+}) {
   const result = validateWorkerResult({
     schema: RESULT_RECEIPT_SCHEMA,
     repository: PREVIEW_REPOSITORY,
@@ -4007,15 +4086,15 @@ async function recordRemovedSelection({ github, context, pr, selection }) {
     reconciliation_basis_digest: selection.reconciliation_basis_digest,
     selection_receipt_run_id: selection.selection_receipt_run_id,
     expected_workflow_sha: selection.expected_workflow_sha,
-    worker_run_id: exactRunId(context.runId, "Controller abort run ID"),
+    worker_run_id: exactRunId(context.runId, runIdLabel),
     worker_run_attempt: exactRunAttempt(context.runAttempt ?? 1),
     github_deployment_id: null,
-    state: "failure",
+    state,
     vercel_deployment_id: null,
     next_deployment_id: null,
     vercel_deployment_url: null,
     smoke_result: "not-run",
-    terminal_reason: "selection-removed-from-pr",
+    terminal_reason: terminalReason,
   });
   await appendJournalReceipt({
     github,
@@ -4027,37 +4106,103 @@ async function recordRemovedSelection({ github, context, pr, selection }) {
   return result;
 }
 
-async function recordSupersededIntent({ github, context, pr, selection }) {
-  const result = validateWorkerResult({
-    schema: RESULT_RECEIPT_SCHEMA,
-    repository: PREVIEW_REPOSITORY,
-    pr,
-    target: PREVIEW_TARGET,
-    sha: selection.sha,
-    controller_key: selection.key,
-    key_digest: selection.key_digest,
-    epoch_anchor_run_id: selection.epoch_anchor_run_id,
-    reconciliation_basis_digest: selection.reconciliation_basis_digest,
-    selection_receipt_run_id: selection.selection_receipt_run_id,
-    expected_workflow_sha: selection.expected_workflow_sha,
-    worker_run_id: exactRunId(context.runId, "Controller upgrade run ID"),
-    worker_run_attempt: exactRunAttempt(context.runAttempt ?? 1),
-    github_deployment_id: null,
-    state: "error",
-    vercel_deployment_id: null,
-    next_deployment_id: null,
-    vercel_deployment_url: null,
-    smoke_result: "not-run",
-    terminal_reason: "controller-workflow-upgraded-before-dispatch",
-  });
-  await appendJournalReceipt({
+function recordRemovedSelection({ github, context, pr, selection }) {
+  return recordControllerTerminalResult({
     github,
     context,
     pr,
-    kind: "result",
-    value: result,
+    selection,
+    state: "failure",
+    terminalReason: "selection-removed-from-pr",
+    runIdLabel: "Controller abort run ID",
   });
-  return result;
+}
+
+function recordSupersededIntent({ github, context, pr, selection }) {
+  return recordControllerTerminalResult({
+    github,
+    context,
+    pr,
+    selection,
+    state: "error",
+    terminalReason: "controller-workflow-upgraded-before-dispatch",
+    runIdLabel: "Controller upgrade run ID",
+  });
+}
+
+function recordNoDispatchIntentWithoutWorker({
+  github,
+  context,
+  pr,
+  selection,
+}) {
+  return recordControllerTerminalResult({
+    github,
+    context,
+    pr,
+    selection,
+    state: "error",
+    terminalReason: NO_DISPATCH_ORPHAN_REASON,
+    runIdLabel: "Controller retirement run ID",
+  });
+}
+
+async function reconcileNoDispatchIntent({
+  github,
+  context,
+  core,
+  pr,
+  state,
+  stateComment,
+  waitForRecovery,
+}) {
+  const selection = state.ui?.active;
+  if (
+    !selection ||
+    selection.dispatch_state !== "intended" ||
+    selection.workflow_run_id !== null
+  ) {
+    return false;
+  }
+  const recoveredRun = await recoverMatchingWorkerRun(
+    github,
+    context,
+    selection,
+    { waitForRetry: waitForRecovery },
+  );
+  if (!recoveredRun) {
+    await recordNoDispatchIntentWithoutWorker({
+      github,
+      context,
+      pr,
+      selection,
+    });
+    core.setOutput("retired_undispatched_intent", "true");
+    return true;
+  }
+  const recoveredState = {
+    ...state,
+    ui: {
+      ...state.ui,
+      active: {
+        ...selection,
+        dispatch_state: "dispatched",
+        ...recoveredRun,
+      },
+    },
+  };
+  await writeControllerState({
+    github,
+    context,
+    pr,
+    state: recoveredState,
+    stateComment,
+  });
+  core.setOutput(
+    "recovered_intended_run_id",
+    String(recoveredRun.workflow_run_id),
+  );
+  return true;
 }
 
 function assertDispatchTrust(pull, selected) {
@@ -4087,6 +4232,14 @@ async function refreshDispatchOwnership({
     return { outcome: "closed" };
   }
   assertDispatchTrust(pull, selected);
+  const previewOwner = await candidateUiPreviewOwner(github, context, pull);
+  if (previewOwner === UI_PREVIEW_OWNER_NATIVE) {
+    return { outcome: UI_PREVIEW_OWNER_NATIVE };
+  }
+  invariant(
+    previewOwner === UI_PREVIEW_OWNER_GITHUB,
+    "GitHub preview dispatch does not own the candidate UI configuration",
+  );
   if (!(await shaIsStillAssociated(github, context, pull, selected.sha))) {
     return { outcome: "removed" };
   }
@@ -4222,6 +4375,20 @@ export async function reconcilePreview({
   reconcileAttempts: for (let attempt = 0; attempt < 3; attempt += 1) {
     try {
       const pull = await pullFromApi(github, context, pr);
+      const currentPull = normalizePullRequest(pull);
+      const previewOwner = await candidateUiPreviewOwner(github, context, pull);
+      invariant(
+        !(
+          currentPull.state === "open" &&
+          currentPull.trust === "trusted" &&
+          controllerMode === "observe-only" &&
+          previewOwner === UI_PREVIEW_OWNER_GITHUB
+        ),
+        "Observe-only controller leaves the candidate UI preview ownerless",
+      );
+      const noDispatch =
+        controllerMode === "observe-only" ||
+        previewOwner === UI_PREVIEW_OWNER_NATIVE;
       const parsed = await loadPreviewJournal(github, context, pr);
       const stateBeforeReconciliation =
         parsed.state === null ? null : canonicalJson(parsed.state);
@@ -4248,7 +4415,21 @@ export async function reconcilePreview({
       });
       let state = reconciled.state;
       let stateComment = parsed.stateComment;
-      if (controllerMode === "observe-only") {
+      if (
+        noDispatch &&
+        (await reconcileNoDispatchIntent({
+          github,
+          context,
+          core,
+          pr,
+          state,
+          stateComment,
+          waitForRecovery,
+        }))
+      ) {
+        continue reconcileAttempts;
+      }
+      if (noDispatch) {
         stateComment = await writeControllerState({
           github,
           context,
@@ -4256,18 +4437,28 @@ export async function reconcilePreview({
           state,
           stateComment,
         });
-        const currentPull = normalizePullRequest(pull);
         if (currentPull.state === "open") {
+          const liveGitHubOwnership =
+            state.ui.active !== null || state.ui.retired_active.length > 0;
+          const nativeOwner = previewOwner === UI_PREVIEW_OWNER_NATIVE;
           await github.rest.repos.createCommitStatus({
             ...ownerRepo(context),
             sha: currentPull.headSha,
-            state: "success",
+            state: nativeOwner && liveGitHubOwnership ? "pending" : "success",
             context: PREVIEW_STATUS_CONTEXT,
-            description: "GitHub preview dispatch is observe-only",
+            description: nativeOwner
+              ? liveGitHubOwnership
+                ? "Draining GitHub preview before native ownership"
+                : "Native Vercel owns this UI preview"
+              : "GitHub preview dispatch is observe-only",
             target_url: controllerUrl,
           });
+          if (nativeOwner && liveGitHubOwnership) {
+            core.setOutput("preview_ownership_draining", "true");
+          }
         }
         core.setOutput("controller_mode", controllerMode);
+        if (previewOwner) core.setOutput("preview_owner", previewOwner);
         core.setOutput("dispatch_skipped", "true");
         core.setOutput("pr_number", String(pr));
         return state;
@@ -4324,6 +4515,9 @@ export async function reconcilePreview({
           });
           continue;
         }
+        if (refreshedOwnership.outcome === UI_PREVIEW_OWNER_NATIVE) {
+          continue reconcileAttempts;
+        }
         let ownershipCheck = refreshedOwnership.ownershipCheck;
 
         let recoveredRun;
@@ -4369,6 +4563,9 @@ export async function reconcilePreview({
             selection: selected,
           });
           continue;
+        }
+        if (refreshedOwnership.outcome === UI_PREVIEW_OWNER_NATIVE) {
+          continue reconcileAttempts;
         }
         ownershipCheck = refreshedOwnership.ownershipCheck;
         if (!recoveredRun && selected.expected_workflow_sha !== workflowSha) {

--- a/scripts/vercel-preview-controller.mjs
+++ b/scripts/vercel-preview-controller.mjs
@@ -70,6 +70,10 @@ const RETRIABLE_TERMINAL_REASONS = new Set([
 const MAX_COMMENTS = 500;
 const MAX_RECEIPTS = 200;
 const MAX_HISTORY = 40;
+// Recovery drains every retained slot in one pass, then ownership flips and
+// terminal receipts need a small fixed number of rereads before publication.
+const MAX_RECONCILIATION_PROGRESS_PASSES = MAX_HISTORY + 4;
+const MAX_SERIALIZED_UPDATE_ATTEMPTS = 3;
 const MAX_JOURNAL_BYTES = 60_000;
 const ACTIVE_CHECKPOINT_BYTES = 40_000;
 const WORKER_RUN_PAGE_SIZE = 100;
@@ -4415,6 +4419,15 @@ async function recoverCompletedOwnedRuns({
   return recovered;
 }
 
+function hasLiveGitHubPreviewOwnership(state) {
+  return (
+    state.ui.active !== null ||
+    state.ui.retired_active.some(
+      (selection) => selection.recovery_quarantine === undefined,
+    )
+  );
+}
+
 export async function reconcilePreview({
   github,
   workerDispatchGithub = null,
@@ -4430,7 +4443,25 @@ export async function reconcilePreview({
   const controllerMode = previewControllerMode(rawControllerMode);
   const workflowSha = exactSha(rawWorkflowSha, "Controller workflow SHA");
   const controllerUrl = `https://github.com/${PREVIEW_REPOSITORY}/actions/runs/${context.runId}`;
-  reconcileAttempts: for (let attempt = 0; attempt < 3; attempt += 1) {
+  let serializedUpdateAttempts = 1;
+  const failClosed = async (error) => {
+    const pull = await pullFromApi(github, context, pr);
+    const headSha = exactSha(pull.head.sha);
+    await github.rest.repos.createCommitStatus({
+      ...ownerRepo(context),
+      sha: headSha,
+      state: "error",
+      context: PREVIEW_STATUS_CONTEXT,
+      description: "Preview controller state is invalid or ambiguous",
+      target_url: controllerUrl,
+    });
+    throw error;
+  };
+  reconcileAttempts: for (
+    let progressPass = 0;
+    progressPass < MAX_RECONCILIATION_PROGRESS_PASSES;
+    progressPass += 1
+  ) {
     try {
       const pull = await pullFromApi(github, context, pr);
       const currentPull = normalizePullRequest(pull);
@@ -4496,8 +4527,7 @@ export async function reconcilePreview({
           stateComment,
         });
         if (currentPull.state === "open") {
-          const liveGitHubOwnership =
-            state.ui.active !== null || state.ui.retired_active.length > 0;
+          const liveGitHubOwnership = hasLiveGitHubPreviewOwnership(state);
           const nativeOwner = previewOwner === UI_PREVIEW_OWNER_NATIVE;
           await github.rest.repos.createCommitStatus({
             ...ownerRepo(context),
@@ -4749,27 +4779,18 @@ export async function reconcilePreview({
       return state;
     } catch (error) {
       if (
-        attempt < 2 &&
+        serializedUpdateAttempts < MAX_SERIALIZED_UPDATE_ATTEMPTS &&
         /serialized update|identity changed|basis changed|changed before status|receipt set changed|ownership changed/.test(
           error.message,
         )
       ) {
+        serializedUpdateAttempts += 1;
         continue;
       }
-      const pull = await pullFromApi(github, context, pr);
-      const headSha = exactSha(pull.head.sha);
-      await github.rest.repos.createCommitStatus({
-        ...ownerRepo(context),
-        sha: headSha,
-        state: "error",
-        context: PREVIEW_STATUS_CONTEXT,
-        description: "Preview controller state is invalid or ambiguous",
-        target_url: controllerUrl,
-      });
-      throw error;
+      return failClosed(error);
     }
   }
-  throw new Error("Controller state update did not converge");
+  return failClosed(new Error("Controller state update did not converge"));
 }
 
 async function loadControllerEvidence(github, context, pr) {

--- a/scripts/vercel-preview-controller.mjs
+++ b/scripts/vercel-preview-controller.mjs
@@ -1010,7 +1010,14 @@ function dedupeResults(results) {
   const byRun = new Map();
   for (const raw of results) {
     const result = validateWorkerResult(raw);
-    const key = `${result.controller_key}:${result.worker_run_id}`;
+    // One no-dispatch controller run may retire same-SHA selections from
+    // multiple epochs. Those synthetic receipts are selection-scoped; every
+    // other controller or real-worker result keeps the stricter run owner.
+    const runOwner =
+      result.terminal_reason === NO_DISPATCH_ORPHAN_REASON
+        ? result.key_digest
+        : result.controller_key;
+    const key = `${runOwner}:${result.worker_run_id}`;
     const previous = byRun.get(key);
     if (previous)
       invariant(
@@ -4147,7 +4154,7 @@ function recordNoDispatchIntentWithoutWorker({
   });
 }
 
-async function reconcileNoDispatchIntent({
+async function reconcileNoDispatchIntents({
   github,
   context,
   core,
@@ -4156,52 +4163,103 @@ async function reconcileNoDispatchIntent({
   stateComment,
   waitForRecovery,
 }) {
-  const selection = state.ui?.active;
+  const candidates = [];
   if (
-    !selection ||
-    selection.dispatch_state !== "intended" ||
-    selection.workflow_run_id !== null
+    state.ui?.active?.dispatch_state === "intended" &&
+    state.ui.active.workflow_run_id === null
   ) {
-    return false;
+    candidates.push({ slot: "active", selection: state.ui.active });
   }
-  const recoveredRun = await recoverMatchingWorkerRun(
-    github,
-    context,
-    selection,
-    { waitForRetry: waitForRecovery },
-  );
-  if (!recoveredRun) {
-    await recordNoDispatchIntentWithoutWorker({
+  for (const selection of state.ui?.retired_active ?? []) {
+    if (
+      selection.dispatch_state === "intended" &&
+      selection.workflow_run_id === null
+    ) {
+      candidates.push({ slot: "retired", selection });
+    }
+  }
+  if (candidates.length === 0) return false;
+
+  const observations = [];
+  for (const candidate of candidates) {
+    observations.push({
+      ...candidate,
+      recoveredRun: await recoverMatchingWorkerRun(
+        github,
+        context,
+        candidate.selection,
+        { waitForRetry: waitForRecovery },
+      ),
+    });
+  }
+
+  const recoveredState = structuredClone(state);
+  const attached = [];
+  let retiredWithoutWorker = false;
+  for (const { slot, selection, recoveredRun } of observations) {
+    if (!recoveredRun) {
+      await recordNoDispatchIntentWithoutWorker({
+        github,
+        context,
+        pr,
+        selection,
+      });
+      retiredWithoutWorker = true;
+      continue;
+    }
+    const recoveredSelection = {
+      ...selection,
+      dispatch_state: "dispatched",
+      ...recoveredRun,
+    };
+    if (slot === "active") {
+      invariant(
+        recoveredState.ui.active?.key_digest === selection.key_digest,
+        "Active no-dispatch intent changed before recovery",
+      );
+      recoveredState.ui.active = recoveredSelection;
+    } else {
+      const retiredIndex = recoveredState.ui.retired_active.findIndex(
+        (candidate) => candidate.key_digest === selection.key_digest,
+      );
+      invariant(retiredIndex >= 0, "Retired no-dispatch intent disappeared");
+      recoveredState.ui.retired_active[retiredIndex] = recoveredSelection;
+    }
+    attached.push({ recoveredRun, recoveredSelection });
+  }
+
+  if (retiredWithoutWorker) {
+    core.setOutput("retired_undispatched_intent", "true");
+  }
+  if (attached.length > 0) {
+    await writeControllerState({
       github,
       context,
       pr,
-      selection,
+      state: recoveredState,
+      stateComment,
     });
-    core.setOutput("retired_undispatched_intent", "true");
-    return true;
+    core.setOutput(
+      "recovered_intended_run_id",
+      String(attached.at(-1).recoveredRun.workflow_run_id),
+    );
   }
-  const recoveredState = {
-    ...state,
-    ui: {
-      ...state.ui,
-      active: {
-        ...selection,
-        dispatch_state: "dispatched",
-        ...recoveredRun,
-      },
-    },
-  };
-  await writeControllerState({
-    github,
-    context,
-    pr,
-    state: recoveredState,
-    stateComment,
-  });
-  core.setOutput(
-    "recovered_intended_run_id",
-    String(recoveredRun.workflow_run_id),
-  );
+  for (const { recoveredRun, recoveredSelection } of attached) {
+    if (recoveredRun.status !== "completed") continue;
+    const workflowRun = await getWorkerRun(
+      github,
+      context,
+      recoveredRun.workflow_run_id,
+      recoveredSelection,
+    );
+    await recoverWorkerResult({
+      github,
+      context,
+      core,
+      workflowRun,
+      waitForRecovery,
+    });
+  }
   return true;
 }
 
@@ -4417,7 +4475,7 @@ export async function reconcilePreview({
       let stateComment = parsed.stateComment;
       if (
         noDispatch &&
-        (await reconcileNoDispatchIntent({
+        (await reconcileNoDispatchIntents({
           github,
           context,
           core,

--- a/scripts/vercel-preview-controller.mjs
+++ b/scripts/vercel-preview-controller.mjs
@@ -4201,7 +4201,7 @@ async function reconcileNoDispatchIntents({
   state,
   stateComment,
   waitForRecovery,
-  orphanTerminalReason = NO_DISPATCH_ORPHAN_REASON,
+  nativeOwnedSelectionKeyDigest = null,
 }) {
   const candidates = [];
   if (
@@ -4243,7 +4243,10 @@ async function reconcileNoDispatchIntents({
         context,
         pr,
         selection,
-        terminalReason: orphanTerminalReason,
+        terminalReason:
+          selection.key_digest === nativeOwnedSelectionKeyDigest
+            ? NATIVE_OWNED_SELECTION_REASON
+            : NO_DISPATCH_ORPHAN_REASON,
       });
       retiredWithoutWorker = true;
       continue;
@@ -4684,10 +4687,10 @@ export async function reconcilePreview({
               state,
               stateComment,
               waitForRecovery,
-              orphanTerminalReason:
+              nativeOwnedSelectionKeyDigest:
                 refreshedOwnership.outcome === "selected-native"
-                  ? NATIVE_OWNED_SELECTION_REASON
-                  : NO_DISPATCH_ORPHAN_REASON,
+                  ? selected.key_digest
+                  : null,
             }),
             "Native-owned selection did not retain its durable intent",
           );
@@ -4754,10 +4757,10 @@ export async function reconcilePreview({
               state,
               stateComment,
               waitForRecovery,
-              orphanTerminalReason:
+              nativeOwnedSelectionKeyDigest:
                 refreshedOwnership.outcome === "selected-native"
-                  ? NATIVE_OWNED_SELECTION_REASON
-                  : NO_DISPATCH_ORPHAN_REASON,
+                  ? selected.key_digest
+                  : null,
             }),
             "Native-owned selection did not retain its durable intent",
           );

--- a/scripts/vercel-preview-controller.mjs
+++ b/scripts/vercel-preview-controller.mjs
@@ -2726,9 +2726,12 @@ export function compactPreviewJournal(value, { pullRequest = null } = {}) {
     (total, receipts) => total + receipts.length,
     0,
   );
+  const liveRetiredOwnership = state.ui.retired_active.filter(
+    isLiveRetiredPreviewOwnership,
+  );
   if (receiptCount === 0) return journal;
   const hasInFlightOwnership =
-    state.ui.active !== null || state.ui.retired_active.length > 0;
+    state.ui.active !== null || liveRetiredOwnership.length > 0;
   if (hasInFlightOwnership) {
     if (
       Buffer.byteLength(journalBody(journal), "utf8") < ACTIVE_CHECKPOINT_BYTES
@@ -2754,7 +2757,7 @@ export function compactPreviewJournal(value, { pullRequest = null } = {}) {
     invariant(tailEvent, "Preview checkpoint tail event is missing");
     const pendingOwner =
       state.ui.active ??
-      state.ui.retired_active.find(
+      liveRetiredOwnership.find(
         (selection) =>
           selection.key_digest === journal.checkpoint?.pending_owner_key_digest,
       ) ??
@@ -2893,22 +2896,33 @@ export function compactPreviewJournal(value, { pullRequest = null } = {}) {
     );
     return validatePreviewJournal(journal, journal.pr);
   }
+  const quarantinedKeyDigests = new Set(
+    state.ui.retired_active
+      .filter((selection) => !isLiveRetiredPreviewOwnership(selection))
+      .map((selection) => selection.key_digest),
+  );
   const resultIdentities = new Set(
     journal.receipts.results.map(
       (result) => `${result.key_digest}:${result.worker_run_id}`,
     ),
   );
   invariant(
-    journal.receipts.worker_evidence.every((evidence) =>
-      resultIdentities.has(`${evidence.key_digest}:${evidence.worker_run_id}`),
+    journal.receipts.worker_evidence.every(
+      (evidence) =>
+        quarantinedKeyDigests.has(evidence.key_digest) ||
+        resultIdentities.has(
+          `${evidence.key_digest}:${evidence.worker_run_id}`,
+        ),
     ),
     "Preview journal cannot checkpoint unfinished worker evidence",
   );
   invariant(
-    journal.receipts.selections.every((selection) =>
-      journal.receipts.results.some(
-        (result) => result.key_digest === selection.key_digest,
-      ),
+    journal.receipts.selections.every(
+      (selection) =>
+        quarantinedKeyDigests.has(selection.key_digest) ||
+        journal.receipts.results.some(
+          (result) => result.key_digest === selection.key_digest,
+        ),
     ),
     "Preview journal cannot checkpoint unfinished selections",
   );
@@ -4419,12 +4433,14 @@ async function recoverCompletedOwnedRuns({
   return recovered;
 }
 
+function isLiveRetiredPreviewOwnership(selection) {
+  return selection.recovery_quarantine === undefined;
+}
+
 function hasLiveGitHubPreviewOwnership(state) {
   return (
     state.ui.active !== null ||
-    state.ui.retired_active.some(
-      (selection) => selection.recovery_quarantine === undefined,
-    )
+    state.ui.retired_active.some(isLiveRetiredPreviewOwnership)
   );
 }
 
@@ -4438,12 +4454,20 @@ export async function reconcilePreview({
   workflowSha: rawWorkflowSha,
   waitForRecovery,
   now = () => new Date().toISOString(),
+  progressPassLimit: rawProgressPassLimit = MAX_RECONCILIATION_PROGRESS_PASSES,
 }) {
   const pr = pullRequestNumber(rawPr);
   const controllerMode = previewControllerMode(rawControllerMode);
   const workflowSha = exactSha(rawWorkflowSha, "Controller workflow SHA");
+  invariant(
+    Number.isSafeInteger(rawProgressPassLimit) &&
+      rawProgressPassLimit >= 0 &&
+      rawProgressPassLimit <= MAX_RECONCILIATION_PROGRESS_PASSES,
+    "Controller progress pass limit is invalid",
+  );
   const controllerUrl = `https://github.com/${PREVIEW_REPOSITORY}/actions/runs/${context.runId}`;
   let serializedUpdateAttempts = 1;
+  let deterministicProgressPasses = 0;
   const failClosed = async (error) => {
     const pull = await pullFromApi(github, context, pr);
     const headSha = exactSha(pull.head.sha);
@@ -4457,11 +4481,14 @@ export async function reconcilePreview({
     });
     throw error;
   };
-  reconcileAttempts: for (
-    let progressPass = 0;
-    progressPass < MAX_RECONCILIATION_PROGRESS_PASSES;
-    progressPass += 1
-  ) {
+  const recordDeterministicProgress = () => {
+    deterministicProgressPasses += 1;
+    invariant(
+      deterministicProgressPasses <= rawProgressPassLimit,
+      "Controller state update did not converge",
+    );
+  };
+  reconcileAttempts: while (true) {
     try {
       const pull = await pullFromApi(github, context, pr);
       const currentPull = normalizePullRequest(pull);
@@ -4490,6 +4517,7 @@ export async function reconcilePreview({
           parsed,
         })
       ) {
+        recordDeterministicProgress();
         continue reconcileAttempts;
       }
       const reconciled = reconcileState({
@@ -4516,6 +4544,7 @@ export async function reconcilePreview({
           waitForRecovery,
         }))
       ) {
+        recordDeterministicProgress();
         continue reconcileAttempts;
       }
       if (noDispatch) {
@@ -4601,9 +4630,11 @@ export async function reconcilePreview({
             pr,
             selection: selected,
           });
-          continue;
+          recordDeterministicProgress();
+          continue reconcileAttempts;
         }
         if (refreshedOwnership.outcome === UI_PREVIEW_OWNER_NATIVE) {
+          recordDeterministicProgress();
           continue reconcileAttempts;
         }
         let ownershipCheck = refreshedOwnership.ownershipCheck;
@@ -4650,9 +4681,11 @@ export async function reconcilePreview({
             pr,
             selection: selected,
           });
-          continue;
+          recordDeterministicProgress();
+          continue reconcileAttempts;
         }
         if (refreshedOwnership.outcome === UI_PREVIEW_OWNER_NATIVE) {
+          recordDeterministicProgress();
           continue reconcileAttempts;
         }
         ownershipCheck = refreshedOwnership.ownershipCheck;
@@ -4663,6 +4696,7 @@ export async function reconcilePreview({
             pr,
             selection: selected,
           });
+          recordDeterministicProgress();
           continue reconcileAttempts;
         }
         let runDetails = recoveredRun;
@@ -4790,7 +4824,6 @@ export async function reconcilePreview({
       return failClosed(error);
     }
   }
-  return failClosed(new Error("Controller state update did not converge"));
 }
 
 async function loadControllerEvidence(github, context, pr) {

--- a/scripts/vercel-preview-controller.mjs
+++ b/scripts/vercel-preview-controller.mjs
@@ -49,6 +49,7 @@ const ALLOWED_PLAN_REASONS = new Set([
   "unsupported-trust-boundary",
   "closed",
 ]);
+const PREVIEW_CONTROLLER_MODES = new Set(["active", "observe-only"]);
 const TERMINAL_STATES = new Set(["success", "failure", "error"]);
 const RETRIABLE_TERMINAL_REASONS = new Set([
   "build-failed-retriable",
@@ -127,6 +128,14 @@ function exactSha(value, label = "Commit SHA") {
   invariant(
     typeof value === "string" && SHA_PATTERN.test(value),
     `${label} must be an immutable lowercase 40-character SHA`,
+  );
+  return value;
+}
+
+function previewControllerMode(value) {
+  invariant(
+    PREVIEW_CONTROLLER_MODES.has(value),
+    "Preview controller mode must be active or observe-only",
   );
   return value;
 }
@@ -3925,8 +3934,12 @@ async function dispatchWorker(
   workerDispatchGithub,
   context,
   selected,
-  { waitForRunDetails = wait } = {},
+  { controllerMode, waitForRunDetails = wait } = {},
 ) {
+  invariant(
+    controllerMode === "active",
+    "Worker dispatch is disabled by preview controller mode",
+  );
   invariant(
     workerDispatchGithub !== null && workerDispatchGithub !== undefined,
     "Worker dispatch credential is unavailable",
@@ -4196,12 +4209,14 @@ export async function reconcilePreview({
   workerDispatchGithub = null,
   context,
   core,
+  controllerMode: rawControllerMode,
   prNumber: rawPr,
   workflowSha: rawWorkflowSha,
   waitForRecovery,
   now = () => new Date().toISOString(),
 }) {
   const pr = pullRequestNumber(rawPr);
+  const controllerMode = previewControllerMode(rawControllerMode);
   const workflowSha = exactSha(rawWorkflowSha, "Controller workflow SHA");
   const controllerUrl = `https://github.com/${PREVIEW_REPOSITORY}/actions/runs/${context.runId}`;
   reconcileAttempts: for (let attempt = 0; attempt < 3; attempt += 1) {
@@ -4220,6 +4235,23 @@ export async function reconcilePreview({
         })
       ) {
         continue reconcileAttempts;
+      }
+      if (controllerMode === "observe-only") {
+        const currentPull = normalizePullRequest(pull);
+        if (currentPull.state === "open") {
+          await github.rest.repos.createCommitStatus({
+            ...ownerRepo(context),
+            sha: currentPull.headSha,
+            state: "success",
+            context: PREVIEW_STATUS_CONTEXT,
+            description: "GitHub preview dispatch is observe-only",
+            target_url: controllerUrl,
+          });
+        }
+        core.setOutput("controller_mode", controllerMode);
+        core.setOutput("dispatch_skipped", "true");
+        core.setOutput("pr_number", String(pr));
+        return parsed.state;
       }
       const reconciled = reconcileState({
         events: parsed.events,
@@ -4349,7 +4381,10 @@ export async function reconcilePreview({
               workerDispatchGithub,
               context,
               selected,
-              { waitForRunDetails: waitForRecovery },
+              {
+                controllerMode,
+                waitForRunDetails: waitForRecovery,
+              },
             );
           } catch (error) {
             if (error instanceof WorkerWorkflowShaMismatchError) {

--- a/scripts/vercel-preview-controller.mjs
+++ b/scripts/vercel-preview-controller.mjs
@@ -1380,6 +1380,14 @@ function statusDecision({
       });
     }
     const priorResult = resultByRun.get(priorRuntime.event_run_id);
+    if (priorResult?.terminal_reason === NATIVE_OWNED_SELECTION_REASON) {
+      return {
+        sha: event.head_sha,
+        state: "success",
+        description: "Native Vercel owns this UI preview",
+        target_url: controllerUrl,
+      };
+    }
     if (priorResult?.state === "success") {
       return {
         sha: event.head_sha,

--- a/scripts/vercel-preview-controller.mjs
+++ b/scripts/vercel-preview-controller.mjs
@@ -90,6 +90,12 @@ const WORKER_RECOVERY_AFTER_MS = 15 * 60 * 1_000;
 const UPLOAD_STARTED_DESCRIPTION = "Prebuilt preview upload starting";
 const RETIRED_RECOVERY_QUARANTINE = "persisted-attempt-invalid-or-unavailable";
 const NO_DISPATCH_ORPHAN_REASON = "dispatch-disabled-intent-without-worker";
+const NATIVE_OWNED_SELECTION_REASON =
+  "native-owned-selection-without-github-worker";
+const SELECTION_SCOPED_CONTROLLER_RESULT_REASONS = new Set([
+  NO_DISPATCH_ORPHAN_REASON,
+  NATIVE_OWNED_SELECTION_REASON,
+]);
 const COMMENT_EXPLANATION = [
   "**No reviewer action is required.**",
   "This repository builds pull request previews in GitHub Actions and deploys them to Vercel.",
@@ -1017,10 +1023,11 @@ function dedupeResults(results) {
     // One no-dispatch controller run may retire same-SHA selections from
     // multiple epochs. Those synthetic receipts are selection-scoped; every
     // other controller or real-worker result keeps the stricter run owner.
-    const runOwner =
-      result.terminal_reason === NO_DISPATCH_ORPHAN_REASON
-        ? result.key_digest
-        : result.controller_key;
+    const runOwner = SELECTION_SCOPED_CONTROLLER_RESULT_REASONS.has(
+      result.terminal_reason,
+    )
+      ? result.key_digest
+      : result.controller_key;
     const key = `${runOwner}:${result.worker_run_id}`;
     const previous = byRun.get(key);
     if (previous)
@@ -1308,7 +1315,7 @@ function statusDecision({
   }
   const eligible = event.plan.targets.includes(PREVIEW_TARGET);
   const result = resultByRun.get(event.event_run_id);
-  if (eligible && result?.terminal_reason === NO_DISPATCH_ORPHAN_REASON) {
+  if (eligible && result?.terminal_reason === NATIVE_OWNED_SELECTION_REASON) {
     return {
       sha: event.head_sha,
       state: "success",
@@ -4173,6 +4180,7 @@ function recordNoDispatchIntentWithoutWorker({
   context,
   pr,
   selection,
+  terminalReason = NO_DISPATCH_ORPHAN_REASON,
 }) {
   return recordControllerTerminalResult({
     github,
@@ -4180,7 +4188,7 @@ function recordNoDispatchIntentWithoutWorker({
     pr,
     selection,
     state: "error",
-    terminalReason: NO_DISPATCH_ORPHAN_REASON,
+    terminalReason,
     runIdLabel: "Controller retirement run ID",
   });
 }
@@ -4193,6 +4201,7 @@ async function reconcileNoDispatchIntents({
   state,
   stateComment,
   waitForRecovery,
+  orphanTerminalReason = NO_DISPATCH_ORPHAN_REASON,
 }) {
   const candidates = [];
   if (
@@ -4234,6 +4243,7 @@ async function reconcileNoDispatchIntents({
         context,
         pr,
         selection,
+        terminalReason: orphanTerminalReason,
       });
       retiredWithoutWorker = true;
       continue;
@@ -4674,6 +4684,10 @@ export async function reconcilePreview({
               state,
               stateComment,
               waitForRecovery,
+              orphanTerminalReason:
+                refreshedOwnership.outcome === "selected-native"
+                  ? NATIVE_OWNED_SELECTION_REASON
+                  : NO_DISPATCH_ORPHAN_REASON,
             }),
             "Native-owned selection did not retain its durable intent",
           );
@@ -4740,6 +4754,10 @@ export async function reconcilePreview({
               state,
               stateComment,
               waitForRecovery,
+              orphanTerminalReason:
+                refreshedOwnership.outcome === "selected-native"
+                  ? NATIVE_OWNED_SELECTION_REASON
+                  : NO_DISPATCH_ORPHAN_REASON,
             }),
             "Native-owned selection did not retain its durable intent",
           );

--- a/scripts/vercel-preview-controller.mjs
+++ b/scripts/vercel-preview-controller.mjs
@@ -92,6 +92,14 @@ const RETIRED_RECOVERY_QUARANTINE = "persisted-attempt-invalid-or-unavailable";
 const NO_DISPATCH_ORPHAN_REASON = "dispatch-disabled-intent-without-worker";
 const NATIVE_OWNED_SELECTION_REASON =
   "native-owned-selection-without-github-worker";
+const CHECKPOINTED_TERMINAL_REASON = "checkpointed-terminal-status";
+const NATIVE_OWNED_STATUS_DESCRIPTION = "Native Vercel owns this UI preview";
+const NATIVE_OWNERSHIP_DRAINING_STATUS_DESCRIPTION =
+  "Draining GitHub preview before native ownership";
+const OBSERVE_ONLY_STATUS_DESCRIPTION =
+  "GitHub preview dispatch is observe-only";
+const CONTROLLER_RUN_URL_PATTERN =
+  /^https:\/\/github\.com\/mento-protocol\/frontend-monorepo\/actions\/runs\/[1-9][0-9]*$/;
 const SELECTION_SCOPED_CONTROLLER_RESULT_REASONS = new Set([
   NO_DISPATCH_ORPHAN_REASON,
   NATIVE_OWNED_SELECTION_REASON,
@@ -1257,6 +1265,14 @@ function statusFromCheckpointRuntime({
   checkpointStatus,
   controllerUrl,
 }) {
+  if (isNativeOwnedCheckpointStatus(checkpointStatus, runtimeEvent)) {
+    return {
+      sha: event.head_sha,
+      state: "success",
+      description: NATIVE_OWNED_STATUS_DESCRIPTION,
+      target_url: controllerUrl,
+    };
+  }
   if (checkpointStatus.state === "success") {
     return {
       sha: event.head_sha,
@@ -1292,6 +1308,42 @@ function statusFromCheckpointRuntime({
   };
 }
 
+function isControllerRunStatusDecision(status, state, description) {
+  return (
+    status?.state === state &&
+    status.description === description &&
+    CONTROLLER_RUN_URL_PATTERN.test(status.target_url ?? "")
+  );
+}
+
+function isNativeOwnedStatusDecision(status) {
+  return isControllerRunStatusDecision(
+    status,
+    "success",
+    NATIVE_OWNED_STATUS_DESCRIPTION,
+  );
+}
+
+function isNativeOwnedCheckpointStatus(status, event) {
+  return (
+    isNativeOwnedStatusDecision(status) &&
+    event.trust === "trusted" &&
+    event.pr_state === "open"
+  );
+}
+
+function isNativeOwnershipDrainingCheckpointStatus(status, event) {
+  return (
+    isControllerRunStatusDecision(
+      status,
+      "pending",
+      NATIVE_OWNERSHIP_DRAINING_STATUS_DESCRIPTION,
+    ) &&
+    event.trust === "trusted" &&
+    event.pr_state === "open"
+  );
+}
+
 function statusDecision({
   event,
   index,
@@ -1319,7 +1371,7 @@ function statusDecision({
     return {
       sha: event.head_sha,
       state: "success",
-      description: "Native Vercel owns this UI preview",
+      description: NATIVE_OWNED_STATUS_DESCRIPTION,
       target_url: controllerUrl,
     };
   }
@@ -1384,7 +1436,7 @@ function statusDecision({
       return {
         sha: event.head_sha,
         state: "success",
-        description: "Native Vercel owns this UI preview",
+        description: NATIVE_OWNED_STATUS_DESCRIPTION,
         target_url: controllerUrl,
       };
     }
@@ -1851,7 +1903,12 @@ export function reconcileState({
       state: selectedCheckpoint.status.state,
       sha: selectedCheckpoint.event.head_sha,
       vercel_deployment_url: selectedCheckpoint.status.target_url,
-      terminal_reason: "checkpointed-terminal-status",
+      terminal_reason: isNativeOwnedCheckpointStatus(
+        selectedCheckpoint.status,
+        selectedCheckpoint.event,
+      )
+        ? NATIVE_OWNED_SELECTION_REASON
+        : CHECKPOINTED_TERMINAL_REASON,
     });
   }
   if (
@@ -2110,7 +2167,10 @@ export function reconcileState({
     ),
   );
   const successes = [...resultByRun.entries()]
-    .filter(([, result]) => result.state === "success")
+    .filter(
+      ([, result]) =>
+        result.state === "success" && result.schema === RESULT_RECEIPT_SCHEMA,
+    )
     .sort(([runA], [runB]) => {
       const indexA = lineage.findIndex((event) => event.event_run_id === runA);
       const indexB = lineage.findIndex((event) => event.event_run_id === runB);
@@ -2442,6 +2502,18 @@ function validatePreviewCheckpoint(value, expectedPr) {
     "Preview checkpoint event identity mismatch",
   );
   const status = validateCheckpointStatus(checkpoint.status, event);
+  if (status.description === NATIVE_OWNED_STATUS_DESCRIPTION) {
+    invariant(
+      isNativeOwnedCheckpointStatus(status, event),
+      "Preview checkpoint native ownership status is invalid",
+    );
+  }
+  if (status.description === NATIVE_OWNERSHIP_DRAINING_STATUS_DESCRIPTION) {
+    invariant(
+      isNativeOwnershipDrainingCheckpointStatus(status, event),
+      "Preview checkpoint native ownership drain status is invalid",
+    );
+  }
   if (checkpoint.pending_owner_key_digest === null) {
     invariant(
       checkpoint.pending_owner_attempt_count === 0,
@@ -4493,6 +4565,54 @@ function hasLiveGitHubPreviewOwnership(state) {
   );
 }
 
+function persistNoDispatchHeadDecision({
+  state,
+  previousState,
+  pull,
+  previewOwner,
+  controllerMode,
+  controllerUrl,
+}) {
+  const index = state.status_decisions.findLastIndex(
+    (decision) => decision.sha === pull.headSha,
+  );
+  invariant(index >= 0, "Current-head no-dispatch status decision is missing");
+  let desired;
+  if (previewOwner === UI_PREVIEW_OWNER_NATIVE) {
+    const liveGitHubOwnership = hasLiveGitHubPreviewOwnership(state);
+    desired = {
+      sha: pull.headSha,
+      state: liveGitHubOwnership ? "pending" : "success",
+      description: liveGitHubOwnership
+        ? NATIVE_OWNERSHIP_DRAINING_STATUS_DESCRIPTION
+        : NATIVE_OWNED_STATUS_DESCRIPTION,
+      target_url: controllerUrl,
+    };
+  } else {
+    invariant(
+      controllerMode === "observe-only",
+      "Active no-dispatch reconciliation has no native preview owner",
+    );
+    desired = {
+      sha: pull.headSha,
+      state: "success",
+      description: OBSERVE_ONLY_STATUS_DESCRIPTION,
+      target_url: controllerUrl,
+    };
+  }
+  const previous = (previousState?.status_decisions ?? []).findLast(
+    (decision) => decision.sha === pull.headSha,
+  );
+  state.status_decisions[index] = isControllerRunStatusDecision(
+    previous,
+    desired.state,
+    desired.description,
+  )
+    ? { ...desired, target_url: previous.target_url }
+    : desired;
+  return structuredClone(state.status_decisions[index]);
+}
+
 export async function reconcilePreview({
   github,
   workerDispatchGithub = null,
@@ -4597,6 +4717,17 @@ export async function reconcilePreview({
         continue reconcileAttempts;
       }
       if (noDispatch) {
+        let headDecision = null;
+        if (currentPull.state === "open") {
+          headDecision = persistNoDispatchHeadDecision({
+            state,
+            previousState: parsed.state,
+            pull: currentPull,
+            previewOwner,
+            controllerMode,
+            controllerUrl,
+          });
+        }
         stateComment = await writeControllerState({
           github,
           context,
@@ -4604,22 +4735,19 @@ export async function reconcilePreview({
           state,
           stateComment,
         });
-        if (currentPull.state === "open") {
-          const liveGitHubOwnership = hasLiveGitHubPreviewOwnership(state);
-          const nativeOwner = previewOwner === UI_PREVIEW_OWNER_NATIVE;
+        if (headDecision) {
           await github.rest.repos.createCommitStatus({
             ...ownerRepo(context),
-            sha: currentPull.headSha,
-            state: nativeOwner && liveGitHubOwnership ? "pending" : "success",
+            sha: headDecision.sha,
+            state: headDecision.state,
             context: PREVIEW_STATUS_CONTEXT,
-            description: nativeOwner
-              ? liveGitHubOwnership
-                ? "Draining GitHub preview before native ownership"
-                : "Native Vercel owns this UI preview"
-              : "GitHub preview dispatch is observe-only",
-            target_url: controllerUrl,
+            description: headDecision.description,
+            target_url: headDecision.target_url,
           });
-          if (nativeOwner && liveGitHubOwnership) {
+          if (
+            previewOwner === UI_PREVIEW_OWNER_NATIVE &&
+            headDecision.state === "pending"
+          ) {
             core.setOutput("preview_ownership_draining", "true");
           }
         }

--- a/scripts/vercel-preview-controller.test.mjs
+++ b/scripts/vercel-preview-controller.test.mjs
@@ -47,6 +47,15 @@ const SHA = Object.fromEntries(
     (index + 1).toString(16).repeat(40),
   ]),
 );
+const UI_VERCEL_CONFIGURATION_PATH = "apps/ui.mento.org/vercel.json";
+const GITHUB_OWNED_UI_VERCEL_CONFIGURATION = {
+  $schema: "https://openapi.vercel.sh/vercel.json",
+  git: { deploymentEnabled: { "**": false, main: true } },
+};
+const NATIVE_OWNED_UI_VERCEL_CONFIGURATION = {
+  $schema: "https://openapi.vercel.sh/vercel.json",
+  git: { deploymentEnabled: { "dependabot/**": false } },
+};
 const workerDispatchClients = new WeakMap();
 
 function reconcilePreview(options) {
@@ -2515,6 +2524,10 @@ function fakeGitHub({
   pullRequests = [],
   beforeListComments,
   beforeListCommitStatuses,
+  uiVercelConfiguration = GITHUB_OWNED_UI_VERCEL_CONFIGURATION,
+  uiVercelConfigurations = [],
+  uiVercelContentResponse,
+  uiVercelContentErrorStatus,
 } = {}) {
   const comments = structuredClone(initialComments);
   const runs = structuredClone(initialRuns);
@@ -2540,10 +2553,12 @@ function fakeGitHub({
   const workflowRunRequests = [];
   const primaryRequests = [];
   const workerDispatchRequests = [];
+  const contentRequests = [];
   const transientDisplayTitles = [...workflowRunDisplayTitles];
   const transientListDisplayTitles = [...workflowRunListDisplayTitles];
   const transientListRunIds = [...workflowRunListRunIds];
   const transientPullRequests = [...pullRequests];
+  const transientUiVercelConfigurations = [...uiVercelConfigurations];
   const attemptFailures = [...workflowRunAttemptFailures];
   const commentUpdateFailures = [...updateCommentFailures];
   const commitStatusListFailureQueue = [...commitStatusListFailures];
@@ -2662,6 +2677,33 @@ function fakeGitHub({
         },
       },
       repos: {
+        getContent: async (request) => {
+          contentRequests.push(structuredClone(request));
+          if (uiVercelContentErrorStatus) {
+            const error = new Error("fixture repository content read failed");
+            error.status = uiVercelContentErrorStatus;
+            throw error;
+          }
+          if (uiVercelContentResponse !== undefined) {
+            return { data: structuredClone(uiVercelContentResponse) };
+          }
+          const configuration =
+            transientUiVercelConfigurations.shift() ?? uiVercelConfiguration;
+          const text =
+            typeof configuration === "string"
+              ? configuration
+              : `${JSON.stringify(configuration, null, 2)}\n`;
+          const content = Buffer.from(text, "utf8");
+          return {
+            data: {
+              type: "file",
+              path: UI_VERCEL_CONFIGURATION_PATH,
+              encoding: "base64",
+              size: content.length,
+              content: content.toString("base64"),
+            },
+          };
+        },
         listDeployments,
         listCommitStatusesForRef,
         createCommitStatus: async (request) => {
@@ -2800,6 +2842,7 @@ function fakeGitHub({
     workflowRunRequests,
     primaryRequests,
     workerDispatchRequests,
+    contentRequests,
   };
 }
 
@@ -4658,7 +4701,191 @@ test("durable dispatch persists intent and waits for the exact run title to mate
   assert.deepEqual(journal.receipts.events, [opened]);
   assert.equal(journal.receipts.selections.length, 1);
   assert.equal(journal.state.ui.active.dispatch_state, "dispatched");
+  assert.ok(fixture.contentRequests.length >= 3);
+  assert.ok(
+    fixture.contentRequests.every(
+      ({ path, ref }) => path === UI_VERCEL_CONFIGURATION_PATH && ref === SHA.A,
+    ),
+  );
 });
+
+test("active controller defers an exact native-config rollback head without a dispatch credential", async () => {
+  const opened = event({
+    run: 121,
+    action: "opened",
+    head: SHA.A,
+    updated: timestamp(1),
+  });
+  const fixture = fakeGitHub({
+    pullRequest: pull({ head: SHA.A, updated: timestamp(1) }),
+    comments: [journalComment({ events: [opened] })],
+    uiVercelConfiguration: NATIVE_OWNED_UI_VERCEL_CONFIGURATION,
+  });
+  const core = fakeCore();
+
+  const state = await reconcilePreview({
+    github: fixture.github,
+    workerDispatchGithub: null,
+    context: fakeContext(),
+    core,
+    prNumber: 519,
+  });
+
+  assert.equal(state.ui.active, null);
+  assert.equal(state.ui.latest_desired_sha, SHA.A);
+  assert.equal(fixture.dispatches.length, 0);
+  assert.equal(fixture.workerDispatchRequests.length, 0);
+  assert.deepEqual(fixture.contentRequests, [
+    {
+      owner: "mento-protocol",
+      repo: "frontend-monorepo",
+      path: UI_VERCEL_CONFIGURATION_PATH,
+      ref: SHA.A,
+    },
+  ]);
+  assert.equal(fixture.commitStatuses.at(-1).state, "success");
+  assert.equal(
+    fixture.commitStatuses.at(-1).description,
+    "Native Vercel owns this UI preview",
+  );
+  assert.equal(
+    fixture.commitStatuses.at(-1).target_url,
+    "https://github.com/mento-protocol/frontend-monorepo/actions/runs/7000",
+  );
+  assert.equal(core.outputs.get("preview_owner"), "native-vercel");
+  assert.equal(core.outputs.get("dispatch_skipped"), "true");
+});
+
+test("active controller rechecks exact-head ownership after recovery and blocks a racing native cutover", async () => {
+  const opened = event({
+    run: 121,
+    action: "opened",
+    head: SHA.A,
+    updated: timestamp(1),
+  });
+  const fixture = fakeGitHub({
+    pullRequest: pull({ head: SHA.A, updated: timestamp(1) }),
+    comments: [journalComment({ events: [opened] })],
+    uiVercelConfiguration: NATIVE_OWNED_UI_VERCEL_CONFIGURATION,
+    uiVercelConfigurations: [
+      GITHUB_OWNED_UI_VERCEL_CONFIGURATION,
+      GITHUB_OWNED_UI_VERCEL_CONFIGURATION,
+      NATIVE_OWNED_UI_VERCEL_CONFIGURATION,
+    ],
+  });
+  const waits = [];
+
+  const state = await reconcilePreview({
+    github: fixture.github,
+    context: fakeContext(),
+    core: fakeCore(),
+    prNumber: 519,
+    waitForRecovery: async (milliseconds) => waits.push(milliseconds),
+  });
+
+  assert.equal(fixture.dispatches.length, 0);
+  assert.equal(fixture.workerDispatchRequests.length, 0);
+  assert.equal(state.ui.active, null);
+  assert.equal(
+    state.ui.terminal_history.at(-1).terminal_reason,
+    "dispatch-disabled-intent-without-worker",
+  );
+  assert.ok(fixture.contentRequests.length >= 5);
+  assert.ok(fixture.contentRequests.every(({ ref }) => ref === SHA.A));
+  assert.deepEqual(waits, [500, 500, 500, 500]);
+  assert.equal(fixture.commitStatuses.at(-1).state, "success");
+  assert.equal(
+    fixture.commitStatuses.at(-1).description,
+    "Native Vercel owns this UI preview",
+  );
+});
+
+test("observe-only controller fails closed for a stale GitHub-owned Phase B head", async () => {
+  const opened = event({
+    run: 121,
+    action: "opened",
+    head: SHA.A,
+    updated: timestamp(1),
+  });
+  const fixture = fakeGitHub({
+    pullRequest: pull({ head: SHA.A, updated: timestamp(1) }),
+    comments: [journalComment({ events: [opened] })],
+  });
+
+  await assert.rejects(
+    reconcilePreview({
+      github: fixture.github,
+      workerDispatchGithub: null,
+      controllerMode: "observe-only",
+      context: fakeContext(),
+      core: fakeCore(),
+      prNumber: 519,
+    }),
+    /leaves the candidate UI preview ownerless/,
+  );
+
+  assert.equal(fixture.dispatches.length, 0);
+  assert.equal(fixture.workerDispatchRequests.length, 0);
+  assert.equal(fixture.commentUpdates.length, 0);
+  assert.equal(fixture.commitStatuses.at(-1).state, "error");
+});
+
+for (const [name, contentOptions, message] of [
+  [
+    "missing",
+    { uiVercelContentErrorStatus: 404 },
+    /fixture repository content read failed/,
+  ],
+  ["malformed", { uiVercelConfiguration: "{" }, /is malformed/],
+  [
+    "oversized",
+    {
+      uiVercelContentResponse: {
+        type: "file",
+        path: UI_VERCEL_CONFIGURATION_PATH,
+        encoding: "base64",
+        size: 2_049,
+        content: Buffer.alloc(2_049).toString("base64"),
+      },
+    },
+    /metadata is invalid/,
+  ],
+  [
+    "unknown",
+    { uiVercelConfiguration: { git: { deploymentEnabled: true } } },
+    /is not recognized/,
+  ],
+]) {
+  test(`candidate UI ownership ${name} fails closed before credentials or journal mutation`, async () => {
+    const opened = event({
+      run: 121,
+      action: "opened",
+      head: SHA.A,
+      updated: timestamp(1),
+    });
+    const fixture = fakeGitHub({
+      pullRequest: pull({ head: SHA.A, updated: timestamp(1) }),
+      comments: [journalComment({ events: [opened] })],
+      ...contentOptions,
+    });
+
+    await assert.rejects(
+      reconcilePreview({
+        github: fixture.github,
+        workerDispatchGithub: null,
+        context: fakeContext(),
+        core: fakeCore(),
+        prNumber: 519,
+      }),
+      message,
+    );
+
+    assert.equal(fixture.dispatches.length, 0);
+    assert.equal(fixture.workerDispatchRequests.length, 0);
+    assert.equal(fixture.commentUpdates.length, 0);
+    assert.equal(fixture.commitStatuses.at(-1).state, "error");
+  });
+}
 
 test("observe-only controller mode records status without creating dispatch intent", async () => {
   const opened = event({
@@ -4670,6 +4897,7 @@ test("observe-only controller mode records status without creating dispatch inte
   const fixture = fakeGitHub({
     pullRequest: pull({ head: SHA.A, updated: timestamp(1) }),
     comments: [journalComment({ events: [opened] })],
+    uiVercelConfiguration: NATIVE_OWNED_UI_VERCEL_CONFIGURATION,
   });
   const core = fakeCore();
 
@@ -4703,7 +4931,7 @@ test("observe-only controller mode records status without creating dispatch inte
         sha: SHA.A,
         state: "success",
         context: "Vercel Preview",
-        description: "GitHub preview dispatch is observe-only",
+        description: "Native Vercel owns this UI preview",
       },
     ],
   );
@@ -4741,6 +4969,7 @@ test("observe-only mode recovers completed work and reconstructs state without d
     pullRequest,
     comments: [journalWithState([opened, runtimeB], dispatched)],
     runs: [completed],
+    uiVercelConfiguration: NATIVE_OWNED_UI_VERCEL_CONFIGURATION,
   });
   const core = fakeCore();
 
@@ -4776,12 +5005,226 @@ test("observe-only mode recovers completed work and reconstructs state without d
       {
         sha: SHA.B,
         state: "success",
-        description: "GitHub preview dispatch is observe-only",
+        description: "Native Vercel owns this UI preview",
       },
     ],
   );
   assert.equal(core.outputs.get("controller_mode"), "observe-only");
   assert.equal(core.outputs.get("dispatch_skipped"), "true");
+});
+
+test("observe-only mode attaches and terminalizes a completed crash-window worker", async () => {
+  const opened = event({
+    run: 121,
+    action: "opened",
+    head: SHA.A,
+    updated: timestamp(1),
+  });
+  const pullRequest = pull({ head: SHA.A, updated: timestamp(1) });
+  const selected = reconcile({ events: [opened], pullRequest });
+  const intended = persistIntent(selected);
+  const completed = workerRun(selected.nextDispatch, {
+    status: "completed",
+    conclusion: "cancelled",
+  });
+  const fixture = fakeGitHub({
+    pullRequest,
+    comments: [journalWithState([opened], intended)],
+    runs: [completed],
+    uiVercelConfiguration: NATIVE_OWNED_UI_VERCEL_CONFIGURATION,
+  });
+  const core = fakeCore();
+
+  const state = await reconcilePreview({
+    github: fixture.github,
+    workerDispatchGithub: null,
+    controllerMode: "observe-only",
+    context: fakeContext({ runId: 7_001 }),
+    core,
+    prNumber: 519,
+    waitForRecovery: async () => {},
+  });
+
+  assert.equal(fixture.dispatches.length, 0);
+  assert.equal(fixture.workerDispatchRequests.length, 0);
+  assert.equal(core.outputs.get("recovered_intended_run_id"), "8000");
+  assert.equal(state.ui.active, null);
+  assert.equal(
+    state.ui.terminal_history.at(-1).terminal_reason,
+    "worker-cancelled",
+  );
+  const journal = journalFromComment(fixture.comments[0]);
+  assert.equal(journal.receipts.results.length, 1);
+  assert.equal(journal.receipts.results[0].worker_run_id, 8_000);
+  assert.equal(journal.state.ui.active, null);
+  assert.equal(fixture.commitStatuses.at(-1).state, "success");
+  assert.equal(
+    fixture.commitStatuses.at(-1).description,
+    "Native Vercel owns this UI preview",
+  );
+});
+
+test("observe-only mode durably attaches an in-progress crash-window worker and stays pending", async () => {
+  const opened = event({
+    run: 121,
+    action: "opened",
+    head: SHA.A,
+    updated: timestamp(1),
+  });
+  const pullRequest = pull({ head: SHA.A, updated: timestamp(1) });
+  const selected = reconcile({ events: [opened], pullRequest });
+  const intended = persistIntent(selected);
+  const queued = workerRun(selected.nextDispatch, { status: "in_progress" });
+  const fixture = fakeGitHub({
+    pullRequest,
+    comments: [journalWithState([opened], intended)],
+    runs: [queued],
+    uiVercelConfiguration: NATIVE_OWNED_UI_VERCEL_CONFIGURATION,
+  });
+  const core = fakeCore();
+
+  const state = await reconcilePreview({
+    github: fixture.github,
+    workerDispatchGithub: null,
+    controllerMode: "observe-only",
+    context: fakeContext({ runId: 7_001 }),
+    core,
+    prNumber: 519,
+    waitForRecovery: async () => {},
+  });
+
+  assert.equal(fixture.dispatches.length, 0);
+  assert.equal(fixture.workerDispatchRequests.length, 0);
+  assert.equal(state.ui.active.dispatch_state, "dispatched");
+  assert.equal(state.ui.active.workflow_run_id, 8_000);
+  const journal = journalFromComment(fixture.comments[0]);
+  assert.equal(journal.state.ui.active.workflow_run_id, 8_000);
+  assert.equal(journal.receipts.results.length, 0);
+  assert.equal(fixture.commitStatuses.at(-1).state, "pending");
+  assert.equal(
+    fixture.commitStatuses.at(-1).description,
+    "Draining GitHub preview before native ownership",
+  );
+  assert.equal(
+    fixture.commitStatuses.at(-1).target_url,
+    "https://github.com/mento-protocol/frontend-monorepo/actions/runs/7001",
+  );
+  assert.equal(core.outputs.get("preview_ownership_draining"), "true");
+});
+
+test("observe-only mode durably retires a crash-window intent with no worker and does not rediscover it", async () => {
+  const opened = event({
+    run: 121,
+    action: "opened",
+    head: SHA.A,
+    updated: timestamp(1),
+  });
+  const pullRequest = pull({ head: SHA.A, updated: timestamp(1) });
+  const selected = reconcile({ events: [opened], pullRequest });
+  const intended = persistIntent(selected);
+  const fixture = fakeGitHub({
+    pullRequest,
+    comments: [journalWithState([opened], intended)],
+    uiVercelConfiguration: NATIVE_OWNED_UI_VERCEL_CONFIGURATION,
+  });
+  const core = fakeCore();
+  const waits = [];
+
+  const state = await reconcilePreview({
+    github: fixture.github,
+    workerDispatchGithub: null,
+    controllerMode: "observe-only",
+    context: fakeContext({ runId: 7_001 }),
+    core,
+    prNumber: 519,
+    waitForRecovery: async (milliseconds) => waits.push(milliseconds),
+  });
+
+  assert.equal(fixture.dispatches.length, 0);
+  assert.equal(fixture.workerDispatchRequests.length, 0);
+  assert.deepEqual(waits, [500, 500]);
+  assert.equal(fixture.workflowRunListRequests.length, 3);
+  assert.equal(core.outputs.get("retired_undispatched_intent"), "true");
+  assert.equal(state.ui.active, null);
+  assert.equal(
+    state.ui.terminal_history.at(-1).terminal_reason,
+    "dispatch-disabled-intent-without-worker",
+  );
+  let journal = journalFromComment(fixture.comments[0]);
+  assert.equal(journal.receipts.results.length, 1);
+  assert.equal(
+    journal.receipts.results[0].terminal_reason,
+    "dispatch-disabled-intent-without-worker",
+  );
+  assert.equal(journal.state.ui.active, null);
+  assert.equal(fixture.commitStatuses.at(-1).state, "success");
+
+  fixture.comments[0].body = journalWithState(
+    [opened],
+    intended,
+    {
+      revision: journal.revision + 1,
+      results: journal.receipts.results,
+    },
+    fixture.comments[0].id,
+  ).body;
+  const lookupCount = fixture.workflowRunListRequests.length;
+  await reconcilePreview({
+    github: fixture.github,
+    workerDispatchGithub: null,
+    controllerMode: "observe-only",
+    context: fakeContext({ runId: 7_002 }),
+    core: fakeCore(),
+    prNumber: 519,
+    waitForRecovery: async () => {},
+  });
+  journal = journalFromComment(fixture.comments[0]);
+  assert.equal(fixture.workflowRunListRequests.length, lookupCount);
+  assert.equal(journal.receipts.results.length, 1);
+  assert.equal(journal.state.ui.active, null);
+});
+
+test("observe-only mode fails closed when multiple workers match one crash-window intent", async () => {
+  const opened = event({
+    run: 121,
+    action: "opened",
+    head: SHA.A,
+    updated: timestamp(1),
+  });
+  const pullRequest = pull({ head: SHA.A, updated: timestamp(1) });
+  const selected = reconcile({ events: [opened], pullRequest });
+  const intended = persistIntent(selected);
+  const fixture = fakeGitHub({
+    pullRequest,
+    comments: [journalWithState([opened], intended)],
+    runs: [
+      workerRun(selected.nextDispatch, { id: 8_000 }),
+      workerRun(selected.nextDispatch, { id: 8_001 }),
+    ],
+    uiVercelConfiguration: NATIVE_OWNED_UI_VERCEL_CONFIGURATION,
+  });
+
+  await assert.rejects(
+    reconcilePreview({
+      github: fixture.github,
+      workerDispatchGithub: null,
+      controllerMode: "observe-only",
+      context: fakeContext({ runId: 7_001 }),
+      core: fakeCore(),
+      prNumber: 519,
+      waitForRecovery: async () => {},
+    }),
+    /Multiple worker runs match one intended controller key/,
+  );
+
+  assert.equal(fixture.dispatches.length, 0);
+  assert.equal(fixture.workerDispatchRequests.length, 0);
+  assert.equal(fixture.commentUpdates.length, 0);
+  assert.equal(
+    journalFromComment(fixture.comments[0]).state.ui.active.dispatch_state,
+    "intended",
+  );
+  assert.equal(fixture.commitStatuses.at(-1).state, "error");
 });
 
 test("controller mode is explicit and rejects unknown values before API access", async () => {

--- a/scripts/vercel-preview-controller.test.mjs
+++ b/scripts/vercel-preview-controller.test.mjs
@@ -251,6 +251,37 @@ function result(
   });
 }
 
+function controllerResult(
+  dispatch,
+  {
+    runId = 7_000,
+    reason = "native-owned-selection-without-github-worker",
+  } = {},
+) {
+  return validateWorkerResult({
+    schema: RESULT_RECEIPT_SCHEMA,
+    repository: PREVIEW_REPOSITORY,
+    pr: dispatch.pr,
+    target: "ui",
+    sha: dispatch.sha,
+    controller_key: dispatch.key,
+    key_digest: dispatch.key_digest,
+    epoch_anchor_run_id: dispatch.epoch_anchor_run_id,
+    reconciliation_basis_digest: dispatch.reconciliation_basis_digest,
+    selection_receipt_run_id: dispatch.selection_receipt_run_id,
+    expected_workflow_sha: dispatch.expected_workflow_sha,
+    worker_run_id: runId,
+    worker_run_attempt: 1,
+    github_deployment_id: null,
+    state: "error",
+    vercel_deployment_id: null,
+    next_deployment_id: null,
+    vercel_deployment_url: null,
+    smoke_result: "not-run",
+    terminal_reason: reason,
+  });
+}
+
 function reconcile({
   events,
   results = [],
@@ -2717,6 +2748,7 @@ function fakeGitHub({
   let nextDeploymentId = 9_000;
   let listCommentRequests = 0;
   let listCommitStatusRequests = 0;
+  let deploymentLookupCallCount = 0;
   const listComments = async () => {};
   const listCommits = async () => {};
   const listDeployments = async () => {};
@@ -2912,7 +2944,10 @@ function fakeGitHub({
       if (method === listCommits) {
         return pullCommits.map((sha) => ({ sha }));
       }
-      if (method === listDeployments) return structuredClone(deployments);
+      if (method === listDeployments) {
+        deploymentLookupCallCount += 1;
+        return structuredClone(deployments);
+      }
       if (method === listCommitStatusesForRef) {
         return structuredClone(
           commitStatusHistory.get(String(request.ref)) ?? [],
@@ -3001,6 +3036,9 @@ function fakeGitHub({
     primaryRequests,
     workerDispatchRequests,
     contentRequests,
+    get deploymentLookupCallCount() {
+      return deploymentLookupCallCount;
+    },
   };
 }
 
@@ -4857,6 +4895,58 @@ test("worker preflight rechecks the immutable selected SHA ownership before depl
   );
   assert.equal(fixture.deployments.length, 0);
   assert.equal(core.outputs.has("should_deploy"), false);
+  assert.equal(fixture.deploymentLookupCallCount, 0);
+});
+
+test("worker preflight rejects native-owned current head before deployment lookup", async () => {
+  const opened = event({
+    run: 120,
+    action: "opened",
+    head: SHA.A,
+    updated: timestamp(1),
+  });
+  const synchronized = event({
+    run: 121,
+    action: "synchronize",
+    before: SHA.A,
+    head: SHA.B,
+    updated: timestamp(2),
+  });
+  const pullRequest = pull({ head: SHA.B, updated: timestamp(2) });
+  const selected = reconcile({
+    events: [opened, synchronized],
+    pullRequest,
+  });
+  assert.equal(selected.nextDispatch.sha, SHA.A);
+  const intended = persistIntent(selected);
+  const fixture = fakeGitHub({
+    pullRequest,
+    pullCommits: [SHA.A, SHA.B],
+    comments: [journalWithState([opened, synchronized], intended)],
+    uiVercelConfigurationsByRef: new Map([
+      [SHA.A, GITHUB_OWNED_UI_VERCEL_CONFIGURATION],
+      [SHA.B, NATIVE_OWNED_UI_VERCEL_CONFIGURATION],
+    ]),
+  });
+  const core = fakeCore();
+
+  await assert.rejects(
+    validateWorkerDispatch({
+      github: fixture.github,
+      context: fakeContext({ runId: 8_000 }),
+      core,
+      inputs: workerInputs(selected.nextDispatch),
+    }),
+    /does not own the current UI configuration/,
+  );
+
+  assert.deepEqual(
+    fixture.contentRequests.map(({ ref }) => ref),
+    [SHA.B],
+  );
+  assert.equal(fixture.deploymentLookupCallCount, 0);
+  assert.equal(fixture.deployments.length, 0);
+  assert.equal(core.outputs.has("should_deploy"), false);
 });
 
 test("durable dispatch persists intent and waits for the exact run title to materialize", async () => {
@@ -4967,6 +5057,76 @@ test("a native-owned receipt followed by a GitHub-owned head retires A and dispa
   );
   assert.ok(fixture.contentRequests.some(({ ref }) => ref === SHA.A));
   assert.ok(fixture.contentRequests.some(({ ref }) => ref === SHA.B));
+});
+
+test("native A through docs-only C stays native until only GitHub-owned B dispatches", async () => {
+  const opened = event({
+    run: 121,
+    action: "opened",
+    head: SHA.A,
+    updated: timestamp(1),
+  });
+  const docsOnly = event({
+    run: 122,
+    action: "synchronize",
+    before: SHA.A,
+    head: SHA.C,
+    runtime: false,
+    updated: timestamp(2),
+  });
+  const synchronized = event({
+    run: 123,
+    action: "synchronize",
+    before: SHA.C,
+    head: SHA.B,
+    updated: timestamp(3),
+  });
+  const fixture = fakeGitHub({
+    pullRequest: pull({ head: SHA.B, updated: timestamp(3) }),
+    pullCommits: [SHA.A, SHA.C, SHA.B],
+    comments: [journalComment({ events: [opened, docsOnly, synchronized] })],
+    uiVercelConfigurationsByRef: new Map([
+      [SHA.A, NATIVE_OWNED_UI_VERCEL_CONFIGURATION],
+      [SHA.B, GITHUB_OWNED_UI_VERCEL_CONFIGURATION],
+    ]),
+  });
+
+  const state = await reconcilePreview({
+    github: fixture.github,
+    context: fakeContext(),
+    core: fakeCore(),
+    prNumber: 519,
+    waitForRecovery: async () => {},
+  });
+
+  assert.equal(fixture.dispatches.length, 1);
+  assert.equal(fixture.workerDispatchRequests.length, 1);
+  assert.equal(fixture.dispatches[0].inputs.commit_sha, SHA.B);
+  assert.equal(state.ui.active.sha, SHA.B);
+  assert.equal(state.ui.active.dispatch_state, "dispatched");
+  assert.equal(state.ui.last_successful_runtime_sha, null);
+  assert.equal(state.ui.last_successful_runtime_url, null);
+  const statusBySha = new Map(
+    state.status_decisions.map((status) => [status.sha, status]),
+  );
+  for (const sha of [SHA.A, SHA.C]) {
+    assert.deepEqual(statusBySha.get(sha), {
+      sha,
+      state: "success",
+      description: "Native Vercel owns this UI preview",
+      target_url:
+        "https://github.com/mento-protocol/frontend-monorepo/actions/runs/7000",
+    });
+  }
+  assert.equal(statusBySha.get(SHA.B).state, "pending");
+  const journal = journalFromComment(fixture.comments[0]);
+  assert.equal(journal.receipts.results.length, 1);
+  assert.equal(journal.receipts.results[0].sha, SHA.A);
+  assert.equal(journal.receipts.results[0].state, "error");
+  assert.equal(
+    journal.receipts.results[0].terminal_reason,
+    "native-owned-selection-without-github-worker",
+  );
 });
 
 test("generic no-dispatch retirement does not claim native ownership of a GitHub-owned SHA", () => {
@@ -6014,6 +6174,69 @@ test("observe-only mode retires same-SHA active and reopened-epoch intents witho
   assert.equal(
     fixture.commitStatuses.at(-1).description,
     "Native Vercel owns this UI preview",
+  );
+});
+
+test("same-SHA native-owned receipts stay distinct across epoch selection digests", () => {
+  const setup = sameShaReopenIntentState();
+  const intended = persistIntent(setup.current);
+  const retiredSelection = intended.ui.retired_active[0];
+  const activeSelection = intended.ui.active;
+  assert.equal(retiredSelection.sha, activeSelection.sha);
+  assert.equal(retiredSelection.key, activeSelection.key);
+  assert.notEqual(
+    retiredSelection.epoch_anchor_run_id,
+    activeSelection.epoch_anchor_run_id,
+  );
+  assert.notEqual(
+    retiredSelection.reconciliation_basis_digest,
+    activeSelection.reconciliation_basis_digest,
+  );
+  assert.notEqual(retiredSelection.key_digest, activeSelection.key_digest);
+
+  const nativeResults = [retiredSelection, activeSelection].map((selection) =>
+    controllerResult(selection, { runId: 7_001 }),
+  );
+  const selections = [retiredSelection, activeSelection].map((selection) =>
+    selectionReceiptFromDispatch(selection),
+  );
+  const reconciled = reconcile({
+    events: setup.events,
+    results: nativeResults,
+    selections,
+    pullRequest: setup.pullRequest,
+    existingState: intended,
+  });
+
+  assert.equal(reconciled.nextDispatch, null);
+  assert.equal(reconciled.state.ui.active, null);
+  assert.deepEqual(reconciled.state.ui.retired_active, []);
+  assert.equal(reconciled.state.ui.last_successful_runtime_sha, null);
+  assert.equal(reconciled.state.ui.last_successful_runtime_url, null);
+  assert.deepEqual(reconciled.state.ui.terminal_result_key_digests, [
+    activeSelection.key_digest,
+  ]);
+  assert.equal(reconciled.state.status_decisions[0].state, "success");
+  assert.equal(
+    reconciled.state.status_decisions[0].description,
+    "Native Vercel owns this UI preview",
+  );
+
+  const journal = createPreviewJournal({
+    pr: 519,
+    events: setup.events,
+    selections,
+    results: nativeResults,
+    state: reconciled.state,
+  });
+  assert.equal(journal.receipts.results.length, 2);
+  assert.equal(
+    new Set(journal.receipts.results.map(({ key_digest }) => key_digest)).size,
+    2,
+  );
+  assert.deepEqual(
+    new Set(journal.receipts.results.map(({ worker_run_id }) => worker_run_id)),
+    new Set([7_001]),
   );
 });
 

--- a/scripts/vercel-preview-controller.test.mjs
+++ b/scripts/vercel-preview-controller.test.mjs
@@ -1679,6 +1679,100 @@ test("capacity checkpointing uses the latest represented receipt when the live P
   );
 });
 
+test("terminal checkpoint folds quarantined retired ownership into bounded audit evidence", () => {
+  const setup = sameShaReopenState();
+  const currentResult = result(setup.current.nextDispatch, { runId: 8_001 });
+  const selections = [
+    selectionReceiptFromDispatch(setup.currentState.ui.retired_active[0]),
+    selectionReceiptFromDispatch(setup.currentState.ui.active),
+  ];
+  const events = [...setup.events];
+  let priorHead = SHA.A;
+  let currentPull = setup.pullRequest;
+  let journal = null;
+
+  for (let index = 1; index <= 45; index += 1) {
+    const head = (900 + index).toString(16).padStart(40, "0");
+    events.push(
+      event({
+        run: 2_100 + index,
+        action: "synchronize",
+        before: priorHead,
+        head,
+        runtime: false,
+        updated: timestamp(index + 3),
+      }),
+    );
+    currentPull = pull({ head, updated: timestamp(index + 3) });
+    const terminal = reconcile({
+      events,
+      results: [currentResult],
+      selections,
+      pullRequest: currentPull,
+      existingState: setup.currentState,
+    });
+    assert.equal(terminal.state.ui.active, null);
+    assert.equal(terminal.state.ui.retired_active.length, 1);
+    const quarantinedState = structuredClone(terminal.state);
+    quarantinedState.ui.retired_active[0] = {
+      ...quarantinedState.ui.retired_active[0],
+      recovery_quarantine: "persisted-attempt-invalid-or-unavailable",
+    };
+    journal = createPreviewJournal({
+      pr: 519,
+      events,
+      selections,
+      results: [currentResult],
+      state: quarantinedState,
+    });
+    priorHead = head;
+    if (Buffer.byteLength(previewJournalBody(journal), "utf8") >= 41_000) {
+      break;
+    }
+  }
+
+  const originalBytes = Buffer.byteLength(previewJournalBody(journal), "utf8");
+  assert.ok(originalBytes >= 41_000, `journal was only ${originalBytes} bytes`);
+  assert.ok(originalBytes < 60_000, `journal was ${originalBytes} bytes`);
+
+  const compacted = compactPreviewJournal(journal, {
+    pullRequest: currentPull,
+  });
+  assert.equal(compacted.checkpoint.pending_owner_key_digest, null);
+  assert.equal(compacted.checkpoint.pending_runtime_event, null);
+  assert.equal(compacted.checkpoint.status.state, "success");
+  assert.match(
+    compacted.checkpoint.cumulative_receipts_digest,
+    /^[0-9a-f]{64}$/,
+  );
+  assert.deepEqual(compacted.checkpoint.pruned_receipt_counts, {
+    events: events.length,
+    selections: 2,
+    worker_evidence: 0,
+    results: 1,
+  });
+  assert.deepEqual(compacted.receipts, {
+    events: [],
+    selections: [],
+    worker_evidence: [],
+    results: [],
+  });
+  assert.equal(compacted.state.ui.retired_active.length, 0);
+  assert.ok(
+    Buffer.byteLength(previewJournalBody(compacted), "utf8") < originalBytes,
+  );
+  assert.doesNotThrow(() =>
+    reconcile({
+      events: compacted.receipts.events,
+      results: compacted.receipts.results,
+      selections: compacted.receipts.selections,
+      pullRequest: currentPull,
+      existingState: compacted.state,
+      checkpoint: compacted.checkpoint,
+    }),
+  );
+});
+
 test("a terminal pending owner resolves a docs-only capacity checkpoint", async () => {
   const openedHead = (300).toString(16).padStart(40, "0");
   const opened = event({
@@ -2561,6 +2655,7 @@ function fakeGitHub({
   workerRunTotalCount,
   workflowRunAttemptFailures = [],
   updateCommentFailures = [],
+  lostSerializedUpdateFailures = 0,
   updateCommentFailureIds = [],
   pullCommits = [pullRequest.head.sha],
   deployments: initialDeployments = [],
@@ -2596,6 +2691,7 @@ function fakeGitHub({
     ]),
   );
   const commentUpdates = [];
+  const lostSerializedUpdates = [];
   const dispatches = [];
   const createdDeploymentStatuses = [];
   const workflowRunAttemptRequests = [];
@@ -2611,6 +2707,7 @@ function fakeGitHub({
   const transientUiVercelConfigurations = [...uiVercelConfigurations];
   const attemptFailures = [...workflowRunAttemptFailures];
   const commentUpdateFailures = [...updateCommentFailures];
+  let lostSerializedUpdateFailureCount = lostSerializedUpdateFailures;
   const commitStatusListFailureQueue = [...commitStatusListFailures];
   const commitStatusFailureQueue = [...commitStatusFailures];
   const commentUpdateFailureIds = new Set(updateCommentFailureIds);
@@ -2666,8 +2763,14 @@ function fakeGitHub({
           }
           const comment = comments.find(({ id }) => id === comment_id);
           assert.ok(comment, "fixture update must target an existing comment");
+          const previousBody = comment.body;
           commentUpdates.push({ comment_id, body });
           comment.body = body;
+          if (lostSerializedUpdateFailureCount > 0) {
+            lostSerializedUpdateFailureCount -= 1;
+            lostSerializedUpdates.push(comment_id);
+            comment.body = previousBody;
+          }
           return { data: comment };
         },
       },
@@ -2885,6 +2988,7 @@ function fakeGitHub({
     statuses,
     commitStatuses,
     commentUpdates,
+    lostSerializedUpdates,
     dispatches,
     createdDeploymentStatuses,
     workflowRunAttemptRequests,
@@ -4903,7 +5007,7 @@ test("active controller settles a completed crash-window worker after a racing n
   );
 });
 
-test("native cutover converges after recovery and an exact-head ownership flip", async () => {
+test("native cutover progress converges independently from a serialized update retry", async () => {
   const opened = event({
     run: 121,
     action: "opened",
@@ -4941,6 +5045,7 @@ test("native cutover converges after recovery and an exact-head ownership flip",
       }),
     ],
     runs: [completedA],
+    lostSerializedUpdateFailures: 1,
     uiVercelConfiguration: NATIVE_OWNED_UI_VERCEL_CONFIGURATION,
     uiVercelConfigurations: [
       GITHUB_OWNED_UI_VERCEL_CONFIGURATION,
@@ -4956,10 +5061,12 @@ test("native cutover converges after recovery and an exact-head ownership flip",
     core: fakeCore(),
     prNumber: 519,
     waitForRecovery: async () => {},
+    progressPassLimit: 3,
   });
 
   assert.equal(fixture.dispatches.length, 0);
   assert.equal(fixture.workerDispatchRequests.length, 0);
+  assert.deepEqual(fixture.lostSerializedUpdates, [1]);
   assert.equal(state.ui.active, null);
   assert.equal(state.ui.latest_desired_sha, SHA.B);
   assert.ok(
@@ -4980,6 +5087,48 @@ test("native cutover converges after recovery and an exact-head ownership flip",
   assert.equal(
     fixture.commitStatuses.at(-1).description,
     "Native Vercel owns this UI preview",
+  );
+});
+
+test("exhausted deterministic progress posts a fail-closed preview status", async () => {
+  const opened = event({
+    run: 121,
+    action: "opened",
+    head: SHA.A,
+    updated: timestamp(1),
+  });
+  const pullRequest = pull({ head: SHA.A, updated: timestamp(1) });
+  const selected = reconcile({ events: [opened], pullRequest });
+  const fixture = fakeGitHub({
+    pullRequest,
+    comments: [journalWithState([opened], persistIntent(selected))],
+    uiVercelConfiguration: NATIVE_OWNED_UI_VERCEL_CONFIGURATION,
+  });
+
+  await assert.rejects(
+    reconcilePreview({
+      github: fixture.github,
+      workerDispatchGithub: null,
+      context: fakeContext({ runId: 7_001 }),
+      core: fakeCore(),
+      prNumber: 519,
+      waitForRecovery: async () => {},
+      progressPassLimit: 0,
+    }),
+    /Controller state update did not converge/,
+  );
+
+  assert.equal(fixture.dispatches.length, 0);
+  assert.equal(fixture.workerDispatchRequests.length, 0);
+  assert.equal(fixture.commitStatuses.at(-1).state, "error");
+  assert.equal(
+    fixture.commitStatuses.at(-1).description,
+    "Preview controller state is invalid or ambiguous",
+  );
+  assert.equal(
+    journalFromComment(fixture.comments[0]).receipts.results.at(-1)
+      .terminal_reason,
+    "dispatch-disabled-intent-without-worker",
   );
 });
 

--- a/scripts/vercel-preview-controller.test.mjs
+++ b/scripts/vercel-preview-controller.test.mjs
@@ -2503,6 +2503,56 @@ function sameShaReopenState() {
   };
 }
 
+function sameShaReopenIntentState() {
+  const opened = event({
+    run: 160,
+    action: "opened",
+    head: SHA.A,
+    updated: timestamp(1),
+  });
+  const old = reconcile({
+    events: [opened],
+    pullRequest: pull({ head: SHA.A, updated: timestamp(1) }),
+  });
+  const oldIntended = persistIntent(old);
+  const closed = event({
+    run: 161,
+    action: "closed",
+    head: SHA.A,
+    updated: timestamp(2),
+  });
+  const closedState = reconcile({
+    events: [opened, closed],
+    pullRequest: pull({
+      head: SHA.A,
+      state: "closed",
+      updated: timestamp(2),
+      closed: timestamp(2),
+    }),
+    existingState: oldIntended,
+  });
+  const reopened = event({
+    run: 162,
+    action: "reopened",
+    head: SHA.A,
+    updated: timestamp(3),
+  });
+  const current = reconcile({
+    events: [opened, closed, reopened],
+    pullRequest: pull({ head: SHA.A, updated: timestamp(3) }),
+    existingState: closedState.state,
+  });
+  assert.equal(current.state.ui.active, null);
+  assert.equal(current.state.ui.retired_active.length, 1);
+  assert.equal(current.state.ui.retired_active[0].dispatch_state, "intended");
+  return {
+    events: [opened, closed, reopened],
+    old,
+    current,
+    pullRequest: pull({ head: SHA.A, updated: timestamp(3) }),
+  };
+}
+
 function fakeGitHub({
   pullRequest,
   comments: initialComments,
@@ -4800,6 +4850,59 @@ test("active controller rechecks exact-head ownership after recovery and blocks 
   );
 });
 
+test("active controller settles a completed crash-window worker after a racing native cutover", async () => {
+  const opened = event({
+    run: 121,
+    action: "opened",
+    head: SHA.A,
+    updated: timestamp(1),
+  });
+  const pullRequest = pull({ head: SHA.A, updated: timestamp(1) });
+  const selected = reconcile({ events: [opened], pullRequest });
+  const completed = workerRun(selected.nextDispatch, {
+    status: "completed",
+    conclusion: "cancelled",
+  });
+  const fixture = fakeGitHub({
+    pullRequest,
+    comments: [journalComment({ events: [opened] })],
+    runs: [completed],
+    uiVercelConfiguration: NATIVE_OWNED_UI_VERCEL_CONFIGURATION,
+    uiVercelConfigurations: [
+      GITHUB_OWNED_UI_VERCEL_CONFIGURATION,
+      GITHUB_OWNED_UI_VERCEL_CONFIGURATION,
+      NATIVE_OWNED_UI_VERCEL_CONFIGURATION,
+    ],
+  });
+  const core = fakeCore();
+
+  const state = await reconcilePreview({
+    github: fixture.github,
+    context: fakeContext({ runId: 7_001 }),
+    core,
+    prNumber: 519,
+    waitForRecovery: async () => {},
+  });
+
+  assert.equal(fixture.dispatches.length, 0);
+  assert.equal(fixture.workerDispatchRequests.length, 0);
+  assert.equal(core.outputs.get("recovered_intended_run_id"), "8000");
+  assert.equal(state.ui.active, null);
+  assert.equal(
+    state.ui.terminal_history.at(-1).terminal_reason,
+    "worker-cancelled",
+  );
+  const journal = journalFromComment(fixture.comments[0]);
+  assert.equal(journal.receipts.results.length, 1);
+  assert.equal(journal.receipts.results[0].worker_run_id, 8_000);
+  assert.equal(journal.state.ui.active, null);
+  assert.equal(fixture.commitStatuses.at(-1).state, "success");
+  assert.equal(
+    fixture.commitStatuses.at(-1).description,
+    "Native Vercel owns this UI preview",
+  );
+});
+
 test("observe-only controller fails closed for a stale GitHub-owned Phase B head", async () => {
   const opened = event({
     run: 121,
@@ -5182,6 +5285,258 @@ test("observe-only mode durably retires a crash-window intent with no worker and
   assert.equal(fixture.workflowRunListRequests.length, lookupCount);
   assert.equal(journal.receipts.results.length, 1);
   assert.equal(journal.state.ui.active, null);
+});
+
+test("observe-only mode retires a reopened epoch's intended worker slot when no worker exists", async () => {
+  const setup = sameShaReopenIntentState();
+  const fixture = fakeGitHub({
+    pullRequest: setup.pullRequest,
+    comments: [
+      journalWithState(setup.events, setup.current.state, {
+        selections: [
+          selectionReceiptFromDispatch(
+            setup.current.state.ui.retired_active[0],
+          ),
+        ],
+      }),
+    ],
+    uiVercelConfiguration: NATIVE_OWNED_UI_VERCEL_CONFIGURATION,
+  });
+  const core = fakeCore();
+  const waits = [];
+
+  const state = await reconcilePreview({
+    github: fixture.github,
+    workerDispatchGithub: null,
+    controllerMode: "observe-only",
+    context: fakeContext({ runId: 7_001 }),
+    core,
+    prNumber: 519,
+    waitForRecovery: async (milliseconds) => waits.push(milliseconds),
+  });
+
+  assert.equal(fixture.dispatches.length, 0);
+  assert.equal(fixture.workerDispatchRequests.length, 0);
+  assert.deepEqual(waits, [500, 500]);
+  assert.equal(fixture.workflowRunListRequests.length, 3);
+  assert.equal(core.outputs.get("retired_undispatched_intent"), "true");
+  assert.equal(state.ui.active, null);
+  assert.equal(state.ui.retired_active.length, 0);
+  const journal = journalFromComment(fixture.comments[0]);
+  assert.equal(journal.receipts.results.length, 1);
+  assert.equal(
+    journal.receipts.results[0].key_digest,
+    setup.old.nextDispatch.key_digest,
+  );
+  assert.equal(journal.state.ui.retired_active.length, 0);
+  assert.equal(fixture.commitStatuses.at(-1).state, "success");
+  assert.equal(
+    fixture.commitStatuses.at(-1).description,
+    "Native Vercel owns this UI preview",
+  );
+});
+
+test("observe-only mode retires same-SHA active and reopened-epoch intents without result collisions", async () => {
+  const setup = sameShaReopenIntentState();
+  const currentIntended = persistIntent(setup.current);
+  const retiredSelection = currentIntended.ui.retired_active[0];
+  const activeSelection = currentIntended.ui.active;
+  assert.equal(retiredSelection.key, activeSelection.key);
+  assert.notEqual(retiredSelection.key_digest, activeSelection.key_digest);
+  const fixture = fakeGitHub({
+    pullRequest: setup.pullRequest,
+    comments: [
+      journalWithState(setup.events, currentIntended, {
+        selections: [
+          selectionReceiptFromDispatch(retiredSelection),
+          selectionReceiptFromDispatch(activeSelection),
+        ],
+      }),
+    ],
+    uiVercelConfiguration: NATIVE_OWNED_UI_VERCEL_CONFIGURATION,
+  });
+  const core = fakeCore();
+  const waits = [];
+
+  const state = await reconcilePreview({
+    github: fixture.github,
+    workerDispatchGithub: null,
+    controllerMode: "observe-only",
+    context: fakeContext({ runId: 7_001 }),
+    core,
+    prNumber: 519,
+    waitForRecovery: async (milliseconds) => waits.push(milliseconds),
+  });
+
+  assert.equal(fixture.dispatches.length, 0);
+  assert.equal(fixture.workerDispatchRequests.length, 0);
+  assert.deepEqual(waits, [500, 500, 500, 500]);
+  assert.equal(fixture.workflowRunListRequests.length, 6);
+  assert.equal(state.ui.active, null);
+  assert.equal(state.ui.retired_active.length, 0);
+  const journal = journalFromComment(fixture.comments[0]);
+  assert.equal(journal.receipts.results.length, 2);
+  assert.ok(
+    journal.receipts.results.every(
+      ({ worker_run_id: workerRunId }) => workerRunId === 7_001,
+    ),
+  );
+  assert.equal(
+    new Set(journal.receipts.results.map(({ key_digest }) => key_digest)).size,
+    2,
+  );
+  assert.equal(journal.state.ui.active, null);
+  assert.equal(journal.state.ui.retired_active.length, 0);
+  assert.equal(fixture.commitStatuses.at(-1).state, "success");
+  assert.equal(
+    fixture.commitStatuses.at(-1).description,
+    "Native Vercel owns this UI preview",
+  );
+});
+
+test("no-dispatch retirement stays authoritative over an earlier real worker result on replay", async () => {
+  const opened = event({
+    run: 121,
+    action: "opened",
+    head: SHA.A,
+    updated: timestamp(1),
+  });
+  const pullRequest = pull({ head: SHA.A, updated: timestamp(1) });
+  const first = reconcile({ events: [opened], pullRequest });
+  const firstDispatched = persistDispatch(first, 8_000);
+  const firstFailure = result(first.nextDispatch, {
+    runId: 8_000,
+    state: "failure",
+    reason: "build-failed-retriable",
+  });
+  const firstSelection = selectionReceiptFromDispatch(
+    firstDispatched.ui.active,
+  );
+  const retry = reconcile({
+    events: [opened],
+    results: [firstFailure],
+    pullRequest,
+    existingState: firstDispatched,
+    selections: [firstSelection],
+  });
+  const retryIntended = persistIntent(retry);
+  const retrySelection = selectionReceiptFromDispatch(retryIntended.ui.active);
+  assert.equal(
+    retrySelection.selection_receipt_run_id,
+    firstSelection.selection_receipt_run_id,
+  );
+  assert.notEqual(retrySelection.key_digest, firstSelection.key_digest);
+  const fixture = fakeGitHub({
+    pullRequest,
+    comments: [
+      journalWithState([opened], retryIntended, {
+        selections: [firstSelection, retrySelection],
+        results: [firstFailure],
+      }),
+    ],
+    uiVercelConfiguration: NATIVE_OWNED_UI_VERCEL_CONFIGURATION,
+  });
+
+  const retired = await reconcilePreview({
+    github: fixture.github,
+    workerDispatchGithub: null,
+    controllerMode: "observe-only",
+    context: fakeContext({ runId: 9_000 }),
+    core: fakeCore(),
+    prNumber: 519,
+    waitForRecovery: async () => {},
+  });
+
+  assert.equal(retired.ui.active, null);
+  assert.equal(
+    retired.ui.terminal_history.at(-1).terminal_reason,
+    "dispatch-disabled-intent-without-worker",
+  );
+  let journal = journalFromComment(fixture.comments[0]);
+  assert.equal(journal.receipts.results.length, 2);
+  assert.equal(
+    journal.receipts.results.find(
+      ({ terminal_reason: terminalReason }) =>
+        terminalReason === "dispatch-disabled-intent-without-worker",
+    ).worker_run_id,
+    9_000,
+  );
+
+  const replayed = await reconcilePreview({
+    github: fixture.github,
+    workerDispatchGithub: null,
+    controllerMode: "observe-only",
+    context: fakeContext({ runId: 9_001 }),
+    core: fakeCore(),
+    prNumber: 519,
+    waitForRecovery: async () => {},
+  });
+
+  assert.equal(replayed.ui.active, null);
+  assert.equal(
+    replayed.ui.terminal_history.at(-1).terminal_reason,
+    "dispatch-disabled-intent-without-worker",
+  );
+  journal = journalFromComment(fixture.comments[0]);
+  assert.equal(journal.receipts.results.length, 2);
+  assert.equal(
+    journal.state.ui.terminal_history.at(-1).terminal_reason,
+    "dispatch-disabled-intent-without-worker",
+  );
+  assert.equal(fixture.commitStatuses.at(-1).state, "success");
+  assert.equal(
+    fixture.commitStatuses.at(-1).description,
+    "Native Vercel owns this UI preview",
+  );
+});
+
+test("observe-only mode attaches a reopened epoch's matching worker in its retired slot", async () => {
+  const setup = sameShaReopenIntentState();
+  const queued = workerRun(setup.current.state.ui.retired_active[0], {
+    status: "in_progress",
+  });
+  const fixture = fakeGitHub({
+    pullRequest: setup.pullRequest,
+    comments: [
+      journalWithState(setup.events, setup.current.state, {
+        selections: [
+          selectionReceiptFromDispatch(
+            setup.current.state.ui.retired_active[0],
+          ),
+        ],
+      }),
+    ],
+    runs: [queued],
+    uiVercelConfiguration: NATIVE_OWNED_UI_VERCEL_CONFIGURATION,
+  });
+  const core = fakeCore();
+
+  const state = await reconcilePreview({
+    github: fixture.github,
+    workerDispatchGithub: null,
+    controllerMode: "observe-only",
+    context: fakeContext({ runId: 7_001 }),
+    core,
+    prNumber: 519,
+    waitForRecovery: async () => {},
+  });
+
+  assert.equal(fixture.dispatches.length, 0);
+  assert.equal(fixture.workerDispatchRequests.length, 0);
+  assert.equal(core.outputs.get("recovered_intended_run_id"), "8000");
+  assert.equal(state.ui.active, null);
+  assert.equal(state.ui.retired_active.length, 1);
+  assert.equal(state.ui.retired_active[0].dispatch_state, "dispatched");
+  assert.equal(state.ui.retired_active[0].workflow_run_id, 8_000);
+  const journal = journalFromComment(fixture.comments[0]);
+  assert.equal(journal.receipts.results.length, 0);
+  assert.equal(journal.state.ui.active, null);
+  assert.equal(journal.state.ui.retired_active[0].workflow_run_id, 8_000);
+  assert.equal(fixture.commitStatuses.at(-1).state, "pending");
+  assert.equal(
+    fixture.commitStatuses.at(-1).description,
+    "Draining GitHub preview before native ownership",
+  );
 });
 
 test("observe-only mode fails closed when multiple workers match one crash-window intent", async () => {

--- a/scripts/vercel-preview-controller.test.mjs
+++ b/scripts/vercel-preview-controller.test.mjs
@@ -4903,6 +4903,86 @@ test("active controller settles a completed crash-window worker after a racing n
   );
 });
 
+test("native cutover converges after recovery and an exact-head ownership flip", async () => {
+  const opened = event({
+    run: 121,
+    action: "opened",
+    head: SHA.A,
+    updated: timestamp(1),
+  });
+  const runtimeB = event({
+    run: 122,
+    action: "synchronize",
+    before: SHA.A,
+    head: SHA.B,
+    updated: timestamp(2),
+  });
+  const pullRequest = pull({ head: SHA.B, updated: timestamp(2) });
+  const selectedA = reconcile({
+    events: [opened],
+    pullRequest: pull({ head: SHA.A, updated: timestamp(1) }),
+  });
+  const pendingB = reconcile({
+    events: [opened, runtimeB],
+    pullRequest,
+    existingState: persistDispatch(selectedA, 8_000),
+  });
+  assert.equal(pendingB.state.ui.active.sha, SHA.A);
+  assert.equal(pendingB.state.ui.latest_desired_sha, SHA.B);
+  const completedA = workerRun(selectedA.nextDispatch, {
+    status: "completed",
+    conclusion: "cancelled",
+  });
+  const fixture = fakeGitHub({
+    pullRequest,
+    comments: [
+      journalWithState([opened, runtimeB], pendingB.state, {
+        selections: [selectionReceiptFromDispatch(pendingB.state.ui.active)],
+      }),
+    ],
+    runs: [completedA],
+    uiVercelConfiguration: NATIVE_OWNED_UI_VERCEL_CONFIGURATION,
+    uiVercelConfigurations: [
+      GITHUB_OWNED_UI_VERCEL_CONFIGURATION,
+      GITHUB_OWNED_UI_VERCEL_CONFIGURATION,
+      GITHUB_OWNED_UI_VERCEL_CONFIGURATION,
+      NATIVE_OWNED_UI_VERCEL_CONFIGURATION,
+    ],
+  });
+
+  const state = await reconcilePreview({
+    github: fixture.github,
+    context: fakeContext({ runId: 7_001 }),
+    core: fakeCore(),
+    prNumber: 519,
+    waitForRecovery: async () => {},
+  });
+
+  assert.equal(fixture.dispatches.length, 0);
+  assert.equal(fixture.workerDispatchRequests.length, 0);
+  assert.equal(state.ui.active, null);
+  assert.equal(state.ui.latest_desired_sha, SHA.B);
+  assert.ok(
+    state.ui.terminal_history.some(
+      ({ sha, terminal_reason: terminalReason }) =>
+        sha === SHA.B &&
+        terminalReason === "dispatch-disabled-intent-without-worker",
+    ),
+  );
+  const journal = journalFromComment(fixture.comments[0]);
+  assert.deepEqual(
+    journal.receipts.results.map(
+      ({ worker_run_id: workerRunId }) => workerRunId,
+    ),
+    [8_000, 7_001],
+  );
+  assert.equal(fixture.commitStatuses.at(-1).state, "success");
+  assert.equal(
+    fixture.commitStatuses.at(-1).description,
+    "Native Vercel owns this UI preview",
+  );
+});
+
 test("observe-only controller fails closed for a stale GitHub-owned Phase B head", async () => {
   const opened = event({
     run: 121,
@@ -6887,7 +6967,7 @@ test("terminal reopened same-SHA ownership survives a delayed old-epoch callback
   assert.equal(journal.receipts.results.length, 2);
 });
 
-test("retired attempt recovery errors are quarantined without poisoning the current epoch", async () => {
+test("quarantined retired recovery cannot block native preview ownership", async () => {
   const setup = sameShaReopenState();
   const currentResult = result(setup.current.nextDispatch, { runId: 8_001 });
   const terminalState = reconcile({
@@ -6919,6 +6999,7 @@ test("retired attempt recovery errors are quarantined without poisoning the curr
       }),
     ],
     runs: [oldLatestAttempt],
+    uiVercelConfiguration: NATIVE_OWNED_UI_VERCEL_CONFIGURATION,
   });
 
   const reconciled = await reconcilePreview({
@@ -6942,6 +7023,10 @@ test("retired attempt recovery errors are quarantined without poisoning the curr
     false,
   );
   assert.equal(fixture.commitStatuses.at(-1).state, "success");
+  assert.equal(
+    fixture.commitStatuses.at(-1).description,
+    "Native Vercel owns this UI preview",
+  );
   assert.deepEqual(fixture.workflowRunAttemptRequests, [
     { run_id: 8_000, attempt_number: 1 },
   ]);
@@ -6957,6 +7042,11 @@ test("retired attempt recovery errors are quarantined without poisoning the curr
   assert.equal(
     fixture.commitStatuses.some(({ state }) => state === "error"),
     false,
+  );
+  assert.equal(fixture.commitStatuses.at(-1).state, "success");
+  assert.equal(
+    fixture.commitStatuses.at(-1).description,
+    "Native Vercel owns this UI preview",
   );
 });
 

--- a/scripts/vercel-preview-controller.test.mjs
+++ b/scripts/vercel-preview-controller.test.mjs
@@ -2233,6 +2233,23 @@ test("docs-only checkpoint tails preserve prior runtime terminal semantics", () 
       runtime: false,
       updated: timestamp(2),
     });
+    if (terminalCase.state === "success") {
+      const baselineWithoutBuildEvidence = structuredClone(journal.state);
+      baselineWithoutBuildEvidence.ui.last_successful_runtime_sha = null;
+      baselineWithoutBuildEvidence.ui.last_successful_runtime_url = null;
+      const syntheticReplay = reconcile({
+        events: [firstDocs],
+        pullRequest: pull({ head: SHA.B, updated: timestamp(2) }),
+        existingState: baselineWithoutBuildEvidence,
+        checkpoint: journal.checkpoint,
+      });
+      assert.match(
+        syntheticReplay.state.status_decisions.at(-1).description,
+        /^Runtime-equivalent to /,
+      );
+      assert.equal(syntheticReplay.state.ui.last_successful_runtime_sha, null);
+      assert.equal(syntheticReplay.state.ui.last_successful_runtime_url, null);
+    }
     const firstDocsState = reconcile({
       events: [firstDocs],
       pullRequest: pull({ head: SHA.B, updated: timestamp(2) }),
@@ -5129,6 +5146,283 @@ test("native A through docs-only C stays native until only GitHub-owned B dispat
   );
 });
 
+test("sequential native ownership checkpoints through docs-only C before only GitHub-owned B dispatches", async () => {
+  const opened = event({
+    run: 124,
+    action: "opened",
+    head: SHA.A,
+    updated: timestamp(1),
+  });
+  const docsOnly = event({
+    run: 125,
+    action: "synchronize",
+    before: SHA.A,
+    head: SHA.C,
+    runtime: false,
+    updated: timestamp(2),
+  });
+  const synchronized = event({
+    run: 126,
+    action: "synchronize",
+    before: SHA.C,
+    head: SHA.B,
+    updated: timestamp(3),
+  });
+  const pullA = pull({ head: SHA.A, updated: timestamp(1) });
+  const pullC = pull({ head: SHA.C, updated: timestamp(2) });
+  const fixture = fakeGitHub({
+    pullRequest: pullC,
+    pullRequests: [pullA],
+    pullCommits: [SHA.A, SHA.C],
+    comments: [journalComment({ events: [opened] })],
+    uiVercelConfigurationsByRef: new Map([
+      [SHA.A, NATIVE_OWNED_UI_VERCEL_CONFIGURATION],
+      [SHA.C, NATIVE_OWNED_UI_VERCEL_CONFIGURATION],
+    ]),
+  });
+
+  const nativeA = await reconcilePreview({
+    github: fixture.github,
+    context: fakeContext({ runId: 7_001 }),
+    core: fakeCore(),
+    prNumber: 519,
+    waitForRecovery: async () => {},
+  });
+  assert.equal(fixture.dispatches.length, 0);
+  assert.equal(fixture.deployments.length, 0);
+  assert.equal(nativeA.ui.last_successful_runtime_sha, null);
+  assert.equal(nativeA.ui.last_successful_runtime_url, null);
+  assert.deepEqual(nativeA.status_decisions, [
+    {
+      sha: SHA.A,
+      state: "success",
+      description: "Native Vercel owns this UI preview",
+      target_url:
+        "https://github.com/mento-protocol/frontend-monorepo/actions/runs/7001",
+    },
+  ]);
+  const externalNativeA = fixture.commitStatuses.at(-1);
+  assert.deepEqual(
+    {
+      sha: externalNativeA.sha,
+      state: externalNativeA.state,
+      description: externalNativeA.description,
+      target_url: externalNativeA.target_url,
+    },
+    nativeA.status_decisions[0],
+  );
+
+  await recordEventReceipt({
+    github: fixture.github,
+    context: fakeContext({ runId: docsOnly.event_run_id }),
+    core: fakeCore(),
+    ...eventRecordInputs(docsOnly),
+  });
+  let journal = journalFromComment(fixture.comments[0]);
+  assert.equal(journal.checkpoint.event.head_sha, SHA.A);
+  assert.equal(journal.checkpoint.status.state, "success");
+  assert.equal(
+    journal.checkpoint.status.description,
+    "Native Vercel owns this UI preview",
+  );
+  assert.deepEqual(journal.receipts.events, [docsOnly]);
+  for (const status of [
+    { ...journal.checkpoint.status, state: "failure" },
+    {
+      ...journal.checkpoint.status,
+      target_url: "https://example.com/actions/runs/7001",
+    },
+  ]) {
+    assert.throws(
+      () =>
+        createPreviewJournal({
+          pr: 519,
+          revision: journal.revision,
+          checkpoint: { ...journal.checkpoint, status },
+          events: journal.receipts.events,
+          selections: journal.receipts.selections,
+          workerEvidence: journal.receipts.worker_evidence,
+          results: journal.receipts.results,
+          state: journal.state,
+        }),
+      /native ownership status is invalid/,
+    );
+  }
+  assert.throws(
+    () =>
+      createPreviewJournal({
+        pr: 519,
+        revision: journal.revision,
+        checkpoint: {
+          ...journal.checkpoint,
+          status: {
+            ...journal.checkpoint.status,
+            description: "Draining GitHub preview before native ownership",
+          },
+        },
+        events: journal.receipts.events,
+        selections: journal.receipts.selections,
+        workerEvidence: journal.receipts.worker_evidence,
+        results: journal.receipts.results,
+        state: journal.state,
+      }),
+    /native ownership drain status is invalid/,
+  );
+
+  const nativeC = await reconcilePreview({
+    github: fixture.github,
+    context: fakeContext({ runId: 7_002 }),
+    core: fakeCore(),
+    prNumber: 519,
+    waitForRecovery: async () => {},
+  });
+  assert.equal(fixture.dispatches.length, 0);
+  assert.equal(fixture.deployments.length, 0);
+  assert.equal(nativeC.ui.last_successful_runtime_sha, null);
+  assert.equal(nativeC.ui.last_successful_runtime_url, null);
+  assert.deepEqual(nativeC.status_decisions.at(-1), {
+    sha: SHA.C,
+    state: "success",
+    description: "Native Vercel owns this UI preview",
+    target_url:
+      "https://github.com/mento-protocol/frontend-monorepo/actions/runs/7002",
+  });
+
+  journal = journalFromComment(fixture.comments[0]);
+  const pullB = pull({ head: SHA.B, updated: timestamp(3) });
+  const githubFixture = fakeGitHub({
+    pullRequest: pullB,
+    pullCommits: [SHA.A, SHA.C, SHA.B],
+    comments: [
+      journalComment({
+        revision: journal.revision,
+        checkpoint: journal.checkpoint,
+        events: journal.receipts.events,
+        selections: journal.receipts.selections,
+        workerEvidence: journal.receipts.worker_evidence,
+        results: journal.receipts.results,
+        state: journal.state,
+      }),
+    ],
+    uiVercelConfigurationsByRef: new Map([
+      [SHA.B, GITHUB_OWNED_UI_VERCEL_CONFIGURATION],
+    ]),
+  });
+  await recordEventReceipt({
+    github: githubFixture.github,
+    context: fakeContext({ runId: synchronized.event_run_id }),
+    core: fakeCore(),
+    ...eventRecordInputs(synchronized),
+  });
+  const beforeGitHubReconcile = journalFromComment(githubFixture.comments[0]);
+  assert.equal(beforeGitHubReconcile.checkpoint.event.head_sha, SHA.C);
+  assert.equal(beforeGitHubReconcile.checkpoint.status.state, "success");
+  assert.equal(
+    beforeGitHubReconcile.checkpoint.status.description,
+    "Native Vercel owns this UI preview",
+  );
+  assert.deepEqual(beforeGitHubReconcile.receipts.events, [synchronized]);
+  assert.equal(
+    beforeGitHubReconcile.state.ui.last_successful_runtime_sha,
+    null,
+  );
+  assert.equal(
+    beforeGitHubReconcile.state.ui.last_successful_runtime_url,
+    null,
+  );
+  const githubB = await reconcilePreview({
+    github: githubFixture.github,
+    context: fakeContext({ runId: 7_003 }),
+    core: fakeCore(),
+    prNumber: 519,
+    waitForRecovery: async () => {},
+  });
+  assert.equal(githubFixture.dispatches.length, 1);
+  assert.equal(githubFixture.workerDispatchRequests.length, 1);
+  assert.equal(githubFixture.dispatches[0].inputs.commit_sha, SHA.B);
+  assert.equal(githubFixture.deployments.length, 0);
+  assert.equal(githubB.ui.active.sha, SHA.B);
+  assert.equal(githubB.ui.last_successful_runtime_sha, null);
+  assert.equal(githubB.ui.last_successful_runtime_url, null);
+  assert.deepEqual(githubB.status_decisions, [
+    {
+      sha: SHA.C,
+      state: "success",
+      description: "Native Vercel owns this UI preview",
+      target_url:
+        "https://github.com/mento-protocol/frontend-monorepo/actions/runs/7002",
+    },
+    {
+      sha: SHA.B,
+      state: "pending",
+      description: "UI preview queued or running",
+      target_url: githubB.ui.active.html_url,
+    },
+  ]);
+  const finalJournal = journalFromComment(githubFixture.comments[0]);
+  assert.equal(finalJournal.receipts.results.length, 0);
+});
+
+test("native no-dispatch status selects the latest current-head decision after a force-reset SHA revisit", async () => {
+  const opened = event({
+    run: 127,
+    action: "opened",
+    head: SHA.A,
+    updated: timestamp(1),
+  });
+  const synchronizedB = event({
+    run: 128,
+    action: "synchronize",
+    before: SHA.A,
+    head: SHA.B,
+    updated: timestamp(2),
+  });
+  const synchronizedA = event({
+    run: 129,
+    action: "synchronize",
+    before: SHA.B,
+    head: SHA.A,
+    updated: timestamp(3),
+  });
+  const fixture = fakeGitHub({
+    pullRequest: pull({ head: SHA.A, updated: timestamp(3) }),
+    pullCommits: [SHA.A, SHA.B],
+    comments: [
+      journalComment({ events: [opened, synchronizedB, synchronizedA] }),
+    ],
+    uiVercelConfigurationsByRef: new Map([
+      [SHA.A, NATIVE_OWNED_UI_VERCEL_CONFIGURATION],
+    ]),
+  });
+
+  const state = await reconcilePreview({
+    github: fixture.github,
+    context: fakeContext({ runId: 7_004 }),
+    core: fakeCore(),
+    prNumber: 519,
+    waitForRecovery: async () => {},
+  });
+
+  assert.equal(fixture.dispatches.length, 0);
+  assert.equal(fixture.deployments.length, 0);
+  const repeatedHeadDecisions = state.status_decisions.filter(
+    ({ sha }) => sha === SHA.A,
+  );
+  assert.equal(repeatedHeadDecisions.length, 2);
+  assert.equal(repeatedHeadDecisions[0].state, "pending");
+  assert.deepEqual(repeatedHeadDecisions[1], {
+    sha: SHA.A,
+    state: "success",
+    description: "Native Vercel owns this UI preview",
+    target_url:
+      "https://github.com/mento-protocol/frontend-monorepo/actions/runs/7004",
+  });
+  assert.deepEqual(
+    fixture.commitStatuses.at(-1).description,
+    repeatedHeadDecisions[1].description,
+  );
+});
+
 test("generic no-dispatch retirement does not claim native ownership of a GitHub-owned SHA", () => {
   const opened = event({
     run: 121,
@@ -5986,6 +6280,13 @@ test("observe-only mode durably attaches an in-progress crash-window worker and 
   const journal = journalFromComment(fixture.comments[0]);
   assert.equal(journal.state.ui.active.workflow_run_id, 8_000);
   assert.equal(journal.receipts.results.length, 0);
+  assert.deepEqual(journal.state.status_decisions.at(-1), {
+    sha: SHA.A,
+    state: "pending",
+    description: "Draining GitHub preview before native ownership",
+    target_url:
+      "https://github.com/mento-protocol/frontend-monorepo/actions/runs/7001",
+  });
   assert.equal(fixture.commitStatuses.at(-1).state, "pending");
   assert.equal(
     fixture.commitStatuses.at(-1).description,

--- a/scripts/vercel-preview-controller.test.mjs
+++ b/scripts/vercel-preview-controller.test.mjs
@@ -4959,7 +4959,7 @@ test("a native-owned receipt followed by a GitHub-owned head retires A and dispa
   assert.equal(journal.receipts.results[0].sha, SHA.A);
   assert.equal(
     journal.receipts.results[0].terminal_reason,
-    "dispatch-disabled-intent-without-worker",
+    "native-owned-selection-without-github-worker",
   );
   assert.equal(
     state.status_decisions.find(({ sha }) => sha === SHA.A).state,
@@ -4967,6 +4967,48 @@ test("a native-owned receipt followed by a GitHub-owned head retires A and dispa
   );
   assert.ok(fixture.contentRequests.some(({ ref }) => ref === SHA.A));
   assert.ok(fixture.contentRequests.some(({ ref }) => ref === SHA.B));
+});
+
+test("generic no-dispatch retirement does not claim native ownership of a GitHub-owned SHA", () => {
+  const opened = event({
+    run: 121,
+    action: "opened",
+    head: SHA.A,
+    updated: timestamp(1),
+  });
+  const synchronized = event({
+    run: 122,
+    action: "synchronize",
+    before: SHA.A,
+    head: SHA.B,
+    updated: timestamp(2),
+  });
+  const pullRequest = pull({ head: SHA.B, updated: timestamp(2) });
+  const selected = reconcile({ events: [opened, synchronized], pullRequest });
+  const intended = persistIntent(selected);
+  const retired = result(selected.nextDispatch, {
+    runId: 7_000,
+    state: "error",
+    reason: "dispatch-disabled-intent-without-worker",
+  });
+
+  const advanced = reconcile({
+    events: [opened, synchronized],
+    results: [retired],
+    selections: [selectionReceiptFromDispatch(intended.ui.active)],
+    pullRequest,
+    existingState: intended,
+  });
+
+  const statusA = advanced.state.status_decisions.find(
+    ({ sha }) => sha === SHA.A,
+  );
+  assert.equal(statusA.state, "error");
+  assert.equal(
+    statusA.description,
+    "UI preview controller or infrastructure error",
+  );
+  assert.doesNotMatch(statusA.description, /Native Vercel/);
 });
 
 test("a native-owned historical receipt attaches its crash-window worker instead of dispatching a duplicate", async () => {

--- a/scripts/vercel-preview-controller.test.mjs
+++ b/scripts/vercel-preview-controller.test.mjs
@@ -2671,6 +2671,7 @@ function fakeGitHub({
   beforeListCommitStatuses,
   uiVercelConfiguration = GITHUB_OWNED_UI_VERCEL_CONFIGURATION,
   uiVercelConfigurations = [],
+  uiVercelConfigurationsByRef = new Map(),
   uiVercelContentResponse,
   uiVercelContentErrorStatus,
 } = {}) {
@@ -2705,6 +2706,7 @@ function fakeGitHub({
   const transientListRunIds = [...workflowRunListRunIds];
   const transientPullRequests = [...pullRequests];
   const transientUiVercelConfigurations = [...uiVercelConfigurations];
+  const configurationsByRef = new Map(uiVercelConfigurationsByRef);
   const attemptFailures = [...workflowRunAttemptFailures];
   const commentUpdateFailures = [...updateCommentFailures];
   let lostSerializedUpdateFailureCount = lostSerializedUpdateFailures;
@@ -2841,7 +2843,9 @@ function fakeGitHub({
             return { data: structuredClone(uiVercelContentResponse) };
           }
           const configuration =
-            transientUiVercelConfigurations.shift() ?? uiVercelConfiguration;
+            (transientUiVercelConfigurations.length > 0
+              ? transientUiVercelConfigurations.shift()
+              : configurationsByRef.get(request.ref)) ?? uiVercelConfiguration;
           const text =
             typeof configuration === "string"
               ? configuration
@@ -4805,6 +4809,56 @@ test("worker preflight rejects expected A versus actual B before any API access"
   assert.equal(apiCalls, 0);
 });
 
+test("worker preflight rechecks the immutable selected SHA ownership before deployment work", async () => {
+  const opened = event({
+    run: 120,
+    action: "opened",
+    head: SHA.A,
+    updated: timestamp(1),
+  });
+  const synchronized = event({
+    run: 121,
+    action: "synchronize",
+    before: SHA.A,
+    head: SHA.B,
+    updated: timestamp(2),
+  });
+  const pullRequest = pull({ head: SHA.B, updated: timestamp(2) });
+  const selected = reconcile({
+    events: [opened, synchronized],
+    pullRequest,
+  });
+  assert.equal(selected.nextDispatch.sha, SHA.A);
+  const intended = persistIntent(selected);
+  const fixture = fakeGitHub({
+    pullRequest,
+    pullCommits: [SHA.A, SHA.B],
+    comments: [journalWithState([opened, synchronized], intended)],
+    uiVercelConfigurationsByRef: new Map([
+      [SHA.A, NATIVE_OWNED_UI_VERCEL_CONFIGURATION],
+      [SHA.B, GITHUB_OWNED_UI_VERCEL_CONFIGURATION],
+    ]),
+  });
+  const core = fakeCore();
+
+  await assert.rejects(
+    validateWorkerDispatch({
+      github: fixture.github,
+      context: fakeContext({ runId: 8_000 }),
+      core,
+      inputs: workerInputs(selected.nextDispatch),
+    }),
+    /does not own the selected UI configuration/,
+  );
+
+  assert.deepEqual(
+    fixture.contentRequests.map(({ ref }) => ref),
+    [SHA.B, SHA.A],
+  );
+  assert.equal(fixture.deployments.length, 0);
+  assert.equal(core.outputs.has("should_deploy"), false);
+});
+
 test("durable dispatch persists intent and waits for the exact run title to materialize", async () => {
   const opened = event({
     run: 121,
@@ -4860,6 +4914,206 @@ test("durable dispatch persists intent and waits for the exact run title to mate
     fixture.contentRequests.every(
       ({ path, ref }) => path === UI_VERCEL_CONFIGURATION_PATH && ref === SHA.A,
     ),
+  );
+});
+
+test("a native-owned receipt followed by a GitHub-owned head retires A and dispatches only B", async () => {
+  const opened = event({
+    run: 121,
+    action: "opened",
+    head: SHA.A,
+    updated: timestamp(1),
+  });
+  const synchronized = event({
+    run: 122,
+    action: "synchronize",
+    before: SHA.A,
+    head: SHA.B,
+    updated: timestamp(2),
+  });
+  const fixture = fakeGitHub({
+    pullRequest: pull({ head: SHA.B, updated: timestamp(2) }),
+    pullCommits: [SHA.A, SHA.B],
+    comments: [journalComment({ events: [opened, synchronized] })],
+    uiVercelConfigurationsByRef: new Map([
+      [SHA.A, NATIVE_OWNED_UI_VERCEL_CONFIGURATION],
+      [SHA.B, GITHUB_OWNED_UI_VERCEL_CONFIGURATION],
+    ]),
+  });
+
+  const state = await reconcilePreview({
+    github: fixture.github,
+    context: fakeContext(),
+    core: fakeCore(),
+    prNumber: 519,
+    waitForRecovery: async () => {},
+  });
+
+  assert.equal(fixture.dispatches.length, 1);
+  assert.equal(fixture.workerDispatchRequests.length, 1);
+  assert.equal(fixture.dispatches[0].inputs.commit_sha, SHA.B);
+  assert.equal(state.ui.active.sha, SHA.B);
+  assert.equal(state.ui.active.dispatch_state, "dispatched");
+  const journal = journalFromComment(fixture.comments[0]);
+  assert.equal(journal.receipts.results.length, 1);
+  assert.equal(journal.receipts.results[0].sha, SHA.A);
+  assert.equal(
+    journal.receipts.results[0].terminal_reason,
+    "dispatch-disabled-intent-without-worker",
+  );
+  assert.equal(
+    state.status_decisions.find(({ sha }) => sha === SHA.A).state,
+    "success",
+  );
+  assert.ok(fixture.contentRequests.some(({ ref }) => ref === SHA.A));
+  assert.ok(fixture.contentRequests.some(({ ref }) => ref === SHA.B));
+});
+
+test("a native-owned historical receipt attaches its crash-window worker instead of dispatching a duplicate", async () => {
+  const opened = event({
+    run: 121,
+    action: "opened",
+    head: SHA.A,
+    updated: timestamp(1),
+  });
+  const synchronized = event({
+    run: 122,
+    action: "synchronize",
+    before: SHA.A,
+    head: SHA.B,
+    updated: timestamp(2),
+  });
+  const pullRequest = pull({ head: SHA.B, updated: timestamp(2) });
+  const selected = reconcile({ events: [opened, synchronized], pullRequest });
+  assert.equal(selected.nextDispatch.sha, SHA.A);
+  const fixture = fakeGitHub({
+    pullRequest,
+    pullCommits: [SHA.A, SHA.B],
+    comments: [journalComment({ events: [opened, synchronized] })],
+    runs: [workerRun(selected.nextDispatch, { status: "in_progress" })],
+    uiVercelConfigurationsByRef: new Map([
+      [SHA.A, NATIVE_OWNED_UI_VERCEL_CONFIGURATION],
+      [SHA.B, GITHUB_OWNED_UI_VERCEL_CONFIGURATION],
+    ]),
+  });
+  const core = fakeCore();
+
+  const state = await reconcilePreview({
+    github: fixture.github,
+    context: fakeContext(),
+    core,
+    prNumber: 519,
+    waitForRecovery: async () => {},
+  });
+
+  assert.equal(fixture.dispatches.length, 0);
+  assert.equal(fixture.workerDispatchRequests.length, 0);
+  assert.equal(core.outputs.get("recovered_intended_run_id"), "8000");
+  assert.equal(state.ui.active.sha, SHA.A);
+  assert.equal(state.ui.active.dispatch_state, "dispatched");
+  assert.equal(state.ui.active.workflow_run_id, 8_000);
+  assert.equal(
+    journalFromComment(fixture.comments[0]).receipts.results.length,
+    0,
+  );
+});
+
+for (const [name, configuration, message] of [
+  ["malformed", "{\n", /configuration is malformed/],
+  [
+    "unknown",
+    { git: { deploymentEnabled: { "feature/**": false } } },
+    /configuration is not recognized/,
+  ],
+]) {
+  test(`${name} selected-SHA ownership fails closed before an A to B dispatch`, async () => {
+    const opened = event({
+      run: 121,
+      action: "opened",
+      head: SHA.A,
+      updated: timestamp(1),
+    });
+    const synchronized = event({
+      run: 122,
+      action: "synchronize",
+      before: SHA.A,
+      head: SHA.B,
+      updated: timestamp(2),
+    });
+    const fixture = fakeGitHub({
+      pullRequest: pull({ head: SHA.B, updated: timestamp(2) }),
+      pullCommits: [SHA.A, SHA.B],
+      comments: [journalComment({ events: [opened, synchronized] })],
+      uiVercelConfigurationsByRef: new Map([
+        [SHA.A, configuration],
+        [SHA.B, GITHUB_OWNED_UI_VERCEL_CONFIGURATION],
+      ]),
+    });
+
+    await assert.rejects(
+      reconcilePreview({
+        github: fixture.github,
+        context: fakeContext(),
+        core: fakeCore(),
+        prNumber: 519,
+        waitForRecovery: async () => {},
+      }),
+      message,
+    );
+
+    assert.equal(fixture.dispatches.length, 0);
+    assert.equal(fixture.workerDispatchRequests.length, 0);
+    assert.equal(fixture.commitStatuses.at(-1).state, "error");
+    assert.deepEqual(
+      new Set(fixture.contentRequests.map(({ ref }) => ref)),
+      new Set([SHA.A, SHA.B]),
+    );
+  });
+}
+
+test("a GitHub-owned receipt followed by a native-owned head never dispatches the stale receipt", async () => {
+  const opened = event({
+    run: 121,
+    action: "opened",
+    head: SHA.A,
+    updated: timestamp(1),
+  });
+  const synchronized = event({
+    run: 122,
+    action: "synchronize",
+    before: SHA.A,
+    head: SHA.B,
+    updated: timestamp(2),
+  });
+  const fixture = fakeGitHub({
+    pullRequest: pull({ head: SHA.B, updated: timestamp(2) }),
+    pullCommits: [SHA.A, SHA.B],
+    comments: [journalComment({ events: [opened, synchronized] })],
+    uiVercelConfigurationsByRef: new Map([
+      [SHA.A, GITHUB_OWNED_UI_VERCEL_CONFIGURATION],
+      [SHA.B, NATIVE_OWNED_UI_VERCEL_CONFIGURATION],
+    ]),
+  });
+
+  const state = await reconcilePreview({
+    github: fixture.github,
+    workerDispatchGithub: null,
+    context: fakeContext(),
+    core: fakeCore(),
+    prNumber: 519,
+  });
+
+  assert.equal(fixture.dispatches.length, 0);
+  assert.equal(fixture.workerDispatchRequests.length, 0);
+  assert.equal(state.ui.active, null);
+  assert.deepEqual(
+    fixture.contentRequests.map(({ ref }) => ref),
+    [SHA.B],
+  );
+  assert.equal(fixture.commitStatuses.at(-1).state, "success");
+  assert.equal(
+    fixture.commitStatuses.at(-1).description,
+    "Native Vercel owns this UI preview",
   );
 });
 
@@ -4944,8 +5198,10 @@ test("active controller rechecks exact-head ownership after recovery and blocks 
     state.ui.terminal_history.at(-1).terminal_reason,
     "dispatch-disabled-intent-without-worker",
   );
-  assert.ok(fixture.contentRequests.length >= 5);
-  assert.ok(fixture.contentRequests.every(({ ref }) => ref === SHA.A));
+  assert.deepEqual(
+    fixture.contentRequests.map(({ ref }) => ref),
+    [SHA.A, SHA.A, SHA.A, SHA.A],
+  );
   assert.deepEqual(waits, [500, 500, 500, 500]);
   assert.equal(fixture.commitStatuses.at(-1).state, "success");
   assert.equal(

--- a/scripts/vercel-preview-controller.test.mjs
+++ b/scripts/vercel-preview-controller.test.mjs
@@ -54,6 +54,7 @@ function reconcilePreview(options) {
     ? options.workerDispatchGithub
     : workerDispatchClients.get(options.github);
   return reconcilePreviewImplementation({
+    controllerMode: "active",
     workflowSha: SHA.E,
     now: () => timestamp(0),
     workerDispatchGithub,
@@ -4657,6 +4658,78 @@ test("durable dispatch persists intent and waits for the exact run title to mate
   assert.deepEqual(journal.receipts.events, [opened]);
   assert.equal(journal.receipts.selections.length, 1);
   assert.equal(journal.state.ui.active.dispatch_state, "dispatched");
+});
+
+test("observe-only controller mode records status without creating dispatch intent", async () => {
+  const opened = event({
+    run: 121,
+    action: "opened",
+    head: SHA.A,
+    updated: timestamp(1),
+  });
+  const fixture = fakeGitHub({
+    pullRequest: pull({ head: SHA.A, updated: timestamp(1) }),
+    comments: [journalComment({ events: [opened] })],
+  });
+  const core = fakeCore();
+
+  const state = await reconcilePreview({
+    github: fixture.github,
+    controllerMode: "observe-only",
+    context: fakeContext(),
+    core,
+    prNumber: 519,
+  });
+
+  assert.equal(state, null);
+  assert.equal(fixture.dispatches.length, 0);
+  assert.equal(fixture.workerDispatchRequests.length, 0);
+  assert.equal(fixture.commentUpdates.length, 0);
+  assert.deepEqual(
+    fixture.commitStatuses.map(({ sha, state, context, description }) => ({
+      sha,
+      state,
+      context,
+      description,
+    })),
+    [
+      {
+        sha: SHA.A,
+        state: "success",
+        context: "Vercel Preview",
+        description: "GitHub preview dispatch is observe-only",
+      },
+    ],
+  );
+  assert.equal(core.outputs.get("controller_mode"), "observe-only");
+  assert.equal(core.outputs.get("dispatch_skipped"), "true");
+  assert.equal(core.outputs.get("pr_number"), "519");
+});
+
+test("controller mode is explicit and rejects unknown values before API access", async () => {
+  let apiCalls = 0;
+  const github = {
+    rest: {
+      pulls: {
+        get: async () => {
+          apiCalls += 1;
+          return { data: pull() };
+        },
+      },
+    },
+  };
+
+  await assert.rejects(
+    reconcilePreview({
+      github,
+      controllerMode: "shadow",
+      context: fakeContext(),
+      core: fakeCore(),
+      prNumber: 519,
+    }),
+    /Preview controller mode must be active or observe-only/,
+  );
+  assert.equal(apiCalls, 0);
 });
 
 test("a missing worker dispatch credential fails closed only when a new dispatch is required", async () => {

--- a/scripts/vercel-preview-controller.test.mjs
+++ b/scripts/vercel-preview-controller.test.mjs
@@ -4681,10 +4681,16 @@ test("observe-only controller mode records status without creating dispatch inte
     prNumber: 519,
   });
 
-  assert.equal(state, null);
+  assert.equal(state.ui.active, null);
+  assert.equal(state.ui.latest_desired_sha, SHA.A);
   assert.equal(fixture.dispatches.length, 0);
   assert.equal(fixture.workerDispatchRequests.length, 0);
-  assert.equal(fixture.commentUpdates.length, 0);
+  assert.equal(fixture.commentUpdates.length, 1);
+  assert.equal(journalFromComment(fixture.comments[0]).state.ui.active, null);
+  assert.equal(
+    journalFromComment(fixture.comments[0]).state.ui.latest_desired_sha,
+    SHA.A,
+  );
   assert.deepEqual(
     fixture.commitStatuses.map(({ sha, state, context, description }) => ({
       sha,
@@ -4704,6 +4710,78 @@ test("observe-only controller mode records status without creating dispatch inte
   assert.equal(core.outputs.get("controller_mode"), "observe-only");
   assert.equal(core.outputs.get("dispatch_skipped"), "true");
   assert.equal(core.outputs.get("pr_number"), "519");
+});
+
+test("observe-only mode recovers completed work and reconstructs state without dispatching the newest SHA", async () => {
+  const opened = event({
+    run: 121,
+    action: "opened",
+    head: SHA.A,
+    updated: timestamp(1),
+  });
+  const runtimeB = event({
+    run: 122,
+    action: "synchronize",
+    before: SHA.A,
+    head: SHA.B,
+    updated: timestamp(2),
+  });
+  const pullRequest = pull({ head: SHA.B, updated: timestamp(2) });
+  const selected = reconcile({
+    events: [opened],
+    pullRequest: pull({ head: SHA.A, updated: timestamp(1) }),
+  });
+  const dispatched = persistDispatch(selected, 8_000);
+  const completed = workerRun(selected.nextDispatch, {
+    status: "completed",
+    conclusion: "cancelled",
+  });
+  completed.name = completed.display_title;
+  const fixture = fakeGitHub({
+    pullRequest,
+    comments: [journalWithState([opened, runtimeB], dispatched)],
+    runs: [completed],
+  });
+  const core = fakeCore();
+
+  const state = await reconcilePreview({
+    github: fixture.github,
+    controllerMode: "observe-only",
+    context: fakeContext({ runId: 7_001 }),
+    core,
+    prNumber: 519,
+    waitForRecovery: async () => {},
+  });
+
+  assert.equal(fixture.dispatches.length, 0);
+  assert.equal(fixture.workerDispatchRequests.length, 0);
+  assert.equal(state.ui.active, null);
+  assert.equal(state.ui.latest_desired_sha, SHA.B);
+  assert.equal(
+    state.ui.terminal_history.at(-1).terminal_reason,
+    "worker-cancelled",
+  );
+  const journal = journalFromComment(fixture.comments[0]);
+  assert.equal(journal.receipts.results.length, 1);
+  assert.equal(journal.state.ui.active, null);
+  assert.equal(journal.state.ui.latest_desired_sha, SHA.B);
+  assert.equal(fixture.createdDeploymentStatuses.at(-1).state, "error");
+  assert.deepEqual(
+    fixture.commitStatuses.map(({ sha, state: statusState, description }) => ({
+      sha,
+      state: statusState,
+      description,
+    })),
+    [
+      {
+        sha: SHA.B,
+        state: "success",
+        description: "GitHub preview dispatch is observe-only",
+      },
+    ],
+  );
+  assert.equal(core.outputs.get("controller_mode"), "observe-only");
+  assert.equal(core.outputs.get("dispatch_skipped"), "true");
 });
 
 test("controller mode is explicit and rejects unknown values before API access", async () => {

--- a/scripts/vercel-preview-controller.test.mjs
+++ b/scripts/vercel-preview-controller.test.mjs
@@ -5011,6 +5011,102 @@ test("generic no-dispatch retirement does not claim native ownership of a GitHub
   assert.doesNotMatch(statusA.description, /Native Vercel/);
 });
 
+test("selected-native retirement keeps unrelated retired GitHub ownership generic", async () => {
+  const oldOpened = event({
+    run: 110,
+    action: "opened",
+    head: SHA.C,
+    updated: timestamp(1),
+  });
+  const old = reconcile({
+    events: [oldOpened],
+    pullRequest: pull({ head: SHA.C, updated: timestamp(1) }),
+  });
+  const oldIntended = persistIntent(old);
+  const closed = event({
+    run: 111,
+    action: "closed",
+    head: SHA.C,
+    updated: timestamp(2),
+  });
+  const closedState = reconcile({
+    events: [oldOpened, closed],
+    pullRequest: pull({
+      head: SHA.C,
+      state: "closed",
+      updated: timestamp(2),
+      closed: timestamp(2),
+    }),
+    existingState: oldIntended,
+  });
+  const reopened = event({
+    run: 112,
+    action: "reopened",
+    head: SHA.A,
+    updated: timestamp(3),
+  });
+  const synchronized = event({
+    run: 113,
+    action: "synchronize",
+    before: SHA.A,
+    head: SHA.B,
+    updated: timestamp(4),
+  });
+  const events = [oldOpened, closed, reopened, synchronized];
+  const pullRequest = pull({ head: SHA.B, updated: timestamp(4) });
+  const selected = reconcile({
+    events,
+    pullRequest,
+    existingState: closedState.state,
+  });
+  assert.equal(selected.nextDispatch.sha, SHA.A);
+  assert.equal(selected.state.ui.retired_active[0].sha, SHA.C);
+  const intended = persistIntent(selected);
+  const fixture = fakeGitHub({
+    pullRequest,
+    pullCommits: [SHA.C, SHA.A, SHA.B],
+    comments: [
+      journalWithState(events, intended, {
+        selections: [
+          selectionReceiptFromDispatch(intended.ui.retired_active[0]),
+          selectionReceiptFromDispatch(intended.ui.active),
+        ],
+      }),
+    ],
+    uiVercelConfigurationsByRef: new Map([
+      [SHA.C, GITHUB_OWNED_UI_VERCEL_CONFIGURATION],
+      [SHA.A, NATIVE_OWNED_UI_VERCEL_CONFIGURATION],
+      [SHA.B, GITHUB_OWNED_UI_VERCEL_CONFIGURATION],
+    ]),
+  });
+
+  const state = await reconcilePreview({
+    github: fixture.github,
+    context: fakeContext(),
+    core: fakeCore(),
+    prNumber: 519,
+    waitForRecovery: async () => {},
+  });
+
+  assert.equal(fixture.dispatches.length, 1);
+  assert.equal(fixture.dispatches[0].inputs.commit_sha, SHA.B);
+  assert.equal(state.ui.active.sha, SHA.B);
+  const resultsBySha = new Map(
+    journalFromComment(fixture.comments[0]).receipts.results.map((entry) => [
+      entry.sha,
+      entry.terminal_reason,
+    ]),
+  );
+  assert.equal(
+    resultsBySha.get(SHA.A),
+    "native-owned-selection-without-github-worker",
+  );
+  assert.equal(
+    resultsBySha.get(SHA.C),
+    "dispatch-disabled-intent-without-worker",
+  );
+});
+
 test("a native-owned historical receipt attaches its crash-window worker instead of dispatching a duplicate", async () => {
   const opened = event({
     run: 121,

--- a/scripts/vercel-preview-workflows.test.mjs
+++ b/scripts/vercel-preview-workflows.test.mjs
@@ -108,16 +108,28 @@ test("controller mode is canonical and reaches every reconciliation call", () =>
   }
 });
 
-test("controller guards cross-ref preview ownership with the candidate exact-head configuration", () => {
+test("controller guards current, selected, and worker preview ownership with immutable configurations", () => {
   const implementation = read("scripts/vercel-preview-controller.mjs");
   assert.match(implementation, /repos\.getContent/);
   assert.match(
     implementation,
-    /path:\s*UI_VERCEL_CONFIGURATION_PATH,\s*ref:\s*normalized\.headSha/s,
+    /function uiPreviewOwnerAtSha[\s\S]+path:\s*UI_VERCEL_CONFIGURATION_PATH,\s*ref:\s*immutableSha/s,
   );
   assert.match(
     implementation,
-    /previewOwner === UI_PREVIEW_OWNER_NATIVE[\s\S]+continue reconcileAttempts/,
+    /candidateUiPreviewOwner[\s\S]+uiPreviewOwnerAtSha\(github, context, normalized\.headSha\)/,
+  );
+  assert.match(
+    implementation,
+    /shaIsStillAssociated[\s\S]+selected\.sha[\s\S]+uiPreviewOwnerAtSha\(github, context, selected\.sha\)/,
+  );
+  assert.match(
+    implementation,
+    /outcome === "selected-native"[\s\S]+reconcileNoDispatchIntents/,
+  );
+  assert.match(
+    implementation,
+    /validateWorkerDispatch[\s\S]+uiPreviewOwnerAtSha[\s\S]+normalizedPull\.headSha[\s\S]+uiPreviewOwnerAtSha\(github, context, sha\)/,
   );
   assert.match(
     implementation,
@@ -735,7 +747,8 @@ test("runbook covers bootstrap, canaries, browser proof, separate cutover, and e
     '"**": false',
     '"main": true',
     '"dependabot/**": false',
-    "exact 40-character head",
+    "immutable 40-character SHAs",
+    "event's own SHA",
     "dispatch-disabled-intent-without-worker",
     "Draining GitHub preview before native ownership",
     "proves only the controller's owner selection",

--- a/scripts/vercel-preview-workflows.test.mjs
+++ b/scripts/vercel-preview-workflows.test.mjs
@@ -80,10 +80,16 @@ test("controller has only the three specified recovery-aware triggers", () => {
   assert.doesNotMatch(raw, /workflow_dispatch|\binputs\./);
 });
 
-test("controller mode is versioned and reaches every reconciliation call", () => {
-  assert.deepEqual(controller.env, {
-    VERCEL_PREVIEW_CONTROLLER_MODE: "active",
-  });
+test("controller mode is canonical and reaches every reconciliation call", () => {
+  assert.deepEqual(Object.keys(controller.env), [
+    "VERCEL_PREVIEW_CONTROLLER_MODE",
+  ]);
+  assert.ok(
+    ["active", "observe-only"].includes(
+      controller.env.VERCEL_PREVIEW_CONTROLLER_MODE,
+    ),
+    "controller mode must be active or observe-only",
+  );
   for (const [jobName, job] of Object.entries(controller.jobs)) {
     const step = job.steps?.find((candidate) =>
       String(candidate.with?.script ?? "").includes("reconcilePreview"),
@@ -712,6 +718,11 @@ test("runbook covers bootstrap, canaries, browser proof, separate cutover, and e
     '"**": false',
     '"main": true',
     '"dependabot/**": false',
+    "vercel-preview-controller.yml",
+    "vercel-preview-worker.yml",
+    "vercel-preview-intake.yml",
+    "queued requested waiting pending in_progress",
+    "gh api --paginate",
     "SHA",
   ]) {
     assert.match(
@@ -721,6 +732,6 @@ test("runbook covers bootstrap, canaries, browser proof, separate cutover, and e
   }
   assert.doesNotMatch(
     docs,
-    /gh workflow run vercel-preview-controller|operation=(?:bootstrap|reconcile)/,
+    /gh workflow run vercel-preview-controller|operation=(?:bootstrap|reconcile)|gh run list --workflow.*--limit/,
   );
 });

--- a/scripts/vercel-preview-workflows.test.mjs
+++ b/scripts/vercel-preview-workflows.test.mjs
@@ -108,6 +108,23 @@ test("controller mode is canonical and reaches every reconciliation call", () =>
   }
 });
 
+test("controller guards cross-ref preview ownership with the candidate exact-head configuration", () => {
+  const implementation = read("scripts/vercel-preview-controller.mjs");
+  assert.match(implementation, /repos\.getContent/);
+  assert.match(
+    implementation,
+    /path:\s*UI_VERCEL_CONFIGURATION_PATH,\s*ref:\s*normalized\.headSha/s,
+  );
+  assert.match(
+    implementation,
+    /previewOwner === UI_PREVIEW_OWNER_NATIVE[\s\S]+continue reconcileAttempts/,
+  );
+  assert.match(
+    implementation,
+    /Observe-only controller leaves the candidate UI preview ownerless/,
+  );
+});
+
 test("Dependabot intake is credentialless and trusted follow-up alone can write status", () => {
   assert.equal(intake.name, "Vercel Preview Intake");
   assert.deepEqual(intake.on, {
@@ -718,6 +735,12 @@ test("runbook covers bootstrap, canaries, browser proof, separate cutover, and e
     '"**": false',
     '"main": true',
     '"dependabot/**": false',
+    "exact 40-character head",
+    "dispatch-disabled-intent-without-worker",
+    "Draining GitHub preview before native ownership",
+    "proves only the controller's owner selection",
+    "native Vercel deployment/status",
+    "stale Phase B branch",
     "vercel-preview-controller.yml",
     "vercel-preview-worker.yml",
     "vercel-preview-intake.yml",

--- a/scripts/vercel-preview-workflows.test.mjs
+++ b/scripts/vercel-preview-workflows.test.mjs
@@ -750,6 +750,7 @@ test("runbook covers bootstrap, canaries, browser proof, separate cutover, and e
     "immutable 40-character SHAs",
     "event's own SHA",
     "dispatch-disabled-intent-without-worker",
+    "native-owned-selection-without-github-worker",
     "Draining GitHub preview before native ownership",
     "proves only the controller's owner selection",
     "native Vercel deployment/status",

--- a/scripts/vercel-preview-workflows.test.mjs
+++ b/scripts/vercel-preview-workflows.test.mjs
@@ -80,6 +80,28 @@ test("controller has only the three specified recovery-aware triggers", () => {
   assert.doesNotMatch(raw, /workflow_dispatch|\binputs\./);
 });
 
+test("controller mode is versioned and reaches every reconciliation call", () => {
+  assert.deepEqual(controller.env, {
+    VERCEL_PREVIEW_CONTROLLER_MODE: "active",
+  });
+  for (const [jobName, job] of Object.entries(controller.jobs)) {
+    const step = job.steps?.find((candidate) =>
+      String(candidate.with?.script ?? "").includes("reconcilePreview"),
+    );
+    if (!step) continue;
+    assert.equal(
+      step.env.CONTROLLER_MODE,
+      "${{ env.VERCEL_PREVIEW_CONTROLLER_MODE }}",
+      `${jobName} must receive the version-controlled controller mode`,
+    );
+    assert.match(
+      step.with.script,
+      /controllerMode:\s*process\.env\.CONTROLLER_MODE/,
+      `${jobName} must pass the controller mode to reconciliation`,
+    );
+  }
+});
+
 test("Dependabot intake is credentialless and trusted follow-up alone can write status", () => {
   assert.equal(intake.name, "Vercel Preview Intake");
   assert.deepEqual(intake.on, {
@@ -372,7 +394,8 @@ test("only reconciliation steps receive the dedicated worker dispatch credential
     "reconcile-request",
     "recover-worker-result",
   ];
-  const secretExpression = "${{ secrets.GH_PREVIEW_WORKFLOW_DISPATCH_TOKEN }}";
+  const secretExpression =
+    "${{ env.VERCEL_PREVIEW_CONTROLLER_MODE == 'active' && secrets.GH_PREVIEW_WORKFLOW_DISPATCH_TOKEN || '' }}";
   const raw = read(controllerPath);
   const secretNames = [...raw.matchAll(/secrets\.([A-Z0-9_]+)/g)].map(
     ([, name]) => name,
@@ -393,12 +416,20 @@ test("only reconciliation steps receive the dedicated worker dispatch credential
         `${jobName} must not receive the worker dispatch credential`,
       );
       assert.equal(step.env.WORKER_DISPATCH_TOKEN, secretExpression);
+      assert.equal(
+        step.env.CONTROLLER_MODE,
+        "${{ env.VERCEL_PREVIEW_CONTROLLER_MODE }}",
+      );
       assert.equal(Object.hasOwn(step.with ?? {}, "github-token"), false);
       assert.match(
         step.with.script,
         /getOctokit\(process\.env\.WORKER_DISPATCH_TOKEN\)/,
       );
       assert.match(step.with.script, /workerDispatchGithub,/);
+      assert.match(
+        step.with.script,
+        /controllerMode:\s*process\.env\.CONTROLLER_MODE/,
+      );
     }
   }
 

--- a/scripts/vercel-preview-workflows.test.mjs
+++ b/scripts/vercel-preview-workflows.test.mjs
@@ -723,6 +723,7 @@ test("runbook covers bootstrap, canaries, browser proof, separate cutover, and e
     "vercel-preview-intake.yml",
     "queued requested waiting pending in_progress",
     "gh api --paginate",
+    "set -euo pipefail",
     "SHA",
   ]) {
     assert.match(


### PR DESCRIPTION
## The Problem

Phase A established the trusted GitHub Actions preview path for `ui.mento.org`, but native Vercel Git still owns branch previews as well. Keeping both automatic owners after the canary phase creates duplicate UI previews and continues spending Vercel build minutes unnecessarily.

The ownership transfer must remain narrow and reversible: native Vercel Git must continue deploying `main`, every non-UI application must remain unchanged, and rollback must not create an overlap or an ownerless gap while the PR head and default-branch controller are on different revisions.

## The Solution

This PR completes the separately observable Phase B cutover for UI branch previews:

- changes only `apps/ui.mento.org/vercel.json` to disable native Vercel Git deployments for branches while explicitly preserving `main`;
- keeps the trusted default-branch GitHub preview controller in version-controlled `active` mode;
- re-reads the candidate's exact-SHA UI ownership config as bounded, untrusted data before reconciliation and again immediately before credentialed dispatch;
- dispatches only for the exact GitHub-owned config, suppresses dispatch for the exact reviewed native rollback config, and fails closed for missing, malformed, or unknown ownership states;
- adds `observe-only` rollback mode, which withholds the dispatch credential and never creates new work while still recovering completed workers and draining active or retired crash-window intents;
- keeps the ownership status pending while any prior GitHub worker remains live, and posts ownership-only success only after GitHub work is fully drained;
- makes controller mode and Vercel Git configuration an executable ownership invariant;
- preserves Vercel Git ownership for UI `main` and for App, Governance, and Reserve;
- updates the current-state runbook and ADRs, clearly separating historical Phase A procedures from current Phase B operation.

### Rollback contract

Rollback remains one reviewed code change rather than independent UI toggles:

1. establish a no-push window;
2. exhaustively drain or cancel every nonterminal Preview Controller, Worker, and Intake run and obtain two empty sweeps;
3. change the controller from `active` to `observe-only`;
4. restore UI's exact prior `dependabot/**: false` Vercel Git configuration;
5. require the native Vercel status and browser proof before merging the rollback;
6. keep `Vercel Preview` non-required until a post-merge native canary succeeds.

The controller's native-ownership status proves ownership selection only; it does not claim that Vercel built or smoke-tested the native preview. Rollback does not change production domains, another application, or recreate Governance QA.

### Validation

- `pnpm vercel:preview:test` — 153/153
- `pnpm vercel:workflow:test` — 82/82
- `pnpm ci:action-pins` — all 22 workflow/composite files pinned
- `pnpm ci:action-pins:test` — 48/48 + 11/11
- `pnpm quality:budgets:test` — 30/30
- `pnpm check-types` — 8/8 tasks
- `pnpm adr:check` — 9/9
- `pnpm pr:description:test` — 25/25
- `trunk check` — clean
- `git diff --check` — clean
- deterministic autoreview — clean
- fresh-context semantic autoreview — clean, confidence 0.96

Chrome DevTools MCP is unavailable in this session. This PR changes deployment ownership rather than rendered UI; the trusted exact-head preview smoke remains the pre-merge browser gate. The definitive single-owner browser proof will use a fresh post-merge UI canary because `pull_request_target` executes the pre-merge default-branch controller.

### Post-merge verification

A fresh same-repository branch created from the Phase B merge SHA will provide the integration evidence. Acceptance requires exactly one controller key, one GitHub Deployment, one Vercel preview, zero native Vercel Git branch previews for the canary SHA, a successful exact-SHA `Vercel Preview` status, browser/console/network/header proof, and a normal native Vercel Git deployment for the merge on `main`.

## Ship Checklist

- [x] ship skill used
- [x] local review and fresh-context semantic review run
- [x] repository validation run
- [x] exact-head CI and feedback sweep complete
- [ ] post-merge single-owner canary complete

Refs #519

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes production CI preview ownership for UI with fail-closed dispatch guards; misconfiguration could block previews or briefly duplicate owners until rollback procedures are followed.
> 
> **Overview**
> Completes **Phase B** for `ui.mento.org`: native Vercel Git branch previews are turned off (`"**": false`, `main` still enabled) while the preview controller workflow runs in version-controlled **`active`** mode.
> 
> The controller gains an **`active` / `observe-only`** switch wired through all reconciliation jobs; the worker dispatch secret is only injected when mode is `active`. Runtime logic reads the PR head’s exact `apps/ui.mento.org/vercel.json`, dispatches only for the GitHub-owned config, suppresses dispatch for the reviewed native rollback config, and in **`observe-only`** drains or retires pending intents without new workers while publishing ownership-only `Vercel Preview` statuses.
> 
> **`scripts/vercel-git-ownership.test.mjs`** enforces that controller mode and UI `vercel.json` stay paired so duplicate or ownerless automatic previews cannot ship. ADRs, README, and **`docs/vercel-deployments.md`** are updated for current Phase B operation and atomic rollback (mode + config + quiescence).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b7d2a67f1d34512b4f3fca0b5733388a99aa685. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

