### PR TITLE
test(ui): prove Phase B single-owner preview

### DIFF
--- a/apps/ui.mento.org/app/layout.tsx
+++ b/apps/ui.mento.org/app/layout.tsx
@@ -27,7 +27,10 @@ export default function RootLayout({
 }): React.ReactElement {
   return (
     <html lang="en" suppressHydrationWarning>
-      <body className={inter.className}>
+      <body
+        className={inter.className}
+        data-vercel-preview-phase-b="single-owner"
+      >
         <AppShell>{children}</AppShell>
       </body>
     </html>


### PR DESCRIPTION
## The Problem

Phase B moved UI branch-preview ownership from native Vercel Git builds to the trusted GitHub Actions controller. The cutover needs an exact post-merge integration proof using the controller code now trusted on main.

## The Solution

This disposable operational canary adds one visible DOM marker to ui.mento.org. Acceptance requires exactly one GitHub-owned preview deployment, zero native Vercel UI branch previews, exact-SHA terminal journal evidence, and a successful browser smoke against the immutable deployment URL.

Do not merge this PR. It will be closed and its branch deleted after the close-event cleanup is verified.

Validation before publish:

- exact parent: f28cb674626eb413ac15baf49f2726d24e8ec5b0
- targeted UI typecheck passed
- Trunk passed
- local browser confirmed the marker and zero console errors

Refs #519

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> One inert DOM data attribute on the app shell for a short-lived operational test; no auth, data, or routing changes.
> 
> **Overview**
> **Disposable canary for Phase B cutover validation** — not intended to merge.
> 
> The root layout’s `<body>` gains `data-vercel-preview-phase-b="single-owner"` so browser smoke and automation can confirm GitHub Actions–owned branch previews after UI preview ownership moves off native Vercel Git builds. The PR exists to prove a single owned preview, no parallel native UI branch previews, and journal/smoke acceptance per the operational checklist; the branch is meant to be closed and deleted after cleanup is verified.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7568c5f56fed0f53fc2516ed396945a81d9f5af7. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->