### PR TITLE
feat(ci): generalize preview controller to four targets

### DIFF
--- a/.github/workflows/vercel-preview-controller.yml
+++ b/.github/workflows/vercel-preview-controller.yml
@@ -89,7 +89,7 @@ jobs:
             });
 
   plan-event:
-    name: Plan UI runtime impact from trusted base
+    name: Plan preview runtime impact from trusted base
     needs: snapshot-event
     if: needs.snapshot-event.outputs.plan_required == 'true'
     runs-on: ubuntu-latest
@@ -225,7 +225,7 @@ jobs:
           persist-credentials: false
           ref: ${{ github.workflow_sha }}
 
-      - name: Persist intent, recover or dispatch one worker, and publish statuses
+      - name: Persist intents, recover or dispatch target workers, and publish statuses
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           CONTROLLER_MODE: ${{ env.VERCEL_PREVIEW_CONTROLLER_MODE }}
@@ -297,7 +297,7 @@ jobs:
             });
 
   plan-bootstrap:
-    name: Plan bootstrap UI runtime impact from trusted base
+    name: Plan bootstrap preview runtime impact from trusted base
     needs: snapshot-bootstrap
     if: needs.snapshot-bootstrap.outputs.plan_required == 'true'
     runs-on: ubuntu-latest

--- a/.github/workflows/vercel-preview-worker.yml
+++ b/.github/workflows/vercel-preview-worker.yml
@@ -121,12 +121,113 @@ jobs:
               },
             });
 
+  deploy-app-preview:
+    name: Run App prebuilt preview pipeline
+    needs: [validate-controller-ownership, validate-app-prerequisites]
+    if: >-
+      inputs.target == 'app' &&
+      needs.validate-controller-ownership.outputs.should_deploy == 'true' &&
+      needs.validate-app-prerequisites.result == 'success'
+    permissions:
+      contents: read
+      deployments: write
+    uses: ./.github/workflows/_vercel-prebuilt.yml
+    with:
+      commit_sha: ${{ inputs.commit_sha }}
+      deploy_permitted: true
+      deployment_idempotency_key: ${{ inputs.controller_key }}
+      deployment_mode: preview
+      expected_root_directory: apps/app.mento.org
+      git_branch: ${{ inputs.git_branch }}
+      github_environment: preview/app/pr-${{ inputs.pull_request_number }}
+      logical_target: app
+      provenance: preview-controller:v2
+      pull_request_number: ${{ inputs.pull_request_number }}
+      turbo_team: ${{ vars.TURBO_TEAM }}
+      vercel_environment: preview
+      vercel_org_id: ${{ vars.VERCEL_ORG_ID }}
+      vercel_project_id: ${{ vars.VERCEL_PROJECT_ID_APP }}
+      vercel_target: preview
+      workspace_package: app.mento.org
+    secrets:
+      turbo_remote_cache_signature_key: ${{ secrets.TURBO_REMOTE_CACHE_SIGNATURE_KEY }}
+      turbo_token: ${{ secrets.TURBO_TOKEN }}
+      vercel_token: ${{ secrets.VERCEL_TOKEN_PREVIEW }}
+
+  deploy-governance-preview:
+    name: Run Governance prebuilt preview pipeline
+    needs: [validate-controller-ownership, validate-governance-prerequisites]
+    if: >-
+      inputs.target == 'governance' &&
+      needs.validate-controller-ownership.outputs.should_deploy == 'true' &&
+      needs.validate-governance-prerequisites.result == 'success'
+    permissions:
+      contents: read
+      deployments: write
+    uses: ./.github/workflows/_vercel-prebuilt.yml
+    with:
+      commit_sha: ${{ inputs.commit_sha }}
+      deploy_permitted: true
+      deployment_idempotency_key: ${{ inputs.controller_key }}
+      deployment_mode: preview
+      expected_root_directory: apps/governance.mento.org
+      git_branch: ${{ inputs.git_branch }}
+      github_environment: preview/governance/pr-${{ inputs.pull_request_number }}
+      logical_target: governance
+      provenance: preview-controller:v2
+      pull_request_number: ${{ inputs.pull_request_number }}
+      turbo_team: ${{ vars.TURBO_TEAM }}
+      vercel_environment: preview
+      vercel_org_id: ${{ vars.VERCEL_ORG_ID }}
+      vercel_project_id: ${{ vars.VERCEL_PROJECT_ID_GOVERNANCE }}
+      vercel_target: preview
+      workspace_package: governance.mento.org
+    secrets:
+      etherscan_api_key: ${{ secrets.ETHERSCAN_API_KEY }}
+      turbo_remote_cache_signature_key: ${{ secrets.TURBO_REMOTE_CACHE_SIGNATURE_KEY }}
+      turbo_token: ${{ secrets.TURBO_TOKEN }}
+      vercel_token: ${{ secrets.VERCEL_TOKEN_PREVIEW }}
+
+  deploy-reserve-preview:
+    name: Run Reserve prebuilt preview pipeline
+    needs: [validate-controller-ownership, validate-reserve-prerequisites]
+    if: >-
+      inputs.target == 'reserve' &&
+      needs.validate-controller-ownership.outputs.should_deploy == 'true' &&
+      needs.validate-reserve-prerequisites.result == 'success'
+    permissions:
+      contents: read
+      deployments: write
+    uses: ./.github/workflows/_vercel-prebuilt.yml
+    with:
+      commit_sha: ${{ inputs.commit_sha }}
+      deploy_permitted: true
+      deployment_idempotency_key: ${{ inputs.controller_key }}
+      deployment_mode: preview
+      expected_root_directory: apps/reserve.mento.org
+      git_branch: ${{ inputs.git_branch }}
+      github_environment: preview/reserve/pr-${{ inputs.pull_request_number }}
+      logical_target: reserve
+      provenance: preview-controller:v2
+      pull_request_number: ${{ inputs.pull_request_number }}
+      turbo_team: ${{ vars.TURBO_TEAM }}
+      vercel_environment: preview
+      vercel_org_id: ${{ vars.VERCEL_ORG_ID }}
+      vercel_project_id: ${{ vars.VERCEL_PROJECT_ID_RESERVE }}
+      vercel_target: preview
+      workspace_package: reserve.mento.org
+    secrets:
+      turbo_remote_cache_signature_key: ${{ secrets.TURBO_REMOTE_CACHE_SIGNATURE_KEY }}
+      turbo_token: ${{ secrets.TURBO_TOKEN }}
+      vercel_token: ${{ secrets.VERCEL_TOKEN_PREVIEW }}
+
   deploy-ui-preview:
     name: Run UI prebuilt preview pipeline
-    needs: [validate-controller-ownership, validate-preview-prerequisites]
+    needs: [validate-controller-ownership, validate-ui-prerequisites]
     if: >-
+      inputs.target == 'ui' &&
       needs.validate-controller-ownership.outputs.should_deploy == 'true' &&
-      needs.validate-preview-prerequisites.result == 'success'
+      needs.validate-ui-prerequisites.result == 'success'
     permissions:
       contents: read
       deployments: write
@@ -140,7 +241,7 @@ jobs:
       git_branch: ${{ inputs.git_branch }}
       github_environment: preview/ui/pr-${{ inputs.pull_request_number }}
       logical_target: ui
-      provenance: preview-controller:v1
+      provenance: preview-controller:v2
       pull_request_number: ${{ inputs.pull_request_number }}
       turbo_team: ${{ vars.TURBO_TEAM }}
       vercel_environment: preview
@@ -153,10 +254,122 @@ jobs:
       turbo_token: ${{ secrets.TURBO_TOKEN }}
       vercel_token: ${{ secrets.VERCEL_TOKEN_PREVIEW }}
 
-  validate-preview-prerequisites:
-    name: Validate preview prerequisite names
+  validate-app-prerequisites:
+    name: Validate App preview prerequisite names
     needs: validate-controller-ownership
-    if: needs.validate-controller-ownership.outputs.should_deploy == 'true'
+    if: >-
+      inputs.target == 'app' &&
+      needs.validate-controller-ownership.outputs.should_deploy == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    permissions: {}
+    env:
+      TURBO_REMOTE_CACHE_SIGNATURE_KEY: ${{ secrets.TURBO_REMOTE_CACHE_SIGNATURE_KEY }}
+      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+      VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
+      VERCEL_PROJECT_ID_APP: ${{ vars.VERCEL_PROJECT_ID_APP }}
+      VERCEL_TOKEN_PREVIEW: ${{ secrets.VERCEL_TOKEN_PREVIEW }}
+    steps:
+      - name: Fail before PR code when an App prerequisite is missing
+        shell: bash
+        run: |
+          missing=()
+          for name in \
+            VERCEL_ORG_ID \
+            VERCEL_PROJECT_ID_APP \
+            TURBO_TEAM \
+            VERCEL_TOKEN_PREVIEW \
+            TURBO_TOKEN \
+            TURBO_REMOTE_CACHE_SIGNATURE_KEY
+          do
+            if [[ -z "${!name}" ]]; then missing+=("$name"); fi
+          done
+          if (( ${#missing[@]} > 0 )); then
+            printf 'Missing required repository names: %s\n' "${missing[*]}" >&2
+            exit 1
+          fi
+
+  validate-governance-prerequisites:
+    name: Validate Governance preview prerequisite names
+    needs: validate-controller-ownership
+    if: >-
+      inputs.target == 'governance' &&
+      needs.validate-controller-ownership.outputs.should_deploy == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    permissions: {}
+    env:
+      ETHERSCAN_API_KEY: ${{ secrets.ETHERSCAN_API_KEY }}
+      TURBO_REMOTE_CACHE_SIGNATURE_KEY: ${{ secrets.TURBO_REMOTE_CACHE_SIGNATURE_KEY }}
+      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+      VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
+      VERCEL_PROJECT_ID_GOVERNANCE: ${{ vars.VERCEL_PROJECT_ID_GOVERNANCE }}
+      VERCEL_TOKEN_PREVIEW: ${{ secrets.VERCEL_TOKEN_PREVIEW }}
+    steps:
+      - name: Fail before PR code when a Governance prerequisite is missing
+        shell: bash
+        run: |
+          missing=()
+          for name in \
+            ETHERSCAN_API_KEY \
+            VERCEL_ORG_ID \
+            VERCEL_PROJECT_ID_GOVERNANCE \
+            TURBO_TEAM \
+            VERCEL_TOKEN_PREVIEW \
+            TURBO_TOKEN \
+            TURBO_REMOTE_CACHE_SIGNATURE_KEY
+          do
+            if [[ -z "${!name}" ]]; then missing+=("$name"); fi
+          done
+          if (( ${#missing[@]} > 0 )); then
+            printf 'Missing required repository names: %s\n' "${missing[*]}" >&2
+            exit 1
+          fi
+
+  validate-reserve-prerequisites:
+    name: Validate Reserve preview prerequisite names
+    needs: validate-controller-ownership
+    if: >-
+      inputs.target == 'reserve' &&
+      needs.validate-controller-ownership.outputs.should_deploy == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    permissions: {}
+    env:
+      TURBO_REMOTE_CACHE_SIGNATURE_KEY: ${{ secrets.TURBO_REMOTE_CACHE_SIGNATURE_KEY }}
+      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+      VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
+      VERCEL_PROJECT_ID_RESERVE: ${{ vars.VERCEL_PROJECT_ID_RESERVE }}
+      VERCEL_TOKEN_PREVIEW: ${{ secrets.VERCEL_TOKEN_PREVIEW }}
+    steps:
+      - name: Fail before PR code when a Reserve prerequisite is missing
+        shell: bash
+        run: |
+          missing=()
+          for name in \
+            VERCEL_ORG_ID \
+            VERCEL_PROJECT_ID_RESERVE \
+            TURBO_TEAM \
+            VERCEL_TOKEN_PREVIEW \
+            TURBO_TOKEN \
+            TURBO_REMOTE_CACHE_SIGNATURE_KEY
+          do
+            if [[ -z "${!name}" ]]; then missing+=("$name"); fi
+          done
+          if (( ${#missing[@]} > 0 )); then
+            printf 'Missing required repository names: %s\n' "${missing[*]}" >&2
+            exit 1
+          fi
+
+  validate-ui-prerequisites:
+    name: Validate UI preview prerequisite names
+    needs: validate-controller-ownership
+    if: >-
+      inputs.target == 'ui' &&
+      needs.validate-controller-ownership.outputs.should_deploy == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 2
     permissions: {}
@@ -189,35 +402,126 @@ jobs:
             exit 1
           fi
 
-  resume-ui-smoke:
-    name: Resume smoke for an existing immutable upload
+  resume-app-smoke:
+    name: Resume App smoke for an existing immutable upload
     needs: validate-controller-ownership
-    if: needs.validate-controller-ownership.outputs.should_resume_smoke == 'true'
+    if: >-
+      inputs.target == 'app' &&
+      needs.validate-controller-ownership.outputs.should_resume_smoke == 'true'
     permissions:
       contents: read
     uses: ./.github/workflows/_vercel-preview-smoke.yml
     with:
-      logical_target: ui
       deployment_url: ${{ needs.validate-controller-ownership.outputs.vercel_deployment_url }}
+      expected_project_id: ${{ vars.VERCEL_PROJECT_ID_APP }}
       expected_sha: ${{ inputs.commit_sha }}
       github_deployment_id: ${{ needs.validate-controller-ownership.outputs.github_deployment_id }}
-      verification_mode: controller
-      verification_key: ${{ inputs.controller_key }}
-      metadata_logical_target: ui
-      metadata_target: preview
-      metadata_repository: ${{ github.repository }}
+      logical_target: app
+      metadata_logical_target: app
+      metadata_project_id: ${{ vars.VERCEL_PROJECT_ID_APP }}
       metadata_ref: ${{ inputs.git_branch }}
+      metadata_repository: mento-protocol/frontend-monorepo
       metadata_sha: ${{ inputs.commit_sha }}
+      metadata_target: preview
       metadata_url: ${{ needs.validate-controller-ownership.outputs.vercel_deployment_url }}
+      next_deployment_id: ${{ needs.validate-controller-ownership.outputs.next_deployment_id }}
       pull_request_number: ${{ inputs.pull_request_number }}
       vercel_deployment_id: ${{ needs.validate-controller-ownership.outputs.vercel_deployment_id }}
+      verification_key: ${{ inputs.controller_key }}
+      verification_mode: controller
+
+  resume-governance-smoke:
+    name: Resume Governance smoke for an existing immutable upload
+    needs: validate-controller-ownership
+    if: >-
+      inputs.target == 'governance' &&
+      needs.validate-controller-ownership.outputs.should_resume_smoke == 'true'
+    permissions:
+      contents: read
+    uses: ./.github/workflows/_vercel-preview-smoke.yml
+    with:
+      deployment_url: ${{ needs.validate-controller-ownership.outputs.vercel_deployment_url }}
+      expected_project_id: ${{ vars.VERCEL_PROJECT_ID_GOVERNANCE }}
+      expected_sha: ${{ inputs.commit_sha }}
+      github_deployment_id: ${{ needs.validate-controller-ownership.outputs.github_deployment_id }}
+      logical_target: governance
+      metadata_logical_target: governance
+      metadata_project_id: ${{ vars.VERCEL_PROJECT_ID_GOVERNANCE }}
+      metadata_ref: ${{ inputs.git_branch }}
+      metadata_repository: mento-protocol/frontend-monorepo
+      metadata_sha: ${{ inputs.commit_sha }}
+      metadata_target: preview
+      metadata_url: ${{ needs.validate-controller-ownership.outputs.vercel_deployment_url }}
       next_deployment_id: ${{ needs.validate-controller-ownership.outputs.next_deployment_id }}
+      pull_request_number: ${{ inputs.pull_request_number }}
+      vercel_deployment_id: ${{ needs.validate-controller-ownership.outputs.vercel_deployment_id }}
+      verification_key: ${{ inputs.controller_key }}
+      verification_mode: controller
+
+  resume-reserve-smoke:
+    name: Resume Reserve smoke for an existing immutable upload
+    needs: validate-controller-ownership
+    if: >-
+      inputs.target == 'reserve' &&
+      needs.validate-controller-ownership.outputs.should_resume_smoke == 'true'
+    permissions:
+      contents: read
+    uses: ./.github/workflows/_vercel-preview-smoke.yml
+    with:
+      deployment_url: ${{ needs.validate-controller-ownership.outputs.vercel_deployment_url }}
+      expected_project_id: ${{ vars.VERCEL_PROJECT_ID_RESERVE }}
+      expected_sha: ${{ inputs.commit_sha }}
+      github_deployment_id: ${{ needs.validate-controller-ownership.outputs.github_deployment_id }}
+      logical_target: reserve
+      metadata_logical_target: reserve
+      metadata_project_id: ${{ vars.VERCEL_PROJECT_ID_RESERVE }}
+      metadata_ref: ${{ inputs.git_branch }}
+      metadata_repository: mento-protocol/frontend-monorepo
+      metadata_sha: ${{ inputs.commit_sha }}
+      metadata_target: preview
+      metadata_url: ${{ needs.validate-controller-ownership.outputs.vercel_deployment_url }}
+      next_deployment_id: ${{ needs.validate-controller-ownership.outputs.next_deployment_id }}
+      pull_request_number: ${{ inputs.pull_request_number }}
+      vercel_deployment_id: ${{ needs.validate-controller-ownership.outputs.vercel_deployment_id }}
+      verification_key: ${{ inputs.controller_key }}
+      verification_mode: controller
+
+  resume-ui-smoke:
+    name: Resume UI smoke for an existing immutable upload
+    needs: validate-controller-ownership
+    if: >-
+      inputs.target == 'ui' &&
+      needs.validate-controller-ownership.outputs.should_resume_smoke == 'true'
+    permissions:
+      contents: read
+    uses: ./.github/workflows/_vercel-preview-smoke.yml
+    with:
+      deployment_url: ${{ needs.validate-controller-ownership.outputs.vercel_deployment_url }}
       expected_project_id: ${{ vars.VERCEL_PROJECT_ID_UI }}
+      expected_sha: ${{ inputs.commit_sha }}
+      github_deployment_id: ${{ needs.validate-controller-ownership.outputs.github_deployment_id }}
+      logical_target: ui
+      metadata_logical_target: ui
       metadata_project_id: ${{ vars.VERCEL_PROJECT_ID_UI }}
+      metadata_ref: ${{ inputs.git_branch }}
+      metadata_repository: mento-protocol/frontend-monorepo
+      metadata_sha: ${{ inputs.commit_sha }}
+      metadata_target: preview
+      metadata_url: ${{ needs.validate-controller-ownership.outputs.vercel_deployment_url }}
+      next_deployment_id: ${{ needs.validate-controller-ownership.outputs.next_deployment_id }}
+      pull_request_number: ${{ inputs.pull_request_number }}
+      vercel_deployment_id: ${{ needs.validate-controller-ownership.outputs.vercel_deployment_id }}
+      verification_key: ${{ inputs.controller_key }}
+      verification_mode: controller
 
   finalize-resumed-smoke:
     name: Finalize resumed smoke lifecycle
-    needs: [validate-controller-ownership, resume-ui-smoke]
+    needs:
+      - validate-controller-ownership
+      - resume-app-smoke
+      - resume-governance-smoke
+      - resume-reserve-smoke
+      - resume-ui-smoke
     if: >-
       always() &&
       needs.validate-controller-ownership.outputs.should_resume_smoke == 'true'
@@ -240,8 +544,8 @@ jobs:
           GITHUB_DEPLOYMENT_ID: ${{ needs.validate-controller-ownership.outputs.github_deployment_id }}
           GITHUB_TOKEN: ${{ github.token }}
           PREBUILT_RESULT: success
-          SMOKE_RESULT: ${{ needs.resume-ui-smoke.result }}
-          VERCEL_DEPLOYMENT_URL: ${{ needs.resume-ui-smoke.outputs.deployment_url }}
+          SMOKE_RESULT: ${{ (inputs.target == 'app' && needs.resume-app-smoke.result) || (inputs.target == 'governance' && needs.resume-governance-smoke.result) || (inputs.target == 'reserve' && needs.resume-reserve-smoke.result) || needs.resume-ui-smoke.result }}
+          VERCEL_DEPLOYMENT_URL: ${{ needs.validate-controller-ownership.outputs.vercel_deployment_url }}
           WORKFLOW_RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}
         run: node "$GITHUB_WORKSPACE/controller/scripts/github-deployment.mjs" complete
 
@@ -249,8 +553,17 @@ jobs:
     name: Persist immutable pre-completion worker evidence
     needs:
       - validate-controller-ownership
-      - validate-preview-prerequisites
+      - validate-app-prerequisites
+      - validate-governance-prerequisites
+      - validate-reserve-prerequisites
+      - validate-ui-prerequisites
+      - deploy-app-preview
+      - deploy-governance-preview
+      - deploy-reserve-preview
       - deploy-ui-preview
+      - resume-app-smoke
+      - resume-governance-smoke
+      - resume-reserve-smoke
       - resume-ui-smoke
       - finalize-resumed-smoke
     if: >-
@@ -280,10 +593,10 @@ jobs:
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           ACTUAL_WORKFLOW_SHA: ${{ github.workflow_sha }}
-          BUILD_DURATION_MS: ${{ needs.deploy-ui-preview.outputs.build_duration_ms }}
-          BUILD_NEXT_DEPLOYMENT_ID: ${{ needs.deploy-ui-preview.outputs.next_deployment_id }}
-          BUILD_VERCEL_DEPLOYMENT_ID: ${{ needs.deploy-ui-preview.outputs.vercel_deployment_id }}
-          BUILD_VERIFIED_UPLOAD_URL: ${{ needs.deploy-ui-preview.outputs.verified_upload_url }}
+          BUILD_DURATION_MS: ${{ (inputs.target == 'app' && needs.deploy-app-preview.outputs.build_duration_ms) || (inputs.target == 'governance' && needs.deploy-governance-preview.outputs.build_duration_ms) || (inputs.target == 'reserve' && needs.deploy-reserve-preview.outputs.build_duration_ms) || needs.deploy-ui-preview.outputs.build_duration_ms }}
+          BUILD_NEXT_DEPLOYMENT_ID: ${{ (inputs.target == 'app' && needs.deploy-app-preview.outputs.next_deployment_id) || (inputs.target == 'governance' && needs.deploy-governance-preview.outputs.next_deployment_id) || (inputs.target == 'reserve' && needs.deploy-reserve-preview.outputs.next_deployment_id) || needs.deploy-ui-preview.outputs.next_deployment_id }}
+          BUILD_VERCEL_DEPLOYMENT_ID: ${{ (inputs.target == 'app' && needs.deploy-app-preview.outputs.vercel_deployment_id) || (inputs.target == 'governance' && needs.deploy-governance-preview.outputs.vercel_deployment_id) || (inputs.target == 'reserve' && needs.deploy-reserve-preview.outputs.vercel_deployment_id) || needs.deploy-ui-preview.outputs.vercel_deployment_id }}
+          BUILD_VERIFIED_UPLOAD_URL: ${{ (inputs.target == 'app' && needs.deploy-app-preview.outputs.verified_upload_url) || (inputs.target == 'governance' && needs.deploy-governance-preview.outputs.verified_upload_url) || (inputs.target == 'reserve' && needs.deploy-reserve-preview.outputs.verified_upload_url) || needs.deploy-ui-preview.outputs.verified_upload_url }}
           COMMIT_SHA: ${{ inputs.commit_sha }}
           CONTROLLER_KEY: ${{ inputs.controller_key }}
           CONTROLLER_KEY_DIGEST: ${{ inputs.controller_key_digest }}

--- a/README.md
+++ b/README.md
@@ -437,37 +437,45 @@ The repository is set up with GitHub Actions for CI:
   check enforces production-source coverage and gzip route limits. Its general
   CI failure notifier opens or updates one issue for an operational workflow
   failure and closes the issue after recovery.
-- **CD**: GitHub Actions automatically builds `ui.mento.org` previews for
-  trusted same-repository PRs with exact-SHA `Vercel Preview` statuses,
-  first-eligible-plus-latest batching, credential-free HTTP and browser smoke,
-  one canonical GitHub Deployment, and one canonical preview-controller journal
-  comment per participating PR. Dependabot events pass through a read-only
+- **CD**: GitHub Actions automatically builds `app.mento.org`,
+  `governance.mento.org`, `reserve.mento.org`, and `ui.mento.org` previews for
+  trusted same-repository PRs with exact-SHA aggregate `Vercel Preview`
+  statuses, independent first-eligible-plus-latest batching per target,
+  credential-free reusable HTTP and browser smoke, one canonical GitHub
+  Deployment per selected target, and one four-target v2 controller-journal
+  comment with a visible outcome table per participating PR. The canonical
+  target definitions, package
+  names, Vercel project variables, configuration paths, and ownership modes live
+  in `scripts/vercel-preview-targets.mjs`; workflow callers remain literal so
+  GitHub can resolve each target's secrets statically. Dependabot events pass
+  through a read-only
   metadata intake; trusted default-branch code re-queries the exact PR head
   before publishing the explicit preview-disabled status. Fork and Dependabot
   PRs remain credential-free. A dedicated repository-scoped GitHub credential
   performs only the worker-dispatch POST so terminal `workflow_run` callbacks
   are created; the normal job token still owns all state and recovery calls.
-  After the Phase A-canary-gated Phase B cutover, GitHub Actions owns UI branch
-  previews and native Vercel Git branch previews are disabled only for UI.
-  The version-controlled controller mode is `active` in that state; the
-  executable ownership test permits rollback only when the same PR switches it
-  to `observe-only` and restores native UI branch previews, preventing duplicate
-  automatic owners. The trusted controller also reads the candidate's bounded
-  exact-head UI Vercel configuration and rechecks it before dispatch: an exact
-  native rollback head suppresses GitHub dispatch even before merge, while an
-  unknown configuration or an `observe-only`/GitHub-owned head fails closed.
+  GitHub Actions is the sole automatic branch-preview owner for UI. App,
+  governance, and reserve initially run in shadow mode, where their existing
+  native Vercel branch previews remain enabled alongside GitHub-built canaries.
+  The version-controlled controller mode is `active`; per-target ownership and
+  exact expected Vercel configurations are executable invariants. The trusted
+  controller reads every selected target's bounded exact-head Vercel
+  configuration and rechecks it before dispatch. An exact native configuration
+  suppresses GitHub dispatch only for a target whose canonical ownership mode
+  is `github`; unknown or contradictory configuration fails closed.
   During rollback, `Vercel Preview` proves owner selection and journal drain
   only; native Vercel deployment status and browser evidence separately prove
   that the preview works.
-  Vercel Git still owns every main/production deployment and all non-UI apps. See
+  Vercel Git still owns every main/production deployment. See
   [ADR 0001](docs/adr/0001-github-actions-vercel-deployment-orchestration.md)
   for the accepted ownership boundary,
   [ADR 0002](docs/adr/0002-single-comment-preview-controller-journal.md) for
   the journal persistence and clean-cutover decision,
   [ADR 0003](docs/adr/0003-preview-worker-dispatch-authentication.md) for the
   worker-dispatch authentication boundary, and
-  [`docs/vercel-deployments.md`](docs/vercel-deployments.md) for the Phase B
-  UI-only cutover, bootstrap, canary, and rollback procedures.
+  [`docs/vercel-deployments.md`](docs/vercel-deployments.md) for the four-target
+  v2 bootstrap, activation canaries, per-target cutover, and rollback
+  procedures.
 
 Dependency-installing jobs use `.github/actions/pnpm-install`, which pins the
 Node/pnpm bootstrap, relies on `actions/setup-node` as the single pnpm-store

--- a/docs/adr/0002-single-comment-preview-controller-journal.md
+++ b/docs/adr/0002-single-comment-preview-controller-journal.md
@@ -3,7 +3,7 @@ title: One canonical pull-request comment stores the preview controller journal
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-07-17
+last_verified: 2026-07-21
 scope: ci/deployment/preview-controller-state
 date: 2026-07
 ---
@@ -49,22 +49,25 @@ Every participating non-Dependabot pull request has exactly one canonical
 targets. The hidden marker and payload schema are:
 
 ```text
-<!-- vercel-preview-journal:v1 -->
-vercel-preview-journal:v1
+<!-- vercel-preview-journal:v2 -->
+vercel-preview-journal:v2
 ```
 
-The comment keeps the reviewer explanation outside one collapsed `<details>`
-block and stores one canonical JSON document inside it. That document contains
-the repository and pull-request identity, a monotonic revision, an optional
-deterministic checkpoint, logically immutable live
-event/selection/worker-evidence/result entries, and the bounded mutable
-controller state. The top-level `journal_digest` covers the checkpoint,
-canonical live receipt set, and mutable state; `state.receipts_digest`
-separately binds reconciliation to the checkpoint plus live receipt set. The
-canonical Markdown envelope includes an
-explicit closing `</details>` tag and permits no extra presentation text. The
-comment ID is stable for the life of the journal. Updates edit that comment;
-they never create another journal or a receipt-specific comment.
+The comment keeps the reviewer explanation and a compact, stable-order
+`app`/`governance`/`reserve`/`ui` outcome table outside one collapsed
+`<details>` block. Each row links the useful immutable deployment or worker run
+when one exists. The table is derived from the journal and is part of the exact
+canonical body; it is not a second state surface. One canonical JSON document
+inside the collapsed block contains the repository and pull-request identity,
+a monotonic revision, an optional deterministic checkpoint, logically
+immutable live event/selection/worker-evidence/result entries, and the bounded
+mutable four-target controller state. The top-level `journal_digest` covers the
+checkpoint, canonical live receipt set, and mutable state;
+`state.receipts_digest` separately binds reconciliation to the checkpoint plus
+live receipt set. The canonical Markdown envelope includes an explicit closing
+`</details>` tag and permits no extra presentation text. The comment ID is
+stable for the life of the journal. Updates edit that comment; they never
+create another journal or a receipt-specific comment.
 
 Receipt immutability is enforced by the journal protocol. A deterministic
 receipt identity may be inserted once. Replaying an identical receipt is a
@@ -77,16 +80,17 @@ receipt set.
 Before appending a later event, a terminal journal with no active or retired
 worker and no unfinished evidence deterministically checkpoints its completed
 prefix in place. The checkpoint retains the cumulative receipt digest and
-counts, the verified lifecycle tail event, and its terminal status. Open state
-uses the reconciled lineage tail; closed state uses the matching closure. The
-mutable state is rebased onto that verified tail and the completed live
-receipts are cleared. Semantic replays of the checkpoint tail are idempotent,
-while a conflicting receipt under the same run identity fails closed. A
-docs-only checkpoint tail carries forward the inherited runtime success URL or
-terminal failure/error meaning for subsequent docs-only pushes. This is one
-atomic revision of the same comment and schema, not rollover, archival, or a
-second persistence path. A 50-preview sequential-cycle fixture peaks at 7,772
-rendered UTF-8 bytes.
+counts, the verified lifecycle tail event, and independent status, runtime,
+and pending-owner evidence for every target. Open state uses the reconciled
+lineage tail; closed state uses the matching closure. The mutable state is
+rebased onto that verified tail and the completed live receipts are cleared.
+Semantic replays of the checkpoint tail are idempotent, while a conflicting
+receipt under the same run identity fails closed. A docs-only checkpoint tail
+carries each target's inherited runtime success URL or terminal failure/error
+meaning for subsequent docs-only pushes. This is one atomic revision of the
+same comment and schema, not rollover, archival, or a second persistence path.
+A four-target 50-preview sequential-cycle fixture remains below a strict
+16,000-byte rendered UTF-8 bound.
 
 The same checkpoint field protects an overlapping push burst before the hard
 body limit is reached. At a 40,000-byte soft threshold, the controller proves a
@@ -124,7 +128,7 @@ After acquiring that queue, a writer:
 3. updates the existing comment, or creates it for an explicit bootstrap, a
    first-attempt `opened`, or another first-attempt non-closed PR event only
    after proving that its `before` and head commits carry no matching
-   `Vercel Preview Journal / PR #<number>` initialization status;
+   `Vercel Preview Journal v2 / PR #<number>` initialization status;
 4. rereads the comment and proves its exact revision, canonical JSON, and
    journal digest before publishing statuses or dispatching work.
 
@@ -137,8 +141,8 @@ contents and current pull-request state continue to determine selection.
 A first-attempt non-closed event may win the queue before `opened`; it may
 create the journal only when no durable controller status for the same PR
 exists on its `before` or head commit. Every durably recorded event ensures a
-separate `Vercel Preview Journal / PR #<number>` success-status witness on its
-head before normal reconciliation. This advances deletion evidence across
+separate `Vercel Preview Journal v2 / PR #<number>` success-status witness on
+its head before normal reconciliation. This advances deletion evidence across
 pushes and lets a retry repair a status write that failed after the journal
 mutation committed. A witness from another PR on a reused or stacked commit is
 not initialization evidence for this PR. The witness never reuses the
@@ -168,52 +172,42 @@ transition can authorize work.
 
 Tokens, environment files, cookies, output directories, bypass values, raw
 provider responses, and credential values never enter the journal. The
-`Vercel Preview` commit status and canonical GitHub Deployment remain the
-reviewer and operator surfaces; the journal is internal coordination evidence,
-not a new required check or deployment.
+journal's compact target table, aggregate `Vercel Preview` commit status, and
+canonical GitHub Deployments are the reviewer and operator surfaces. The
+collapsed JSON remains internal coordination evidence, not a new required
+check or deployment.
 
 ### Clean cutover, cleanup, and rollback
 
-There is no dual-read period and no compatibility path for already-running
-legacy workers. Before merging the journal implementation, operators inventory
-all preview controller, worker, and intake runs and let them terminate or cancel
-them. The cutover must not proceed while a legacy run can still write a receipt
-comment, dispatch work, or act on legacy controller state. The implementation
-contains no legacy-comment reader, presentation upgrader, payload importer, or
-rematerialization path.
+There is no dual-read period and no compatibility path for v1 journals or
+already-running v1 workers. Before merging v2, operators establish a no-push
+window; drain or cancel every preview controller, worker, and intake run; and
+inventory the exact comment ID of every open participating PR's trusted
+`<!-- vercel-preview-journal:v1 -->` comment. The cutover must not proceed while
+a v1 run can still write a journal, dispatch work, or publish preview state.
+The v2 implementation contains no v1 reader, writer, presentation upgrader,
+payload importer, deleter, rematerializer, or compatibility worker.
 
 After the merge, every open participating pull request is bootstrapped from its
-current live PR metadata and a fresh fail-closed plan. The bootstrap creates a
-new journal epoch; it does not import, translate, trust, or reconcile legacy
-comment payloads. Previously created preview evidence is outside the new
-journal's ownership unless the fresh controller independently proves it through
-the normal GitHub Deployment and provider APIs.
+current live PR metadata and a fresh fail-closed four-target plan. Bootstrap
+creates an independent v2 journal epoch; it does not import, translate, trust,
+or reconcile the v1 payload. Operators must prove exactly one trusted
+`<!-- vercel-preview-journal:v2 -->` comment with a stable ID, all four target
+states/checkpoints, and an exact-head aggregate status consistent with worker,
+Deployment, native-owner, or no-runtime evidence.
 
-Only after each fresh journal is reread and its status/dispatch decision is
-valid may an operator delete legacy machine comments. Deletion is restricted
-to comments authored by `github-actions[bot]` whose complete body validates
-under one of the exact retired `vercel-preview-event-receipt:v1`,
-`vercel-preview-selection:v1`, `vercel-preview-worker-evidence:v1`,
-`vercel-preview-worker-result:v1`, or `vercel-preview-controller:v1`
-marker/schema pairs and one of the retired canonical Markdown envelopes.
-Unknown, malformed, human, review, third-party-bot, and journal comments are
-never deleted. Closed historical pull requests need no new journal; after the
-run inventory proves quiescence, their exact validated legacy machine comments
-may be removed as historical cleanup.
+Only after every open PR's v2 journal is proven may an operator manually delete
+the inventoried v1 comment IDs. Each deletion rereads and requires the exact
+recorded ID, exact `github-actions[bot]` author, and complete v1 journal marker.
+Unknown, malformed, human, review, and third-party-bot comments are never
+deleted. Cleanup is an operator step; it is deliberately absent from v2 runtime
+code.
 
-Cleanup failure is cosmetic and retryable because the new journal is the only
-authoritative source after cutover. Legacy comments that remain temporarily are
-ignored by the new controller. A journal write or verification failure is not
-cosmetic and blocks status progression and dispatch.
-
-Rollback is also a clean restart, not a data migration. Operators first drain
-or cancel journal-era controller and worker runs, merge the reviewed rollback,
-and bootstrap the restored controller afresh from live pull-request state. The
-rollback does not rematerialize legacy receipts from the journal and must not
-claim continuity with journal-owned epochs. Journal comments may be retained
-as inert audit evidence until the restored controller is proven; deletion, if
-desired, requires exact `github-actions[bot]` authorship and full validation of
-the journal marker, schema, and canonical body.
+Rollback is a v2 roll-forward restart, not a data migration. Operators first
+drain or cancel v2 controller and worker runs, merge the reviewed corrective
+change, and bootstrap v2 afresh from live pull-request state. Never restore the
+v1 controller, import a v1 payload, rematerialize a deleted v1 journal, or claim
+continuity with the discarded epoch.
 
 ## Alternatives considered
 
@@ -269,8 +263,9 @@ cost, retention policy, and operator dependency for preview deployment.
 
 ## Consequences
 
-- Reviewers see at most one explanatory, collapsed preview-controller journal
-  rather than one card per procedural receipt.
+- Reviewers see at most one explanatory preview-controller journal with four
+  visible target outcomes and collapsed machine state, rather than one card per
+  procedural receipt.
 - The journal comment is a single persistence object. Deletion, corruption,
   duplicate creation, or ambiguous ownership fails closed.
 - Receipt immutability becomes protocol-enforced inside a mutable envelope

--- a/docs/vercel-deployments.md
+++ b/docs/vercel-deployments.md
@@ -1,27 +1,27 @@
 # Vercel deployments from GitHub Actions
 
-This runbook documents the repository-owned planning, build, and automatic UI
-preview controller used by the GitHub Actions deployment migration tracked in
+This runbook documents the repository-owned planning, build, and automatic
+four-target preview controller used by the GitHub Actions deployment migration tracked in
 [issue #515](https://github.com/mento-protocol/frontend-monorepo/issues/515).
 The ownership boundary and its trade-offs are recorded in
 [ADR 0001](adr/0001-github-actions-vercel-deployment-orchestration.md).
-Phase A enabled GitHub-built previews for trusted same-repository UI pull
-requests while native Vercel Git UI previews remained enabled for canary
-comparison. After that evidence gate, Phase B transferred only UI branch-preview
-ownership to GitHub Actions. Native Vercel Git previews are now disabled for UI
-branches other than `main`; production/main and every non-UI application remain
-owned by Vercel Git.
+The v2 controller builds App, Governance, Reserve, and UI independently from one
+target-ordered plan. UI branch-preview ownership is GitHub-only. App,
+Governance, and Reserve are in shadow mode: GitHub builds run alongside their
+native Vercel Git previews until each target completes its own canary and a
+separate atomic ownership cutover. Vercel Git continues to own every main and
+production deployment.
 
 The automatic controller's version-controlled
 `VERCEL_PREVIEW_CONTROLLER_MODE` is `active` in this ownership state. The only
 other accepted value is `observe-only`, which records receipts, recovers or
 retires already-persisted dispatch ownership, and publishes a truthful
-no-dispatch status but cannot create a worker. The executable ownership test
-requires `active` to be paired with disabled native UI branch previews and
-`observe-only` to be paired with restored native previews. The runtime
-controller separately validates the candidate's exact-head UI Vercel
-configuration, covering the pull-request window in which the trusted workflow
-still comes from `main` while Vercel already reads the candidate branch.
+no-dispatch status but cannot create a worker. The canonical target order,
+workspace/root/project mapping, exact native/GitHub `vercel.json` shapes, and
+per-target `shadow` or `github` mode live together in
+`scripts/vercel-preview-targets.mjs`. The workflow topology, runtime ownership
+guards, and ownership tests import or structurally verify that source; do not
+copy a second ownership table into executable code.
 
 ## Pinned prerequisites
 
@@ -332,26 +332,26 @@ The workspace and Root Directory are not independent free-form selectors: each
 must match the selected target. All four identities are standard `preview`
 builds. Automatic identity is also target-bound to
 `preview/<target>/pr-<number>` and
-`vercel-preview:v1:pr:<number>:target:<target>:sha:<sha>`. Each future literal
-caller must still pass its own opaque `VERCEL_PROJECT_ID_*` value explicitly;
+`vercel-preview:v1:pr:<number>:target:<target>:sha:<sha>`. This external key
+intentionally retains `v1` so existing GitHub/Vercel Deployment identity stays
+stable across the internal controller migration. Each literal caller passes
+its own opaque `VERCEL_PROJECT_ID_*` value explicitly;
 the reusable workflow contains no matrix or dynamic project/secret lookup.
 
-This generic core does not itself activate the remaining applications. The
-current automatic worker continues to call only the UI target with
-`preview-controller:v1`. Both its initial upload path and its same-upload retry
-call the secretless four-target `_vercel-preview-smoke.yml` workflow with the
-complete verified tuple before canonical Deployment success. App, Governance,
-and Reserve already have target-specific smoke implementations, but their
-literal controller callers remain absent until the separate atomic activation
-change. No ownership configuration changes as part of this interface
-preparation.
+The automatic worker has four literal caller jobs in stable `app`,
+`governance`, `reserve`, `ui` order and writes internal
+`preview-controller:v2` provenance. There is no matrix, dynamic secret name,
+or `secrets: inherit`. Initial uploads and same-upload retries call the single
+secretless `_vercel-preview-smoke.yml` workflow with the complete verified
+target tuple before canonical Deployment success. The v2 activation does not
+change any target's `vercel.json`; App, Governance, and Reserve therefore remain
+dual-run shadow canaries while UI remains GitHub-owned.
 
 The reusable declaration has the three common secrets
 (`VERCEL_TOKEN_PREVIEW`, `TURBO_TOKEN`, and
 `TURBO_REMOTE_CACHE_SIGNATURE_KEY`) plus one optional Governance-only
-`ETHERSCAN_API_KEY` input. Current UI callers pass only the three common
-secrets. A future literal Governance caller must pass `ETHERSCAN_API_KEY`;
-App, Reserve, and UI must not. No preview caller declares or passes
+`ETHERSCAN_API_KEY` input. App, Reserve, and UI pass only the three common
+secrets; Governance alone also passes `ETHERSCAN_API_KEY`. No preview caller declares or passes
 `SENTRY_AUTH_TOKEN`, and the preflight rejects either Sensitive name if it
 appears in the Vercel-pulled file before candidate code can execute.
 
@@ -776,7 +776,7 @@ run-specific evidence only. The adapter receives no PAT, Vercel token, Turbo
 token, or application secret and is deleted after all native consumers leave
 the observation window.
 
-## Automatic trusted UI previews (current; introduced in Phase A)
+## Automatic trusted four-target previews (current v2 controller)
 
 `.github/workflows/vercel-preview-controller.yml` is the only automatic event
 controller. It runs trusted default-branch code for `pull_request_target`
@@ -787,21 +787,22 @@ completed `Vercel Preview Worker` callbacks; and accepts the default-branch-boun
 one validated PR number. The controller has no Vercel/Turbo credential and no
 write-token job checks out or executes PR code.
 
-The workflow-level `VERCEL_PREVIEW_CONTROLLER_MODE` is an executable ownership
+The workflow-level `VERCEL_PREVIEW_CONTROLLER_MODE` is an executable global
 switch, not a secret or an operator-set repository variable. Every
 reconciliation passes it to the trusted controller implementation. For each
-open trusted PR, the controller reads `apps/ui.mento.org/vercel.json` through
-the Contents API at immutable 40-character SHAs. The current PR head selects
-the controller's overall mode, but every historical event selected for dispatch
-is checked again at that event's own SHA after its PR-lineage association is
-proven. It accepts only the bounded, valid UTF-8 JSON representation of the two
-exact reviewed ownership configurations in this runbook; missing, oversized,
-malformed, or unknown content fails closed before any worker-dispatch request.
+open trusted PR, the controller reads all four canonical `vercel.json` paths
+through the Contents API at immutable 40-character SHAs. Each target is
+evaluated independently against its canonical mode in
+`scripts/vercel-preview-targets.mjs`: `shadow` always permits the GitHub canary
+alongside an exact native configuration, while `github` requires the exact
+GitHub-owned configuration. Every selected historical event is rechecked at its
+own SHA after PR-lineage proof. Missing, oversized, malformed, or unknown
+content fails closed before any worker-dispatch request.
 
-`active` can create a worker only while both the current head and the selected
-event SHA have the exact GitHub-owned configuration, and rechecks both immutable
-ownership inputs immediately before the dispatch credential can make its only
-POST. A selected native-owned receipt is persisted as an intent and routed
+`active` creates at most one independent worker per affected target and
+rechecks the current and selected immutable ownership inputs immediately before
+the dispatch credential can make its only POST. A selected native-owned receipt
+for a GitHub-mode target is persisted as an intent and routed
 through the same bounded no-dispatch recovery path: one already-created worker
 is attached and drained, while no matching worker produces the durable
 `native-owned-selection-without-github-worker` result and advances
@@ -809,9 +810,10 @@ reconciliation to the next receipt. That dedicated terminal reason is
 ownership-success, not GitHub build evidence; it creates no GitHub Deployment.
 The generic `dispatch-disabled-intent-without-worker` result remains an error
 for the SHA whose GitHub-owned intent was retired, so a later ownership flip
-cannot falsely relabel that historical SHA as native-owned. The exact native
-configuration also suppresses dispatch when the default-branch workflow is
-still `active`, which protects a rollback PR before it merges. `observe-only`
+cannot falsely relabel that historical SHA as native-owned. For a GitHub-mode
+target, the exact native configuration also suppresses dispatch when the
+default-branch workflow is still `active`, which protects a rollback PR before
+it merges. `observe-only`
 never creates a new dispatch intent or worker.
 It does, however, reconcile every previously persisted `intended` entry in both
 the current and epoch-retired ownership slots: one unique existing worker is
@@ -819,9 +821,9 @@ attached without the secondary credential, a completed worker is terminalized
 in the same reconciliation attempt, an in-progress worker remains durably
 attached in its original slot for its callback, and no match after bounded
 observation is retired as `dispatch-disabled-intent-without-worker`. Multiple
-matches fail closed. An `observe-only` controller paired with the GitHub-owned
-candidate configuration also fails closed because neither automatic preview
-path would own that head.
+matches fail closed. An `observe-only` controller fails closed when any target
+would otherwise require GitHub ownership, because that target would have no
+automatic preview owner.
 
 Dependabot is intentionally split out before any write boundary.
 `.github/workflows/vercel-preview-intake.yml` receives the same PR activities
@@ -873,14 +875,17 @@ separate credentialless intake contract above. The journal's hidden marker and
 payload schema are exactly:
 
 ```text
-<!-- vercel-preview-journal:v1 -->
-vercel-preview-journal:v1
+<!-- vercel-preview-journal:v2 -->
+vercel-preview-journal:v2
 ```
 
 The journal is an internal coordination record, not review feedback. Its
-reviewer explanation remains visible while one collapsed GitHub `<details>`
-block contains canonical JSON. That document holds the repository and PR
-identity, a monotonic revision, an optional deterministic checkpoint, a
+reviewer explanation and stable-order App/Governance/Reserve/UI outcome table
+remain visible; useful immutable deployment or worker URLs are linked from the
+matching outcome. One collapsed GitHub `<details>` block contains canonical
+JSON. The visible table is derived from that JSON and is part of the exact
+canonical body, not a second state surface. The document holds the repository
+and PR identity, a monotonic revision, an optional deterministic checkpoint, a
 top-level journal digest over that checkpoint, the canonical live receipt set,
 and mutable state, logically immutable live
 event/selection/worker-evidence/result entries, and bounded mutable controller
@@ -898,7 +903,7 @@ journal count and complete canonical body, applies one idempotent transition,
 updates the comment, or initially creates it for an explicit bootstrap, a
 first-attempt `opened`, or another first-attempt non-closed PR event whose
 `before` and head commits have no prior PR-scoped
-`Vercel Preview Journal / PR #<number>` initialization status,
+`Vercel Preview Journal v2 / PR #<number>` initialization status,
 then rereads and proves the expected
 revision, canonical JSON, journal digest, and, when state exists,
 `state.receipts_digest` before publishing a status or dispatching a worker.
@@ -907,7 +912,7 @@ ambiguous reread fail closed.
 
 A first-attempt non-closed event can therefore preserve an out-of-order receipt
 when it wins the queue before `opened`. Every durably recorded event ensures a
-`Vercel Preview Journal / PR #<number>` success-status witness on its head before
+`Vercel Preview Journal v2 / PR #<number>` success-status witness on its head before
 normal reconciliation. That lets a retry repair a witness write that failed
 after the journal mutation and carries deletion evidence across every push. The
 PR suffix prevents a status left on a reused or stacked commit by another PR
@@ -925,7 +930,8 @@ restart.
 Before a later event is appended, a terminal journal with no active or retired
 worker and no unfinished evidence folds its completed prefix into one
 deterministic in-place checkpoint. The checkpoint holds cumulative receipt
-counts and digest, the verified lifecycle tail event, and its terminal status.
+counts and digest, the verified lifecycle tail event, and independent status,
+runtime, and pending-owner evidence for all four targets.
 For an open PR the tail is the last reconciled lineage event; for a closed PR
 it is the closure whose timestamp matches current GitHub state. State is
 rebased onto that tail and completed live receipts are cleared in the same
@@ -935,10 +941,10 @@ with another workflow run ID is already represented and is therefore a no-op;
 the same run ID with conflicting content still fails closed. When a docs-only
 tail is checkpointed, its inherited terminal runtime state, immutable URL, and
 failure or cancellation meaning continue across later docs-only pushes rather
-than reverting to a fresh no-runtime success. A 50-preview sequential-cycle
-test peaks at 7,772 rendered UTF-8 bytes. This is still one comment, schema,
-and controller path: there is no archive, rollover, second comment, or
-compatibility reader.
+than reverting to a fresh no-runtime success. The four-target 50-preview
+sequential-cycle fixture remains below a strict 16,000-byte bound. This is still
+one comment, schema, and controller path: there is no archive, rollover, second
+comment, or compatibility reader.
 
 An overlapping push burst uses the same checkpoint field before the rendered
 body reaches capacity. At the 40,000-byte soft threshold, the controller proves
@@ -978,11 +984,13 @@ base-to-head transition. Title, body, label, and other unrelated edits create
 neither an entry nor a reconciliation.
 
 `Vercel Preview` is reserved for a Statuses API commit status, not a workflow
-job/check name. Every exact journal event SHA gets one truthful result: pending,
-verified, no runtime impact, runtime-equivalent to a prior preview, unsupported
-trust boundary, durably coalesced, failure, or controller error. Detailed
-PR/SHA/key/run/Deployment evidence remains in the canonical journal because
-status descriptions are bounded.
+job/check name. Every exact journal event SHA gets one aggregate result whose
+bounded description reports `app`, `governance`, `reserve`, and `ui` outcomes
+in that stable order. The aggregate fails on any target error/failure, remains
+pending while any target is pending, and otherwise succeeds. Each target's
+independent outcome and exact-SHA evidence remain in the v2 journal; the status
+target prefers the relevant immutable deployment or worker URL over a neutral
+controller link.
 
 Terminal status targets are durable evidence rather than the URL of whichever
 controller invocation happened to reconcile them. Verified uploads, including
@@ -1002,14 +1010,15 @@ reconciliation: the controller conservatively writes the canonical status
 again, so an externally deleted or altered status is repaired while a genuine
 pending-to-terminal or target transition remains visible.
 
-For each open/reopen/base-retarget/bootstrap epoch, the oldest journal event
-entry that actually affects the UI is `first_eligible_sha`. It always runs
-first. An identical bootstrap aliases an existing lifecycle anchor instead of
-creating a second epoch. While that worker is queued/running, later runtime
-pushes replace only `latest_desired_sha`; when the first worker terminates, only
-that latest SHA runs. Documentation/test-only pushes never replace the desired
-runtime SHA. After a verified runtime preview, a later non-runtime SHA succeeds
-by linking to that runtime-equivalent immutable preview without rebuilding.
+For each open/reopen/base-retarget/bootstrap epoch and each target, the oldest
+event that affects that target is its `first_eligible_sha` and runs first.
+Targets advance independently in canonical order. An identical bootstrap
+aliases an existing lifecycle anchor instead of creating a second epoch. While
+one target's worker is queued/running, later affected pushes replace only that
+target's `latest_desired_sha`; after the first worker terminates, only its latest
+SHA runs. A push may therefore deploy one target while another remains active,
+coalesced, runtime-equivalent, or unaffected. Documentation/test-only pushes do
+not replace any desired runtime SHA.
 
 Each selected transition is bound to its lifecycle epoch, canonical
 reconciliation-basis digest, immutable journal event entry, and the exact
@@ -1133,8 +1142,8 @@ Git-ownership cutover.
 The canonical Deployment key and environment are:
 
 ```text
-vercel-preview:v1:pr:<number>:target:ui:sha:<40-hex-sha>
-preview/ui/pr-<number>
+vercel-preview:v1:pr:<number>:target:<target>:sha:<40-hex-sha>
+preview/<target>/pr-<number>
 ```
 
 The explicit REST Deployment uses the exact SHA, `auto_merge: false`, empty
@@ -1149,11 +1158,12 @@ exact SHA ancestry, bot-owned active journal state, and canonical Deployment.
 The evidence writer repeats the immutable-SHA comparison and persists that SHA
 in non-terminal and terminal journal entries. A mismatch fails before any build
 or deployment credential is reachable. A separate trusted preflight prints
-only missing repository variable/secret names. The literal UI reusable caller
+only missing repository variable/secret names. Each literal reusable caller
 receives only `VERCEL_TOKEN_PREVIEW`, `TURBO_TOKEN`, and
-`TURBO_REMOTE_CACHE_SIGNATURE_KEY`, plus `VERCEL_ORG_ID`,
-`VERCEL_PROJECT_ID_UI`, and `TURBO_TEAM`. The direct smoke/resume jobs receive no
-deployment credential.
+`TURBO_REMOTE_CACHE_SIGNATURE_KEY`, its literal `VERCEL_PROJECT_ID_*`, plus
+`VERCEL_ORG_ID` and `TURBO_TEAM`. Governance alone additionally receives
+`ETHERSCAN_API_KEY`; no preview caller receives a Sentry token. Direct
+smoke/resume jobs receive no deployment credential.
 
 The worker is dispatched on `main`, and the reusable contract requires both
 `refs/heads/main` and the exact main-branch `vercel-preview-worker.yml` caller
@@ -1257,63 +1267,109 @@ repository names must be provisioned by a maintainer; automation may check
 presence but must never retrieve, export, reconstruct, or print credential
 values.
 
-### Clean journal cutover and legacy cleanup
+### Clean v1-to-v2 journal migration
 
-The journal rollout is a clean cutover. It has no dual-read window, legacy
-worker compatibility, payload import, or in-controller migration path.
+The four-target v2 controller is a clean replacement for the UI-only v1
+controller. Runtime code has no v1 reader, writer, importer, deleter,
+compatibility worker, or dual-read window. The migration deliberately abandons
+v1 lifecycle continuity and rebuilds authoritative state from current GitHub
+PR metadata.
 
-1. Before merging, inventory all runs of the preview controller, preview
-   worker, and preview intake workflows. Let every listed run terminate, or
-   cancel it, and verify that no legacy run can still write a comment or
-   dispatch work.
-2. Merge the journal implementation.
-3. Inventory every open participating PR from current GitHub state and dispatch
-   `vercel-preview-bootstrap` for each one using the command above. Bootstrap
-   plans from live PR metadata; it must not read, translate, trust, or reconcile
-   any retired comment payload.
-4. For each PR, prove that exactly one trusted-bot comment has the
-   `<!-- vercel-preview-journal:v1 -->` marker, record its comment ID, reread its
-   canonical JSON, and verify that the exact-head `Vercel Preview` status and
-   worker/Deployment decision agree with the fresh plan. Subsequent transitions
-   must edit that same comment ID.
-5. Only after step 4 succeeds, run the reviewed cleanup against the inventory.
-   Delete a comment only when its author is exactly `github-actions[bot]`, its
-   complete hidden marker validates, and its complete JSON body validates under
-   the matching retired schema: `vercel-preview-event-receipt:v1`,
-   `vercel-preview-selection:v1`, `vercel-preview-worker-evidence:v1`,
-   `vercel-preview-worker-result:v1`, or `vercel-preview-controller:v1`.
+1. Establish a coordinated no-push window. Inventory every non-completed run of
+   the preview controller, worker, and intake workflows. Let each run terminate
+   or cancel it, then verify that no v1 run can still edit a journal, dispatch a
+   worker, or publish preview state.
+2. Inventory every open participating PR and record the exact comment ID of
+   each `github-actions[bot]` comment whose complete marker is
+   `<!-- vercel-preview-journal:v1 -->`. Treat those comments only as retired
+   audit evidence; do not copy or translate their payloads.
+3. Merge the v2 controller without changing any Vercel project configuration.
+4. Dispatch `vercel-preview-bootstrap` once for every open participating PR by
+   using the command above. Bootstrap must plan from the live PR head and
+   current repository files, never from the v1 journal.
+5. For each PR, prove that exactly one trusted-bot comment has the
+   `<!-- vercel-preview-journal:v2 -->` marker and record its stable comment ID.
+   Verify its `vercel-preview-journal:v2` payload contains independent state and
+   checkpoint records for `app`, `governance`, `reserve`, and `ui`; its aggregate
+   exact-head `Vercel Preview` status must agree with the expected worker,
+   Deployment, native-owner, or no-runtime result for every target. A later
+   transition must edit that same v2 comment instead of creating another one.
+6. Only after every v2 bootstrap in step 5 is proven, manually delete the
+   inventoried v1 comments. Before each deletion, reread the comment and require
+   the exact recorded ID, `github-actions[bot]` author, and complete v1 journal
+   marker. Do not delete by substring, age, or author alone; leave malformed,
+   unknown, human, third-party-bot, and review comments untouched. This is an
+   operator cleanup step, not a code path in the v2 controller.
+7. Release the no-push window after all open participating PRs have a verified
+   v2 journal. Subsequent reconcile, worker callback, close, and reopen events
+   must continue using only v2 state.
 
-The retired marker shapes eligible for that full-body validator are:
+Rollback is a v2 roll-forward restart: drain or cancel all v2 controller and
+worker runs, merge the reviewed corrective change, and bootstrap fresh v2
+journals from live PR state. Never restore the v1 controller, import a v1
+payload, rematerialize a deleted v1 journal, or claim lifecycle continuity
+across the restart.
 
-| Retired schema                      | Exact marker shape                                                     |
-| ----------------------------------- | ---------------------------------------------------------------------- |
-| `vercel-preview-event-receipt:v1`   | `<!-- vercel-preview-event-receipt:v1:run:<run-id> -->`                |
-| `vercel-preview-selection:v1`       | `<!-- vercel-preview-selection:v1:key:<key-digest> -->`                |
-| `vercel-preview-worker-evidence:v1` | `<!-- vercel-preview-worker-evidence:v1:<key-digest>:run:<run-id> -->` |
-| `vercel-preview-worker-result:v1`   | `<!-- vercel-preview-worker-result:v1:<key-digest>:run:<run-id> -->`   |
-| `vercel-preview-controller:v1`      | `<!-- vercel-preview-controller:v1 -->`                                |
+### Four-target v2 activation canary and later ownership cutovers
 
-The validator must also accept only the two retired canonical Markdown
-envelopes: the original marker-plus-JSON-fence body and the later
-reviewer-explanation-plus-`<details>` body. A marker prefix or schema field by
-itself is never deletion evidence.
+Activating the v2 controller does not edit a Vercel project configuration. In
+the initial ownership map, GitHub Actions is the sole automatic branch-preview
+owner for `ui`; `app`, `governance`, and `reserve` remain in shadow mode so
+their native Vercel and GitHub-built previews run together. Main and production
+deployments remain native for every target.
 
-The cleanup must leave unknown or malformed comments, human and third-party-bot
-comments, review discussion, and every `vercel-preview-journal:v1` comment
-untouched. Do not delete by body substring, comment age, or author alone. Closed
-historical PRs do not receive a journal; after the run inventory proves
-quiescence, the same exact author-plus-marker-plus-schema validator may remove
-their retired comments. Cleanup failures are cosmetic and retryable because the
-journal controller ignores legacy comments after cutover. Journal creation,
-update, or reread failures remain blocking.
+After the v2 bootstrap, exercise one runtime-affecting PR per target before a
+single PR that affects multiple targets. For every canary, record the PR and
+exact SHA, controller and worker run URLs, canonical Deployment ID and
+environment, GitHub-built immutable URL, native immutable URL when the target
+is shadowed, v2 journal comment ID and revision, exact-head aggregate status,
+and browser evidence. Prove all of the following:
 
-Rollback is another clean restart. Drain or cancel journal-era controller and
-worker runs, merge the reviewed rollback, then bootstrap the restored
-controller afresh from live PR state. Do not rematerialize legacy comments from
-journal entries or claim lifecycle continuity across the rollback. Retain
-journal comments as inert audit evidence until the restored controller has been
-proven; if they are later removed, apply the same exact trusted-author and
-full-body schema validation.
+1. only the affected targets advance, while unaffected target checkpoints stay
+   stable;
+2. each selected target uses
+   `preview/<target>/pr-<number>` and the unchanged external key
+   `vercel-preview:v1:pr:<number>:target:<target>:sha:<sha>`;
+3. all selected targets use the single reusable smoke workflow for both the
+   initial upload and same-upload retry;
+4. `app`, `governance`, and `reserve` show both a native preview and one
+   canonical GitHub Deployment, while `ui` shows only the GitHub Deployment;
+5. the one v2 journal comment is edited in place and its four target outcomes
+   agree with the compact aggregate `Vercel Preview` status; and
+6. first-eligible-plus-latest batching and recovery operate independently per
+   target, including a multi-target PR with overlapping pushes.
+
+A later native-to-GitHub ownership cutover is a separate atomic change per
+target. In the same reviewed PR, change that target's exact `vercel.json` from
+the canonical native configuration to its canonical GitHub configuration and
+change only that target's `ownershipMode` in
+`scripts/vercel-preview-targets.mjs` from `shadow` to `github`. Update structural
+tests and this runbook in that PR. Do not flip a global ownership mode or
+hand-copy a configuration from another target; the app target intentionally has
+an additional `v2` branch exception in its canonical GitHub configuration.
+
+Perform those later cutovers strictly in the order **Reserve → Governance →
+App**, with one reviewed merge and completed live canary between targets. Stop
+after any failed target: keep every already-proven target in its accepted owner
+state, leave all later targets in shadow mode, and diagnose or roll back only
+the failed target. App may not cut over until Governance has completed its own
+cutover and browser-verified canary. This controller-expansion change ends at
+shadow activation and must not include any of those three configuration
+cutovers.
+
+Before each Reserve, Governance, or App cutover, inventory open branches and
+PRs that still contain that target's pre-cutover `vercel.json`. Every branch
+used to validate the cutover must merge or rebase the resulting current `main`
+before its canary is accepted. Record any intentionally deferred stale PR with
+its owner and follow-up action; do not claim repository-wide duplicate
+prevention while an unaccounted stale branch can still request a native
+preview.
+
+For rollback, first establish a coordinated no-push window and drain controller
+and worker ownership for the target. Atomically restore both its canonical
+native Vercel configuration and `shadow` ownership mode, then require an exact
+head native deployment plus browser proof before accepting the rollback. Never
+split the configuration and ownership edits across merges.
 
 ### Phase A canary evidence template
 

--- a/scripts/github-deployment.mjs
+++ b/scripts/github-deployment.mjs
@@ -7,7 +7,7 @@ import process from "node:process";
 import { fileURLToPath } from "node:url";
 import { resolve } from "node:path";
 
-const CONTROLLER_SCHEMA = "mento-vercel-prebuilt/v1";
+const CONTROLLER_SCHEMA = "mento-vercel-prebuilt/v2";
 const DEPLOYMENT_STATES = [
   "queued",
   "in_progress",

--- a/scripts/github-deployment.test.mjs
+++ b/scripts/github-deployment.test.mjs
@@ -39,7 +39,7 @@ test("create request is exact-SHA, transient, non-production, and secretless", (
     production_environment: false,
     description: "Vercel prebuilt ui preview",
     payload: {
-      controller_schema: "mento-vercel-prebuilt/v1",
+      controller_schema: "mento-vercel-prebuilt/v2",
       idempotency_key: `vercel-pilot:v1:ui:sha:${SHA}:run:123:attempt:1`,
       logical_target: "ui",
       sha: SHA,

--- a/scripts/vercel-git-ownership.test.mjs
+++ b/scripts/vercel-git-ownership.test.mjs
@@ -1,30 +1,13 @@
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { test } from "node:test";
-import { isDeepStrictEqual } from "node:util";
 
 import { parse } from "yaml";
-
-const SCHEMA = "https://openapi.vercel.sh/vercel.json";
-
-const ROLLBACK_CONFIGURATION = {
-  $schema: SCHEMA,
-  git: {
-    deploymentEnabled: {
-      "dependabot/**": false,
-    },
-  },
-};
-
-const CUTOVER_CONFIGURATION = {
-  $schema: SCHEMA,
-  git: {
-    deploymentEnabled: {
-      "**": false,
-      main: true,
-    },
-  },
-};
+import {
+  PREVIEW_OWNERSHIP_MODES,
+  PREVIEW_TARGET_CONFIG,
+  PREVIEW_TARGETS,
+} from "./vercel-preview-targets.mjs";
 
 const ACTIVE_CONTROLLER_MODE = "active";
 const OBSERVE_ONLY_CONTROLLER_MODE = "observe-only";
@@ -39,10 +22,13 @@ const controller = parse(
   ),
 );
 
-function configuration(app) {
+function configuration(target) {
   return JSON.parse(
     readFileSync(
-      new URL(`../apps/${app}/vercel.json`, import.meta.url),
+      new URL(
+        `../${PREVIEW_TARGET_CONFIG[target].vercelConfigurationPath}`,
+        import.meta.url,
+      ),
       "utf8",
     ),
   );
@@ -54,85 +40,65 @@ function assertExactOwnership(value, expected) {
   assert.deepEqual(Object.keys(value.git), ["deploymentEnabled"]);
 }
 
-function assertSinglePreviewOwner(value, controllerMode) {
-  assert.ok(
-    isDeepStrictEqual(value, CUTOVER_CONFIGURATION) ||
-      isDeepStrictEqual(value, ROLLBACK_CONFIGURATION),
-    "UI Vercel Git ownership must match a reviewed exact state",
-  );
+function assertControllerMode(controllerMode) {
   assert.ok(
     [ACTIVE_CONTROLLER_MODE, OBSERVE_ONLY_CONTROLLER_MODE].includes(
       controllerMode,
     ),
     "Preview controller mode must match a reviewed exact state",
   );
-  const githubActionsOwnsBranchPreviews =
-    controllerMode === ACTIVE_CONTROLLER_MODE;
-  const nativeVercelOwnsBranchPreviews = isDeepStrictEqual(
-    value,
-    ROLLBACK_CONFIGURATION,
-  );
-  assert.notEqual(
-    githubActionsOwnsBranchPreviews,
-    nativeVercelOwnsBranchPreviews,
-    "Exactly one of GitHub Actions or native Vercel must own UI branch previews",
-  );
 }
 
-test("repository has exactly one canonical UI branch-preview owner", () => {
-  const uiConfiguration = configuration("ui.mento.org");
-  assertSinglePreviewOwner(
-    uiConfiguration,
-    controller.env.VERCEL_PREVIEW_CONTROLLER_MODE,
-  );
+test("repository pairs every target with its canonical exact ownership configuration", () => {
+  assertControllerMode(controller.env.VERCEL_PREVIEW_CONTROLLER_MODE);
+  for (const target of PREVIEW_TARGETS) {
+    const targetConfiguration = PREVIEW_TARGET_CONFIG[target];
+    const expected =
+      targetConfiguration.ownershipMode === PREVIEW_OWNERSHIP_MODES.GITHUB
+        ? targetConfiguration.githubVercelConfiguration
+        : targetConfiguration.nativeVercelConfiguration;
+    assertExactOwnership(configuration(target), expected);
+  }
 });
 
-test("cutover and rollback permit only the two reviewed steady-state ownership pairs", () => {
-  assert.notDeepEqual(CUTOVER_CONFIGURATION, ROLLBACK_CONFIGURATION);
-  assertExactOwnership(
-    structuredClone(CUTOVER_CONFIGURATION),
-    CUTOVER_CONFIGURATION,
-  );
-  assertExactOwnership(
-    structuredClone(ROLLBACK_CONFIGURATION),
-    ROLLBACK_CONFIGURATION,
-  );
-  assert.equal(CUTOVER_CONFIGURATION.git.deploymentEnabled["**"], false);
-  assert.equal(CUTOVER_CONFIGURATION.git.deploymentEnabled.main, true);
-  assert.equal(
-    ROLLBACK_CONFIGURATION.git.deploymentEnabled["dependabot/**"],
-    false,
-  );
-  assertSinglePreviewOwner(CUTOVER_CONFIGURATION, ACTIVE_CONTROLLER_MODE);
-  assertSinglePreviewOwner(
-    ROLLBACK_CONFIGURATION,
-    OBSERVE_ONLY_CONTROLLER_MODE,
-  );
+test("every target exposes reviewed, distinct native and GitHub ownership states", () => {
+  for (const target of PREVIEW_TARGETS) {
+    const { githubVercelConfiguration, nativeVercelConfiguration } =
+      PREVIEW_TARGET_CONFIG[target];
+    assert.notDeepEqual(githubVercelConfiguration, nativeVercelConfiguration);
+    assertExactOwnership(
+      structuredClone(githubVercelConfiguration),
+      githubVercelConfiguration,
+    );
+    assertExactOwnership(
+      structuredClone(nativeVercelConfiguration),
+      nativeVercelConfiguration,
+    );
+    assert.equal(githubVercelConfiguration.git.deploymentEnabled["**"], false);
+    assert.equal(githubVercelConfiguration.git.deploymentEnabled.main, true);
+    assert.equal(
+      nativeVercelConfiguration.git.deploymentEnabled["dependabot/**"],
+      false,
+    );
+  }
   assert.throws(
-    () =>
-      assertSinglePreviewOwner(ROLLBACK_CONFIGURATION, ACTIVE_CONTROLLER_MODE),
-    /Exactly one/,
-  );
-  assert.throws(
-    () =>
-      assertSinglePreviewOwner(
-        CUTOVER_CONFIGURATION,
-        OBSERVE_ONLY_CONTROLLER_MODE,
-      ),
-    /Exactly one/,
-  );
-  assert.throws(
-    () => assertSinglePreviewOwner(CUTOVER_CONFIGURATION, "disabled"),
+    () => assertControllerMode("disabled"),
     /Preview controller mode must match a reviewed exact state/,
   );
 });
 
-test("Phase B does not change another application's Vercel Git ownership", () => {
-  for (const app of [
-    "app.mento.org",
-    "governance.mento.org",
-    "reserve.mento.org",
-  ]) {
-    assertExactOwnership(configuration(app), ROLLBACK_CONFIGURATION);
-  }
+test("initial rollout shadows three native owners while UI remains GitHub-only", () => {
+  assert.deepEqual(
+    PREVIEW_TARGETS.filter(
+      (target) =>
+        PREVIEW_TARGET_CONFIG[target].ownershipMode ===
+        PREVIEW_OWNERSHIP_MODES.SHADOW,
+    ),
+    ["app", "governance", "reserve"],
+  );
+  assert.equal(
+    PREVIEW_TARGET_CONFIG.ui.ownershipMode,
+    PREVIEW_OWNERSHIP_MODES.GITHUB,
+  );
+  assert.equal(controller.env.VERCEL_PREVIEW_CONTROLLER_MODE, "active");
 });

--- a/scripts/vercel-git-ownership.test.mjs
+++ b/scripts/vercel-git-ownership.test.mjs
@@ -87,6 +87,27 @@ test("every target exposes reviewed, distinct native and GitHub ownership states
   );
 });
 
+test("ownership configurations keep only their reviewed branch exceptions", () => {
+  assert.deepEqual(
+    PREVIEW_TARGET_CONFIG.app.githubVercelConfiguration.git.deploymentEnabled,
+    { "**": false, main: true, v2: true },
+  );
+  for (const target of ["governance", "reserve", "ui"]) {
+    assert.deepEqual(
+      PREVIEW_TARGET_CONFIG[target].githubVercelConfiguration.git
+        .deploymentEnabled,
+      { "**": false, main: true },
+    );
+  }
+  for (const target of PREVIEW_TARGETS) {
+    assert.deepEqual(
+      PREVIEW_TARGET_CONFIG[target].nativeVercelConfiguration.git
+        .deploymentEnabled,
+      { "dependabot/**": false },
+    );
+  }
+});
+
 test("initial rollout shadows three native owners while UI remains GitHub-only", () => {
   assert.deepEqual(
     PREVIEW_TARGETS.filter(

--- a/scripts/vercel-prebuilt-workflow.mjs
+++ b/scripts/vercel-prebuilt-workflow.mjs
@@ -41,29 +41,20 @@ import {
   assertPrebuiltDeploymentId,
   generateVercelDeploymentId,
 } from "./vercel-prebuilt.mjs";
+import { PREVIEW_TARGET_CONFIG } from "./vercel-preview-targets.mjs";
 
-export const PREBUILT_TARGETS = Object.freeze({
-  app: Object.freeze({
-    logicalTarget: "app",
-    workspacePackage: "app.mento.org",
-    expectedRootDirectory: "apps/app.mento.org",
-  }),
-  governance: Object.freeze({
-    logicalTarget: "governance",
-    workspacePackage: "governance.mento.org",
-    expectedRootDirectory: "apps/governance.mento.org",
-  }),
-  reserve: Object.freeze({
-    logicalTarget: "reserve",
-    workspacePackage: "reserve.mento.org",
-    expectedRootDirectory: "apps/reserve.mento.org",
-  }),
-  ui: Object.freeze({
-    logicalTarget: "ui",
-    workspacePackage: "ui.mento.org",
-    expectedRootDirectory: "apps/ui.mento.org",
-  }),
-});
+export const PREBUILT_TARGETS = Object.freeze(
+  Object.fromEntries(
+    Object.entries(PREVIEW_TARGET_CONFIG).map(([target, configuration]) => [
+      target,
+      Object.freeze({
+        logicalTarget: configuration.logicalTarget,
+        workspacePackage: configuration.workspacePackage,
+        expectedRootDirectory: configuration.expectedRootDirectory,
+      }),
+    ]),
+  ),
+);
 
 // Preserve the Phase A manual pilot contract while the reusable internals are
 // prepared for the four literal automatic-preview callers.
@@ -130,7 +121,7 @@ const UPLOAD_LOOKUP_WINDOW_MS = 45 * 60 * 1_000;
 const TRUSTED_CALLER_WORKFLOW = {
   "manual-pilot":
     "mento-protocol/frontend-monorepo/.github/workflows/vercel-prebuilt-pilot.yml@refs/heads/main",
-  "preview-controller:v1":
+  "preview-controller:v2":
     "mento-protocol/frontend-monorepo/.github/workflows/vercel-preview-worker.yml@refs/heads/main",
 };
 function requiredText(value, label, { maximum = 2_048 } = {}) {
@@ -232,7 +223,7 @@ function validateAutomaticPreviewIdentity(values) {
       "Automatic preview environment does not match the pull request",
     );
   }
-  if (values.provenance !== "preview-controller:v1") {
+  if (values.provenance !== "preview-controller:v2") {
     throw new Error("Automatic preview provenance is invalid");
   }
   if (

--- a/scripts/vercel-prebuilt-workflow.test.mjs
+++ b/scripts/vercel-prebuilt-workflow.test.mjs
@@ -280,7 +280,7 @@ test("automatic preview contract binds PR, environment, provenance, and exact SH
     githubEnvironment: "preview/ui/pr-519",
     idempotencyKey: `vercel-preview:v1:pr:519:target:ui:sha:${SHA}`,
     pullRequestNumber: "519",
-    provenance: "preview-controller:v1",
+    provenance: "preview-controller:v2",
     githubWorkflowRef:
       "mento-protocol/frontend-monorepo/.github/workflows/vercel-preview-worker.yml@refs/heads/main",
   });
@@ -312,7 +312,7 @@ test("automatic preview contract accepts only the four literal target mappings",
       githubEnvironment: `preview/${target.logicalTarget}/pr-519`,
       idempotencyKey: `vercel-preview:v1:pr:519:target:${target.logicalTarget}:sha:${SHA}`,
       pullRequestNumber: "519",
-      provenance: "preview-controller:v1",
+      provenance: "preview-controller:v2",
       githubWorkflowRef:
         "mento-protocol/frontend-monorepo/.github/workflows/vercel-preview-worker.yml@refs/heads/main",
     });
@@ -340,7 +340,7 @@ test("automatic preview contract accepts only the four literal target mappings",
       validatePilotContract(
         pilotContract({
           logicalTarget,
-          provenance: "preview-controller:v1",
+          provenance: "preview-controller:v2",
         }),
       ),
     );

--- a/scripts/vercel-preview-controller.mjs
+++ b/scripts/vercel-preview-controller.mjs
@@ -3,30 +3,32 @@
 import { Buffer } from "node:buffer";
 import { createHash } from "node:crypto";
 
+import {
+  PREVIEW_OWNERSHIP_MODES,
+  PREVIEW_TARGET_CONFIG,
+  PREVIEW_TARGETS,
+  previewTarget,
+  previewTargetConfig,
+} from "./vercel-preview-targets.mjs";
+
+export { PREVIEW_TARGETS } from "./vercel-preview-targets.mjs";
+
 export const PREVIEW_REPOSITORY = "mento-protocol/frontend-monorepo";
-const PREVIEW_TARGET = "ui";
 const PREVIEW_STATUS_CONTEXT = "Vercel Preview";
-const PREVIEW_INITIALIZATION_STATUS_CONTEXT = "Vercel Preview Journal";
-const UI_VERCEL_CONFIGURATION_PATH = "apps/ui.mento.org/vercel.json";
-const UI_VERCEL_CONFIGURATION_MAX_BYTES = 2_048;
-const UI_PREVIEW_OWNER_GITHUB = "github-actions";
-const UI_PREVIEW_OWNER_NATIVE = "native-vercel";
-const UI_VERCEL_GITHUB_CONFIGURATION = {
-  $schema: "https://openapi.vercel.sh/vercel.json",
-  git: { deploymentEnabled: { "**": false, main: true } },
-};
-const UI_VERCEL_NATIVE_CONFIGURATION = {
-  $schema: "https://openapi.vercel.sh/vercel.json",
-  git: { deploymentEnabled: { "dependabot/**": false } },
-};
-export const EVENT_RECEIPT_SCHEMA = "vercel-preview-event-receipt:v1";
-const WORKER_EVIDENCE_SCHEMA = "vercel-preview-worker-evidence:v1";
-export const RESULT_RECEIPT_SCHEMA = "vercel-preview-worker-result:v1";
-export const SELECTION_RECEIPT_SCHEMA = "vercel-preview-selection:v1";
-export const CONTROLLER_SCHEMA = "vercel-preview-controller:v1";
-export const PREVIEW_JOURNAL_SCHEMA = "vercel-preview-journal:v1";
-export const PREVIEW_JOURNAL_MARKER = "<!-- vercel-preview-journal:v1 -->";
-const PREVIEW_CHECKPOINT_SCHEMA = "vercel-preview-checkpoint:v1";
+const PREVIEW_INITIALIZATION_STATUS_CONTEXT = "Vercel Preview Journal v2";
+const VERCEL_CONFIGURATION_MAX_BYTES = 2_048;
+const PREVIEW_OWNER_GITHUB = "github-actions";
+const PREVIEW_OWNER_NATIVE = "native-vercel";
+const PREBUILT_DEPLOYMENT_SCHEMA = "mento-vercel-prebuilt/v2";
+const PREVIEW_CONTROLLER_PROVENANCE = "preview-controller:v2";
+export const EVENT_RECEIPT_SCHEMA = "vercel-preview-event-receipt:v2";
+export const WORKER_EVIDENCE_SCHEMA = "vercel-preview-worker-evidence:v2";
+export const RESULT_RECEIPT_SCHEMA = "vercel-preview-worker-result:v2";
+export const SELECTION_RECEIPT_SCHEMA = "vercel-preview-selection:v2";
+export const CONTROLLER_SCHEMA = "vercel-preview-controller:v2";
+export const PREVIEW_JOURNAL_SCHEMA = "vercel-preview-journal:v2";
+export const PREVIEW_JOURNAL_MARKER = "<!-- vercel-preview-journal:v2 -->";
+const PREVIEW_CHECKPOINT_SCHEMA = "vercel-preview-checkpoint:v2";
 const WORKER_WORKFLOW = "vercel-preview-worker.yml";
 const WORKER_WORKFLOW_NAME = "Vercel Preview Worker";
 const INTAKE_WORKFLOW = "vercel-preview-intake.yml";
@@ -93,11 +95,10 @@ const NO_DISPATCH_ORPHAN_REASON = "dispatch-disabled-intent-without-worker";
 const NATIVE_OWNED_SELECTION_REASON =
   "native-owned-selection-without-github-worker";
 const CHECKPOINTED_TERMINAL_REASON = "checkpointed-terminal-status";
-const NATIVE_OWNED_STATUS_DESCRIPTION = "Native Vercel owns this UI preview";
-const NATIVE_OWNERSHIP_DRAINING_STATUS_DESCRIPTION =
-  "Draining GitHub preview before native ownership";
 const OBSERVE_ONLY_STATUS_DESCRIPTION =
   "GitHub preview dispatch is observe-only";
+const OWNERSHIP_DRAINING_STATUS_DESCRIPTION =
+  "Draining GitHub preview before native ownership";
 const CONTROLLER_RUN_URL_PATTERN =
   /^https:\/\/github\.com\/mento-protocol\/frontend-monorepo\/actions\/runs\/[1-9][0-9]*$/;
 const SELECTION_SCOPED_CONTROLLER_RESULT_REASONS = new Set([
@@ -498,7 +499,7 @@ export function normalizePlannerResult(
     raw === ""
   ) {
     return {
-      targets: [PREVIEW_TARGET],
+      targets: [...PREVIEW_TARGETS],
       reason: "planner-job-failed",
       base: event.change_base_sha,
       head: event.head_sha,
@@ -511,7 +512,7 @@ export function normalizePlannerResult(
     Array.isArray(parsed.deployments),
     "Planner deployments must be an array",
   );
-  const allowed = ["app", "governance", "reserve", "ui"];
+  const allowed = PREVIEW_TARGETS;
   invariant(
     parsed.deployments.length <= allowed.length,
     "Planner returned too many targets",
@@ -537,9 +538,7 @@ export function normalizePlannerResult(
     "Planner head SHA does not match event",
   );
   return {
-    targets: parsed.deployments.includes(PREVIEW_TARGET)
-      ? [PREVIEW_TARGET]
-      : [],
+    targets: [...parsed.deployments],
     reason,
     base: event.change_base_sha,
     head: event.head_sha,
@@ -550,12 +549,19 @@ export function normalizePlannerResult(
 function validatePlan(plan, event) {
   plainObject(plan, "Event plan");
   invariant(
-    Array.isArray(plan.targets) && plan.targets.length <= 1,
+    Array.isArray(plan.targets) &&
+      plan.targets.length <= PREVIEW_TARGETS.length,
     "Plan targets are invalid",
   );
   invariant(
-    plan.targets.every((target) => target === PREVIEW_TARGET),
-    "Plan may target only UI",
+    plan.targets.every(
+      (target, index) =>
+        PREVIEW_TARGETS.includes(target) &&
+        (index === 0 ||
+          PREVIEW_TARGETS.indexOf(target) >
+            PREVIEW_TARGETS.indexOf(plan.targets[index - 1])),
+    ),
+    "Plan targets are malformed or unordered",
   );
   invariant(
     ALLOWED_PLAN_REASONS.has(boundedText(plan.reason, "Plan reason", 64)),
@@ -685,8 +691,9 @@ function anchorAliasKey(event) {
   });
 }
 
-function controllerKey(prNumber, sha) {
-  return `vercel-preview:v1:pr:${pullRequestNumber(prNumber)}:target:${PREVIEW_TARGET}:sha:${exactSha(sha)}`;
+export function controllerKey(prNumber, sha, target) {
+  const logicalTarget = previewTarget(target);
+  return `vercel-preview:v1:pr:${pullRequestNumber(prNumber)}:target:${logicalTarget}:sha:${exactSha(sha)}`;
 }
 
 function controllerKeyDigest(
@@ -721,12 +728,9 @@ function validateSelectionReceipt(value) {
   );
   validatedRepository(selection.repository);
   const pr = pullRequestNumber(selection.pr);
-  invariant(
-    selection.target === PREVIEW_TARGET,
-    "Preview selection target mismatch",
-  );
+  const target = previewTarget(selection.target, "Preview selection target");
   const sha = exactSha(selection.sha);
-  const key = controllerKey(pr, sha);
+  const key = controllerKey(pr, sha, target);
   invariant(selection.key === key, "Preview selection key mismatch");
   const epochAnchorRunId = exactRunId(
     selection.epoch_anchor_run_id,
@@ -781,7 +785,7 @@ export function selectionReceiptFromDispatch(selection) {
     schema: SELECTION_RECEIPT_SCHEMA,
     repository: PREVIEW_REPOSITORY,
     pr: dispatch.pr,
-    target: PREVIEW_TARGET,
+    target: dispatch.target,
     sha: dispatch.sha,
     key: dispatch.key,
     key_digest: dispatch.key_digest,
@@ -793,8 +797,8 @@ export function selectionReceiptFromDispatch(selection) {
   });
 }
 
-export function workerRunName({ pr, sha, keyDigest }) {
-  return `Vercel preview worker | pr=${pullRequestNumber(pr)} | target=${PREVIEW_TARGET} | sha=${exactSha(sha)} | key=${boundedText(keyDigest, "Key digest", 24)}`;
+export function workerRunName({ pr, target, sha, keyDigest }) {
+  return `Vercel preview worker | pr=${pullRequestNumber(pr)} | target=${previewTarget(target)} | sha=${exactSha(sha)} | key=${boundedText(keyDigest, "Key digest", 24)}`;
 }
 
 export function dependabotIntakeRunName({ pr, sha, action }) {
@@ -826,14 +830,14 @@ function parseDependabotIntakeRunName(value) {
 
 export function parseWorkerRunName(value) {
   const match = String(value ?? "").match(
-    /^Vercel preview worker \| pr=([1-9][0-9]{0,9}) \| target=ui \| sha=([0-9a-f]{40}) \| key=([0-9a-f]{24})$/,
+    /^Vercel preview worker \| pr=([1-9][0-9]{0,9}) \| target=(app|governance|reserve|ui) \| sha=([0-9a-f]{40}) \| key=([0-9a-f]{24})$/,
   );
   invariant(match, WORKER_RUN_NAME_PARSE_ERROR);
   return {
     pr: pullRequestNumber(match[1]),
-    target: PREVIEW_TARGET,
-    sha: exactSha(match[2]),
-    keyDigest: match[3],
+    target: previewTarget(match[2], "Worker run target"),
+    sha: exactSha(match[3]),
+    keyDigest: match[4],
   };
 }
 
@@ -845,9 +849,9 @@ export function validateWorkerResult(value) {
   );
   validatedRepository(result.repository);
   pullRequestNumber(result.pr);
-  invariant(result.target === PREVIEW_TARGET, "Worker result target mismatch");
+  const target = previewTarget(result.target, "Worker result target");
   exactSha(result.sha);
-  const expectedKey = controllerKey(result.pr, result.sha);
+  const expectedKey = controllerKey(result.pr, result.sha, target);
   invariant(
     result.controller_key === expectedKey,
     "Worker result controller key mismatch",
@@ -908,12 +912,9 @@ function validateWorkerEvidence(value) {
   );
   validatedRepository(evidence.repository);
   pullRequestNumber(evidence.pr);
-  invariant(
-    evidence.target === PREVIEW_TARGET,
-    "Worker evidence target mismatch",
-  );
+  const target = previewTarget(evidence.target, "Worker evidence target");
   exactSha(evidence.sha);
-  const expectedKey = controllerKey(evidence.pr, evidence.sha);
+  const expectedKey = controllerKey(evidence.pr, evidence.sha, target);
   invariant(
     evidence.controller_key === expectedKey,
     "Worker evidence controller key mismatch",
@@ -1000,15 +1001,18 @@ function persistedEventRunIds(state, results, selections) {
   };
   if (state) {
     add(state.epoch.anchor_run_id);
-    add(state.ui?.idle_cursor_receipt_run_id);
-    add(state.ui?.latest_desired_receipt_run_id);
-    for (const selection of [
-      state.ui?.active,
-      ...(state.ui?.retired_active ?? []),
-      ...(state.ui?.terminal_history ?? []),
-    ].filter(Boolean)) {
-      add(selection.epoch_anchor_run_id);
-      add(selection.selection_receipt_run_id);
+    for (const target of PREVIEW_TARGETS) {
+      const targetState = state.targets[target];
+      add(targetState.idle_cursor_receipt_run_id);
+      add(targetState.latest_desired_receipt_run_id);
+      for (const selection of [
+        targetState.active,
+        ...targetState.retired_active,
+        ...targetState.terminal_history,
+      ].filter(Boolean)) {
+        add(selection.epoch_anchor_run_id);
+        add(selection.selection_receipt_run_id);
+      }
     }
   }
   for (const result of results) {
@@ -1236,14 +1240,17 @@ function selectCurrentEpoch(events, pull, checkpoint = null) {
   return candidates[0];
 }
 
-function resultForSelection(results, anchorRunId, event, selection) {
+function resultForSelection(results, anchorRunId, event, selection, target) {
+  const logicalTarget = previewTarget(target);
   return (
     results
       .filter(
         (result) =>
+          result.target === logicalTarget &&
           result.epoch_anchor_run_id === anchorRunId &&
           result.selection_receipt_run_id === event.event_run_id &&
-          result.controller_key === controllerKey(result.pr, event.head_sha) &&
+          result.controller_key ===
+            controllerKey(result.pr, event.head_sha, logicalTarget) &&
           (!selection ||
             (result.reconciliation_basis_digest ===
               selection.reconciliation_basis_digest &&
@@ -1259,51 +1266,55 @@ function resultForSelection(results, anchorRunId, event, selection) {
   );
 }
 
+function nativeOwnedStatusDescription(target) {
+  return `${previewTarget(target)}: native Vercel owns preview`;
+}
+
 function statusFromCheckpointRuntime({
-  event,
+  target,
   runtimeEvent,
   checkpointStatus,
   controllerUrl,
 }) {
-  if (isNativeOwnedCheckpointStatus(checkpointStatus, runtimeEvent)) {
+  if (isNativeOwnedCheckpointStatus(checkpointStatus, runtimeEvent, target)) {
     return {
-      sha: event.head_sha,
       state: "success",
-      description: NATIVE_OWNED_STATUS_DESCRIPTION,
+      outcome: "native-owned",
+      description: nativeOwnedStatusDescription(target),
       target_url: controllerUrl,
     };
   }
   if (checkpointStatus.state === "success") {
     return {
-      sha: event.head_sha,
       state: "success",
-      description: `Runtime-equivalent to ${runtimeEvent.head_sha.slice(0, 7)}`,
+      outcome: "runtime-equivalent",
+      description: `${target}: runtime-equivalent to ${runtimeEvent.head_sha.slice(0, 7)}`,
       target_url: checkpointStatus.target_url,
     };
   }
   if (checkpointStatus.state === "failure") {
     const cancelled = checkpointStatus.description.includes("cancelled");
     return {
-      sha: event.head_sha,
       state: "failure",
+      outcome: "failed",
       description: cancelled
-        ? `Runtime preview ${runtimeEvent.head_sha.slice(0, 7)} was cancelled`
-        : `Runtime preview ${runtimeEvent.head_sha.slice(0, 7)} failed`,
+        ? `${target}: runtime ${runtimeEvent.head_sha.slice(0, 7)} cancelled`
+        : `${target}: runtime ${runtimeEvent.head_sha.slice(0, 7)} failed`,
       target_url: checkpointStatus.target_url ?? controllerUrl,
     };
   }
   if (checkpointStatus.state === "pending") {
     return {
-      sha: event.head_sha,
       state: "pending",
-      description: `Waiting for runtime preview ${runtimeEvent.head_sha.slice(0, 7)}`,
+      outcome: "pending",
+      description: `${target}: waiting for ${runtimeEvent.head_sha.slice(0, 7)}`,
       target_url: checkpointStatus.target_url ?? controllerUrl,
     };
   }
   return {
-    sha: event.head_sha,
     state: "error",
-    description: `Runtime preview ${runtimeEvent.head_sha.slice(0, 7)} errored`,
+    outcome: "error",
+    description: `${target}: runtime ${runtimeEvent.head_sha.slice(0, 7)} errored`,
     target_url: checkpointStatus.target_url ?? controllerUrl,
   };
 }
@@ -1316,35 +1327,24 @@ function isControllerRunStatusDecision(status, state, description) {
   );
 }
 
-function isNativeOwnedStatusDecision(status) {
+function isNativeOwnedStatusDecision(status, target) {
   return isControllerRunStatusDecision(
     status,
     "success",
-    NATIVE_OWNED_STATUS_DESCRIPTION,
+    nativeOwnedStatusDescription(target),
   );
 }
 
-function isNativeOwnedCheckpointStatus(status, event) {
+function isNativeOwnedCheckpointStatus(status, event, target) {
   return (
-    isNativeOwnedStatusDecision(status) &&
+    isNativeOwnedStatusDecision(status, target) &&
     event.trust === "trusted" &&
     event.pr_state === "open"
   );
 }
 
-function isNativeOwnershipDrainingCheckpointStatus(status, event) {
-  return (
-    isControllerRunStatusDecision(
-      status,
-      "pending",
-      NATIVE_OWNERSHIP_DRAINING_STATUS_DESCRIPTION,
-    ) &&
-    event.trust === "trusted" &&
-    event.pr_state === "open"
-  );
-}
-
-function statusDecision({
+function targetStatusDecision({
+  target,
   event,
   index,
   lineage,
@@ -1354,78 +1354,80 @@ function statusDecision({
   controllerUrl,
   checkpointStatus,
   checkpointBaselineStatus,
-  checkpointBaselineEvent,
+  checkpointRuntimeEvent,
 }) {
   if (checkpointStatus) return structuredClone(checkpointStatus);
   if (event.trust !== "trusted") {
     return {
-      sha: event.head_sha,
       state: "success",
-      description: "Preview unsupported for this PR source",
+      outcome: "unsupported trust boundary",
+      description: `${target}: unsupported trust boundary`,
       target_url: controllerUrl,
     };
   }
-  const eligible = event.plan.targets.includes(PREVIEW_TARGET);
+  const eligible = event.plan.targets.includes(target);
   const result = resultByRun.get(event.event_run_id);
   if (eligible && result?.terminal_reason === NATIVE_OWNED_SELECTION_REASON) {
     return {
-      sha: event.head_sha,
       state: "success",
-      description: NATIVE_OWNED_STATUS_DESCRIPTION,
+      outcome: "native-owned",
+      description: nativeOwnedStatusDescription(target),
       target_url: controllerUrl,
     };
   }
   if (eligible && result?.state === "success") {
     return {
-      sha: event.head_sha,
       state: "success",
-      description: "UI preview verified for this exact SHA",
+      outcome: "deployed",
+      description: `${target}: deployed and smoke verified`,
       target_url: result.vercel_deployment_url,
     };
   }
   if (eligible && result?.state === "failure") {
     return {
-      sha: event.head_sha,
       state: "failure",
-      description: "UI preview build, deploy, or smoke failed",
+      outcome: "failed",
+      description: `${target}: build, deploy, or smoke failed`,
       target_url: terminalResultUrl(result, controllerUrl),
     };
   }
   if (eligible && result?.state === "error") {
     const cancelled = result.terminal_reason === "worker-cancelled";
     return {
-      sha: event.head_sha,
       state: cancelled ? "failure" : "error",
+      outcome: cancelled ? "failed" : "error",
       description: cancelled
-        ? "UI preview worker was cancelled"
-        : "UI preview controller or infrastructure error",
+        ? `${target}: worker cancelled`
+        : `${target}: controller or infrastructure error`,
       target_url: terminalResultUrl(result, controllerUrl),
     };
   }
   if (!eligible) {
     const priorRuntime = lineage
       .slice(0, index)
-      .findLast((candidate) => candidate.plan.targets.includes(PREVIEW_TARGET));
+      .findLast((candidate) => candidate.plan.targets.includes(target));
     if (!priorRuntime) {
-      if (checkpointBaselineStatus) {
-        return {
-          ...structuredClone(checkpointBaselineStatus),
-          sha: event.head_sha,
-        };
+      if (checkpointBaselineStatus && checkpointRuntimeEvent) {
+        return statusFromCheckpointRuntime({
+          target,
+          runtimeEvent: checkpointRuntimeEvent,
+          checkpointStatus: checkpointBaselineStatus,
+          controllerUrl,
+        });
       }
       return {
-        sha: event.head_sha,
         state: "success",
-        description: "No UI runtime impact",
+        outcome: "not affected",
+        description: `${target}: not affected`,
         target_url: controllerUrl,
       };
     }
     if (
       checkpointBaselineStatus &&
-      checkpointBaselineEvent?.event_run_id === priorRuntime.event_run_id
+      checkpointRuntimeEvent?.event_run_id === priorRuntime.event_run_id
     ) {
       return statusFromCheckpointRuntime({
-        event,
+        target,
         runtimeEvent: priorRuntime,
         checkpointStatus: checkpointBaselineStatus,
         controllerUrl,
@@ -1434,60 +1436,106 @@ function statusDecision({
     const priorResult = resultByRun.get(priorRuntime.event_run_id);
     if (priorResult?.terminal_reason === NATIVE_OWNED_SELECTION_REASON) {
       return {
-        sha: event.head_sha,
         state: "success",
-        description: NATIVE_OWNED_STATUS_DESCRIPTION,
+        outcome: "native-owned",
+        description: nativeOwnedStatusDescription(target),
         target_url: controllerUrl,
       };
     }
     if (priorResult?.state === "success") {
       return {
-        sha: event.head_sha,
         state: "success",
-        description: `Runtime-equivalent to ${priorRuntime.head_sha.slice(0, 7)}`,
+        outcome: "runtime-equivalent",
+        description: `${target}: runtime-equivalent to ${priorRuntime.head_sha.slice(0, 7)}`,
         target_url: priorResult.vercel_deployment_url,
       };
     }
     if (priorResult?.state === "failure") {
       return {
-        sha: event.head_sha,
         state: "failure",
-        description: `Runtime preview ${priorRuntime.head_sha.slice(0, 7)} failed`,
+        outcome: "failed",
+        description: `${target}: runtime ${priorRuntime.head_sha.slice(0, 7)} failed`,
         target_url: terminalResultUrl(priorResult, controllerUrl),
       };
     }
     if (priorResult?.state === "error") {
       const cancelled = priorResult.terminal_reason === "worker-cancelled";
       return {
-        sha: event.head_sha,
         state: cancelled ? "failure" : "error",
+        outcome: cancelled ? "failed" : "error",
         description: cancelled
-          ? `Runtime preview ${priorRuntime.head_sha.slice(0, 7)} was cancelled`
-          : `Runtime preview ${priorRuntime.head_sha.slice(0, 7)} errored`,
+          ? `${target}: runtime ${priorRuntime.head_sha.slice(0, 7)} cancelled`
+          : `${target}: runtime ${priorRuntime.head_sha.slice(0, 7)} errored`,
         target_url: terminalResultUrl(priorResult, controllerUrl),
       };
     }
     return {
-      sha: event.head_sha,
       state: "pending",
-      description: `Waiting for runtime preview ${priorRuntime.head_sha.slice(0, 7)}`,
+      outcome: "pending",
+      description: `${target}: waiting for ${priorRuntime.head_sha.slice(0, 7)}`,
       target_url: active?.html_url ?? controllerUrl,
     };
   }
   const coalescedTo = coalescedToByRun.get(event.event_run_id);
   if (coalescedTo) {
     return {
-      sha: event.head_sha,
       state: "success",
-      description: `Coalesced to ${coalescedTo.head_sha.slice(0, 7)}`,
+      outcome: "coalesced",
+      description: `${target}: coalesced to ${coalescedTo.head_sha.slice(0, 7)}`,
       target_url: controllerUrl,
     };
   }
   return {
-    sha: event.head_sha,
     state: "pending",
-    description: "UI preview queued or running",
+    outcome: "pending",
+    description: `${target}: queued or running`,
     target_url: active?.html_url ?? controllerUrl,
+  };
+}
+
+function aggregateStatusDecision(event, targetDecisions, controllerUrl) {
+  const decisions = PREVIEW_TARGETS.map((target) => targetDecisions[target]);
+  const state = decisions.some((decision) => decision.state === "error")
+    ? "error"
+    : decisions.some((decision) => decision.state === "failure")
+      ? "failure"
+      : decisions.some((decision) => decision.state === "pending")
+        ? "pending"
+        : "success";
+  const targets = Object.fromEntries(
+    PREVIEW_TARGETS.map((target) => [target, targetDecisions[target].outcome]),
+  );
+  const compactOutcome = (outcome) =>
+    ({
+      "runtime-equivalent": "equivalent",
+      "not affected": "none",
+      "native-owned": "native",
+      "unsupported trust boundary": "unsupported",
+    })[outcome] ?? outcome;
+  const description = PREVIEW_TARGETS.map(
+    (target) => `${target}=${compactOutcome(targets[target])}`,
+  ).join("; ");
+  invariant(description.length <= 140, "Aggregate status summary is too long");
+  const stateDecisions = decisions.filter(
+    (decision) => decision.state === state,
+  );
+  const priority =
+    stateDecisions.find(
+      (decision) =>
+        decision.target_url !== controllerUrl &&
+        ["deployed", "runtime-equivalent"].includes(decision.outcome),
+    ) ??
+    stateDecisions.find((decision) => decision.target_url !== controllerUrl) ??
+    stateDecisions.find((decision) =>
+      ["deployed", "runtime-equivalent"].includes(decision.outcome),
+    ) ??
+    stateDecisions[0];
+  return {
+    sha: event.head_sha,
+    state,
+    description,
+    target_url: priority?.target_url ?? controllerUrl,
+    targets,
   };
 }
 
@@ -1525,12 +1573,13 @@ function preserveSettledControllerTarget(
 }
 
 function statusFromPendingRuntimeResult({
-  checkpointEvent,
+  target,
   runtimeEvent,
   result,
   controllerUrl,
 }) {
-  const runtimeStatus = statusDecision({
+  return targetStatusDecision({
+    target,
     event: runtimeEvent,
     index: 0,
     lineage: [runtimeEvent],
@@ -1540,25 +1589,17 @@ function statusFromPendingRuntimeResult({
     controllerUrl,
     checkpointStatus: null,
     checkpointBaselineStatus: null,
-    checkpointBaselineEvent: null,
-  });
-  if (checkpointEvent.event_run_id === runtimeEvent.event_run_id) {
-    return { ...runtimeStatus, sha: checkpointEvent.head_sha };
-  }
-  return statusFromCheckpointRuntime({
-    event: checkpointEvent,
-    runtimeEvent,
-    checkpointStatus: runtimeStatus,
-    controllerUrl,
+    checkpointRuntimeEvent: null,
   });
 }
 
 function validatePersistedDispatch(value, pr, label) {
   const dispatch = plainObject(value, label);
+  const target = previewTarget(dispatch.target, `${label} target`);
   exactSha(dispatch.sha);
   exactSha(dispatch.expected_workflow_sha, `${label} expected workflow SHA`);
   invariant(
-    dispatch.key === controllerKey(pr, dispatch.sha),
+    dispatch.key === controllerKey(pr, dispatch.sha, target),
     `${label} key mismatch`,
   );
   exactRunId(dispatch.epoch_anchor_run_id, `${label} epoch anchor run ID`);
@@ -1643,7 +1684,10 @@ function normalizeExistingState(value, pr) {
   );
   validatedRepository(state.repository);
   invariant(pullRequestNumber(state.pr) === pr, "Controller state PR mismatch");
-  const ui = plainObject(state.ui, "Controller UI state");
+  invariant(
+    typeof state.closed === "boolean",
+    "Controller closed flag is invalid",
+  );
   invariant(
     /^[0-9a-f]{64}$/.test(state.receipts_digest),
     "Controller receipt digest is invalid",
@@ -1654,67 +1698,143 @@ function normalizeExistingState(value, pr) {
     /^[0-9a-f]{64}$/.test(state.epoch?.basis_digest),
     "State epoch basis digest is invalid",
   );
-  if (ui.idle_cursor_receipt_run_id !== null) {
-    exactRunId(
-      ui.idle_cursor_receipt_run_id,
-      "State idle cursor receipt run ID",
+  const targets = plainObject(state.targets, "Controller target states");
+  invariant(
+    Object.keys(targets).sort().join(",") ===
+      [...PREVIEW_TARGETS].sort().join(","),
+    "Controller target state keys are invalid",
+  );
+  for (const target of PREVIEW_TARGETS) {
+    const targetState = plainObject(
+      targets[target],
+      `${target} controller state`,
     );
-  }
-  if (ui.active !== null && ui.active !== undefined) {
-    const active = validateActiveDispatch(ui.active, pr, "Active dispatch");
-    invariant(
-      active.recovery_quarantine === undefined,
-      "Current active dispatch cannot be recovery-quarantined",
-    );
-  }
-  invariant(
-    Array.isArray(ui.retired_active ?? []),
-    "Retired active selections must be an array",
-  );
-  invariant(
-    (ui.retired_active ?? []).length <= MAX_HISTORY,
-    "Too many retired active selections",
-  );
-  for (const selection of ui.retired_active ?? []) {
-    validateActiveDispatch(selection, pr, "Retired active dispatch");
-  }
-  const terminalHistory = ui.terminal_history ?? [];
-  invariant(
-    Array.isArray(terminalHistory) && terminalHistory.length <= MAX_HISTORY,
-    "Terminal history is invalid",
-  );
-  for (const terminal of terminalHistory) {
-    validatePersistedDispatch(terminal, pr, "Terminal selection");
-    invariant(
-      TERMINAL_STATES.has(terminal.state),
-      "Terminal selection state is invalid",
-    );
-  }
-  const terminalResultKeyDigests = ui.terminal_result_key_digests;
-  invariant(
-    Array.isArray(terminalResultKeyDigests) &&
-      terminalResultKeyDigests.length <= MAX_RECEIPTS,
-    "Terminal result ownership is invalid",
-  );
-  const terminalResultKeys = new Set();
-  for (const keyDigest of terminalResultKeyDigests) {
-    invariant(
-      typeof keyDigest === "string" && /^[0-9a-f]{24}$/.test(keyDigest),
-      "Terminal result ownership key is invalid",
+    for (const [name, sha] of [
+      ["first eligible", targetState.first_eligible_sha],
+      ["latest desired", targetState.latest_desired_sha],
+      ["last successful runtime", targetState.last_successful_runtime_sha],
+    ]) {
+      if (sha !== null) exactSha(sha, `${target} ${name} SHA`);
+    }
+    if (targetState.latest_desired_receipt_run_id !== null) {
+      exactRunId(
+        targetState.latest_desired_receipt_run_id,
+        `${target} latest desired receipt run ID`,
+      );
+    }
+    if (targetState.idle_cursor_receipt_run_id !== null) {
+      exactRunId(
+        targetState.idle_cursor_receipt_run_id,
+        `${target} idle cursor receipt run ID`,
+      );
+    }
+    optionalHttpsUrl(
+      targetState.last_successful_runtime_url,
+      `${target} last successful runtime URL`,
     );
     invariant(
-      !terminalResultKeys.has(keyDigest),
-      "Terminal result ownership contains duplicates",
+      (targetState.last_successful_runtime_sha === null) ===
+        (targetState.last_successful_runtime_url === null),
+      `${target} last successful runtime is incomplete`,
     );
-    terminalResultKeys.add(keyDigest);
+    if (targetState.active !== null) {
+      const active = validateActiveDispatch(
+        targetState.active,
+        pr,
+        `${target} active dispatch`,
+      );
+      invariant(
+        active.target === target && active.recovery_quarantine === undefined,
+        `${target} current active dispatch is invalid`,
+      );
+    }
+    invariant(
+      Array.isArray(targetState.retired_active) &&
+        targetState.retired_active.length <= MAX_HISTORY,
+      `${target} retired active selections are invalid`,
+    );
+    for (const selection of targetState.retired_active) {
+      const retired = validateActiveDispatch(
+        selection,
+        pr,
+        `${target} retired active dispatch`,
+      );
+      invariant(retired.target === target, `${target} retired target mismatch`);
+    }
+    invariant(
+      Array.isArray(targetState.terminal_history) &&
+        targetState.terminal_history.length <= MAX_HISTORY,
+      `${target} terminal history is invalid`,
+    );
+    for (const terminal of targetState.terminal_history) {
+      const persisted = validatePersistedDispatch(
+        terminal,
+        pr,
+        `${target} terminal selection`,
+      );
+      invariant(
+        persisted.target === target && TERMINAL_STATES.has(terminal.state),
+        `${target} terminal selection is invalid`,
+      );
+    }
+    const terminalResultKeys = new Set();
+    invariant(
+      Array.isArray(targetState.terminal_result_key_digests) &&
+        targetState.terminal_result_key_digests.length <= MAX_RECEIPTS,
+      `${target} terminal result ownership is invalid`,
+    );
+    for (const keyDigest of targetState.terminal_result_key_digests) {
+      invariant(
+        typeof keyDigest === "string" && /^[0-9a-f]{24}$/.test(keyDigest),
+        `${target} terminal result ownership key is invalid`,
+      );
+      invariant(
+        !terminalResultKeys.has(keyDigest),
+        `${target} terminal result ownership contains duplicates`,
+      );
+      terminalResultKeys.add(keyDigest);
+    }
   }
-  return {
-    ...state,
-    ui: {
-      ...ui,
-      terminal_result_key_digests: terminalResultKeyDigests,
-    },
-  };
+  invariant(
+    Array.isArray(state.status_decisions) &&
+      state.status_decisions.length <= MAX_RECEIPTS,
+    "Controller status decisions are invalid",
+  );
+  for (const decision of state.status_decisions) {
+    exactSha(decision.sha, "Controller status SHA");
+    invariant(
+      ["pending", "success", "failure", "error"].includes(decision.state),
+      "Controller status state is invalid",
+    );
+    boundedText(decision.description, "Controller status description", 140);
+    optionalHttpsUrl(decision.target_url, "Controller status URL");
+    const outcomes = plainObject(
+      decision.targets,
+      "Controller target status outcomes",
+    );
+    invariant(
+      Object.keys(outcomes).sort().join(",") ===
+        [...PREVIEW_TARGETS].sort().join(","),
+      "Controller target status outcome keys are invalid",
+    );
+    for (const outcome of Object.values(outcomes)) {
+      invariant(
+        [
+          "deployed",
+          "runtime-equivalent",
+          "not affected",
+          "native-owned",
+          "coalesced",
+          "unsupported trust boundary",
+          "pending",
+          "failed",
+          "error",
+        ].includes(outcome),
+        "Controller target status outcome is invalid",
+      );
+    }
+  }
+  return state;
 }
 
 export function reconcileState({
@@ -1759,55 +1879,18 @@ export function reconcileState({
   const epochSelections = allSelections.filter(
     (selection) => selection.epoch_anchor_run_id === anchor.event_run_id,
   );
-  const pendingCheckpointOwnerKey =
-    selectedCheckpoint?.pending_owner_key_digest ?? null;
-  const priorOwners = [
-    previous?.ui?.active,
-    ...(previous?.ui?.retired_active ?? []),
-    ...(previous?.ui?.terminal_history ?? []),
-  ].filter(Boolean);
-  const pendingCheckpointSelection = pendingCheckpointOwnerKey
-    ? (allSelections.find(
-        (selection) => selection.key_digest === pendingCheckpointOwnerKey,
-      ) ?? null)
-    : null;
-  const pendingCheckpointOwner = pendingCheckpointOwnerKey
-    ? (priorOwners.find(
-        (owner) => owner.key_digest === pendingCheckpointOwnerKey,
-      ) ??
-      pendingCheckpointSelection ??
-      null)
-    : null;
-  invariant(
-    pendingCheckpointOwnerKey === null || pendingCheckpointOwner !== null,
-    "Preview checkpoint pending owner is not persisted",
-  );
-  const pendingCheckpointResult = pendingCheckpointOwner
-    ? ([...allResults]
-        .filter(
-          (result) =>
-            result.key_digest === pendingCheckpointOwner.key_digest &&
-            result.epoch_anchor_run_id ===
-              pendingCheckpointOwner.epoch_anchor_run_id &&
-            result.selection_receipt_run_id ===
-              pendingCheckpointOwner.selection_receipt_run_id,
-        )
-        .sort(
-          (a, b) =>
-            b.worker_run_id - a.worker_run_id ||
-            b.worker_run_attempt - a.worker_run_attempt,
-        )[0] ?? null)
-    : null;
   if (epochResults.length > 0) {
     invariant(
       previous?.epoch?.anchor_run_id === anchor.event_run_id,
       "Current-epoch result exists without persisted epoch ownership",
     );
-    const ownedKeyDigests = new Set([
-      previous.ui?.active?.key_digest,
-      ...previous.ui.terminal_result_key_digests,
-    ]);
     for (const result of epochResults) {
+      const targetState = previous.targets[result.target];
+      const ownedKeyDigests = new Set([
+        targetState.active?.key_digest,
+        ...targetState.retired_active.map((owner) => owner.key_digest),
+        ...targetState.terminal_result_key_digests,
+      ]);
       invariant(
         ownedKeyDigests.has(result.key_digest),
         "Worker result is not bound to a persisted epoch selection",
@@ -1820,334 +1903,388 @@ export function reconcileState({
     closure: closure ? semanticEventKey(closure) : null,
     lineage: lineage.map(semanticEventKey),
     results: epochResults.map(canonicalJson).sort(),
-    pending_checkpoint_result: pendingCheckpointResult
-      ? canonicalJson(pendingCheckpointResult)
-      : null,
   });
   const sameEpoch = previous?.epoch?.anchor_run_id === anchor.event_run_id;
-  const lineageCandidates = lineage.filter((event) =>
-    event.plan.targets.includes(PREVIEW_TARGET),
-  );
-  const pendingRuntimeEvent = selectedCheckpoint?.pending_runtime_event ?? null;
-  const candidates =
-    pendingRuntimeEvent &&
-    !lineageCandidates.some(
-      (event) => event.event_run_id === pendingRuntimeEvent.event_run_id,
-    )
-      ? [pendingRuntimeEvent, ...lineageCandidates]
-      : lineageCandidates;
-  const candidateByRun = new Map(
-    candidates.map((event) => [event.event_run_id, event]),
-  );
-  const persistedOwners = priorOwners;
-  const ownerByKeyDigest = new Map(
-    persistedOwners.map((owner) => [owner.key_digest, owner]),
-  );
-  for (const terminal of epochResults) {
-    if (!ownerByKeyDigest.has(terminal.key_digest)) {
-      ownerByKeyDigest.set(terminal.key_digest, {
-        pr: terminal.pr,
-        target: terminal.target,
-        sha: terminal.sha,
-        key: terminal.controller_key,
-        key_digest: terminal.key_digest,
-        epoch_anchor_run_id: terminal.epoch_anchor_run_id,
-        reconciliation_basis_digest: terminal.reconciliation_basis_digest,
-        selection_receipt_run_id: terminal.selection_receipt_run_id,
-        expected_workflow_sha: terminal.expected_workflow_sha,
+  const controllerTargetUrl = optionalHttpsUrl(controllerUrl, "Controller URL");
+  const targetStates = {};
+  const targetStatuses = {};
+  const nextDispatches = [];
+
+  for (const target of PREVIEW_TARGETS) {
+    const previousTarget = previous?.targets[target] ?? null;
+    const checkpointTarget = selectedCheckpoint?.targets[target] ?? null;
+    const targetResults = epochResults.filter(
+      (result) => result.target === target,
+    );
+    const targetSelections = epochSelections.filter(
+      (selection) => selection.target === target,
+    );
+    const priorOwners = [
+      previousTarget?.active,
+      ...(previousTarget?.retired_active ?? []),
+      ...(previousTarget?.terminal_history ?? []),
+    ].filter(Boolean);
+    const pendingOwnerKey = checkpointTarget?.pending_owner_key_digest ?? null;
+    const pendingOwnerSelection = pendingOwnerKey
+      ? (allSelections.find(
+          (selection) => selection.key_digest === pendingOwnerKey,
+        ) ?? null)
+      : null;
+    const pendingOwner = pendingOwnerKey
+      ? (priorOwners.find((owner) => owner.key_digest === pendingOwnerKey) ??
+        pendingOwnerSelection ??
+        null)
+      : null;
+    invariant(
+      pendingOwnerKey === null || pendingOwner?.target === target,
+      `${target} checkpoint pending owner is not persisted`,
+    );
+    const pendingOwnerResult = pendingOwner
+      ? ([...allResults]
+          .filter(
+            (result) =>
+              result.target === target &&
+              result.key_digest === pendingOwner.key_digest &&
+              result.epoch_anchor_run_id === pendingOwner.epoch_anchor_run_id &&
+              result.selection_receipt_run_id ===
+                pendingOwner.selection_receipt_run_id,
+          )
+          .sort(
+            (a, b) =>
+              b.worker_run_id - a.worker_run_id ||
+              b.worker_run_attempt - a.worker_run_attempt,
+          )[0] ?? null)
+      : null;
+    const liveCandidates = lineage.filter((event) =>
+      event.plan.targets.includes(target),
+    );
+    const checkpointRuntimeEvent =
+      checkpointTarget?.latest_runtime_event ?? null;
+    const checkpointOwnerEvent = checkpointTarget?.pending_owner_event ?? null;
+    const candidates = [
+      checkpointOwnerEvent,
+      checkpointRuntimeEvent,
+      ...liveCandidates,
+    ]
+      .filter(Boolean)
+      .filter(
+        (event, index, values) =>
+          values.findIndex(
+            (candidate) => candidate.event_run_id === event.event_run_id,
+          ) === index,
+      );
+    const candidateByRun = new Map(
+      candidates.map((event) => [event.event_run_id, event]),
+    );
+    const ownerByKeyDigest = new Map(
+      priorOwners.map((owner) => [owner.key_digest, owner]),
+    );
+    for (const result of targetResults) {
+      if (!ownerByKeyDigest.has(result.key_digest)) {
+        ownerByKeyDigest.set(result.key_digest, {
+          pr: result.pr,
+          target,
+          sha: result.sha,
+          key: result.controller_key,
+          key_digest: result.key_digest,
+          epoch_anchor_run_id: result.epoch_anchor_run_id,
+          reconciliation_basis_digest: result.reconciliation_basis_digest,
+          selection_receipt_run_id: result.selection_receipt_run_id,
+          expected_workflow_sha: result.expected_workflow_sha,
+        });
+      }
+    }
+    for (const selection of targetSelections) {
+      const selectedEvent = candidateByRun.get(
+        selection.selection_receipt_run_id,
+      );
+      invariant(
+        selectedEvent &&
+          selectedEvent.head_sha === selection.sha &&
+          selection.key === controllerKey(pull.number, selection.sha, target),
+        `${target} selection is outside current eligible lineage`,
+      );
+      const owner = ownerByKeyDigest.get(selection.key_digest);
+      invariant(
+        owner &&
+          owner.target === target &&
+          owner.sha === selection.sha &&
+          owner.key === selection.key &&
+          owner.epoch_anchor_run_id === selection.epoch_anchor_run_id &&
+          owner.reconciliation_basis_digest ===
+            selection.reconciliation_basis_digest &&
+          owner.selection_receipt_run_id ===
+            selection.selection_receipt_run_id &&
+          owner.expected_workflow_sha === selection.expected_workflow_sha,
+        `${target} selection is not bound to persisted ownership`,
+      );
+    }
+    const resultByRun = new Map();
+    for (const event of candidates) {
+      const result = resultForSelection(
+        targetResults,
+        anchor.event_run_id,
+        event,
+        sameEpoch &&
+          previousTarget?.active?.selection_receipt_run_id ===
+            event.event_run_id
+          ? previousTarget.active
+          : null,
+        target,
+      );
+      if (result) resultByRun.set(event.event_run_id, result);
+    }
+    if (
+      checkpointTarget &&
+      checkpointRuntimeEvent &&
+      TERMINAL_STATES.has(checkpointTarget.status.state)
+    ) {
+      resultByRun.set(checkpointRuntimeEvent.event_run_id, {
+        state: checkpointTarget.status.state,
+        sha: checkpointRuntimeEvent.head_sha,
+        vercel_deployment_url:
+          checkpointTarget.status.state === "success"
+            ? checkpointTarget.status.target_url
+            : null,
+        worker_run_id:
+          checkpointTarget.status.state === "success"
+            ? null
+            : workflowRunIdFromUrl(checkpointTarget.status.target_url),
+        terminal_reason: isNativeOwnedCheckpointStatus(
+          checkpointTarget.status,
+          selectedCheckpoint.event,
+          target,
+        )
+          ? NATIVE_OWNED_SELECTION_REASON
+          : CHECKPOINTED_TERMINAL_REASON,
       });
     }
-  }
-  for (const selection of epochSelections) {
-    const selectedEvent = candidateByRun.get(
-      selection.selection_receipt_run_id,
-    );
-    invariant(
-      selectedEvent &&
-        selectedEvent.head_sha === selection.sha &&
-        controllerKey(pull.number, selectedEvent.head_sha) === selection.key,
-      "Preview selection receipt is outside current eligible lineage",
-    );
-    const owner = ownerByKeyDigest.get(selection.key_digest);
-    invariant(
-      owner &&
-        owner.sha === selection.sha &&
-        owner.key === selection.key &&
-        owner.epoch_anchor_run_id === selection.epoch_anchor_run_id &&
-        owner.reconciliation_basis_digest ===
-          selection.reconciliation_basis_digest &&
-        owner.selection_receipt_run_id === selection.selection_receipt_run_id &&
-        owner.expected_workflow_sha === selection.expected_workflow_sha,
-      "Preview selection receipt is not bound to persisted ownership",
-    );
-  }
-  const resultByRun = new Map();
-  for (const event of candidates) {
-    const result = resultForSelection(
-      epochResults,
-      anchor.event_run_id,
-      event,
-      sameEpoch &&
-        previous?.ui?.active?.selection_receipt_run_id === event.event_run_id
-        ? previous.ui.active
-        : null,
-    );
-    if (result) resultByRun.set(event.event_run_id, result);
-  }
-  if (
-    selectedCheckpoint &&
-    TERMINAL_STATES.has(selectedCheckpoint.status.state) &&
-    selectedCheckpoint.event.plan.targets.includes(PREVIEW_TARGET)
-  ) {
-    resultByRun.set(selectedCheckpoint.event.event_run_id, {
-      state: selectedCheckpoint.status.state,
-      sha: selectedCheckpoint.event.head_sha,
-      vercel_deployment_url: selectedCheckpoint.status.target_url,
-      terminal_reason: isNativeOwnedCheckpointStatus(
-        selectedCheckpoint.status,
-        selectedCheckpoint.event,
-      )
-        ? NATIVE_OWNED_SELECTION_REASON
-        : CHECKPOINTED_TERMINAL_REASON,
-    });
-  }
-  if (
-    pendingRuntimeEvent &&
-    pendingCheckpointOwner &&
-    pendingCheckpointResult &&
-    pendingRuntimeEvent.head_sha === pendingCheckpointOwner.sha &&
-    (!RETRIABLE_TERMINAL_REASONS.has(pendingCheckpointResult.terminal_reason) ||
-      selectedCheckpoint.pending_owner_attempt_count >= 2) &&
-    !resultByRun.has(pendingRuntimeEvent.event_run_id)
-  ) {
-    resultByRun.set(pendingRuntimeEvent.event_run_id, pendingCheckpointResult);
-  }
-  const selectedReceiptRunIds = new Set(
-    epochSelections.map((selection) => selection.selection_receipt_run_id),
-  );
-  const coalescedToByRun = new Map();
-  for (const selection of epochSelections) {
-    const selectedEvent = candidateByRun.get(
-      selection.selection_receipt_run_id,
-    );
-    const selectedIndex = candidates.findIndex(
-      (event) => event.event_run_id === selectedEvent.event_run_id,
-    );
-    for (const coalescedRunId of selection.coalesced_receipt_run_ids) {
-      const coalescedIndex = candidates.findIndex(
-        (event) => event.event_run_id === coalescedRunId,
-      );
-      invariant(
-        coalescedIndex >= 0 &&
-          coalescedIndex < selectedIndex &&
-          !resultByRun.has(coalescedRunId) &&
-          !selectedReceiptRunIds.has(coalescedRunId),
-        "Preview coalescing evidence contradicts durable selection ownership",
-      );
-      const prior = coalescedToByRun.get(coalescedRunId);
-      invariant(
-        !prior || prior.event_run_id === selectedEvent.event_run_id,
-        "Preview event has conflicting coalescing evidence",
-      );
-      coalescedToByRun.set(coalescedRunId, selectedEvent);
+    if (
+      checkpointOwnerEvent &&
+      pendingOwner &&
+      pendingOwnerResult &&
+      checkpointOwnerEvent.head_sha === pendingOwner.sha &&
+      (!RETRIABLE_TERMINAL_REASONS.has(pendingOwnerResult.terminal_reason) ||
+        checkpointTarget.pending_owner_attempt_count >= 2) &&
+      !resultByRun.has(checkpointOwnerEvent.event_run_id)
+    ) {
+      resultByRun.set(checkpointOwnerEvent.event_run_id, pendingOwnerResult);
     }
-  }
-
-  let active = null;
-  let idleCursor = sameEpoch
-    ? (previous.ui?.idle_cursor_receipt_run_id ?? null)
-    : null;
-  let latestDesired = null;
-  let completedActive = null;
-  let completedResult = null;
-  if (sameEpoch && previous.ui?.active) {
-    const previousActive = previous.ui.active;
-    const selectedEvent = candidateByRun.get(
-      previousActive.selection_receipt_run_id,
+    const selectedRunIds = new Set(
+      targetSelections.map((selection) => selection.selection_receipt_run_id),
     );
-    invariant(
-      selectedEvent,
-      "Active selection receipt is outside current lineage",
-    );
-    const terminal = resultForSelection(
-      epochResults,
-      anchor.event_run_id,
-      selectedEvent,
-      previousActive,
-    );
-    if (terminal) {
-      completedActive = previousActive;
-      completedResult = terminal;
-      idleCursor = previousActive.selection_receipt_run_id;
-    } else {
-      active = { ...previousActive };
-      const activeIndex = candidates.findIndex(
-        (event) =>
-          event.event_run_id === previousActive.selection_receipt_run_id,
+    const coalescedToByRun = new Map();
+    for (const selection of targetSelections) {
+      const selectedEvent = candidateByRun.get(
+        selection.selection_receipt_run_id,
       );
-      latestDesired = candidates.slice(activeIndex).at(-1) ?? selectedEvent;
-    }
-  }
-
-  let selected = null;
-  if (!active && pull.state === "open" && pull.trust === "trusted") {
-    if (completedActive) {
-      const previousDesiredRun = previous.ui?.latest_desired_receipt_run_id;
-      const desired = candidateByRun.get(previousDesiredRun);
-      if (
-        desired &&
-        desired.event_run_id !== completedActive.selection_receipt_run_id &&
-        !resultByRun.has(desired.event_run_id)
-      ) {
-        selected = desired;
-      }
-      const inheritedAttempts =
-        pendingCheckpointOwner?.selection_receipt_run_id ===
-        completedActive.selection_receipt_run_id
-          ? selectedCheckpoint.pending_owner_attempt_count -
-            Number(
-              pendingCheckpointOwner.key_digest === completedActive.key_digest,
-            )
-          : 0;
-      const attemptsForReceipt =
-        inheritedAttempts +
-        epochResults.filter(
-          (result) =>
-            result.selection_receipt_run_id ===
-              completedActive.selection_receipt_run_id &&
-            result.terminal_reason !==
-              "controller-workflow-upgraded-before-dispatch",
-        ).length;
-      if (
-        !selected &&
-        RETRIABLE_TERMINAL_REASONS.has(completedResult?.terminal_reason) &&
-        attemptsForReceipt < 2
-      ) {
-        selected = candidateByRun.get(completedActive.selection_receipt_run_id);
-      }
-      if (
-        !selected &&
-        completedResult?.terminal_reason ===
-          "controller-workflow-upgraded-before-dispatch" &&
-        completedResult.expected_workflow_sha !== expectedWorkflowSha
-      ) {
-        selected = candidateByRun.get(completedActive.selection_receipt_run_id);
-      }
-    }
-    if (!selected) {
-      const cursorIndex = idleCursor
-        ? candidates.findIndex((event) => event.event_run_id === idleCursor)
-        : -1;
-      invariant(
-        idleCursor === null || cursorIndex >= 0,
-        "Idle cursor is outside current event lineage",
-      );
-      const unprocessed = candidates
-        .slice(cursorIndex + 1)
-        .filter((event) => !resultByRun.has(event.event_run_id));
-      selected = unprocessed[0] ?? null;
-      latestDesired = unprocessed.at(-1) ?? null;
-    } else {
       const selectedIndex = candidates.findIndex(
-        (event) => event.event_run_id === selected.event_run_id,
+        (event) => event.event_run_id === selectedEvent.event_run_id,
       );
-      latestDesired = candidates.slice(selectedIndex).at(-1) ?? selected;
+      for (const coalescedRunId of selection.coalesced_receipt_run_ids) {
+        const coalescedIndex = candidates.findIndex(
+          (event) => event.event_run_id === coalescedRunId,
+        );
+        invariant(
+          coalescedIndex >= 0 &&
+            coalescedIndex < selectedIndex &&
+            !resultByRun.has(coalescedRunId) &&
+            !selectedRunIds.has(coalescedRunId),
+          `${target} coalescing evidence contradicts durable ownership`,
+        );
+        const prior = coalescedToByRun.get(coalescedRunId);
+        invariant(
+          !prior || prior.event_run_id === selectedEvent.event_run_id,
+          `${target} event has conflicting coalescing evidence`,
+        );
+        coalescedToByRun.set(coalescedRunId, selectedEvent);
+      }
     }
-  }
-  if (pendingCheckpointResult && !active) {
-    const desired = candidates.at(-1) ?? null;
-    if (desired && !resultByRun.has(desired.event_run_id)) {
-      selected = desired;
-      latestDesired = desired;
-    }
-  }
-  if (pendingCheckpointOwner && !pendingCheckpointResult) selected = null;
 
-  const nextDispatch = selected
-    ? (() => {
-        const key = controllerKey(pull.number, selected.head_sha);
+    let active = null;
+    let idleCursor = sameEpoch
+      ? (previousTarget?.idle_cursor_receipt_run_id ?? null)
+      : null;
+    let latestDesired = null;
+    let completedActive = null;
+    let completedResult = null;
+    if (sameEpoch && previousTarget?.active) {
+      const previousActive = previousTarget.active;
+      const selectedEvent = candidateByRun.get(
+        previousActive.selection_receipt_run_id,
+      );
+      invariant(selectedEvent, `${target} active selection left the lineage`);
+      const terminal = resultForSelection(
+        targetResults,
+        anchor.event_run_id,
+        selectedEvent,
+        previousActive,
+        target,
+      );
+      if (terminal) {
+        completedActive = previousActive;
+        completedResult = terminal;
+        idleCursor = previousActive.selection_receipt_run_id;
+      } else {
+        active = { ...previousActive };
+        const activeIndex = candidates.findIndex(
+          (event) =>
+            event.event_run_id === previousActive.selection_receipt_run_id,
+        );
+        latestDesired = candidates.slice(activeIndex).at(-1) ?? selectedEvent;
+      }
+    }
+
+    let selected = null;
+    if (!active && pull.state === "open" && pull.trust === "trusted") {
+      if (completedActive) {
+        const desired = candidateByRun.get(
+          previousTarget?.latest_desired_receipt_run_id,
+        );
+        if (
+          desired &&
+          desired.event_run_id !== completedActive.selection_receipt_run_id &&
+          !resultByRun.has(desired.event_run_id)
+        ) {
+          selected = desired;
+        }
+        const inheritedAttempts =
+          pendingOwner?.selection_receipt_run_id ===
+          completedActive.selection_receipt_run_id
+            ? checkpointTarget.pending_owner_attempt_count -
+              Number(pendingOwner.key_digest === completedActive.key_digest)
+            : 0;
+        const attemptsForReceipt =
+          inheritedAttempts +
+          targetResults.filter(
+            (result) =>
+              result.selection_receipt_run_id ===
+                completedActive.selection_receipt_run_id &&
+              result.terminal_reason !==
+                "controller-workflow-upgraded-before-dispatch",
+          ).length;
+        if (
+          !selected &&
+          RETRIABLE_TERMINAL_REASONS.has(completedResult?.terminal_reason) &&
+          attemptsForReceipt < 2
+        ) {
+          selected = candidateByRun.get(
+            completedActive.selection_receipt_run_id,
+          );
+        }
+        if (
+          !selected &&
+          completedResult?.terminal_reason ===
+            "controller-workflow-upgraded-before-dispatch" &&
+          completedResult.expected_workflow_sha !== expectedWorkflowSha
+        ) {
+          selected = candidateByRun.get(
+            completedActive.selection_receipt_run_id,
+          );
+        }
+      }
+      if (!selected) {
+        const cursorIndex = idleCursor
+          ? candidates.findIndex((event) => event.event_run_id === idleCursor)
+          : -1;
+        invariant(
+          idleCursor === null || cursorIndex >= 0,
+          `${target} idle cursor is outside current lineage`,
+        );
+        const unprocessed = candidates
+          .slice(cursorIndex + 1)
+          .filter((event) => !resultByRun.has(event.event_run_id));
+        selected = unprocessed[0] ?? null;
+        latestDesired = unprocessed.at(-1) ?? null;
+      } else {
         const selectedIndex = candidates.findIndex(
           (event) => event.event_run_id === selected.event_run_id,
         );
-        const completedIndex = completedActive
-          ? candidates.findIndex(
-              (event) =>
-                event.event_run_id === completedActive.selection_receipt_run_id,
-            )
-          : -1;
-        const coalescingStartIndex = pendingCheckpointResult
-          ? 0
-          : completedIndex + 1;
-        const coalescedReceiptRunIds =
-          coalescingStartIndex >= 0 && selectedIndex > coalescingStartIndex
-            ? candidates
-                .slice(coalescingStartIndex, selectedIndex)
-                .filter(
-                  (event) =>
-                    !resultByRun.has(event.event_run_id) &&
-                    !selectedReceiptRunIds.has(event.event_run_id),
-                )
-                .map((event) => event.event_run_id)
-            : [];
-        return {
-          pr: pull.number,
-          target: PREVIEW_TARGET,
-          sha: selected.head_sha,
-          git_ref: selected.head_ref,
-          key,
-          epoch_anchor_run_id: anchor.event_run_id,
-          reconciliation_basis_digest: basisDigest,
-          selection_receipt_run_id: selected.event_run_id,
-          expected_workflow_sha: expectedWorkflowSha,
-          coalesced_receipt_run_ids: coalescedReceiptRunIds,
-          key_digest: controllerKeyDigest(key, {
-            epochAnchorRunId: anchor.event_run_id,
-            basisDigest,
-            selectionReceiptRunId: selected.event_run_id,
-            expectedWorkflowSha,
-          }),
-        };
-      })()
-    : null;
+        latestDesired = candidates.slice(selectedIndex).at(-1) ?? selected;
+      }
+    }
+    if (pendingOwnerResult && !active) {
+      const desired = candidates.at(-1) ?? null;
+      if (desired && !resultByRun.has(desired.event_run_id)) {
+        selected = desired;
+        latestDesired = desired;
+      }
+    }
+    if (pendingOwner && !pendingOwnerResult) selected = null;
 
-  const controllerTargetUrl = optionalHttpsUrl(controllerUrl, "Controller URL");
-  let effectiveCheckpointStatus = selectedCheckpoint?.status ?? null;
-  const pendingRuntimeResult = pendingRuntimeEvent
-    ? resultByRun.get(pendingRuntimeEvent.event_run_id)
-    : null;
-  if (selectedCheckpoint && pendingRuntimeEvent && pendingRuntimeResult) {
-    effectiveCheckpointStatus = statusFromPendingRuntimeResult({
-      checkpointEvent: selectedCheckpoint.event,
-      runtimeEvent: pendingRuntimeEvent,
-      result: pendingRuntimeResult,
-      controllerUrl: controllerTargetUrl,
-    });
-  } else if (
-    selectedCheckpoint &&
-    pendingCheckpointResult &&
-    pull.state === "closed"
-  ) {
-    effectiveCheckpointStatus = {
-      sha: selectedCheckpoint.event.head_sha,
-      state: "success",
-      description: "Preview no longer required for closed PR",
-      target_url: controllerTargetUrl,
-    };
-  } else if (effectiveCheckpointStatus?.state === "pending" && active) {
-    effectiveCheckpointStatus = {
-      ...effectiveCheckpointStatus,
-      target_url: active.html_url ?? controllerTargetUrl,
-    };
-  }
-  const previousStatusBySha = new Map(
-    (previous?.status_decisions ?? []).map((decision) => [
-      decision.sha,
-      decision,
-    ]),
-  );
-  const statuses = lineage.map((event, index) =>
-    preserveSettledControllerTarget(
-      statusDecision({
+    if (selected) {
+      const key = controllerKey(pull.number, selected.head_sha, target);
+      const selectedIndex = candidates.findIndex(
+        (event) => event.event_run_id === selected.event_run_id,
+      );
+      const completedIndex = completedActive
+        ? candidates.findIndex(
+            (event) =>
+              event.event_run_id === completedActive.selection_receipt_run_id,
+          )
+        : -1;
+      const coalescingStartIndex = pendingOwnerResult ? 0 : completedIndex + 1;
+      const coalescedReceiptRunIds = candidates
+        .slice(coalescingStartIndex, selectedIndex)
+        .filter(
+          (event) =>
+            !resultByRun.has(event.event_run_id) &&
+            !selectedRunIds.has(event.event_run_id),
+        )
+        .map((event) => event.event_run_id);
+      nextDispatches.push({
+        pr: pull.number,
+        target,
+        sha: selected.head_sha,
+        git_ref: selected.head_ref,
+        key,
+        epoch_anchor_run_id: anchor.event_run_id,
+        reconciliation_basis_digest: basisDigest,
+        selection_receipt_run_id: selected.event_run_id,
+        expected_workflow_sha: expectedWorkflowSha,
+        coalesced_receipt_run_ids: coalescedReceiptRunIds,
+        key_digest: controllerKeyDigest(key, {
+          epochAnchorRunId: anchor.event_run_id,
+          basisDigest,
+          selectionReceiptRunId: selected.event_run_id,
+          expectedWorkflowSha,
+        }),
+      });
+    }
+
+    let effectiveCheckpointStatus = checkpointTarget?.status ?? null;
+    const checkpointPendingEvent =
+      checkpointOwnerEvent ?? checkpointRuntimeEvent;
+    const pendingRuntimeResult = checkpointPendingEvent
+      ? resultByRun.get(checkpointPendingEvent.event_run_id)
+      : null;
+    if (checkpointTarget && checkpointPendingEvent && pendingRuntimeResult) {
+      effectiveCheckpointStatus = statusFromPendingRuntimeResult({
+        target,
+        runtimeEvent: checkpointPendingEvent,
+        result: pendingRuntimeResult,
+        controllerUrl: controllerTargetUrl,
+      });
+    } else if (
+      checkpointTarget &&
+      pendingOwnerResult &&
+      pull.state === "closed"
+    ) {
+      effectiveCheckpointStatus = {
+        state: "success",
+        outcome: "not affected",
+        description: `${target}: no preview required for closed PR`,
+        target_url: controllerTargetUrl,
+      };
+    } else if (effectiveCheckpointStatus?.state === "pending" && active) {
+      effectiveCheckpointStatus = {
+        ...effectiveCheckpointStatus,
+        target_url: active.html_url ?? controllerTargetUrl,
+      };
+    }
+    targetStatuses[target] = lineage.map((event, index) =>
+      targetStatusDecision({
+        target,
         event,
         index,
         lineage,
@@ -2160,65 +2297,114 @@ export function reconcileState({
             ? effectiveCheckpointStatus
             : null,
         checkpointBaselineStatus: effectiveCheckpointStatus,
-        checkpointBaselineEvent: selectedCheckpoint?.event ?? null,
+        checkpointRuntimeEvent,
       }),
+    );
+
+    const successes = [...resultByRun.entries()]
+      .filter(
+        ([, result]) =>
+          result.state === "success" && result.schema === RESULT_RECEIPT_SCHEMA,
+      )
+      .sort(([runA], [runB]) => {
+        const indexA = candidates.findIndex(
+          (event) => event.event_run_id === runA,
+        );
+        const indexB = candidates.findIndex(
+          (event) => event.event_run_id === runB,
+        );
+        return indexB - indexA;
+      });
+    const lastSuccess = successes[0]?.[1] ?? null;
+    const terminalHistory = targetResults
+      .sort((a, b) => a.worker_run_id - b.worker_run_id)
+      .slice(-MAX_HISTORY)
+      .map((result) => ({
+        target,
+        sha: result.sha,
+        key: result.controller_key,
+        key_digest: result.key_digest,
+        epoch_anchor_run_id: result.epoch_anchor_run_id,
+        reconciliation_basis_digest: result.reconciliation_basis_digest,
+        selection_receipt_run_id: result.selection_receipt_run_id,
+        expected_workflow_sha: result.expected_workflow_sha,
+        state: result.state,
+        worker_run_id: result.worker_run_id,
+        github_deployment_id: result.github_deployment_id,
+        vercel_deployment_url: result.vercel_deployment_url,
+        terminal_reason: result.terminal_reason,
+      }));
+    const allResultKeys = new Set(
+      allResults.map((result) => result.key_digest),
+    );
+    const retiredActive = [
+      ...(previousTarget?.retired_active ?? []),
+      ...(!sameEpoch && previousTarget?.active ? [previousTarget.active] : []),
+    ]
+      .filter(
+        (selection, index, values) =>
+          values.findIndex(
+            (candidate) => candidate.key_digest === selection.key_digest,
+          ) === index,
+      )
+      .filter((selection) => !allResultKeys.has(selection.key_digest));
+    invariant(
+      retiredActive.length <= MAX_HISTORY,
+      `${target} has too many unfinished retired workers`,
+    );
+    const latestDesiredEvent =
+      latestDesired ??
+      (sameEpoch
+        ? candidateByRun.get(previousTarget?.latest_desired_receipt_run_id)
+        : null) ??
+      candidates.at(-1) ??
+      null;
+    targetStates[target] = {
+      first_eligible_sha:
+        checkpointTarget?.first_eligible_sha ??
+        (sameEpoch ? previousTarget?.first_eligible_sha : null) ??
+        candidates[0]?.head_sha ??
+        null,
+      latest_desired_sha: latestDesiredEvent?.head_sha ?? null,
+      latest_desired_receipt_run_id: latestDesiredEvent?.event_run_id ?? null,
+      idle_cursor_receipt_run_id: idleCursor,
+      active,
+      retired_active: retiredActive,
+      last_successful_runtime_sha:
+        lastSuccess?.sha ?? previousTarget?.last_successful_runtime_sha ?? null,
+      last_successful_runtime_url:
+        lastSuccess?.vercel_deployment_url ??
+        previousTarget?.last_successful_runtime_url ??
+        null,
+      terminal_result_key_digests: [
+        ...new Set(targetResults.map((result) => result.key_digest)),
+      ],
+      terminal_history: terminalHistory,
+    };
+  }
+
+  const previousStatusBySha = new Map(
+    (previous?.status_decisions ?? []).map((decision) => [
+      decision.sha,
+      decision,
+    ]),
+  );
+  const statuses = lineage.map((event, index) =>
+    preserveSettledControllerTarget(
+      aggregateStatusDecision(
+        event,
+        Object.fromEntries(
+          PREVIEW_TARGETS.map((target) => [
+            target,
+            targetStatuses[target][index],
+          ]),
+        ),
+        controllerTargetUrl,
+      ),
       previousStatusBySha,
       controllerTargetUrl,
     ),
   );
-  const successes = [...resultByRun.entries()]
-    .filter(
-      ([, result]) =>
-        result.state === "success" && result.schema === RESULT_RECEIPT_SCHEMA,
-    )
-    .sort(([runA], [runB]) => {
-      const indexA = lineage.findIndex((event) => event.event_run_id === runA);
-      const indexB = lineage.findIndex((event) => event.event_run_id === runB);
-      return indexB - indexA;
-    });
-  const lastSuccess = successes[0]?.[1] ?? null;
-  const terminalHistory = epochResults
-    .sort((a, b) => a.worker_run_id - b.worker_run_id)
-    .slice(-MAX_HISTORY)
-    .map((result) => ({
-      sha: result.sha,
-      key: result.controller_key,
-      key_digest: result.key_digest,
-      epoch_anchor_run_id: result.epoch_anchor_run_id,
-      reconciliation_basis_digest: result.reconciliation_basis_digest,
-      selection_receipt_run_id: result.selection_receipt_run_id,
-      expected_workflow_sha: result.expected_workflow_sha,
-      state: result.state,
-      worker_run_id: result.worker_run_id,
-      github_deployment_id: result.github_deployment_id,
-      vercel_deployment_url: result.vercel_deployment_url,
-      terminal_reason: result.terminal_reason,
-    }));
-  const terminalResultKeyDigests = new Set(
-    allResults.map((result) => result.key_digest),
-  );
-  const retiredActive = [
-    ...(previous?.ui?.retired_active ?? []),
-    ...(!sameEpoch && previous?.ui?.active ? [previous.ui.active] : []),
-  ]
-    .filter(
-      (selection, index, values) =>
-        values.findIndex(
-          (candidate) => candidate.key_digest === selection.key_digest,
-        ) === index,
-    )
-    .filter((selection) => !terminalResultKeyDigests.has(selection.key_digest));
-  invariant(
-    retiredActive.length <= MAX_HISTORY,
-    `Preview controller cannot retain more than ${MAX_HISTORY} unfinished retired workers`,
-  );
-  const latestDesiredEvent =
-    latestDesired ??
-    (sameEpoch
-      ? candidateByRun.get(previous.ui?.latest_desired_receipt_run_id)
-      : null) ??
-    candidates.at(-1) ??
-    null;
   const state = {
     schema: CONTROLLER_SCHEMA,
     repository: PREVIEW_REPOSITORY,
@@ -2242,27 +2428,10 @@ export function reconcileState({
       pull.number,
       checkpoint,
     ),
-    ui: {
-      first_eligible_sha: candidates[0]?.head_sha ?? null,
-      latest_desired_sha: latestDesiredEvent?.head_sha ?? null,
-      latest_desired_receipt_run_id: latestDesiredEvent?.event_run_id ?? null,
-      idle_cursor_receipt_run_id: idleCursor,
-      active,
-      retired_active: retiredActive,
-      last_successful_runtime_sha:
-        lastSuccess?.sha ?? previous?.ui?.last_successful_runtime_sha ?? null,
-      last_successful_runtime_url:
-        lastSuccess?.vercel_deployment_url ??
-        previous?.ui?.last_successful_runtime_url ??
-        null,
-      terminal_result_key_digests: [
-        ...new Set(epochResults.map((result) => result.key_digest)),
-      ],
-      terminal_history: terminalHistory,
-    },
+    targets: targetStates,
     status_decisions: statuses,
   };
-  return { state, nextDispatch, lineage, basisDigest };
+  return { state, nextDispatches, lineage, basisDigest };
 }
 
 function ownerRepo(context) {
@@ -2274,67 +2443,111 @@ function ownerRepo(context) {
   return context.repo;
 }
 
-async function uiPreviewOwnerAtSha(github, context, sha) {
-  const immutableSha = exactSha(sha, "Candidate UI Vercel configuration SHA");
+async function previewOwnerAtSha(github, context, target, sha) {
+  const targetConfiguration = previewTargetConfig(target);
+  const immutableSha = exactSha(
+    sha,
+    `Candidate ${target} Vercel configuration SHA`,
+  );
   const { data } = await github.rest.repos.getContent({
     ...ownerRepo(context),
-    path: UI_VERCEL_CONFIGURATION_PATH,
+    path: targetConfiguration.vercelConfigurationPath,
     ref: immutableSha,
   });
-  const file = plainObject(data, "Candidate UI Vercel configuration");
+  const file = plainObject(data, `Candidate ${target} Vercel configuration`);
   invariant(
-    file.type === "file" && file.path === UI_VERCEL_CONFIGURATION_PATH,
-    "Candidate UI Vercel configuration is not the expected file",
+    file.type === "file" &&
+      file.path === targetConfiguration.vercelConfigurationPath,
+    `Candidate ${target} Vercel configuration is not the expected file`,
   );
   invariant(
     file.encoding === "base64" &&
       Number.isSafeInteger(file.size) &&
       file.size > 0 &&
-      file.size <= UI_VERCEL_CONFIGURATION_MAX_BYTES,
-    "Candidate UI Vercel configuration metadata is invalid",
+      file.size <= VERCEL_CONFIGURATION_MAX_BYTES,
+    `Candidate ${target} Vercel configuration metadata is invalid`,
   );
   invariant(
     typeof file.content === "string" &&
       file.content.length > 0 &&
       file.content.length <=
-        Math.ceil(UI_VERCEL_CONFIGURATION_MAX_BYTES / 3) * 4 + 128 &&
+        Math.ceil(VERCEL_CONFIGURATION_MAX_BYTES / 3) * 4 + 128 &&
       /^[A-Za-z0-9+/=\r\n]+$/.test(file.content),
-    "Candidate UI Vercel configuration encoding is invalid",
+    `Candidate ${target} Vercel configuration encoding is invalid`,
   );
   const encoded = file.content.replace(/[\r\n]/g, "");
   const bytes = Buffer.from(encoded, "base64");
   invariant(
     bytes.length === file.size && bytes.toString("base64") === encoded,
-    "Candidate UI Vercel configuration encoding is invalid",
+    `Candidate ${target} Vercel configuration encoding is invalid`,
   );
   const text = bytes.toString("utf8");
   invariant(
     Buffer.from(text, "utf8").equals(bytes),
-    "Candidate UI Vercel configuration is not valid UTF-8",
+    `Candidate ${target} Vercel configuration is not valid UTF-8`,
   );
   let configuration;
   try {
     configuration = JSON.parse(text);
   } catch {
-    throw new Error("Candidate UI Vercel configuration is malformed");
+    throw new Error(`Candidate ${target} Vercel configuration is malformed`);
   }
-  plainObject(configuration, "Candidate UI Vercel configuration");
+  plainObject(configuration, `Candidate ${target} Vercel configuration`);
   const candidate = canonicalJson(configuration);
-  if (candidate === canonicalJson(UI_VERCEL_GITHUB_CONFIGURATION)) {
-    return UI_PREVIEW_OWNER_GITHUB;
+  if (
+    candidate === canonicalJson(targetConfiguration.githubVercelConfiguration)
+  ) {
+    return PREVIEW_OWNER_GITHUB;
   }
-  if (candidate === canonicalJson(UI_VERCEL_NATIVE_CONFIGURATION)) {
-    return UI_PREVIEW_OWNER_NATIVE;
+  if (
+    candidate === canonicalJson(targetConfiguration.nativeVercelConfiguration)
+  ) {
+    return PREVIEW_OWNER_NATIVE;
   }
-  throw new Error("Candidate UI Vercel configuration is not recognized");
+  throw new Error(`Candidate ${target} Vercel configuration is not recognized`);
 }
 
-async function candidateUiPreviewOwner(github, context, pull) {
+async function candidatePreviewOwners(github, context, pull) {
   const normalized = normalizePullRequest(pull);
   if (normalized.state !== "open" || normalized.trust !== "trusted") {
-    return null;
+    return Object.fromEntries(PREVIEW_TARGETS.map((target) => [target, null]));
   }
-  return uiPreviewOwnerAtSha(github, context, normalized.headSha);
+  return Object.fromEntries(
+    await Promise.all(
+      PREVIEW_TARGETS.map(async (target) => [
+        target,
+        await previewOwnerAtSha(github, context, target, normalized.headSha),
+      ]),
+    ),
+  );
+}
+
+async function assertWorkflowOwnershipMap(github, context, workflowSha) {
+  for (const target of PREVIEW_TARGETS) {
+    const expected =
+      PREVIEW_TARGET_CONFIG[target].ownershipMode ===
+      PREVIEW_OWNERSHIP_MODES.GITHUB
+        ? PREVIEW_OWNER_GITHUB
+        : PREVIEW_OWNER_NATIVE;
+    invariant(
+      (await previewOwnerAtSha(github, context, target, workflowSha)) ===
+        expected,
+      `${target} workflow ownership map disagrees with its immutable Vercel configuration`,
+    );
+  }
+}
+
+function githubPreviewDispatchAllowed(target, previewOwner) {
+  const configuration = previewTargetConfig(target);
+  invariant(
+    previewOwner === PREVIEW_OWNER_GITHUB ||
+      previewOwner === PREVIEW_OWNER_NATIVE,
+    `${target} preview ownership is invalid`,
+  );
+  return (
+    configuration.ownershipMode === PREVIEW_OWNERSHIP_MODES.SHADOW ||
+    previewOwner === PREVIEW_OWNER_GITHUB
+  );
 }
 
 async function listComments(github, context, pr) {
@@ -2438,19 +2651,30 @@ function previewJournalDigest(receipts, state, checkpoint = null) {
   });
 }
 
-function validateCheckpointStatus(value, event) {
-  const status = plainObject(value, "Preview checkpoint status");
+function validateCheckpointStatus(value, target) {
+  const status = plainObject(value, `${target} checkpoint status`);
   invariant(
-    Object.keys(status).sort().join(",") === "description,sha,state,target_url",
+    Object.keys(status).sort().join(",") ===
+      "description,outcome,state,target_url",
     "Preview checkpoint status fields are invalid",
-  );
-  invariant(
-    exactSha(status.sha) === event.head_sha,
-    "Preview checkpoint status SHA mismatch",
   );
   invariant(
     ["pending", "success", "failure", "error"].includes(status.state),
     "Preview checkpoint status state is invalid",
+  );
+  invariant(
+    [
+      "deployed",
+      "runtime-equivalent",
+      "not affected",
+      "native-owned",
+      "coalesced",
+      "unsupported trust boundary",
+      "pending",
+      "failed",
+      "error",
+    ].includes(status.outcome),
+    "Preview checkpoint status outcome is invalid",
   );
   boundedText(status.description, "Preview checkpoint status description", 140);
   optionalHttpsUrl(status.target_url, "Preview checkpoint status URL");
@@ -2462,7 +2686,7 @@ function validatePreviewCheckpoint(value, expectedPr) {
   const checkpoint = plainObject(value, "Preview checkpoint");
   invariant(
     Object.keys(checkpoint).sort().join(",") ===
-      "cumulative_receipts_digest,event,pending_owner_attempt_count,pending_owner_key_digest,pending_runtime_event,pruned_receipt_counts,schema,sequence,status,through_event_run_id",
+      "cumulative_receipts_digest,event,pruned_receipt_counts,schema,sequence,targets,through_event_run_id",
     "Preview checkpoint fields are invalid",
   );
   invariant(
@@ -2501,54 +2725,90 @@ function validatePreviewCheckpoint(value, expectedPr) {
     checkpoint.through_event_run_id === event.event_run_id,
     "Preview checkpoint event identity mismatch",
   );
-  const status = validateCheckpointStatus(checkpoint.status, event);
-  if (status.description === NATIVE_OWNED_STATUS_DESCRIPTION) {
-    invariant(
-      isNativeOwnedCheckpointStatus(status, event),
-      "Preview checkpoint native ownership status is invalid",
-    );
-  }
-  if (status.description === NATIVE_OWNERSHIP_DRAINING_STATUS_DESCRIPTION) {
-    invariant(
-      isNativeOwnershipDrainingCheckpointStatus(status, event),
-      "Preview checkpoint native ownership drain status is invalid",
-    );
-  }
-  if (checkpoint.pending_owner_key_digest === null) {
-    invariant(
-      checkpoint.pending_owner_attempt_count === 0,
-      "Preview checkpoint has an attempt count without an owner",
+  const targets = plainObject(checkpoint.targets, "Preview checkpoint targets");
+  invariant(
+    Object.keys(targets).sort().join(",") ===
+      [...PREVIEW_TARGETS].sort().join(","),
+    "Preview checkpoint target keys are invalid",
+  );
+  for (const target of PREVIEW_TARGETS) {
+    const targetCheckpoint = plainObject(
+      targets[target],
+      `${target} preview checkpoint`,
     );
     invariant(
-      checkpoint.pending_runtime_event === null,
-      "Preview checkpoint has a runtime dependency without an owner",
+      Object.keys(targetCheckpoint).sort().join(",") ===
+        "first_eligible_sha,last_successful_runtime_sha,last_successful_runtime_url,latest_desired_sha,latest_runtime_event,pending_owner_attempt_count,pending_owner_event,pending_owner_key_digest,status",
+      `${target} preview checkpoint fields are invalid`,
+    );
+    for (const [name, sha] of [
+      ["first eligible", targetCheckpoint.first_eligible_sha],
+      ["latest desired", targetCheckpoint.latest_desired_sha],
+      ["last successful runtime", targetCheckpoint.last_successful_runtime_sha],
+    ]) {
+      if (sha !== null) exactSha(sha, `${target} checkpoint ${name} SHA`);
+    }
+    optionalHttpsUrl(
+      targetCheckpoint.last_successful_runtime_url,
+      `${target} checkpoint last successful runtime URL`,
     );
     invariant(
-      status.state !== "pending",
-      "Preview checkpoint pending status has no owner",
+      (targetCheckpoint.last_successful_runtime_sha === null) ===
+        (targetCheckpoint.last_successful_runtime_url === null),
+      `${target} checkpoint last successful runtime is incomplete`,
     );
-  } else {
+    const status = validateCheckpointStatus(targetCheckpoint.status, target);
+    if (status.outcome === "native-owned") {
+      invariant(
+        isNativeOwnedCheckpointStatus(status, event, target),
+        `${target} checkpoint native ownership status is invalid`,
+      );
+    }
+    const latestRuntimeEvent =
+      targetCheckpoint.latest_runtime_event === null
+        ? null
+        : validateEventReceipt(targetCheckpoint.latest_runtime_event);
     invariant(
-      /^[0-9a-f]{24}$/.test(checkpoint.pending_owner_key_digest),
-      "Preview checkpoint pending owner is invalid",
+      !latestRuntimeEvent ||
+        (latestRuntimeEvent.pr === event.pr &&
+          latestRuntimeEvent.plan.targets.includes(target)),
+      `${target} checkpoint latest runtime event is invalid`,
     );
+    const pendingOwnerEvent =
+      targetCheckpoint.pending_owner_event === null
+        ? null
+        : validateEventReceipt(targetCheckpoint.pending_owner_event);
     invariant(
-      Number.isSafeInteger(checkpoint.pending_owner_attempt_count) &&
-        checkpoint.pending_owner_attempt_count >= 1 &&
-        checkpoint.pending_owner_attempt_count <= 2,
-      "Preview checkpoint pending owner attempt count is invalid",
+      !pendingOwnerEvent ||
+        (pendingOwnerEvent.pr === event.pr &&
+          pendingOwnerEvent.plan.targets.includes(target)),
+      `${target} checkpoint pending owner event is invalid`,
     );
-    const pendingRuntime = validateEventReceipt(
-      checkpoint.pending_runtime_event,
-    );
+    if (targetCheckpoint.pending_owner_key_digest === null) {
+      invariant(
+        targetCheckpoint.pending_owner_attempt_count === 0 &&
+          pendingOwnerEvent === null,
+        `${target} checkpoint has attempt evidence without an owner`,
+      );
+    } else {
+      invariant(
+        /^[0-9a-f]{24}$/.test(targetCheckpoint.pending_owner_key_digest),
+        `${target} checkpoint pending owner is invalid`,
+      );
+      invariant(
+        Number.isSafeInteger(targetCheckpoint.pending_owner_attempt_count) &&
+          targetCheckpoint.pending_owner_attempt_count >= 1 &&
+          targetCheckpoint.pending_owner_attempt_count <= 2,
+        `${target} checkpoint pending owner attempt count is invalid`,
+      );
+      invariant(
+        pendingOwnerEvent && status.state === "pending",
+        `${target} checkpoint pending owner has no pending runtime`,
+      );
+    }
     invariant(
-      pendingRuntime.pr === event.pr &&
-        pendingRuntime.plan.targets.includes(PREVIEW_TARGET),
-      "Preview checkpoint pending runtime event is invalid",
-    );
-    invariant(
-      status.state === "pending",
-      "Preview checkpoint pending owner has a terminal status",
+      status.state !== "pending" || latestRuntimeEvent || pendingOwnerEvent,
+      `${target} checkpoint pending status has no runtime event`,
     );
   }
   return checkpoint;
@@ -2697,19 +2957,22 @@ function validatePreviewJournal(value, expectedPr) {
   }
   if (journal.state !== null) {
     const state = normalizeExistingState(journal.state, pr);
-    for (const dispatch of [
-      state.ui?.active,
-      ...(state.ui?.retired_active ?? []),
-    ].filter(Boolean)) {
-      invariant(
-        receipts.selections.some(
-          (selection) =>
-            selection.key_digest === dispatch.key_digest &&
-            selection.selection_receipt_run_id ===
-              dispatch.selection_receipt_run_id,
-        ),
-        "Journal state dispatch has no matching selection",
-      );
+    for (const target of PREVIEW_TARGETS) {
+      for (const dispatch of [
+        state.targets[target].active,
+        ...state.targets[target].retired_active,
+      ].filter(Boolean)) {
+        invariant(
+          receipts.selections.some(
+            (selection) =>
+              selection.target === target &&
+              selection.key_digest === dispatch.key_digest &&
+              selection.selection_receipt_run_id ===
+                dispatch.selection_receipt_run_id,
+          ),
+          "Journal state dispatch has no matching selection",
+        );
+      }
     }
   }
   invariant(
@@ -2761,7 +3024,12 @@ function emptyReceiptCounts() {
 
 function checkpointBaselineState(state, checkpoint) {
   const event = checkpoint.event;
-  const eligible = event.plan.targets.includes(PREVIEW_TARGET);
+  const targetStatuses = Object.fromEntries(
+    PREVIEW_TARGETS.map((target) => [
+      target,
+      checkpoint.targets[target].status,
+    ]),
+  );
   return {
     schema: CONTROLLER_SCHEMA,
     repository: PREVIEW_REPOSITORY,
@@ -2785,36 +3053,171 @@ function checkpointBaselineState(state, checkpoint) {
     },
     closed: state.closed,
     receipts_digest: controllerReceiptsDigest([], [], [], event.pr, checkpoint),
-    ui: {
-      first_eligible_sha: eligible ? event.head_sha : null,
-      latest_desired_sha: eligible ? event.head_sha : null,
-      latest_desired_receipt_run_id: eligible ? event.event_run_id : null,
-      idle_cursor_receipt_run_id: eligible ? event.event_run_id : null,
-      active: null,
-      retired_active: [],
-      last_successful_runtime_sha: state.ui.last_successful_runtime_sha,
-      last_successful_runtime_url: state.ui.last_successful_runtime_url,
-      terminal_result_key_digests: [],
-      terminal_history: [],
-    },
-    status_decisions: [structuredClone(checkpoint.status)],
+    targets: Object.fromEntries(
+      PREVIEW_TARGETS.map((target) => {
+        const targetCheckpoint = checkpoint.targets[target];
+        const runtimeEvent = targetCheckpoint.latest_runtime_event;
+        return [
+          target,
+          {
+            first_eligible_sha: targetCheckpoint.first_eligible_sha,
+            latest_desired_sha: targetCheckpoint.latest_desired_sha,
+            latest_desired_receipt_run_id: runtimeEvent?.event_run_id ?? null,
+            idle_cursor_receipt_run_id: runtimeEvent?.event_run_id ?? null,
+            active: null,
+            retired_active: [],
+            last_successful_runtime_sha:
+              targetCheckpoint.last_successful_runtime_sha,
+            last_successful_runtime_url:
+              targetCheckpoint.last_successful_runtime_url,
+            terminal_result_key_digests: [],
+            terminal_history: [],
+          },
+        ];
+      }),
+    ),
+    status_decisions: [aggregateStatusDecision(event, targetStatuses, null)],
   };
+}
+
+function outcomeState(outcome) {
+  if (outcome === "pending") return "pending";
+  if (outcome === "failed") return "failure";
+  if (outcome === "error") return "error";
+  return "success";
+}
+
+function checkpointTargetStatus({
+  target,
+  targetState,
+  aggregate,
+  pending,
+  priorStatus,
+}) {
+  const outcome = pending
+    ? "pending"
+    : (aggregate?.targets?.[target] ??
+      (targetState.last_successful_runtime_sha
+        ? "runtime-equivalent"
+        : "not affected"));
+  const state = outcomeState(outcome);
+  const terminal = [...targetState.terminal_history]
+    .reverse()
+    .find(
+      (candidate) =>
+        candidate.sha === targetState.latest_desired_sha &&
+        (state === "failure"
+          ? candidate.state === "failure" ||
+            (candidate.state === "error" &&
+              candidate.terminal_reason === "worker-cancelled")
+          : state === "error"
+            ? candidate.state === "error" &&
+              candidate.terminal_reason !== "worker-cancelled"
+            : false),
+    );
+  const nativeTerminal = [...targetState.terminal_history]
+    .reverse()
+    .find(
+      (candidate) =>
+        candidate.sha === targetState.latest_desired_sha &&
+        candidate.terminal_reason === NATIVE_OWNED_SELECTION_REASON,
+    );
+  const nativeControllerUrl =
+    (CONTROLLER_RUN_URL_PATTERN.test(aggregate?.target_url ?? "")
+      ? aggregate.target_url
+      : null) ??
+    terminalResultUrl(nativeTerminal, null) ??
+    (priorStatus?.outcome === "native-owned" &&
+    CONTROLLER_RUN_URL_PATTERN.test(priorStatus.target_url ?? "")
+      ? priorStatus.target_url
+      : null);
+  const targetUrl =
+    outcome === "native-owned"
+      ? nativeControllerUrl
+      : outcome === "deployed" || outcome === "runtime-equivalent"
+        ? targetState.last_successful_runtime_url
+        : state === "pending"
+          ? (targetState.active?.html_url ??
+            (priorStatus?.state === "pending" ? priorStatus.target_url : null))
+          : state === "failure" || state === "error"
+            ? (terminalResultUrl(terminal, null) ??
+              (priorStatus?.outcome === outcome
+                ? priorStatus.target_url
+                : null))
+            : priorStatus?.outcome === outcome
+              ? priorStatus.target_url
+              : null;
+  return {
+    state,
+    outcome,
+    description:
+      outcome === "native-owned"
+        ? nativeOwnedStatusDescription(target)
+        : `${target}: ${outcome}`,
+    target_url: targetUrl,
+  };
+}
+
+function runtimeEventForTarget(lineage, checkpoint, target) {
+  return (
+    [...lineage]
+      .reverse()
+      .find((event) => event.plan.targets.includes(target)) ??
+    checkpoint?.targets[target].latest_runtime_event ??
+    null
+  );
+}
+
+function assertCheckpointableReceipts(
+  receipts,
+  allResults,
+  exemptKeyDigests = new Set(),
+) {
+  const resultIdentities = new Set(
+    allResults.map((result) => `${result.key_digest}:${result.worker_run_id}`),
+  );
+  invariant(
+    receipts.worker_evidence.every(
+      (evidence) =>
+        exemptKeyDigests.has(evidence.key_digest) ||
+        resultIdentities.has(
+          `${evidence.key_digest}:${evidence.worker_run_id}`,
+        ),
+    ),
+    "Preview journal cannot checkpoint unfinished worker evidence",
+  );
+  invariant(
+    receipts.selections.every(
+      (selection) =>
+        exemptKeyDigests.has(selection.key_digest) ||
+        allResults.some((result) => result.key_digest === selection.key_digest),
+    ),
+    "Preview journal cannot checkpoint unfinished selections",
+  );
 }
 
 export function compactPreviewJournal(value, { pullRequest = null } = {}) {
   const journal = validatePreviewJournal(value, value.pr);
   if (journal.state === null) return journal;
   const state = normalizeExistingState(journal.state, journal.pr);
-  const terminalResultKeyDigests = new Set(
+  const terminalKeys = new Set(
     journal.receipts.results.map((result) => result.key_digest),
   );
-  const unresolvedRetired = state.ui.retired_active.filter(
-    (selection) =>
-      selection.key_digest === journal.checkpoint?.pending_owner_key_digest ||
-      !terminalResultKeyDigests.has(selection.key_digest),
-  );
-  if (unresolvedRetired.length !== state.ui.retired_active.length) {
-    state.ui.retired_active = unresolvedRetired;
+  let stateChanged = false;
+  for (const target of PREVIEW_TARGETS) {
+    const pendingKey =
+      journal.checkpoint?.targets[target].pending_owner_key_digest ?? null;
+    const unresolved = state.targets[target].retired_active.filter(
+      (selection) =>
+        selection.key_digest === pendingKey ||
+        !terminalKeys.has(selection.key_digest),
+    );
+    if (unresolved.length !== state.targets[target].retired_active.length) {
+      state.targets[target].retired_active = unresolved;
+      stateChanged = true;
+    }
+  }
+  if (stateChanged) {
     journal.state = structuredClone(state);
     journal.journal_digest = previewJournalDigest(
       journal.receipts,
@@ -2826,214 +3229,34 @@ export function compactPreviewJournal(value, { pullRequest = null } = {}) {
     (total, receipts) => total + receipts.length,
     0,
   );
-  const liveRetiredOwnership = state.ui.retired_active.filter(
-    isLiveRetiredPreviewOwnership,
-  );
   if (receiptCount === 0) return journal;
-  const hasInFlightOwnership =
-    state.ui.active !== null || liveRetiredOwnership.length > 0;
-  if (hasInFlightOwnership) {
-    if (
-      Buffer.byteLength(journalBody(journal), "utf8") < ACTIVE_CHECKPOINT_BYTES
-    ) {
-      return journal;
-    }
-    if (pullRequest !== null) {
-      invariant(
-        normalizePullRequest(pullRequest).number === journal.pr,
-        "Capacity checkpoint PR mismatch",
-      );
-    }
-    const pull = representedPullRequest(
-      journal.receipts.events,
-      journal.checkpoint,
-    );
-    const { closure, lineage } = selectCurrentEpoch(
-      journal.receipts.events,
-      pull,
-      journal.checkpoint,
-    );
-    const tailEvent = closure ?? lineage.at(-1) ?? null;
-    invariant(tailEvent, "Preview checkpoint tail event is missing");
-    const pendingOwner =
-      state.ui.active ??
-      liveRetiredOwnership.find(
-        (selection) =>
-          selection.key_digest === journal.checkpoint?.pending_owner_key_digest,
-      ) ??
-      null;
-    invariant(pendingOwner, "Capacity checkpoint pending owner is missing");
-    const samePendingReceipt =
-      journal.checkpoint?.pending_runtime_event?.event_run_id ===
-      pendingOwner.selection_receipt_run_id;
-    const pendingOwnerAttemptCount = samePendingReceipt
-      ? (journal.checkpoint.pending_owner_attempt_count ?? 0) +
-        Number(
-          journal.checkpoint.pending_owner_key_digest !==
-            pendingOwner.key_digest,
-        )
-      : 1 +
-        state.ui.terminal_history.filter(
-          (terminal) =>
-            terminal.selection_receipt_run_id ===
-              pendingOwner.selection_receipt_run_id &&
-            terminal.terminal_reason !==
-              "controller-workflow-upgraded-before-dispatch",
-        ).length;
-    invariant(
-      pendingOwnerAttemptCount <= 2,
-      "Preview runtime retry budget is already exhausted",
-    );
-    const pendingRuntimeEvent =
-      [...lineage]
-        .reverse()
-        .find((event) => event.plan.targets.includes(PREVIEW_TARGET)) ??
-      journal.checkpoint?.pending_runtime_event ??
-      null;
-    invariant(
-      pendingRuntimeEvent,
-      "Capacity checkpoint pending runtime event is missing",
-    );
-    const persistedStatus = [...state.status_decisions]
-      .reverse()
-      .find((decision) => decision.sha === tailEvent.head_sha);
-    const status = persistedStatus ?? {
-      sha: tailEvent.head_sha,
-      state: "pending",
-      description: "Preview reconciliation pending",
-      target_url: state.ui.active?.html_url ?? null,
-    };
-    const protectedKeyDigests = new Set(
-      [state.ui.active, ...state.ui.retired_active]
-        .filter(Boolean)
-        .map((selection) => selection.key_digest),
-    );
-    const retainedReceipts = {
-      events: [],
-      selections: journal.receipts.selections.filter((selection) =>
-        protectedKeyDigests.has(selection.key_digest),
-      ),
-      worker_evidence: journal.receipts.worker_evidence.filter((evidence) =>
-        protectedKeyDigests.has(evidence.key_digest),
-      ),
-      results: journal.receipts.results.filter((result) =>
-        protectedKeyDigests.has(result.key_digest),
-      ),
-    };
-    const prunedReceipts = {
-      events: journal.receipts.events,
-      selections: journal.receipts.selections.filter(
-        (selection) => !protectedKeyDigests.has(selection.key_digest),
-      ),
-      worker_evidence: journal.receipts.worker_evidence.filter(
-        (evidence) => !protectedKeyDigests.has(evidence.key_digest),
-      ),
-      results: journal.receipts.results.filter(
-        (result) => !protectedKeyDigests.has(result.key_digest),
-      ),
-    };
-    const resultIdentities = new Set(
-      journal.receipts.results.map(
-        (result) => `${result.key_digest}:${result.worker_run_id}`,
-      ),
-    );
-    invariant(
-      prunedReceipts.worker_evidence.every((evidence) =>
-        resultIdentities.has(
-          `${evidence.key_digest}:${evidence.worker_run_id}`,
-        ),
-      ),
-      "Preview journal cannot checkpoint unfinished worker evidence",
-    );
-    invariant(
-      prunedReceipts.selections.every((selection) =>
-        journal.receipts.results.some(
-          (result) => result.key_digest === selection.key_digest,
-        ),
-      ),
-      "Preview journal cannot checkpoint unfinished selections",
-    );
-    const prunedCount = Object.values(prunedReceipts).reduce(
-      (total, receipts) => total + receipts.length,
-      0,
-    );
-    if (prunedCount === 0) return journal;
-    const previousCounts =
-      journal.checkpoint?.pruned_receipt_counts ?? emptyReceiptCounts();
-    const prunedReceiptCounts = Object.fromEntries(
-      Object.entries(previousCounts).map(([name, count]) => [
-        name,
-        count + prunedReceipts[name].length,
-      ]),
-    );
-    const checkpoint = {
-      schema: PREVIEW_CHECKPOINT_SCHEMA,
-      sequence: (journal.checkpoint?.sequence ?? 0) + 1,
-      through_event_run_id: tailEvent.event_run_id,
-      cumulative_receipts_digest: digest({
-        previous: journal.checkpoint?.cumulative_receipts_digest ?? null,
-        receipts: receiptSetDigest(prunedReceipts),
-        state: digest(state),
-      }),
-      pruned_receipt_counts: prunedReceiptCounts,
-      event: structuredClone(tailEvent),
-      status: {
-        sha: status.sha,
-        state: status.state,
-        description: status.description,
-        target_url: status.target_url ?? null,
-      },
-      pending_owner_key_digest: pendingOwner.key_digest,
-      pending_owner_attempt_count: pendingOwnerAttemptCount,
-      pending_runtime_event: structuredClone(pendingRuntimeEvent),
-    };
-    journal.checkpoint = checkpoint;
-    journal.receipts = retainedReceipts;
-    journal.journal_digest = previewJournalDigest(
-      journal.receipts,
-      journal.state,
-      checkpoint,
-    );
-    return validatePreviewJournal(journal, journal.pr);
+  const hasInFlightOwnership = PREVIEW_TARGETS.some(
+    (target) =>
+      state.targets[target].active !== null ||
+      state.targets[target].retired_active.some(isLiveRetiredPreviewOwnership),
+  );
+  if (
+    hasInFlightOwnership &&
+    Buffer.byteLength(journalBody(journal), "utf8") < ACTIVE_CHECKPOINT_BYTES
+  ) {
+    return journal;
   }
-  const quarantinedKeyDigests = new Set(
-    state.ui.retired_active
-      .filter((selection) => !isLiveRetiredPreviewOwnership(selection))
-      .map((selection) => selection.key_digest),
+  if (pullRequest !== null) {
+    invariant(
+      normalizePullRequest(pullRequest).number === journal.pr,
+      "Capacity checkpoint PR mismatch",
+    );
+  }
+  const pull = representedPullRequest(
+    journal.receipts.events,
+    journal.checkpoint,
   );
-  const resultIdentities = new Set(
-    journal.receipts.results.map(
-      (result) => `${result.key_digest}:${result.worker_run_id}`,
-    ),
+  const { closure, lineage } = selectCurrentEpoch(
+    journal.receipts.events,
+    pull,
+    journal.checkpoint,
   );
-  invariant(
-    journal.receipts.worker_evidence.every(
-      (evidence) =>
-        quarantinedKeyDigests.has(evidence.key_digest) ||
-        resultIdentities.has(
-          `${evidence.key_digest}:${evidence.worker_run_id}`,
-        ),
-    ),
-    "Preview journal cannot checkpoint unfinished worker evidence",
-  );
-  invariant(
-    journal.receipts.selections.every(
-      (selection) =>
-        quarantinedKeyDigests.has(selection.key_digest) ||
-        journal.receipts.results.some(
-          (result) => result.key_digest === selection.key_digest,
-        ),
-    ),
-    "Preview journal cannot checkpoint unfinished selections",
-  );
-  const tailEvent =
-    journal.receipts.events.find(
-      (event) => event.event_run_id === state.epoch.tail_receipt_run_id,
-    ) ??
-    (journal.checkpoint?.through_event_run_id ===
-    state.epoch.tail_receipt_run_id
-      ? journal.checkpoint.event
-      : null);
+  const tailEvent = closure ?? lineage.at(-1) ?? null;
   invariant(tailEvent, "Preview checkpoint tail event is missing");
   invariant(
     !state.closed ||
@@ -3041,20 +3264,167 @@ export function compactPreviewJournal(value, { pullRequest = null } = {}) {
         tailEvent.pr_closed_at === state.epoch.closed_at),
     "Preview checkpoint closure does not match persisted lifecycle state",
   );
-  const status = [...state.status_decisions]
+  const aggregate = [...state.status_decisions]
     .reverse()
     .find((decision) => decision.sha === tailEvent.head_sha);
-  invariant(status, "Preview checkpoint tail status is missing");
-  invariant(
-    status.state !== "pending",
-    "Preview journal cannot checkpoint a pending tail status",
+  const quarantinedKeys = new Set(
+    PREVIEW_TARGETS.flatMap((target) =>
+      state.targets[target].retired_active
+        .filter((selection) => !isLiveRetiredPreviewOwnership(selection))
+        .map((selection) => selection.key_digest),
+    ),
   );
+  if (!hasInFlightOwnership) {
+    invariant(aggregate, "Preview checkpoint tail status is missing");
+    invariant(
+      aggregate.state !== "pending",
+      "Preview journal cannot checkpoint a pending tail status",
+    );
+    assertCheckpointableReceipts(
+      journal.receipts,
+      journal.receipts.results,
+      quarantinedKeys,
+    );
+  }
+
+  const checkpointTargets = {};
+  const protectedKeys = new Set();
+  for (const target of PREVIEW_TARGETS) {
+    const targetState = state.targets[target];
+    const priorTarget = journal.checkpoint?.targets[target] ?? null;
+    const liveRetired = targetState.retired_active.filter(
+      isLiveRetiredPreviewOwnership,
+    );
+    const pendingOwner =
+      targetState.active ??
+      liveRetired.find(
+        (selection) =>
+          selection.key_digest === priorTarget?.pending_owner_key_digest,
+      ) ??
+      liveRetired[0] ??
+      null;
+    for (const selection of [targetState.active, ...liveRetired].filter(
+      Boolean,
+    )) {
+      protectedKeys.add(selection.key_digest);
+    }
+    const latestRuntimeEvent = runtimeEventForTarget(
+      lineage,
+      journal.checkpoint,
+      target,
+    );
+    const pendingOwnerEvent = pendingOwner
+      ? (lineage.find(
+          (event) =>
+            event.event_run_id === pendingOwner.selection_receipt_run_id,
+        ) ??
+        [
+          priorTarget?.pending_owner_event,
+          priorTarget?.latest_runtime_event,
+        ].find(
+          (event) =>
+            event?.event_run_id === pendingOwner.selection_receipt_run_id,
+        ) ??
+        null)
+      : null;
+    invariant(
+      !pendingOwner || pendingOwnerEvent,
+      `${target} checkpoint pending owner event is missing`,
+    );
+    const samePendingReceipt =
+      pendingOwner &&
+      priorTarget?.pending_owner_event?.event_run_id ===
+        pendingOwner.selection_receipt_run_id;
+    const pendingOwnerAttemptCount = pendingOwner
+      ? samePendingReceipt
+        ? (priorTarget.pending_owner_attempt_count ?? 0) +
+          Number(
+            priorTarget.pending_owner_key_digest !== pendingOwner.key_digest,
+          )
+        : 1 +
+          targetState.terminal_history.filter(
+            (terminal) =>
+              terminal.selection_receipt_run_id ===
+                pendingOwner.selection_receipt_run_id &&
+              terminal.terminal_reason !==
+                "controller-workflow-upgraded-before-dispatch",
+          ).length
+      : 0;
+    invariant(
+      pendingOwnerAttemptCount <= 2,
+      `${target} runtime retry budget is already exhausted`,
+    );
+    const pending = Boolean(
+      pendingOwner ||
+      (!aggregate && latestRuntimeEvent) ||
+      aggregate?.targets?.[target] === "pending",
+    );
+    checkpointTargets[target] = {
+      first_eligible_sha:
+        targetState.first_eligible_sha ?? latestRuntimeEvent?.head_sha ?? null,
+      latest_desired_sha: targetState.latest_desired_sha,
+      last_successful_runtime_sha: targetState.last_successful_runtime_sha,
+      last_successful_runtime_url: targetState.last_successful_runtime_url,
+      status: checkpointTargetStatus({
+        target,
+        targetState,
+        aggregate,
+        pending,
+        priorStatus: priorTarget?.status ?? null,
+      }),
+      pending_owner_key_digest: pendingOwner?.key_digest ?? null,
+      pending_owner_attempt_count: pendingOwnerAttemptCount,
+      pending_owner_event:
+        pendingOwnerEvent === null ? null : structuredClone(pendingOwnerEvent),
+      latest_runtime_event:
+        latestRuntimeEvent === null
+          ? null
+          : structuredClone(latestRuntimeEvent),
+    };
+  }
+
+  const retainedReceipts = hasInFlightOwnership
+    ? {
+        events: [],
+        selections: journal.receipts.selections.filter((selection) =>
+          protectedKeys.has(selection.key_digest),
+        ),
+        worker_evidence: journal.receipts.worker_evidence.filter((evidence) =>
+          protectedKeys.has(evidence.key_digest),
+        ),
+        results: journal.receipts.results.filter((result) =>
+          protectedKeys.has(result.key_digest),
+        ),
+      }
+    : { events: [], selections: [], worker_evidence: [], results: [] };
+  const prunedReceipts = {
+    events: journal.receipts.events,
+    selections: journal.receipts.selections.filter(
+      (selection) => !protectedKeys.has(selection.key_digest),
+    ),
+    worker_evidence: journal.receipts.worker_evidence.filter(
+      (evidence) => !protectedKeys.has(evidence.key_digest),
+    ),
+    results: journal.receipts.results.filter(
+      (result) => !protectedKeys.has(result.key_digest),
+    ),
+  };
+  assertCheckpointableReceipts(
+    prunedReceipts,
+    journal.receipts.results,
+    quarantinedKeys,
+  );
+  const prunedCount = Object.values(prunedReceipts).reduce(
+    (total, receipts) => total + receipts.length,
+    0,
+  );
+  if (hasInFlightOwnership && prunedCount === 0) return journal;
   const previousCounts =
     journal.checkpoint?.pruned_receipt_counts ?? emptyReceiptCounts();
   const prunedReceiptCounts = Object.fromEntries(
     Object.entries(previousCounts).map(([name, count]) => [
       name,
-      count + journal.receipts[name].length,
+      count + prunedReceipts[name].length,
     ]),
   );
   const checkpoint = {
@@ -3063,29 +3433,18 @@ export function compactPreviewJournal(value, { pullRequest = null } = {}) {
     through_event_run_id: tailEvent.event_run_id,
     cumulative_receipts_digest: digest({
       previous: journal.checkpoint?.cumulative_receipts_digest ?? null,
-      receipts: receiptSetDigest(journal.receipts),
+      receipts: receiptSetDigest(prunedReceipts),
       state: digest(state),
     }),
     pruned_receipt_counts: prunedReceiptCounts,
     event: structuredClone(tailEvent),
-    status: {
-      sha: status.sha,
-      state: status.state,
-      description: status.description,
-      target_url: status.target_url ?? null,
-    },
-    pending_owner_key_digest: null,
-    pending_owner_attempt_count: 0,
-    pending_runtime_event: null,
+    targets: checkpointTargets,
   };
   journal.checkpoint = checkpoint;
-  journal.receipts = {
-    events: [],
-    selections: [],
-    worker_evidence: [],
-    results: [],
-  };
-  journal.state = checkpointBaselineState(state, checkpoint);
+  journal.receipts = retainedReceipts;
+  if (!hasInFlightOwnership) {
+    journal.state = checkpointBaselineState(state, checkpoint);
+  }
   journal.journal_digest = previewJournalDigest(
     journal.receipts,
     journal.state,
@@ -3274,14 +3633,20 @@ async function appendJournalReceipt({
         const terminalKeys = new Set(
           journal.receipts.results.map((result) => result.key_digest),
         );
-        const hasUnfinishedOwnership =
-          state.ui.active !== null ||
-          state.ui.retired_active.some(
-            (selection) =>
-              selection.key_digest ===
-                journal.checkpoint?.pending_owner_key_digest ||
-              !terminalKeys.has(selection.key_digest),
+        const hasUnfinishedOwnership = PREVIEW_TARGETS.some((target) => {
+          const targetState = state.targets[target];
+          const pendingKey =
+            journal.checkpoint?.targets[target].pending_owner_key_digest ??
+            null;
+          return (
+            targetState.active !== null ||
+            targetState.retired_active.some(
+              (selection) =>
+                selection.key_digest === pendingKey ||
+                !terminalKeys.has(selection.key_digest),
+            )
           );
+        });
         if (hasUnfinishedOwnership) {
           compactAfterAppend = true;
         } else if (liveReceiptsAreRepresented) {
@@ -3341,15 +3706,20 @@ async function writeControllerState({
   return updated.journalComment;
 }
 
-async function writeControllerIntent({
+async function writeControllerIntents({
   github,
   context,
   pr,
   state,
-  selection,
+  selections,
   stateComment,
 }) {
-  const receipt = validateSelectionReceipt(selection);
+  const receipts = selections.map(validateSelectionReceipt);
+  invariant(
+    new Set(receipts.map((receipt) => receipt.key_digest)).size ===
+      receipts.length,
+    "Controller intents contain duplicate selections",
+  );
   const updated = await mutatePreviewJournal({
     github,
     context,
@@ -3357,14 +3727,18 @@ async function writeControllerIntent({
     expectedComment: stateComment,
     mutate(journal) {
       journal.state = structuredClone(state);
-      const existing = journal.receipts.selections.find(
-        (candidate) => candidate.key_digest === receipt.key_digest,
-      );
-      invariant(
-        !existing || canonicalJson(existing) === canonicalJson(receipt),
-        "Conflicting selection receipt in preview journal",
-      );
-      if (!existing) journal.receipts.selections.push(structuredClone(receipt));
+      for (const receipt of receipts) {
+        const existing = journal.receipts.selections.find(
+          (candidate) => candidate.key_digest === receipt.key_digest,
+        );
+        invariant(
+          !existing || canonicalJson(existing) === canonicalJson(receipt),
+          "Conflicting selection receipt in preview journal",
+        );
+        if (!existing) {
+          journal.receipts.selections.push(structuredClone(receipt));
+        }
+      }
     },
   });
   return updated.journalComment;
@@ -3866,6 +4240,7 @@ function classifyWorkerRuns(
     }
     if (
       parsed.pr !== selected.pr ||
+      parsed.target !== selected.target ||
       parsed.sha !== selected.sha ||
       parsed.keyDigest !== selected.key_digest
     ) {
@@ -4071,6 +4446,7 @@ export function validateWorkerRunIdentity(run, selected) {
   const parsed = parseWorkerRunName(displayTitle);
   invariant(
     parsed.pr === selected.pr &&
+      parsed.target === selected.target &&
       parsed.sha === selected.sha &&
       parsed.keyDigest === selected.key_digest,
     "Worker run identity does not match selection",
@@ -4148,7 +4524,7 @@ async function dispatchWorker(
       ref: "main",
       inputs: {
         pull_request_number: String(selected.pr),
-        target: PREVIEW_TARGET,
+        target: selected.target,
         commit_sha: selected.sha,
         git_branch: selected.git_ref,
         controller_key: selected.key,
@@ -4203,7 +4579,7 @@ async function recordControllerTerminalResult({
     schema: RESULT_RECEIPT_SCHEMA,
     repository: PREVIEW_REPOSITORY,
     pr,
-    target: PREVIEW_TARGET,
+    target: selection.target,
     sha: selection.sha,
     controller_key: selection.key,
     key_digest: selection.key_digest,
@@ -4281,21 +4657,39 @@ async function reconcileNoDispatchIntents({
   state,
   stateComment,
   waitForRecovery,
-  nativeOwnedSelectionKeyDigest = null,
+  nativeOwnedSelectionKeyDigests = new Set(),
+  selectionKeyDigests = null,
 }) {
   const candidates = [];
-  if (
-    state.ui?.active?.dispatch_state === "intended" &&
-    state.ui.active.workflow_run_id === null
-  ) {
-    candidates.push({ slot: "active", selection: state.ui.active });
-  }
-  for (const selection of state.ui?.retired_active ?? []) {
+  for (const target of PREVIEW_TARGETS) {
+    const targetState = state.targets[target];
     if (
-      selection.dispatch_state === "intended" &&
-      selection.workflow_run_id === null
+      targetState.active?.dispatch_state === "intended" &&
+      targetState.active.workflow_run_id === null
     ) {
-      candidates.push({ slot: "retired", selection });
+      if (
+        selectionKeyDigests === null ||
+        selectionKeyDigests.has(targetState.active.key_digest)
+      ) {
+        candidates.push({
+          slot: "active",
+          target,
+          selection: targetState.active,
+        });
+      }
+    }
+    for (const selection of targetState.retired_active) {
+      if (
+        selection.dispatch_state === "intended" &&
+        selection.workflow_run_id === null
+      ) {
+        if (
+          selectionKeyDigests === null ||
+          selectionKeyDigests.has(selection.key_digest)
+        ) {
+          candidates.push({ slot: "retired", target, selection });
+        }
+      }
     }
   }
   if (candidates.length === 0) return false;
@@ -4316,17 +4710,16 @@ async function reconcileNoDispatchIntents({
   const recoveredState = structuredClone(state);
   const attached = [];
   let retiredWithoutWorker = false;
-  for (const { slot, selection, recoveredRun } of observations) {
+  for (const { slot, target, selection, recoveredRun } of observations) {
     if (!recoveredRun) {
       await recordNoDispatchIntentWithoutWorker({
         github,
         context,
         pr,
         selection,
-        terminalReason:
-          selection.key_digest === nativeOwnedSelectionKeyDigest
-            ? NATIVE_OWNED_SELECTION_REASON
-            : NO_DISPATCH_ORPHAN_REASON,
+        terminalReason: nativeOwnedSelectionKeyDigests.has(selection.key_digest)
+          ? NATIVE_OWNED_SELECTION_REASON
+          : NO_DISPATCH_ORPHAN_REASON,
       });
       retiredWithoutWorker = true;
       continue;
@@ -4338,16 +4731,20 @@ async function reconcileNoDispatchIntents({
     };
     if (slot === "active") {
       invariant(
-        recoveredState.ui.active?.key_digest === selection.key_digest,
+        recoveredState.targets[target].active?.key_digest ===
+          selection.key_digest,
         "Active no-dispatch intent changed before recovery",
       );
-      recoveredState.ui.active = recoveredSelection;
+      recoveredState.targets[target].active = recoveredSelection;
     } else {
-      const retiredIndex = recoveredState.ui.retired_active.findIndex(
+      const retiredIndex = recoveredState.targets[
+        target
+      ].retired_active.findIndex(
         (candidate) => candidate.key_digest === selection.key_digest,
       );
       invariant(retiredIndex >= 0, "Retired no-dispatch intent disappeared");
-      recoveredState.ui.retired_active[retiredIndex] = recoveredSelection;
+      recoveredState.targets[target].retired_active[retiredIndex] =
+        recoveredSelection;
     }
     attached.push({ recoveredRun, recoveredSelection });
   }
@@ -4414,32 +4811,26 @@ async function refreshDispatchOwnership({
     return { outcome: "closed" };
   }
   const normalized = assertDispatchTrust(pull, selected);
-  const currentPreviewOwner = await uiPreviewOwnerAtSha(
+  const target = previewTarget(selected.target, "Selected preview target");
+  const currentPreviewOwner = await previewOwnerAtSha(
     github,
     context,
+    target,
     normalized.headSha,
   );
-  if (currentPreviewOwner === UI_PREVIEW_OWNER_NATIVE) {
+  if (!githubPreviewDispatchAllowed(target, currentPreviewOwner)) {
     return { outcome: "current-head-native" };
   }
-  invariant(
-    currentPreviewOwner === UI_PREVIEW_OWNER_GITHUB,
-    "GitHub preview dispatch does not own the current UI configuration",
-  );
   if (!(await shaIsStillAssociated(github, context, pull, selected.sha))) {
     return { outcome: "removed" };
   }
   const selectedPreviewOwner =
     selected.sha === normalized.headSha
       ? currentPreviewOwner
-      : await uiPreviewOwnerAtSha(github, context, selected.sha);
-  if (selectedPreviewOwner === UI_PREVIEW_OWNER_NATIVE) {
+      : await previewOwnerAtSha(github, context, target, selected.sha);
+  if (!githubPreviewDispatchAllowed(target, selectedPreviewOwner)) {
     return { outcome: "selected-native" };
   }
-  invariant(
-    selectedPreviewOwner === UI_PREVIEW_OWNER_GITHUB,
-    "GitHub preview dispatch does not own the selected UI configuration",
-  );
   const comments = await loadPreviewJournal(github, context, pr);
   const ownershipCheck = reconcileState({
     events: comments.events,
@@ -4453,11 +4844,14 @@ async function refreshDispatchOwnership({
   });
   invariant(
     ownershipCheck.state.epoch.anchor_run_id === selected.epoch_anchor_run_id &&
-      ownershipCheck.state.ui.active?.key_digest === selected.key_digest &&
-      ownershipCheck.state.ui.active?.reconciliation_basis_digest ===
+      ownershipCheck.state.targets[target].active?.key_digest ===
+        selected.key_digest &&
+      ownershipCheck.state.targets[target].active
+        ?.reconciliation_basis_digest ===
         selected.reconciliation_basis_digest &&
-      ownershipCheck.state.ui.active?.dispatch_state === "intended" &&
-      ownershipCheck.state.ui.active?.workflow_run_id === null,
+      ownershipCheck.state.targets[target].active?.dispatch_state ===
+        "intended" &&
+      ownershipCheck.state.targets[target].active?.workflow_run_id === null,
     "Persisted dispatch ownership changed before credentials",
   );
   return { outcome: "owned", ownershipCheck };
@@ -4472,29 +4866,41 @@ async function recoverCompletedOwnedRuns({
 }) {
   if (!parsed.state) return false;
   const state = structuredClone(normalizeExistingState(parsed.state, pr));
-  const currentActive = state.ui?.active;
-  const selections = [
-    currentActive,
-    ...(state.ui?.retired_active ?? []),
-  ].filter(Boolean);
+  const selections = PREVIEW_TARGETS.flatMap((target) => [
+    ...(state.targets[target].active
+      ? [
+          {
+            target,
+            selection: state.targets[target].active,
+            isCurrentActive: true,
+          },
+        ]
+      : []),
+    ...state.targets[target].retired_active.map((selection) => ({
+      target,
+      selection,
+      isCurrentActive: false,
+    })),
+  ]);
   let recovered = false;
   let quarantined = false;
-  const quarantineRetiredSelection = (selection) => {
-    const retiredIndex = state.ui.retired_active.findIndex(
+  const quarantineRetiredSelection = (target, selection) => {
+    const retiredIndex = state.targets[target].retired_active.findIndex(
       (candidate) => candidate.key_digest === selection.key_digest,
     );
     invariant(retiredIndex >= 0, "Retired worker ownership disappeared");
-    state.ui.retired_active = [...state.ui.retired_active];
-    state.ui.retired_active[retiredIndex] = {
+    state.targets[target].retired_active = [
+      ...state.targets[target].retired_active,
+    ];
+    state.targets[target].retired_active[retiredIndex] = {
       ...selection,
       recovery_quarantine: RETIRED_RECOVERY_QUARANTINE,
     };
     core.setOutput("retired_recovery_quarantined", "true");
     quarantined = true;
   };
-  for (const selection of selections) {
+  for (const { target, selection, isCurrentActive } of selections) {
     if (selection.workflow_run_id === null) continue;
-    const isCurrentActive = selection === currentActive;
     if (!isCurrentActive && selection.recovery_quarantine) continue;
     const alreadyRecorded = parsed.results.some(
       (result) =>
@@ -4513,7 +4919,7 @@ async function recoverCompletedOwnedRuns({
     } catch (error) {
       if (isCurrentActive) throw error;
       if (error?.status === 404 || error?.response?.status === 404) {
-        quarantineRetiredSelection(selection);
+        quarantineRetiredSelection(target, selection);
       } else {
         core.setOutput("retired_recovery_retryable", "true");
       }
@@ -4524,7 +4930,7 @@ async function recoverCompletedOwnedRuns({
       queried = validateWorkerRunIdentity(workflowRun, selection);
     } catch (error) {
       if (isCurrentActive) throw error;
-      quarantineRetiredSelection(selection);
+      quarantineRetiredSelection(target, selection);
       continue;
     }
     if (queried.status !== "completed") continue;
@@ -4558,18 +4964,30 @@ function isLiveRetiredPreviewOwnership(selection) {
   return selection.recovery_quarantine === undefined;
 }
 
-function hasLiveGitHubPreviewOwnership(state) {
+function hasLiveGitHubPreviewOwnership(state, target) {
+  const targetState = state.targets[previewTarget(target)];
   return (
-    state.ui.active !== null ||
-    state.ui.retired_active.some(isLiveRetiredPreviewOwnership)
+    targetState.active !== null ||
+    targetState.retired_active.some(isLiveRetiredPreviewOwnership)
   );
 }
 
-function persistNoDispatchHeadDecision({
+function undispatchedIntentKeyDigests(state, target) {
+  const targetState = state.targets[previewTarget(target)];
+  return [targetState.active, ...targetState.retired_active]
+    .filter(
+      (selection) =>
+        selection?.dispatch_state === "intended" &&
+        selection.workflow_run_id === null,
+    )
+    .map((selection) => selection.key_digest);
+}
+
+function overrideNativeHeadOwnership({
   state,
   previousState,
   pull,
-  previewOwner,
+  previewOwners,
   controllerMode,
   controllerUrl,
 }) {
@@ -4577,29 +4995,80 @@ function persistNoDispatchHeadDecision({
     (decision) => decision.sha === pull.headSha,
   );
   invariant(index >= 0, "Current-head no-dispatch status decision is missing");
-  let desired;
-  if (previewOwner === UI_PREVIEW_OWNER_NATIVE) {
-    const liveGitHubOwnership = hasLiveGitHubPreviewOwnership(state);
-    desired = {
-      sha: pull.headSha,
-      state: liveGitHubOwnership ? "pending" : "success",
-      description: liveGitHubOwnership
-        ? NATIVE_OWNERSHIP_DRAINING_STATUS_DESCRIPTION
-        : NATIVE_OWNED_STATUS_DESCRIPTION,
-      target_url: controllerUrl,
-    };
-  } else {
-    invariant(
-      controllerMode === "observe-only",
-      "Active no-dispatch reconciliation has no native preview owner",
-    );
-    desired = {
-      sha: pull.headSha,
-      state: "success",
-      description: OBSERVE_ONLY_STATUS_DESCRIPTION,
-      target_url: controllerUrl,
-    };
+  const targets = {
+    ...state.status_decisions[index].targets,
+  };
+  let nativeOwnershipChanged = false;
+  let nativeOwnershipApplied = false;
+  for (const target of PREVIEW_TARGETS) {
+    if (
+      PREVIEW_TARGET_CONFIG[target].ownershipMode !==
+        PREVIEW_OWNERSHIP_MODES.GITHUB ||
+      previewOwners[target] !== PREVIEW_OWNER_NATIVE
+    ) {
+      continue;
+    }
+    nativeOwnershipApplied = true;
+    const nativeOutcome = hasLiveGitHubPreviewOwnership(state, target)
+      ? "pending"
+      : "native-owned";
+    nativeOwnershipChanged ||= targets[target] !== nativeOutcome;
+    targets[target] = nativeOutcome;
   }
+  if (controllerMode !== "observe-only" && !nativeOwnershipApplied) {
+    return structuredClone(state.status_decisions[index]);
+  }
+  const values = Object.values(targets);
+  const desiredState = values.includes("error")
+    ? "error"
+    : values.includes("failed")
+      ? "failure"
+      : values.includes("pending")
+        ? "pending"
+        : "success";
+  const compactOutcome = (outcome) =>
+    ({
+      "runtime-equivalent": "equivalent",
+      "not affected": "none",
+      "native-owned": "native",
+      "unsupported trust boundary": "unsupported",
+    })[outcome] ?? outcome;
+  let description = PREVIEW_TARGETS.map(
+    (target) => `${target}=${compactOutcome(targets[target])}`,
+  ).join("; ");
+  const ownershipDraining = PREVIEW_TARGETS.some(
+    (target) =>
+      PREVIEW_TARGET_CONFIG[target].ownershipMode ===
+        PREVIEW_OWNERSHIP_MODES.GITHUB &&
+      previewOwners[target] === PREVIEW_OWNER_NATIVE &&
+      hasLiveGitHubPreviewOwnership(state, target),
+  );
+  if (controllerMode === "observe-only") {
+    invariant(
+      PREVIEW_TARGETS.every(
+        (target) => previewOwners[target] !== PREVIEW_OWNER_GITHUB,
+      ),
+      "Observe-only controller leaves a candidate preview ownerless",
+    );
+    description = ownershipDraining
+      ? OWNERSHIP_DRAINING_STATUS_DESCRIPTION
+      : OBSERVE_ONLY_STATUS_DESCRIPTION;
+  }
+  const desired = {
+    sha: pull.headSha,
+    state:
+      controllerMode === "observe-only"
+        ? ownershipDraining
+          ? "pending"
+          : "success"
+        : desiredState,
+    description,
+    target_url:
+      controllerMode === "observe-only" || nativeOwnershipChanged
+        ? controllerUrl
+        : state.status_decisions[index].target_url,
+    targets,
+  };
   const previous = (previousState?.status_decisions ?? []).findLast(
     (decision) => decision.sha === pull.headSha,
   );
@@ -4635,8 +5104,10 @@ export async function reconcilePreview({
     "Controller progress pass limit is invalid",
   );
   const controllerUrl = `https://github.com/${PREVIEW_REPOSITORY}/actions/runs/${context.runId}`;
+  const dispatchedRunIds = [];
   let serializedUpdateAttempts = 1;
   let deterministicProgressPasses = 0;
+  let ownershipMapValidated = false;
   const failClosed = async (error) => {
     const pull = await pullFromApi(github, context, pr);
     const headSha = exactSha(pull.head.sha);
@@ -4657,23 +5128,24 @@ export async function reconcilePreview({
       "Controller state update did not converge",
     );
   };
+
   reconcileAttempts: while (true) {
     try {
+      if (!ownershipMapValidated) {
+        await assertWorkflowOwnershipMap(github, context, workflowSha);
+        ownershipMapValidated = true;
+      }
       const pull = await pullFromApi(github, context, pr);
       const currentPull = normalizePullRequest(pull);
-      const previewOwner = await candidateUiPreviewOwner(github, context, pull);
-      invariant(
-        !(
-          currentPull.state === "open" &&
-          currentPull.trust === "trusted" &&
-          controllerMode === "observe-only" &&
-          previewOwner === UI_PREVIEW_OWNER_GITHUB
-        ),
-        "Observe-only controller leaves the candidate UI preview ownerless",
-      );
-      const noDispatch =
-        controllerMode === "observe-only" ||
-        previewOwner === UI_PREVIEW_OWNER_NATIVE;
+      const previewOwners = await candidatePreviewOwners(github, context, pull);
+      if (controllerMode === "observe-only") {
+        invariant(
+          PREVIEW_TARGETS.every(
+            (target) => previewOwners[target] !== PREVIEW_OWNER_GITHUB,
+          ),
+          "Observe-only controller leaves a candidate preview ownerless",
+        );
+      }
       const parsed = await loadPreviewJournal(github, context, pr);
       const stateBeforeReconciliation =
         parsed.state === null ? null : canonicalJson(parsed.state);
@@ -4701,29 +5173,29 @@ export async function reconcilePreview({
       });
       let state = reconciled.state;
       let stateComment = parsed.stateComment;
-      if (
-        noDispatch &&
-        (await reconcileNoDispatchIntents({
-          github,
-          context,
-          core,
-          pr,
-          state,
-          stateComment,
-          waitForRecovery,
-        }))
-      ) {
-        recordDeterministicProgress();
-        continue reconcileAttempts;
-      }
-      if (noDispatch) {
+
+      if (controllerMode === "observe-only") {
+        if (
+          await reconcileNoDispatchIntents({
+            github,
+            context,
+            core,
+            pr,
+            state,
+            stateComment,
+            waitForRecovery,
+          })
+        ) {
+          recordDeterministicProgress();
+          continue reconcileAttempts;
+        }
         let headDecision = null;
         if (currentPull.state === "open") {
-          headDecision = persistNoDispatchHeadDecision({
+          headDecision = overrideNativeHeadOwnership({
             state,
             previousState: parsed.state,
             pull: currentPull,
-            previewOwner,
+            previewOwners,
             controllerMode,
             controllerUrl,
           });
@@ -4745,29 +5217,24 @@ export async function reconcilePreview({
             target_url: headDecision.target_url,
           });
           if (
-            previewOwner === UI_PREVIEW_OWNER_NATIVE &&
-            headDecision.state === "pending"
+            headDecision.state === "pending" &&
+            headDecision.description === OWNERSHIP_DRAINING_STATUS_DESCRIPTION
           ) {
             core.setOutput("preview_ownership_draining", "true");
           }
         }
         core.setOutput("controller_mode", controllerMode);
-        if (previewOwner) core.setOutput("preview_owner", previewOwner);
+        core.setOutput("preview_owners", JSON.stringify(previewOwners));
         core.setOutput("dispatch_skipped", "true");
         core.setOutput("pr_number", String(pr));
         return state;
       }
-      let selected = state.closed
-        ? null
-        : (reconciled.nextDispatch ??
-          (state.ui.active?.dispatch_state === "intended" &&
-          state.ui.active.workflow_run_id === null
-            ? state.ui.active
-            : null));
-      if (selected) {
-        if (reconciled.nextDispatch) {
-          selected = {
-            ...selected,
+
+      const selected = [];
+      if (!state.closed) {
+        for (const dispatch of reconciled.nextDispatches) {
+          const intended = {
+            ...dispatch,
             dispatch_started_at: exactTimestamp(now()),
             dispatch_state: "intended",
             workflow_run_id: null,
@@ -4776,188 +5243,31 @@ export async function reconcilePreview({
             run_url: null,
             html_url: null,
           };
-          state.ui.active = selected;
+          state.targets[dispatch.target].active = intended;
+          selected.push(intended);
         }
-        const selectionReceipt = selectionReceiptFromDispatch(selected);
-        stateComment = await writeControllerIntent({
+        for (const target of PREVIEW_TARGETS) {
+          const active = state.targets[target].active;
+          if (
+            active?.dispatch_state === "intended" &&
+            active.workflow_run_id === null &&
+            !selected.some(
+              (candidate) => candidate.key_digest === active.key_digest,
+            )
+          ) {
+            selected.push(active);
+          }
+        }
+      }
+      if (selected.length > 0) {
+        stateComment = await writeControllerIntents({
           github,
           context,
           pr,
           state,
-          selection: selectionReceipt,
+          selections: selected.map(selectionReceiptFromDispatch),
           stateComment,
         });
-
-        let refreshedOwnership = await refreshDispatchOwnership({
-          github,
-          context,
-          pr,
-          selected,
-          controllerUrl,
-          workflowSha,
-        });
-        if (refreshedOwnership.outcome === "closed") {
-          core.setOutput("dispatch_skipped_closed", "true");
-          return state;
-        }
-        if (refreshedOwnership.outcome === "removed") {
-          await recordRemovedSelection({
-            github,
-            context,
-            pr,
-            selection: selected,
-          });
-          recordDeterministicProgress();
-          continue reconcileAttempts;
-        }
-        if (
-          refreshedOwnership.outcome === "current-head-native" ||
-          refreshedOwnership.outcome === "selected-native"
-        ) {
-          invariant(
-            await reconcileNoDispatchIntents({
-              github,
-              context,
-              core,
-              pr,
-              state,
-              stateComment,
-              waitForRecovery,
-              nativeOwnedSelectionKeyDigest:
-                refreshedOwnership.outcome === "selected-native"
-                  ? selected.key_digest
-                  : null,
-            }),
-            "Native-owned selection did not retain its durable intent",
-          );
-          recordDeterministicProgress();
-          continue reconcileAttempts;
-        }
-        let ownershipCheck = refreshedOwnership.ownershipCheck;
-
-        let recoveredRun;
-        try {
-          recoveredRun = await recoverMatchingWorkerRun(
-            github,
-            context,
-            selected,
-            {
-              waitForRetry: waitForRecovery,
-              ignoreWorkflowShaMismatch:
-                selected.expected_workflow_sha !== workflowSha,
-            },
-          );
-        } catch (error) {
-          if (error instanceof WorkerWorkflowShaMismatchError) {
-            await recordSupersededIntent({
-              github,
-              context,
-              pr,
-              selection: selected,
-            });
-          }
-          throw error;
-        }
-        refreshedOwnership = await refreshDispatchOwnership({
-          github,
-          context,
-          pr,
-          selected,
-          controllerUrl,
-          workflowSha,
-        });
-        if (refreshedOwnership.outcome === "closed") {
-          core.setOutput("dispatch_skipped_closed", "true");
-          return state;
-        }
-        if (refreshedOwnership.outcome === "removed") {
-          await recordRemovedSelection({
-            github,
-            context,
-            pr,
-            selection: selected,
-          });
-          recordDeterministicProgress();
-          continue reconcileAttempts;
-        }
-        if (
-          refreshedOwnership.outcome === "current-head-native" ||
-          refreshedOwnership.outcome === "selected-native"
-        ) {
-          invariant(
-            await reconcileNoDispatchIntents({
-              github,
-              context,
-              core,
-              pr,
-              state,
-              stateComment,
-              waitForRecovery,
-              nativeOwnedSelectionKeyDigest:
-                refreshedOwnership.outcome === "selected-native"
-                  ? selected.key_digest
-                  : null,
-            }),
-            "Native-owned selection did not retain its durable intent",
-          );
-          recordDeterministicProgress();
-          continue reconcileAttempts;
-        }
-        ownershipCheck = refreshedOwnership.ownershipCheck;
-        if (!recoveredRun && selected.expected_workflow_sha !== workflowSha) {
-          await recordSupersededIntent({
-            github,
-            context,
-            pr,
-            selection: selected,
-          });
-          recordDeterministicProgress();
-          continue reconcileAttempts;
-        }
-        let runDetails = recoveredRun;
-        if (!runDetails) {
-          try {
-            runDetails = await dispatchWorker(
-              github,
-              workerDispatchGithub,
-              context,
-              selected,
-              {
-                controllerMode,
-                waitForRunDetails: waitForRecovery,
-              },
-            );
-          } catch (error) {
-            if (error instanceof WorkerWorkflowShaMismatchError) {
-              await recordSupersededIntent({
-                github,
-                context,
-                pr,
-                selection: selected,
-              });
-            }
-            throw error;
-          }
-        }
-        state = {
-          ...ownershipCheck.state,
-          ui: {
-            ...ownershipCheck.state.ui,
-            active: {
-              ...ownershipCheck.state.ui.active,
-              dispatch_state: "dispatched",
-              ...runDetails,
-            },
-          },
-        };
-        stateComment = await writeControllerState({
-          github,
-          context,
-          pr,
-          state,
-          stateComment,
-        });
-        core.setOutput("dispatched_run_id", String(runDetails.workflow_run_id));
       } else {
         stateComment = await writeControllerState({
           github,
@@ -4968,7 +5278,213 @@ export async function reconcilePreview({
         });
       }
 
+      const nativeSelectionKeys = new Set();
+      const noDispatchSelectionKeys = new Set();
+      for (const selection of selected) {
+        const refreshed = await refreshDispatchOwnership({
+          github,
+          context,
+          pr,
+          selected: selection,
+          controllerUrl,
+          workflowSha,
+        });
+        if (refreshed.outcome === "closed") {
+          core.setOutput("dispatch_skipped_closed", "true");
+          return state;
+        }
+        if (refreshed.outcome === "removed") {
+          await recordRemovedSelection({
+            github,
+            context,
+            pr,
+            selection,
+          });
+          recordDeterministicProgress();
+          continue reconcileAttempts;
+        }
+        if (
+          refreshed.outcome === "current-head-native" ||
+          refreshed.outcome === "selected-native"
+        ) {
+          for (const keyDigest of undispatchedIntentKeyDigests(
+            state,
+            selection.target,
+          )) {
+            noDispatchSelectionKeys.add(keyDigest);
+          }
+          if (
+            refreshed.outcome === "selected-native" ||
+            selection.sha === currentPull.headSha
+          ) {
+            nativeSelectionKeys.add(selection.key_digest);
+          }
+        }
+      }
+      if (noDispatchSelectionKeys.size > 0) {
+        invariant(
+          await reconcileNoDispatchIntents({
+            github,
+            context,
+            core,
+            pr,
+            state,
+            stateComment,
+            waitForRecovery,
+            nativeOwnedSelectionKeyDigests: nativeSelectionKeys,
+            selectionKeyDigests: noDispatchSelectionKeys,
+          }),
+          "Native-owned selection did not retain its durable intent",
+        );
+        recordDeterministicProgress();
+        continue reconcileAttempts;
+      }
+
+      let restartReconciliation = false;
+      for (const selection of selected) {
+        let recoveredRun;
+        try {
+          recoveredRun = await recoverMatchingWorkerRun(
+            github,
+            context,
+            selection,
+            {
+              waitForRetry: waitForRecovery,
+              ignoreWorkflowShaMismatch:
+                selection.expected_workflow_sha !== workflowSha,
+            },
+          );
+        } catch (error) {
+          if (error instanceof WorkerWorkflowShaMismatchError) {
+            await recordSupersededIntent({
+              github,
+              context,
+              pr,
+              selection,
+            });
+          }
+          throw error;
+        }
+        const refreshed = await refreshDispatchOwnership({
+          github,
+          context,
+          pr,
+          selected: selection,
+          controllerUrl,
+          workflowSha,
+        });
+        if (refreshed.outcome === "closed") {
+          core.setOutput("dispatch_skipped_closed", "true");
+          return state;
+        }
+        if (refreshed.outcome === "removed") {
+          await recordRemovedSelection({
+            github,
+            context,
+            pr,
+            selection,
+          });
+          restartReconciliation = true;
+          break;
+        }
+        if (
+          refreshed.outcome === "current-head-native" ||
+          refreshed.outcome === "selected-native"
+        ) {
+          const selectionKeys = new Set(
+            undispatchedIntentKeyDigests(state, selection.target),
+          );
+          const nativeSelectionKeys =
+            refreshed.outcome === "selected-native" ||
+            selection.sha === currentPull.headSha
+              ? new Set([selection.key_digest])
+              : new Set();
+          invariant(
+            await reconcileNoDispatchIntents({
+              github,
+              context,
+              core,
+              pr,
+              state,
+              stateComment,
+              waitForRecovery,
+              nativeOwnedSelectionKeyDigests: nativeSelectionKeys,
+              selectionKeyDigests: selectionKeys,
+            }),
+            "Racing native-owned selection lost durable intent",
+          );
+          restartReconciliation = true;
+          break;
+        }
+        if (!recoveredRun && selection.expected_workflow_sha !== workflowSha) {
+          await recordSupersededIntent({
+            github,
+            context,
+            pr,
+            selection,
+          });
+          restartReconciliation = true;
+          break;
+        }
+        let runDetails = recoveredRun;
+        if (!runDetails) {
+          try {
+            runDetails = await dispatchWorker(
+              github,
+              workerDispatchGithub,
+              context,
+              selection,
+              { controllerMode, waitForRunDetails: waitForRecovery },
+            );
+          } catch (error) {
+            if (error instanceof WorkerWorkflowShaMismatchError) {
+              await recordSupersededIntent({
+                github,
+                context,
+                pr,
+                selection,
+              });
+            }
+            throw error;
+          }
+        }
+        state = {
+          ...refreshed.ownershipCheck.state,
+          targets: {
+            ...refreshed.ownershipCheck.state.targets,
+            [selection.target]: {
+              ...refreshed.ownershipCheck.state.targets[selection.target],
+              active: {
+                ...refreshed.ownershipCheck.state.targets[selection.target]
+                  .active,
+                dispatch_state: "dispatched",
+                ...runDetails,
+              },
+            },
+          },
+        };
+        stateComment = await writeControllerState({
+          github,
+          context,
+          pr,
+          state,
+          stateComment,
+        });
+        dispatchedRunIds.push(runDetails.workflow_run_id);
+      }
+      if (restartReconciliation) {
+        recordDeterministicProgress();
+        continue reconcileAttempts;
+      }
+      core.setOutput("dispatched_run_ids", JSON.stringify(dispatchedRunIds));
+
       const finalPull = await pullFromApi(github, context, pr);
+      const finalCurrentPull = normalizePullRequest(finalPull);
+      const finalOwners = await candidatePreviewOwners(
+        github,
+        context,
+        finalPull,
+      );
       const finalComments = await loadPreviewJournal(github, context, pr);
       const finalReconciled = reconcileState({
         events: finalComments.events,
@@ -4987,6 +5503,16 @@ export async function reconcilePreview({
         "Reconciliation basis changed before status publication",
       );
       state = finalReconciled.state;
+      if (finalCurrentPull.state === "open") {
+        overrideNativeHeadOwnership({
+          state,
+          previousState: finalComments.state,
+          pull: finalCurrentPull,
+          previewOwners: finalOwners,
+          controllerMode,
+          controllerUrl,
+        });
+      }
       stateComment = await writeControllerState({
         github,
         context,
@@ -5024,6 +5550,7 @@ export async function reconcilePreview({
           stateBeforeReconciliation !== null &&
           stateBeforeReconciliation === canonicalJson(state),
       });
+      core.setOutput("preview_owners", JSON.stringify(finalOwners));
       core.setOutput("pr_number", String(pr));
       return state;
     } catch (error) {
@@ -5054,10 +5581,12 @@ function workerResultAffectsCurrentReconciliation({
   selection,
   currentSelection,
 }) {
+  const target = previewTarget(selection.target, "Worker result target");
   return (
     (selection === currentSelection &&
       selection.epoch_anchor_run_id === state.epoch.anchor_run_id) ||
-    evidence.checkpoint?.pending_owner_key_digest === selection.key_digest
+    evidence.checkpoint?.targets[target].pending_owner_key_digest ===
+      selection.key_digest
   );
 }
 
@@ -5068,17 +5597,20 @@ async function foldCompletedRetiredOwner({
   state,
   selection,
 }) {
+  const target = previewTarget(selection.target, "Completed worker target");
+  const targetState = state.targets[target];
   if (
-    evidence.checkpoint?.pending_owner_key_digest === selection.key_digest ||
-    state.ui.active?.key_digest === selection.key_digest
+    evidence.checkpoint?.targets[target].pending_owner_key_digest ===
+      selection.key_digest ||
+    targetState.active?.key_digest === selection.key_digest
   ) {
     return;
   }
-  const retained = state.ui.retired_active.filter(
+  const retained = targetState.retired_active.filter(
     (candidate) => candidate.key_digest !== selection.key_digest,
   );
-  if (retained.length === state.ui.retired_active.length) return;
-  state.ui.retired_active = retained;
+  if (retained.length === targetState.retired_active.length) return;
+  targetState.retired_active = retained;
   await writeControllerState({
     github,
     context,
@@ -5214,11 +5746,14 @@ export async function validateWorkerDispatch({
     "Actual worker workflow SHA does not match controller-authorized SHA",
   );
   const pr = pullRequestNumber(inputs.pull_request_number);
-  invariant(inputs.target === PREVIEW_TARGET, "Worker target must be UI");
+  const target = previewTarget(inputs.target, "Worker target");
   const sha = exactSha(inputs.commit_sha);
   const gitRef = validatedWorkerHeadRef(inputs.git_branch);
   const key = boundedText(inputs.controller_key, "Controller key", 255);
-  invariant(key === controllerKey(pr, sha), "Worker controller key is invalid");
+  invariant(
+    key === controllerKey(pr, sha, target),
+    "Worker controller key is invalid",
+  );
   const epochAnchorRunId = exactRunId(
     inputs.epoch_anchor_run_id,
     "Worker epoch anchor run ID",
@@ -5257,26 +5792,27 @@ export async function validateWorkerDispatch({
     await shaIsStillAssociated(github, context, pull, sha),
     "Selected SHA is no longer associated with the PR lineage",
   );
-  const currentPreviewOwner = await uiPreviewOwnerAtSha(
+  const currentPreviewOwner = await previewOwnerAtSha(
     github,
     context,
+    target,
     normalizedPull.headSha,
   );
   invariant(
-    currentPreviewOwner === UI_PREVIEW_OWNER_GITHUB,
-    "GitHub preview worker does not own the current UI configuration",
+    githubPreviewDispatchAllowed(target, currentPreviewOwner),
+    `GitHub preview worker is not allowed for the current ${target} configuration`,
   );
   const selectedPreviewOwner =
     sha === normalizedPull.headSha
       ? currentPreviewOwner
-      : await uiPreviewOwnerAtSha(github, context, sha);
+      : await previewOwnerAtSha(github, context, target, sha);
   invariant(
-    selectedPreviewOwner === UI_PREVIEW_OWNER_GITHUB,
-    "GitHub preview worker does not own the selected UI configuration",
+    githubPreviewDispatchAllowed(target, selectedPreviewOwner),
+    `GitHub preview worker is not allowed for the selected ${target} configuration`,
   );
   const evidence = await loadControllerEvidence(github, context, pr);
   const state = evidence.state;
-  const active = state.ui?.active;
+  const active = state.targets[target]?.active;
   const selectionReceipt = evidence.selections.find(
     (selection) => selection.key_digest === keyDigest,
   );
@@ -5292,6 +5828,7 @@ export async function validateWorkerDispatch({
   );
   invariant(
     selectionReceipt &&
+      selectionReceipt.target === target &&
       selectionReceipt.sha === sha &&
       selectionReceipt.epoch_anchor_run_id === epochAnchorRunId &&
       selectionReceipt.reconciliation_basis_digest === basisDigest &&
@@ -5323,6 +5860,7 @@ export async function validateWorkerDispatch({
     pr,
     sha,
     key,
+    target,
   });
   if (deployment) {
     const statuses = await deploymentStatusHistory(
@@ -5414,8 +5952,13 @@ function deploymentPayload(value) {
   }
 }
 
-async function findCanonicalDeployment(github, context, { pr, sha, key }) {
-  const environment = `preview/ui/pr-${pr}`;
+async function findCanonicalDeployment(
+  github,
+  context,
+  { pr, sha, key, target: rawTarget },
+) {
+  const target = previewTarget(rawTarget, "Deployment target");
+  const environment = `preview/${target}/pr-${pr}`;
   const deployments = await github.paginate(github.rest.repos.listDeployments, {
     ...ownerRepo(context),
     sha,
@@ -5427,9 +5970,11 @@ async function findCanonicalDeployment(github, context, { pr, sha, key }) {
     return (
       deployment.ref === sha &&
       deployment.environment === environment &&
+      payload?.controller_schema === PREBUILT_DEPLOYMENT_SCHEMA &&
       payload?.idempotency_key === key &&
       payload?.sha === sha &&
-      payload?.logical_target === PREVIEW_TARGET
+      payload?.logical_target === target &&
+      payload?.provenance === PREVIEW_CONTROLLER_PROVENANCE
     );
   });
   invariant(
@@ -5446,24 +5991,25 @@ async function createRecoveryDeployment(
   selection,
   run,
 ) {
+  const target = previewTarget(parsed.target, "Recovery deployment target");
   const { data } = await github.rest.repos.createDeployment({
     ...ownerRepo(context),
     ref: parsed.sha,
     auto_merge: false,
     required_contexts: [],
-    environment: `preview/ui/pr-${parsed.pr}`,
+    environment: `preview/${target}/pr-${parsed.pr}`,
     transient_environment: true,
     production_environment: false,
-    description: "Vercel prebuilt UI preview recovery",
+    description: `Vercel prebuilt ${target} preview recovery`,
     payload: {
-      controller_schema: "mento-vercel-prebuilt/v1",
+      controller_schema: PREBUILT_DEPLOYMENT_SCHEMA,
       idempotency_key: selection.key,
-      logical_target: PREVIEW_TARGET,
+      logical_target: target,
       sha: parsed.sha,
       git_ref: validatedWorkerHeadRef(selection.git_ref),
       workflow_run_url: optionalHttpsUrl(run.html_url, "Worker run URL"),
       pull_request_number: parsed.pr,
-      provenance: "preview-controller-recovery",
+      provenance: PREVIEW_CONTROLLER_PROVENANCE,
     },
   });
   return data;
@@ -5514,10 +6060,13 @@ function workerOutcomeSelection(inputs, rawWorkflowSha) {
     "Actual worker workflow SHA does not match controller-authorized SHA",
   );
   const pr = pullRequestNumber(inputs.pull_request_number);
-  invariant(inputs.target === PREVIEW_TARGET, "Worker target must be UI");
+  const target = previewTarget(inputs.target, "Worker target");
   const sha = exactSha(inputs.commit_sha);
   const key = boundedText(inputs.controller_key, "Controller key", 255);
-  invariant(key === controllerKey(pr, sha), "Worker controller key is invalid");
+  invariant(
+    key === controllerKey(pr, sha, target),
+    "Worker controller key is invalid",
+  );
   const epochAnchorRunId = exactRunId(inputs.epoch_anchor_run_id);
   const basisDigest = boundedText(
     inputs.reconciliation_basis_digest,
@@ -5546,6 +6095,7 @@ function workerOutcomeSelection(inputs, rawWorkflowSha) {
   );
   return {
     pr,
+    target,
     sha,
     key,
     keyDigest,
@@ -5565,9 +6115,10 @@ export async function recordWorkerEvidence({
 }) {
   const selection = workerOutcomeSelection(inputs, workflowSha);
   const evidence = await loadControllerEvidence(github, context, selection.pr);
+  const targetState = evidence.state.targets[selection.target];
   const ownedSelection = [
-    evidence.state.ui?.active,
-    ...(evidence.state.ui?.retired_active ?? []),
+    targetState.active,
+    ...targetState.retired_active,
   ].find(
     (candidate) =>
       candidate?.key === selection.key &&
@@ -5595,6 +6146,7 @@ export async function recordWorkerEvidence({
     pr: selection.pr,
     sha: selection.sha,
     key: selection.key,
+    target: selection.target,
   });
   if (!deployment) {
     core.setOutput("evidence_deferred_to_recovery", "true");
@@ -5626,7 +6178,7 @@ export async function recordWorkerEvidence({
     schema: WORKER_EVIDENCE_SCHEMA,
     repository: PREVIEW_REPOSITORY,
     pr: selection.pr,
-    target: PREVIEW_TARGET,
+    target: selection.target,
     sha: selection.sha,
     controller_key: selection.key,
     key_digest: selection.keyDigest,
@@ -5664,11 +6216,12 @@ export async function recoverWorkerResult({
   const { displayTitle, workflowRunId: runId } =
     validateWorkerRunSource(workflowRun);
   const parsed = parseWorkerRunName(displayTitle);
-  const key = controllerKey(parsed.pr, parsed.sha);
+  const key = controllerKey(parsed.pr, parsed.sha, parsed.target);
   const evidence = await loadControllerEvidence(github, context, parsed.pr);
   const state = evidence.state;
-  let currentSelection = state.ui?.active;
-  let selection = [currentSelection, ...(state.ui?.retired_active ?? [])].find(
+  const targetState = state.targets[parsed.target];
+  let currentSelection = targetState.active;
+  let selection = [currentSelection, ...targetState.retired_active].find(
     (candidate) =>
       candidate?.key === key && candidate?.key_digest === parsed.keyDigest,
   );
@@ -5682,7 +6235,7 @@ export async function recoverWorkerResult({
   }
   const currentEpochOwnsSameKey = [
     currentSelection,
-    ...(state.ui?.terminal_history ?? []),
+    ...targetState.terminal_history,
     ...evidence.results,
   ]
     .filter(Boolean)
@@ -5779,18 +6332,18 @@ export async function recoverWorkerResult({
       ...queriedRun,
     };
     if (selection === currentSelection) {
-      state.ui.active = recoveredSelection;
+      targetState.active = recoveredSelection;
       currentSelection = recoveredSelection;
     } else {
-      const retiredIndex = state.ui.retired_active.findIndex(
+      const retiredIndex = targetState.retired_active.findIndex(
         (candidate) => candidate.key_digest === selection.key_digest,
       );
       invariant(
         retiredIndex >= 0,
         "Intended retired worker ownership disappeared",
       );
-      state.ui.retired_active = [...state.ui.retired_active];
-      state.ui.retired_active[retiredIndex] = recoveredSelection;
+      targetState.retired_active = [...targetState.retired_active];
+      targetState.retired_active[retiredIndex] = recoveredSelection;
     }
     await writeControllerState({
       github,
@@ -5812,6 +6365,7 @@ export async function recoverWorkerResult({
     pr: parsed.pr,
     sha: parsed.sha,
     key,
+    target: parsed.target,
   });
   invariant(queriedRun.status === "completed", "Worker run is not completed");
   const conclusion = boundedText(
@@ -5996,7 +6550,7 @@ export async function recoverWorkerResult({
     schema: RESULT_RECEIPT_SCHEMA,
     repository: PREVIEW_REPOSITORY,
     pr: parsed.pr,
-    target: PREVIEW_TARGET,
+    target: parsed.target,
     sha: parsed.sha,
     controller_key: key,
     key_digest: parsed.keyDigest,
@@ -6064,7 +6618,7 @@ export async function postWorkerRecoveryError({
     return false;
   }
   const evidence = await loadControllerEvidence(github, context, parsed.pr);
-  const active = evidence.state.ui?.active;
+  const active = evidence.state.targets[parsed.target]?.active;
   if (
     active?.sha !== parsed.sha ||
     active?.key_digest !== parsed.keyDigest ||

--- a/scripts/vercel-preview-controller.mjs
+++ b/scripts/vercel-preview-controller.mjs
@@ -11,8 +11,6 @@ import {
   previewTargetConfig,
 } from "./vercel-preview-targets.mjs";
 
-export { PREVIEW_TARGETS } from "./vercel-preview-targets.mjs";
-
 export const PREVIEW_REPOSITORY = "mento-protocol/frontend-monorepo";
 const PREVIEW_STATUS_CONTEXT = "Vercel Preview";
 const PREVIEW_INITIALIZATION_STATUS_CONTEXT = "Vercel Preview Journal v2";
@@ -22,7 +20,7 @@ const PREVIEW_OWNER_NATIVE = "native-vercel";
 const PREBUILT_DEPLOYMENT_SCHEMA = "mento-vercel-prebuilt/v2";
 const PREVIEW_CONTROLLER_PROVENANCE = "preview-controller:v2";
 export const EVENT_RECEIPT_SCHEMA = "vercel-preview-event-receipt:v2";
-export const WORKER_EVIDENCE_SCHEMA = "vercel-preview-worker-evidence:v2";
+const WORKER_EVIDENCE_SCHEMA = "vercel-preview-worker-evidence:v2";
 export const RESULT_RECEIPT_SCHEMA = "vercel-preview-worker-result:v2";
 export const SELECTION_RECEIPT_SCHEMA = "vercel-preview-selection:v2";
 export const CONTROLLER_SCHEMA = "vercel-preview-controller:v2";

--- a/scripts/vercel-preview-controller.mjs
+++ b/scripts/vercel-preview-controller.mjs
@@ -296,8 +296,49 @@ function digest(value, length = 64) {
     .slice(0, length);
 }
 
-function journalBody(value) {
-  const body = `${PREVIEW_JOURNAL_MARKER}\n\n${COMMENT_EXPLANATION}\n\n<details>\n<summary>${COMMENT_DETAILS_SUMMARY}</summary>\n\n\`\`\`json\n${JSON.stringify(value, null, 2)}\n\`\`\`\n\n</details>\n`;
+function reviewerOutcomeUrl(value, target, outcome) {
+  const targetState = value.state?.targets?.[target];
+  if (!targetState) return null;
+  if (["deployed", "runtime-equivalent"].includes(outcome)) {
+    return targetState.last_successful_runtime_url ?? null;
+  }
+  if (outcome === "pending") return targetState.active?.html_url ?? null;
+  if (!["failed", "error"].includes(outcome)) return null;
+  const terminal = [...targetState.terminal_history]
+    .reverse()
+    .find(
+      (candidate) =>
+        candidate.sha === targetState.latest_desired_sha &&
+        (outcome === "failed"
+          ? candidate.state === "failure" ||
+            (candidate.state === "error" &&
+              candidate.terminal_reason === "worker-cancelled")
+          : candidate.state === "error" &&
+            candidate.terminal_reason !== "worker-cancelled"),
+    );
+  return terminalResultUrl(terminal, null);
+}
+
+function reviewerOutcomeSummary(value) {
+  const latestDecision = value.state?.status_decisions?.at(-1) ?? null;
+  const rows = PREVIEW_TARGETS.map((target) => {
+    const outcome =
+      latestDecision?.targets?.[target] ?? "awaiting reconciliation";
+    const url = reviewerOutcomeUrl(value, target, outcome);
+    return `| \`${target}\` | \`${outcome}\`${url ? ` ([open](${url}))` : ""} |`;
+  });
+  return [
+    "**Preview outcomes**",
+    "",
+    "| Target | Outcome |",
+    "| --- | --- |",
+    ...rows,
+  ].join("\n");
+}
+
+export function renderPreviewJournalBody(value) {
+  const reviewerSummary = reviewerOutcomeSummary(value);
+  const body = `${PREVIEW_JOURNAL_MARKER}\n\n${COMMENT_EXPLANATION}\n\n${reviewerSummary}\n\n<details>\n<summary>${COMMENT_DETAILS_SUMMARY}</summary>\n\n\`\`\`json\n${JSON.stringify(value, null, 2)}\n\`\`\`\n\n</details>\n`;
   invariant(
     Buffer.byteLength(body, "utf8") <= MAX_JOURNAL_BYTES,
     "Preview journal comment is too large",
@@ -311,13 +352,20 @@ function parseJournalBody(body) {
     Buffer.byteLength(body, "utf8") <= MAX_JOURNAL_BYTES,
     "Preview journal comment is too large",
   );
-  const prefix = `${PREVIEW_JOURNAL_MARKER}\n\n${COMMENT_EXPLANATION}\n\n<details>\n<summary>${COMMENT_DETAILS_SUMMARY}</summary>\n\n\`\`\`json\n`;
+  const prefix = `${PREVIEW_JOURNAL_MARKER}\n\n${COMMENT_EXPLANATION}\n\n`;
+  const jsonPrefix = `\n\n<details>\n<summary>${COMMENT_DETAILS_SUMMARY}</summary>\n\n\`\`\`json\n`;
   const suffix = "\n```\n\n</details>\n";
+  const jsonPrefixIndex = body.indexOf(jsonPrefix, prefix.length);
   invariant(
-    body.startsWith(prefix) && body.endsWith(suffix),
+    body.startsWith(prefix) &&
+      jsonPrefixIndex > prefix.length &&
+      body.indexOf(jsonPrefix, jsonPrefixIndex + 1) === -1 &&
+      body.endsWith(suffix),
     "Preview journal JSON block is missing",
   );
-  return JSON.parse(body.slice(prefix.length, -suffix.length));
+  return JSON.parse(
+    body.slice(jsonPrefixIndex + jsonPrefix.length, -suffix.length),
+  );
 }
 
 function isTrustedGitHubActionsBot(actor) {
@@ -2982,7 +3030,7 @@ function validatePreviewJournal(value, expectedPr) {
         previewJournalDigest(receipts, journal.state, checkpoint),
     "Preview journal digest mismatch",
   );
-  journalBody(journal);
+  renderPreviewJournalBody(journal);
   return journal;
 }
 
@@ -3237,7 +3285,8 @@ export function compactPreviewJournal(value, { pullRequest = null } = {}) {
   );
   if (
     hasInFlightOwnership &&
-    Buffer.byteLength(journalBody(journal), "utf8") < ACTIVE_CHECKPOINT_BYTES
+    Buffer.byteLength(renderPreviewJournalBody(journal), "utf8") <
+      ACTIVE_CHECKPOINT_BYTES
   ) {
     return journal;
   }
@@ -3485,7 +3534,7 @@ function parsePreviewJournalComments(
   }
   const journal = validatePreviewJournal(parseJournalBody(matches[0].body), pr);
   invariant(
-    matches[0].body === journalBody(journal),
+    matches[0].body === renderPreviewJournalBody(journal),
     "Preview journal body is not canonical",
   );
   return journalRecords(journal, matches[0]);
@@ -3538,7 +3587,7 @@ async function mutatePreviewJournal({
   if (!changed && loaded) return { ...loaded, created: false };
   candidate.revision = loaded ? current.revision + 1 : 1;
   const journal = validatePreviewJournal(candidate, pr);
-  const body = journalBody(journal);
+  const body = renderPreviewJournalBody(journal);
   let data;
   if (loaded) {
     ({ data } = await github.rest.issues.updateComment({
@@ -4819,7 +4868,12 @@ async function refreshDispatchOwnership({
     normalized.headSha,
   );
   if (!githubPreviewDispatchAllowed(target, currentPreviewOwner)) {
-    return { outcome: "current-head-native" };
+    return {
+      outcome: "current-head-native",
+      currentPull: normalized,
+      currentPreviewOwner,
+      selectedPreviewOwner: null,
+    };
   }
   if (!(await shaIsStillAssociated(github, context, pull, selected.sha))) {
     return { outcome: "removed" };
@@ -4829,7 +4883,12 @@ async function refreshDispatchOwnership({
       ? currentPreviewOwner
       : await previewOwnerAtSha(github, context, target, selected.sha);
   if (!githubPreviewDispatchAllowed(target, selectedPreviewOwner)) {
-    return { outcome: "selected-native" };
+    return {
+      outcome: "selected-native",
+      currentPull: normalized,
+      currentPreviewOwner,
+      selectedPreviewOwner,
+    };
   }
   const comments = await loadPreviewJournal(github, context, pr);
   const ownershipCheck = reconcileState({
@@ -4854,7 +4913,24 @@ async function refreshDispatchOwnership({
       ownershipCheck.state.targets[target].active?.workflow_run_id === null,
     "Persisted dispatch ownership changed before credentials",
   );
-  return { outcome: "owned", ownershipCheck };
+  return {
+    outcome: "owned",
+    currentPull: normalized,
+    currentPreviewOwner,
+    selectedPreviewOwner,
+    ownershipCheck,
+  };
+}
+
+function refreshedSelectionIsNativeOwned(selection, refreshed) {
+  if (refreshed.outcome === "selected-native") {
+    return refreshed.selectedPreviewOwner === PREVIEW_OWNER_NATIVE;
+  }
+  return (
+    refreshed.outcome === "current-head-native" &&
+    refreshed.currentPreviewOwner === PREVIEW_OWNER_NATIVE &&
+    selection.sha === refreshed.currentPull.headSha
+  );
 }
 
 async function recoverCompletedOwnedRuns({
@@ -5313,10 +5389,7 @@ export async function reconcilePreview({
           )) {
             noDispatchSelectionKeys.add(keyDigest);
           }
-          if (
-            refreshed.outcome === "selected-native" ||
-            selection.sha === currentPull.headSha
-          ) {
+          if (refreshedSelectionIsNativeOwned(selection, refreshed)) {
             nativeSelectionKeys.add(selection.key_digest);
           }
         }
@@ -5394,11 +5467,12 @@ export async function reconcilePreview({
           const selectionKeys = new Set(
             undispatchedIntentKeyDigests(state, selection.target),
           );
-          const nativeSelectionKeys =
-            refreshed.outcome === "selected-native" ||
-            selection.sha === currentPull.headSha
-              ? new Set([selection.key_digest])
-              : new Set();
+          const nativeSelectionKeys = refreshedSelectionIsNativeOwned(
+            selection,
+            refreshed,
+          )
+            ? new Set([selection.key_digest])
+            : new Set();
           invariant(
             await reconcileNoDispatchIntents({
               github,

--- a/scripts/vercel-preview-controller.test.mjs
+++ b/scripts/vercel-preview-controller.test.mjs
@@ -13,6 +13,7 @@ import {
   RESULT_RECEIPT_SCHEMA,
   SELECTION_RECEIPT_SCHEMA,
   compactPreviewJournal,
+  controllerKey,
   createPreviewJournal,
   dependabotIntakeRunName,
   normalizePlannerResult,
@@ -38,6 +39,10 @@ import {
   writeRepositoryDispatchOutputs,
 } from "./vercel-preview-controller.mjs";
 import { validateGitBranch } from "./vercel-prebuilt-workflow.mjs";
+import {
+  PREVIEW_TARGET_CONFIG,
+  PREVIEW_TARGETS,
+} from "./vercel-preview-targets.mjs";
 
 const CONTROLLER_URL =
   "https://github.com/mento-protocol/frontend-monorepo/actions/runs/999";
@@ -117,6 +122,7 @@ function event({
   head,
   before = null,
   runtime = true,
+  targets = runtime ? ["ui"] : [],
   updated,
   state = action === "closed" ? "closed" : "open",
   closed = action === "closed" ? updated : null,
@@ -142,19 +148,20 @@ function event({
     },
     run,
   );
-  const rawPlan = runtime
-    ? {
-        deployments: ["ui"],
-        base: snapshot.change_base_sha,
-        head: snapshot.head_sha,
-        reason: "affected-packages",
-      }
-    : {
-        deployments: [],
-        base: snapshot.change_base_sha,
-        head: snapshot.head_sha,
-        reason: "non-runtime-only",
-      };
+  const rawPlan =
+    targets.length > 0
+      ? {
+          deployments: targets,
+          base: snapshot.change_base_sha,
+          head: snapshot.head_sha,
+          reason: "affected-packages",
+        }
+      : {
+          deployments: [],
+          base: snapshot.change_base_sha,
+          head: snapshot.head_sha,
+          reason: "non-runtime-only",
+        };
   return validateEventReceipt({
     ...snapshot,
     plan: normalizePlannerResult(rawPlan, snapshot),
@@ -180,17 +187,20 @@ function persistDispatch(reconciled, runId = 8_000) {
   assert.ok(reconciled.nextDispatch, "fixture must have a dispatch");
   return {
     ...structuredClone(reconciled.state),
-    ui: {
-      ...structuredClone(reconciled.state.ui),
-      active: {
-        ...structuredClone(reconciled.nextDispatch),
-        dispatch_started_at: timestamp(0),
-        dispatch_state: "dispatched",
-        workflow_run_id: runId,
-        workflow_sha: reconciled.nextDispatch.expected_workflow_sha,
-        workflow_run_attempt: 1,
-        run_url: `https://api.github.com/repos/mento-protocol/frontend-monorepo/actions/runs/${runId}`,
-        html_url: `https://github.com/mento-protocol/frontend-monorepo/actions/runs/${runId}`,
+    targets: {
+      ...structuredClone(reconciled.state.targets),
+      ui: {
+        ...structuredClone(reconciled.state.targets.ui),
+        active: {
+          ...structuredClone(reconciled.nextDispatch),
+          dispatch_started_at: timestamp(0),
+          dispatch_state: "dispatched",
+          workflow_run_id: runId,
+          workflow_sha: reconciled.nextDispatch.expected_workflow_sha,
+          workflow_run_attempt: 1,
+          run_url: `https://api.github.com/repos/mento-protocol/frontend-monorepo/actions/runs/${runId}`,
+          html_url: `https://github.com/mento-protocol/frontend-monorepo/actions/runs/${runId}`,
+        },
       },
     },
   };
@@ -200,20 +210,40 @@ function persistIntent(reconciled) {
   assert.ok(reconciled.nextDispatch, "fixture must have a dispatch");
   return {
     ...structuredClone(reconciled.state),
-    ui: {
-      ...structuredClone(reconciled.state.ui),
-      active: {
-        ...structuredClone(reconciled.nextDispatch),
-        dispatch_started_at: timestamp(0),
-        dispatch_state: "intended",
-        workflow_run_id: null,
-        workflow_sha: null,
-        workflow_run_attempt: null,
-        run_url: null,
-        html_url: null,
+    targets: {
+      ...structuredClone(reconciled.state.targets),
+      ui: {
+        ...structuredClone(reconciled.state.targets.ui),
+        active: {
+          ...structuredClone(reconciled.nextDispatch),
+          dispatch_started_at: timestamp(0),
+          dispatch_state: "intended",
+          workflow_run_id: null,
+          workflow_sha: null,
+          workflow_run_attempt: null,
+          run_url: null,
+          html_url: null,
+        },
       },
     },
   };
+}
+
+function persistAllIntents(reconciled) {
+  const state = structuredClone(reconciled.state);
+  for (const dispatch of reconciled.nextDispatches) {
+    state.targets[dispatch.target].active = {
+      ...structuredClone(dispatch),
+      dispatch_started_at: timestamp(0),
+      dispatch_state: "intended",
+      workflow_run_id: null,
+      workflow_sha: null,
+      workflow_run_attempt: null,
+      run_url: null,
+      html_url: null,
+    };
+  }
+  return state;
 }
 
 function result(
@@ -223,7 +253,7 @@ function result(
     state = "success",
     reason = state === "success" ? "verified" : "worker-failure",
     vercelDeploymentUrl = state === "success"
-      ? `https://ui-${runId}.vercel.app`
+      ? `https://${dispatch.target}-${runId}.vercel.app`
       : null,
   } = {},
 ) {
@@ -231,7 +261,7 @@ function result(
     schema: RESULT_RECEIPT_SCHEMA,
     repository: PREVIEW_REPOSITORY,
     pr: dispatch.pr,
-    target: "ui",
+    target: dispatch.target,
     sha: dispatch.sha,
     controller_key: dispatch.key,
     key_digest: dispatch.key_digest,
@@ -244,7 +274,8 @@ function result(
     github_deployment_id: 9_000 + runId,
     state,
     vercel_deployment_id: state === "success" ? `dpl_${runId}` : null,
-    next_deployment_id: state === "success" ? `m-ui-${runId}` : null,
+    next_deployment_id:
+      state === "success" ? `m-${dispatch.target}-${runId}` : null,
     vercel_deployment_url: vercelDeploymentUrl,
     smoke_result: state === "success" ? "passed" : "failed",
     terminal_reason: reason,
@@ -262,7 +293,7 @@ function controllerResult(
     schema: RESULT_RECEIPT_SCHEMA,
     repository: PREVIEW_REPOSITORY,
     pr: dispatch.pr,
-    target: "ui",
+    target: dispatch.target,
     sha: dispatch.sha,
     controller_key: dispatch.key,
     key_digest: dispatch.key_digest,
@@ -291,7 +322,7 @@ function reconcile({
   checkpoint = null,
   expectedWorkflowSha = SHA.E,
 }) {
-  return reconcileState({
+  const reconciled = reconcileState({
     events,
     results,
     pullRequest,
@@ -301,6 +332,11 @@ function reconcile({
     controllerUrl: CONTROLLER_URL,
     expectedWorkflowSha,
   });
+  return {
+    ...reconciled,
+    nextDispatch:
+      reconciled.nextDispatches.find(({ target }) => target === "ui") ?? null,
+  };
 }
 
 test("trusted snapshot entrypoints emit bounded event and bootstrap outputs", async () => {
@@ -437,6 +473,134 @@ test("receipt schema distinguishes lifecycle fields and synchronize before -> he
   assert.equal(synchronized.plan.planner_source_sha, SHA.E);
 });
 
+test("v2 is the only internal journal and controller schema while external keys stay v1", () => {
+  assert.equal(CONTROLLER_SCHEMA, "vercel-preview-controller:v2");
+  assert.equal(EVENT_RECEIPT_SCHEMA, "vercel-preview-event-receipt:v2");
+  assert.equal(RESULT_RECEIPT_SCHEMA, "vercel-preview-worker-result:v2");
+  assert.equal(SELECTION_RECEIPT_SCHEMA, "vercel-preview-selection:v2");
+  assert.equal(PREVIEW_JOURNAL_SCHEMA, "vercel-preview-journal:v2");
+  assert.equal(PREVIEW_JOURNAL_MARKER, "<!-- vercel-preview-journal:v2 -->");
+  assert.equal(
+    controllerKey(519, SHA.A, "reserve"),
+    `vercel-preview:v1:pr:519:target:reserve:sha:${SHA.A}`,
+  );
+  assert.throws(() => controllerKey(519, SHA.A), /target is invalid/);
+  assert.throws(
+    () =>
+      validateEventReceipt({
+        ...event({
+          run: 9,
+          action: "opened",
+          head: SHA.A,
+          updated: timestamp(1),
+        }),
+        schema: "vercel-preview-event-receipt:v1",
+      }),
+    /schema mismatch/,
+  );
+});
+
+test("planner preserves canonical four-target order and fails closed to all targets", () => {
+  const receipt = event({
+    run: 10,
+    action: "opened",
+    head: SHA.A,
+    updated: timestamp(1),
+    targets: [],
+  });
+  const snapshot = structuredClone(receipt);
+  delete snapshot.plan;
+  assert.deepEqual(
+    normalizePlannerResult("", snapshot, "failure").targets,
+    PREVIEW_TARGETS,
+  );
+  assert.throws(
+    () =>
+      normalizePlannerResult(
+        {
+          deployments: ["ui", "app"],
+          base: snapshot.change_base_sha,
+          head: snapshot.head_sha,
+          reason: "affected-packages",
+        },
+        snapshot,
+      ),
+    /malformed or unordered/,
+  );
+});
+
+test("one affected event selects four independent workers in stable order", () => {
+  const opened = event({
+    run: 11,
+    action: "opened",
+    head: SHA.A,
+    updated: timestamp(1),
+    targets: PREVIEW_TARGETS,
+  });
+  const reconciled = reconcile({
+    events: [opened],
+    pullRequest: pull({ head: SHA.A, updated: timestamp(1) }),
+  });
+  assert.deepEqual(
+    reconciled.nextDispatches.map(({ target }) => target),
+    PREVIEW_TARGETS,
+  );
+  assert.deepEqual(reconciled.state.status_decisions[0].targets, {
+    app: "pending",
+    governance: "pending",
+    reserve: "pending",
+    ui: "pending",
+  });
+  for (const target of PREVIEW_TARGETS) {
+    assert.equal(reconciled.state.targets[target].first_eligible_sha, SHA.A);
+    assert.equal(reconciled.state.targets[target].latest_desired_sha, SHA.A);
+  }
+});
+
+test("one target completion advances independently while other workers remain active", () => {
+  const opened = event({
+    run: 12,
+    action: "opened",
+    head: SHA.A,
+    updated: timestamp(1),
+    targets: PREVIEW_TARGETS,
+  });
+  const appUpdate = event({
+    run: 13,
+    action: "synchronize",
+    before: SHA.A,
+    head: SHA.B,
+    updated: timestamp(2),
+    targets: ["app"],
+  });
+  const initial = reconcile({
+    events: [opened, appUpdate],
+    pullRequest: pull({ head: SHA.B, updated: timestamp(2) }),
+  });
+  const persisted = persistAllIntents(initial);
+  const selections = PREVIEW_TARGETS.map((target) =>
+    selectionReceiptFromDispatch(persisted.targets[target].active),
+  );
+  const appDispatch = initial.nextDispatches.find(
+    ({ target }) => target === "app",
+  );
+  const advanced = reconcile({
+    events: [opened, appUpdate],
+    results: [result(appDispatch, { runId: 8_012 })],
+    selections,
+    pullRequest: pull({ head: SHA.B, updated: timestamp(2) }),
+    existingState: persisted,
+  });
+  assert.deepEqual(
+    advanced.nextDispatches.map(({ target, sha }) => [target, sha]),
+    [["app", SHA.B]],
+  );
+  for (const target of ["governance", "reserve", "ui"]) {
+    assert.equal(advanced.state.targets[target].active.sha, SHA.A);
+  }
+  assert.equal(advanced.state.status_decisions.at(-1).targets.app, "pending");
+});
+
 test("base retarget edits snapshot the new trusted base and reject unrelated edits", () => {
   const retargetedPull = pull({
     head: SHA.A,
@@ -497,7 +661,7 @@ test("base retarget starts a new same-head epoch and replans its runtime impact"
     pullRequest: pull({ head: SHA.A, updated: timestamp(1) }),
   });
   assert.equal(initial.nextDispatch, null);
-  assert.match(initial.state.status_decisions[0].description, /No UI runtime/);
+  assert.match(initial.state.status_decisions[0].description, /ui=none/);
 
   const editedSnapshot = snapshotPullRequestEvent(
     {
@@ -594,7 +758,7 @@ test("synchronize can reconcile before opened without changing lineage order", (
     [SHA.A, SHA.B],
   );
   assert.equal(ordered.nextDispatch.sha, SHA.A);
-  assert.equal(ordered.state.ui.latest_desired_sha, SHA.B);
+  assert.equal(ordered.state.targets.ui.latest_desired_sha, SHA.B);
 });
 
 test("first active survives a burst and terminal completion advances newest only", () => {
@@ -620,7 +784,7 @@ test("first active survives a burst and terminal completion advances newest only
     pullRequest: pull({ head: SHA.C, updated: timestamp(3) }),
   });
   assert.equal(first.nextDispatch.sha, SHA.A);
-  assert.equal(first.state.ui.latest_desired_sha, SHA.C);
+  assert.equal(first.state.targets.ui.latest_desired_sha, SHA.C);
   const activeState = persistDispatch(first);
   const whileActive = reconcile({
     events,
@@ -628,7 +792,7 @@ test("first active survives a burst and terminal completion advances newest only
     existingState: activeState,
   });
   assert.equal(whileActive.nextDispatch, null);
-  assert.equal(whileActive.state.ui.active.sha, SHA.A);
+  assert.equal(whileActive.state.targets.ui.active.sha, SHA.A);
   const completed = reconcile({
     events,
     results: [result(first.nextDispatch)],
@@ -658,7 +822,7 @@ test("a fresh idle burst selects its first SHA and retains only latest", () => {
     existingState: active,
   });
   assert.equal(idle.nextDispatch, null);
-  assert.equal(idle.state.ui.idle_cursor_receipt_run_id, 30);
+  assert.equal(idle.state.targets.ui.idle_cursor_receipt_run_id, 30);
 
   const runtimeB = event({
     run: 31,
@@ -681,7 +845,7 @@ test("a fresh idle burst selects its first SHA and retains only latest", () => {
     existingState: idle.state,
   });
   assert.equal(burst.nextDispatch.sha, SHA.B);
-  assert.equal(burst.state.ui.latest_desired_sha, SHA.C);
+  assert.equal(burst.state.targets.ui.latest_desired_sha, SHA.C);
 });
 
 test("docs-only states never dispatch and reuse the last verified runtime", () => {
@@ -698,10 +862,7 @@ test("docs-only states never dispatch and reuse the last verified runtime", () =
   });
   assert.equal(noRuntime.nextDispatch, null);
   assert.equal(noRuntime.state.status_decisions[0].state, "success");
-  assert.match(
-    noRuntime.state.status_decisions[0].description,
-    /No UI runtime/,
-  );
+  assert.match(noRuntime.state.status_decisions[0].description, /ui=none/);
 
   const runtimeB = event({
     run: 41,
@@ -738,7 +899,7 @@ test("docs-only states never dispatch and reuse the last verified runtime", () =
   });
   const docsStatus = completed.state.status_decisions.at(-1);
   assert.equal(docsStatus.state, "success");
-  assert.match(docsStatus.description, /Runtime-equivalent/);
+  assert.match(docsStatus.description, /ui=equivalent/);
 
   const failed = reconcile({
     events: [docsA, runtimeB, docsC],
@@ -755,7 +916,7 @@ test("docs-only states never dispatch and reuse the last verified runtime", () =
   const failedDocsStatus = failed.state.status_decisions.at(-1);
   assert.equal(failed.nextDispatch, null);
   assert.equal(failedDocsStatus.state, "failure");
-  assert.match(failedDocsStatus.description, /Runtime preview .* failed/);
+  assert.equal(failedDocsStatus.targets.ui, "failed");
 
   const cancelled = reconcile({
     events: [docsA, runtimeB, docsC],
@@ -771,7 +932,7 @@ test("docs-only states never dispatch and reuse the last verified runtime", () =
   });
   const cancelledDocsStatus = cancelled.state.status_decisions.at(-1);
   assert.equal(cancelledDocsStatus.state, "failure");
-  assert.match(cancelledDocsStatus.description, /was cancelled/);
+  assert.equal(cancelledDocsStatus.targets.ui, "failed");
 });
 
 test("coalescing needs an immutable later selection receipt", () => {
@@ -811,7 +972,9 @@ test("coalescing needs an immutable later selection receipt", () => {
     existingState: intendedC,
   });
   assert.equal(withoutProof.state.status_decisions[1].state, "pending");
-  const coalescingProof = selectionReceiptFromDispatch(intendedC.ui.active);
+  const coalescingProof = selectionReceiptFromDispatch(
+    intendedC.targets.ui.active,
+  );
   assert.deepEqual(coalescingProof.coalesced_receipt_run_ids, [51]);
   const withProof = reconcile({
     events,
@@ -821,7 +984,7 @@ test("coalescing needs an immutable later selection receipt", () => {
     selections: [coalescingProof],
   });
   assert.equal(withProof.state.status_decisions[1].state, "success");
-  assert.match(withProof.state.status_decisions[1].description, /Coalesced/);
+  assert.match(withProof.state.status_decisions[1].description, /ui=coalesced/);
 });
 
 test("more than 25 pushes converge from first preview to latest with compact proof", () => {
@@ -863,7 +1026,7 @@ test("more than 25 pushes converge from first preview to latest with compact pro
   assert.equal(latest.nextDispatch.sha, shas.at(-1));
   assert.equal(latest.nextDispatch.coalesced_receipt_run_ids.length, 29);
   const intendedLatest = persistIntent(latest);
-  const proof = selectionReceiptFromDispatch(intendedLatest.ui.active);
+  const proof = selectionReceiptFromDispatch(intendedLatest.targets.ui.active);
   assert.equal(proof.schema, SELECTION_RECEIPT_SCHEMA);
   const converged = reconcile({
     events,
@@ -873,8 +1036,8 @@ test("more than 25 pushes converge from first preview to latest with compact pro
     existingState: intendedLatest,
   });
   assert.equal(
-    converged.state.status_decisions.filter(({ description }) =>
-      description.startsWith("Coalesced to "),
+    converged.state.status_decisions.filter(
+      ({ targets }) => targets.ui === "coalesced",
     ).length,
     29,
   );
@@ -967,7 +1130,7 @@ test("transition instances survive a force-reset SHA revisit", () => {
     ],
   );
   assert.equal(state.nextDispatch.selection_receipt_run_id, 70);
-  assert.equal(state.state.ui.latest_desired_receipt_run_id, 72);
+  assert.equal(state.state.targets.ui.latest_desired_receipt_run_id, 72);
 });
 
 test("ambiguous repeated transitions fail closed without inferring scheduler order", () => {
@@ -1089,9 +1252,12 @@ test("a delayed lower-run duplicate preserves the persisted active selection rec
   assert.equal(current.lineage.length, 2);
   assert.equal(current.state.epoch.anchor_run_id, 70);
   assert.equal(current.lineage[1].event_run_id, 81);
-  assert.equal(current.state.ui.active.selection_receipt_run_id, 81);
-  assert.equal(current.state.ui.active.key_digest, active.ui.active.key_digest);
-  assert.equal(current.state.ui.active.workflow_run_id, 8_000);
+  assert.equal(current.state.targets.ui.active.selection_receipt_run_id, 81);
+  assert.equal(
+    current.state.targets.ui.active.key_digest,
+    active.targets.ui.active.key_digest,
+  );
+  assert.equal(current.state.targets.ui.active.workflow_run_id, 8_000);
   assert.equal(current.nextDispatch, null);
 });
 
@@ -1116,7 +1282,7 @@ test("semantic aliases with conflicting persisted representatives fail closed", 
     pullRequest: pull({ head: SHA.B, updated: timestamp(2) }),
   });
   const conflicting = persistDispatch(initial);
-  conflicting.ui.latest_desired_receipt_run_id = 80;
+  conflicting.targets.ui.latest_desired_receipt_run_id = 80;
   assert.throws(
     () =>
       reconcile({
@@ -1225,11 +1391,11 @@ test("controller state schema is explicit and bounded", () => {
   assert.equal(state.nextDispatch.expected_workflow_sha, SHA.E);
   assert.match(state.nextDispatch.key_digest, /^[0-9a-f]{24}$/);
   const persisted = persistDispatch(state);
-  assert.deepEqual(persisted.ui.terminal_result_key_digests, []);
-  assert.equal(persisted.ui.active.expected_workflow_sha, SHA.E);
-  assert.equal(persisted.ui.active.workflow_sha, SHA.E);
+  assert.deepEqual(persisted.targets.ui.terminal_result_key_digests, []);
+  assert.equal(persisted.targets.ui.active.expected_workflow_sha, SHA.E);
+  assert.equal(persisted.targets.ui.active.workflow_sha, SHA.E);
   const missingStateWorkflowSha = structuredClone(persisted);
-  delete missingStateWorkflowSha.ui.active.expected_workflow_sha;
+  delete missingStateWorkflowSha.targets.ui.active.expected_workflow_sha;
   assert.throws(
     () =>
       reconcile({
@@ -1240,7 +1406,7 @@ test("controller state schema is explicit and bounded", () => {
     /expected workflow SHA/,
   );
   const missingTerminalOwnership = structuredClone(persisted);
-  delete missingTerminalOwnership.ui.terminal_result_key_digests;
+  delete missingTerminalOwnership.targets.ui.terminal_result_key_digests;
   assert.throws(
     () =>
       reconcile({
@@ -1248,15 +1414,18 @@ test("controller state schema is explicit and bounded", () => {
         pullRequest: pull({ head: SHA.A, updated: timestamp(1) }),
         existingState: missingTerminalOwnership,
       }),
-    /Terminal result ownership/,
+    /ui terminal result ownership/,
   );
   for (const malformedOwnership of [
     null,
     ["not-a-key-digest"],
-    [persisted.ui.active.key_digest, persisted.ui.active.key_digest],
+    [
+      persisted.targets.ui.active.key_digest,
+      persisted.targets.ui.active.key_digest,
+    ],
   ]) {
     const malformedState = structuredClone(persisted);
-    malformedState.ui.terminal_result_key_digests = malformedOwnership;
+    malformedState.targets.ui.terminal_result_key_digests = malformedOwnership;
     assert.throws(
       () =>
         reconcile({
@@ -1264,7 +1433,7 @@ test("controller state schema is explicit and bounded", () => {
           pullRequest: pull({ head: SHA.A, updated: timestamp(1) }),
           existingState: malformedState,
         }),
-      /Terminal result ownership/,
+      /ui terminal result ownership/,
     );
   }
   const validResult = result(state.nextDispatch);
@@ -1318,8 +1487,8 @@ test("compact terminal ownership survives more results than rendered history", (
     priorSha = head;
   }
 
-  assert.equal(existingState.ui.terminal_history.length, 40);
-  assert.equal(existingState.ui.terminal_result_key_digests.length, 41);
+  assert.equal(existingState.targets.ui.terminal_history.length, 40);
+  assert.equal(existingState.targets.ui.terminal_result_key_digests.length, 41);
   assert.doesNotThrow(() =>
     reconcile({
       events,
@@ -1355,7 +1524,7 @@ test("terminal checkpoints bound one journal across fifty sequential previews", 
     });
     assert.equal(selected.nextDispatch.selection_receipt_run_id, 1_000 + index);
     const active = persistDispatch(selected, 30_000 + index);
-    const selection = selectionReceiptFromDispatch(active.ui.active);
+    const selection = selectionReceiptFromDispatch(active.targets.ui.active);
     const terminal = result(selected.nextDispatch, { runId: 30_000 + index });
     const completed = reconcile({
       events,
@@ -1387,7 +1556,7 @@ test("terminal checkpoints bound one journal across fifty sequential previews", 
     worker_evidence: 0,
     results: 49,
   });
-  assert.ok(maximumBytes < 8_000, `maximum journal size was ${maximumBytes}`);
+  assert.ok(maximumBytes < 16_000, `maximum journal size was ${maximumBytes}`);
 
   const compacted = compactPreviewJournal(journal);
   const docsHead = "f".repeat(40);
@@ -1408,7 +1577,7 @@ test("terminal checkpoints bound one journal across fifty sequential previews", 
   assert.equal(docsState.nextDispatch, null);
   assert.match(
     docsState.state.status_decisions.at(-1).description,
-    /^Runtime-equivalent to /,
+    /ui=equivalent/,
   );
 
   const delayedEvent = event({
@@ -1457,7 +1626,7 @@ test("capacity checkpoints keep a long overlapping push burst recoverable", () =
   let journal = createPreviewJournal({
     pr: 519,
     events: [opened],
-    selections: [selectionReceiptFromDispatch(state.ui.active)],
+    selections: [selectionReceiptFromDispatch(state.targets.ui.active)],
     state,
   });
   let priorHead = openedHead;
@@ -1489,7 +1658,7 @@ test("capacity checkpoints keep a long overlapping push burst recoverable", () =
     if (reconciled.nextDispatch) {
       additionalDispatches += 1;
       state = persistDispatch(reconciled, 40_000 + index);
-      selections.push(selectionReceiptFromDispatch(state.ui.active));
+      selections.push(selectionReceiptFromDispatch(state.targets.ui.active));
     }
     journal = createPreviewJournal({
       pr: 519,
@@ -1510,14 +1679,14 @@ test("capacity checkpoints keep a long overlapping push burst recoverable", () =
   assert.ok(journal.checkpoint.sequence >= 1);
   assert.equal(additionalDispatches, 0);
   assert.ok(journal.receipts.events.length < 50);
-  assert.equal(journal.state.ui.latest_desired_sha, priorHead);
+  assert.equal(journal.state.targets.ui.latest_desired_sha, priorHead);
   assert.ok(maximumBytes < 60_000, `maximum journal size was ${maximumBytes}`);
   assert.equal(
     journal.receipts.selections.length,
-    Number(journal.state.ui.active !== null) +
-      journal.state.ui.retired_active.length,
+    Number(journal.state.targets.ui.active !== null) +
+      journal.state.targets.ui.retired_active.length,
   );
-  assert.equal(journal.checkpoint.status.state, "pending");
+  assert.equal(journal.checkpoint.targets.ui.status.state, "pending");
 
   const docsHead = (150).toString(16).padStart(40, "0");
   const docsReceipt = event({
@@ -1539,7 +1708,7 @@ test("capacity checkpoints keep a long overlapping push burst recoverable", () =
   assert.equal(docsState.state.status_decisions.at(-1).state, "pending");
   assert.match(
     docsState.state.status_decisions.at(-1).description,
-    /Waiting for runtime preview/,
+    /ui=pending/,
   );
 });
 
@@ -1554,7 +1723,7 @@ test("capacity checkpoints preserve the newest queued runtime before reconciliat
   let currentPull = pull({ head: openedHead, updated: timestamp(1) });
   const first = reconcile({ events: [opened], pullRequest: currentPull });
   const active = persistDispatch(first, 41_000);
-  const selection = selectionReceiptFromDispatch(active.ui.active);
+  const selection = selectionReceiptFromDispatch(active.targets.ui.active);
   let journal = createPreviewJournal({
     pr: 519,
     events: [opened],
@@ -1588,8 +1757,8 @@ test("capacity checkpoints preserve the newest queued runtime before reconciliat
 
   assert.ok(journal.checkpoint);
   assert.equal(
-    journal.checkpoint.pending_owner_key_digest,
-    active.ui.active.key_digest,
+    journal.checkpoint.targets.ui.pending_owner_key_digest,
+    active.targets.ui.active.key_digest,
   );
   assert.ok(Buffer.byteLength(previewJournalBody(journal), "utf8") < 60_000);
   const waiting = reconcile({
@@ -1602,7 +1771,7 @@ test("capacity checkpoints preserve the newest queued runtime before reconciliat
   });
   assert.equal(waiting.nextDispatch, null);
   assert.equal(waiting.state.epoch.tail_receipt_run_id, 1_847);
-  assert.equal(waiting.state.ui.latest_desired_sha, priorHead);
+  assert.equal(waiting.state.targets.ui.latest_desired_sha, priorHead);
   assert.equal(waiting.state.status_decisions.at(-1).state, "pending");
 
   const afterOriginal = reconcile({
@@ -1617,7 +1786,9 @@ test("capacity checkpoints preserve the newest queued runtime before reconciliat
   assert.equal(afterOriginal.nextDispatch.selection_receipt_run_id, 1_847);
 
   const latestActive = persistDispatch(afterOriginal, 41_001);
-  const latestSelection = selectionReceiptFromDispatch(latestActive.ui.active);
+  const latestSelection = selectionReceiptFromDispatch(
+    latestActive.targets.ui.active,
+  );
   const latestResult = result(afterOriginal.nextDispatch, { runId: 41_001 });
   const finished = reconcile({
     events: journal.receipts.events,
@@ -1629,7 +1800,7 @@ test("capacity checkpoints preserve the newest queued runtime before reconciliat
   });
   assert.equal(finished.nextDispatch, null);
   assert.equal(finished.state.status_decisions.at(-1).state, "success");
-  assert.equal(finished.state.ui.retired_active.length, 0);
+  assert.equal(finished.state.targets.ui.retired_active.length, 0);
   assert.doesNotThrow(() =>
     reconcile({
       events: journal.receipts.events,
@@ -1656,7 +1827,7 @@ test("capacity checkpointing uses the latest represented receipt when the live P
     pullRequest: pull({ head: openedHead, updated: timestamp(1) }),
   });
   const active = persistDispatch(first, 41_500);
-  const selection = selectionReceiptFromDispatch(active.ui.active);
+  const selection = selectionReceiptFromDispatch(active.targets.ui.active);
   let journal = createPreviewJournal({
     pr: 519,
     events: representedEvents,
@@ -1695,7 +1866,7 @@ test("capacity checkpointing uses the latest represented receipt when the live P
     pullRequest: liveAhead,
   });
   assert.equal(compacted.checkpoint.event.head_sha, representedHead);
-  assert.equal(compacted.checkpoint.status.state, "pending");
+  assert.equal(compacted.checkpoint.targets.ui.status.state, "pending");
   assert.doesNotThrow(() =>
     reconcile({
       events: compacted.receipts.events,
@@ -1714,8 +1885,10 @@ test("terminal checkpoint folds quarantined retired ownership into bounded audit
   const setup = sameShaReopenState();
   const currentResult = result(setup.current.nextDispatch, { runId: 8_001 });
   const selections = [
-    selectionReceiptFromDispatch(setup.currentState.ui.retired_active[0]),
-    selectionReceiptFromDispatch(setup.currentState.ui.active),
+    selectionReceiptFromDispatch(
+      setup.currentState.targets.ui.retired_active[0],
+    ),
+    selectionReceiptFromDispatch(setup.currentState.targets.ui.active),
   ];
   const events = [...setup.events];
   let priorHead = SHA.A;
@@ -1742,11 +1915,11 @@ test("terminal checkpoint folds quarantined retired ownership into bounded audit
       pullRequest: currentPull,
       existingState: setup.currentState,
     });
-    assert.equal(terminal.state.ui.active, null);
-    assert.equal(terminal.state.ui.retired_active.length, 1);
+    assert.equal(terminal.state.targets.ui.active, null);
+    assert.equal(terminal.state.targets.ui.retired_active.length, 1);
     const quarantinedState = structuredClone(terminal.state);
-    quarantinedState.ui.retired_active[0] = {
-      ...quarantinedState.ui.retired_active[0],
+    quarantinedState.targets.ui.retired_active[0] = {
+      ...quarantinedState.targets.ui.retired_active[0],
       recovery_quarantine: "persisted-attempt-invalid-or-unavailable",
     };
     journal = createPreviewJournal({
@@ -1769,9 +1942,9 @@ test("terminal checkpoint folds quarantined retired ownership into bounded audit
   const compacted = compactPreviewJournal(journal, {
     pullRequest: currentPull,
   });
-  assert.equal(compacted.checkpoint.pending_owner_key_digest, null);
-  assert.equal(compacted.checkpoint.pending_runtime_event, null);
-  assert.equal(compacted.checkpoint.status.state, "success");
+  assert.equal(compacted.checkpoint.targets.ui.pending_owner_key_digest, null);
+  assert.equal(compacted.checkpoint.targets.ui.pending_owner_event, null);
+  assert.equal(compacted.checkpoint.targets.ui.status.state, "success");
   assert.match(
     compacted.checkpoint.cumulative_receipts_digest,
     /^[0-9a-f]{64}$/,
@@ -1788,7 +1961,7 @@ test("terminal checkpoint folds quarantined retired ownership into bounded audit
     worker_evidence: [],
     results: [],
   });
-  assert.equal(compacted.state.ui.retired_active.length, 0);
+  assert.equal(compacted.state.targets.ui.retired_active.length, 0);
   assert.ok(
     Buffer.byteLength(previewJournalBody(compacted), "utf8") < originalBytes,
   );
@@ -1815,9 +1988,12 @@ test("a terminal pending owner resolves a docs-only capacity checkpoint", async 
   const firstPull = pull({ head: openedHead, updated: timestamp(1) });
   const first = reconcile({ events: [opened], pullRequest: firstPull });
   const active = persistDispatch(first, 42_000);
-  const selection = selectionReceiptFromDispatch(active.ui.active);
+  const selection = selectionReceiptFromDispatch(active.targets.ui.active);
   const events = [opened];
   let priorHead = openedHead;
+  let currentPull = firstPull;
+  let pending = null;
+  let candidateJournal = null;
 
   for (let index = 1; index <= 38; index += 1) {
     const head = (300 + index).toString(16).padStart(40, "0");
@@ -1832,26 +2008,39 @@ test("a terminal pending owner resolves a docs-only capacity checkpoint", async 
       }),
     );
     priorHead = head;
-  }
-  const currentPull = pull({ head: priorHead, updated: timestamp(39) });
-  const pending = reconcile({
-    events,
-    selections: [selection],
-    pullRequest: currentPull,
-    existingState: active,
-  });
-  const compacted = compactPreviewJournal(
-    createPreviewJournal({
+    currentPull = pull({ head: priorHead, updated: timestamp(index + 1) });
+    pending = reconcile({
+      events,
+      selections: [selection],
+      pullRequest: currentPull,
+      existingState: active,
+    });
+    candidateJournal = createPreviewJournal({
       pr: 519,
       events,
       selections: [selection],
       state: pending.state,
-    }),
-    { pullRequest: currentPull },
+    });
+    const candidateBytes = Buffer.byteLength(
+      previewJournalBody(candidateJournal),
+      "utf8",
+    );
+    if (candidateBytes >= 41_000) {
+      assert.ok(candidateBytes < 60_000);
+      break;
+    }
+  }
+  assert.ok(pending);
+  assert.ok(candidateJournal);
+  assert.ok(
+    Buffer.byteLength(previewJournalBody(candidateJournal), "utf8") >= 41_000,
   );
-  assert.equal(compacted.checkpoint.status.state, "pending");
+  const compacted = compactPreviewJournal(candidateJournal, {
+    pullRequest: currentPull,
+  });
+  assert.equal(compacted.checkpoint.targets.ui.status.state, "pending");
   assert.equal(
-    compacted.checkpoint.pending_runtime_event.event_run_id,
+    compacted.checkpoint.targets.ui.pending_owner_event.event_run_id,
     opened.event_run_id,
   );
 
@@ -1875,10 +2064,10 @@ test("a terminal pending owner resolves a docs-only capacity checkpoint", async 
   const decision = completed.state.status_decisions.at(-1);
   assert.equal(completed.nextDispatch, null);
   assert.equal(decision.state, "success");
-  assert.match(decision.description, /^Runtime-equivalent to /);
+  assert.equal(decision.targets.ui, "deployed");
   assert.equal(decision.target_url, "https://ui-42000.vercel.app");
-  assert.equal(completed.state.ui.active, null);
-  assert.equal(completed.state.ui.retired_active.length, 0);
+  assert.equal(completed.state.targets.ui.active, null);
+  assert.equal(completed.state.targets.ui.retired_active.length, 0);
   assert.doesNotThrow(() =>
     reconcile({
       events: compacted.receipts.events,
@@ -1913,6 +2102,7 @@ test("a terminal pending owner resolves a docs-only capacity checkpoint", async 
         sha: openedHead,
         environment: "preview/ui/pr-519",
         payload: {
+          ...canonicalDeploymentBinding(),
           idempotency_key: first.nextDispatch.key,
           sha: openedHead,
           logical_target: "ui",
@@ -1952,10 +2142,10 @@ test("a terminal pending owner resolves a docs-only capacity checkpoint", async 
       state: completed.state,
     }),
   );
-  assert.equal(terminal.checkpoint.status.state, "success");
+  assert.equal(terminal.checkpoint.targets.ui.status.state, "success");
   assert.equal(terminal.checkpoint.event.head_sha, priorHead);
-  assert.equal(terminal.checkpoint.pending_owner_key_digest, null);
-  assert.equal(terminal.checkpoint.pending_runtime_event, null);
+  assert.equal(terminal.checkpoint.targets.ui.pending_owner_key_digest, null);
+  assert.equal(terminal.checkpoint.targets.ui.pending_owner_event, null);
   assert.deepEqual(terminal.receipts, {
     events: [],
     selections: [],
@@ -1976,8 +2166,11 @@ test("a capacity checkpoint carries the original attempt into the retry budget",
   const firstPull = pull({ head: openedHead, updated: timestamp(1) });
   const first = reconcile({ events, pullRequest: firstPull });
   const active = persistDispatch(first, 43_000);
-  const firstSelection = selectionReceiptFromDispatch(active.ui.active);
+  const firstSelection = selectionReceiptFromDispatch(active.targets.ui.active);
   let priorHead = openedHead;
+  let currentPull = firstPull;
+  let pending = null;
+  let candidateJournal = null;
   for (let index = 1; index <= 38; index += 1) {
     const head = (350 + index).toString(16).padStart(40, "0");
     events.push(
@@ -1991,24 +2184,37 @@ test("a capacity checkpoint carries the original attempt into the retry budget",
       }),
     );
     priorHead = head;
-  }
-  const currentPull = pull({ head: priorHead, updated: timestamp(39) });
-  const pending = reconcile({
-    events,
-    selections: [firstSelection],
-    pullRequest: currentPull,
-    existingState: active,
-  });
-  const compacted = compactPreviewJournal(
-    createPreviewJournal({
+    currentPull = pull({ head: priorHead, updated: timestamp(index + 1) });
+    pending = reconcile({
+      events,
+      selections: [firstSelection],
+      pullRequest: currentPull,
+      existingState: active,
+    });
+    candidateJournal = createPreviewJournal({
       pr: 519,
       events,
       selections: [firstSelection],
       state: pending.state,
-    }),
-    { pullRequest: currentPull },
+    });
+    const candidateBytes = Buffer.byteLength(
+      previewJournalBody(candidateJournal),
+      "utf8",
+    );
+    if (candidateBytes >= 41_000) {
+      assert.ok(candidateBytes < 60_000);
+      break;
+    }
+  }
+  assert.ok(pending);
+  assert.ok(candidateJournal);
+  assert.ok(
+    Buffer.byteLength(previewJournalBody(candidateJournal), "utf8") >= 41_000,
   );
-  assert.equal(compacted.checkpoint.pending_owner_attempt_count, 1);
+  const compacted = compactPreviewJournal(candidateJournal, {
+    pullRequest: currentPull,
+  });
+  assert.equal(compacted.checkpoint.targets.ui.pending_owner_attempt_count, 1);
   const waiting = reconcile({
     events: compacted.receipts.events,
     selections: compacted.receipts.selections,
@@ -2034,7 +2240,9 @@ test("a capacity checkpoint carries the original attempt into the retry budget",
     opened.event_run_id,
   );
   const retryActive = persistDispatch(retry, 43_001);
-  const retrySelection = selectionReceiptFromDispatch(retryActive.ui.active);
+  const retrySelection = selectionReceiptFromDispatch(
+    retryActive.targets.ui.active,
+  );
   const retryFailure = result(retry.nextDispatch, {
     runId: 43_001,
     state: "failure",
@@ -2075,15 +2283,15 @@ function unfinishedEpochs(count) {
       existingState: state,
     });
     state = persistDispatch(reconciled, 50_000 + index);
-    selections.push(selectionReceiptFromDispatch(state.ui.active));
+    selections.push(selectionReceiptFromDispatch(state.targets.ui.active));
   }
   return { events, selections, state, currentPull };
 }
 
 test("terminalized retired owners are folded before the history limit", () => {
   const setup = unfinishedEpochs(41);
-  assert.equal(setup.state.ui.retired_active.length, 40);
-  const oldest = setup.state.ui.retired_active[0];
+  assert.equal(setup.state.targets.ui.retired_active.length, 40);
+  const oldest = setup.state.targets.ui.retired_active[0];
   const terminal = result(oldest, { runId: oldest.workflow_run_id });
   const completed = reconcile({
     events: setup.events,
@@ -2092,16 +2300,16 @@ test("terminalized retired owners are folded before the history limit", () => {
     pullRequest: setup.currentPull,
     existingState: setup.state,
   });
-  assert.equal(completed.state.ui.retired_active.length, 39);
+  assert.equal(completed.state.targets.ui.retired_active.length, 39);
   assert.equal(
-    completed.state.ui.retired_active.some(
+    completed.state.targets.ui.retired_active.some(
       (selection) => selection.key_digest === oldest.key_digest,
     ),
     false,
   );
   assert.equal(
-    completed.state.ui.active.key_digest,
-    setup.state.ui.active.key_digest,
+    completed.state.targets.ui.active.key_digest,
+    setup.state.targets.ui.active.key_digest,
   );
 
   const nextHead = (541).toString(16).padStart(40, "0");
@@ -2119,9 +2327,9 @@ test("terminalized retired owners are folded before the history limit", () => {
     existingState: completed.state,
   });
   const persisted = persistDispatch(next, 50_041);
-  assert.equal(persisted.ui.retired_active.length, 40);
+  assert.equal(persisted.targets.ui.retired_active.length, 40);
   assert.equal(
-    persisted.ui.retired_active.some(
+    persisted.targets.ui.retired_active.some(
       (selection) => selection.key_digest === oldest.key_digest,
     ),
     false,
@@ -2131,8 +2339,8 @@ test("terminalized retired owners are folded before the history limit", () => {
 test("more than forty unfinished retired owners fail closed", () => {
   const setup = unfinishedEpochs(41);
   const ownershipBefore = new Set([
-    setup.state.ui.active.key_digest,
-    ...setup.state.ui.retired_active.map(({ key_digest: key }) => key),
+    setup.state.targets.ui.active.key_digest,
+    ...setup.state.targets.ui.retired_active.map(({ key_digest: key }) => key),
   ]);
   const nextHead = (541).toString(16).padStart(40, "0");
   const nextEvent = event({
@@ -2150,12 +2358,14 @@ test("more than forty unfinished retired owners fail closed", () => {
         pullRequest: pull({ head: nextHead, updated: timestamp(42) }),
         existingState: setup.state,
       }),
-    /cannot retain more than 40 unfinished retired workers/,
+    /ui has too many unfinished retired workers/,
   );
   assert.deepEqual(
     new Set([
-      setup.state.ui.active.key_digest,
-      ...setup.state.ui.retired_active.map(({ key_digest: key }) => key),
+      setup.state.targets.ui.active.key_digest,
+      ...setup.state.targets.ui.retired_active.map(
+        ({ key_digest: key }) => key,
+      ),
     ]),
     ownershipBefore,
   );
@@ -2167,25 +2377,25 @@ test("docs-only checkpoint tails preserve prior runtime terminal semantics", () 
       state: "success",
       reason: "verified",
       expectedState: "success",
-      expectedDescription: /^Runtime-equivalent to /,
+      expectedOutcome: "runtime-equivalent",
     },
     {
       state: "failure",
       reason: "worker-failure",
       expectedState: "failure",
-      expectedDescription: /^Runtime preview .* failed$/,
+      expectedOutcome: "failed",
     },
     {
       state: "error",
       reason: "worker-failure",
       expectedState: "error",
-      expectedDescription: /^Runtime preview .* errored$/,
+      expectedOutcome: "error",
     },
     {
       state: "error",
       reason: "worker-cancelled",
       expectedState: "failure",
-      expectedDescription: /^Runtime preview .* was cancelled$/,
+      expectedOutcome: "failed",
     },
   ];
 
@@ -2202,7 +2412,7 @@ test("docs-only checkpoint tails preserve prior runtime terminal semantics", () 
     });
     const workerRunId = 31_000 + index;
     const active = persistDispatch(selected, workerRunId);
-    const selection = selectionReceiptFromDispatch(active.ui.active);
+    const selection = selectionReceiptFromDispatch(active.targets.ui.active);
     const terminal = result(selected.nextDispatch, {
       runId: workerRunId,
       state: terminalCase.state,
@@ -2235,8 +2445,10 @@ test("docs-only checkpoint tails preserve prior runtime terminal semantics", () 
     });
     if (terminalCase.state === "success") {
       const baselineWithoutBuildEvidence = structuredClone(journal.state);
-      baselineWithoutBuildEvidence.ui.last_successful_runtime_sha = null;
-      baselineWithoutBuildEvidence.ui.last_successful_runtime_url = null;
+      baselineWithoutBuildEvidence.targets.ui.last_successful_runtime_sha =
+        null;
+      baselineWithoutBuildEvidence.targets.ui.last_successful_runtime_url =
+        null;
       const syntheticReplay = reconcile({
         events: [firstDocs],
         pullRequest: pull({ head: SHA.B, updated: timestamp(2) }),
@@ -2245,10 +2457,16 @@ test("docs-only checkpoint tails preserve prior runtime terminal semantics", () 
       });
       assert.match(
         syntheticReplay.state.status_decisions.at(-1).description,
-        /^Runtime-equivalent to /,
+        /ui=equivalent/,
       );
-      assert.equal(syntheticReplay.state.ui.last_successful_runtime_sha, null);
-      assert.equal(syntheticReplay.state.ui.last_successful_runtime_url, null);
+      assert.equal(
+        syntheticReplay.state.targets.ui.last_successful_runtime_sha,
+        null,
+      );
+      assert.equal(
+        syntheticReplay.state.targets.ui.last_successful_runtime_url,
+        null,
+      );
     }
     const firstDocsState = reconcile({
       events: [firstDocs],
@@ -2287,7 +2505,7 @@ test("docs-only checkpoint tails preserve prior runtime terminal semantics", () 
     assert.equal(secondDocsState.nextDispatch, null);
     assert.equal(decision.sha, SHA.C);
     assert.equal(decision.state, terminalCase.expectedState);
-    assert.match(decision.description, terminalCase.expectedDescription);
+    assert.equal(decision.targets.ui, terminalCase.expectedOutcome);
     assert.equal(
       decision.target_url,
       terminalCase.state === "success"
@@ -2330,7 +2548,7 @@ test("docs-only checkpoint tails preserve prior runtime terminal semantics", () 
   });
   assert.equal(
     laterDocsState.state.status_decisions.at(-1).description,
-    "No UI runtime impact",
+    "app=none; governance=none; reserve=none; ui=none",
   );
 });
 
@@ -2472,8 +2690,12 @@ function journalWithState(
   state,
   {
     revision = 1,
-    selections = state?.ui?.active
-      ? [selectionReceiptFromDispatch(state.ui.active)]
+    selections = state
+      ? PREVIEW_TARGETS.flatMap((target) =>
+          state.targets[target]?.active
+            ? [selectionReceiptFromDispatch(state.targets[target].active)]
+            : [],
+        )
       : [],
     workerEvidence = [],
     results = [],
@@ -2491,6 +2713,13 @@ function oldReceiptComment(marker, value, id = 99) {
     id,
     user: { type: "Bot", login: "github-actions[bot]" },
     body: `${marker}\n\n\`\`\`json\n${JSON.stringify(value, null, 2)}\n\`\`\`\n`,
+  };
+}
+
+function canonicalDeploymentBinding() {
+  return {
+    controller_schema: "mento-vercel-prebuilt/v2",
+    provenance: "preview-controller:v2",
   };
 }
 
@@ -2515,6 +2744,7 @@ function workerRun(
     run_attempt: attempt,
     display_title: workerRunName({
       pr: selection.pr,
+      target: selection.target,
       sha: selection.sha,
       keyDigest: selection.key_digest,
     }),
@@ -2585,7 +2815,7 @@ function dependabotIntakeRun({
 function workerInputs(selection) {
   return {
     pull_request_number: String(selection.pr),
-    target: "ui",
+    target: selection.target,
     commit_sha: selection.sha,
     git_branch: selection.git_ref,
     controller_key: selection.key,
@@ -2684,9 +2914,12 @@ function sameShaReopenIntentState() {
     pullRequest: pull({ head: SHA.A, updated: timestamp(3) }),
     existingState: closedState.state,
   });
-  assert.equal(current.state.ui.active, null);
-  assert.equal(current.state.ui.retired_active.length, 1);
-  assert.equal(current.state.ui.retired_active[0].dispatch_state, "intended");
+  assert.equal(current.state.targets.ui.active, null);
+  assert.equal(current.state.targets.ui.retired_active.length, 1);
+  assert.equal(
+    current.state.targets.ui.retired_active[0].dispatch_state,
+    "intended",
+  );
   return {
     events: [opened, closed, reopened],
     old,
@@ -2883,6 +3116,30 @@ function fakeGitHub({
       repos: {
         getContent: async (request) => {
           contentRequests.push(structuredClone(request));
+          const target = PREVIEW_TARGETS.find(
+            (candidate) =>
+              PREVIEW_TARGET_CONFIG[candidate].vercelConfigurationPath ===
+              request.path,
+          );
+          assert.ok(
+            target,
+            "fixture content request must target Vercel config",
+          );
+          if (target !== "ui") {
+            const configuration =
+              PREVIEW_TARGET_CONFIG[target].nativeVercelConfiguration;
+            const text = `${JSON.stringify(configuration, null, 2)}\n`;
+            const content = Buffer.from(text, "utf8");
+            return {
+              data: {
+                type: "file",
+                path: request.path,
+                encoding: "base64",
+                size: content.length,
+                content: content.toString("base64"),
+              },
+            };
+          }
           if (uiVercelContentErrorStatus) {
             const error = new Error("fixture repository content read failed");
             error.status = uiVercelContentErrorStatus;
@@ -2892,9 +3149,13 @@ function fakeGitHub({
             return { data: structuredClone(uiVercelContentResponse) };
           }
           const configuration =
-            (transientUiVercelConfigurations.length > 0
-              ? transientUiVercelConfigurations.shift()
-              : configurationsByRef.get(request.ref)) ?? uiVercelConfiguration;
+            (configurationsByRef.has(request.ref)
+              ? configurationsByRef.get(request.ref)
+              : request.ref === SHA.E
+                ? GITHUB_OWNED_UI_VERCEL_CONFIGURATION
+                : transientUiVercelConfigurations.length > 0
+                  ? transientUiVercelConfigurations.shift()
+                  : uiVercelConfiguration) ?? uiVercelConfiguration;
           const text =
             typeof configuration === "string"
               ? configuration
@@ -2903,7 +3164,7 @@ function fakeGitHub({
           return {
             data: {
               type: "file",
-              path: UI_VERCEL_CONFIGURATION_PATH,
+              path: request.path,
               encoding: "base64",
               size: content.length,
               content: content.toString("base64"),
@@ -3021,6 +3282,7 @@ function fakeGitHub({
       const id = 8_000 + dispatches.length;
       const selection = {
         pr: Number(request.inputs.pull_request_number),
+        target: request.inputs.target,
         sha: request.inputs.commit_sha,
         key_digest: request.inputs.controller_key_digest,
         expected_workflow_sha: request.inputs.expected_workflow_sha,
@@ -3096,6 +3358,21 @@ function previewCommitStatuses(decisions) {
     ]);
   }
   return statuses;
+}
+
+function nativeUiAggregateStatus(sha, runId) {
+  return {
+    sha,
+    state: "success",
+    description: "app=none; governance=none; reserve=none; ui=native",
+    target_url: `https://github.com/${PREVIEW_REPOSITORY}/actions/runs/${runId}`,
+    targets: {
+      app: "not affected",
+      governance: "not affected",
+      reserve: "not affected",
+      ui: "native-owned",
+    },
+  };
 }
 
 async function assertSettledReplayIsIdempotent({
@@ -3174,7 +3451,7 @@ test("settled reconcile replays preserve journal and status intent across termin
     const pullRequest = pull({ head: SHA.A, updated: timestamp(1) });
     const selected = reconcile({ events: [opened], pullRequest });
     const active = persistDispatch(selected, runId + 1);
-    const selection = selectionReceiptFromDispatch(active.ui.active);
+    const selection = selectionReceiptFromDispatch(active.targets.ui.active);
     const terminalResult = result(selected.nextDispatch, {
       runId: runId + 1,
       ...terminal,
@@ -3261,7 +3538,7 @@ test("settled reconcile replays preserve journal and status intent across termin
   const burstPull = pull({ head: SHA.C, updated: timestamp(3) });
   const selectedA = reconcile({ events: burst, pullRequest: burstPull });
   const activeA = persistDispatch(selectedA, 7_223);
-  const selectionA = selectionReceiptFromDispatch(activeA.ui.active);
+  const selectionA = selectionReceiptFromDispatch(activeA.targets.ui.active);
   const resultA = result(selectedA.nextDispatch, { runId: 7_223 });
   const selectedC = reconcile({
     events: burst,
@@ -3271,7 +3548,7 @@ test("settled reconcile replays preserve journal and status intent across termin
     existingState: activeA,
   });
   const activeC = persistDispatch(selectedC, 7_224);
-  const selectionC = selectionReceiptFromDispatch(activeC.ui.active);
+  const selectionC = selectionReceiptFromDispatch(activeC.targets.ui.active);
   const resultC = result(selectedC.nextDispatch, { runId: 7_224 });
   const burstState = reconcile({
     events: burst,
@@ -3280,7 +3557,7 @@ test("settled reconcile replays preserve journal and status intent across termin
     pullRequest: burstPull,
     existingState: activeC,
   }).state;
-  assert.match(burstState.status_decisions[1].description, /Coalesced/);
+  assert.match(burstState.status_decisions[1].description, /ui=coalesced/);
   await assertSettledReplayIsIdempotent({
     events: burst,
     pullRequest: burstPull,
@@ -3430,7 +3707,7 @@ test("reconcile still publishes genuine terminal changes and repairs a missing s
   const pullRequest = pull({ head: SHA.A, updated: timestamp(1) });
   const selected = reconcile({ events: [opened], pullRequest });
   const active = persistDispatch(selected, 7_301);
-  const selection = selectionReceiptFromDispatch(active.ui.active);
+  const selection = selectionReceiptFromDispatch(active.targets.ui.active);
   const terminalResult = result(selected.nextDispatch, {
     runId: 7_301,
     state: "failure",
@@ -3580,7 +3857,7 @@ test("malformed successful planner output is recorded as fail-closed UI impact",
     planRaw: '{"deployments":["ui"],"base":"wrong"}',
     plannerOutcome: "success",
   });
-  assert.deepEqual(receipt.plan.targets, ["ui"]);
+  assert.deepEqual(receipt.plan.targets, PREVIEW_TARGETS);
   assert.equal(receipt.plan.reason, "planner-job-failed");
   assert.equal(receipt.plan.base, SHA.E);
   assert.equal(receipt.plan.head, SHA.A);
@@ -3654,7 +3931,7 @@ test("closed event receipt keeps one stable idempotent journal and publishes no 
   assert.equal(journalFromComment(fixture.comments[0]).revision, 2);
   assert.deepEqual(
     fixture.commitStatuses.map(({ context, state }) => ({ context, state })),
-    [{ context: "Vercel Preview Journal / PR #519", state: "success" }],
+    [{ context: "Vercel Preview Journal v2 / PR #519", state: "success" }],
   );
 
   const malformedComment = journalComment({ events: [opened, first] });
@@ -3736,7 +4013,7 @@ test("a missing close fails closed when its head proves prior journal initializa
         SHA.A,
         [
           {
-            context: "Vercel Preview Journal / PR #519",
+            context: "Vercel Preview Journal v2 / PR #519",
             state: "success",
           },
         ],
@@ -3807,7 +4084,9 @@ test("initialization witnesses advance with every head and block recreation afte
 
   assert.deepEqual(
     fixture.commitStatuses
-      .filter(({ context }) => context === "Vercel Preview Journal / PR #519")
+      .filter(
+        ({ context }) => context === "Vercel Preview Journal v2 / PR #519",
+      )
       .map(({ sha }) => sha),
     [SHA.A, SHA.B],
   );
@@ -3874,7 +4153,7 @@ test("a rerun repairs a witness after its first status write fails", async () =>
   assert.deepEqual(
     fixture.commitStatuses.map(({ context, state }) => ({ context, state })),
     [
-      { context: "Vercel Preview Journal / PR #519", state: "success" },
+      { context: "Vercel Preview Journal v2 / PR #519", state: "success" },
       { context: "Vercel Preview", state: "pending" },
     ],
   );
@@ -3963,7 +4242,7 @@ test("the first receipt after a terminal checkpoint remains live for reconciliat
   const firstPull = pull({ head: SHA.A, updated: timestamp(1) });
   const selected = reconcile({ events: [opened], pullRequest: firstPull });
   const active = persistDispatch(selected, 60_000);
-  const selection = selectionReceiptFromDispatch(active.ui.active);
+  const selection = selectionReceiptFromDispatch(active.targets.ui.active);
   const terminalResult = result(selected.nextDispatch, { runId: 60_000 });
   const terminalState = reconcile({
     events: [opened],
@@ -4029,7 +4308,7 @@ test("queued receipts after a terminal checkpoint preserve every transition", as
   const firstPull = pull({ head: SHA.A, updated: timestamp(1) });
   const selected = reconcile({ events: [opened], pullRequest: firstPull });
   const active = persistDispatch(selected, 61_000);
-  const selection = selectionReceiptFromDispatch(active.ui.active);
+  const selection = selectionReceiptFromDispatch(active.targets.ui.active);
   const terminalResult = result(selected.nextDispatch, { runId: 61_000 });
   const terminalState = reconcile({
     events: [opened],
@@ -4295,7 +4574,7 @@ test("a first-attempt synchronize can initialize only without durable status evi
       state,
     })),
     [
-      { context: "Vercel Preview Journal / PR #519", state: "success" },
+      { context: "Vercel Preview Journal v2 / PR #519", state: "success" },
       { context: "Vercel Preview", state: "pending" },
     ],
   );
@@ -4322,7 +4601,7 @@ test("a first-attempt synchronize can initialize only without durable status evi
     core: fakeCore(),
     prNumber: 519,
   });
-  assert.equal(recovered.ui.active.selection_receipt_run_id, 121);
+  assert.equal(recovered.targets.ui.active.selection_receipt_run_id, 121);
 
   const rerun = fakeGitHub({
     pullRequest: pull({ head: opened.head_sha, updated: opened.pr_updated_at }),
@@ -4349,7 +4628,7 @@ test("a first-attempt synchronize can initialize only without durable status evi
         synchronize.change_base_sha,
         [
           {
-            context: "Vercel Preview Journal / PR #518",
+            context: "Vercel Preview Journal v2 / PR #518",
             state: "success",
           },
         ],
@@ -4377,7 +4656,7 @@ test("a first-attempt synchronize can initialize only without durable status evi
         synchronize.change_base_sha,
         [
           {
-            context: "Vercel Preview Journal / PR #519",
+            context: "Vercel Preview Journal v2 / PR #519",
             state: "success",
           },
         ],
@@ -4477,8 +4756,8 @@ test("malformed and oversized preview journals fail closed without mutation", as
   };
   const noncanonical = journalComment({ events: [opened] });
   noncanonical.body = noncanonical.body.replace(
-    '  "schema": "vercel-preview-journal:v1",',
-    '    "schema": "vercel-preview-journal:v1",',
+    '  "schema": "vercel-preview-journal:v2",',
+    '    "schema": "vercel-preview-journal:v2",',
   );
 
   for (const [comment, message] of [
@@ -4569,7 +4848,7 @@ test("closed reconciliation preserves an unbound intent without dispatching it",
     comments: [
       journalComment({
         events: [opened, closed],
-        selections: [selectionReceiptFromDispatch(intended.ui.active)],
+        selections: [selectionReceiptFromDispatch(intended.targets.ui.active)],
         state: intended,
       }),
     ],
@@ -4864,6 +5143,45 @@ test("worker preflight rejects expected A versus actual B before any API access"
   assert.equal(apiCalls, 0);
 });
 
+test("worker preflight permits GitHub canaries for every native-owned shadow target", async () => {
+  for (const [index, target] of ["app", "governance", "reserve"].entries()) {
+    const opened = event({
+      run: 116 + index,
+      action: "opened",
+      head: SHA.A,
+      updated: timestamp(1),
+      targets: [target],
+    });
+    const pullRequest = pull({ head: SHA.A, updated: timestamp(1) });
+    const selected = reconcile({ events: [opened], pullRequest });
+    const dispatch = selected.nextDispatches.find(
+      (candidate) => candidate.target === target,
+    );
+    assert.ok(dispatch);
+    const intended = persistAllIntents(selected);
+    const fixture = fakeGitHub({
+      pullRequest,
+      comments: [journalWithState([opened], intended)],
+    });
+    const core = fakeCore();
+
+    const decision = await validateWorkerDispatch({
+      github: fixture.github,
+      context: fakeContext({ runId: 8_000 + index }),
+      core,
+      inputs: workerInputs(dispatch),
+    });
+
+    assert.equal(decision.shouldDeploy, true);
+    assert.equal(core.outputs.get("should_deploy"), "true");
+    assert.equal(fixture.deploymentLookupCallCount, 1);
+    assert.deepEqual(
+      fixture.contentRequests.map(({ path, ref }) => [path, ref]),
+      [[PREVIEW_TARGET_CONFIG[target].vercelConfigurationPath, SHA.A]],
+    );
+  }
+});
+
 test("worker preflight rechecks the immutable selected SHA ownership before deployment work", async () => {
   const opened = event({
     run: 120,
@@ -4903,7 +5221,7 @@ test("worker preflight rechecks the immutable selected SHA ownership before depl
       core,
       inputs: workerInputs(selected.nextDispatch),
     }),
-    /does not own the selected UI configuration/,
+    /not allowed for the selected ui configuration/,
   );
 
   assert.deepEqual(
@@ -4954,7 +5272,7 @@ test("worker preflight rejects native-owned current head before deployment looku
       core,
       inputs: workerInputs(selected.nextDispatch),
     }),
-    /does not own the current UI configuration/,
+    /not allowed for the current ui configuration/,
   );
 
   assert.deepEqual(
@@ -4998,12 +5316,12 @@ test("durable dispatch persists intent and waits for the exact run title to mate
     fixture.primaryRequests.some(({ route }) => route.includes("/dispatches")),
     false,
   );
-  assert.equal(state.ui.active.dispatch_state, "dispatched");
-  assert.equal(state.ui.active.workflow_run_id, 8_000);
-  assert.equal(state.ui.active.workflow_sha, SHA.E);
+  assert.equal(state.targets.ui.active.dispatch_state, "dispatched");
+  assert.equal(state.targets.ui.active.workflow_run_id, 8_000);
+  assert.equal(state.targets.ui.active.workflow_sha, SHA.E);
   assert.deepEqual(waits, [500, 500, ...Array(10).fill(1_000)]);
   assert.deepEqual(fixture.workflowRunRequests, Array(11).fill(8_000));
-  assert.equal(core.outputs.get("dispatched_run_id"), "8000");
+  assert.equal(core.outputs.get("dispatched_run_ids"), "[8000]");
   assert.equal(fixture.commitStatuses.at(-1).context, "Vercel Preview");
   assert.equal(fixture.commitStatuses.at(-1).sha, SHA.A);
   assert.equal(fixture.comments.length, 1);
@@ -5015,13 +5333,12 @@ test("durable dispatch persists intent and waits for the exact run title to mate
   const journal = journalFromComment(fixture.comments[0]);
   assert.deepEqual(journal.receipts.events, [opened]);
   assert.equal(journal.receipts.selections.length, 1);
-  assert.equal(journal.state.ui.active.dispatch_state, "dispatched");
-  assert.ok(fixture.contentRequests.length >= 3);
-  assert.ok(
-    fixture.contentRequests.every(
-      ({ path, ref }) => path === UI_VERCEL_CONFIGURATION_PATH && ref === SHA.A,
-    ),
-  );
+  assert.equal(journal.state.targets.ui.active.dispatch_state, "dispatched");
+  const uiConfigurationRefs = fixture.contentRequests
+    .filter(({ path }) => path === UI_VERCEL_CONFIGURATION_PATH)
+    .map(({ ref }) => ref);
+  assert.ok(uiConfigurationRefs.length >= 3);
+  assert.deepEqual(new Set(uiConfigurationRefs), new Set([SHA.E, SHA.A]));
 });
 
 test("a native-owned receipt followed by a GitHub-owned head retires A and dispatches only B", async () => {
@@ -5059,8 +5376,8 @@ test("a native-owned receipt followed by a GitHub-owned head retires A and dispa
   assert.equal(fixture.dispatches.length, 1);
   assert.equal(fixture.workerDispatchRequests.length, 1);
   assert.equal(fixture.dispatches[0].inputs.commit_sha, SHA.B);
-  assert.equal(state.ui.active.sha, SHA.B);
-  assert.equal(state.ui.active.dispatch_state, "dispatched");
+  assert.equal(state.targets.ui.active.sha, SHA.B);
+  assert.equal(state.targets.ui.active.dispatch_state, "dispatched");
   const journal = journalFromComment(fixture.comments[0]);
   assert.equal(journal.receipts.results.length, 1);
   assert.equal(journal.receipts.results[0].sha, SHA.A);
@@ -5119,21 +5436,15 @@ test("native A through docs-only C stays native until only GitHub-owned B dispat
   assert.equal(fixture.dispatches.length, 1);
   assert.equal(fixture.workerDispatchRequests.length, 1);
   assert.equal(fixture.dispatches[0].inputs.commit_sha, SHA.B);
-  assert.equal(state.ui.active.sha, SHA.B);
-  assert.equal(state.ui.active.dispatch_state, "dispatched");
-  assert.equal(state.ui.last_successful_runtime_sha, null);
-  assert.equal(state.ui.last_successful_runtime_url, null);
+  assert.equal(state.targets.ui.active.sha, SHA.B);
+  assert.equal(state.targets.ui.active.dispatch_state, "dispatched");
+  assert.equal(state.targets.ui.last_successful_runtime_sha, null);
+  assert.equal(state.targets.ui.last_successful_runtime_url, null);
   const statusBySha = new Map(
     state.status_decisions.map((status) => [status.sha, status]),
   );
   for (const sha of [SHA.A, SHA.C]) {
-    assert.deepEqual(statusBySha.get(sha), {
-      sha,
-      state: "success",
-      description: "Native Vercel owns this UI preview",
-      target_url:
-        "https://github.com/mento-protocol/frontend-monorepo/actions/runs/7000",
-    });
+    assert.deepEqual(statusBySha.get(sha), nativeUiAggregateStatus(sha, 7_000));
   }
   assert.equal(statusBySha.get(SHA.B).state, "pending");
   const journal = journalFromComment(fixture.comments[0]);
@@ -5172,7 +5483,7 @@ test("sequential native ownership checkpoints through docs-only C before only Gi
   const pullC = pull({ head: SHA.C, updated: timestamp(2) });
   const fixture = fakeGitHub({
     pullRequest: pullC,
-    pullRequests: [pullA],
+    pullRequests: [pullA, pullA, pullA, pullA],
     pullCommits: [SHA.A, SHA.C],
     comments: [journalComment({ events: [opened] })],
     uiVercelConfigurationsByRef: new Map([
@@ -5190,16 +5501,10 @@ test("sequential native ownership checkpoints through docs-only C before only Gi
   });
   assert.equal(fixture.dispatches.length, 0);
   assert.equal(fixture.deployments.length, 0);
-  assert.equal(nativeA.ui.last_successful_runtime_sha, null);
-  assert.equal(nativeA.ui.last_successful_runtime_url, null);
+  assert.equal(nativeA.targets.ui.last_successful_runtime_sha, null);
+  assert.equal(nativeA.targets.ui.last_successful_runtime_url, null);
   assert.deepEqual(nativeA.status_decisions, [
-    {
-      sha: SHA.A,
-      state: "success",
-      description: "Native Vercel owns this UI preview",
-      target_url:
-        "https://github.com/mento-protocol/frontend-monorepo/actions/runs/7001",
-    },
+    nativeUiAggregateStatus(SHA.A, 7_001),
   ]);
   const externalNativeA = fixture.commitStatuses.at(-1);
   assert.deepEqual(
@@ -5209,7 +5514,12 @@ test("sequential native ownership checkpoints through docs-only C before only Gi
       description: externalNativeA.description,
       target_url: externalNativeA.target_url,
     },
-    nativeA.status_decisions[0],
+    {
+      sha: nativeA.status_decisions[0].sha,
+      state: nativeA.status_decisions[0].state,
+      description: nativeA.status_decisions[0].description,
+      target_url: nativeA.status_decisions[0].target_url,
+    },
   );
 
   await recordEventReceipt({
@@ -5220,16 +5530,16 @@ test("sequential native ownership checkpoints through docs-only C before only Gi
   });
   let journal = journalFromComment(fixture.comments[0]);
   assert.equal(journal.checkpoint.event.head_sha, SHA.A);
-  assert.equal(journal.checkpoint.status.state, "success");
+  assert.equal(journal.checkpoint.targets.ui.status.state, "success");
   assert.equal(
-    journal.checkpoint.status.description,
-    "Native Vercel owns this UI preview",
+    journal.checkpoint.targets.ui.status.description,
+    "ui: native Vercel owns preview",
   );
   assert.deepEqual(journal.receipts.events, [docsOnly]);
   for (const status of [
-    { ...journal.checkpoint.status, state: "failure" },
+    { ...journal.checkpoint.targets.ui.status, state: "failure" },
     {
-      ...journal.checkpoint.status,
+      ...journal.checkpoint.targets.ui.status,
       target_url: "https://example.com/actions/runs/7001",
     },
   ]) {
@@ -5238,14 +5548,20 @@ test("sequential native ownership checkpoints through docs-only C before only Gi
         createPreviewJournal({
           pr: 519,
           revision: journal.revision,
-          checkpoint: { ...journal.checkpoint, status },
+          checkpoint: {
+            ...journal.checkpoint,
+            targets: {
+              ...journal.checkpoint.targets,
+              ui: { ...journal.checkpoint.targets.ui, status },
+            },
+          },
           events: journal.receipts.events,
           selections: journal.receipts.selections,
           workerEvidence: journal.receipts.worker_evidence,
           results: journal.receipts.results,
           state: journal.state,
         }),
-      /native ownership status is invalid/,
+      /ui checkpoint native ownership status is invalid/,
     );
   }
   assert.throws(
@@ -5255,9 +5571,15 @@ test("sequential native ownership checkpoints through docs-only C before only Gi
         revision: journal.revision,
         checkpoint: {
           ...journal.checkpoint,
-          status: {
-            ...journal.checkpoint.status,
-            description: "Draining GitHub preview before native ownership",
+          targets: {
+            ...journal.checkpoint.targets,
+            ui: {
+              ...journal.checkpoint.targets.ui,
+              status: {
+                ...journal.checkpoint.targets.ui.status,
+                description: "Draining GitHub preview before native ownership",
+              },
+            },
           },
         },
         events: journal.receipts.events,
@@ -5266,7 +5588,7 @@ test("sequential native ownership checkpoints through docs-only C before only Gi
         results: journal.receipts.results,
         state: journal.state,
       }),
-    /native ownership drain status is invalid/,
+    /ui checkpoint native ownership status is invalid/,
   );
 
   const nativeC = await reconcilePreview({
@@ -5278,15 +5600,12 @@ test("sequential native ownership checkpoints through docs-only C before only Gi
   });
   assert.equal(fixture.dispatches.length, 0);
   assert.equal(fixture.deployments.length, 0);
-  assert.equal(nativeC.ui.last_successful_runtime_sha, null);
-  assert.equal(nativeC.ui.last_successful_runtime_url, null);
-  assert.deepEqual(nativeC.status_decisions.at(-1), {
-    sha: SHA.C,
-    state: "success",
-    description: "Native Vercel owns this UI preview",
-    target_url:
-      "https://github.com/mento-protocol/frontend-monorepo/actions/runs/7002",
-  });
+  assert.equal(nativeC.targets.ui.last_successful_runtime_sha, null);
+  assert.equal(nativeC.targets.ui.last_successful_runtime_url, null);
+  assert.deepEqual(
+    nativeC.status_decisions.at(-1),
+    nativeUiAggregateStatus(SHA.C, 7_002),
+  );
 
   journal = journalFromComment(fixture.comments[0]);
   const pullB = pull({ head: SHA.B, updated: timestamp(3) });
@@ -5316,18 +5635,21 @@ test("sequential native ownership checkpoints through docs-only C before only Gi
   });
   const beforeGitHubReconcile = journalFromComment(githubFixture.comments[0]);
   assert.equal(beforeGitHubReconcile.checkpoint.event.head_sha, SHA.C);
-  assert.equal(beforeGitHubReconcile.checkpoint.status.state, "success");
   assert.equal(
-    beforeGitHubReconcile.checkpoint.status.description,
-    "Native Vercel owns this UI preview",
+    beforeGitHubReconcile.checkpoint.targets.ui.status.state,
+    "success",
+  );
+  assert.equal(
+    beforeGitHubReconcile.checkpoint.targets.ui.status.description,
+    "ui: native Vercel owns preview",
   );
   assert.deepEqual(beforeGitHubReconcile.receipts.events, [synchronized]);
   assert.equal(
-    beforeGitHubReconcile.state.ui.last_successful_runtime_sha,
+    beforeGitHubReconcile.state.targets.ui.last_successful_runtime_sha,
     null,
   );
   assert.equal(
-    beforeGitHubReconcile.state.ui.last_successful_runtime_url,
+    beforeGitHubReconcile.state.targets.ui.last_successful_runtime_url,
     null,
   );
   const githubB = await reconcilePreview({
@@ -5341,22 +5663,22 @@ test("sequential native ownership checkpoints through docs-only C before only Gi
   assert.equal(githubFixture.workerDispatchRequests.length, 1);
   assert.equal(githubFixture.dispatches[0].inputs.commit_sha, SHA.B);
   assert.equal(githubFixture.deployments.length, 0);
-  assert.equal(githubB.ui.active.sha, SHA.B);
-  assert.equal(githubB.ui.last_successful_runtime_sha, null);
-  assert.equal(githubB.ui.last_successful_runtime_url, null);
+  assert.equal(githubB.targets.ui.active.sha, SHA.B);
+  assert.equal(githubB.targets.ui.last_successful_runtime_sha, null);
+  assert.equal(githubB.targets.ui.last_successful_runtime_url, null);
   assert.deepEqual(githubB.status_decisions, [
-    {
-      sha: SHA.C,
-      state: "success",
-      description: "Native Vercel owns this UI preview",
-      target_url:
-        "https://github.com/mento-protocol/frontend-monorepo/actions/runs/7002",
-    },
+    nativeUiAggregateStatus(SHA.C, 7_002),
     {
       sha: SHA.B,
       state: "pending",
-      description: "UI preview queued or running",
-      target_url: githubB.ui.active.html_url,
+      description: "app=none; governance=none; reserve=none; ui=pending",
+      target_url: githubB.targets.ui.active.html_url,
+      targets: {
+        app: "not affected",
+        governance: "not affected",
+        reserve: "not affected",
+        ui: "pending",
+      },
     },
   ]);
   const finalJournal = journalFromComment(githubFixture.comments[0]);
@@ -5409,16 +5731,13 @@ test("native no-dispatch status selects the latest current-head decision after a
     ({ sha }) => sha === SHA.A,
   );
   assert.equal(repeatedHeadDecisions.length, 2);
-  assert.equal(repeatedHeadDecisions[0].state, "pending");
-  assert.deepEqual(repeatedHeadDecisions[1], {
-    sha: SHA.A,
-    state: "success",
-    description: "Native Vercel owns this UI preview",
-    target_url:
-      "https://github.com/mento-protocol/frontend-monorepo/actions/runs/7004",
-  });
   assert.deepEqual(
-    fixture.commitStatuses.at(-1).description,
+    repeatedHeadDecisions[1],
+    nativeUiAggregateStatus(SHA.A, 7_004),
+  );
+  assert.deepEqual(
+    fixture.commitStatuses.filter(({ sha }) => sha === SHA.A).at(-1)
+      .description,
     repeatedHeadDecisions[1].description,
   );
 });
@@ -5449,7 +5768,7 @@ test("generic no-dispatch retirement does not claim native ownership of a GitHub
   const advanced = reconcile({
     events: [opened, synchronized],
     results: [retired],
-    selections: [selectionReceiptFromDispatch(intended.ui.active)],
+    selections: [selectionReceiptFromDispatch(intended.targets.ui.active)],
     pullRequest,
     existingState: intended,
   });
@@ -5458,9 +5777,10 @@ test("generic no-dispatch retirement does not claim native ownership of a GitHub
     ({ sha }) => sha === SHA.A,
   );
   assert.equal(statusA.state, "error");
+  assert.equal(statusA.targets.ui, "error");
   assert.equal(
     statusA.description,
-    "UI preview controller or infrastructure error",
+    "app=none; governance=none; reserve=none; ui=error",
   );
   assert.doesNotMatch(statusA.description, /Native Vercel/);
 });
@@ -5514,7 +5834,7 @@ test("selected-native retirement keeps unrelated retired GitHub ownership generi
     existingState: closedState.state,
   });
   assert.equal(selected.nextDispatch.sha, SHA.A);
-  assert.equal(selected.state.ui.retired_active[0].sha, SHA.C);
+  assert.equal(selected.state.targets.ui.retired_active[0].sha, SHA.C);
   const intended = persistIntent(selected);
   const fixture = fakeGitHub({
     pullRequest,
@@ -5522,8 +5842,8 @@ test("selected-native retirement keeps unrelated retired GitHub ownership generi
     comments: [
       journalWithState(events, intended, {
         selections: [
-          selectionReceiptFromDispatch(intended.ui.retired_active[0]),
-          selectionReceiptFromDispatch(intended.ui.active),
+          selectionReceiptFromDispatch(intended.targets.ui.retired_active[0]),
+          selectionReceiptFromDispatch(intended.targets.ui.active),
         ],
       }),
     ],
@@ -5544,7 +5864,7 @@ test("selected-native retirement keeps unrelated retired GitHub ownership generi
 
   assert.equal(fixture.dispatches.length, 1);
   assert.equal(fixture.dispatches[0].inputs.commit_sha, SHA.B);
-  assert.equal(state.ui.active.sha, SHA.B);
+  assert.equal(state.targets.ui.active.sha, SHA.B);
   const resultsBySha = new Map(
     journalFromComment(fixture.comments[0]).receipts.results.map((entry) => [
       entry.sha,
@@ -5601,9 +5921,9 @@ test("a native-owned historical receipt attaches its crash-window worker instead
   assert.equal(fixture.dispatches.length, 0);
   assert.equal(fixture.workerDispatchRequests.length, 0);
   assert.equal(core.outputs.get("recovered_intended_run_id"), "8000");
-  assert.equal(state.ui.active.sha, SHA.A);
-  assert.equal(state.ui.active.dispatch_state, "dispatched");
-  assert.equal(state.ui.active.workflow_run_id, 8_000);
+  assert.equal(state.targets.ui.active.sha, SHA.A);
+  assert.equal(state.targets.ui.active.dispatch_state, "dispatched");
+  assert.equal(state.targets.ui.active.workflow_run_id, 8_000);
   assert.equal(
     journalFromComment(fixture.comments[0]).receipts.results.length,
     0,
@@ -5658,7 +5978,7 @@ for (const [name, configuration, message] of [
     assert.equal(fixture.commitStatuses.at(-1).state, "error");
     assert.deepEqual(
       new Set(fixture.contentRequests.map(({ ref }) => ref)),
-      new Set([SHA.A, SHA.B]),
+      new Set([SHA.E, SHA.A, SHA.B]),
     );
   });
 }
@@ -5697,15 +6017,16 @@ test("a GitHub-owned receipt followed by a native-owned head never dispatches th
 
   assert.equal(fixture.dispatches.length, 0);
   assert.equal(fixture.workerDispatchRequests.length, 0);
-  assert.equal(state.ui.active, null);
-  assert.deepEqual(
-    fixture.contentRequests.map(({ ref }) => ref),
-    [SHA.B],
-  );
+  assert.equal(state.targets.ui.active, null);
+  const uiConfigurationRefs = fixture.contentRequests
+    .filter(({ path }) => path === UI_VERCEL_CONFIGURATION_PATH)
+    .map(({ ref }) => ref);
+  assert.ok(uiConfigurationRefs.includes(SHA.B));
+  assert.equal(uiConfigurationRefs.includes(SHA.A), false);
   assert.equal(fixture.commitStatuses.at(-1).state, "success");
   assert.equal(
     fixture.commitStatuses.at(-1).description,
-    "Native Vercel owns this UI preview",
+    "app=none; governance=none; reserve=none; ui=native",
   );
 });
 
@@ -5731,29 +6052,32 @@ test("active controller defers an exact native-config rollback head without a di
     prNumber: 519,
   });
 
-  assert.equal(state.ui.active, null);
-  assert.equal(state.ui.latest_desired_sha, SHA.A);
+  assert.equal(state.targets.ui.active, null);
+  assert.equal(state.targets.ui.latest_desired_sha, SHA.A);
   assert.equal(fixture.dispatches.length, 0);
   assert.equal(fixture.workerDispatchRequests.length, 0);
-  assert.deepEqual(fixture.contentRequests, [
-    {
-      owner: "mento-protocol",
-      repo: "frontend-monorepo",
-      path: UI_VERCEL_CONFIGURATION_PATH,
-      ref: SHA.A,
-    },
-  ]);
+  assert.deepEqual(
+    new Set(
+      fixture.contentRequests
+        .filter(({ path }) => path === UI_VERCEL_CONFIGURATION_PATH)
+        .map(({ ref }) => ref),
+    ),
+    new Set([SHA.E, SHA.A]),
+  );
   assert.equal(fixture.commitStatuses.at(-1).state, "success");
   assert.equal(
     fixture.commitStatuses.at(-1).description,
-    "Native Vercel owns this UI preview",
+    "app=none; governance=none; reserve=none; ui=native",
   );
   assert.equal(
     fixture.commitStatuses.at(-1).target_url,
     "https://github.com/mento-protocol/frontend-monorepo/actions/runs/7000",
   );
-  assert.equal(core.outputs.get("preview_owner"), "native-vercel");
-  assert.equal(core.outputs.get("dispatch_skipped"), "true");
+  assert.equal(
+    JSON.parse(core.outputs.get("preview_owners")).ui,
+    "native-vercel",
+  );
+  assert.equal(core.outputs.get("dispatched_run_ids"), "[]");
 });
 
 test("active controller rechecks exact-head ownership after recovery and blocks a racing native cutover", async () => {
@@ -5785,20 +6109,24 @@ test("active controller rechecks exact-head ownership after recovery and blocks 
 
   assert.equal(fixture.dispatches.length, 0);
   assert.equal(fixture.workerDispatchRequests.length, 0);
-  assert.equal(state.ui.active, null);
+  assert.equal(state.targets.ui.active, null);
   assert.equal(
-    state.ui.terminal_history.at(-1).terminal_reason,
-    "dispatch-disabled-intent-without-worker",
+    state.targets.ui.terminal_history.at(-1).terminal_reason,
+    "native-owned-selection-without-github-worker",
   );
   assert.deepEqual(
-    fixture.contentRequests.map(({ ref }) => ref),
-    [SHA.A, SHA.A, SHA.A, SHA.A],
+    new Set(
+      fixture.contentRequests
+        .filter(({ path }) => path === UI_VERCEL_CONFIGURATION_PATH)
+        .map(({ ref }) => ref),
+    ),
+    new Set([SHA.E, SHA.A]),
   );
   assert.deepEqual(waits, [500, 500, 500, 500]);
   assert.equal(fixture.commitStatuses.at(-1).state, "success");
   assert.equal(
     fixture.commitStatuses.at(-1).description,
-    "Native Vercel owns this UI preview",
+    "app=none; governance=none; reserve=none; ui=native",
   );
 });
 
@@ -5839,19 +6167,19 @@ test("active controller settles a completed crash-window worker after a racing n
   assert.equal(fixture.dispatches.length, 0);
   assert.equal(fixture.workerDispatchRequests.length, 0);
   assert.equal(core.outputs.get("recovered_intended_run_id"), "8000");
-  assert.equal(state.ui.active, null);
+  assert.equal(state.targets.ui.active, null);
   assert.equal(
-    state.ui.terminal_history.at(-1).terminal_reason,
+    state.targets.ui.terminal_history.at(-1).terminal_reason,
     "worker-cancelled",
   );
   const journal = journalFromComment(fixture.comments[0]);
   assert.equal(journal.receipts.results.length, 1);
   assert.equal(journal.receipts.results[0].worker_run_id, 8_000);
-  assert.equal(journal.state.ui.active, null);
+  assert.equal(journal.state.targets.ui.active, null);
   assert.equal(fixture.commitStatuses.at(-1).state, "success");
   assert.equal(
     fixture.commitStatuses.at(-1).description,
-    "Native Vercel owns this UI preview",
+    "app=none; governance=none; reserve=none; ui=native",
   );
 });
 
@@ -5879,8 +6207,8 @@ test("native cutover progress converges independently from a serialized update r
     pullRequest,
     existingState: persistDispatch(selectedA, 8_000),
   });
-  assert.equal(pendingB.state.ui.active.sha, SHA.A);
-  assert.equal(pendingB.state.ui.latest_desired_sha, SHA.B);
+  assert.equal(pendingB.state.targets.ui.active.sha, SHA.A);
+  assert.equal(pendingB.state.targets.ui.latest_desired_sha, SHA.B);
   const completedA = workerRun(selectedA.nextDispatch, {
     status: "completed",
     conclusion: "cancelled",
@@ -5889,7 +6217,9 @@ test("native cutover progress converges independently from a serialized update r
     pullRequest,
     comments: [
       journalWithState([opened, runtimeB], pendingB.state, {
-        selections: [selectionReceiptFromDispatch(pendingB.state.ui.active)],
+        selections: [
+          selectionReceiptFromDispatch(pendingB.state.targets.ui.active),
+        ],
       }),
     ],
     runs: [completedA],
@@ -5915,13 +6245,13 @@ test("native cutover progress converges independently from a serialized update r
   assert.equal(fixture.dispatches.length, 0);
   assert.equal(fixture.workerDispatchRequests.length, 0);
   assert.deepEqual(fixture.lostSerializedUpdates, [1]);
-  assert.equal(state.ui.active, null);
-  assert.equal(state.ui.latest_desired_sha, SHA.B);
+  assert.equal(state.targets.ui.active, null);
+  assert.equal(state.targets.ui.latest_desired_sha, SHA.B);
   assert.ok(
-    state.ui.terminal_history.some(
+    state.targets.ui.terminal_history.some(
       ({ sha, terminal_reason: terminalReason }) =>
         sha === SHA.B &&
-        terminalReason === "dispatch-disabled-intent-without-worker",
+        terminalReason === "native-owned-selection-without-github-worker",
     ),
   );
   const journal = journalFromComment(fixture.comments[0]);
@@ -5934,7 +6264,7 @@ test("native cutover progress converges independently from a serialized update r
   assert.equal(fixture.commitStatuses.at(-1).state, "success");
   assert.equal(
     fixture.commitStatuses.at(-1).description,
-    "Native Vercel owns this UI preview",
+    "app=none; governance=none; reserve=none; ui=native",
   );
 });
 
@@ -5976,7 +6306,7 @@ test("exhausted deterministic progress posts a fail-closed preview status", asyn
   assert.equal(
     journalFromComment(fixture.comments[0]).receipts.results.at(-1)
       .terminal_reason,
-    "dispatch-disabled-intent-without-worker",
+    "native-owned-selection-without-github-worker",
   );
 });
 
@@ -6001,7 +6331,7 @@ test("observe-only controller fails closed for a stale GitHub-owned Phase B head
       core: fakeCore(),
       prNumber: 519,
     }),
-    /leaves the candidate UI preview ownerless/,
+    /leaves a candidate preview ownerless/,
   );
 
   assert.equal(fixture.dispatches.length, 0);
@@ -6089,14 +6419,17 @@ test("observe-only controller mode records status without creating dispatch inte
     prNumber: 519,
   });
 
-  assert.equal(state.ui.active, null);
-  assert.equal(state.ui.latest_desired_sha, SHA.A);
+  assert.equal(state.targets.ui.active, null);
+  assert.equal(state.targets.ui.latest_desired_sha, SHA.A);
   assert.equal(fixture.dispatches.length, 0);
   assert.equal(fixture.workerDispatchRequests.length, 0);
   assert.equal(fixture.commentUpdates.length, 1);
-  assert.equal(journalFromComment(fixture.comments[0]).state.ui.active, null);
   assert.equal(
-    journalFromComment(fixture.comments[0]).state.ui.latest_desired_sha,
+    journalFromComment(fixture.comments[0]).state.targets.ui.active,
+    null,
+  );
+  assert.equal(
+    journalFromComment(fixture.comments[0]).state.targets.ui.latest_desired_sha,
     SHA.A,
   );
   assert.deepEqual(
@@ -6111,7 +6444,7 @@ test("observe-only controller mode records status without creating dispatch inte
         sha: SHA.A,
         state: "success",
         context: "Vercel Preview",
-        description: "Native Vercel owns this UI preview",
+        description: "GitHub preview dispatch is observe-only",
       },
     ],
   );
@@ -6164,16 +6497,16 @@ test("observe-only mode recovers completed work and reconstructs state without d
 
   assert.equal(fixture.dispatches.length, 0);
   assert.equal(fixture.workerDispatchRequests.length, 0);
-  assert.equal(state.ui.active, null);
-  assert.equal(state.ui.latest_desired_sha, SHA.B);
+  assert.equal(state.targets.ui.active, null);
+  assert.equal(state.targets.ui.latest_desired_sha, SHA.B);
   assert.equal(
-    state.ui.terminal_history.at(-1).terminal_reason,
+    state.targets.ui.terminal_history.at(-1).terminal_reason,
     "worker-cancelled",
   );
   const journal = journalFromComment(fixture.comments[0]);
   assert.equal(journal.receipts.results.length, 1);
-  assert.equal(journal.state.ui.active, null);
-  assert.equal(journal.state.ui.latest_desired_sha, SHA.B);
+  assert.equal(journal.state.targets.ui.active, null);
+  assert.equal(journal.state.targets.ui.latest_desired_sha, SHA.B);
   assert.equal(fixture.createdDeploymentStatuses.at(-1).state, "error");
   assert.deepEqual(
     fixture.commitStatuses.map(({ sha, state: statusState, description }) => ({
@@ -6185,7 +6518,7 @@ test("observe-only mode recovers completed work and reconstructs state without d
       {
         sha: SHA.B,
         state: "success",
-        description: "Native Vercel owns this UI preview",
+        description: "GitHub preview dispatch is observe-only",
       },
     ],
   );
@@ -6228,19 +6561,19 @@ test("observe-only mode attaches and terminalizes a completed crash-window worke
   assert.equal(fixture.dispatches.length, 0);
   assert.equal(fixture.workerDispatchRequests.length, 0);
   assert.equal(core.outputs.get("recovered_intended_run_id"), "8000");
-  assert.equal(state.ui.active, null);
+  assert.equal(state.targets.ui.active, null);
   assert.equal(
-    state.ui.terminal_history.at(-1).terminal_reason,
+    state.targets.ui.terminal_history.at(-1).terminal_reason,
     "worker-cancelled",
   );
   const journal = journalFromComment(fixture.comments[0]);
   assert.equal(journal.receipts.results.length, 1);
   assert.equal(journal.receipts.results[0].worker_run_id, 8_000);
-  assert.equal(journal.state.ui.active, null);
+  assert.equal(journal.state.targets.ui.active, null);
   assert.equal(fixture.commitStatuses.at(-1).state, "success");
   assert.equal(
     fixture.commitStatuses.at(-1).description,
-    "Native Vercel owns this UI preview",
+    "GitHub preview dispatch is observe-only",
   );
 });
 
@@ -6275,10 +6608,10 @@ test("observe-only mode durably attaches an in-progress crash-window worker and 
 
   assert.equal(fixture.dispatches.length, 0);
   assert.equal(fixture.workerDispatchRequests.length, 0);
-  assert.equal(state.ui.active.dispatch_state, "dispatched");
-  assert.equal(state.ui.active.workflow_run_id, 8_000);
+  assert.equal(state.targets.ui.active.dispatch_state, "dispatched");
+  assert.equal(state.targets.ui.active.workflow_run_id, 8_000);
   const journal = journalFromComment(fixture.comments[0]);
-  assert.equal(journal.state.ui.active.workflow_run_id, 8_000);
+  assert.equal(journal.state.targets.ui.active.workflow_run_id, 8_000);
   assert.equal(journal.receipts.results.length, 0);
   assert.deepEqual(journal.state.status_decisions.at(-1), {
     sha: SHA.A,
@@ -6286,6 +6619,12 @@ test("observe-only mode durably attaches an in-progress crash-window worker and 
     description: "Draining GitHub preview before native ownership",
     target_url:
       "https://github.com/mento-protocol/frontend-monorepo/actions/runs/7001",
+    targets: {
+      app: "not affected",
+      governance: "not affected",
+      reserve: "not affected",
+      ui: "pending",
+    },
   });
   assert.equal(fixture.commitStatuses.at(-1).state, "pending");
   assert.equal(
@@ -6332,9 +6671,9 @@ test("observe-only mode durably retires a crash-window intent with no worker and
   assert.deepEqual(waits, [500, 500]);
   assert.equal(fixture.workflowRunListRequests.length, 3);
   assert.equal(core.outputs.get("retired_undispatched_intent"), "true");
-  assert.equal(state.ui.active, null);
+  assert.equal(state.targets.ui.active, null);
   assert.equal(
-    state.ui.terminal_history.at(-1).terminal_reason,
+    state.targets.ui.terminal_history.at(-1).terminal_reason,
     "dispatch-disabled-intent-without-worker",
   );
   let journal = journalFromComment(fixture.comments[0]);
@@ -6343,7 +6682,7 @@ test("observe-only mode durably retires a crash-window intent with no worker and
     journal.receipts.results[0].terminal_reason,
     "dispatch-disabled-intent-without-worker",
   );
-  assert.equal(journal.state.ui.active, null);
+  assert.equal(journal.state.targets.ui.active, null);
   assert.equal(fixture.commitStatuses.at(-1).state, "success");
 
   fixture.comments[0].body = journalWithState(
@@ -6368,7 +6707,7 @@ test("observe-only mode durably retires a crash-window intent with no worker and
   journal = journalFromComment(fixture.comments[0]);
   assert.equal(fixture.workflowRunListRequests.length, lookupCount);
   assert.equal(journal.receipts.results.length, 1);
-  assert.equal(journal.state.ui.active, null);
+  assert.equal(journal.state.targets.ui.active, null);
 });
 
 test("observe-only mode retires a reopened epoch's intended worker slot when no worker exists", async () => {
@@ -6379,7 +6718,7 @@ test("observe-only mode retires a reopened epoch's intended worker slot when no 
       journalWithState(setup.events, setup.current.state, {
         selections: [
           selectionReceiptFromDispatch(
-            setup.current.state.ui.retired_active[0],
+            setup.current.state.targets.ui.retired_active[0],
           ),
         ],
       }),
@@ -6404,27 +6743,27 @@ test("observe-only mode retires a reopened epoch's intended worker slot when no 
   assert.deepEqual(waits, [500, 500]);
   assert.equal(fixture.workflowRunListRequests.length, 3);
   assert.equal(core.outputs.get("retired_undispatched_intent"), "true");
-  assert.equal(state.ui.active, null);
-  assert.equal(state.ui.retired_active.length, 0);
+  assert.equal(state.targets.ui.active, null);
+  assert.equal(state.targets.ui.retired_active.length, 0);
   const journal = journalFromComment(fixture.comments[0]);
   assert.equal(journal.receipts.results.length, 1);
   assert.equal(
     journal.receipts.results[0].key_digest,
     setup.old.nextDispatch.key_digest,
   );
-  assert.equal(journal.state.ui.retired_active.length, 0);
+  assert.equal(journal.state.targets.ui.retired_active.length, 0);
   assert.equal(fixture.commitStatuses.at(-1).state, "success");
   assert.equal(
     fixture.commitStatuses.at(-1).description,
-    "Native Vercel owns this UI preview",
+    "GitHub preview dispatch is observe-only",
   );
 });
 
 test("observe-only mode retires same-SHA active and reopened-epoch intents without result collisions", async () => {
   const setup = sameShaReopenIntentState();
   const currentIntended = persistIntent(setup.current);
-  const retiredSelection = currentIntended.ui.retired_active[0];
-  const activeSelection = currentIntended.ui.active;
+  const retiredSelection = currentIntended.targets.ui.retired_active[0];
+  const activeSelection = currentIntended.targets.ui.active;
   assert.equal(retiredSelection.key, activeSelection.key);
   assert.notEqual(retiredSelection.key_digest, activeSelection.key_digest);
   const fixture = fakeGitHub({
@@ -6456,8 +6795,8 @@ test("observe-only mode retires same-SHA active and reopened-epoch intents witho
   assert.equal(fixture.workerDispatchRequests.length, 0);
   assert.deepEqual(waits, [500, 500, 500, 500]);
   assert.equal(fixture.workflowRunListRequests.length, 6);
-  assert.equal(state.ui.active, null);
-  assert.equal(state.ui.retired_active.length, 0);
+  assert.equal(state.targets.ui.active, null);
+  assert.equal(state.targets.ui.retired_active.length, 0);
   const journal = journalFromComment(fixture.comments[0]);
   assert.equal(journal.receipts.results.length, 2);
   assert.ok(
@@ -6469,20 +6808,20 @@ test("observe-only mode retires same-SHA active and reopened-epoch intents witho
     new Set(journal.receipts.results.map(({ key_digest }) => key_digest)).size,
     2,
   );
-  assert.equal(journal.state.ui.active, null);
-  assert.equal(journal.state.ui.retired_active.length, 0);
+  assert.equal(journal.state.targets.ui.active, null);
+  assert.equal(journal.state.targets.ui.retired_active.length, 0);
   assert.equal(fixture.commitStatuses.at(-1).state, "success");
   assert.equal(
     fixture.commitStatuses.at(-1).description,
-    "Native Vercel owns this UI preview",
+    "GitHub preview dispatch is observe-only",
   );
 });
 
 test("same-SHA native-owned receipts stay distinct across epoch selection digests", () => {
   const setup = sameShaReopenIntentState();
   const intended = persistIntent(setup.current);
-  const retiredSelection = intended.ui.retired_active[0];
-  const activeSelection = intended.ui.active;
+  const retiredSelection = intended.targets.ui.retired_active[0];
+  const activeSelection = intended.targets.ui.active;
   assert.equal(retiredSelection.sha, activeSelection.sha);
   assert.equal(retiredSelection.key, activeSelection.key);
   assert.notEqual(
@@ -6510,17 +6849,17 @@ test("same-SHA native-owned receipts stay distinct across epoch selection digest
   });
 
   assert.equal(reconciled.nextDispatch, null);
-  assert.equal(reconciled.state.ui.active, null);
-  assert.deepEqual(reconciled.state.ui.retired_active, []);
-  assert.equal(reconciled.state.ui.last_successful_runtime_sha, null);
-  assert.equal(reconciled.state.ui.last_successful_runtime_url, null);
-  assert.deepEqual(reconciled.state.ui.terminal_result_key_digests, [
+  assert.equal(reconciled.state.targets.ui.active, null);
+  assert.deepEqual(reconciled.state.targets.ui.retired_active, []);
+  assert.equal(reconciled.state.targets.ui.last_successful_runtime_sha, null);
+  assert.equal(reconciled.state.targets.ui.last_successful_runtime_url, null);
+  assert.deepEqual(reconciled.state.targets.ui.terminal_result_key_digests, [
     activeSelection.key_digest,
   ]);
   assert.equal(reconciled.state.status_decisions[0].state, "success");
   assert.equal(
     reconciled.state.status_decisions[0].description,
-    "Native Vercel owns this UI preview",
+    "app=none; governance=none; reserve=none; ui=native",
   );
 
   const journal = createPreviewJournal({
@@ -6557,7 +6896,7 @@ test("no-dispatch retirement stays authoritative over an earlier real worker res
     reason: "build-failed-retriable",
   });
   const firstSelection = selectionReceiptFromDispatch(
-    firstDispatched.ui.active,
+    firstDispatched.targets.ui.active,
   );
   const retry = reconcile({
     events: [opened],
@@ -6567,7 +6906,9 @@ test("no-dispatch retirement stays authoritative over an earlier real worker res
     selections: [firstSelection],
   });
   const retryIntended = persistIntent(retry);
-  const retrySelection = selectionReceiptFromDispatch(retryIntended.ui.active);
+  const retrySelection = selectionReceiptFromDispatch(
+    retryIntended.targets.ui.active,
+  );
   assert.equal(
     retrySelection.selection_receipt_run_id,
     firstSelection.selection_receipt_run_id,
@@ -6594,9 +6935,9 @@ test("no-dispatch retirement stays authoritative over an earlier real worker res
     waitForRecovery: async () => {},
   });
 
-  assert.equal(retired.ui.active, null);
+  assert.equal(retired.targets.ui.active, null);
   assert.equal(
-    retired.ui.terminal_history.at(-1).terminal_reason,
+    retired.targets.ui.terminal_history.at(-1).terminal_reason,
     "dispatch-disabled-intent-without-worker",
   );
   let journal = journalFromComment(fixture.comments[0]);
@@ -6619,27 +6960,27 @@ test("no-dispatch retirement stays authoritative over an earlier real worker res
     waitForRecovery: async () => {},
   });
 
-  assert.equal(replayed.ui.active, null);
+  assert.equal(replayed.targets.ui.active, null);
   assert.equal(
-    replayed.ui.terminal_history.at(-1).terminal_reason,
+    replayed.targets.ui.terminal_history.at(-1).terminal_reason,
     "dispatch-disabled-intent-without-worker",
   );
   journal = journalFromComment(fixture.comments[0]);
   assert.equal(journal.receipts.results.length, 2);
   assert.equal(
-    journal.state.ui.terminal_history.at(-1).terminal_reason,
+    journal.state.targets.ui.terminal_history.at(-1).terminal_reason,
     "dispatch-disabled-intent-without-worker",
   );
   assert.equal(fixture.commitStatuses.at(-1).state, "success");
   assert.equal(
     fixture.commitStatuses.at(-1).description,
-    "Native Vercel owns this UI preview",
+    "GitHub preview dispatch is observe-only",
   );
 });
 
 test("observe-only mode attaches a reopened epoch's matching worker in its retired slot", async () => {
   const setup = sameShaReopenIntentState();
-  const queued = workerRun(setup.current.state.ui.retired_active[0], {
+  const queued = workerRun(setup.current.state.targets.ui.retired_active[0], {
     status: "in_progress",
   });
   const fixture = fakeGitHub({
@@ -6648,7 +6989,7 @@ test("observe-only mode attaches a reopened epoch's matching worker in its retir
       journalWithState(setup.events, setup.current.state, {
         selections: [
           selectionReceiptFromDispatch(
-            setup.current.state.ui.retired_active[0],
+            setup.current.state.targets.ui.retired_active[0],
           ),
         ],
       }),
@@ -6671,14 +7012,17 @@ test("observe-only mode attaches a reopened epoch's matching worker in its retir
   assert.equal(fixture.dispatches.length, 0);
   assert.equal(fixture.workerDispatchRequests.length, 0);
   assert.equal(core.outputs.get("recovered_intended_run_id"), "8000");
-  assert.equal(state.ui.active, null);
-  assert.equal(state.ui.retired_active.length, 1);
-  assert.equal(state.ui.retired_active[0].dispatch_state, "dispatched");
-  assert.equal(state.ui.retired_active[0].workflow_run_id, 8_000);
+  assert.equal(state.targets.ui.active, null);
+  assert.equal(state.targets.ui.retired_active.length, 1);
+  assert.equal(state.targets.ui.retired_active[0].dispatch_state, "dispatched");
+  assert.equal(state.targets.ui.retired_active[0].workflow_run_id, 8_000);
   const journal = journalFromComment(fixture.comments[0]);
   assert.equal(journal.receipts.results.length, 0);
-  assert.equal(journal.state.ui.active, null);
-  assert.equal(journal.state.ui.retired_active[0].workflow_run_id, 8_000);
+  assert.equal(journal.state.targets.ui.active, null);
+  assert.equal(
+    journal.state.targets.ui.retired_active[0].workflow_run_id,
+    8_000,
+  );
   assert.equal(fixture.commitStatuses.at(-1).state, "pending");
   assert.equal(
     fixture.commitStatuses.at(-1).description,
@@ -6723,7 +7067,8 @@ test("observe-only mode fails closed when multiple workers match one crash-windo
   assert.equal(fixture.workerDispatchRequests.length, 0);
   assert.equal(fixture.commentUpdates.length, 0);
   assert.equal(
-    journalFromComment(fixture.comments[0]).state.ui.active.dispatch_state,
+    journalFromComment(fixture.comments[0]).state.targets.ui.active
+      .dispatch_state,
     "intended",
   );
   assert.equal(fixture.commitStatuses.at(-1).state, "error");
@@ -6788,8 +7133,8 @@ test("a missing worker dispatch credential fails closed only when a new dispatch
   assert.equal(fixture.commitStatuses.at(-1).state, "error");
   const journal = journalFromComment(fixture.comments[0]);
   assert.equal(journal.receipts.selections.length, 1);
-  assert.equal(journal.state.ui.active.dispatch_state, "intended");
-  assert.equal(journal.state.ui.active.workflow_run_id, null);
+  assert.equal(journal.state.targets.ui.active.dispatch_state, "intended");
+  assert.equal(journal.state.targets.ui.active.workflow_run_id, null);
 });
 
 test("durable dispatch fails closed when the exact run title never materializes", async () => {
@@ -6851,7 +7196,7 @@ test("recovery rechecks PR openness immediately before dispatch", async () => {
     waitForRecovery: async (milliseconds) => waits.push(milliseconds),
   });
 
-  assert.equal(state.ui.active.dispatch_state, "intended");
+  assert.equal(state.targets.ui.active.dispatch_state, "intended");
   assert.equal(fixture.dispatches.length, 0);
   assert.deepEqual(waits, [500, 500]);
   assert.equal(core.outputs.get("dispatch_skipped_closed"), "true");
@@ -6876,7 +7221,7 @@ test("recovery reuses an intent rebound while it waits for run visibility", asyn
     comments: [
       journalComment({
         events: [opened],
-        selections: [selectionReceiptFromDispatch(intended.ui.active)],
+        selections: [selectionReceiptFromDispatch(intended.targets.ui.active)],
         state: intended,
       }),
     ],
@@ -6900,7 +7245,9 @@ test("recovery reuses an intent rebound while it waits for run visibility", asyn
         {
           revision: 2,
           events: [opened],
-          selections: [selectionReceiptFromDispatch(intended.ui.active)],
+          selections: [
+            selectionReceiptFromDispatch(intended.targets.ui.active),
+          ],
           state: persistDispatch(selected, 8_000),
         },
         comment.id,
@@ -6908,8 +7255,8 @@ test("recovery reuses an intent rebound while it waits for run visibility", asyn
     },
   });
 
-  assert.equal(state.ui.active.dispatch_state, "dispatched");
-  assert.equal(state.ui.active.workflow_run_id, 8_000);
+  assert.equal(state.targets.ui.active.dispatch_state, "dispatched");
+  assert.equal(state.targets.ui.active.workflow_run_id, 8_000);
   assert.equal(fixture.dispatches.length, 0);
   assert.equal(fixture.commitStatuses.at(-1).state, "pending");
 });
@@ -6990,9 +7337,9 @@ test("a dispatch racing a main advance is terminalized and automatically reselec
     fixture.dispatches[1].inputs.controller_key_digest,
     fixture.dispatches[0].inputs.controller_key_digest,
   );
-  assert.equal(recoveredState.ui.active.expected_workflow_sha, SHA.B);
-  assert.equal(recoveredState.ui.active.dispatch_state, "dispatched");
-  assert.equal(recoveredState.ui.active.workflow_run_id, 8_001);
+  assert.equal(recoveredState.targets.ui.active.expected_workflow_sha, SHA.B);
+  assert.equal(recoveredState.targets.ui.active.dispatch_state, "dispatched");
+  assert.equal(recoveredState.targets.ui.active.workflow_run_id, 8_001);
 });
 
 test("intended dispatch recovery attaches exactly one run and fails closed on ambiguity", async () => {
@@ -7025,7 +7372,7 @@ test("intended dispatch recovery attaches exactly one run and fails closed on am
   });
   assert.equal(recovered.dispatches.length, 0);
   assert.equal(recovered.workerDispatchRequests.length, 0);
-  assert.equal(state.ui.active.workflow_run_id, existingRun.id);
+  assert.equal(state.targets.ui.active.workflow_run_id, existingRun.id);
 
   const ambiguous = fakeGitHub({
     pullRequest,
@@ -7080,7 +7427,7 @@ test("intended recovery waits for a default-title run without redispatching", as
   });
 
   assert.equal(fixture.dispatches.length, 0);
-  assert.equal(state.ui.active.workflow_run_id, existingRun.id);
+  assert.equal(state.targets.ui.active.workflow_run_id, existingRun.id);
   assert.deepEqual(waits, Array(10).fill(1_000));
   assert.equal(fixture.workflowRunListRequests.length, 11);
   assert.equal(fixture.workflowRunRequests.length, 9);
@@ -7248,7 +7595,7 @@ test("intended recovery attaches one exact owner after a default title settles u
   });
 
   assert.equal(fixture.dispatches.length, 0);
-  assert.equal(state.ui.active.workflow_run_id, exactRun.id);
+  assert.equal(state.targets.ui.active.workflow_run_id, exactRun.id);
   assert.deepEqual(waits, [1_000]);
   assert.equal(fixture.workflowRunListRequests.length, 2);
 });
@@ -7333,10 +7680,13 @@ test("intended recovery ignores wrong-SHA artifacts and reselects stale intents"
     SHA.B,
   );
   assert.equal(
-    conflictingRecoveredState.ui.active.expected_workflow_sha,
+    conflictingRecoveredState.targets.ui.active.expected_workflow_sha,
     SHA.B,
   );
-  assert.equal(conflictingRecoveredState.ui.active.workflow_run_id, 8_000);
+  assert.equal(
+    conflictingRecoveredState.targets.ui.active.workflow_run_id,
+    8_000,
+  );
   assert.ok(
     conflictingRun.comments.some(({ body }) =>
       body.includes(
@@ -7362,8 +7712,8 @@ test("intended recovery ignores wrong-SHA artifacts and reselects stale intents"
     mainAdvancedBeforeDispatch.dispatches[0].inputs.expected_workflow_sha,
     SHA.B,
   );
-  assert.equal(recoveredState.ui.active.expected_workflow_sha, SHA.B);
-  assert.equal(recoveredState.ui.active.dispatch_state, "dispatched");
+  assert.equal(recoveredState.targets.ui.active.expected_workflow_sha, SHA.B);
+  assert.equal(recoveredState.targets.ui.active.dispatch_state, "dispatched");
   assert.ok(
     mainAdvancedBeforeDispatch.comments.some(
       ({ body }) =>
@@ -7454,7 +7804,7 @@ test("intended recovery paginates its time window and ignores more than 300 olde
     waitForRecovery: async () => {},
   });
   assert.equal(paginated.dispatches.length, 0);
-  assert.equal(state.ui.active.workflow_run_id, 8_000);
+  assert.equal(state.targets.ui.active.workflow_run_id, 8_000);
 
   const olderHistory = Array.from({ length: 350 }, (_, index) =>
     workerRun(
@@ -7475,7 +7825,7 @@ test("intended recovery paginates its time window and ignores more than 300 olde
     waitForRecovery: async () => {},
   });
   assert.equal(bounded.dispatches.length, 0);
-  assert.equal(boundedState.ui.active.workflow_run_id, 8_000);
+  assert.equal(boundedState.targets.ui.active.workflow_run_id, 8_000);
   assert.equal(
     bounded.workflowRunListRequests[0].created,
     `${timestamp(0).replace("10:00:00", "09:58:00")}..${timestamp(0).replace("10:00:00", "10:15:00")}`,
@@ -7510,9 +7860,9 @@ test("manual reconcile recovers a completed REST-named worker when its callback 
     waitForRecovery: async () => {},
   });
   assert.equal(fixture.dispatches.length, 0);
-  assert.equal(state.ui.active, null);
+  assert.equal(state.targets.ui.active, null);
   assert.equal(
-    state.ui.terminal_history.at(-1).terminal_reason,
+    state.targets.ui.terminal_history.at(-1).terminal_reason,
     "worker-cancelled",
   );
   assert.equal(fixture.commitStatuses.at(-1).sha, SHA.A);
@@ -7562,7 +7912,7 @@ test("a force-pushed-away active selection is aborted before credentials and new
   });
   assert.equal(fixture.dispatches.length, 1);
   assert.equal(fixture.dispatches[0].inputs.commit_sha, SHA.C);
-  assert.equal(state.ui.active.sha, SHA.C);
+  assert.equal(state.targets.ui.active.sha, SHA.C);
   assert.ok(
     fixture.comments.some(({ body }) =>
       body.includes('"terminal_reason": "selection-removed-from-pr"'),
@@ -7781,6 +8131,7 @@ test("same-SHA reopened epoch resumes verified old upload evidence before its ca
     sha: SHA.A,
     environment: "preview/ui/pr-519",
     payload: {
+      ...canonicalDeploymentBinding(),
       idempotency_key: setup.old.nextDispatch.key,
       sha: SHA.A,
       logical_target: "ui",
@@ -7793,8 +8144,10 @@ test("same-SHA reopened epoch resumes verified old upload evidence before its ca
     comments: [
       journalWithState(setup.events, setup.currentState, {
         selections: [
-          selectionReceiptFromDispatch(setup.currentState.ui.retired_active[0]),
-          selectionReceiptFromDispatch(setup.currentState.ui.active),
+          selectionReceiptFromDispatch(
+            setup.currentState.targets.ui.retired_active[0],
+          ),
+          selectionReceiptFromDispatch(setup.currentState.targets.ui.active),
         ],
       }),
     ],
@@ -7874,7 +8227,10 @@ test("same-SHA reopened epoch resumes verified old upload evidence before its ca
   const journal = journalFromComment(fixture.comments[0]);
   assert.deepEqual(journal.state, {
     ...controllerStateBefore,
-    ui: { ...controllerStateBefore.ui, retired_active: [] },
+    targets: {
+      ...controllerStateBefore.targets,
+      ui: { ...controllerStateBefore.targets.ui, retired_active: [] },
+    },
   });
   assert.equal(journal.receipts.worker_evidence.length, 1);
   assert.equal(journal.receipts.results.length, 1);
@@ -7892,8 +8248,10 @@ test("delayed old-epoch cancellation cannot claim or terminalize a same-SHA Depl
     comments: [
       journalWithState(setup.events, setup.currentState, {
         selections: [
-          selectionReceiptFromDispatch(setup.currentState.ui.retired_active[0]),
-          selectionReceiptFromDispatch(setup.currentState.ui.active),
+          selectionReceiptFromDispatch(
+            setup.currentState.targets.ui.retired_active[0],
+          ),
+          selectionReceiptFromDispatch(setup.currentState.targets.ui.active),
         ],
       }),
     ],
@@ -7905,6 +8263,7 @@ test("delayed old-epoch cancellation cannot claim or terminalize a same-SHA Depl
         sha: SHA.A,
         environment: "preview/ui/pr-519",
         payload: {
+          ...canonicalDeploymentBinding(),
           idempotency_key: setup.current.nextDispatch.key,
           sha: SHA.A,
           logical_target: "ui",
@@ -7953,6 +8312,7 @@ test("terminal reopened same-SHA ownership survives a delayed old-epoch callback
     sha: SHA.A,
     environment: "preview/ui/pr-519",
     payload: {
+      ...canonicalDeploymentBinding(),
       idempotency_key: setup.current.nextDispatch.key,
       sha: SHA.A,
       logical_target: "ui",
@@ -7965,8 +8325,10 @@ test("terminal reopened same-SHA ownership survives a delayed old-epoch callback
     comments: [
       journalWithState(setup.events, setup.currentState, {
         selections: [
-          selectionReceiptFromDispatch(setup.currentState.ui.retired_active[0]),
-          selectionReceiptFromDispatch(setup.currentState.ui.active),
+          selectionReceiptFromDispatch(
+            setup.currentState.targets.ui.retired_active[0],
+          ),
+          selectionReceiptFromDispatch(setup.currentState.targets.ui.active),
         ],
       }),
     ],
@@ -8000,9 +8362,9 @@ test("terminal reopened same-SHA ownership survives a delayed old-epoch callback
     prNumber: 519,
     waitForRecovery: async () => {},
   });
-  assert.equal(terminalState.ui.active, null);
+  assert.equal(terminalState.targets.ui.active, null);
   assert.equal(
-    terminalState.ui.terminal_history.at(-1).key_digest,
+    terminalState.targets.ui.terminal_history.at(-1).key_digest,
     setup.current.nextDispatch.key_digest,
   );
 
@@ -8029,7 +8391,10 @@ test("terminal reopened same-SHA ownership survives a delayed old-epoch callback
   const journal = journalFromComment(fixture.comments[0]);
   assert.deepEqual(journal.state, {
     ...controllerStateBefore,
-    ui: { ...controllerStateBefore.ui, retired_active: [] },
+    targets: {
+      ...controllerStateBefore.targets,
+      ui: { ...controllerStateBefore.targets.ui, retired_active: [] },
+    },
   });
   assert.equal(journal.receipts.results.length, 2);
 });
@@ -8043,9 +8408,9 @@ test("quarantined retired recovery cannot block native preview ownership", async
     pullRequest: setup.pullRequest,
     existingState: setup.currentState,
   }).state;
-  assert.equal(terminalState.ui.active, null);
+  assert.equal(terminalState.targets.ui.active, null);
   assert.equal(
-    terminalState.ui.terminal_history.at(-1).key_digest,
+    terminalState.targets.ui.terminal_history.at(-1).key_digest,
     setup.current.nextDispatch.key_digest,
   );
   const oldLatestAttempt = workerRun(setup.old.nextDispatch, {
@@ -8060,8 +8425,10 @@ test("quarantined retired recovery cannot block native preview ownership", async
       journalWithState(setup.events, terminalState, {
         results: [currentResult],
         selections: [
-          selectionReceiptFromDispatch(setup.currentState.ui.retired_active[0]),
-          selectionReceiptFromDispatch(setup.currentState.ui.active),
+          selectionReceiptFromDispatch(
+            setup.currentState.targets.ui.retired_active[0],
+          ),
+          selectionReceiptFromDispatch(setup.currentState.targets.ui.active),
         ],
       }),
     ],
@@ -8076,13 +8443,13 @@ test("quarantined retired recovery cannot block native preview ownership", async
     prNumber: 519,
     waitForRecovery: async () => {},
   });
-  assert.equal(reconciled.ui.active, null);
+  assert.equal(reconciled.targets.ui.active, null);
   assert.equal(
-    reconciled.ui.terminal_history.at(-1).key_digest,
+    reconciled.targets.ui.terminal_history.at(-1).key_digest,
     setup.current.nextDispatch.key_digest,
   );
   assert.equal(
-    reconciled.ui.retired_active.at(-1).recovery_quarantine,
+    reconciled.targets.ui.retired_active.at(-1).recovery_quarantine,
     "persisted-attempt-invalid-or-unavailable",
   );
   assert.equal(
@@ -8092,7 +8459,7 @@ test("quarantined retired recovery cannot block native preview ownership", async
   assert.equal(fixture.commitStatuses.at(-1).state, "success");
   assert.equal(
     fixture.commitStatuses.at(-1).description,
-    "Native Vercel owns this UI preview",
+    "app=none; governance=none; reserve=none; ui=native",
   );
   assert.deepEqual(fixture.workflowRunAttemptRequests, [
     { run_id: 8_000, attempt_number: 1 },
@@ -8113,7 +8480,7 @@ test("quarantined retired recovery cannot block native preview ownership", async
   assert.equal(fixture.commitStatuses.at(-1).state, "success");
   assert.equal(
     fixture.commitStatuses.at(-1).description,
-    "Native Vercel owns this UI preview",
+    "app=none; governance=none; reserve=none; ui=native",
   );
 });
 
@@ -8137,8 +8504,10 @@ test("transient retired recovery failures remain retryable and never poison the 
       journalWithState(setup.events, terminalState, {
         results: [currentResult],
         selections: [
-          selectionReceiptFromDispatch(setup.currentState.ui.retired_active[0]),
-          selectionReceiptFromDispatch(setup.currentState.ui.active),
+          selectionReceiptFromDispatch(
+            setup.currentState.targets.ui.retired_active[0],
+          ),
+          selectionReceiptFromDispatch(setup.currentState.targets.ui.active),
         ],
       }),
     ],
@@ -8154,8 +8523,11 @@ test("transient retired recovery failures remain retryable and never poison the 
     prNumber: 519,
     waitForRecovery: async () => {},
   });
-  assert.equal(first.ui.active, null);
-  assert.equal(first.ui.retired_active.at(-1).recovery_quarantine, undefined);
+  assert.equal(first.targets.ui.active, null);
+  assert.equal(
+    first.targets.ui.retired_active.at(-1).recovery_quarantine,
+    undefined,
+  );
   assert.equal(firstCore.outputs.get("retired_recovery_retryable"), "true");
   assert.equal(
     fixture.commitStatuses.some(({ state }) => state === "error"),
@@ -8169,9 +8541,9 @@ test("transient retired recovery failures remain retryable and never poison the 
     prNumber: 519,
     waitForRecovery: async () => {},
   });
-  assert.equal(second.ui.active, null);
+  assert.equal(second.targets.ui.active, null);
   assert.equal(
-    second.ui.terminal_history.at(-1).key_digest,
+    second.targets.ui.terminal_history.at(-1).key_digest,
     setup.current.nextDispatch.key_digest,
   );
   assert.equal(
@@ -8207,8 +8579,10 @@ test("transient quarantine persistence failure remains retryable without a curre
       journalWithState(setup.events, terminalState, {
         results: [currentResult],
         selections: [
-          selectionReceiptFromDispatch(setup.currentState.ui.retired_active[0]),
-          selectionReceiptFromDispatch(setup.currentState.ui.active),
+          selectionReceiptFromDispatch(
+            setup.currentState.targets.ui.retired_active[0],
+          ),
+          selectionReceiptFromDispatch(setup.currentState.targets.ui.active),
         ],
       }),
     ],
@@ -8224,7 +8598,10 @@ test("transient quarantine persistence failure remains retryable without a curre
     prNumber: 519,
     waitForRecovery: async () => {},
   });
-  assert.equal(first.ui.retired_active.at(-1).recovery_quarantine, undefined);
+  assert.equal(
+    first.targets.ui.retired_active.at(-1).recovery_quarantine,
+    undefined,
+  );
   assert.equal(firstCore.outputs.get("retired_recovery_retryable"), "true");
   assert.equal(
     fixture.commitStatuses.some(({ state }) => state === "error"),
@@ -8239,7 +8616,7 @@ test("transient quarantine persistence failure remains retryable without a curre
     waitForRecovery: async () => {},
   });
   assert.equal(
-    second.ui.retired_active.at(-1).recovery_quarantine,
+    second.targets.ui.retired_active.at(-1).recovery_quarantine,
     "persisted-attempt-invalid-or-unavailable",
   );
   assert.equal(
@@ -8264,8 +8641,10 @@ test("delayed old-epoch success reads only its own same-SHA Deployment status hi
     comments: [
       journalWithState(setup.events, setup.currentState, {
         selections: [
-          selectionReceiptFromDispatch(setup.currentState.ui.retired_active[0]),
-          selectionReceiptFromDispatch(setup.currentState.ui.active),
+          selectionReceiptFromDispatch(
+            setup.currentState.targets.ui.retired_active[0],
+          ),
+          selectionReceiptFromDispatch(setup.currentState.targets.ui.active),
         ],
       }),
     ],
@@ -8277,6 +8656,7 @@ test("delayed old-epoch success reads only its own same-SHA Deployment status hi
         sha: SHA.A,
         environment: "preview/ui/pr-519",
         payload: {
+          ...canonicalDeploymentBinding(),
           idempotency_key: setup.old.nextDispatch.key,
           sha: SHA.A,
           logical_target: "ui",
@@ -8336,6 +8716,7 @@ test("duplicate worker absorbs an existing verified canonical Deployment without
     sha: SHA.A,
     environment: "preview/ui/pr-519",
     payload: {
+      ...canonicalDeploymentBinding(),
       idempotency_key: selected.nextDispatch.key,
       sha: SHA.A,
       logical_target: "ui",
@@ -8408,6 +8789,7 @@ test("verified deployment success survives a later evidence persistence failure"
     sha: SHA.A,
     environment: "preview/ui/pr-519",
     payload: {
+      ...canonicalDeploymentBinding(),
       idempotency_key: selected.nextDispatch.key,
       sha: SHA.A,
       logical_target: "ui",
@@ -8516,6 +8898,7 @@ test("smoke failure records immutable upload evidence and the one retry resumes 
     sha: SHA.A,
     environment: "preview/ui/pr-519",
     payload: {
+      ...canonicalDeploymentBinding(),
       idempotency_key: selected.nextDispatch.key,
       sha: SHA.A,
       logical_target: "ui",
@@ -8630,8 +9013,8 @@ test("smoke failure records immutable upload evidence and the one retry resumes 
     comments: [
       journalWithState([opened], retryState, {
         selections: [
-          selectionReceiptFromDispatch(dispatched.ui.active),
-          selectionReceiptFromDispatch(retryState.ui.active),
+          selectionReceiptFromDispatch(dispatched.targets.ui.active),
+          selectionReceiptFromDispatch(retryState.targets.ui.active),
         ],
         workerEvidence: firstJournal.receipts.worker_evidence,
         results: firstJournal.receipts.results,
@@ -8692,6 +9075,7 @@ test("failure after the durable upload boundary fails closed without a rebuild r
     sha: SHA.A,
     environment: "preview/ui/pr-519",
     payload: {
+      ...canonicalDeploymentBinding(),
       idempotency_key: selected.nextDispatch.key,
       sha: SHA.A,
       logical_target: "ui",
@@ -8780,6 +9164,7 @@ test("completed build failure before the upload boundary gets one rebuild retry"
     sha: SHA.A,
     environment: "preview/ui/pr-519",
     payload: {
+      ...canonicalDeploymentBinding(),
       idempotency_key: selected.nextDispatch.key,
       sha: SHA.A,
       logical_target: "ui",
@@ -8833,8 +9218,8 @@ test("completed build failure before the upload boundary gets one rebuild retry"
     comments: [
       journalWithState([opened], retryState, {
         selections: [
-          selectionReceiptFromDispatch(dispatched.ui.active),
-          selectionReceiptFromDispatch(retryState.ui.active),
+          selectionReceiptFromDispatch(dispatched.targets.ui.active),
+          selectionReceiptFromDispatch(retryState.targets.ui.active),
         ],
         workerEvidence: firstJournal.receipts.worker_evidence,
         results: firstJournal.receipts.results,

--- a/scripts/vercel-preview-controller.test.mjs
+++ b/scripts/vercel-preview-controller.test.mjs
@@ -23,6 +23,7 @@ import {
   prepareBootstrap,
   recordEventReceipt,
   recordWorkerEvidence as recordWorkerEvidenceImplementation,
+  renderPreviewJournalBody,
   reconcilePreview as reconcilePreviewImplementation,
   reconcileState,
   recoverWorkerResult,
@@ -183,20 +184,28 @@ function eventRecordInputs(receipt) {
   };
 }
 
-function persistDispatch(reconciled, runId = 8_000) {
-  assert.ok(reconciled.nextDispatch, "fixture must have a dispatch");
+function targetDispatch(reconciled, target) {
+  const dispatch = reconciled.nextDispatches.find(
+    (candidate) => candidate.target === target,
+  );
+  assert.ok(dispatch, `fixture must have a ${target} dispatch`);
+  return dispatch;
+}
+
+function persistTargetDispatch(reconciled, target, runId = 8_000) {
+  const dispatch = targetDispatch(reconciled, target);
   return {
     ...structuredClone(reconciled.state),
     targets: {
       ...structuredClone(reconciled.state.targets),
-      ui: {
-        ...structuredClone(reconciled.state.targets.ui),
+      [target]: {
+        ...structuredClone(reconciled.state.targets[target]),
         active: {
-          ...structuredClone(reconciled.nextDispatch),
+          ...structuredClone(dispatch),
           dispatch_started_at: timestamp(0),
           dispatch_state: "dispatched",
           workflow_run_id: runId,
-          workflow_sha: reconciled.nextDispatch.expected_workflow_sha,
+          workflow_sha: dispatch.expected_workflow_sha,
           workflow_run_attempt: 1,
           run_url: `https://api.github.com/repos/mento-protocol/frontend-monorepo/actions/runs/${runId}`,
           html_url: `https://github.com/mento-protocol/frontend-monorepo/actions/runs/${runId}`,
@@ -206,16 +215,20 @@ function persistDispatch(reconciled, runId = 8_000) {
   };
 }
 
-function persistIntent(reconciled) {
-  assert.ok(reconciled.nextDispatch, "fixture must have a dispatch");
+function persistDispatch(reconciled, runId = 8_000) {
+  return persistTargetDispatch(reconciled, "ui", runId);
+}
+
+function persistTargetIntent(reconciled, target) {
+  const dispatch = targetDispatch(reconciled, target);
   return {
     ...structuredClone(reconciled.state),
     targets: {
       ...structuredClone(reconciled.state.targets),
-      ui: {
-        ...structuredClone(reconciled.state.targets.ui),
+      [target]: {
+        ...structuredClone(reconciled.state.targets[target]),
         active: {
-          ...structuredClone(reconciled.nextDispatch),
+          ...structuredClone(dispatch),
           dispatch_started_at: timestamp(0),
           dispatch_state: "intended",
           workflow_run_id: null,
@@ -227,6 +240,10 @@ function persistIntent(reconciled) {
       },
     },
   };
+}
+
+function persistIntent(reconciled) {
+  return persistTargetIntent(reconciled, "ui");
 }
 
 function persistAllIntents(reconciled) {
@@ -934,6 +951,87 @@ test("docs-only states never dispatch and reuse the last verified runtime", () =
   assert.equal(cancelledDocsStatus.state, "failure");
   assert.equal(cancelledDocsStatus.targets.ui, "failed");
 });
+
+for (const [targetIndex, target] of PREVIEW_TARGETS.entries()) {
+  test(`${target} carries its verified runtime through a docs-only head without touching peers`, () => {
+    const runtime = event({
+      run: 50 + targetIndex * 2,
+      action: "opened",
+      head: SHA.A,
+      targets: [target],
+      updated: timestamp(1),
+    });
+    const runtimePull = pull({ head: SHA.A, updated: timestamp(1) });
+    const selected = reconcile({ events: [runtime], pullRequest: runtimePull });
+    const dispatch = targetDispatch(selected, target);
+    const workerRunId = 8_050 + targetIndex;
+    const active = persistTargetDispatch(selected, target, workerRunId);
+    const terminal = result(dispatch, { runId: workerRunId });
+    const settled = reconcile({
+      events: [runtime],
+      results: [terminal],
+      pullRequest: runtimePull,
+      existingState: active,
+    });
+    const immutableUrl = `https://${target}-${workerRunId}.vercel.app`;
+    assert.equal(settled.nextDispatches.length, 0);
+    assert.equal(settled.state.targets[target].first_eligible_sha, SHA.A);
+    assert.equal(settled.state.targets[target].latest_desired_sha, SHA.A);
+    assert.equal(
+      settled.state.targets[target].last_successful_runtime_url,
+      immutableUrl,
+    );
+
+    const docs = event({
+      run: 51 + targetIndex * 2,
+      action: "synchronize",
+      before: SHA.A,
+      head: SHA.B,
+      runtime: false,
+      updated: timestamp(2),
+    });
+    const carried = reconcile({
+      events: [runtime, docs],
+      results: [terminal],
+      pullRequest: pull({ head: SHA.B, updated: timestamp(2) }),
+      existingState: settled.state,
+    });
+
+    assert.equal(carried.nextDispatches.length, 0);
+    assert.equal(carried.state.targets[target].first_eligible_sha, SHA.A);
+    assert.equal(carried.state.targets[target].latest_desired_sha, SHA.A);
+    assert.equal(
+      carried.state.targets[target].last_successful_runtime_sha,
+      SHA.A,
+    );
+    assert.equal(
+      carried.state.targets[target].last_successful_runtime_url,
+      immutableUrl,
+    );
+    const docsStatus = carried.state.status_decisions.at(-1);
+    assert.equal(docsStatus.sha, SHA.B);
+    assert.equal(docsStatus.state, "success");
+    assert.equal(docsStatus.targets[target], "runtime-equivalent");
+    assert.equal(docsStatus.target_url, immutableUrl);
+    for (const otherTarget of PREVIEW_TARGETS.filter(
+      (candidate) => candidate !== target,
+    )) {
+      assert.deepEqual(carried.state.targets[otherTarget], {
+        first_eligible_sha: null,
+        latest_desired_sha: null,
+        latest_desired_receipt_run_id: null,
+        idle_cursor_receipt_run_id: null,
+        active: null,
+        retired_active: [],
+        last_successful_runtime_sha: null,
+        last_successful_runtime_url: null,
+        terminal_result_key_digests: [],
+        terminal_history: [],
+      });
+      assert.equal(docsStatus.targets[otherTarget], "not affected");
+    }
+  });
+}
 
 test("coalescing needs an immutable later selection receipt", () => {
   const events = [
@@ -2636,15 +2734,8 @@ test("closed checkpoints retain matching closure across late events and reopen",
   assert.equal(reopenedState.nextDispatch, null);
 });
 
-const expectedCommentExplanation = [
-  "**No reviewer action is required.**",
-  "This repository builds pull request previews in GitHub Actions and deploys them to Vercel.",
-  "This record lets the preview automation handle overlapping pushes and recover safely from retries.",
-  "[How previews work](https://github.com/mento-protocol/frontend-monorepo/blob/main/docs/vercel-deployments.md#event-status-and-batching-contract).",
-].join(" ");
-
 function previewJournalBody(value) {
-  return `${PREVIEW_JOURNAL_MARKER}\n\n${expectedCommentExplanation}\n\n<details>\n<summary>Show machine-readable preview automation record</summary>\n\n\`\`\`json\n${JSON.stringify(value, null, 2)}\n\`\`\`\n\n</details>\n`;
+  return renderPreviewJournalBody(value);
 }
 
 function journalFromComment(comment) {
@@ -3374,6 +3465,71 @@ function nativeUiAggregateStatus(sha, runId) {
     },
   };
 }
+
+test("journal comment visibly summarizes all target outcomes in canonical order", async () => {
+  const opened = event({
+    run: 118,
+    action: "opened",
+    head: SHA.A,
+    targets: ["ui"],
+    updated: timestamp(1),
+  });
+  const pullRequest = pull({ head: SHA.A, updated: timestamp(1) });
+  const selected = reconcile({ events: [opened], pullRequest });
+  const active = persistTargetDispatch(selected, "ui");
+  const selection = selectionReceiptFromDispatch(active.targets.ui.active);
+  const success = result(targetDispatch(selected, "ui"));
+  const settled = reconcile({
+    events: [opened],
+    results: [success],
+    selections: [selection],
+    pullRequest,
+    existingState: active,
+  });
+  const body = previewJournalBody(
+    createPreviewJournal({
+      pr: 519,
+      events: [opened],
+      selections: [selection],
+      results: [success],
+      state: settled.state,
+    }),
+  );
+  const expectedRows = [
+    "| `app` | `not affected` |",
+    "| `governance` | `not affected` |",
+    "| `reserve` | `not affected` |",
+    "| `ui` | `deployed` ([open](https://ui-8000.vercel.app)) |",
+  ];
+  let previousIndex = body.indexOf("**Preview outcomes**");
+  for (const row of expectedRows) {
+    const index = body.indexOf(row);
+    assert.ok(index > previousIndex, `${row} must follow the prior target row`);
+    previousIndex = index;
+  }
+  assert.ok(body.indexOf("<details>") > previousIndex);
+
+  const tampered = body.replace("| `ui` | `deployed`", "| `ui` | `error`");
+  const fixture = fakeGitHub({
+    pullRequest,
+    comments: [
+      {
+        id: 1,
+        user: { type: "Bot", login: "github-actions[bot]" },
+        body: tampered,
+      },
+    ],
+  });
+  await assert.rejects(
+    reconcilePreview({
+      github: fixture.github,
+      context: fakeContext(),
+      core: fakeCore(),
+      prNumber: 519,
+    }),
+    /Preview journal body is not canonical/,
+  );
+});
 
 async function assertSettledReplayIsIdempotent({
   events,
@@ -6030,6 +6186,54 @@ test("a GitHub-owned receipt followed by a native-owned head never dispatches th
   );
 });
 
+test("a refreshed native B head cannot relabel the stale A selection as native-owned", async () => {
+  const opened = event({
+    run: 121,
+    action: "opened",
+    head: SHA.A,
+    updated: timestamp(1),
+  });
+  const headA = pull({ head: SHA.A, updated: timestamp(1) });
+  const headB = pull({ head: SHA.B, updated: timestamp(2) });
+  const fixture = fakeGitHub({
+    pullRequest: headA,
+    pullRequests: [headA, headB],
+    pullCommits: [SHA.A, SHA.B],
+    comments: [journalComment({ events: [opened] })],
+    uiVercelConfigurationsByRef: new Map([
+      [SHA.A, GITHUB_OWNED_UI_VERCEL_CONFIGURATION],
+      [SHA.B, NATIVE_OWNED_UI_VERCEL_CONFIGURATION],
+    ]),
+  });
+
+  const state = await reconcilePreview({
+    github: fixture.github,
+    context: fakeContext(),
+    core: fakeCore(),
+    prNumber: 519,
+    waitForRecovery: async () => {},
+  });
+
+  assert.equal(fixture.dispatches.length, 0);
+  assert.equal(fixture.workerDispatchRequests.length, 0);
+  const staleResult = journalFromComment(fixture.comments[0])
+    .receipts.results.filter(
+      (entry) => entry.target === "ui" && entry.sha === SHA.A,
+    )
+    .at(-1);
+  assert.equal(
+    staleResult.terminal_reason,
+    "dispatch-disabled-intent-without-worker",
+  );
+  assert.equal(state.targets.ui.active, null);
+  assert.equal(state.status_decisions.at(-1).targets.ui, "error");
+  assert.ok(
+    fixture.contentRequests.some(
+      ({ path, ref }) => path === UI_VERCEL_CONFIGURATION_PATH && ref === SHA.B,
+    ),
+  );
+});
+
 test("active controller defers an exact native-config rollback head without a dispatch credential", async () => {
   const opened = event({
     run: 121,
@@ -7926,83 +8130,176 @@ test("a force-pushed-away active selection is aborted before credentials and new
   );
 });
 
-test("cancelled worker before Deployment creation gets one canonical error Deployment and result receipt", async () => {
-  const opened = event({
-    run: 123,
-    action: "opened",
-    head: SHA.A,
-    updated: timestamp(1),
-  });
-  const pullRequest = pull({ head: SHA.A, updated: timestamp(1) });
-  const selected = reconcile({ events: [opened], pullRequest });
-  const dispatched = persistDispatch(selected, 8_000);
-  const completed = workerRun(selected.nextDispatch, {
-    status: "completed",
-    conclusion: "cancelled",
-  });
-  const fixture = fakeGitHub({
-    pullRequest,
-    comments: [journalWithState([opened], dispatched)],
-    runs: [completed],
-  });
-  const result = await recoverWorkerResult({
-    github: fixture.github,
-    context: fakeContext({ workflowRun: completed }),
-    core: fakeCore(),
-  });
-  assert.equal(result.state, "error");
-  assert.equal(result.terminal_reason, "worker-cancelled");
-  assert.equal(fixture.deployments.length, 1);
-  assert.equal(fixture.deployments[0].ref, SHA.A);
-  assert.equal(fixture.deployments[0].environment, "preview/ui/pr-519");
-  assert.equal(fixture.createdDeploymentStatuses.length, 1);
-  assert.equal(fixture.createdDeploymentStatuses[0].state, "error");
-  assert.equal(fixture.comments.length, 1);
-  assert.equal(
-    journalFromComment(fixture.comments[0]).receipts.results.length,
-    1,
-  );
-});
+for (const target of PREVIEW_TARGETS) {
+  test(`${target} cancellation before Deployment creation binds the exact target tuple`, async () => {
+    const opened = event({
+      run: 123,
+      action: "opened",
+      head: SHA.A,
+      targets: [target],
+      updated: timestamp(1),
+    });
+    const pullRequest = pull({ head: SHA.A, updated: timestamp(1) });
+    const selected = reconcile({ events: [opened], pullRequest });
+    const dispatch = targetDispatch(selected, target);
+    const dispatched = persistTargetDispatch(selected, target, 8_000);
+    const completed = workerRun(dispatch, {
+      status: "completed",
+      conclusion: "cancelled",
+    });
+    const fixture = fakeGitHub({
+      pullRequest,
+      comments: [journalWithState([opened], dispatched)],
+      runs: [completed],
+    });
+    const recovered = await recoverWorkerResult({
+      github: fixture.github,
+      context: fakeContext({ workflowRun: completed }),
+      core: fakeCore(),
+    });
 
-test("completed callback durably binds an intended dispatch after a controller crash", async () => {
-  const opened = event({
-    run: 123,
-    action: "opened",
-    head: SHA.A,
-    updated: timestamp(1),
+    assert.deepEqual(
+      {
+        pr: recovered.pr,
+        target: recovered.target,
+        sha: recovered.sha,
+        key: recovered.controller_key,
+        keyDigest: recovered.key_digest,
+        state: recovered.state,
+        terminalReason: recovered.terminal_reason,
+      },
+      {
+        pr: 519,
+        target,
+        sha: SHA.A,
+        key: dispatch.key,
+        keyDigest: dispatch.key_digest,
+        state: "error",
+        terminalReason: "worker-cancelled",
+      },
+    );
+    assert.equal(fixture.deployments.length, 1);
+    assert.deepEqual(
+      {
+        ref: fixture.deployments[0].ref,
+        environment: fixture.deployments[0].environment,
+        schema: fixture.deployments[0].payload.controller_schema,
+        provenance: fixture.deployments[0].payload.provenance,
+        key: fixture.deployments[0].payload.idempotency_key,
+        target: fixture.deployments[0].payload.logical_target,
+        sha: fixture.deployments[0].payload.sha,
+      },
+      {
+        ref: SHA.A,
+        environment: `preview/${target}/pr-519`,
+        schema: "mento-vercel-prebuilt/v2",
+        provenance: "preview-controller:v2",
+        key: dispatch.key,
+        target,
+        sha: SHA.A,
+      },
+    );
+    assert.deepEqual(
+      fixture.createdDeploymentStatuses.map(({ state }) => state),
+      ["error"],
+    );
+    const journal = journalFromComment(fixture.comments[0]);
+    assert.deepEqual(
+      journal.receipts.results.map((entry) => entry.target),
+      [target],
+    );
+    for (const otherTarget of PREVIEW_TARGETS.filter(
+      (candidate) => candidate !== target,
+    )) {
+      assert.equal(journal.state.targets[otherTarget].active, null);
+      assert.deepEqual(journal.state.targets[otherTarget].terminal_history, []);
+    }
   });
-  const pullRequest = pull({ head: SHA.A, updated: timestamp(1) });
-  const selected = reconcile({ events: [opened], pullRequest });
-  const intended = persistIntent(selected);
-  const completed = workerRun(selected.nextDispatch, {
-    status: "completed",
-    conclusion: "cancelled",
+
+  test(`${target} completed callback recovers an orphaned intent without cross-target mutation`, async () => {
+    const opened = event({
+      run: 124,
+      action: "opened",
+      head: SHA.A,
+      targets: [target],
+      updated: timestamp(1),
+    });
+    const pullRequest = pull({ head: SHA.A, updated: timestamp(1) });
+    const selected = reconcile({ events: [opened], pullRequest });
+    const dispatch = targetDispatch(selected, target);
+    const intended = persistTargetIntent(selected, target);
+    const completed = workerRun(dispatch, {
+      status: "completed",
+      conclusion: "cancelled",
+    });
+    const fixture = fakeGitHub({
+      pullRequest,
+      comments: [journalWithState([opened], intended)],
+      runs: [completed],
+      workflowRunDisplayTitles: ["Vercel Preview Worker"],
+    });
+    const core = fakeCore();
+    const waits = [];
+    const outcome = await recoverWorkerResult({
+      github: fixture.github,
+      context: fakeContext({ workflowRun: completed }),
+      core,
+      waitForRecovery: async (milliseconds) => waits.push(milliseconds),
+    });
+    assert.equal(outcome.target, target);
+    assert.equal(outcome.controller_key, dispatch.key);
+    assert.equal(outcome.key_digest, dispatch.key_digest);
+    assert.equal(outcome.terminal_reason, "worker-cancelled");
+    assert.equal(core.outputs.get("recovered_intended_run_id"), "8000");
+    assert.deepEqual(waits, [1_000]);
+    assert.deepEqual(fixture.workflowRunRequests, [8_000, 8_000]);
+    const attachedJournal = journalFromComment(fixture.comments[0]);
+    assert.equal(
+      attachedJournal.state.targets[target].active.workflow_run_id,
+      8_000,
+    );
+    assert.equal(
+      attachedJournal.state.targets[target].active.workflow_sha,
+      SHA.E,
+    );
+
+    const reconciled = await reconcilePreview({
+      github: fixture.github,
+      context: fakeContext({ runId: 7_001 }),
+      core: fakeCore(),
+      prNumber: 519,
+      waitForRecovery: async () => {},
+    });
+    assert.equal(reconciled.targets[target].active, null);
+    assert.equal(
+      reconciled.targets[target].terminal_history.at(-1).terminal_reason,
+      "worker-cancelled",
+    );
+    const expectedOutcomes = Object.fromEntries(
+      PREVIEW_TARGETS.map((candidate) => [
+        candidate,
+        candidate === target ? "failed" : "not affected",
+      ]),
+    );
+    assert.deepEqual(
+      reconciled.status_decisions.at(-1).targets,
+      expectedOutcomes,
+    );
+    assert.equal(fixture.commitStatuses.at(-1).sha, SHA.A);
+    assert.equal(fixture.commitStatuses.at(-1).state, "failure");
+    assert.equal(
+      fixture.commitStatuses.at(-1).target_url,
+      "https://github.com/mento-protocol/frontend-monorepo/actions/runs/8000",
+    );
+    for (const otherTarget of PREVIEW_TARGETS.filter(
+      (candidate) => candidate !== target,
+    )) {
+      assert.equal(reconciled.targets[otherTarget].active, null);
+      assert.deepEqual(reconciled.targets[otherTarget].terminal_history, []);
+      assert.equal(reconciled.targets[otherTarget].latest_desired_sha, null);
+    }
   });
-  const fixture = fakeGitHub({
-    pullRequest,
-    comments: [journalWithState([opened], intended)],
-    runs: [completed],
-    workflowRunDisplayTitles: ["Vercel Preview Worker"],
-  });
-  const core = fakeCore();
-  const waits = [];
-  const outcome = await recoverWorkerResult({
-    github: fixture.github,
-    context: fakeContext({ workflowRun: completed }),
-    core,
-    waitForRecovery: async (milliseconds) => waits.push(milliseconds),
-  });
-  assert.equal(outcome.terminal_reason, "worker-cancelled");
-  assert.equal(core.outputs.get("recovered_intended_run_id"), "8000");
-  assert.deepEqual(waits, [1_000]);
-  assert.deepEqual(fixture.workflowRunRequests, [8_000, 8_000]);
-  const controllerState = fixture.comments.find(({ body }) =>
-    body.startsWith(PREVIEW_JOURNAL_MARKER),
-  );
-  assert.match(controllerState.body, /"dispatch_state": "dispatched"/);
-  assert.match(controllerState.body, /"workflow_run_id": 8000/);
-  assert.match(controllerState.body, new RegExp(`"workflow_sha": "${SHA.E}"`));
-});
+}
 
 test("completed intended callback fails closed unless its run is the unique recoverable owner", async () => {
   const opened = event({

--- a/scripts/vercel-preview-smoke-workflows.test.mjs
+++ b/scripts/vercel-preview-smoke-workflows.test.mjs
@@ -112,12 +112,14 @@ test("reusable smoke validates metadata before common and target-specific browse
   assert.match(walletSpec, /test\.afterEach/);
 });
 
-test("automatic UI build and resume use the single reusable smoke without activating other targets", () => {
+test("all four automatic build and resume paths use the single reusable smoke", () => {
   const prebuilt = workflow(".github/workflows/_vercel-prebuilt.yml");
   const worker = workflow(".github/workflows/vercel-preview-worker.yml");
   const buildSmoke = prebuilt.jobs.smoke;
-  const resumeSmoke = worker.jobs["resume-ui-smoke"];
-  for (const smoke of [buildSmoke, resumeSmoke]) {
+  const resumeSmokes = ["app", "governance", "reserve", "ui"].map(
+    (target) => worker.jobs[`resume-${target}-smoke`],
+  );
+  for (const smoke of [buildSmoke, ...resumeSmokes]) {
     assert.equal(smoke.uses, "./.github/workflows/_vercel-preview-smoke.yml");
     assert.equal(Object.hasOwn(smoke, "steps"), false);
     assert.equal(Object.hasOwn(smoke, "secrets"), false);
@@ -147,15 +149,25 @@ test("automatic UI build and resume use the single reusable smoke without activa
     }
   }
   assert.equal(buildSmoke.with.logical_target, "${{ inputs.logical_target }}");
-  assert.equal(resumeSmoke.with.logical_target, "ui");
-  assert.equal(resumeSmoke.with.verification_mode, "controller");
+  assert.deepEqual(
+    resumeSmokes.map(({ with: inputs }) => inputs.logical_target),
+    ["app", "governance", "reserve", "ui"],
+  );
+  for (const resumeSmoke of resumeSmokes) {
+    assert.equal(resumeSmoke.with.verification_mode, "controller");
+  }
 
   const prebuiltCallers = Object.entries(worker.jobs).filter(
     ([, job]) => job.uses === "./.github/workflows/_vercel-prebuilt.yml",
   );
   assert.deepEqual(
     prebuiltCallers.map(([name, job]) => [name, job.with.logical_target]),
-    [["deploy-ui-preview", "ui"]],
+    [
+      ["deploy-app-preview", "app"],
+      ["deploy-governance-preview", "governance"],
+      ["deploy-reserve-preview", "reserve"],
+      ["deploy-ui-preview", "ui"],
+    ],
   );
   assert.doesNotMatch(
     `${read(".github/workflows/_vercel-prebuilt.yml")}\n${read(

--- a/scripts/vercel-preview-smoke.test.mjs
+++ b/scripts/vercel-preview-smoke.test.mjs
@@ -238,7 +238,7 @@ test("native classifier rejects production, inactive, main, controller, and acto
 
   const controller = nativeEvent("app");
   controller.deployment.payload = {
-    controller_schema: "mento-vercel-prebuilt/v1",
+    controller_schema: "mento-vercel-prebuilt/v2",
   };
   assert.equal(
     classifyNativePreviewEvent(controller, runtime()).eligible,

--- a/scripts/vercel-preview-targets.mjs
+++ b/scripts/vercel-preview-targets.mjs
@@ -1,0 +1,86 @@
+export const PREVIEW_OWNERSHIP_MODES = Object.freeze({
+  GITHUB: "github",
+  SHADOW: "shadow",
+});
+
+const NATIVE_VERCEL_CONFIGURATION = Object.freeze({
+  $schema: "https://openapi.vercel.sh/vercel.json",
+  git: Object.freeze({
+    deploymentEnabled: Object.freeze({ "dependabot/**": false }),
+  }),
+});
+
+const GITHUB_VERCEL_CONFIGURATION = Object.freeze({
+  $schema: "https://openapi.vercel.sh/vercel.json",
+  git: Object.freeze({
+    deploymentEnabled: Object.freeze({ "**": false, main: true }),
+  }),
+});
+
+const APP_GITHUB_VERCEL_CONFIGURATION = Object.freeze({
+  $schema: "https://openapi.vercel.sh/vercel.json",
+  git: Object.freeze({
+    deploymentEnabled: Object.freeze({ "**": false, main: true, v2: true }),
+  }),
+});
+
+export const PREVIEW_TARGET_CONFIG = Object.freeze({
+  app: Object.freeze({
+    logicalTarget: "app",
+    workspacePackage: "app.mento.org",
+    expectedRootDirectory: "apps/app.mento.org",
+    projectVariable: "VERCEL_PROJECT_ID_APP",
+    ownershipMode: PREVIEW_OWNERSHIP_MODES.SHADOW,
+    vercelConfigurationPath: "apps/app.mento.org/vercel.json",
+    githubVercelConfiguration: APP_GITHUB_VERCEL_CONFIGURATION,
+    nativeVercelConfiguration: NATIVE_VERCEL_CONFIGURATION,
+  }),
+  governance: Object.freeze({
+    logicalTarget: "governance",
+    workspacePackage: "governance.mento.org",
+    expectedRootDirectory: "apps/governance.mento.org",
+    projectVariable: "VERCEL_PROJECT_ID_GOVERNANCE",
+    ownershipMode: PREVIEW_OWNERSHIP_MODES.SHADOW,
+    vercelConfigurationPath: "apps/governance.mento.org/vercel.json",
+    githubVercelConfiguration: GITHUB_VERCEL_CONFIGURATION,
+    nativeVercelConfiguration: NATIVE_VERCEL_CONFIGURATION,
+  }),
+  reserve: Object.freeze({
+    logicalTarget: "reserve",
+    workspacePackage: "reserve.mento.org",
+    expectedRootDirectory: "apps/reserve.mento.org",
+    projectVariable: "VERCEL_PROJECT_ID_RESERVE",
+    ownershipMode: PREVIEW_OWNERSHIP_MODES.SHADOW,
+    vercelConfigurationPath: "apps/reserve.mento.org/vercel.json",
+    githubVercelConfiguration: GITHUB_VERCEL_CONFIGURATION,
+    nativeVercelConfiguration: NATIVE_VERCEL_CONFIGURATION,
+  }),
+  ui: Object.freeze({
+    logicalTarget: "ui",
+    workspacePackage: "ui.mento.org",
+    expectedRootDirectory: "apps/ui.mento.org",
+    projectVariable: "VERCEL_PROJECT_ID_UI",
+    ownershipMode: PREVIEW_OWNERSHIP_MODES.GITHUB,
+    vercelConfigurationPath: "apps/ui.mento.org/vercel.json",
+    githubVercelConfiguration: GITHUB_VERCEL_CONFIGURATION,
+    nativeVercelConfiguration: NATIVE_VERCEL_CONFIGURATION,
+  }),
+});
+
+export const PREVIEW_TARGETS = Object.freeze(
+  Object.keys(PREVIEW_TARGET_CONFIG),
+);
+
+export function previewTarget(value, label = "Preview target") {
+  if (
+    typeof value !== "string" ||
+    !Object.hasOwn(PREVIEW_TARGET_CONFIG, value)
+  ) {
+    throw new Error(`${label} is invalid`);
+  }
+  return value;
+}
+
+export function previewTargetConfig(value, label = "Preview target") {
+  return PREVIEW_TARGET_CONFIG[previewTarget(value, label)];
+}

--- a/scripts/vercel-preview-workflows.test.mjs
+++ b/scripts/vercel-preview-workflows.test.mjs
@@ -108,32 +108,32 @@ test("controller mode is canonical and reaches every reconciliation call", () =>
   }
 });
 
-test("controller guards current, selected, and worker preview ownership with immutable configurations", () => {
+test("controller guards every target with the canonical immutable ownership map", () => {
   const implementation = read("scripts/vercel-preview-controller.mjs");
   assert.match(implementation, /repos\.getContent/);
   assert.match(
     implementation,
-    /function uiPreviewOwnerAtSha[\s\S]+path:\s*UI_VERCEL_CONFIGURATION_PATH,\s*ref:\s*immutableSha/s,
+    /function previewOwnerAtSha[\s\S]+previewTargetConfig\(target\)[\s\S]+path:\s*targetConfiguration\.vercelConfigurationPath,\s*ref:\s*immutableSha/s,
   );
   assert.match(
     implementation,
-    /candidateUiPreviewOwner[\s\S]+uiPreviewOwnerAtSha\(github, context, normalized\.headSha\)/,
+    /function candidatePreviewOwners[\s\S]+PREVIEW_TARGETS[\s\S]+previewOwnerAtSha\(github, context, target, normalized\.headSha\)/,
   );
   assert.match(
     implementation,
-    /shaIsStillAssociated[\s\S]+selected\.sha[\s\S]+uiPreviewOwnerAtSha\(github, context, selected\.sha\)/,
+    /function assertWorkflowOwnershipMap[\s\S]+PREVIEW_TARGET_CONFIG\[target\]\.ownershipMode[\s\S]+previewOwnerAtSha\(github, context, target, workflowSha\)/,
   );
   assert.match(
     implementation,
-    /outcome === "selected-native"[\s\S]+reconcileNoDispatchIntents/,
+    /for \(const target of PREVIEW_TARGETS\)[\s\S]+reconcileNoDispatchIntents/,
   );
   assert.match(
     implementation,
-    /validateWorkerDispatch[\s\S]+uiPreviewOwnerAtSha[\s\S]+normalizedPull\.headSha[\s\S]+uiPreviewOwnerAtSha\(github, context, sha\)/,
+    /validateWorkerDispatch[\s\S]+previewOwnerAtSha[\s\S]+target,[\s\S]+normalizedPull\.headSha[\s\S]+previewOwnerAtSha\(github, context, target, sha\)/,
   );
-  assert.match(
+  assert.doesNotMatch(
     implementation,
-    /Observe-only controller leaves the candidate UI preview ownerless/,
+    /uiPreviewOwnerAtSha|UI_PREVIEW_OWNER|UI_VERCEL_CONFIGURATION_PATH/,
   );
 });
 
@@ -516,7 +516,7 @@ test("every controller reconciliation binds selections to its immutable workflow
   }
 });
 
-test("worker is dispatch-only with strict identity inputs and one literal UI caller", () => {
+test("worker is dispatch-only with strict identity inputs and four literal callers", () => {
   assert.deepEqual(Object.keys(worker.on), ["workflow_dispatch"]);
   assert.deepEqual(Object.keys(worker.on.workflow_dispatch.inputs), [
     "pull_request_number",
@@ -534,31 +534,55 @@ test("worker is dispatch-only with strict identity inputs and one literal UI cal
   assert.deepEqual(worker.permissions, {});
   assert.equal(worker.concurrency["cancel-in-progress"], false);
 
-  const callers = Object.values(worker.jobs).filter(
-    (job) => job.uses === "./.github/workflows/_vercel-prebuilt.yml",
+  const mappings = {
+    app: ["app.mento.org", "apps/app.mento.org", "APP"],
+    governance: [
+      "governance.mento.org",
+      "apps/governance.mento.org",
+      "GOVERNANCE",
+    ],
+    reserve: ["reserve.mento.org", "apps/reserve.mento.org", "RESERVE"],
+    ui: ["ui.mento.org", "apps/ui.mento.org", "UI"],
+  };
+  assert.deepEqual(
+    Object.keys(worker.jobs).filter((name) => name.startsWith("deploy-")),
+    [
+      "deploy-app-preview",
+      "deploy-governance-preview",
+      "deploy-reserve-preview",
+      "deploy-ui-preview",
+    ],
   );
-  assert.equal(callers.length, 1);
-  const caller = callers[0];
-  assert.equal(caller.uses, "./.github/workflows/_vercel-prebuilt.yml");
-  assert.equal(caller.with.logical_target, "ui");
-  assert.equal(caller.with.workspace_package, "ui.mento.org");
-  assert.equal(
-    caller.with.vercel_project_id,
-    "${{ vars.VERCEL_PROJECT_ID_UI }}",
-  );
-  assert.equal(
-    caller.with.github_environment,
-    "preview/ui/pr-${{ inputs.pull_request_number }}",
-  );
-  assert.deepEqual(Object.keys(caller.secrets), [
-    "turbo_remote_cache_signature_key",
-    "turbo_token",
-    "vercel_token",
-  ]);
-  assert.doesNotMatch(
-    JSON.stringify(caller),
-    /secrets:\s*inherit|VERCEL_PROJECT_ID_(?!UI)/,
-  );
+  for (const [
+    target,
+    [workspacePackage, root, projectSuffix],
+  ] of Object.entries(mappings)) {
+    const caller = worker.jobs[`deploy-${target}-preview`];
+    assert.equal(caller.uses, "./.github/workflows/_vercel-prebuilt.yml");
+    assert.equal(caller.with.logical_target, target);
+    assert.equal(caller.with.workspace_package, workspacePackage);
+    assert.equal(caller.with.expected_root_directory, root);
+    assert.equal(
+      caller.with.vercel_project_id,
+      `\${{ vars.VERCEL_PROJECT_ID_${projectSuffix} }}`,
+    );
+    assert.equal(
+      caller.with.github_environment,
+      `preview/${target}/pr-\${{ inputs.pull_request_number }}`,
+    );
+    assert.equal(caller.with.provenance, "preview-controller:v2");
+    assert.match(caller.if, new RegExp(`inputs\\.target == '${target}'`));
+    assert.deepEqual(Object.keys(caller.secrets), [
+      ...(target === "governance" ? ["etherscan_api_key"] : []),
+      "turbo_remote_cache_signature_key",
+      "turbo_token",
+      "vercel_token",
+    ]);
+    assert.doesNotMatch(JSON.stringify(caller), /secrets:\s*inherit|SENTRY/);
+  }
+  const raw = read(workerPath);
+  assert.doesNotMatch(raw, /\bmatrix\b|secrets:\s*inherit|SENTRY/);
+  assert.equal((raw.match(/secrets\.ETHERSCAN_API_KEY/g) ?? []).length, 2);
 });
 
 test("worker credentials are unreachable until trusted validation and named preflight pass", () => {
@@ -591,71 +615,86 @@ test("worker credentials are unreachable until trusted validation and named pref
     /expected_workflow_sha:\s*process\.env\.EXPECTED_WORKFLOW_SHA/,
   );
 
-  const preflight = worker.jobs["validate-preview-prerequisites"];
-  assert.deepEqual(preflight.permissions, {});
-  assert.equal(preflight.needs, "validate-controller-ownership");
-  assert.match(JSON.stringify(preflight), /Missing required repository names/);
-  assert.equal(Object.hasOwn(preflight, "uses"), false);
+  const projectSuffixByTarget = {
+    app: "APP",
+    governance: "GOVERNANCE",
+    reserve: "RESERVE",
+    ui: "UI",
+  };
+  for (const [target, projectSuffix] of Object.entries(projectSuffixByTarget)) {
+    const preflight = worker.jobs[`validate-${target}-prerequisites`];
+    assert.deepEqual(preflight.permissions, {});
+    assert.equal(preflight.needs, "validate-controller-ownership");
+    assert.match(
+      JSON.stringify(preflight),
+      /Missing required repository names/,
+    );
+    assert.match(preflight.if, new RegExp(`inputs\\.target == '${target}'`));
+    assert.equal(Object.hasOwn(preflight, "uses"), false);
+    const preflightRaw = JSON.stringify(preflight);
+    if (target === "governance") {
+      assert.match(preflightRaw, /ETHERSCAN_API_KEY/);
+    } else {
+      assert.doesNotMatch(preflightRaw, /ETHERSCAN_API_KEY/);
+    }
 
-  const caller = worker.jobs["deploy-ui-preview"];
-  assert.deepEqual(caller.needs, [
-    "validate-controller-ownership",
-    "validate-preview-prerequisites",
-  ]);
-  assert.deepEqual(caller.permissions, {
-    contents: "read",
-    deployments: "write",
-  });
-  assert.doesNotMatch(
-    JSON.stringify(caller.permissions),
-    /issues|actions|statuses|pull-requests/,
-  );
+    const caller = worker.jobs[`deploy-${target}-preview`];
+    assert.deepEqual(caller.needs, [
+      "validate-controller-ownership",
+      `validate-${target}-prerequisites`,
+    ]);
+    assert.deepEqual(caller.permissions, {
+      contents: "read",
+      deployments: "write",
+    });
+    assert.doesNotMatch(
+      JSON.stringify(caller.permissions),
+      /issues|actions|statuses|pull-requests/,
+    );
 
-  const resumedSmoke = worker.jobs["resume-ui-smoke"];
-  assert.deepEqual(resumedSmoke.permissions, { contents: "read" });
-  assert.equal(
-    resumedSmoke.uses,
-    "./.github/workflows/_vercel-preview-smoke.yml",
-  );
-  assert.equal(Object.hasOwn(resumedSmoke, "steps"), false);
-  assert.equal(Object.hasOwn(resumedSmoke, "secrets"), false);
-  assert.doesNotMatch(
-    JSON.stringify(resumedSmoke),
-    /secrets\.|VERCEL_TOKEN|TURBO_TOKEN|TURBO_REMOTE_CACHE_SIGNATURE_KEY/,
-  );
-  assert.equal(resumedSmoke.with.logical_target, "ui");
-  assert.equal(resumedSmoke.with.verification_mode, "controller");
-  assert.equal(
-    resumedSmoke.with.verification_key,
-    "${{ inputs.controller_key }}",
-  );
-  assert.equal(
-    resumedSmoke.with.deployment_url,
-    "${{ needs.validate-controller-ownership.outputs.vercel_deployment_url }}",
-  );
-  assert.equal(
-    resumedSmoke.with.github_deployment_id,
-    "${{ needs.validate-controller-ownership.outputs.github_deployment_id }}",
-  );
-  assert.equal(
-    resumedSmoke.with.vercel_deployment_id,
-    "${{ needs.validate-controller-ownership.outputs.vercel_deployment_id }}",
-  );
-  assert.equal(
-    resumedSmoke.with.next_deployment_id,
-    "${{ needs.validate-controller-ownership.outputs.next_deployment_id }}",
-  );
-  assert.equal(
-    resumedSmoke.with.expected_project_id,
-    "${{ vars.VERCEL_PROJECT_ID_UI }}",
-  );
-  assert.equal(
-    resumedSmoke.with.metadata_project_id,
-    "${{ vars.VERCEL_PROJECT_ID_UI }}",
-  );
-  assert.equal(caller.with.logical_target, "ui");
-  assert.equal(caller.with.workspace_package, "ui.mento.org");
-  assert.equal(caller.with.expected_root_directory, "apps/ui.mento.org");
+    const resumedSmoke = worker.jobs[`resume-${target}-smoke`];
+    assert.deepEqual(resumedSmoke.permissions, { contents: "read" });
+    assert.equal(
+      resumedSmoke.uses,
+      "./.github/workflows/_vercel-preview-smoke.yml",
+    );
+    assert.equal(Object.hasOwn(resumedSmoke, "steps"), false);
+    assert.equal(Object.hasOwn(resumedSmoke, "secrets"), false);
+    assert.doesNotMatch(
+      JSON.stringify(resumedSmoke),
+      /secrets\.|VERCEL_TOKEN|TURBO_TOKEN|TURBO_REMOTE_CACHE_SIGNATURE_KEY|ETHERSCAN_API_KEY|SENTRY/,
+    );
+    assert.equal(resumedSmoke.with.logical_target, target);
+    assert.equal(resumedSmoke.with.verification_mode, "controller");
+    assert.equal(
+      resumedSmoke.with.verification_key,
+      "${{ inputs.controller_key }}",
+    );
+    assert.equal(
+      resumedSmoke.with.deployment_url,
+      "${{ needs.validate-controller-ownership.outputs.vercel_deployment_url }}",
+    );
+    assert.equal(
+      resumedSmoke.with.github_deployment_id,
+      "${{ needs.validate-controller-ownership.outputs.github_deployment_id }}",
+    );
+    assert.equal(
+      resumedSmoke.with.vercel_deployment_id,
+      "${{ needs.validate-controller-ownership.outputs.vercel_deployment_id }}",
+    );
+    assert.equal(
+      resumedSmoke.with.next_deployment_id,
+      "${{ needs.validate-controller-ownership.outputs.next_deployment_id }}",
+    );
+    assert.equal(
+      resumedSmoke.with.expected_project_id,
+      `\${{ vars.VERCEL_PROJECT_ID_${projectSuffix} }}`,
+    );
+    assert.equal(
+      resumedSmoke.with.metadata_project_id,
+      `\${{ vars.VERCEL_PROJECT_ID_${projectSuffix} }}`,
+    );
+  }
 
   const evidence = worker.jobs["record-worker-evidence"];
   assert.match(JSON.stringify(evidence), /recordWorkerEvidence/);
@@ -739,10 +778,12 @@ test("automatic workflow creates no implicit or Vercel-owned Deployment", () => 
   for (const job of Object.values(worker.jobs)) {
     assert.equal(Object.hasOwn(job, "environment"), false);
   }
-  assert.match(
-    worker.jobs["deploy-ui-preview"].with.deployment_idempotency_key,
-    /inputs\.controller_key/,
-  );
+  for (const target of ["app", "governance", "reserve", "ui"]) {
+    assert.match(
+      worker.jobs[`deploy-${target}-preview`].with.deployment_idempotency_key,
+      /inputs\.controller_key/,
+    );
+  }
 });
 
 test("runbook covers bootstrap, canaries, browser proof, separate cutover, and exact rollback", () => {

--- a/scripts/vercel-preview-workflows.test.mjs
+++ b/scripts/vercel-preview-workflows.test.mjs
@@ -137,6 +137,25 @@ test("controller guards every target with the canonical immutable ownership map"
   );
 });
 
+test("automatic preview runtime has no v1 journal or worker compatibility path", () => {
+  const runtime = [
+    read("scripts/vercel-preview-controller.mjs"),
+    read("scripts/vercel-prebuilt-workflow.mjs"),
+    read("scripts/github-deployment.mjs"),
+    read(controllerPath),
+    read(workerPath),
+  ].join("\n");
+
+  assert.match(runtime, /vercel-preview-journal:v2/);
+  assert.match(runtime, /vercel-preview-controller:v2/);
+  assert.match(runtime, /mento-vercel-prebuilt\/v2/);
+  assert.match(runtime, /preview-controller:v2/);
+  assert.doesNotMatch(
+    runtime,
+    /vercel-preview-journal:v1|vercel-preview-controller:v1|mento-vercel-prebuilt\/v1|preview-controller:v1/,
+  );
+});
+
 test("Dependabot intake is credentialless and trusted follow-up alone can write status", () => {
   assert.equal(intake.name, "Vercel Preview Intake");
   assert.deepEqual(intake.on, {
@@ -786,12 +805,25 @@ test("automatic workflow creates no implicit or Vercel-owned Deployment", () => 
   }
 });
 
-test("runbook covers bootstrap, canaries, browser proof, separate cutover, and exact rollback", () => {
+test("runbook covers v2 migration, four-target canaries, cutover, and exact rollback", () => {
   const docs = read("docs/vercel-deployments.md");
   for (const expected of [
     "vercel-preview-bootstrap",
     "vercel-preview-reconcile",
     "/dispatches",
+    "Clean v1-to-v2 journal migration",
+    "no v1 reader, writer, importer, deleter",
+    "vercel-preview-journal:v2",
+    "app`, `governance`, `reserve`, and `ui",
+    "without changing any Vercel project configuration",
+    "Four-target v2 activation canary and later ownership cutovers",
+    "single PR that affects multiple targets",
+    "scripts/vercel-preview-targets.mjs",
+    "Perform those later cutovers strictly in the order",
+    "App may not cut over until Governance",
+    "leave all later targets in shadow mode",
+    "intentionally deferred stale PR",
+    "shadow activation",
     "Phase A canary evidence template",
     "repository browser protocol",
     "UI Vercel Git cutover (Phase B)",
@@ -799,7 +831,8 @@ test("runbook covers bootstrap, canaries, browser proof, separate cutover, and e
     '"main": true',
     '"dependabot/**": false',
     "immutable 40-character SHAs",
-    "event's own SHA",
+    "selected historical event is rechecked",
+    "own SHA after PR-lineage proof",
     "dispatch-disabled-intent-without-worker",
     "native-owned-selection-without-github-worker",
     "Draining GitHub preview before native ownership",


### PR DESCRIPTION
## The Problem

Issue #520 needs the proven exact-SHA preview controller to manage App, Governance, Reserve, and UI independently before any remaining Vercel Git ownership cutover can begin. The merged controller still had a UI-only journal/state/recovery model, so it could not safely preserve per-target first/latest batching, recover target-local failures, or publish one truthful aggregate status across all four applications.

## The Solution

- replace the active UI-only journal/controller schemas with a clean v2 four-target model in stable `app`, `governance`, `reserve`, `ui` order, without a legacy reader, importer, dual-write, or fallback path
- keep the external idempotency key contract while binding every receipt, selection, Deployment, worker result, and recovery decision to its literal target
- add four literal worker callers with explicit project and secret mappings; Governance alone receives `ETHERSCAN_API_KEY`, no preview caller receives Sentry credentials, and no caller uses a matrix, dynamic secret lookup, or `secrets: inherit`
- preserve App, Governance, and Reserve in explicit `shadow` mode while UI remains GitHub-owned, enabling the required dual-run canaries without changing any application `vercel.json`
- make first/latest batching, docs-only runtime equivalence, retry/resume, cancellation/orphan recovery, ownership drain, and retired-intent cleanup independent per target
- publish one exact-SHA `Vercel Preview` status and one mutable controller comment with a reviewer-facing four-target outcome table above the collapsed machine journal
- harden refreshed-head ownership races so a newer native rollback head cannot relabel an older GitHub-selected SHA
- update the active ADR and runbook for the clean v2 bootstrap, shadow rollout, ordered Reserve → Governance → App cutovers, stop-on-failure behavior, stale-branch gates, and copy-safe rollback maps

This is the workflow-expansion/shadow slice only. It does not cut over Reserve, Governance, or App ownership and does not modify any application Vercel Git configuration.

Part of #520.

## Validation

- `node --test scripts/vercel-preview-controller.test.mjs` — 146/146 passed
- `pnpm vercel:preview:test` — 197/197 passed
- `pnpm vercel:primitives:test` — 53/53 passed
- `pnpm quality:budgets:test` — 30/30 passed
- `pnpm check-types` — 8/8 workspaces passed
- `pnpm knip` — passed
- `pnpm ci:action-pins` — passed
- `pnpm ci:action-pins:test` — passed (48/48 + 11/11)
- `pnpm adr:check:test` — 9/9 passed
- `pnpm adr:check` — advisory check passed
- version-skew, lockfile-integrity, and pinned Vercel-version checks — passed
- `trunk fmt` and `trunk check` — passed
- `git diff --check` — passed
- `pnpm vercel:workflow:test` — 82/83 locally; the sole failure is the isolated offline-copy fixture lacking the public `@eslint/js@9.39.2` tarball in this machine's pnpm store, reproduced after a successful frozen public-registry install with no credential prompt or output
- `pnpm test` — reaches the same single offline-copy fixture blocker after the ADR and primitive suites pass; GitHub CI remains the clean-runner source of truth for this environment-specific case

## Review

- independent controller security/correctness review: clean on the final behavioral stack; refreshed A→B ownership race, trust, URL, and journal invariants verified fail-closed
- independent workflow/topology review: clean on exact head `05585490c90455fa3c0cee2a0cbac8a19ad5db41`
- exact-head export/caller audit: no consumers of the two final internalized exports; controller tests and Knip remain green

## Architecture Decision

Updated `docs/adr/0002-single-comment-preview-controller-journal.md` because this slice changes the active controller/journal schema and its human presentation while preserving the accepted single-comment persistence decision.

## Ship Checklist

- [x] Based on exact merged PR #583 main commit `d2edfb8a9f0d293deb12c8a39d578d9abdc2524f`
- [x] Ready-for-review, independently reviewed, and exact head pushed
- [x] App/Governance/Reserve remain shadow-owned; UI remains GitHub-owned
- [x] No application `vercel.json` cutover is included
- [x] No Governance QA environment, path, domain, or variable is recreated or referenced
- [x] Active ADR, README, and deployment runbook are synchronized
