### PR TITLE
refactor(ci): unify Vercel preview smoke

### DIFF
--- a/.github/workflows/_vercel-prebuilt.yml
+++ b/.github/workflows/_vercel-prebuilt.yml
@@ -1532,60 +1532,27 @@ jobs:
     name: Smoke verified ${{ inputs.logical_target }} preview
     needs: prebuilt
     if: needs.prebuilt.result == 'success'
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
     permissions:
       contents: read
-    outputs:
-      deployment_url: ${{ steps.smoke.outputs.smoke_deployment_url }}
-      smoke_commit_sha: ${{ steps.smoke.outputs.smoke_commit_sha }}
-    steps:
-      - name: Check out trusted smoke controller only
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          fetch-depth: 1
-          path: controller
-          persist-credentials: false
-          ref: ${{ github.workflow_sha }}
-
-      - name: Smoke immutable UI preview without deployment credentials
-        id: smoke
-        env:
-          DEPLOY_SHA: ${{ needs.prebuilt.outputs.commit_sha }}
-          GITHUB_DEPLOYMENT_ID: ${{ needs.prebuilt.outputs.github_deployment_id }}
-          LOGICAL_TARGET: ${{ inputs.logical_target }}
-          MENTO_NEXT_DEPLOYMENT_ID: ${{ needs.prebuilt.outputs.next_deployment_id }}
-          VERCEL_DEPLOYMENT_ID: ${{ needs.prebuilt.outputs.vercel_deployment_id }}
-          VERCEL_DEPLOYMENT_URL: ${{ needs.prebuilt.outputs.verified_deployment_url }}
-        run: node "$GITHUB_WORKSPACE/controller/scripts/vercel-prebuilt-workflow.mjs" smoke
-
-      - name: Set up pinned pnpm for trusted browser smoke
-        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v4
-        with:
-          version: 10.34.4
-
-      - name: Set up pinned Node.js and trusted pnpm cache
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: 22
-          cache: pnpm
-          cache-dependency-path: controller/pnpm-lock.yaml
-
-      - name: Install trusted browser smoke dependencies
-        working-directory: controller
-        env:
-          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: "1"
-        run: pnpm install --frozen-lockfile --ignore-scripts --filter ui.mento.org...
-
-      - name: Interact with immutable UI preview in system Chrome
-        env:
-          DEPLOYMENT_IDEMPOTENCY_KEY: ${{ inputs.deployment_idempotency_key }}
-          DEPLOY_SHA: ${{ needs.prebuilt.outputs.commit_sha }}
-          GITHUB_DEPLOYMENT_ID: ${{ needs.prebuilt.outputs.github_deployment_id }}
-          MENTO_NEXT_DEPLOYMENT_ID: ${{ needs.prebuilt.outputs.next_deployment_id }}
-          VERCEL_DEPLOYMENT_ID: ${{ needs.prebuilt.outputs.vercel_deployment_id }}
-          VERCEL_DEPLOYMENT_URL: ${{ needs.prebuilt.outputs.verified_deployment_url }}
-        run: node "$GITHUB_WORKSPACE/controller/apps/ui.mento.org/e2e/vercel-preview-browser-smoke.mjs"
+    uses: ./.github/workflows/_vercel-preview-smoke.yml
+    with:
+      logical_target: ${{ inputs.logical_target }}
+      deployment_url: ${{ needs.prebuilt.outputs.verified_deployment_url }}
+      expected_sha: ${{ needs.prebuilt.outputs.commit_sha }}
+      github_deployment_id: ${{ needs.prebuilt.outputs.github_deployment_id }}
+      verification_mode: ${{ inputs.provenance == 'manual-pilot' && 'manual-pilot' || 'controller' }}
+      verification_key: ${{ inputs.deployment_idempotency_key }}
+      metadata_logical_target: ${{ inputs.logical_target }}
+      metadata_target: ${{ inputs.vercel_target }}
+      metadata_repository: ${{ github.repository }}
+      metadata_ref: ${{ inputs.git_branch }}
+      metadata_sha: ${{ needs.prebuilt.outputs.commit_sha }}
+      metadata_url: ${{ needs.prebuilt.outputs.verified_deployment_url }}
+      pull_request_number: ${{ inputs.pull_request_number }}
+      vercel_deployment_id: ${{ needs.prebuilt.outputs.vercel_deployment_id }}
+      next_deployment_id: ${{ needs.prebuilt.outputs.next_deployment_id }}
+      expected_project_id: ${{ inputs.vercel_project_id }}
+      metadata_project_id: ${{ inputs.vercel_project_id }}
 
   finalize:
     name: Finalize ${{ inputs.logical_target }} deployment lifecycle
@@ -1633,7 +1600,7 @@ jobs:
         continue-on-error: true
         env:
           BUILD_DURATION_MS: ${{ needs.prebuilt.outputs.build_duration_ms }}
-          COMMIT_SHA: ${{ needs.smoke.outputs.smoke_commit_sha }}
+          COMMIT_SHA: ${{ needs.smoke.outputs.expected_sha }}
           DEPLOY_DURATION_MS: ${{ needs.prebuilt.outputs.deploy_duration_ms }}
           GITHUB_DEPLOYMENT_ID: ${{ needs.prebuilt.outputs.github_deployment_id }}
           LOGICAL_TARGET: ${{ inputs.logical_target }}

--- a/.github/workflows/_vercel-preview-smoke.yml
+++ b/.github/workflows/_vercel-preview-smoke.yml
@@ -1,0 +1,193 @@
+name: Reusable Vercel Preview Smoke
+
+on:
+  workflow_call:
+    inputs:
+      logical_target:
+        description: Literal app, governance, reserve, or ui target
+        required: true
+        type: string
+      deployment_url:
+        description: Immutable allowlisted Vercel team URL
+        required: true
+        type: string
+      expected_sha:
+        description: Exact source SHA already verified by the trusted caller
+        required: true
+        type: string
+      github_deployment_id:
+        description: Canonical GitHub Deployment ID
+        required: true
+        type: string
+      verification_mode:
+        description: controller, manual-pilot, or native-adapter
+        required: true
+        type: string
+      verification_key:
+        description: Exact mode-bound verification key
+        required: true
+        type: string
+      metadata_logical_target:
+        description: Logical target from trusted deployment metadata
+        required: true
+        type: string
+      metadata_target:
+        description: Vercel target from trusted deployment metadata
+        required: true
+        type: string
+      metadata_repository:
+        description: Repository from trusted deployment metadata
+        required: true
+        type: string
+      metadata_ref:
+        description: Source ref from trusted deployment metadata
+        required: true
+        type: string
+      metadata_sha:
+        description: Source SHA from trusted deployment metadata
+        required: true
+        type: string
+      metadata_url:
+        description: Immutable URL from trusted deployment metadata
+        required: true
+        type: string
+      pull_request_number:
+        description: Controller PR number; empty outside controller mode
+        required: false
+        default: ""
+        type: string
+      vercel_deployment_id:
+        description: Verified Vercel Deployment ID; empty only for native-adapter mode
+        required: false
+        default: ""
+        type: string
+      next_deployment_id:
+        description: Target-bound Next.js deployment ID; empty only for native-adapter mode
+        required: false
+        default: ""
+        type: string
+      expected_project_id:
+        description: Literal caller project ID; empty only for native-adapter mode
+        required: false
+        default: ""
+        type: string
+      metadata_project_id:
+        description: Project ID from verified Vercel metadata
+        required: false
+        default: ""
+        type: string
+      metadata_environment:
+        description: Exact native GitHub Deployment environment
+        required: false
+        default: ""
+        type: string
+      metadata_actor_login:
+        description: Exact native Deployment actor login
+        required: false
+        default: ""
+        type: string
+      metadata_actor_id:
+        description: Exact native Deployment actor ID
+        required: false
+        default: ""
+        type: string
+      metadata_actor_type:
+        description: Exact native Deployment actor type
+        required: false
+        default: ""
+        type: string
+    outputs:
+      deployment_url:
+        description: Validated immutable preview URL
+        value: ${{ jobs.smoke.outputs.deployment_url }}
+      expected_sha:
+        description: Validated exact source SHA
+        value: ${{ jobs.smoke.outputs.expected_sha }}
+      artifact_identity:
+        description: Target, SHA, and GitHub Deployment evidence key
+        value: ${{ jobs.smoke.outputs.artifact_identity }}
+
+permissions: {}
+
+jobs:
+  smoke:
+    name: Smoke ${{ inputs.logical_target }} ${{ inputs.expected_sha }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    container:
+      image: mcr.microsoft.com/playwright:v1.61.1-noble
+    env:
+      DEPLOY_SHA: ${{ inputs.expected_sha }}
+      EXPECTED_PROJECT_ID: ${{ inputs.expected_project_id }}
+      GITHUB_DEPLOYMENT_ID: ${{ inputs.github_deployment_id }}
+      LOGICAL_TARGET: ${{ inputs.logical_target }}
+      MENTO_NEXT_DEPLOYMENT_ID: ${{ inputs.next_deployment_id }}
+      METADATA_ACTOR_ID: ${{ inputs.metadata_actor_id }}
+      METADATA_ACTOR_LOGIN: ${{ inputs.metadata_actor_login }}
+      METADATA_ACTOR_TYPE: ${{ inputs.metadata_actor_type }}
+      METADATA_ENVIRONMENT: ${{ inputs.metadata_environment }}
+      METADATA_LOGICAL_TARGET: ${{ inputs.metadata_logical_target }}
+      METADATA_PROJECT_ID: ${{ inputs.metadata_project_id }}
+      METADATA_REF: ${{ inputs.metadata_ref }}
+      METADATA_REPOSITORY: ${{ inputs.metadata_repository }}
+      METADATA_SHA: ${{ inputs.metadata_sha }}
+      METADATA_TARGET: ${{ inputs.metadata_target }}
+      METADATA_URL: ${{ inputs.metadata_url }}
+      PULL_REQUEST_NUMBER: ${{ inputs.pull_request_number }}
+      VERCEL_DEPLOYMENT_ID: ${{ inputs.vercel_deployment_id }}
+      VERCEL_DEPLOYMENT_URL: ${{ inputs.deployment_url }}
+      VERIFICATION_KEY: ${{ inputs.verification_key }}
+      VERIFICATION_MODE: ${{ inputs.verification_mode }}
+      WORKFLOW_RUN_ATTEMPT: ${{ github.run_attempt }}
+      WORKFLOW_RUN_ID: ${{ github.run_id }}
+    outputs:
+      deployment_url: ${{ steps.tuple.outputs.deployment_url }}
+      expected_sha: ${{ steps.tuple.outputs.expected_sha }}
+      artifact_identity: ${{ steps.tuple.outputs.artifact_identity }}
+    steps:
+      - name: Check out trusted smoke implementation only
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+          ref: ${{ github.workflow_sha }}
+
+      - name: Install trusted smoke dependencies
+        uses: ./.github/actions/pnpm-install
+
+      - name: Validate the complete credential-free deployment tuple
+        id: tuple
+        run: node scripts/vercel-preview-smoke.mjs validate
+
+      - name: Run common HTTP, header, build-ID, and representative-asset smoke
+        run: node scripts/vercel-preview-smoke.mjs http
+
+      - name: Exercise App and Governance wallet list and team-preview mock wallet
+        if: inputs.logical_target == 'app' || inputs.logical_target == 'governance'
+        env:
+          PREVIEW_URL: ${{ inputs.deployment_url }}
+        run: pnpm --filter app.mento.org test:preview
+
+      - name: Run App, Governance, or Reserve browser smoke
+        if: inputs.logical_target != 'ui'
+        env:
+          PLAYWRIGHT_BROWSER_CHANNEL: bundled
+        run: node scripts/vercel-preview-browser-smoke.mjs
+
+      - name: Run UI deployment identity and interaction smoke
+        if: inputs.logical_target == 'ui'
+        env:
+          DEPLOYMENT_IDEMPOTENCY_KEY: ${{ inputs.verification_key }}
+          PLAYWRIGHT_BROWSER_CHANNEL: bundled
+        run: node apps/ui.mento.org/e2e/vercel-preview-browser-smoke.mjs
+
+      - name: Upload target-bound Playwright artifacts on failure
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: preview-smoke-${{ inputs.logical_target }}-${{ inputs.expected_sha }}-${{ inputs.github_deployment_id }}
+          path: apps/app.mento.org/test-results/
+          if-no-files-found: ignore
+          retention-days: 7

--- a/.github/workflows/preview-smoke.yml
+++ b/.github/workflows/preview-smoke.yml
@@ -1,68 +1,139 @@
-name: Preview Smoke
+name: Native Vercel Preview Smoke Adapter
 
-# Replacement for the deleted deployment_status smoke-test-*.yml workflows
-# (real-wallet Synpress suite in mento-protocol/mento-automation-tests, see
-# #480/#481). Walletless: boots the deployed preview and connects the
-# repo's mock wallet (hostname-allowlisted to `-mentolabs.vercel.app`
-# previews in packages/web3/src/config/e2e-mode.ts) — no extension, no
-# secrets, no real wallet.
+# Temporary bridge while Vercel Git still owns App and Governance branch
+# previews. Every exact qualifying Vercel success runs the full secretless
+# reusable smoke; no prior status is queried or trusted as dedupe evidence.
 on:
   deployment_status:
 
-permissions: read-all
-
-# Keyed on the deployment URL (not github.ref) — a branch can redeploy
-# several times and only the newest preview for that URL matters.
-concurrency:
-  group: preview-smoke-${{ github.event.deployment_status.environment_url }}
-  cancel-in-progress: true
+permissions: {}
 
 jobs:
-  preview-smoke:
-    name: Preview smoke (mock wallet)
-    # App Mento and Governance previews only (Vercel project host prefixes,
-    # same as the deleted smoke-test-app-mento.yml / smoke-test-governance.yml
-    # target_url_pattern filters: "appmento" / "governancemento"). Reserve
-    # ("reservemento...") and UI ("uimento...") previews don't match either
-    # prefix and are skipped — no pixel/functional preview suite for them yet.
-    # `-mentolabs.vercel.app` restricts to the team's own previews, matching
-    # the e2e-mode.ts gate this spec depends on.
-    if: >-
-      github.event.deployment_status.state == 'success' &&
-      github.event.deployment.ref != 'main' &&
-      (
-        startsWith(github.event.deployment_status.environment_url, 'https://appmento') ||
-        startsWith(github.event.deployment_status.environment_url, 'https://governancemento')
-      ) &&
-      endsWith(github.event.deployment_status.environment_url, '-mentolabs.vercel.app')
-    timeout-minutes: 10
+  classify:
+    name: Classify exact native Vercel preview event
     runs-on: ubuntu-latest
-    # Same pinned Playwright image as e2e.yml/visual.yml (browsers
-    # preinstalled — no `playwright install` step needed).
-    container:
-      image: mcr.microsoft.com/playwright:v1.61.1-noble
-
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    outputs:
+      eligible: ${{ steps.native.outputs.eligible }}
+      reason: ${{ steps.native.outputs.reason }}
+      logical_target: ${{ steps.native.outputs.logical_target }}
+      deployment_url: ${{ steps.native.outputs.deployment_url }}
+      expected_sha: ${{ steps.native.outputs.expected_sha }}
+      github_deployment_id: ${{ steps.native.outputs.github_deployment_id }}
+      verification_mode: ${{ steps.native.outputs.verification_mode }}
+      verification_key: ${{ steps.native.outputs.verification_key }}
+      metadata_logical_target: ${{ steps.native.outputs.metadata_logical_target }}
+      metadata_target: ${{ steps.native.outputs.metadata_target }}
+      metadata_repository: ${{ steps.native.outputs.metadata_repository }}
+      metadata_ref: ${{ steps.native.outputs.metadata_ref }}
+      metadata_sha: ${{ steps.native.outputs.metadata_sha }}
+      metadata_url: ${{ steps.native.outputs.metadata_url }}
+      metadata_environment: ${{ steps.native.outputs.metadata_environment }}
+      metadata_actor_login: ${{ steps.native.outputs.metadata_actor_login }}
+      metadata_actor_id: ${{ steps.native.outputs.metadata_actor_id }}
+      metadata_actor_type: ${{ steps.native.outputs.metadata_actor_type }}
     steps:
-      - name: Check out code
+      - name: Check out trusted native adapter only
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-
-      - name: Install pnpm dependencies
-        uses: ./.github/actions/pnpm-install
-
-      # No build step: the spec targets the ALREADY-DEPLOYED preview bundle,
-      # not a local build. app-agnostic — runs from app.mento.org's package
-      # regardless of which app's preview URL it's pointed at (shared
-      # ConnectButton in packages/web3).
-      - name: Run preview smoke
-        env:
-          PREVIEW_URL: ${{ github.event.deployment_status.environment_url }}
-        run: pnpm --filter app.mento.org test:preview
-
-      - name: Upload Playwright artifacts on failure
-        if: failure()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: preview-smoke-artifacts
-          path: apps/app.mento.org/test-results/
-          if-no-files-found: ignore
-          retention-days: 7
+          fetch-depth: 1
+          persist-credentials: false
+          ref: ${{ github.workflow_sha }}
+
+      - name: Validate native event, actor, environment, and immutable URL
+        id: native
+        run: node scripts/vercel-preview-smoke.mjs classify-native
+
+  smoke-app:
+    name: Smoke native App preview
+    needs: classify
+    if: needs.classify.outputs.eligible == 'true' && needs.classify.outputs.logical_target == 'app'
+    permissions:
+      contents: read
+    uses: ./.github/workflows/_vercel-preview-smoke.yml
+    with:
+      logical_target: app
+      deployment_url: ${{ needs.classify.outputs.deployment_url }}
+      expected_sha: ${{ needs.classify.outputs.expected_sha }}
+      github_deployment_id: ${{ needs.classify.outputs.github_deployment_id }}
+      verification_mode: ${{ needs.classify.outputs.verification_mode }}
+      verification_key: ${{ needs.classify.outputs.verification_key }}
+      metadata_logical_target: app
+      metadata_target: ${{ needs.classify.outputs.metadata_target }}
+      metadata_repository: ${{ needs.classify.outputs.metadata_repository }}
+      metadata_ref: ${{ needs.classify.outputs.metadata_ref }}
+      metadata_sha: ${{ needs.classify.outputs.metadata_sha }}
+      metadata_url: ${{ needs.classify.outputs.metadata_url }}
+      metadata_environment: ${{ needs.classify.outputs.metadata_environment }}
+      metadata_actor_login: ${{ needs.classify.outputs.metadata_actor_login }}
+      metadata_actor_id: ${{ needs.classify.outputs.metadata_actor_id }}
+      metadata_actor_type: ${{ needs.classify.outputs.metadata_actor_type }}
+
+  smoke-governance:
+    name: Smoke native Governance preview
+    needs: classify
+    if: needs.classify.outputs.eligible == 'true' && needs.classify.outputs.logical_target == 'governance'
+    permissions:
+      contents: read
+    uses: ./.github/workflows/_vercel-preview-smoke.yml
+    with:
+      logical_target: governance
+      deployment_url: ${{ needs.classify.outputs.deployment_url }}
+      expected_sha: ${{ needs.classify.outputs.expected_sha }}
+      github_deployment_id: ${{ needs.classify.outputs.github_deployment_id }}
+      verification_mode: ${{ needs.classify.outputs.verification_mode }}
+      verification_key: ${{ needs.classify.outputs.verification_key }}
+      metadata_logical_target: governance
+      metadata_target: ${{ needs.classify.outputs.metadata_target }}
+      metadata_repository: ${{ needs.classify.outputs.metadata_repository }}
+      metadata_ref: ${{ needs.classify.outputs.metadata_ref }}
+      metadata_sha: ${{ needs.classify.outputs.metadata_sha }}
+      metadata_url: ${{ needs.classify.outputs.metadata_url }}
+      metadata_environment: ${{ needs.classify.outputs.metadata_environment }}
+      metadata_actor_login: ${{ needs.classify.outputs.metadata_actor_login }}
+      metadata_actor_id: ${{ needs.classify.outputs.metadata_actor_id }}
+      metadata_actor_type: ${{ needs.classify.outputs.metadata_actor_type }}
+
+  record-native-result:
+    name: Record run-bound native smoke evidence
+    needs: [classify, smoke-app, smoke-governance]
+    if: always() && needs.classify.outputs.eligible == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      deployments: write
+    steps:
+      - name: Append the bounded terminal status without lookup or reuse
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          APP_RESULT: ${{ needs.smoke-app.result }}
+          DEPLOYMENT_ENVIRONMENT: ${{ needs.classify.outputs.metadata_environment }}
+          DEPLOYMENT_URL: ${{ needs.classify.outputs.deployment_url }}
+          GITHUB_DEPLOYMENT_ID: ${{ needs.classify.outputs.github_deployment_id }}
+          GOVERNANCE_RESULT: ${{ needs.smoke-governance.result }}
+          LOGICAL_TARGET: ${{ needs.classify.outputs.logical_target }}
+        with:
+          script: |
+            const target = process.env.LOGICAL_TARGET;
+            const result = target === "app"
+              ? process.env.APP_RESULT
+              : process.env.GOVERNANCE_RESULT;
+            const state = result === "success"
+              ? "success"
+              : result === "failure"
+                ? "failure"
+                : "error";
+            const description = `Native ${target} preview smoke ${state}; run ${context.runId}/${process.env.GITHUB_RUN_ATTEMPT}`;
+            await github.rest.repos.createDeploymentStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              deployment_id: Number(process.env.GITHUB_DEPLOYMENT_ID),
+              state,
+              description,
+              environment: process.env.DEPLOYMENT_ENVIRONMENT,
+              environment_url: process.env.DEPLOYMENT_URL,
+              log_url: `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}/attempts/${process.env.GITHUB_RUN_ATTEMPT}`,
+              auto_inactive: false,
+            });

