### PR TITLE
test(ci): exercise v2 preview shadow batching canary

### DIFF
--- a/apps/app.mento.org/vercel-preview-v2-canary.md
+++ b/apps/app.mento.org/vercel-preview-v2-canary.md
@@ -1,0 +1,4 @@
+# Vercel preview v2 App canary
+
+Disposable, behavior-free marker for issue #520. Remove it when the canary PR
+closes.

--- a/docs/vercel-preview-v2-shadow-canary.md
+++ b/docs/vercel-preview-v2-shadow-canary.md
@@ -1,0 +1,4 @@
+# Vercel preview v2 shadow canary marker
+
+This disposable marker is the documentation-only final push for the issue #520
+shadow canary. Remove it when the canary pull request closes.

--- a/packages/ui/vercel-preview-v2-canary.md
+++ b/packages/ui/vercel-preview-v2-canary.md
@@ -1,0 +1,4 @@
+# Vercel preview v2 shadow canary
+
+Disposable, behavior-free marker for issue #520. Remove it when the canary PR
+closes.

--- a/packages/web3/vercel-preview-v2-canary.md
+++ b/packages/web3/vercel-preview-v2-canary.md
@@ -1,0 +1,4 @@
+# Vercel preview v2 Web3 canary
+
+Disposable, behavior-free marker for issue #520. Remove it when the canary PR
+closes.


### PR DESCRIPTION
## The Problem

Issue #520 needs live evidence that the v2 preview controller preserves independent per-target ownership, first-plus-latest batching, and documentation-only runtime inheritance across overlapping pushes. The exercise must not change product behavior, secrets, Vercel project configuration, or the canonical ownership map.

## The Solution

Open a disposable same-repository canary whose commits add only inert Markdown marker files. Commit A selects App, Governance, Reserve, and UI through `packages/ui`; controlled follow-up pushes select App only, then App/Governance/Reserve through `packages/web3`, then no runtime target through `docs/**`.

**Never merge this pull request.** After terminal controller, worker, Deployment, journal, and browser evidence is recorded, close it without merging and delete the disposable branch.

## Canary sequence

- A: all four targets become first-eligible.
- B: App alone becomes a newer desired runtime.
- C: App, Governance, and Reserve supersede their latest desired runtime while A remains active; B must be durably coalesced for App.
- D: documentation-only and must create no worker or Deployment.
- Expected terminal inheritance: App/Governance/Reserve use C; UI uses A; D reuses those runtime outcomes.

## Validation

- `pnpm vercel:plan` returned the exact expected target set for all four transitions.
- `node --test scripts/plan-vercel-deployments.test.mjs` — 29/29 passed.
- `pnpm vercel:preview:test` — 197/197 passed.
- `pnpm adr:check` passed.
- Mandatory pre-push Trunk, type-check/build, and Knip gates passed for commit A.

## Ship Checklist

- [x] ship skill used
- [x] local review run
- [x] validation run
- [x] ready-for-review PR requested
- [ ] live canary evidence complete
- [ ] PR closed without merge
