### PR TITLE
fix(ci): wait for preview route hydration

### DIFF
--- a/apps/ui.mento.org/e2e/vercel-preview-browser-smoke.mjs
+++ b/apps/ui.mento.org/e2e/vercel-preview-browser-smoke.mjs
@@ -382,6 +382,7 @@ export async function runBrowserSmoke({ chromium, input, timeoutMs = 30_000 }) {
     await page
       .getByRole("heading", { name: "Form Components", exact: true })
       .waitFor({ state: "visible" });
+    await deploymentIdentityMonitor.waitForIdle(timeoutMs);
     const checkbox = page.getByRole("checkbox", {
       name: "Checkbox option",
       exact: true,

--- a/apps/ui.mento.org/e2e/vercel-preview-browser-smoke.test.mjs
+++ b/apps/ui.mento.org/e2e/vercel-preview-browser-smoke.test.mjs
@@ -33,6 +33,7 @@ class FakePage extends EventEmitter {
       `${INPUT.deploymentUrl}/_next/static/app.css?dpl=${NEXT_DEPLOYMENT_ID}`,
     ],
     navigationAssetReferences = [],
+    navigationAssetDelayMs = null,
   } = {}) {
     super();
     this.afterInteraction = afterInteraction;
@@ -41,6 +42,8 @@ class FakePage extends EventEmitter {
     this.htmlDeploymentIdReads = 0;
     this.assetReferences = assetReferences;
     this.navigationAssetReferences = navigationAssetReferences;
+    this.navigationAssetDelayMs = navigationAssetDelayMs;
+    this.checkboxInteractive = navigationAssetDelayMs === null;
     this.currentUrl = INPUT.deploymentUrl;
     this.checkboxChecked = false;
     this.calls = [];
@@ -120,7 +123,16 @@ class FakePage extends EventEmitter {
         click: async () => {
           this.calls.push(["click", "Textarea"]);
           for (const reference of this.navigationAssetReferences) {
-            this.emitAssetRequest(reference);
+            if (this.navigationAssetDelayMs === null) {
+              this.emitAssetRequest(reference);
+              continue;
+            }
+            const request = this.startAssetRequest(reference);
+            setTimeout(() => {
+              this.calls.push(["navigation-asset-terminal", reference]);
+              this.checkboxInteractive = true;
+              this.emit("requestfinished", request);
+            }, this.navigationAssetDelayMs);
           }
           this.currentUrl = new URL(
             "/form-components",
@@ -133,7 +145,7 @@ class FakePage extends EventEmitter {
       return {
         click: async () => {
           this.calls.push(["click", "Checkbox option"]);
-          this.checkboxChecked = true;
+          if (this.checkboxInteractive) this.checkboxChecked = true;
         },
         isChecked: async () => this.checkboxChecked,
       };
@@ -312,6 +324,28 @@ test("browser smoke renders, navigates through search, and changes a control", a
       (call) => call[0] === "click" && call[1] === "Checkbox option",
     ),
   );
+});
+
+test("browser smoke waits for route assets before testing hydration", async () => {
+  const routeAsset = `${INPUT.deploymentUrl}/_next/static/form.js?dpl=${NEXT_DEPLOYMENT_ID}`;
+  const page = new FakePage({
+    navigationAssetReferences: [routeAsset],
+    navigationAssetDelayMs: 10,
+  });
+  const fake = fakeChromium(page);
+
+  await runBrowserSmoke({ chromium: fake.chromium, input: INPUT });
+
+  const routeReady = page.calls.findIndex(
+    (call) => call[0] === "navigation-asset-terminal",
+  );
+  const checkboxClick = page.calls.findIndex(
+    (call) => call[0] === "click" && call[1] === "Checkbox option",
+  );
+  assert.ok(routeReady >= 0);
+  assert.ok(checkboxClick > routeReady);
+  assert.equal(page.checkboxChecked, true);
+  assert.equal(fake.state.closed, true);
 });
 
 test("browser smoke rejects conflicting route-specific asset identity", async () => {


### PR DESCRIPTION
## The Problem

PR #578's exact-SHA Vercel preview built successfully, but the trusted browser smoke failed twice at the immediate checkbox assertion. The same immutable deployment passed the unchanged smoke locally, and the UI/package diff was empty. After client navigation, the smoke waited for the server-rendered heading but could click before the route-specific JavaScript finished loading and React attached the checkbox handler.

## The Solution

Wait for the existing bounded deployment-asset monitor to reach an idle window after the Form Components route appears and before interacting with its checkbox. Add a deterministic regression that holds a route asset request open and makes the fake checkbox interactive only after that request reaches a terminal event.

This is a prerequisite for #578: once merged to `main`, the trusted preview worker can retry #578 with the hydration-aware smoke implementation.

## Verification

- `node --test apps/ui.mento.org/e2e/vercel-preview-browser-smoke.test.mjs` — 14/14
- `pnpm vercel:workflow:test` — 82/82
- `pnpm vercel:preview:test` — 116/116
- `pnpm quality:budgets:test` — 30/30
- `pnpm adr:check`
- Trunk format/check and `git diff --check`
- Patched smoke passed end-to-end against #578's immutable deployment `https://uimento-em5zbtt2g-mentolabs.vercel.app`

## Rollback

Revert this commit to restore the prior immediate post-heading interaction. No deployment configuration, credentials, or application runtime code changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> E2E smoke and unit tests only; no app runtime, auth, or deployment config changes. Rollback is a single revert.
> 
> **Overview**
> Fixes flaky Vercel preview browser smoke by **waiting for route `/_next/static` assets to go idle** after the Form Components heading is visible and **before** clicking the checkbox—same pattern already used on the initial Basic Components load.
> 
> The failure mode was client navigation finishing (heading visible) while route-specific JS was still loading, so React had not yet wired the checkbox and the immediate assertion failed on slow previews.
> 
> **Test harness:** `FakePage` gains delayed navigation assets (`navigationAssetDelayMs`) and only marks the checkbox interactive after those requests finish. A new test asserts the smoke waits for `navigation-asset-terminal` before the checkbox click.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d248e5f3e679d266ba1467d0019204ba5da08d8c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->