--- a/.github/workflows/vercel-preview-worker.yml
+++ b/.github/workflows/vercel-preview-worker.yml
@@ -193,59 +193,27 @@ jobs:
     name: Resume smoke for an existing immutable upload
     needs: validate-controller-ownership
     if: needs.validate-controller-ownership.outputs.should_resume_smoke == 'true'
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
     permissions:
       contents: read
-    outputs:
-      deployment_url: ${{ steps.smoke.outputs.smoke_deployment_url }}
-    steps:
-      - name: Check out trusted smoke controller only
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          fetch-depth: 1
-          path: controller
-          persist-credentials: false
-          ref: ${{ github.workflow_sha }}
-
-      - name: Re-run direct smoke without deployment credentials
-        id: smoke
-        env:
-          DEPLOY_SHA: ${{ inputs.commit_sha }}
-          GITHUB_DEPLOYMENT_ID: ${{ needs.validate-controller-ownership.outputs.github_deployment_id }}
-          LOGICAL_TARGET: ui
-          MENTO_NEXT_DEPLOYMENT_ID: ${{ needs.validate-controller-ownership.outputs.next_deployment_id }}
-          VERCEL_DEPLOYMENT_ID: ${{ needs.validate-controller-ownership.outputs.vercel_deployment_id }}
-          VERCEL_DEPLOYMENT_URL: ${{ needs.validate-controller-ownership.outputs.vercel_deployment_url }}
-        run: node "$GITHUB_WORKSPACE/controller/scripts/vercel-prebuilt-workflow.mjs" smoke
-
-      - name: Set up pinned pnpm for trusted browser smoke
-        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v4
-        with:
-          version: 10.34.4
-
-      - name: Set up pinned Node.js and trusted pnpm cache
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: 22
-          cache: pnpm
-          cache-dependency-path: controller/pnpm-lock.yaml
-
-      - name: Install trusted browser smoke dependencies
-        working-directory: controller
-        env:
-          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: "1"
-        run: pnpm install --frozen-lockfile --ignore-scripts --filter ui.mento.org...
-
-      - name: Re-run browser interaction in system Chrome
-        env:
-          DEPLOYMENT_IDEMPOTENCY_KEY: ${{ inputs.controller_key }}
-          DEPLOY_SHA: ${{ inputs.commit_sha }}
-          GITHUB_DEPLOYMENT_ID: ${{ needs.validate-controller-ownership.outputs.github_deployment_id }}
-          MENTO_NEXT_DEPLOYMENT_ID: ${{ needs.validate-controller-ownership.outputs.next_deployment_id }}
-          VERCEL_DEPLOYMENT_ID: ${{ needs.validate-controller-ownership.outputs.vercel_deployment_id }}
-          VERCEL_DEPLOYMENT_URL: ${{ needs.validate-controller-ownership.outputs.vercel_deployment_url }}
-        run: node "$GITHUB_WORKSPACE/controller/apps/ui.mento.org/e2e/vercel-preview-browser-smoke.mjs"
+    uses: ./.github/workflows/_vercel-preview-smoke.yml
+    with:
+      logical_target: ui
+      deployment_url: ${{ needs.validate-controller-ownership.outputs.vercel_deployment_url }}
+      expected_sha: ${{ inputs.commit_sha }}
+      github_deployment_id: ${{ needs.validate-controller-ownership.outputs.github_deployment_id }}
+      verification_mode: controller
+      verification_key: ${{ inputs.controller_key }}
+      metadata_logical_target: ui
+      metadata_target: preview
+      metadata_repository: ${{ github.repository }}
+      metadata_ref: ${{ inputs.git_branch }}
+      metadata_sha: ${{ inputs.commit_sha }}
+      metadata_url: ${{ needs.validate-controller-ownership.outputs.vercel_deployment_url }}
+      pull_request_number: ${{ inputs.pull_request_number }}
+      vercel_deployment_id: ${{ needs.validate-controller-ownership.outputs.vercel_deployment_id }}
+      next_deployment_id: ${{ needs.validate-controller-ownership.outputs.next_deployment_id }}
+      expected_project_id: ${{ vars.VERCEL_PROJECT_ID_UI }}
+      metadata_project_id: ${{ vars.VERCEL_PROJECT_ID_UI }}
 
   finalize-resumed-smoke:
     name: Finalize resumed smoke lifecycle

--- a/.github/workflows/visual.yml
+++ b/.github/workflows/visual.yml
@@ -130,8 +130,8 @@ jobs:
     # Render in the SAME pinned image used to generate baselines — the CI
     # render must equal the baseline render (font subpixel rendering is the #1
     # false-positive source). Tag must match @playwright/test in package.json.
-    # NOTE: deliberate divergence from the deployment_status smoke-tests, which
-    # run against the live Vercel preview; that render env is not byte-pinnable.
+    # NOTE: deliberate divergence from the reusable live-preview smoke, whose
+    # deployed Vercel render environment is not byte-pinnable.
     container:
       image: mcr.microsoft.com/playwright:v1.61.1-noble
 
@@ -177,8 +177,8 @@ jobs:
     # Render in the SAME pinned image used to generate baselines — the CI
     # render must equal the baseline render (font subpixel rendering is the #1
     # false-positive source). Tag must match @playwright/test in package.json.
-    # NOTE: deliberate divergence from the deployment_status smoke-tests, which
-    # run against the live Vercel preview; that render env is not byte-pinnable.
+    # NOTE: deliberate divergence from the reusable live-preview smoke, whose
+    # deployed Vercel render environment is not byte-pinnable.
     container:
       image: mcr.microsoft.com/playwright:v1.61.1-noble
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,7 +59,7 @@ pnpm fork:seed:monad                 # Monad sibling of fork:seed (Reserve colla
 pnpm pr:description:test             # Test the required PR-description format validator
 pnpm vercel:primitives:test          # Test affected planning, custom deployment IDs, and build-env contracts
 pnpm vercel:workflow:test            # Test the manual prebuilt pilot, REST lifecycle, CLI args, and HTTP/browser smoke
-pnpm vercel:preview:test             # Test automatic UI preview state, trust boundaries, retries, and Git ownership
+pnpm vercel:preview:test             # Test preview state plus reusable smoke trust, native-adapter, and Git-ownership boundaries
 pnpm vercel:versions:check           # Verify pinned Next.js/Vercel CLI custom-ID prerequisites
 pnpm vercel:plan --base <sha> --head <sha>  # Emit the fail-closed Vercel target plan
 gh pr view --json body --jq .body | pnpm pr:description:check  # Validate the current PR body
@@ -128,7 +128,17 @@ See [docs/wallet-testing.md](docs/wallet-testing.md) for the full runbook.
 
 In CI, `.github/workflows/e2e.yml` triggers on every PR (plus the nightly schedule and manual `workflow_dispatch`) and always reports both check runs. An `e2e-plan` job computes `run_app`/`run_gov`/`run_monad` from changed files (`apps/app.mento.org/**` -> `run_app` + `run_monad`; `apps/governance.mento.org/**` -> `run_gov`; `packages/web3/**` and `packages/ui/**` -> all three; `scripts/fork-seed-monad.*` -> `run_monad`; root-level files like `package.json`/`turbo.json`/the workflow itself -> all three) and fast-no-ops the fork jobs to a green skip when their surface didn't change — that "always reports" property is the prerequisite for eventually adding these checks to the required-checks ruleset (`strict_required_status_checks_policy` would otherwise deadlock non-matching PRs). Scheduled and manually-dispatched runs force both outputs true (no "changed files" concept for a cron trigger, and a manual run's point is to run regardless of what changed). A cheap `fork-seed-self-test` job (no anvil, no network) runs unconditionally on every trigger; if it fails, the fork jobs still start (so the failure surfaces as a real check failure, not a silently-passing skip) but bail out in their first step instead of running the full 30-minute anvil suite. `e2e-connected` ("Connected swap (anvil fork)") and `e2e-governance` ("Connected governance (anvil fork)") both fork Celo mainnet pinned to `FORK_BLOCK` (bump roughly monthly). The fork source is a keyless public archive RPC probed at run time — forno cannot serve pinned-block forks because it prunes a block's state within minutes. A nightly scheduled run (04:20 UTC) repeats the suites at a freshly resolved recent block instead of the pin, to catch chain drift (oracle config, pool, or contract changes) that plan-gated PR runs never see. `e2e-connected-monad` ("Connected swap (Monad anvil fork)") is the Monad sibling: it forks Monad mainnet (chain 143) on port 8546 via `scripts/fork-seed-monad.mjs`, gated on `run_monad`. Unlike the Celo jobs it resolves a fresh block near `finalized` on every trigger (rpc.monad.xyz primary, monad.drpc.org fallback) rather than pinning, because Monad's public RPCs' deep archive retention is unproven while forking near finalized is the verified-servable window. None of these checks is a required check yet.
 
-Native Vercel Git previews additionally get a walletless smoke via `.github/workflows/preview-smoke.yml`: mock wallet connect on `*-mentolabs.vercel.app` hosts, real-chain reads (no fork), no transactions. GitHub-built UI previews use direct credential-free HTTP and browser smoke inside `.github/workflows/_vercel-prebuilt.yml`; `GITHUB_TOKEN` Deployment statuses do not trigger the legacy smoke workflow. The automatic exact-SHA controller, bootstrap, canary, cutover, and rollback contract is in `docs/vercel-deployments.md`.
+All preview verification lives in the secretless reusable
+`.github/workflows/_vercel-preview-smoke.yml`: common immutable-URL, metadata,
+header, asset, console, and browser checks plus target-specific App/Governance
+wallet flow, Reserve tab/data interaction, or UI deployment-identity flow. The
+temporary `.github/workflows/preview-smoke.yml` adapter calls that reusable
+workflow for every exact native Vercel App/Governance success; it performs no
+status lookup or reuse and receives no deployment credential. GitHub-built
+workers call the reusable workflow directly because a `GITHUB_TOKEN` Deployment
+status is evidence, not a downstream trigger contract. The automatic exact-SHA
+controller, bootstrap, canary, cutover, and rollback contract is in
+`docs/vercel-deployments.md`.
 
 ## Coding Conventions
 

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ pnpm vercel:primitives:test
 # Test the manual UI prebuilt workflow, GitHub Deployment lifecycle, and smoke controller
 pnpm vercel:workflow:test
 
-# Test automatic UI preview state, workflow trust boundaries, and Git ownership
+# Test preview state, reusable smoke trust, native-adapter, and Git ownership
 pnpm vercel:preview:test
 
 # Verify exact Next.js and Vercel CLI custom deployment-ID prerequisites

--- a/apps/app.mento.org/e2e/preview/smoke.spec.ts
+++ b/apps/app.mento.org/e2e/preview/smoke.spec.ts
@@ -1,13 +1,86 @@
-import { expect, test } from "@playwright/test";
+import { expect, test, type Page } from "@playwright/test";
 
 // Walletless + mock-wallet smoke against a REAL deployed preview (real forno
 // reads, no fork, no transactions). Run via
 // `PREVIEW_URL=<url> pnpm --filter app.mento.org test:preview`. See
-// docs/wallet-testing.md's "Preview smoke" section and
-// .github/workflows/preview-smoke.yml (triggers this on `deployment_status`
-// for team `-mentolabs.vercel.app` previews of app.mento.org/governance.mento.org).
+// docs/wallet-testing.md's "Preview smoke" section and the secretless reusable
+// .github/workflows/_vercel-preview-smoke.yml. The temporary native adapter and
+// GitHub-built workers both call that same target-bound implementation.
 
 const BLOCK_SCREEN_HEADINGS = ["Access Restricted", "Verification unavailable"];
+const MAXIMUM_BROWSER_FAILURES = 100;
+const browserFailures = new WeakMap<Page, string[]>();
+
+function concise(value: unknown) {
+  return String(value).replaceAll(/\s+/g, " ").trim().slice(0, 500);
+}
+
+function isExpectedNextNavigationAbort(
+  urlValue: string,
+  resourceType: string,
+  errorText: string,
+  expectedOrigin: string,
+) {
+  try {
+    const url = new URL(urlValue);
+    return (
+      url.origin === expectedOrigin &&
+      url.searchParams.has("_rsc") &&
+      errorText === "net::ERR_ABORTED" &&
+      (resourceType === "fetch" || resourceType === "xhr")
+    );
+  } catch {
+    return false;
+  }
+}
+
+function attachBrowserFailureMonitor(page: Page, expectedOrigin: string) {
+  const failures: string[] = [];
+  browserFailures.set(page, failures);
+  const record = (failure: string) => {
+    if (failures.length < MAXIMUM_BROWSER_FAILURES) failures.push(failure);
+  };
+  const sameOrigin = (value: string) => {
+    try {
+      return new URL(value).origin === expectedOrigin;
+    } catch {
+      return false;
+    }
+  };
+
+  page.on("pageerror", (error) => {
+    record(`page error: ${concise(error.message)}`);
+  });
+  page.on("console", (message) => {
+    if (message.type() === "error") {
+      record(`console error: ${concise(message.text())}`);
+    }
+  });
+  page.on("requestfailed", (request) => {
+    const errorText = request.failure()?.errorText ?? "unknown error";
+    if (
+      !sameOrigin(request.url()) ||
+      isExpectedNextNavigationAbort(
+        request.url(),
+        request.resourceType(),
+        errorText,
+        expectedOrigin,
+      )
+    ) {
+      return;
+    }
+    record(
+      `same-origin request failed: ${request.method()} ${concise(request.url())} (${concise(errorText)})`,
+    );
+  });
+  page.on("response", (response) => {
+    if (sameOrigin(response.url()) && response.status() >= 400) {
+      record(
+        `same-origin response failed: HTTP ${response.status()} ${concise(response.url())}`,
+      );
+    }
+  });
+}
 
 // Preflight: playwright.preview.config.ts deliberately does NOT validate
 // PREVIEW_URL at config-load time (that would break knip's static config
@@ -19,6 +92,23 @@ test.beforeAll(() => {
       "PREVIEW_URL env var is required — e.g. PREVIEW_URL=https://appmento-<hash>-mentolabs.vercel.app pnpm --filter app.mento.org test:preview",
     );
   }
+});
+
+test.beforeEach(({ page }) => {
+  attachBrowserFailureMonitor(
+    page,
+    new URL(process.env.PREVIEW_URL as string).origin,
+  );
+});
+
+test.afterEach(async ({ page }) => {
+  // Capture failures emitted by hydration or wallet state updates immediately
+  // after the final visible assertion, not only during initial page load.
+  await page.waitForTimeout(250);
+  const failures = browserFailures.get(page) ?? [];
+  expect(failures, `Preview browser failures:\n${failures.join("\n")}`).toEqual(
+    [],
+  );
 });
 
 test("deployed bundle boots and lists real wallets", async ({ page }) => {

--- a/apps/app.mento.org/playwright.preview.config.ts
+++ b/apps/app.mento.org/playwright.preview.config.ts
@@ -11,8 +11,8 @@ import { defineConfig } from "@playwright/test";
 // no network blocking, no clock freezing — this exercises real deployed
 // infra (real forno reads) rather than a deterministic local snapshot. See
 // docs/wallet-testing.md's "Preview smoke" section and
-// .github/workflows/preview-smoke.yml, which sets PREVIEW_URL from the
-// triggering deployment_status event.
+// .github/workflows/_vercel-preview-smoke.yml, which sets PREVIEW_URL from a
+// trusted, target-bound deployment tuple.
 export default defineConfig({
   testDir: "./e2e/preview",
   fullyParallel: true,

--- a/apps/ui.mento.org/e2e/vercel-preview-browser-smoke.mjs
+++ b/apps/ui.mento.org/e2e/vercel-preview-browser-smoke.mjs
@@ -329,10 +329,21 @@ function createBrowserDeploymentIdentityMonitor(page, expectedOrigin) {
   };
 }
 
-export async function runBrowserSmoke({ chromium, input, timeoutMs = 30_000 }) {
+export async function runBrowserSmoke({
+  chromium,
+  input,
+  timeoutMs = 30_000,
+  browserChannel = "chrome",
+}) {
   const validated = validateBrowserSmokeInput(input);
   const baseUrl = new URL(validated.deploymentUrl);
-  const browser = await chromium.launch({ channel: "chrome", headless: true });
+  if (browserChannel !== "chrome" && browserChannel !== "bundled") {
+    throw new Error("Browser smoke channel is invalid");
+  }
+  const browser = await chromium.launch({
+    ...(browserChannel === "chrome" ? { channel: "chrome" } : {}),
+    headless: true,
+  });
   try {
     const context = await browser.newContext();
     const page = await context.newPage();
@@ -440,6 +451,7 @@ async function runBrowserSmokeFromEnvironment({
 } = {}) {
   const result = await runBrowserSmoke({
     chromium: await loadChromium(controllerRoot),
+    browserChannel: environment.PLAYWRIGHT_BROWSER_CHANNEL ?? "chrome",
     input: {
       deploymentUrl: environment.VERCEL_DEPLOYMENT_URL,
       commitSha: environment.DEPLOY_SHA,

--- a/apps/ui.mento.org/e2e/vercel-preview-browser-smoke.test.mjs
+++ b/apps/ui.mento.org/e2e/vercel-preview-browser-smoke.test.mjs
@@ -326,6 +326,20 @@ test("browser smoke renders, navigates through search, and changes a control", a
   );
 });
 
+test("browser smoke can use the bundled Playwright Chromium in the reusable smoke container", async () => {
+  const page = new FakePage();
+  const fake = fakeChromium(page);
+
+  await runBrowserSmoke({
+    chromium: fake.chromium,
+    input: INPUT,
+    browserChannel: "bundled",
+  });
+
+  assert.deepEqual(fake.state.launchOptions, { headless: true });
+  assert.equal(fake.state.closed, true);
+});
+
 test("browser smoke waits for route assets before testing hydration", async () => {
   const routeAsset = `${INPUT.deploymentUrl}/_next/static/form.js?dpl=${NEXT_DEPLOYMENT_ID}`;
   const page = new FakePage({

--- a/docs/adr/0001-github-actions-vercel-deployment-orchestration.md
+++ b/docs/adr/0001-github-actions-vercel-deployment-orchestration.md
@@ -142,6 +142,19 @@ success. App and governance additionally retain the temporary native
 a status created with the repository `GITHUB_TOKEN` is evidence, not a trigger
 contract.
 
+The direct smoke is one credential-free reusable workflow shared by all four
+targets and the temporary native adapter. Its input is an already verified,
+mode-discriminated metadata tuple; it never looks up deployment metadata with a
+token. Native App/Governance events are accepted only for the exact Vercel bot,
+exact preview environment, empty native payload, successful status, and exact
+project-slug team host. They always run the full smoke: historical status reuse
+was rejected because deployment-status writers could forge description-only
+dedupe and the extra reconstruction complexity would save public Actions
+minutes rather than Vercel build minutes. The adapter also has no shared
+concurrency group: GitHub may replace an older pending member of a concurrency
+group even with `cancel-in-progress: false`, so grouping would violate the
+one-full-smoke-per-qualifying-event invariant.
+
 ### Path-aware planning
 
 Deployment planning is repository-owned, deterministic, and offline-testable.

--- a/docs/vercel-deployments.md
+++ b/docs/vercel-deployments.md
@@ -711,12 +711,12 @@ reusable workflow published `deployment_url` only from the smoke-backed success
 step; it never fell back to the unverified upload output.
 
 A Deployment or status created with the repository `GITHUB_TOKEN` does not
-trigger another workflow run. Therefore `.github/workflows/preview-smoke.yml`
-did not recurse for the pilot. Direct smoke in the reusable worker was the
-required success gate. Do not add a PAT to force `deployment_status` recursion;
-the Phase A pilot did not need one. The dedicated worker-dispatch PAT was not
-an exception; its sole purpose was the automatic controller's worker
-`workflow_dispatch` POST described below.
+trigger another workflow run. Therefore workers call the secretless
+`.github/workflows/_vercel-preview-smoke.yml` directly before terminal success;
+they never depend on `deployment_status` recursion. Do not add a PAT to force
+that recursion. The dedicated worker-dispatch credential is not an exception;
+its sole purpose is the automatic controller's worker `workflow_dispatch` POST
+described below.
 
 ### Historical Phase A evidence and browser verification
 
@@ -738,6 +738,40 @@ after Phase B disables native UI branch previews; current validation uses the
 The cost go/no-go record in issue #518 and the Phase A live-canary evidence
 below were prerequisites for the final UI Git-ownership cutover. The current
 Phase B ownership model reflects that gate having completed.
+
+## Reusable secretless preview verification
+
+`.github/workflows/_vercel-preview-smoke.yml` is the one smoke implementation
+for App, Governance, Reserve, and UI. Its caller supplies an already verified,
+target-bound tuple: logical target, immutable team URL, exact SHA, canonical
+GitHub Deployment ID, mode-specific verification key, and trusted deployment
+metadata. Controller/manual-pilot mode additionally binds the literal Vercel
+project, Vercel Deployment ID, and target-specific Next.js deployment ID.
+Native-adapter mode is restricted to App/Governance and binds the exact native
+environment plus Vercel bot identity; it cannot fabricate a controller key.
+
+The reusable workflow declares no secrets and performs no authenticated Vercel
+or GitHub lookup. It validates the tuple before any request, checks the root
+response, security headers, representative JavaScript/CSS/font assets, browser
+console/page errors, and same-origin failures, then runs the target interaction:
+
+- App/Governance: real wallet list and team-host-only mock wallet connection;
+- Reserve: Overview data plus Supply tab and URL/state transition;
+- UI: exact build/asset identity, navigation, and hydrated control interaction.
+
+The temporary `.github/workflows/preview-smoke.yml` native adapter classifies
+only exact successful `Preview – app.mento.org` and
+`Preview – governance.mento.org` events created by Vercel's fixed bot identity
+on the exact project-slug team host. Production/v3, inactive/skipped, main,
+controller-payload, actor-lookalike, Reserve, and UI events do not call smoke.
+Every qualifying event runs the full reusable workflow. No historical status
+is listed or trusted for dedupe, and the adapter deliberately declares no
+workflow or job concurrency group: GitHub replaces an older pending run in a
+shared group even when `cancel-in-progress` is false, which would violate the
+one-full-smoke-per-event contract. The appended terminal status is bounded,
+run-specific evidence only. The adapter receives no PAT, Vercel token, Turbo
+token, or application secret and is deleted after all native consumers leave
+the observation window.
 
 ## Automatic trusted UI previews (current; introduced in Phase A)
 

--- a/docs/vercel-deployments.md
+++ b/docs/vercel-deployments.md
@@ -338,10 +338,13 @@ the reusable workflow contains no matrix or dynamic project/secret lookup.
 
 This generic core does not itself activate the remaining applications. The
 current automatic worker continues to call only the UI target with
-`preview-controller:v1`, and the current direct browser smoke remains UI-only.
-App, Governance, and Reserve callers plus their target-specific smoke must land
-before those targets can dispatch. No ownership configuration changes as part
-of this interface preparation.
+`preview-controller:v1`. Both its initial upload path and its same-upload retry
+call the secretless four-target `_vercel-preview-smoke.yml` workflow with the
+complete verified tuple before canonical Deployment success. App, Governance,
+and Reserve already have target-specific smoke implementations, but their
+literal controller callers remain absent until the separate atomic activation
+change. No ownership configuration changes as part of this interface
+preparation.
 
 The reusable declaration has the three common secrets
 (`VERCEL_TOKEN_PREVIEW`, `TURBO_TOKEN`, and
@@ -1162,20 +1165,23 @@ through the protected Node.js runtime copied before candidate execution, not
 the hosted toolcache path the candidate can reach.
 
 Lifecycle is `queued -> in_progress -> success|failure|error`. Success and the
-public `environment_url` exist only after exact-SHA/ID verification and direct
-UI smoke. Every initial or resumed credential-free smoke attempt keeps the
-HTTP/header/static-asset checks, then uses the trusted main-branch smoke
-controller with Playwright and the GitHub runner's system Chrome to render the
-showcase, search and navigate to a second route, change a form control, and fail
-on page/console errors or failed same-origin requests and responses. The direct
-HTTP phase verifies the server-rendered `data-dpl-id`; after hydration, the
-browser phase requires every loaded same-origin `/_next/static/` asset to carry
-exactly the expected `?dpl=` value and rejects any conflicting retained HTML
-deployment marker. Controller-side request monitoring remains active through
-the second-route interaction, so dynamically loaded chunks cannot escape the
-same identity check. The controller waits for all observed static requests to
-finish and for a quiet window before its final assertion. This preserves
-fail-closed deployment-identity proof when
+public `environment_url` exist only after exact-SHA/ID verification and the
+single secretless reusable smoke. Both the initial upload and same-upload retry
+pass the complete controller-bound tuple to
+`.github/workflows/_vercel-preview-smoke.yml`; the old embedded UI-only HTTP and
+parallel browser paths no longer exist. The reusable workflow runs in the
+pinned Playwright container and keeps the common bounded
+HTTP/header/static-asset checks before the trusted UI deployment-identity
+browser flow renders the showcase, searches and navigates to a second route,
+changes a form control, and fails on page/console errors or failed same-origin
+requests and responses. The HTTP phase verifies the server-rendered
+`data-dpl-id`; after hydration, the browser phase requires every loaded
+same-origin `/_next/static/` asset to carry exactly the expected `?dpl=` value
+and rejects any conflicting retained HTML deployment marker. Request monitoring
+remains active through the second-route interaction, so dynamically loaded
+chunks cannot escape the same identity check. The controller waits for all
+observed static requests to finish and for a quiet window before its final
+assertion. This preserves fail-closed deployment-identity proof when
 React reconciles the server-injected HTML attribute out of the live DOM. Chrome
 also waits for the initial page load before changing controlled inputs, then
 rechecks the changed form control after the hydration/interaction settle. Its

--- a/docs/wallet-testing.md
+++ b/docs/wallet-testing.md
@@ -220,16 +220,30 @@ Maintenance couplings specific to this spec:
 
 ## Preview smoke
 
-A separate, walletless smoke runs against REAL deployed Vercel previews
-(real forno reads, no fork, no transactions) — no local anvil, no build
-step. `.github/workflows/preview-smoke.yml` triggers on `deployment_status`
-for team `*-mentolabs.vercel.app` previews of app.mento.org and
-governance.mento.org, and runs
+A separate, walletless smoke runs against REAL deployed Vercel previews (real
+forno reads, no fork, no transactions) — no local anvil and no build step.
+`.github/workflows/_vercel-preview-smoke.yml` is the secretless reusable
+implementation for App, Governance, Reserve, and UI. It validates a trusted,
+target-bound deployment tuple, then runs common immutable-host, security-header,
+representative-asset, console, and same-origin network checks. App and
+Governance additionally run
 `PREVIEW_URL=<deployment url> pnpm --filter app.mento.org test:preview`
 (config: `apps/app.mento.org/playwright.preview.config.ts`, spec:
-`apps/app.mento.org/e2e/preview/smoke.spec.ts`). It checks that the deployed
-bundle boots and lists the real wallet options, then that the mock wallet
-can connect on a preview host. Run it locally against any live preview URL:
+`apps/app.mento.org/e2e/preview/smoke.spec.ts`). That flow checks that the
+deployed bundle lists the real wallet options and that the mock wallet can
+connect only on an allowlisted team preview host.
+
+GitHub-built workers call the reusable workflow directly before posting a
+successful canonical Deployment status. While native Vercel Git still owns App
+and Governance branch previews, `.github/workflows/preview-smoke.yml` is a
+temporary `deployment_status` adapter. It accepts only the exact Vercel bot,
+exact `Preview – <project>` environment, successful status, empty native
+Deployment payload, and exact project-slug team hostname. Every qualifying
+event runs the full smoke; the adapter does not query or reuse earlier statuses
+or use a lossy shared concurrency group, and has no PAT or Vercel credential.
+
+Run the wallet-specific portion locally against any live App or Governance
+preview URL:
 
 ```bash
 PREVIEW_URL=https://appmento-<hash>-mentolabs.vercel.app pnpm --filter app.mento.org test:preview

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "vercel:env:check": "node scripts/vercel-build-environment.mjs check",
     "vercel:plan": "node scripts/plan-vercel-deployments.mjs",
     "vercel:prebuilt:assert": "node scripts/vercel-prebuilt.mjs assert-output",
-    "vercel:preview:test": "node --test scripts/vercel-preview-controller.test.mjs scripts/vercel-preview-workflows.test.mjs scripts/vercel-git-ownership.test.mjs",
+    "vercel:preview:test": "node --test scripts/vercel-preview-controller.test.mjs scripts/vercel-preview-workflows.test.mjs scripts/vercel-preview-smoke.test.mjs scripts/vercel-preview-browser-smoke.test.mjs scripts/vercel-preview-smoke-workflows.test.mjs scripts/vercel-git-ownership.test.mjs",
     "vercel:primitives:test": "node --test scripts/plan-vercel-deployments.test.mjs scripts/vercel-build-environment.test.mjs scripts/vercel-prebuilt.test.mjs",
     "vercel:versions:check": "node scripts/vercel-prebuilt.mjs check-versions",
     "vercel:workflow:test": "node --test scripts/github-deployment.test.mjs scripts/vercel-prebuilt-workflow.test.mjs scripts/vercel-prebuilt-workflows.test.mjs apps/ui.mento.org/e2e/vercel-preview-browser-smoke.test.mjs"

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
   },
   "devDependencies": {
     "@eslint/js": "catalog:",
+    "@playwright/test": "catalog:",
     "@repo/eslint-config": "workspace:*",
     "@types/node": "catalog:",
     "eslint": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,9 @@ catalogs:
     '@metamask/jazzicon':
       specifier: github:jmrossy/jazzicon#7a8df28
       version: 2.1.0
+    '@playwright/test':
+      specifier: 1.61.1
+      version: 1.61.1
     '@rainbow-me/rainbowkit':
       specifier: ^2.2.11
       version: 2.2.11
@@ -173,6 +176,9 @@ importers:
       '@eslint/js':
         specifier: 'catalog:'
         version: 9.39.2
+      '@playwright/test':
+        specifier: 'catalog:'
+        version: 1.61.1
       '@repo/eslint-config':
         specifier: workspace:*
         version: link:packages/eslint-config

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,6 +6,7 @@ catalog:
   "@eslint/js": ^9.39.2
   "@mento-protocol/mento-sdk": 3.3.0-beta.5
   "@metamask/jazzicon": github:jmrossy/jazzicon#7a8df28
+  "@playwright/test": 1.61.1
   "@rainbow-me/rainbowkit": ^2.2.11
   "@sentry/nextjs": ^10.35.0
   "@t3-oss/env-nextjs": ^0.13.11

--- a/scripts/vercel-prebuilt-workflow.mjs
+++ b/scripts/vercel-prebuilt-workflow.mjs
@@ -2895,156 +2895,6 @@ export async function withValidatedPrebuiltUpload(options, upload) {
   return upload();
 }
 
-function requireHeader(response, name, expected) {
-  const value = response.headers.get(name);
-  if (
-    expected instanceof RegExp
-      ? !expected.test(value ?? "")
-      : value !== expected
-  ) {
-    throw new Error(`Preview response has an invalid ${name} header`);
-  }
-}
-
-function successfulText(response, body, label) {
-  if (!response.ok)
-    throw new Error(`${label} returned HTTP ${response.status}`);
-  if (typeof body !== "string") {
-    throw new Error(`${label} returned an invalid body`);
-  }
-  return body;
-}
-
-async function fetchWithTimeout({
-  fetchImplementation,
-  url,
-  options,
-  bodyType,
-  label,
-  timeoutMs,
-}) {
-  if (!Number.isSafeInteger(timeoutMs) || timeoutMs < 1 || timeoutMs > 30_000) {
-    throw new Error("Preview smoke request timeout is invalid");
-  }
-  const controller = new AbortController();
-  let timeout;
-  try {
-    const request = (async () => {
-      const response = await fetchImplementation(url, {
-        ...options,
-        signal: controller.signal,
-      });
-      if (!response.ok) return { response, body: undefined };
-      const body =
-        bodyType === "text"
-          ? await response.text()
-          : await response.arrayBuffer();
-      return { response, body };
-    })();
-    return await Promise.race([
-      request,
-      new Promise((_, reject) => {
-        timeout = setTimeout(() => {
-          controller.abort();
-          reject(new Error(`${label} timed out`));
-        }, timeoutMs);
-      }),
-    ]);
-  } finally {
-    clearTimeout(timeout);
-  }
-}
-
-export async function smokeUiPreview({
-  deploymentUrl,
-  deploymentId,
-  fetchImplementation = fetch,
-  requestTimeoutMs = 15_000,
-}) {
-  const baseUrl = immutableVercelUrl(deploymentUrl);
-  const { response: mainResponse, body: mainBody } = await fetchWithTimeout({
-    fetchImplementation,
-    url: baseUrl,
-    options: { redirect: "follow" },
-    bodyType: "text",
-    label: "UI preview",
-    timeoutMs: requestTimeoutMs,
-  });
-  const html = successfulText(mainResponse, mainBody, "UI preview");
-  if (!html.includes("Basic Components")) {
-    throw new Error("UI preview did not render the Basic Components page");
-  }
-  if (!html.includes(`data-dpl-id="${deploymentId}"`)) {
-    throw new Error(
-      "UI preview HTML does not carry the expected build deployment ID",
-    );
-  }
-  requireHeader(
-    mainResponse,
-    "content-security-policy",
-    "frame-ancestors 'none'",
-  );
-  requireHeader(mainResponse, "x-frame-options", "DENY");
-  requireHeader(mainResponse, "x-content-type-options", "nosniff");
-  requireHeader(
-    mainResponse,
-    "content-security-policy-report-only",
-    /https:\/\/vercel\.live/,
-  );
-
-  const { response: navigationResponse, body: navigationBody } =
-    await fetchWithTimeout({
-      fetchImplementation,
-      url: new URL("/form-components", baseUrl),
-      options: { redirect: "follow" },
-      bodyType: "text",
-      label: "UI preview navigation",
-      timeoutMs: requestTimeoutMs,
-    });
-  const navigationHtml = successfulText(
-    navigationResponse,
-    navigationBody,
-    "UI preview navigation",
-  );
-  if (!navigationHtml.includes("Form Components")) {
-    throw new Error("UI preview primary navigation destination did not render");
-  }
-
-  const assets = [
-    ...html.matchAll(/(?:src|href)="([^" ]*\/_next\/static\/[^" ]+)"/g),
-  ].map((match) => match[1].replaceAll("&amp;", "&"));
-  const representatives = [".js", ".css", ".woff2"].map((extension) =>
-    assets.find((asset) =>
-      new URL(asset, baseUrl).pathname.endsWith(extension),
-    ),
-  );
-  if (representatives.some((asset) => asset === undefined)) {
-    throw new Error(
-      "UI preview HTML is missing script, stylesheet, or font assets",
-    );
-  }
-  for (const asset of representatives) {
-    const { response } = await fetchWithTimeout({
-      fetchImplementation,
-      url: new URL(asset, baseUrl),
-      options: { redirect: "follow" },
-      bodyType: "bytes",
-      label: "UI preview static asset",
-      timeoutMs: requestTimeoutMs,
-    });
-    if (!response.ok) {
-      throw new Error(
-        `UI preview static asset returned HTTP ${response.status}`,
-      );
-    }
-  }
-  return {
-    deploymentUrl: baseUrl,
-    deploymentId,
-    checkedAssets: representatives.length,
-  };
-}
-
 function output(name, value) {
   if (!process.env.GITHUB_OUTPUT) throw new Error("GITHUB_OUTPUT is required");
   appendFileSync(process.env.GITHUB_OUTPUT, `${name}=${value}\n`);
@@ -3357,25 +3207,6 @@ function verifyFromEnvironment() {
   );
 }
 
-async function smokeFromEnvironment() {
-  if (!/^[1-9][0-9]*$/.test(process.env.GITHUB_DEPLOYMENT_ID ?? "")) {
-    throw new Error("Smoke requires the canonical GitHub Deployment ID");
-  }
-  if (process.env.LOGICAL_TARGET !== "ui") {
-    throw new Error(
-      "Direct prebuilt smoke is not implemented for this validated target",
-    );
-  }
-  const result = await smokeUiPreview({
-    deploymentUrl: process.env.VERCEL_DEPLOYMENT_URL,
-    deploymentId: process.env.MENTO_NEXT_DEPLOYMENT_ID,
-  });
-  output("smoke_deployment_url", result.deploymentUrl);
-  output("smoke_deployment_id", process.env.VERCEL_DEPLOYMENT_ID);
-  output("smoke_github_deployment_id", process.env.GITHUB_DEPLOYMENT_ID);
-  output("smoke_commit_sha", process.env.DEPLOY_SHA);
-}
-
 function totalFromEnvironment() {
   if (!/^[0-9]+$/.test(process.env.STARTED_AT_MS ?? "")) {
     throw new Error("Workflow start time is invalid");
@@ -3461,11 +3292,10 @@ if (isCliEntrypoint()) {
     process.stdout.write(`${layout.modulesDir}\n`);
   } else if (command === "deploy") await deployFromEnvironment();
   else if (command === "verify") verifyFromEnvironment();
-  else if (command === "smoke") await smokeFromEnvironment();
   else if (command === "total") totalFromEnvironment();
   else {
     throw new Error(
-      "Usage: vercel-prebuilt-workflow.mjs prepare|validate-source|materialize-source|stage-runtime|stage-pnpm-bootstrap|stage-pnpm-runtime|stage-pnpm-launcher|prepare-link|prepare-pull-staging|pull|validate-pull|validate-pull-staging|stage-pull|validate-candidate-pull|build|assert-output|trusted-install-modules-dir|deploy|verify|smoke|total",
+      "Usage: vercel-prebuilt-workflow.mjs prepare|validate-source|materialize-source|stage-runtime|stage-pnpm-bootstrap|stage-pnpm-runtime|stage-pnpm-launcher|prepare-link|prepare-pull-staging|pull|validate-pull|validate-pull-staging|stage-pull|validate-candidate-pull|build|assert-output|trusted-install-modules-dir|deploy|verify|total",
     );
   }
 }

--- a/scripts/vercel-prebuilt-workflow.test.mjs
+++ b/scripts/vercel-prebuilt-workflow.test.mjs
@@ -46,7 +46,6 @@ import {
   PREBUILT_TARGETS,
   prepareVercelPullStaging,
   queryVercelDeployments,
-  smokeUiPreview,
   stageVercelPullForCandidate,
   stageTrustedPnpmBootstrapManifest,
   stageTrustedPnpmLauncher,
@@ -3400,99 +3399,4 @@ test("upload guard rejects unsafe links, special nodes, and runner-writable stat
       fixture.cleanup();
     }
   }
-});
-
-test("direct UI smoke binds URL, custom build ID, navigation, assets, and headers", async () => {
-  const requested = [];
-  const html = `<!doctype html><html data-dpl-id="${DEPLOYMENT_ID}"><body>
-    <h1>Basic Components</h1>
-    <script src="/_next/static/chunks/app.js?dpl=${DEPLOYMENT_ID}"></script>
-    <link href="/_next/static/css/app.css?dpl=${DEPLOYMENT_ID}" rel="stylesheet">
-    <link href="/_next/static/media/inter.woff2" rel="preload">
-  </body></html>`;
-  const fetchImplementation = async (url, options) => {
-    const parsed = new URL(url);
-    requested.push({
-      url: parsed.toString(),
-      headers: options.headers,
-      signal: options.signal,
-    });
-    if (parsed.pathname === "/form-components") {
-      return new Response("<h1>Form Components</h1>");
-    }
-    if (parsed.pathname.startsWith("/_next/static/")) {
-      return new Response("asset");
-    }
-    return new Response(html, {
-      headers: {
-        "content-security-policy": "frame-ancestors 'none'",
-        "content-security-policy-report-only":
-          "default-src 'self'; frame-src https://vercel.live",
-        "x-content-type-options": "nosniff",
-        "x-frame-options": "DENY",
-      },
-    });
-  };
-
-  assert.deepEqual(
-    await smokeUiPreview({
-      deploymentUrl: DEPLOYMENT_URL,
-      deploymentId: DEPLOYMENT_ID,
-      fetchImplementation,
-    }),
-    {
-      deploymentUrl: DEPLOYMENT_URL,
-      deploymentId: DEPLOYMENT_ID,
-      checkedAssets: 3,
-    },
-  );
-  assert.equal(requested.length, 5);
-  assert.ok(requested.every(({ headers }) => headers === undefined));
-  assert.ok(requested.every(({ signal }) => signal instanceof AbortSignal));
-});
-
-test("direct UI smoke fails closed on missing build identity or security evidence", async () => {
-  const response = new Response("<h1>Basic Components</h1>", {
-    headers: {
-      "content-security-policy": "frame-ancestors 'none'",
-      "content-security-policy-report-only": "frame-src https://vercel.live",
-      "x-content-type-options": "nosniff",
-      "x-frame-options": "DENY",
-    },
-  });
-  await assert.rejects(
-    smokeUiPreview({
-      deploymentUrl: DEPLOYMENT_URL,
-      deploymentId: DEPLOYMENT_ID,
-      fetchImplementation: async () => response,
-    }),
-    /does not carry the expected build deployment ID/,
-  );
-});
-
-test("direct UI smoke bounds every network request", async () => {
-  await assert.rejects(
-    smokeUiPreview({
-      deploymentUrl: DEPLOYMENT_URL,
-      deploymentId: DEPLOYMENT_ID,
-      fetchImplementation: async () => new Promise(() => {}),
-      requestTimeoutMs: 5,
-    }),
-    /UI preview timed out/,
-  );
-});
-
-test("direct UI smoke bounds response body consumption", async () => {
-  const stalledBody = new ReadableStream({
-    start() {},
-  });
-  await assert.rejects(
-    smokeUiPreview({
-      deploymentUrl: DEPLOYMENT_URL,
-      deploymentId: DEPLOYMENT_ID,
-      fetchImplementation: async () => new Response(stalledBody),
-      requestTimeoutMs: 5,
-    }),
-    /UI preview timed out/,
-  );
 });

--- a/scripts/vercel-prebuilt-workflows.test.mjs
+++ b/scripts/vercel-prebuilt-workflows.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { readdirSync, readFileSync } from "node:fs";
+import { readFileSync } from "node:fs";
 import { test } from "node:test";
 
 import { parse } from "yaml";
@@ -671,61 +671,34 @@ test("uncredentialed smoke gates the always-run trusted lifecycle finalizer", ()
   const smoke = reusable.jobs.smoke;
   const finalize = reusable.jobs.finalize;
   assert.equal(smoke.needs, "prebuilt");
-  assert.equal(smoke["runs-on"], "ubuntu-latest");
   assert.match(smoke.if, /needs\.prebuilt\.result == 'success'/);
+  assert.equal(smoke.uses, "./.github/workflows/_vercel-preview-smoke.yml");
+  assert.equal(Object.hasOwn(smoke, "steps"), false);
+  assert.equal(Object.hasOwn(smoke, "secrets"), false);
+  assert.deepEqual(smoke.permissions, { contents: "read" });
   assert.deepEqual(finalize.needs, ["prebuilt", "smoke"]);
   assert.equal(finalize.if, "always()");
-  assert.deepEqual(
-    smoke.steps.map(({ name }) => name),
-    [
-      "Check out trusted smoke controller only",
-      "Smoke immutable UI preview without deployment credentials",
-      "Set up pinned pnpm for trusted browser smoke",
-      "Set up pinned Node.js and trusted pnpm cache",
-      "Install trusted browser smoke dependencies",
-      "Interact with immutable UI preview in system Chrome",
-    ],
-  );
-  const smokeStep = smoke.steps[1];
-  assert.match(smokeStep.run, /vercel-prebuilt-workflow\.mjs" smoke/);
-  assert.equal(smokeStep.env.LOGICAL_TARGET, "${{ inputs.logical_target }}");
-  const install = smoke.steps.find(
-    ({ name }) => name === "Install trusted browser smoke dependencies",
-  );
-  assert.equal(install["working-directory"], "controller");
-  assert.equal(install.env.PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD, "1");
-  assert.match(install.run, /--frozen-lockfile/);
-  assert.match(install.run, /--ignore-scripts/);
-  assert.match(install.run, /--filter ui\.mento\.org\.\.\./);
-  const smokeCheckout = smoke.steps[0];
-  assert.equal(smokeCheckout.with.path, "controller");
-  assert.equal(smokeCheckout.with.ref, "${{ github.workflow_sha }}");
-  assert.equal(smokeCheckout.with["persist-credentials"], false);
-  assert.equal(
-    smoke.steps.some((step) => step.with?.path === "source"),
-    false,
-  );
-  const nodeSetup = smoke.steps.find(
-    ({ name }) => name === "Set up pinned Node.js and trusted pnpm cache",
-  );
-  assert.equal(
-    nodeSetup.with["cache-dependency-path"],
-    "controller/pnpm-lock.yaml",
-  );
-  const browserSmoke = smoke.steps.find(
-    ({ name }) =>
-      name === "Interact with immutable UI preview in system Chrome",
-  );
-  assert.match(
-    browserSmoke.run,
-    /apps\/ui\.mento\.org\/e2e\/vercel-preview-browser-smoke\.mjs/,
-  );
-  assert.doesNotMatch(browserSmoke.run, /playwright install/);
-  assert.equal(
-    browserSmoke.env.DEPLOYMENT_IDEMPOTENCY_KEY,
-    "${{ inputs.deployment_idempotency_key }}",
-  );
-  assert.ok(smoke.steps.indexOf(smokeStep) < smoke.steps.indexOf(browserSmoke));
+  const expectedTuple = {
+    logical_target: "${{ inputs.logical_target }}",
+    deployment_url: "${{ needs.prebuilt.outputs.verified_deployment_url }}",
+    expected_sha: "${{ needs.prebuilt.outputs.commit_sha }}",
+    github_deployment_id: "${{ needs.prebuilt.outputs.github_deployment_id }}",
+    verification_mode:
+      "${{ inputs.provenance == 'manual-pilot' && 'manual-pilot' || 'controller' }}",
+    verification_key: "${{ inputs.deployment_idempotency_key }}",
+    metadata_logical_target: "${{ inputs.logical_target }}",
+    metadata_target: "${{ inputs.vercel_target }}",
+    metadata_repository: "${{ github.repository }}",
+    metadata_ref: "${{ inputs.git_branch }}",
+    metadata_sha: "${{ needs.prebuilt.outputs.commit_sha }}",
+    metadata_url: "${{ needs.prebuilt.outputs.verified_deployment_url }}",
+    pull_request_number: "${{ inputs.pull_request_number }}",
+    vercel_deployment_id: "${{ needs.prebuilt.outputs.vercel_deployment_id }}",
+    next_deployment_id: "${{ needs.prebuilt.outputs.next_deployment_id }}",
+    expected_project_id: "${{ inputs.vercel_project_id }}",
+    metadata_project_id: "${{ inputs.vercel_project_id }}",
+  };
+  assert.deepEqual(smoke.with, expectedTuple);
   assert.doesNotMatch(
     JSON.stringify(smoke),
     /VERCEL_TOKEN|TURBO_TOKEN|TURBO_REMOTE_CACHE_SIGNATURE_KEY|BYPASS|secrets\./i,
@@ -737,47 +710,39 @@ test("uncredentialed smoke gates the always-run trusted lifecycle finalizer", ()
   assert.match(complete.env.VERCEL_DEPLOYMENT_URL, /needs\.smoke\.outputs/);
   assert.match(complete.env.PREBUILT_RESULT, /needs\.prebuilt\.result/);
   assert.match(complete.env.SMOKE_RESULT, /needs\.smoke\.result/);
+  const evidence = finalize.steps.find(
+    ({ name }) => name === "Record comparison evidence (best effort)",
+  );
+  assert.equal(
+    evidence.env.COMMIT_SHA,
+    "${{ needs.smoke.outputs.expected_sha }}",
+  );
   assert.match(
     reusable.jobs.prebuilt.outputs.github_deployment_id,
     /steps\.create\.outputs\.github_deployment_id/,
   );
 });
 
-test("every direct prebuilt smoke invocation sets its validated logical target", () => {
-  const workflowDirectory = new URL("../.github/workflows/", import.meta.url);
-  const invocations = readdirSync(workflowDirectory)
-    .filter((fileName) => /\.ya?ml$/.test(fileName))
-    .sort()
-    .flatMap((fileName) => {
-      const document = workflow(`.github/workflows/${fileName}`);
-      return Object.entries(document.jobs ?? {}).flatMap(([jobName, job]) =>
-        (job.steps ?? [])
-          .filter(({ run }) =>
-            /vercel-prebuilt-workflow\.mjs["']?\s+smoke\b/.test(run ?? ""),
-          )
-          .map((step) => ({
-            path: `.github/workflows/${fileName}`,
-            job: jobName,
-            step: step.name,
-            logicalTarget: step.env?.LOGICAL_TARGET,
-          })),
-      );
-    });
-
-  assert.deepEqual(invocations, [
-    {
-      path: reusablePath,
-      job: "smoke",
-      step: "Smoke immutable UI preview without deployment credentials",
-      logicalTarget: "${{ inputs.logical_target }}",
-    },
-    {
-      path: ".github/workflows/vercel-preview-worker.yml",
-      job: "resume-ui-smoke",
-      step: "Re-run direct smoke without deployment credentials",
-      logicalTarget: "ui",
-    },
-  ]);
+test("prebuilt and resume paths use only the reusable smoke implementation", () => {
+  const worker = workflow(".github/workflows/vercel-preview-worker.yml");
+  assert.equal(
+    workflow(reusablePath).jobs.smoke.uses,
+    "./.github/workflows/_vercel-preview-smoke.yml",
+  );
+  assert.equal(
+    worker.jobs["resume-ui-smoke"].uses,
+    "./.github/workflows/_vercel-preview-smoke.yml",
+  );
+  for (const path of [
+    reusablePath,
+    ".github/workflows/vercel-preview-worker.yml",
+    "scripts/vercel-prebuilt-workflow.mjs",
+  ]) {
+    assert.doesNotMatch(
+      read(path),
+      /vercel-prebuilt-workflow\.mjs["']?\s+smoke\b|smokeUiPreview|smokeFromEnvironment/,
+    );
+  }
 });
 
 test("public deployment URL exists only after smoke-backed success", () => {

--- a/scripts/vercel-preview-browser-smoke.mjs
+++ b/scripts/vercel-preview-browser-smoke.mjs
@@ -1,0 +1,259 @@
+#!/usr/bin/env node
+
+import { createRequire } from "node:module";
+import { join, resolve } from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+import { validatePreviewSmokeTuple } from "./vercel-preview-smoke.mjs";
+
+const MAXIMUM_FAILURES = 100;
+
+function concise(value) {
+  return String(value).replaceAll(/\s+/g, " ").trim().slice(0, 500);
+}
+
+function sameOrigin(value, expectedOrigin) {
+  try {
+    return new URL(value).origin === expectedOrigin;
+  } catch {
+    return false;
+  }
+}
+
+function expectedNextNavigationAbort(request, expectedOrigin) {
+  try {
+    const url = new URL(request.url());
+    return (
+      url.origin === expectedOrigin &&
+      url.searchParams.has("_rsc") &&
+      request.failure()?.errorText === "net::ERR_ABORTED" &&
+      (!request.resourceType ||
+        request.resourceType() === "fetch" ||
+        request.resourceType() === "xhr")
+    );
+  } catch {
+    return false;
+  }
+}
+
+export function createBrowserFailureMonitor(page, expectedOrigin) {
+  const failures = [];
+  const assets = { scripts: 0, styles: 0, fonts: 0 };
+  const record = (message) => {
+    if (failures.length < MAXIMUM_FAILURES) failures.push(message);
+  };
+
+  page.on("pageerror", (error) => {
+    record(`page error: ${concise(error?.message ?? error)}`);
+  });
+  page.on("console", (message) => {
+    if (message.type() !== "error") return;
+    const location = message.location?.();
+    const suffix = location?.url ? ` (${concise(location.url)})` : "";
+    record(`console error: ${concise(message.text())}${suffix}`);
+  });
+  page.on("requestfailed", (request) => {
+    if (!sameOrigin(request.url(), expectedOrigin)) return;
+    // Next's App Router intentionally aborts a superseded RSC navigation or
+    // prefetch. Static assets and every other same-origin failure still fail.
+    if (expectedNextNavigationAbort(request, expectedOrigin)) return;
+    record(
+      `same-origin request failed: ${concise(request.method())} ${concise(
+        request.url(),
+      )} (${concise(request.failure()?.errorText ?? "unknown error")})`,
+    );
+  });
+  page.on("response", (response) => {
+    if (!sameOrigin(response.url(), expectedOrigin)) return;
+    if (response.status() >= 400) {
+      record(
+        `same-origin response failed: HTTP ${response.status()} ${concise(
+          response.url(),
+        )}`,
+      );
+      return;
+    }
+    if (response.status() >= 200 && response.status() < 300) {
+      const pathname = new URL(response.url()).pathname;
+      if (pathname.endsWith(".js")) assets.scripts += 1;
+      if (pathname.endsWith(".css")) assets.styles += 1;
+      if (/\.(?:woff2?|ttf)$/.test(pathname)) assets.fonts += 1;
+    }
+  });
+
+  return {
+    assets,
+    assertClean() {
+      if (failures.length > 0) {
+        throw new Error(
+          `Browser smoke observed failures:\n- ${failures.join("\n- ")}`,
+        );
+      }
+      for (const [kind, count] of Object.entries(assets)) {
+        if (count === 0)
+          throw new Error(`Browser smoke observed no successful ${kind}`);
+      }
+    },
+  };
+}
+
+function requireSecurityHeaders(response) {
+  const headers = response.headers();
+  if (headers["content-security-policy"] !== "frame-ancestors 'none'") {
+    throw new Error("Preview response has an invalid content-security-policy");
+  }
+  if (headers["x-frame-options"] !== "DENY") {
+    throw new Error("Preview response has an invalid x-frame-options");
+  }
+  if (headers["x-content-type-options"] !== "nosniff") {
+    throw new Error("Preview response has an invalid x-content-type-options");
+  }
+}
+
+async function runTargetInteraction(page, target, deploymentUrl) {
+  if (target === "reserve") {
+    const overview = page.getByRole("tab", { name: "Overview", exact: true });
+    await overview.waitFor({ state: "visible" });
+    if ((await overview.getAttribute("aria-selected")) !== "true") {
+      throw new Error("Reserve Overview tab was not initially selected");
+    }
+    await page
+      .getByText("Supply Breakdown", { exact: true })
+      .waitFor({ state: "visible" });
+    const supply = page.getByRole("tab", { name: "Supply", exact: true });
+    await supply.click();
+    await page.waitForURL(
+      (currentUrl) =>
+        currentUrl.origin === deploymentUrl.origin &&
+        currentUrl.searchParams.get("tab") === "stablecoins",
+      { waitUntil: "commit" },
+    );
+    if (new URL(page.url()).searchParams.get("tab") !== "stablecoins") {
+      throw new Error("Reserve Supply tab URL state did not persist");
+    }
+    if ((await supply.getAttribute("aria-selected")) !== "true") {
+      throw new Error("Reserve Supply tab did not become selected");
+    }
+    return "overview-data-and-supply-tab";
+  }
+  await page.locator("body").waitFor({ state: "visible" });
+  return "wallet-flow-runs-in-the-target-specific-suite";
+}
+
+export async function runBrowserSmoke({
+  chromium,
+  values,
+  timeoutMs = 30_000,
+  browserChannel = "bundled",
+}) {
+  const tuple = validatePreviewSmokeTuple(values);
+  if (tuple.logicalTarget === "ui") {
+    throw new Error("UI must use its deployment-identity browser smoke");
+  }
+  if (browserChannel !== "chrome" && browserChannel !== "bundled") {
+    throw new Error("Browser smoke channel is invalid");
+  }
+  const baseUrl = new URL(tuple.deploymentUrl);
+  const browser = await chromium.launch({
+    ...(browserChannel === "chrome" ? { channel: "chrome" } : {}),
+    headless: true,
+  });
+  try {
+    const context = await browser.newContext({ colorScheme: "dark" });
+    const page = await context.newPage();
+    page.setDefaultTimeout(timeoutMs);
+    page.setDefaultNavigationTimeout(timeoutMs);
+    const monitor = createBrowserFailureMonitor(page, baseUrl.origin);
+    const response = await page.goto(baseUrl.toString(), {
+      waitUntil: "domcontentloaded",
+    });
+    if (!response || !response.ok()) {
+      throw new Error(
+        `Browser navigation failed with HTTP ${response?.status() ?? "unknown"}`,
+      );
+    }
+    if (new URL(page.url()).origin !== baseUrl.origin) {
+      throw new Error("Browser smoke escaped the immutable preview origin");
+    }
+    requireSecurityHeaders(response);
+    const interaction = await runTargetInteraction(
+      page,
+      tuple.logicalTarget,
+      baseUrl,
+    );
+    await page.waitForLoadState("load");
+    await page.waitForTimeout(250);
+    monitor.assertClean();
+    return {
+      logicalTarget: tuple.logicalTarget,
+      deploymentUrl: tuple.deploymentUrl,
+      commitSha: tuple.commitSha,
+      githubDeploymentId: tuple.githubDeploymentId,
+      interaction,
+      assets: monitor.assets,
+    };
+  } finally {
+    await browser.close();
+  }
+}
+
+export async function loadTrustedChromium(controllerRoot) {
+  const require = createRequire(
+    join(controllerRoot, "apps/ui.mento.org/package.json"),
+  );
+  const playwright = require("@playwright/test");
+  if (!playwright?.chromium) {
+    throw new Error("Trusted Playwright chromium dependency is unavailable");
+  }
+  return playwright.chromium;
+}
+
+function valuesFromEnvironment(environment = process.env) {
+  return {
+    logicalTarget: environment.LOGICAL_TARGET,
+    deploymentUrl: environment.VERCEL_DEPLOYMENT_URL,
+    commitSha: environment.DEPLOY_SHA,
+    pullRequestNumber: environment.PULL_REQUEST_NUMBER,
+    githubDeploymentId: environment.GITHUB_DEPLOYMENT_ID,
+    verificationMode: environment.VERIFICATION_MODE,
+    verificationKey: environment.VERIFICATION_KEY,
+    workflowRunId: environment.WORKFLOW_RUN_ID,
+    workflowRunAttempt: environment.WORKFLOW_RUN_ATTEMPT,
+    vercelDeploymentId: environment.VERCEL_DEPLOYMENT_ID,
+    nextDeploymentId: environment.MENTO_NEXT_DEPLOYMENT_ID,
+    expectedProjectId: environment.EXPECTED_PROJECT_ID,
+    metadataLogicalTarget: environment.METADATA_LOGICAL_TARGET,
+    metadataProjectId: environment.METADATA_PROJECT_ID,
+    metadataTarget: environment.METADATA_TARGET,
+    metadataRepository: environment.METADATA_REPOSITORY,
+    metadataRef: environment.METADATA_REF,
+    metadataSha: environment.METADATA_SHA,
+    metadataUrl: environment.METADATA_URL,
+    metadataEnvironment: environment.METADATA_ENVIRONMENT,
+    metadataActorLogin: environment.METADATA_ACTOR_LOGIN,
+    metadataActorId: environment.METADATA_ACTOR_ID,
+    metadataActorType: environment.METADATA_ACTOR_TYPE,
+  };
+}
+
+async function runFromEnvironment({
+  environment = process.env,
+  controllerRoot = fileURLToPath(new URL("../", import.meta.url)),
+} = {}) {
+  const result = await runBrowserSmoke({
+    chromium: await loadTrustedChromium(controllerRoot),
+    values: valuesFromEnvironment(environment),
+    browserChannel: environment.PLAYWRIGHT_BROWSER_CHANNEL ?? "bundled",
+  });
+  process.stdout.write(`${JSON.stringify(result)}\n`);
+}
+
+function isCliEntrypoint() {
+  return (
+    process.argv[1] !== undefined &&
+    fileURLToPath(import.meta.url) === resolve(process.argv[1])
+  );
+}
+
+if (isCliEntrypoint()) await runFromEnvironment();

--- a/scripts/vercel-preview-browser-smoke.test.mjs
+++ b/scripts/vercel-preview-browser-smoke.test.mjs
@@ -1,0 +1,316 @@
+import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
+import { test } from "node:test";
+
+import {
+  createBrowserFailureMonitor,
+  loadTrustedChromium,
+  runBrowserSmoke,
+} from "./vercel-preview-browser-smoke.mjs";
+
+const repoRoot = new URL("../", import.meta.url).pathname;
+const SHA = "0123456789abcdef0123456789abcdef01234567";
+
+function controllerTuple(target) {
+  const deploymentUrl = `https://${target === "reserve" ? "reservemento" : "appmento"}-abc123-mentolabs.vercel.app/`;
+  return {
+    logicalTarget: target,
+    deploymentUrl,
+    commitSha: SHA,
+    pullRequestNumber: "520",
+    githubDeploymentId: "1234",
+    verificationMode: "controller",
+    verificationKey: `vercel-preview:v1:pr:520:target:${target}:sha:${SHA}`,
+    vercelDeploymentId: "dpl_Abc123",
+    nextDeploymentId: `m-${target}-0123456789abcdef012`,
+    expectedProjectId: `prj_${target}`,
+    metadataLogicalTarget: target,
+    metadataProjectId: `prj_${target}`,
+    metadataTarget: "preview",
+    metadataRepository: "mento-protocol/frontend-monorepo",
+    metadataRef: "feature/multi-app-preview",
+    metadataSha: SHA,
+    metadataUrl: deploymentUrl,
+    metadataEnvironment: "",
+    metadataActorLogin: "",
+    metadataActorId: "",
+    metadataActorType: "",
+  };
+}
+
+class FakePage extends EventEmitter {
+  constructor(values, { afterInteraction } = {}) {
+    super();
+    this.values = values;
+    this.afterInteraction = afterInteraction;
+    this.currentUrl = values.deploymentUrl;
+    this.supplySelected = false;
+    this.calls = [];
+  }
+
+  setDefaultTimeout(timeout) {
+    this.calls.push(["timeout", timeout]);
+  }
+
+  setDefaultNavigationTimeout(timeout) {
+    this.calls.push(["navigation-timeout", timeout]);
+  }
+
+  async goto(url, options) {
+    this.calls.push(["goto", url, options]);
+    for (const path of [
+      "/_next/static/app.js",
+      "/_next/static/app.css",
+      "/_next/static/font.woff2",
+    ]) {
+      this.emit("response", {
+        url: () => new URL(path, url).toString(),
+        status: () => 200,
+      });
+    }
+    return {
+      ok: () => true,
+      status: () => 200,
+      headers: () => ({
+        "content-security-policy": "frame-ancestors 'none'",
+        "x-frame-options": "DENY",
+        "x-content-type-options": "nosniff",
+      }),
+    };
+  }
+
+  url() {
+    return this.currentUrl;
+  }
+
+  locator(selector) {
+    assert.equal(selector, "body");
+    return {
+      waitFor: async (options) => {
+        this.calls.push(["body", options]);
+      },
+    };
+  }
+
+  getByText(text, options) {
+    assert.equal(text, "Supply Breakdown");
+    assert.deepEqual(options, { exact: true });
+    return {
+      waitFor: async (waitOptions) => {
+        this.calls.push(["supply-data", waitOptions]);
+      },
+    };
+  }
+
+  getByRole(role, options) {
+    assert.equal(role, "tab");
+    if (options.name === "Overview") {
+      return {
+        waitFor: async (waitOptions) => {
+          this.calls.push(["overview", waitOptions]);
+        },
+        getAttribute: async (attribute) => {
+          assert.equal(attribute, "aria-selected");
+          return "true";
+        },
+      };
+    }
+    if (options.name === "Supply") {
+      return {
+        click: async () => {
+          this.supplySelected = true;
+          this.currentUrl = new URL(
+            "/?tab=stablecoins",
+            this.values.deploymentUrl,
+          ).toString();
+          this.calls.push(["supply-click"]);
+        },
+        getAttribute: async (attribute) => {
+          assert.equal(attribute, "aria-selected");
+          return this.supplySelected ? "true" : "false";
+        },
+      };
+    }
+    throw new Error(`Unexpected role ${options.name}`);
+  }
+
+  async waitForURL(matcher, options) {
+    assert.equal(matcher(new URL(this.currentUrl)), true);
+    assert.deepEqual(options, { waitUntil: "commit" });
+    this.calls.push(["wait-for-url", this.currentUrl]);
+  }
+
+  async waitForLoadState(state) {
+    assert.equal(state, "load");
+    this.calls.push(["load"]);
+  }
+
+  async waitForTimeout(timeout) {
+    this.calls.push(["settle", timeout]);
+    this.afterInteraction?.(this);
+  }
+}
+
+function fakeChromium(page) {
+  const state = { launchOptions: null, contextOptions: null, closed: false };
+  return {
+    state,
+    chromium: {
+      async launch(options) {
+        state.launchOptions = options;
+        return {
+          async newContext(contextOptions) {
+            state.contextOptions = contextOptions;
+            return { newPage: async () => page };
+          },
+          async close() {
+            state.closed = true;
+          },
+        };
+      },
+    },
+  };
+}
+
+test("Reserve browser smoke renders runtime data and changes the Supply tab state", async () => {
+  const values = controllerTuple("reserve");
+  const page = new FakePage(values);
+  const fake = fakeChromium(page);
+  const result = await runBrowserSmoke({ chromium: fake.chromium, values });
+
+  assert.deepEqual(fake.state.launchOptions, { headless: true });
+  assert.deepEqual(fake.state.contextOptions, { colorScheme: "dark" });
+  assert.equal(fake.state.closed, true);
+  assert.equal(result.interaction, "overview-data-and-supply-tab");
+  assert.equal(page.supplySelected, true);
+  assert.ok(page.calls.some(([name]) => name === "supply-data"));
+});
+
+test("App browser smoke uses system Chrome when explicitly requested", async () => {
+  const values = controllerTuple("app");
+  const page = new FakePage(values);
+  const fake = fakeChromium(page);
+  const result = await runBrowserSmoke({
+    chromium: fake.chromium,
+    values,
+    browserChannel: "chrome",
+  });
+
+  assert.deepEqual(fake.state.launchOptions, {
+    channel: "chrome",
+    headless: true,
+  });
+  assert.equal(
+    result.interaction,
+    "wallet-flow-runs-in-the-target-specific-suite",
+  );
+  assert.ok(page.calls.some(([name]) => name === "body"));
+});
+
+test("browser failure monitor fails on console, page, and same-origin asset errors", () => {
+  const origin = "https://appmento-abc123-mentolabs.vercel.app";
+  const page = new EventEmitter();
+  const monitor = createBrowserFailureMonitor(page, origin);
+  page.emit("console", {
+    type: () => "error",
+    text: () => "hydration failed",
+    location: () => ({ url: `${origin}/_next/static/app.js` }),
+  });
+  page.emit("pageerror", new Error("render exploded"));
+  page.emit("requestfailed", {
+    url: () => `${origin}/_next/static/app.js`,
+    method: () => "GET",
+    failure: () => ({ errorText: "net::ERR_FAILED" }),
+  });
+  assert.throws(() => monitor.assertClean(), /hydration failed/);
+});
+
+test("browser failure monitor ignores only Next's expected superseded RSC abort", () => {
+  const origin = "https://reservemento-abc123-mentolabs.vercel.app";
+  const page = new EventEmitter();
+  const monitor = createBrowserFailureMonitor(page, origin);
+  for (const path of [
+    "/_next/static/app.js",
+    "/_next/static/app.css",
+    "/_next/static/font.woff2",
+  ]) {
+    page.emit("response", {
+      url: () => new URL(path, origin).toString(),
+      status: () => 200,
+    });
+  }
+  page.emit("requestfailed", {
+    url: () => `${origin}/?tab=stablecoins&_rsc=route`,
+    method: () => "GET",
+    resourceType: () => "fetch",
+    failure: () => ({ errorText: "net::ERR_ABORTED" }),
+  });
+  assert.doesNotThrow(() => monitor.assertClean());
+
+  page.emit("requestfailed", {
+    url: () => `${origin}/_next/static/app.js`,
+    method: () => "GET",
+    resourceType: () => "script",
+    failure: () => ({ errorText: "net::ERR_ABORTED" }),
+  });
+  assert.throws(() => monitor.assertClean(), /same-origin request failed/);
+});
+
+test("browser failure monitor does not count redirects as successful assets", () => {
+  const origin = "https://appmento-abc123-mentolabs.vercel.app";
+  const page = new EventEmitter();
+  const monitor = createBrowserFailureMonitor(page, origin);
+  for (const path of [
+    "/_next/static/app.js",
+    "/_next/static/app.css",
+    "/_next/static/font.woff2",
+  ]) {
+    page.emit("response", {
+      url: () => new URL(path, origin).toString(),
+      status: () => 302,
+    });
+  }
+  assert.throws(() => monitor.assertClean(), /observed no successful scripts/);
+});
+
+test("browser smoke closes Chromium after an interaction-time failure", async () => {
+  const values = controllerTuple("app");
+  const page = new FakePage(values, {
+    afterInteraction(currentPage) {
+      currentPage.emit("pageerror", new Error("late hydration failure"));
+    },
+  });
+  const fake = fakeChromium(page);
+  await assert.rejects(
+    runBrowserSmoke({ chromium: fake.chromium, values }),
+    /late hydration failure/,
+  );
+  assert.equal(fake.state.closed, true);
+});
+
+test("generic target smoke rejects UI so the stronger deployment-identity path cannot be bypassed", async () => {
+  const values = controllerTuple("app");
+  const uiValues = {
+    ...values,
+    logicalTarget: "ui",
+    deploymentUrl: "https://uimento-abc123-mentolabs.vercel.app/",
+    verificationKey: `vercel-preview:v1:pr:520:target:ui:sha:${SHA}`,
+    nextDeploymentId: "m-ui-0123456789abcdef012",
+    expectedProjectId: "prj_ui",
+    metadataLogicalTarget: "ui",
+    metadataProjectId: "prj_ui",
+    metadataUrl: "https://uimento-abc123-mentolabs.vercel.app/",
+  };
+  await assert.rejects(
+    runBrowserSmoke({
+      chromium: fakeChromium(new FakePage(uiValues)).chromium,
+      values: uiValues,
+    }),
+    /UI must use its deployment-identity browser smoke/,
+  );
+});
+
+test("trusted checkout resolves the pinned Playwright package", async () => {
+  const chromium = await loadTrustedChromium(repoRoot);
+  assert.equal(typeof chromium.launch, "function");
+});

--- a/scripts/vercel-preview-smoke-workflows.test.mjs
+++ b/scripts/vercel-preview-smoke-workflows.test.mjs
@@ -1,0 +1,169 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { test } from "node:test";
+
+import { parse } from "yaml";
+
+function read(relativePath) {
+  return readFileSync(new URL(`../${relativePath}`, import.meta.url), "utf8");
+}
+
+function workflow(relativePath) {
+  return parse(read(relativePath));
+}
+
+const reusablePath = ".github/workflows/_vercel-preview-smoke.yml";
+const adapterPath = ".github/workflows/preview-smoke.yml";
+
+test("reusable preview smoke is workflow_call-only, secretless, and target-bound", () => {
+  const reusable = workflow(reusablePath);
+  assert.deepEqual(Object.keys(reusable.on), ["workflow_call"]);
+  assert.equal(Object.hasOwn(reusable.on.workflow_call, "secrets"), false);
+  assert.deepEqual(reusable.permissions, {});
+  const inputs = reusable.on.workflow_call.inputs;
+  for (const name of [
+    "logical_target",
+    "deployment_url",
+    "expected_sha",
+    "github_deployment_id",
+    "verification_mode",
+    "verification_key",
+    "metadata_logical_target",
+    "metadata_target",
+    "metadata_repository",
+    "metadata_ref",
+    "metadata_sha",
+    "metadata_url",
+  ]) {
+    assert.equal(inputs[name].required, true, `${name} must be required`);
+  }
+  assert.deepEqual(Object.keys(reusable.jobs), ["smoke"]);
+  const smoke = reusable.jobs.smoke;
+  assert.deepEqual(smoke.permissions, { contents: "read" });
+  assert.equal(
+    smoke.container.image,
+    "mcr.microsoft.com/playwright:v1.61.1-noble",
+  );
+  assert.equal(Object.hasOwn(smoke, "environment"), false);
+  assert.match(
+    smoke.outputs.artifact_identity,
+    /steps\.tuple\.outputs\.artifact_identity/,
+  );
+  assert.doesNotMatch(
+    read(reusablePath),
+    /secrets\.|github\.token|GITHUB_TOKEN|VERCEL_TOKEN|TURBO_TOKEN|SENTRY_AUTH_TOKEN|ETHERSCAN_API_KEY/,
+  );
+});
+
+test("reusable smoke validates metadata before common and target-specific browser checks", () => {
+  const smoke = workflow(reusablePath).jobs.smoke;
+  const names = smoke.steps.map(({ name }) => name);
+  const checkout = smoke.steps[0];
+  assert.equal(checkout.with.ref, "${{ github.workflow_sha }}");
+  assert.equal(checkout.with["persist-credentials"], false);
+  assert.ok(
+    names.indexOf("Validate the complete credential-free deployment tuple") <
+      names.indexOf(
+        "Run common HTTP, header, build-ID, and representative-asset smoke",
+      ),
+  );
+  assert.ok(
+    names.indexOf(
+      "Run common HTTP, header, build-ID, and representative-asset smoke",
+    ) <
+      names.indexOf(
+        "Exercise App and Governance wallet list and team-preview mock wallet",
+      ),
+  );
+  const wallet = smoke.steps.find(({ name }) =>
+    name.startsWith("Exercise App"),
+  );
+  assert.match(
+    wallet.if,
+    /logical_target == 'app'.*logical_target == 'governance'/,
+  );
+  assert.equal(wallet.run, "pnpm --filter app.mento.org test:preview");
+  const genericBrowser = smoke.steps.find(({ name }) =>
+    name.startsWith("Run App, Governance, or Reserve"),
+  );
+  assert.equal(genericBrowser.if, "inputs.logical_target != 'ui'");
+  assert.match(
+    genericBrowser.run,
+    /scripts\/vercel-preview-browser-smoke\.mjs/,
+  );
+  const uiBrowser = smoke.steps.find(({ name }) =>
+    name.startsWith("Run UI deployment"),
+  );
+  assert.equal(uiBrowser.if, "inputs.logical_target == 'ui'");
+  assert.match(
+    uiBrowser.run,
+    /apps\/ui\.mento\.org\/e2e\/vercel-preview-browser-smoke\.mjs/,
+  );
+
+  const walletSpec = read("apps/app.mento.org/e2e/preview/smoke.spec.ts");
+  for (const monitoredEvent of [
+    "pageerror",
+    "console",
+    "requestfailed",
+    "response",
+  ]) {
+    assert.match(walletSpec, new RegExp(`page\\.on\\("${monitoredEvent}"`));
+  }
+  assert.match(walletSpec, /test\.afterEach/);
+});
+
+test("native adapter always classifies and runs full App or Governance smoke without lookup or dedupe", () => {
+  const adapter = workflow(adapterPath);
+  assert.deepEqual(adapter.on, { deployment_status: null });
+  assert.deepEqual(adapter.permissions, {});
+  assert.equal(Object.hasOwn(adapter, "concurrency"), false);
+  assert.deepEqual(Object.keys(adapter.jobs), [
+    "classify",
+    "smoke-app",
+    "smoke-governance",
+    "record-native-result",
+  ]);
+  const classify = adapter.jobs.classify;
+  assert.equal(Object.hasOwn(classify, "if"), false);
+  assert.deepEqual(classify.permissions, { contents: "read" });
+  assert.equal(classify.steps[0].with.ref, "${{ github.workflow_sha }}");
+  assert.equal(classify.steps[0].with["persist-credentials"], false);
+  assert.match(JSON.stringify(classify), /classify-native/);
+
+  for (const [jobName, target] of [
+    ["smoke-app", "app"],
+    ["smoke-governance", "governance"],
+  ]) {
+    const job = adapter.jobs[jobName];
+    assert.equal(job.uses, "./.github/workflows/_vercel-preview-smoke.yml");
+    assert.equal(job.with.logical_target, target);
+    assert.match(job.if, new RegExp(`logical_target == '${target}'`));
+    assert.equal(
+      Object.hasOwn(job, "concurrency"),
+      false,
+      "every qualifying event must retain its own full smoke run",
+    );
+  }
+  const raw = read(adapterPath);
+  assert.doesNotMatch(
+    raw,
+    /matrix|concurrency|secrets\.|github\.token|GITHUB_TOKEN|VERCEL_TOKEN|TURBO_TOKEN/,
+  );
+  assert.doesNotMatch(
+    raw,
+    /listDeploymentStatuses|github\.rest\.repos\.getDeployment|github\.request\(|gh api|curl/i,
+  );
+});
+
+test("native adapter records only run-bound terminal evidence and never uses it to skip smoke", () => {
+  const finalizer = workflow(adapterPath).jobs["record-native-result"];
+  assert.match(finalizer.if, /always\(\).*eligible == 'true'/);
+  assert.deepEqual(finalizer.permissions, { deployments: "write" });
+  const script = finalizer.steps[0].with.script;
+  assert.match(script, /createDeploymentStatus/);
+  assert.match(script, /context\.runId/);
+  assert.doesNotMatch(
+    script,
+    /listDeploymentStatuses|github\.rest\.repos\.getDeployment|github\.request\(/,
+  );
+});

--- a/scripts/vercel-preview-smoke-workflows.test.mjs
+++ b/scripts/vercel-preview-smoke-workflows.test.mjs
@@ -112,6 +112,59 @@ test("reusable smoke validates metadata before common and target-specific browse
   assert.match(walletSpec, /test\.afterEach/);
 });
 
+test("automatic UI build and resume use the single reusable smoke without activating other targets", () => {
+  const prebuilt = workflow(".github/workflows/_vercel-prebuilt.yml");
+  const worker = workflow(".github/workflows/vercel-preview-worker.yml");
+  const buildSmoke = prebuilt.jobs.smoke;
+  const resumeSmoke = worker.jobs["resume-ui-smoke"];
+  for (const smoke of [buildSmoke, resumeSmoke]) {
+    assert.equal(smoke.uses, "./.github/workflows/_vercel-preview-smoke.yml");
+    assert.equal(Object.hasOwn(smoke, "steps"), false);
+    assert.equal(Object.hasOwn(smoke, "secrets"), false);
+    for (const tupleField of [
+      "logical_target",
+      "deployment_url",
+      "expected_sha",
+      "github_deployment_id",
+      "verification_mode",
+      "verification_key",
+      "metadata_logical_target",
+      "metadata_target",
+      "metadata_repository",
+      "metadata_ref",
+      "metadata_sha",
+      "metadata_url",
+      "pull_request_number",
+      "vercel_deployment_id",
+      "next_deployment_id",
+      "expected_project_id",
+      "metadata_project_id",
+    ]) {
+      assert.ok(
+        Object.hasOwn(smoke.with, tupleField),
+        `${tupleField} must cross the trusted smoke seam`,
+      );
+    }
+  }
+  assert.equal(buildSmoke.with.logical_target, "${{ inputs.logical_target }}");
+  assert.equal(resumeSmoke.with.logical_target, "ui");
+  assert.equal(resumeSmoke.with.verification_mode, "controller");
+
+  const prebuiltCallers = Object.entries(worker.jobs).filter(
+    ([, job]) => job.uses === "./.github/workflows/_vercel-prebuilt.yml",
+  );
+  assert.deepEqual(
+    prebuiltCallers.map(([name, job]) => [name, job.with.logical_target]),
+    [["deploy-ui-preview", "ui"]],
+  );
+  assert.doesNotMatch(
+    `${read(".github/workflows/_vercel-prebuilt.yml")}\n${read(
+      ".github/workflows/vercel-preview-worker.yml",
+    )}\n${read("scripts/vercel-prebuilt-workflow.mjs")}`,
+    /vercel-prebuilt-workflow\.mjs["']?\s+smoke\b|smokeUiPreview|smokeFromEnvironment/,
+  );
+});
+
 test("native adapter always classifies and runs full App or Governance smoke without lookup or dedupe", () => {
   const adapter = workflow(adapterPath);
   assert.deepEqual(adapter.on, { deployment_status: null });

--- a/scripts/vercel-preview-smoke.mjs
+++ b/scripts/vercel-preview-smoke.mjs
@@ -404,10 +404,6 @@ export function classifyNativePreviewEvent(event, runtime) {
       "Native Deployment payload must be empty",
     );
     invariant(
-      deployment.production_environment === false,
-      "Native preview was marked production",
-    );
-    invariant(
       deployment.transient_environment === false,
       "Native preview transient flag mismatch",
     );

--- a/scripts/vercel-preview-smoke.mjs
+++ b/scripts/vercel-preview-smoke.mjs
@@ -334,12 +334,13 @@ function exactVercelActor(value) {
 }
 
 function runtimeHasExactVercelActor(runtime) {
+  // `actor` remains the original event actor on a workflow re-run, while
+  // `triggering_actor` becomes the maintainer who requested that re-run.
   return (
     runtime.eventName === "deployment_status" &&
     runtime.repository === REPOSITORY &&
     runtime.actor === VERCEL_ACTOR.login &&
-    String(runtime.actorId) === String(VERCEL_ACTOR.id) &&
-    runtime.triggeringActor === VERCEL_ACTOR.login
+    String(runtime.actorId) === String(VERCEL_ACTOR.id)
   );
 }
 
@@ -560,18 +561,54 @@ function representativeAssets(html, baseUrl) {
   const references = [
     ...html.matchAll(/(?:src|href)=["']([^"']*\/_next\/static\/[^"']+)["']/g),
   ].map((match) => match[1].replaceAll("&amp;", "&"));
-  const extensions = [".js", ".css", ".woff2"];
-  return extensions.map((extension) => {
-    const reference = references.find((candidate) => {
-      const url = new URL(candidate, baseUrl);
-      return url.origin === baseUrl.origin && url.pathname.endsWith(extension);
-    });
+  invariant(
+    references.length <= 512,
+    "Preview HTML contains too many static asset references",
+  );
+
+  const assets = [];
+  const seen = new Set();
+  for (const reference of references) {
+    let asset;
+    try {
+      asset = new URL(reference, baseUrl);
+    } catch {
+      throw new Error("Preview HTML contains an invalid static asset URL");
+    }
     invariant(
-      reference,
-      `Preview HTML is missing a representative ${extension} asset`,
+      asset.origin === baseUrl.origin,
+      "Preview HTML contains a cross-origin static asset",
     );
-    return new URL(reference, baseUrl);
-  });
+    if (seen.has(asset.toString())) continue;
+    seen.add(asset.toString());
+    assets.push(asset);
+  }
+
+  const script = assets.find((asset) => asset.pathname.endsWith(".js"));
+  const style = assets.find((asset) => asset.pathname.endsWith(".css"));
+  invariant(script, "Preview HTML is missing a representative .js asset");
+  invariant(style, "Preview HTML is missing a representative .css asset");
+
+  const optionalAssets = assets.filter((asset) =>
+    /\.(?:avif|gif|ico|jpe?g|otf|png|svg|ttf|webp|woff2?)$/i.test(
+      asset.pathname,
+    ),
+  );
+  invariant(
+    optionalAssets.length <= 32,
+    "Preview HTML contains too many font or image assets",
+  );
+  return [script, style, ...optionalAssets];
+}
+
+function requireUiHtmlDeploymentIdentity(html, expectedDeploymentId) {
+  const deploymentIds = [
+    ...html.matchAll(/\bdata-dpl-id=(["'])([^"']+)\1/g),
+  ].map((match) => match[2]);
+  invariant(
+    deploymentIds.length === 1 && deploymentIds[0] === expectedDeploymentId,
+    "UI preview HTML does not carry only the expected build deployment ID",
+  );
 }
 
 export async function smokePreviewHttp({
@@ -600,6 +637,9 @@ export async function smokePreviewHttp({
     ),
     "Preview did not render a target-specific document marker",
   );
+  if (tuple.logicalTarget === "ui") {
+    requireUiHtmlDeploymentIdentity(html, tuple.nextDeploymentId);
+  }
   const assets = representativeAssets(html, baseUrl);
   for (const asset of assets) {
     if (tuple.nextDeploymentId) {

--- a/scripts/vercel-preview-smoke.mjs
+++ b/scripts/vercel-preview-smoke.mjs
@@ -1,0 +1,753 @@
+#!/usr/bin/env node
+
+/* eslint-disable turbo/no-undeclared-env-vars -- this trusted entrypoint validates GitHub workflow-only inputs. */
+
+import { createHash } from "node:crypto";
+import { appendFileSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+export const PREVIEW_SMOKE_TARGETS = ["app", "governance", "reserve", "ui"];
+
+const REPOSITORY = "mento-protocol/frontend-monorepo";
+const VERCEL_ACTOR = Object.freeze({
+  login: "vercel[bot]",
+  id: 35_613_825,
+  type: "Bot",
+});
+const SHA_PATTERN = /^[0-9a-f]{40}$/;
+const POSITIVE_INTEGER_PATTERN = /^[1-9][0-9]*$/;
+const PROJECT_ID_PATTERN = /^prj_[A-Za-z0-9]+$/;
+const VERCEL_DEPLOYMENT_ID_PATTERN = /^dpl_[A-Za-z0-9]+$/;
+const REF_PATTERN =
+  /^(?![-/])(?!.*(?:\.\.|\/\/|@\{|[~^:?*[\\\s]))(?!.*(?:\/|\.|\.lock)$).+$/;
+const MAXIMUM_RESPONSE_BYTES = 5 * 1024 * 1024;
+
+const TARGET_CONTRACTS = Object.freeze({
+  app: Object.freeze({
+    hostPattern: /^appmento-[a-z0-9]{6,64}-mentolabs\.vercel\.app$/,
+    nativeEnvironment: "Preview – app.mento.org",
+    documentMarkers: ["Mento App", "Mento"],
+  }),
+  governance: Object.freeze({
+    hostPattern: /^governancemento-[a-z0-9]{6,64}-mentolabs\.vercel\.app$/,
+    nativeEnvironment: "Preview – governance.mento.org",
+    documentMarkers: ["Mento Governance", "Governance"],
+  }),
+  reserve: Object.freeze({
+    hostPattern: /^reservemento-[a-z0-9]{6,64}-mentolabs\.vercel\.app$/,
+    nativeEnvironment: "Preview – reserve.mento.org",
+    documentMarkers: ["Mento Reserve", "Supply Breakdown"],
+  }),
+  ui: Object.freeze({
+    hostPattern: /^uimento-[a-z0-9]{6,64}-mentolabs\.vercel\.app$/,
+    nativeEnvironment: "Preview – ui.mento.org",
+    documentMarkers: ["Basic Components"],
+  }),
+});
+
+function invariant(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+function isPlainObject(value) {
+  return (
+    value !== null &&
+    typeof value === "object" &&
+    !Array.isArray(value) &&
+    Object.getPrototypeOf(value) === Object.prototype
+  );
+}
+
+function requiredText(value, label, pattern, maximum = 2_048) {
+  invariant(
+    typeof value === "string" &&
+      value.length > 0 &&
+      value.length <= maximum &&
+      (!pattern || pattern.test(value)),
+    `${label} is missing or invalid`,
+  );
+  return value;
+}
+
+function optionalEmpty(value, label) {
+  invariant(
+    value === undefined || value === null || value === "",
+    `${label} must be empty`,
+  );
+}
+
+function logicalTarget(value) {
+  invariant(
+    PREVIEW_SMOKE_TARGETS.includes(value),
+    "Logical target is missing or invalid",
+  );
+  return value;
+}
+
+function positiveInteger(value, label) {
+  const text = requiredText(String(value), label, POSITIVE_INTEGER_PATTERN, 20);
+  const number = Number(text);
+  invariant(Number.isSafeInteger(number), `${label} is missing or invalid`);
+  return number;
+}
+
+export function immutableTargetPreviewUrl(value, target) {
+  const contract = TARGET_CONTRACTS[logicalTarget(target)];
+  const text = requiredText(value, "Vercel deployment URL");
+  let parsed;
+  try {
+    parsed = new URL(text);
+  } catch {
+    throw new Error(
+      "Vercel deployment URL is not an immutable target preview URL",
+    );
+  }
+  invariant(
+    parsed.protocol === "https:" &&
+      !parsed.username &&
+      !parsed.password &&
+      !parsed.port &&
+      parsed.pathname === "/" &&
+      !parsed.search &&
+      !parsed.hash &&
+      contract.hostPattern.test(parsed.hostname),
+    "Vercel deployment URL is not an immutable target preview URL",
+  );
+  return parsed.toString();
+}
+
+function nativeVerificationKey(githubDeploymentId, deploymentUrl) {
+  const urlDigest = createHash("sha256").update(deploymentUrl).digest("hex");
+  return {
+    verificationKey: `vercel-native-preview:v1:deployment:${githubDeploymentId}:url-sha256:${urlDigest}`,
+    urlDigest,
+  };
+}
+
+function validateCommonMetadata(values, target, sha, deploymentUrl) {
+  invariant(
+    values.metadataLogicalTarget === target,
+    "Metadata target mismatch",
+  );
+  invariant(
+    values.metadataTarget === "preview",
+    "Metadata Vercel target mismatch",
+  );
+  invariant(
+    values.metadataRepository === REPOSITORY,
+    "Metadata repository mismatch",
+  );
+  invariant(
+    requiredText(values.metadataSha, "Metadata SHA", SHA_PATTERN) === sha,
+    "Metadata SHA mismatch",
+  );
+  const metadataRef = requiredText(
+    values.metadataRef,
+    "Metadata ref",
+    REF_PATTERN,
+    255,
+  );
+  invariant(
+    immutableTargetPreviewUrl(values.metadataUrl, target) === deploymentUrl,
+    "Metadata URL mismatch",
+  );
+  return metadataRef;
+}
+
+function validateCredentialedTuple(values, common) {
+  const expectedProjectId = requiredText(
+    values.expectedProjectId,
+    "Expected project ID",
+    PROJECT_ID_PATTERN,
+    128,
+  );
+  invariant(
+    requiredText(
+      values.metadataProjectId,
+      "Metadata project ID",
+      PROJECT_ID_PATTERN,
+      128,
+    ) === expectedProjectId,
+    "Metadata project ID mismatch",
+  );
+  const vercelDeploymentId = requiredText(
+    values.vercelDeploymentId,
+    "Vercel Deployment ID",
+    VERCEL_DEPLOYMENT_ID_PATTERN,
+    128,
+  );
+  const nextDeploymentId = requiredText(
+    values.nextDeploymentId,
+    "Next.js deployment ID",
+    new RegExp(`^m-${common.logicalTarget}-[0-9a-f]{19}$`),
+    64,
+  );
+  optionalEmpty(values.metadataEnvironment, "Native metadata environment");
+  optionalEmpty(values.metadataActorLogin, "Native metadata actor login");
+  optionalEmpty(values.metadataActorId, "Native metadata actor ID");
+  optionalEmpty(values.metadataActorType, "Native metadata actor type");
+  return {
+    ...common,
+    expectedProjectId,
+    vercelDeploymentId,
+    nextDeploymentId,
+  };
+}
+
+function validateControllerTuple(values, common) {
+  const pullRequestNumber = positiveInteger(
+    values.pullRequestNumber,
+    "Pull request number",
+  );
+  const expectedKey = `vercel-preview:v1:pr:${pullRequestNumber}:target:${common.logicalTarget}:sha:${common.commitSha}`;
+  invariant(
+    values.verificationKey === expectedKey,
+    "Controller verification key does not match the tuple",
+  );
+  return {
+    ...validateCredentialedTuple(values, common),
+    pullRequestNumber,
+  };
+}
+
+function validateManualPilotTuple(values, common) {
+  invariant(
+    common.logicalTarget === "ui",
+    "Manual pilot smoke supports only UI",
+  );
+  const runId = positiveInteger(values.workflowRunId, "Workflow run ID");
+  const runAttempt = positiveInteger(
+    values.workflowRunAttempt,
+    "Workflow run attempt",
+  );
+  const expectedKey = `vercel-pilot:v1:ui:sha:${common.commitSha}:run:${runId}:attempt:${runAttempt}`;
+  invariant(
+    values.verificationKey === expectedKey,
+    "Manual pilot verification key does not match the tuple",
+  );
+  optionalEmpty(values.pullRequestNumber, "Pull request number");
+  return {
+    ...validateCredentialedTuple(values, common),
+    pullRequestNumber: null,
+  };
+}
+
+function validateNativeTuple(values, common) {
+  invariant(
+    common.logicalTarget === "app" || common.logicalTarget === "governance",
+    "Native adapter smoke supports only App and Governance",
+  );
+  const contract = TARGET_CONTRACTS[common.logicalTarget];
+  invariant(
+    values.metadataEnvironment === contract.nativeEnvironment,
+    "Native metadata environment mismatch",
+  );
+  invariant(common.metadataRef !== "main", "Native adapter cannot smoke main");
+  invariant(
+    values.metadataActorLogin === VERCEL_ACTOR.login,
+    "Native metadata actor login mismatch",
+  );
+  invariant(
+    positiveInteger(values.metadataActorId, "Native metadata actor ID") ===
+      VERCEL_ACTOR.id,
+    "Native metadata actor ID mismatch",
+  );
+  invariant(
+    values.metadataActorType === VERCEL_ACTOR.type,
+    "Native metadata actor type mismatch",
+  );
+  const expected = nativeVerificationKey(
+    common.githubDeploymentId,
+    common.deploymentUrl,
+  );
+  invariant(
+    values.verificationKey === expected.verificationKey,
+    "Native verification key does not match the tuple",
+  );
+  optionalEmpty(values.pullRequestNumber, "Pull request number");
+  optionalEmpty(values.expectedProjectId, "Expected project ID");
+  optionalEmpty(values.metadataProjectId, "Metadata project ID");
+  optionalEmpty(values.vercelDeploymentId, "Vercel Deployment ID");
+  optionalEmpty(values.nextDeploymentId, "Next.js deployment ID");
+  return {
+    ...common,
+    pullRequestNumber: null,
+    expectedProjectId: null,
+    vercelDeploymentId: null,
+    nextDeploymentId: null,
+    urlDigest: expected.urlDigest,
+  };
+}
+
+export function validatePreviewSmokeTuple(values) {
+  const target = logicalTarget(values.logicalTarget);
+  const commitSha = requiredText(values.commitSha, "Commit SHA", SHA_PATTERN);
+  const deploymentUrl = immutableTargetPreviewUrl(values.deploymentUrl, target);
+  const githubDeploymentId = positiveInteger(
+    values.githubDeploymentId,
+    "GitHub Deployment ID",
+  );
+  const verificationMode = requiredText(
+    values.verificationMode,
+    "Verification mode",
+    /^(?:controller|manual-pilot|native-adapter)$/,
+    32,
+  );
+  const verificationKey = requiredText(
+    values.verificationKey,
+    "Verification key",
+    undefined,
+    512,
+  );
+  const metadataRef = validateCommonMetadata(
+    values,
+    target,
+    commitSha,
+    deploymentUrl,
+  );
+  const common = {
+    logicalTarget: target,
+    deploymentUrl,
+    commitSha,
+    githubDeploymentId,
+    verificationMode,
+    verificationKey,
+    metadataRef,
+  };
+
+  if (verificationMode === "native-adapter")
+    return validateNativeTuple(values, common);
+  if (verificationMode === "manual-pilot")
+    return validateManualPilotTuple(values, common);
+  return validateControllerTuple(values, common);
+}
+
+function exactVercelActor(value) {
+  return (
+    isPlainObject(value) &&
+    value.login === VERCEL_ACTOR.login &&
+    value.id === VERCEL_ACTOR.id &&
+    value.type === VERCEL_ACTOR.type
+  );
+}
+
+function runtimeHasExactVercelActor(runtime) {
+  return (
+    runtime.eventName === "deployment_status" &&
+    runtime.repository === REPOSITORY &&
+    runtime.actor === VERCEL_ACTOR.login &&
+    String(runtime.actorId) === String(VERCEL_ACTOR.id) &&
+    runtime.triggeringActor === VERCEL_ACTOR.login
+  );
+}
+
+function nativeTargetFromEnvironment(environment) {
+  return Object.entries(TARGET_CONTRACTS).find(
+    ([target, contract]) =>
+      (target === "app" || target === "governance") &&
+      contract.nativeEnvironment === environment,
+  )?.[0];
+}
+
+export function classifyNativePreviewEvent(event, runtime) {
+  try {
+    invariant(isPlainObject(event), "Event payload is invalid");
+    const deployment = event.deployment;
+    const status = event.deployment_status;
+    invariant(
+      isPlainObject(deployment) && isPlainObject(status),
+      "Deployment event tuple is invalid",
+    );
+
+    const target = nativeTargetFromEnvironment(status.environment);
+    if (!target || status.state !== "success") {
+      return {
+        eligible: false,
+        reason: "not-app-governance-native-preview-success",
+      };
+    }
+    const contract = TARGET_CONTRACTS[target];
+    invariant(
+      deployment.environment === contract.nativeEnvironment,
+      "Deployment environment mismatch",
+    );
+    invariant(
+      status.description === "Deployment has completed",
+      "Deployment status description mismatch",
+    );
+    invariant(
+      exactVercelActor(event.sender),
+      "Event sender is not the exact Vercel bot",
+    );
+    invariant(
+      exactVercelActor(deployment.creator),
+      "Deployment creator is not the exact Vercel bot",
+    );
+    invariant(
+      exactVercelActor(status.creator),
+      "Status creator is not the exact Vercel bot",
+    );
+    invariant(
+      runtimeHasExactVercelActor(runtime),
+      "Workflow actor tuple is not the exact Vercel bot",
+    );
+    invariant(
+      event.repository?.full_name === REPOSITORY,
+      "Event repository mismatch",
+    );
+    invariant(deployment.task === "deploy", "Deployment task mismatch");
+    invariant(
+      isPlainObject(deployment.payload) &&
+        Object.keys(deployment.payload).length === 0,
+      "Native Deployment payload must be empty",
+    );
+    invariant(
+      deployment.production_environment === false,
+      "Native preview was marked production",
+    );
+    invariant(
+      deployment.transient_environment === false,
+      "Native preview transient flag mismatch",
+    );
+    const githubDeploymentId = positiveInteger(
+      deployment.id,
+      "GitHub Deployment ID",
+    );
+    const commitSha = requiredText(deployment.sha, "Commit SHA", SHA_PATTERN);
+    const metadataRef = requiredText(
+      deployment.ref,
+      "Deployment ref",
+      REF_PATTERN,
+      255,
+    );
+    invariant(metadataRef !== "main", "Native adapter cannot smoke main");
+    const deploymentUrl = immutableTargetPreviewUrl(
+      status.environment_url,
+      target,
+    );
+    invariant(
+      immutableTargetPreviewUrl(status.log_url, target) === deploymentUrl,
+      "Deployment status log URL mismatch",
+    );
+    const key = nativeVerificationKey(githubDeploymentId, deploymentUrl);
+    return {
+      eligible: true,
+      reason: "exact-native-preview-success",
+      logicalTarget: target,
+      deploymentUrl,
+      expectedSha: commitSha,
+      githubDeploymentId: String(githubDeploymentId),
+      verificationMode: "native-adapter",
+      verificationKey: key.verificationKey,
+      urlDigest: key.urlDigest,
+      metadataLogicalTarget: target,
+      metadataTarget: "preview",
+      metadataRepository: REPOSITORY,
+      metadataRef,
+      metadataSha: commitSha,
+      metadataUrl: deploymentUrl,
+      metadataEnvironment: contract.nativeEnvironment,
+      metadataActorLogin: VERCEL_ACTOR.login,
+      metadataActorId: String(VERCEL_ACTOR.id),
+      metadataActorType: VERCEL_ACTOR.type,
+    };
+  } catch (error) {
+    return {
+      eligible: false,
+      reason: `rejected:${String(error?.message ?? error).slice(0, 200)}`,
+    };
+  }
+}
+
+function requireSecurityHeaders(response) {
+  invariant(
+    response.headers.get("content-security-policy") ===
+      "frame-ancestors 'none'",
+    "Preview response has an invalid content-security-policy",
+  );
+  invariant(
+    response.headers.get("x-frame-options") === "DENY",
+    "Preview response has an invalid x-frame-options",
+  );
+  invariant(
+    response.headers.get("x-content-type-options") === "nosniff",
+    "Preview response has an invalid x-content-type-options",
+  );
+}
+
+async function readBoundedResponseBody(response, bodyType, controller) {
+  const contentLength = response.headers.get("content-length");
+  if (contentLength !== null) {
+    const advertisedBytes = Number(contentLength);
+    if (
+      !Number.isSafeInteger(advertisedBytes) ||
+      advertisedBytes < 0 ||
+      advertisedBytes > MAXIMUM_RESPONSE_BYTES
+    ) {
+      controller.abort();
+      throw new Error("Preview response is too large");
+    }
+  }
+  invariant(
+    response.body && typeof response.body.getReader === "function",
+    "Preview response body is unavailable",
+  );
+
+  const reader = response.body.getReader();
+  const chunks = [];
+  let bodyBytes = 0;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      const chunk = value instanceof Uint8Array ? value : new Uint8Array(value);
+      bodyBytes += chunk.byteLength;
+      if (bodyBytes > MAXIMUM_RESPONSE_BYTES) {
+        controller.abort();
+        try {
+          await reader.cancel("Preview response is too large");
+        } catch {
+          // Aborting the request can close the stream before cancel resolves.
+        }
+        throw new Error("Preview response is too large");
+      }
+      chunks.push(chunk);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  const bytes = new Uint8Array(bodyBytes);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return bodyType === "text" ? new TextDecoder().decode(bytes) : bytes.buffer;
+}
+
+async function fetchWithTimeout(fetchImplementation, url, bodyType, timeoutMs) {
+  invariant(
+    Number.isSafeInteger(timeoutMs) && timeoutMs >= 1 && timeoutMs <= 30_000,
+    "Smoke request timeout is invalid",
+  );
+  const controller = new AbortController();
+  let timer;
+  try {
+    const request = (async () => {
+      const response = await fetchImplementation(url, {
+        redirect: "follow",
+        signal: controller.signal,
+      });
+      const body = await readBoundedResponseBody(
+        response,
+        bodyType,
+        controller,
+      );
+      return { response, body };
+    })();
+    const timeout = new Promise((_, reject) => {
+      timer = setTimeout(() => {
+        controller.abort();
+        reject(new Error("Preview smoke request timed out"));
+      }, timeoutMs);
+    });
+    return await Promise.race([request, timeout]);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function representativeAssets(html, baseUrl) {
+  const references = [
+    ...html.matchAll(/(?:src|href)=["']([^"']*\/_next\/static\/[^"']+)["']/g),
+  ].map((match) => match[1].replaceAll("&amp;", "&"));
+  const extensions = [".js", ".css", ".woff2"];
+  return extensions.map((extension) => {
+    const reference = references.find((candidate) => {
+      const url = new URL(candidate, baseUrl);
+      return url.origin === baseUrl.origin && url.pathname.endsWith(extension);
+    });
+    invariant(
+      reference,
+      `Preview HTML is missing a representative ${extension} asset`,
+    );
+    return new URL(reference, baseUrl);
+  });
+}
+
+export async function smokePreviewHttp({
+  values,
+  fetchImplementation = fetch,
+  requestTimeoutMs = 15_000,
+}) {
+  const tuple = validatePreviewSmokeTuple(values);
+  const baseUrl = new URL(tuple.deploymentUrl);
+  const { response, body } = await fetchWithTimeout(
+    fetchImplementation,
+    baseUrl,
+    "text",
+    requestTimeoutMs,
+  );
+  invariant(response.ok, `Preview returned HTTP ${response.status}`);
+  invariant(
+    new URL(response.url || baseUrl).origin === baseUrl.origin,
+    "Preview escaped the immutable deployment origin",
+  );
+  requireSecurityHeaders(response);
+  const html = String(body);
+  invariant(
+    TARGET_CONTRACTS[tuple.logicalTarget].documentMarkers.some((marker) =>
+      html.includes(marker),
+    ),
+    "Preview did not render a target-specific document marker",
+  );
+  const assets = representativeAssets(html, baseUrl);
+  for (const asset of assets) {
+    if (tuple.nextDeploymentId) {
+      const deploymentIds = asset.searchParams.getAll("dpl");
+      invariant(
+        deploymentIds.length === 1 &&
+          deploymentIds[0] === tuple.nextDeploymentId,
+        "Preview asset does not carry only the target-bound build ID",
+      );
+    }
+    const assetResult = await fetchWithTimeout(
+      fetchImplementation,
+      asset,
+      "bytes",
+      requestTimeoutMs,
+    );
+    invariant(
+      assetResult.response.ok,
+      `Preview asset returned HTTP ${assetResult.response.status}`,
+    );
+    invariant(
+      new URL(assetResult.response.url || asset).origin === baseUrl.origin,
+      "Preview asset escaped the immutable deployment origin",
+    );
+  }
+  return {
+    logicalTarget: tuple.logicalTarget,
+    deploymentUrl: tuple.deploymentUrl,
+    commitSha: tuple.commitSha,
+    githubDeploymentId: tuple.githubDeploymentId,
+    checkedAssets: assets.length,
+  };
+}
+
+function tupleFromEnvironment(environment = process.env) {
+  return {
+    logicalTarget: environment.LOGICAL_TARGET,
+    deploymentUrl: environment.VERCEL_DEPLOYMENT_URL,
+    commitSha: environment.DEPLOY_SHA,
+    pullRequestNumber: environment.PULL_REQUEST_NUMBER,
+    githubDeploymentId: environment.GITHUB_DEPLOYMENT_ID,
+    verificationMode: environment.VERIFICATION_MODE,
+    verificationKey: environment.VERIFICATION_KEY,
+    workflowRunId: environment.WORKFLOW_RUN_ID,
+    workflowRunAttempt: environment.WORKFLOW_RUN_ATTEMPT,
+    vercelDeploymentId: environment.VERCEL_DEPLOYMENT_ID,
+    nextDeploymentId: environment.MENTO_NEXT_DEPLOYMENT_ID,
+    expectedProjectId: environment.EXPECTED_PROJECT_ID,
+    metadataLogicalTarget: environment.METADATA_LOGICAL_TARGET,
+    metadataProjectId: environment.METADATA_PROJECT_ID,
+    metadataTarget: environment.METADATA_TARGET,
+    metadataRepository: environment.METADATA_REPOSITORY,
+    metadataRef: environment.METADATA_REF,
+    metadataSha: environment.METADATA_SHA,
+    metadataUrl: environment.METADATA_URL,
+    metadataEnvironment: environment.METADATA_ENVIRONMENT,
+    metadataActorLogin: environment.METADATA_ACTOR_LOGIN,
+    metadataActorId: environment.METADATA_ACTOR_ID,
+    metadataActorType: environment.METADATA_ACTOR_TYPE,
+  };
+}
+
+function writeOutput(name, value) {
+  invariant(process.env.GITHUB_OUTPUT, "GITHUB_OUTPUT is required");
+  appendFileSync(process.env.GITHUB_OUTPUT, `${name}=${String(value)}\n`);
+}
+
+function writeClassificationOutputs(classification) {
+  const names = [
+    "eligible",
+    "reason",
+    "logicalTarget",
+    "deploymentUrl",
+    "expectedSha",
+    "githubDeploymentId",
+    "verificationMode",
+    "verificationKey",
+    "metadataLogicalTarget",
+    "metadataTarget",
+    "metadataRepository",
+    "metadataRef",
+    "metadataSha",
+    "metadataUrl",
+    "metadataEnvironment",
+    "metadataActorLogin",
+    "metadataActorId",
+    "metadataActorType",
+  ];
+  for (const name of names) {
+    const outputName = name.replaceAll(
+      /[A-Z]/g,
+      (letter) => `_${letter.toLowerCase()}`,
+    );
+    writeOutput(outputName, classification[name] ?? "");
+  }
+}
+
+async function runCli(command) {
+  if (command === "classify-native") {
+    const eventPath = requiredText(
+      process.env.GITHUB_EVENT_PATH,
+      "GITHUB_EVENT_PATH",
+      undefined,
+      4_096,
+    );
+    const event = JSON.parse(readFileSync(eventPath, "utf8"));
+    const classification = classifyNativePreviewEvent(event, {
+      eventName: process.env.GITHUB_EVENT_NAME,
+      repository: process.env.GITHUB_REPOSITORY,
+      actor: process.env.GITHUB_ACTOR,
+      actorId: process.env.GITHUB_ACTOR_ID,
+      triggeringActor: process.env.GITHUB_TRIGGERING_ACTOR,
+    });
+    writeClassificationOutputs(classification);
+    process.stdout.write(
+      `${JSON.stringify({ eligible: classification.eligible, reason: classification.reason })}\n`,
+    );
+    return;
+  }
+  if (command === "validate") {
+    const tuple = validatePreviewSmokeTuple(tupleFromEnvironment());
+    writeOutput("logical_target", tuple.logicalTarget);
+    writeOutput("deployment_url", tuple.deploymentUrl);
+    writeOutput("expected_sha", tuple.commitSha);
+    writeOutput(
+      "artifact_identity",
+      `${tuple.logicalTarget}-${tuple.commitSha}-${tuple.githubDeploymentId}`,
+    );
+    return;
+  }
+  if (command === "http") {
+    process.stdout.write(
+      `${JSON.stringify(await smokePreviewHttp({ values: tupleFromEnvironment() }))}\n`,
+    );
+    return;
+  }
+  throw new Error("Expected classify-native, validate, or http command");
+}
+
+function isCliEntrypoint() {
+  return (
+    process.argv[1] !== undefined &&
+    fileURLToPath(import.meta.url) === resolve(process.argv[1])
+  );
+}
+
+if (isCliEntrypoint()) await runCli(process.argv[2]);

--- a/scripts/vercel-preview-smoke.test.mjs
+++ b/scripts/vercel-preview-smoke.test.mjs
@@ -1,0 +1,360 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  classifyNativePreviewEvent,
+  smokePreviewHttp,
+  validatePreviewSmokeTuple,
+} from "./vercel-preview-smoke.mjs";
+
+const SHA = "0123456789abcdef0123456789abcdef01234567";
+const VERCEL_ACTOR = { login: "vercel[bot]", id: 35_613_825, type: "Bot" };
+const URLS = {
+  app: "https://appmento-abc123-mentolabs.vercel.app/",
+  governance: "https://governancemento-abc123-mentolabs.vercel.app/",
+  reserve: "https://reservemento-abc123-mentolabs.vercel.app/",
+  ui: "https://uimento-abc123-mentolabs.vercel.app/",
+};
+
+function controllerTuple(target, overrides = {}) {
+  return {
+    logicalTarget: target,
+    deploymentUrl: URLS[target],
+    commitSha: SHA,
+    pullRequestNumber: "520",
+    githubDeploymentId: "1234",
+    verificationMode: "controller",
+    verificationKey: `vercel-preview:v1:pr:520:target:${target}:sha:${SHA}`,
+    vercelDeploymentId: "dpl_Abc123",
+    nextDeploymentId: `m-${target}-0123456789abcdef012`,
+    expectedProjectId: `prj_${target}`,
+    metadataLogicalTarget: target,
+    metadataProjectId: `prj_${target}`,
+    metadataTarget: "preview",
+    metadataRepository: "mento-protocol/frontend-monorepo",
+    metadataRef: "feature/multi-app-preview",
+    metadataSha: SHA,
+    metadataUrl: URLS[target],
+    metadataEnvironment: "",
+    metadataActorLogin: "",
+    metadataActorId: "",
+    metadataActorType: "",
+    ...overrides,
+  };
+}
+
+function runtime(overrides = {}) {
+  return {
+    eventName: "deployment_status",
+    repository: "mento-protocol/frontend-monorepo",
+    actor: "vercel[bot]",
+    actorId: "35613825",
+    triggeringActor: "vercel[bot]",
+    triggeringActorId: "35613825",
+    ...overrides,
+  };
+}
+
+function nativeEvent(target = "app", overrides = {}) {
+  const domain = target === "app" ? "app.mento.org" : "governance.mento.org";
+  const project = target === "app" ? "appmento" : "governancemento";
+  const environment = `Preview – ${domain}`;
+  const url = `https://${project}-abc123-mentolabs.vercel.app`;
+  return {
+    repository: { full_name: "mento-protocol/frontend-monorepo" },
+    sender: { ...VERCEL_ACTOR },
+    deployment: {
+      id: 1234,
+      sha: SHA,
+      ref: "feature/native-preview",
+      task: "deploy",
+      environment,
+      production_environment: false,
+      transient_environment: false,
+      payload: {},
+      creator: { ...VERCEL_ACTOR },
+    },
+    deployment_status: {
+      state: "success",
+      description: "Deployment has completed",
+      environment,
+      environment_url: url,
+      log_url: url,
+      creator: { ...VERCEL_ACTOR },
+    },
+    ...overrides,
+  };
+}
+
+test("controller smoke tuple is target, project, SHA, and build-ID bound for all four targets", () => {
+  for (const target of ["app", "governance", "reserve", "ui"]) {
+    const tuple = validatePreviewSmokeTuple(controllerTuple(target));
+    assert.equal(tuple.logicalTarget, target);
+    assert.equal(tuple.expectedProjectId, `prj_${target}`);
+    assert.equal(tuple.nextDeploymentId, `m-${target}-0123456789abcdef012`);
+    assert.throws(
+      () =>
+        validatePreviewSmokeTuple(
+          controllerTuple(target, { metadataProjectId: "prj_wrong" }),
+        ),
+      /project ID mismatch/,
+    );
+    assert.throws(
+      () =>
+        validatePreviewSmokeTuple(
+          controllerTuple(target, {
+            nextDeploymentId: `${target === "ui" ? "m-app" : "m-ui"}-0123456789abcdef012`,
+          }),
+        ),
+      /Next\.js deployment ID is missing or invalid/,
+    );
+  }
+});
+
+test("controller smoke rejects cross-target keys and lookalike project hosts", () => {
+  assert.throws(
+    () =>
+      validatePreviewSmokeTuple(
+        controllerTuple("reserve", {
+          verificationKey: `vercel-preview:v1:pr:520:target:app:sha:${SHA}`,
+        }),
+      ),
+    /Controller verification key does not match/,
+  );
+  assert.throws(
+    () =>
+      validatePreviewSmokeTuple(
+        controllerTuple("app", {
+          deploymentUrl: "https://appmentoevil-abc123-mentolabs.vercel.app/",
+        }),
+      ),
+    /immutable target preview URL/,
+  );
+});
+
+test("native classifier accepts only the exact Vercel actor and App or Governance preview success", () => {
+  for (const target of ["app", "governance"]) {
+    const classification = classifyNativePreviewEvent(
+      nativeEvent(target),
+      runtime(),
+    );
+    assert.equal(classification.eligible, true);
+    assert.equal(classification.logicalTarget, target);
+    assert.match(
+      classification.verificationKey,
+      /^vercel-native-preview:v1:deployment:1234:url-sha256:[0-9a-f]{64}$/,
+    );
+    const tuple = validatePreviewSmokeTuple({
+      logicalTarget: classification.logicalTarget,
+      deploymentUrl: classification.deploymentUrl,
+      commitSha: classification.expectedSha,
+      githubDeploymentId: classification.githubDeploymentId,
+      verificationMode: classification.verificationMode,
+      verificationKey: classification.verificationKey,
+      metadataLogicalTarget: classification.metadataLogicalTarget,
+      metadataTarget: classification.metadataTarget,
+      metadataRepository: classification.metadataRepository,
+      metadataRef: classification.metadataRef,
+      metadataSha: classification.metadataSha,
+      metadataUrl: classification.metadataUrl,
+      metadataEnvironment: classification.metadataEnvironment,
+      metadataActorLogin: classification.metadataActorLogin,
+      metadataActorId: classification.metadataActorId,
+      metadataActorType: classification.metadataActorType,
+      pullRequestNumber: "",
+      expectedProjectId: "",
+      metadataProjectId: "",
+      vercelDeploymentId: "",
+      nextDeploymentId: "",
+    });
+    assert.equal(tuple.vercelDeploymentId, null);
+    assert.equal(tuple.nextDeploymentId, null);
+  }
+});
+
+test("native classifier rejects production, inactive, main, controller, and actor-lookalike events", () => {
+  const production = nativeEvent("app");
+  production.deployment.environment = "v3 – app.mento.org";
+  production.deployment_status.environment = "v3 – app.mento.org";
+  assert.equal(
+    classifyNativePreviewEvent(production, runtime()).eligible,
+    false,
+  );
+
+  const inactive = nativeEvent("app");
+  inactive.deployment_status.state = "inactive";
+  inactive.deployment_status.description = "Skipped - Not affected";
+  assert.equal(classifyNativePreviewEvent(inactive, runtime()).eligible, false);
+
+  const main = nativeEvent("governance");
+  main.deployment.ref = "main";
+  assert.equal(classifyNativePreviewEvent(main, runtime()).eligible, false);
+
+  const controller = nativeEvent("app");
+  controller.deployment.payload = {
+    controller_schema: "mento-vercel-prebuilt/v1",
+  };
+  assert.equal(
+    classifyNativePreviewEvent(controller, runtime()).eligible,
+    false,
+  );
+
+  const wrongActor = nativeEvent("app");
+  wrongActor.deployment_status.creator = { ...VERCEL_ACTOR, id: 1 };
+  assert.equal(
+    classifyNativePreviewEvent(wrongActor, runtime()).eligible,
+    false,
+  );
+  assert.equal(
+    classifyNativePreviewEvent(nativeEvent("app"), runtime({ actor: "vercel" }))
+      .eligible,
+    false,
+  );
+});
+
+function fakeResponse(url, body, { status = 200, headers = {} } = {}) {
+  const normalizedHeaders = new Headers(headers);
+  const encoded = new TextEncoder().encode(body);
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    url: String(url),
+    headers: normalizedHeaders,
+    body: new ReadableStream({
+      start(controller) {
+        controller.enqueue(encoded);
+        controller.close();
+      },
+    }),
+    async text() {
+      return body;
+    },
+    async arrayBuffer() {
+      return new TextEncoder().encode(body).buffer;
+    },
+  };
+}
+
+test("common HTTP smoke checks target marker, headers, assets, and controller build identity", async () => {
+  const values = controllerTuple("reserve");
+  const requested = [];
+  const html = `<title>Mento Reserve</title>
+    <script src="/_next/static/app.js?dpl=${values.nextDeploymentId}"></script>
+    <link rel="stylesheet" href="/_next/static/app.css?dpl=${values.nextDeploymentId}">
+    <link rel="preload" href="/_next/static/font.woff2?dpl=${values.nextDeploymentId}">`;
+  const fetchImplementation = async (url) => {
+    const parsed = new URL(url);
+    requested.push(parsed.toString());
+    if (parsed.pathname.startsWith("/_next/static/"))
+      return fakeResponse(parsed, "asset");
+    return fakeResponse(parsed, html, {
+      headers: {
+        "content-security-policy": "frame-ancestors 'none'",
+        "x-frame-options": "DENY",
+        "x-content-type-options": "nosniff",
+      },
+    });
+  };
+
+  assert.deepEqual(await smokePreviewHttp({ values, fetchImplementation }), {
+    logicalTarget: "reserve",
+    deploymentUrl: values.deploymentUrl,
+    commitSha: SHA,
+    githubDeploymentId: 1234,
+    checkedAssets: 3,
+  });
+  assert.equal(requested.length, 4);
+});
+
+test("common HTTP smoke fails closed on missing headers and mixed deployment assets", async () => {
+  const values = controllerTuple("ui");
+  const html = `<h1>Basic Components</h1>
+    <script src="/_next/static/app.js?dpl=${values.nextDeploymentId}"></script>
+    <link rel="stylesheet" href="/_next/static/app.css?dpl=wrong">
+    <link rel="preload" href="/_next/static/font.woff2?dpl=${values.nextDeploymentId}">`;
+  const response = (headers) => async (url) =>
+    new URL(url).pathname.startsWith("/_next/static/")
+      ? fakeResponse(url, "asset")
+      : fakeResponse(url, html, { headers });
+
+  await assert.rejects(
+    smokePreviewHttp({ values, fetchImplementation: response({}) }),
+    /content-security-policy/,
+  );
+  await assert.rejects(
+    smokePreviewHttp({
+      values,
+      fetchImplementation: response({
+        "content-security-policy": "frame-ancestors 'none'",
+        "x-frame-options": "DENY",
+        "x-content-type-options": "nosniff",
+      }),
+    }),
+    /target-bound build ID/,
+  );
+});
+
+test("common HTTP smoke rejects representative assets redirected off the immutable origin", async () => {
+  const values = controllerTuple("app");
+  const html = `<title>Mento App</title>
+    <script src="/_next/static/app.js?dpl=${values.nextDeploymentId}"></script>
+    <link rel="stylesheet" href="/_next/static/app.css?dpl=${values.nextDeploymentId}">
+    <link rel="preload" href="/_next/static/font.woff2?dpl=${values.nextDeploymentId}">`;
+  const fetchImplementation = async (url) => {
+    const parsed = new URL(url);
+    if (parsed.pathname.startsWith("/_next/static/")) {
+      return fakeResponse(
+        new URL(parsed.pathname, "https://assets.example.invalid"),
+        "asset",
+      );
+    }
+    return fakeResponse(parsed, html, {
+      headers: {
+        "content-security-policy": "frame-ancestors 'none'",
+        "x-frame-options": "DENY",
+        "x-content-type-options": "nosniff",
+      },
+    });
+  };
+
+  await assert.rejects(
+    smokePreviewHttp({ values, fetchImplementation }),
+    /asset escaped the immutable deployment origin/,
+  );
+});
+
+test("common HTTP smoke aborts a streaming response as soon as it exceeds 5 MiB", async () => {
+  const values = controllerTuple("governance");
+  let emittedChunks = 0;
+  let observedSignal;
+  const fetchImplementation = async (url, options) => {
+    observedSignal = options.signal;
+    return {
+      ok: true,
+      status: 200,
+      url: String(url),
+      headers: new Headers(),
+      body: new ReadableStream({
+        pull(controller) {
+          emittedChunks += 1;
+          controller.enqueue(new Uint8Array(1024 * 1024));
+        },
+      }),
+      async text() {
+        throw new Error("response.text() must not buffer the stream");
+      },
+      async arrayBuffer() {
+        throw new Error("response.arrayBuffer() must not buffer the stream");
+      },
+    };
+  };
+
+  await assert.rejects(
+    smokePreviewHttp({ values, fetchImplementation }),
+    /Preview response is too large/,
+  );
+  // Web streams may prefetch one chunk, but the reader stops immediately at
+  // the first chunk that crosses the cap instead of draining the body.
+  assert.ok(emittedChunks >= 6 && emittedChunks <= 7);
+  assert.equal(observedSignal.aborted, true);
+});

--- a/scripts/vercel-preview-smoke.test.mjs
+++ b/scripts/vercel-preview-smoke.test.mjs
@@ -174,6 +174,9 @@ test("native classifier accepts only the exact Vercel actor and App or Governanc
 
 test("native classifier rejects production, inactive, main, controller, and actor-lookalike events", () => {
   const production = nativeEvent("app");
+  // Vercel's live GitHub metadata reports this boolean as false even for its
+  // named Production/v3 Deployments. Exact environment names own routing.
+  production.deployment.production_environment = false;
   production.deployment.environment = "v3 – app.mento.org";
   production.deployment_status.environment = "v3 – app.mento.org";
   assert.equal(
@@ -209,6 +212,13 @@ test("native classifier rejects production, inactive, main, controller, and acto
     classifyNativePreviewEvent(nativeEvent("app"), runtime({ actor: "vercel" }))
       .eligible,
     false,
+  );
+
+  const misleadingBoolean = nativeEvent("governance");
+  misleadingBoolean.deployment.production_environment = true;
+  assert.equal(
+    classifyNativePreviewEvent(misleadingBoolean, runtime()).eligible,
+    true,
   );
 });
 

--- a/scripts/vercel-preview-smoke.test.mjs
+++ b/scripts/vercel-preview-smoke.test.mjs
@@ -86,6 +86,37 @@ function nativeEvent(target = "app", overrides = {}) {
   };
 }
 
+function nativeSmokeValues(target, runtimeOverrides = {}) {
+  const classification = classifyNativePreviewEvent(
+    nativeEvent(target),
+    runtime(runtimeOverrides),
+  );
+  assert.equal(classification.eligible, true);
+  return {
+    logicalTarget: classification.logicalTarget,
+    deploymentUrl: classification.deploymentUrl,
+    commitSha: classification.expectedSha,
+    githubDeploymentId: classification.githubDeploymentId,
+    verificationMode: classification.verificationMode,
+    verificationKey: classification.verificationKey,
+    metadataLogicalTarget: classification.metadataLogicalTarget,
+    metadataTarget: classification.metadataTarget,
+    metadataRepository: classification.metadataRepository,
+    metadataRef: classification.metadataRef,
+    metadataSha: classification.metadataSha,
+    metadataUrl: classification.metadataUrl,
+    metadataEnvironment: classification.metadataEnvironment,
+    metadataActorLogin: classification.metadataActorLogin,
+    metadataActorId: classification.metadataActorId,
+    metadataActorType: classification.metadataActorType,
+    pullRequestNumber: "",
+    expectedProjectId: "",
+    metadataProjectId: "",
+    vercelDeploymentId: "",
+    nextDeploymentId: "",
+  };
+}
+
 test("controller smoke tuple is target, project, SHA, and build-ID bound for all four targets", () => {
   for (const target of ["app", "governance", "reserve", "ui"]) {
     const tuple = validatePreviewSmokeTuple(controllerTuple(target));
@@ -172,6 +203,18 @@ test("native classifier accepts only the exact Vercel actor and App or Governanc
   }
 });
 
+test("native classifier preserves the original Vercel actor trust on maintainer reruns", () => {
+  const classification = classifyNativePreviewEvent(
+    nativeEvent("governance"),
+    runtime({
+      triggeringActor: "maintainer",
+      triggeringActorId: "987654",
+    }),
+  );
+  assert.equal(classification.eligible, true);
+  assert.equal(classification.logicalTarget, "governance");
+});
+
 test("native classifier rejects production, inactive, main, controller, and actor-lookalike events", () => {
   const production = nativeEvent("app");
   // Vercel's live GitHub metadata reports this boolean as false even for its
@@ -251,7 +294,8 @@ test("common HTTP smoke checks target marker, headers, assets, and controller bu
   const html = `<title>Mento Reserve</title>
     <script src="/_next/static/app.js?dpl=${values.nextDeploymentId}"></script>
     <link rel="stylesheet" href="/_next/static/app.css?dpl=${values.nextDeploymentId}">
-    <link rel="preload" href="/_next/static/font.woff2?dpl=${values.nextDeploymentId}">`;
+    <link rel="preload" href="/_next/static/font.woff2?dpl=${values.nextDeploymentId}">
+    <img src="/_next/static/media/graph.webp?dpl=${values.nextDeploymentId}">`;
   const fetchImplementation = async (url) => {
     const parsed = new URL(url);
     requested.push(parsed.toString());
@@ -271,14 +315,73 @@ test("common HTTP smoke checks target marker, headers, assets, and controller bu
     deploymentUrl: values.deploymentUrl,
     commitSha: SHA,
     githubDeploymentId: 1234,
-    checkedAssets: 3,
+    checkedAssets: 4,
   });
-  assert.equal(requested.length, 4);
+  assert.equal(requested.length, 5);
+});
+
+test("common HTTP smoke accepts native App and Governance profiles without font assets", async () => {
+  for (const target of ["app", "governance"]) {
+    const values = nativeSmokeValues(target);
+    const marker = target === "app" ? "Mento App" : "Mento Governance";
+    const html = `<title>${marker}</title>
+      <script src="/_next/static/app.js"></script>
+      <link rel="stylesheet" href="/_next/static/app.css">`;
+    const fetchImplementation = async (url) => {
+      const parsed = new URL(url);
+      if (parsed.pathname.startsWith("/_next/static/"))
+        return fakeResponse(parsed, "asset");
+      return fakeResponse(parsed, html, {
+        headers: {
+          "content-security-policy": "frame-ancestors 'none'",
+          "x-frame-options": "DENY",
+          "x-content-type-options": "nosniff",
+        },
+      });
+    };
+
+    const result = await smokePreviewHttp({ values, fetchImplementation });
+    assert.equal(result.logicalTarget, target);
+    assert.equal(result.checkedAssets, 2);
+  }
+});
+
+test("common HTTP smoke still requires representative JavaScript and CSS assets", async () => {
+  const values = controllerTuple("reserve");
+  const response = (html) => async (url) =>
+    new URL(url).pathname.startsWith("/_next/static/")
+      ? fakeResponse(url, "asset")
+      : fakeResponse(url, html, {
+          headers: {
+            "content-security-policy": "frame-ancestors 'none'",
+            "x-frame-options": "DENY",
+            "x-content-type-options": "nosniff",
+          },
+        });
+
+  await assert.rejects(
+    smokePreviewHttp({
+      values,
+      fetchImplementation: response(
+        `<title>Mento Reserve</title><link rel="stylesheet" href="/_next/static/app.css?dpl=${values.nextDeploymentId}">`,
+      ),
+    }),
+    /representative \.js asset/,
+  );
+  await assert.rejects(
+    smokePreviewHttp({
+      values,
+      fetchImplementation: response(
+        `<title>Mento Reserve</title><script src="/_next/static/app.js?dpl=${values.nextDeploymentId}"></script>`,
+      ),
+    }),
+    /representative \.css asset/,
+  );
 });
 
 test("common HTTP smoke fails closed on missing headers and mixed deployment assets", async () => {
   const values = controllerTuple("ui");
-  const html = `<h1>Basic Components</h1>
+  const html = `<main data-dpl-id="${values.nextDeploymentId}"><h1>Basic Components</h1></main>
     <script src="/_next/static/app.js?dpl=${values.nextDeploymentId}"></script>
     <link rel="stylesheet" href="/_next/static/app.css?dpl=wrong">
     <link rel="preload" href="/_next/static/font.woff2?dpl=${values.nextDeploymentId}">`;
@@ -301,6 +404,40 @@ test("common HTTP smoke fails closed on missing headers and mixed deployment ass
       }),
     }),
     /target-bound build ID/,
+  );
+});
+
+test("UI common HTTP smoke requires the exact server-rendered deployment identity", async () => {
+  const values = controllerTuple("ui");
+  const response = (deploymentMarker) => async (url) => {
+    const parsed = new URL(url);
+    if (parsed.pathname.startsWith("/_next/static/"))
+      return fakeResponse(parsed, "asset");
+    return fakeResponse(
+      parsed,
+      `<main ${deploymentMarker}><h1>Basic Components</h1></main>
+        <script src="/_next/static/app.js?dpl=${values.nextDeploymentId}"></script>
+        <link rel="stylesheet" href="/_next/static/app.css?dpl=${values.nextDeploymentId}">`,
+      {
+        headers: {
+          "content-security-policy": "frame-ancestors 'none'",
+          "x-frame-options": "DENY",
+          "x-content-type-options": "nosniff",
+        },
+      },
+    );
+  };
+
+  await assert.rejects(
+    smokePreviewHttp({ values, fetchImplementation: response("") }),
+    /HTML does not carry only the expected build deployment ID/,
+  );
+  await assert.rejects(
+    smokePreviewHttp({
+      values,
+      fetchImplementation: response('data-dpl-id="m-ui-wrongwrongwrong12"'),
+    }),
+    /HTML does not carry only the expected build deployment ID/,
   );
 });
 

--- a/scripts/vercel-preview-workflows.test.mjs
+++ b/scripts/vercel-preview-workflows.test.mjs
@@ -534,7 +534,9 @@ test("worker is dispatch-only with strict identity inputs and one literal UI cal
   assert.deepEqual(worker.permissions, {});
   assert.equal(worker.concurrency["cancel-in-progress"], false);
 
-  const callers = Object.values(worker.jobs).filter((job) => job.uses);
+  const callers = Object.values(worker.jobs).filter(
+    (job) => job.uses === "./.github/workflows/_vercel-prebuilt.yml",
+  );
   assert.equal(callers.length, 1);
   const caller = callers[0];
   assert.equal(caller.uses, "./.github/workflows/_vercel-prebuilt.yml");
@@ -611,41 +613,49 @@ test("worker credentials are unreachable until trusted validation and named pref
 
   const resumedSmoke = worker.jobs["resume-ui-smoke"];
   assert.deepEqual(resumedSmoke.permissions, { contents: "read" });
+  assert.equal(
+    resumedSmoke.uses,
+    "./.github/workflows/_vercel-preview-smoke.yml",
+  );
+  assert.equal(Object.hasOwn(resumedSmoke, "steps"), false);
+  assert.equal(Object.hasOwn(resumedSmoke, "secrets"), false);
   assert.doesNotMatch(
     JSON.stringify(resumedSmoke),
     /secrets\.|VERCEL_TOKEN|TURBO_TOKEN|TURBO_REMOTE_CACHE_SIGNATURE_KEY/,
   );
-  assert.match(
-    JSON.stringify(resumedSmoke),
-    /vercel-prebuilt-workflow\.mjs.*smoke/,
-  );
-  assert.equal(resumedSmoke["runs-on"], "ubuntu-latest");
-  const resumeSteps = resumedSmoke.steps;
-  const resumeCheckout = resumeSteps[0];
-  assert.equal(resumeCheckout.with.path, "controller");
-  assert.equal(resumeCheckout.with.ref, "${{ github.workflow_sha }}");
-  assert.equal(resumeCheckout.with["persist-credentials"], false);
-  const resumeInstall = resumeSteps.find(
-    ({ name }) => name === "Install trusted browser smoke dependencies",
-  );
-  assert.equal(resumeInstall["working-directory"], "controller");
-  assert.equal(resumeInstall.env.PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD, "1");
-  assert.match(resumeInstall.run, /--frozen-lockfile/);
-  assert.match(resumeInstall.run, /--ignore-scripts/);
-  const resumeBrowser = resumeSteps.find(
-    ({ name }) => name === "Re-run browser interaction in system Chrome",
-  );
-  assert.match(
-    resumeBrowser.run,
-    /apps\/ui\.mento\.org\/e2e\/vercel-preview-browser-smoke\.mjs/,
-  );
+  assert.equal(resumedSmoke.with.logical_target, "ui");
+  assert.equal(resumedSmoke.with.verification_mode, "controller");
   assert.equal(
-    resumeBrowser.env.DEPLOYMENT_IDEMPOTENCY_KEY,
+    resumedSmoke.with.verification_key,
     "${{ inputs.controller_key }}",
   );
-  assert.ok(
-    resumeSteps.indexOf(resumeInstall) < resumeSteps.indexOf(resumeBrowser),
+  assert.equal(
+    resumedSmoke.with.deployment_url,
+    "${{ needs.validate-controller-ownership.outputs.vercel_deployment_url }}",
   );
+  assert.equal(
+    resumedSmoke.with.github_deployment_id,
+    "${{ needs.validate-controller-ownership.outputs.github_deployment_id }}",
+  );
+  assert.equal(
+    resumedSmoke.with.vercel_deployment_id,
+    "${{ needs.validate-controller-ownership.outputs.vercel_deployment_id }}",
+  );
+  assert.equal(
+    resumedSmoke.with.next_deployment_id,
+    "${{ needs.validate-controller-ownership.outputs.next_deployment_id }}",
+  );
+  assert.equal(
+    resumedSmoke.with.expected_project_id,
+    "${{ vars.VERCEL_PROJECT_ID_UI }}",
+  );
+  assert.equal(
+    resumedSmoke.with.metadata_project_id,
+    "${{ vars.VERCEL_PROJECT_ID_UI }}",
+  );
+  assert.equal(caller.with.logical_target, "ui");
+  assert.equal(caller.with.workspace_package, "ui.mento.org");
+  assert.equal(caller.with.expected_root_directory, "apps/ui.mento.org");
 
   const evidence = worker.jobs["record-worker-evidence"];
   assert.match(JSON.stringify(evidence), /recordWorkerEvidence/);


### PR DESCRIPTION
## The Problem

Issue #520 needs one credential-free, target-aware preview verification path before App, Governance, and Reserve controller dispatch can be activated. The merged UI prebuilt and resume paths still carried parallel UI-only smoke implementations, while native App/Governance preview events needed the same exact deployment tuple checks without granting Vercel credentials to browser verification.

## The Solution

- add a secretless reusable preview-smoke workflow for the literal App, Governance, Reserve, and UI targets
- route both the automatic UI build and serialized resume paths through that workflow before the canonical GitHub Deployment can become successful
- validate and bind the immutable URL, exact SHA, GitHub/Vercel deployment IDs, project, repository, ref, target, and verification key before any target smoke runs
- preserve the temporary native App/Governance adapter with exact actor/environment/status classification and deterministic receipt markers
- remove the embedded UI-only smoke command and browser path rather than retaining a compatibility route
- keep App/Governance/Reserve controller dispatch inactive for the later atomic activation PR

Part of #520.

## Validation

- `pnpm vercel:preview:test` — 178/178 passed
- `node --test scripts/vercel-preview-smoke.test.mjs` — 12/12 passed
- `pnpm ci:action-pins` — passed
- `pnpm knip` — passed (only the existing Tailwind configuration hint)
- `pnpm supply-chain:lockfile-lint` — passed
- `pnpm supply-chain:version-skew` — passed
- `pnpm quality:budgets:test` — 30/30 passed
- `trunk fmt` — passed
- `trunk check` — passed (1,102 files)
- `git diff --check` — passed
- `pnpm adr:check --include-untracked` — advisory reminder acknowledged; this extends accepted ADR 0001 rather than introducing a separate decision
- `pnpm vercel:workflow:test` — 82/83 passed; the remaining fixture cannot hydrate the locally absent offline tarball for `@types/node@25.9.3`
- exact-head native App smoke — run [29866476525](https://github.com/mento-protocol/frontend-monorepo/actions/runs/29866476525) passed for GitHub Deployment `5545359312` at https://appmento-6v0caxhtz-mentolabs.vercel.app/
- exact-head native Governance smoke — run [29866454597](https://github.com/mento-protocol/frontend-monorepo/actions/runs/29866454597), attempt 2 maintainer rerun, passed for GitHub Deployment `5545352613` at https://governancemento-d53xrwiow-mentolabs.vercel.app/
- exact-head GitHub-driven UI preview — worker run [29866434585](https://github.com/mento-protocol/frontend-monorepo/actions/runs/29866434585) passed for GitHub Deployment `5545371648`, Vercel deployment `dpl_D46z1fP35zxBYrkb6RabczTFM7kM`, at https://uimento-ibr1fafaq-mentolabs.vercel.app/
- System Chrome: exact immutable UI/App/Governance/Reserve previews rendered and primary interactions passed with zero console/page/HTTP errors and zero broken images; UI SSR `data-dpl-id` `m-ui-171b24a83dc1bbe776c` matched all 26 observed static requests. Reserve at https://reservemento-oxeoh3frz-mentolabs.vercel.app/ had only expected navigation-cancelled requests.

## Architecture Decision

Applicable and documented by extending `docs/adr/0001-github-actions-vercel-deployment-orchestration.md`; no new decision record is needed for this implementation slice.

## Ship Checklist

- [x] Rebased onto the exact merged PR #581 head on `main`
- [x] Focused workflow, tuple-validation, and browser-smoke tests pass
- [x] Workflow actions remain SHA-pinned and smoke receives no deployment credentials
- [x] Documentation and the existing ADR describe the reusable path and inactive target callers
- [x] App/Governance/Reserve controller activation remains out of scope
