### PR TITLE
fix(ci): stamp preview controller run identity

### DIFF
--- a/.github/workflows/vercel-preview-controller.yml
+++ b/.github/workflows/vercel-preview-controller.yml
@@ -1,4 +1,8 @@
 name: Vercel Preview Controller
+run-name: >-
+  ${{ github.event_name == 'pull_request_target' &&
+  format('Vercel preview controller event | id={0} | number={1} | pr={2} | sha={3} | before={4} | action={5} | receipt={6}', github.run_id, github.run_number, github.event.pull_request.number, github.event.pull_request.head.sha, github.event.action == 'synchronize' && github.event.before || 'none', github.event.action, github.event.pull_request.user.login != 'dependabot[bot]' && github.event.pull_request.head.ref != 'dependabot' && !startsWith(github.event.pull_request.head.ref, 'dependabot/') && (github.event.action != 'edited' || github.event.changes.base != null)) ||
+  format('Vercel Preview Controller | event={0} | id={1}', github.event_name, github.run_id) }}
 
 on:
   pull_request_target:
@@ -85,6 +89,7 @@ jobs:
             writeEventSnapshotOutputs({
               payload: context.payload,
               runId: context.runId,
+              runNumber: context.runNumber,
               core,
             });
 

--- a/docs/adr/0002-single-comment-preview-controller-journal.md
+++ b/docs/adr/0002-single-comment-preview-controller-journal.md
@@ -156,6 +156,16 @@ run. A delayed non-closed event also remains inert when the live PR is already
 closed and no journal or witness exists. Explicit bootstrap remains the only
 operator-authorized clean restart.
 
+As precursor evidence for stronger gap detection, every `pull_request_target`
+run uses a strict machine-readable title that binds run ID, workflow-monotonic
+run number, PR, action, head SHA, synchronize `before` SHA, and whether a receipt
+is required. Dependabot events and unrelated edits encode `receipt=false`,
+matching the jobs that do not append a controller receipt. New event and
+bootstrap receipts persist the run number when it is available. This precursor
+does not query Actions, establish an admission frontier, or alter reconciliation
+behavior; existing v2 receipts without the optional field remain valid and keep
+their canonical digest.
+
 GitHub currently bounds `queue: max` at 100 pending jobs. The controller must
 keep journal mutations short, expose queue pressure during canaries, and treat
 an admitted-event gap as ambiguous. It may recover current intent only by

--- a/docs/vercel-deployments.md
+++ b/docs/vercel-deployments.md
@@ -991,6 +991,17 @@ event is likewise inert when the live PR is already closed and neither journal
 nor witness exists. Explicit bootstrap is the sole operator-authorized clean
 restart.
 
+Each `pull_request_target` workflow run now has a strict machine-readable title
+that binds its run ID and workflow-monotonic run number to the PR, action, head
+SHA, synchronize `before` SHA, and whether that event requires a receipt. New
+Dependabot events and unrelated edits encode `receipt=false`, matching the jobs
+that do not append a controller receipt. Event and bootstrap receipts also
+persist that run number when GitHub supplies it. This is evidence groundwork
+only: reconciliation does not yet scan Actions, establish an admission frontier,
+or change its receipt-selection behavior. Already-persisted v2 receipts without
+`event_run_number` remain valid and retain their existing canonical journal
+digests.
+
 Before a later event is appended, a terminal journal with no active or retired
 worker and no unfinished evidence folds its completed prefix into one
 deterministic in-place checkpoint. The checkpoint holds cumulative receipt

--- a/scripts/vercel-preview-controller.mjs
+++ b/scripts/vercel-preview-controller.mjs
@@ -377,10 +377,12 @@ function isTrustedBotComment(comment) {
 function classifyTrust({ headRepository, headRef, author }) {
   validatedHeadRef(headRef);
   validatedLogin(author);
+  const normalizedAuthor = author.toLowerCase();
+  const normalizedHeadRef = headRef.toLowerCase();
   if (
-    author === "dependabot[bot]" ||
-    headRef === "dependabot" ||
-    headRef.startsWith("dependabot/")
+    normalizedAuthor === "dependabot[bot]" ||
+    normalizedHeadRef === "dependabot" ||
+    normalizedHeadRef.startsWith("dependabot/")
   ) {
     return "dependabot";
   }
@@ -452,7 +454,7 @@ function representedPullRequest(events, checkpoint = null) {
   return [...snapshots.values()][0];
 }
 
-export function snapshotPullRequestEvent(payload, runId) {
+export function snapshotPullRequestEvent(payload, runId, runNumber = null) {
   plainObject(payload, "GitHub event payload");
   const action = boundedText(payload.action, "Event action", 32);
   invariant(
@@ -473,6 +475,9 @@ export function snapshotPullRequestEvent(payload, runId) {
     repository,
     pr: pull.number,
     event_run_id: exactRunId(runId),
+    ...(runNumber === null
+      ? {}
+      : { event_run_number: exactRunId(runNumber, "Event run number") }),
     event_action: action,
     pr_state: pull.state,
     pr_updated_at: pull.updatedAt,
@@ -488,7 +493,7 @@ export function snapshotPullRequestEvent(payload, runId) {
   };
 }
 
-function snapshotBootstrapPullRequest(rawPull, runId) {
+function snapshotBootstrapPullRequest(rawPull, runId, runNumber = null) {
   const pull = normalizePullRequest(rawPull);
   invariant(pull.state === "open", "Bootstrap requires an open PR");
   return {
@@ -496,6 +501,9 @@ function snapshotBootstrapPullRequest(rawPull, runId) {
     repository: PREVIEW_REPOSITORY,
     pr: pull.number,
     event_run_id: exactRunId(runId),
+    ...(runNumber === null
+      ? {}
+      : { event_run_number: exactRunId(runNumber, "Event run number") }),
     event_action: "bootstrap",
     pr_state: pull.state,
     pr_updated_at: pull.updatedAt,
@@ -644,6 +652,9 @@ export function validateEventReceipt(value, { requirePlan = true } = {}) {
   validatedRepository(event.repository);
   pullRequestNumber(event.pr);
   exactRunId(event.event_run_id, "Event run ID");
+  if (event.event_run_number !== undefined) {
+    exactRunId(event.event_run_number, "Event run number");
+  }
   invariant(
     ALLOWED_EVENT_ACTIONS.has(event.event_action),
     "Event receipt action is invalid",
@@ -3987,7 +3998,11 @@ export async function prepareBootstrap({
   prNumber: rawPr,
 }) {
   const pull = await pullFromApi(github, context, rawPr);
-  const snapshot = snapshotBootstrapPullRequest(pull, context.runId);
+  const snapshot = snapshotBootstrapPullRequest(
+    pull,
+    context.runId,
+    context.runNumber ?? null,
+  );
   core.setOutput("snapshot", JSON.stringify(snapshot));
   for (const [name, value] of Object.entries({
     pr_number: snapshot.pr,
@@ -4001,8 +4016,8 @@ export async function prepareBootstrap({
   return snapshot;
 }
 
-export function writeEventSnapshotOutputs({ payload, runId, core }) {
-  const snapshot = snapshotPullRequestEvent(payload, runId);
+export function writeEventSnapshotOutputs({ payload, runId, runNumber, core }) {
+  const snapshot = snapshotPullRequestEvent(payload, runId, runNumber);
   core.setOutput("snapshot", JSON.stringify(snapshot));
   for (const [name, value] of Object.entries({
     pr_number: snapshot.pr,
@@ -4029,7 +4044,11 @@ export async function recordEventReceipt({
   try {
     snapshot = snapshotRaw
       ? JSON.parse(snapshotRaw)
-      : snapshotPullRequestEvent(context.payload, context.runId);
+      : snapshotPullRequestEvent(
+          context.payload,
+          context.runId,
+          context.runNumber ?? null,
+        );
   } catch (error) {
     const fallback = context.payload?.pull_request?.head?.sha;
     if (SHA_PATTERN.test(fallback ?? "")) {

--- a/scripts/vercel-preview-controller.test.mjs
+++ b/scripts/vercel-preview-controller.test.mjs
@@ -371,9 +371,11 @@ test("trusted snapshot entrypoints emit bounded event and bootstrap outputs", as
       pull_request: openedPull,
     },
     runId: 1,
+    runNumber: 10,
     core,
   });
   assert.equal(eventSnapshot.event_action, "opened");
+  assert.equal(eventSnapshot.event_run_number, 10);
   assert.equal(outputs.get("pr_number"), "519");
   assert.equal(outputs.get("head_sha"), SHA.A);
   assert.equal(outputs.get("plan_required"), "true");
@@ -399,14 +401,53 @@ test("trusted snapshot entrypoints emit bounded event and bootstrap outputs", as
     context: {
       repo: { owner: "mento-protocol", repo: "frontend-monorepo" },
       runId: 2,
+      runNumber: 20,
     },
     core,
     prNumber: "519",
   });
   assert.equal(bootstrapSnapshot.event_action, "bootstrap");
+  assert.equal(bootstrapSnapshot.event_run_number, 20);
   assert.equal(outputs.get("trusted_base_sha"), SHA.E);
   assert.equal(outputs.get("change_base_sha"), SHA.E);
   assert.deepEqual(JSON.parse(outputs.get("snapshot")), bootstrapSnapshot);
+
+  outputs.clear();
+  const legacyBootstrapSnapshot = await prepareBootstrap({
+    github,
+    context: {
+      repo: { owner: "mento-protocol", repo: "frontend-monorepo" },
+      runId: 3,
+    },
+    core,
+    prNumber: "519",
+  });
+  assert.equal(
+    Object.hasOwn(legacyBootstrapSnapshot, "event_run_number"),
+    false,
+  );
+  const legacyBootstrapPlan = normalizePlannerResult(
+    {
+      deployments: ["ui"],
+      base: SHA.E,
+      head: SHA.A,
+      reason: "affected-packages",
+    },
+    legacyBootstrapSnapshot,
+  );
+  const legacyBootstrapJournal = createPreviewJournal({
+    pr: 519,
+    events: [
+      validateEventReceipt({
+        ...legacyBootstrapSnapshot,
+        plan: legacyBootstrapPlan,
+      }),
+    ],
+  });
+  assert.equal(
+    legacyBootstrapJournal.journal_digest,
+    "2c5ca5e1899615ed4c8af1527123bf704f927327ce530e40720d42715b4e9672",
+  );
 });
 
 test("repository dispatch accepts only one validated PR number and two operations", () => {
@@ -488,6 +529,30 @@ test("receipt schema distinguishes lifecycle fields and synchronize before -> he
   assert.equal(synchronized.plan.base, SHA.A);
   assert.equal(synchronized.plan.head, SHA.B);
   assert.equal(synchronized.plan.planner_source_sha, SHA.E);
+});
+
+test("event run numbers are optional without changing persisted v2 receipt digests", () => {
+  const legacy = event({
+    run: 101,
+    action: "opened",
+    head: SHA.A,
+    updated: timestamp(1),
+  });
+  assert.equal(Object.hasOwn(legacy, "event_run_number"), false);
+  assert.equal(
+    createPreviewJournal({ pr: 519, events: [legacy] }).journal_digest,
+    "5e900812f56fdb504f5188970a09c5d153a070b3212bc0889016f5883680f697",
+  );
+
+  const numbered = validateEventReceipt({
+    ...structuredClone(legacy),
+    event_run_number: 55,
+  });
+  assert.equal(numbered.event_run_number, 55);
+  assert.throws(
+    () => validateEventReceipt({ ...numbered, event_run_number: 0 }),
+    /Event run number/,
+  );
 });
 
 test("v2 is the only internal journal and controller schema while external keys stay v1", () => {
@@ -1407,7 +1472,28 @@ test("fork and Dependabot events succeed unsupported without dispatch", () => {
       head: SHA.A,
       updated: timestamp(1),
       author: "dependabot[bot]",
+    }),
+    event({
+      run: 92,
+      action: "opened",
+      head: SHA.A,
+      updated: timestamp(1),
+      ref: "dependabot",
+    }),
+    event({
+      run: 93,
+      action: "opened",
+      head: SHA.A,
+      updated: timestamp(1),
       ref: "dependabot/npm/pnpm",
+    }),
+    event({
+      run: 94,
+      action: "opened",
+      head: SHA.A,
+      updated: timestamp(1),
+      author: "Dependabot[bot]",
+      ref: "Dependabot/npm/pnpm",
     }),
   ]) {
     const state = reconcile({
@@ -1429,7 +1515,7 @@ test("fork and Dependabot events succeed unsupported without dispatch", () => {
 test("controller and prebuilt worker agree that refs/* head names are unsupported", () => {
   assert.throws(() => validateGitBranch("refs/foo"), /option-like/);
   const unsupported = event({
-    run: 92,
+    run: 94,
     action: "opened",
     head: SHA.A,
     updated: timestamp(1),

--- a/scripts/vercel-preview-workflows.test.mjs
+++ b/scripts/vercel-preview-workflows.test.mjs
@@ -26,6 +26,23 @@ function permissionWrites(job) {
   );
 }
 
+function controllerTitleReceiptRequired({
+  action = "opened",
+  author = "trusted-author",
+  headRef = "feature/preview-controller",
+  baseChanged = false,
+} = {}) {
+  // GitHub Actions string comparisons and startsWith() are case-insensitive.
+  const normalizedAuthor = author.toLowerCase();
+  const normalizedHeadRef = headRef.toLowerCase();
+  return (
+    normalizedAuthor !== "dependabot[bot]" &&
+    normalizedHeadRef !== "dependabot" &&
+    !normalizedHeadRef.startsWith("dependabot/") &&
+    (action !== "edited" || baseChanged)
+  );
+}
+
 function queuedStateConcurrency(prExpression) {
   return {
     group: `vercel-preview-state-pr-${prExpression}`,
@@ -72,12 +89,42 @@ test("controller has only the three specified recovery-aware triggers", () => {
     "vercel-preview-reconcile",
   ]);
   assert.deepEqual(controller.permissions, {});
+  assert.equal(
+    controller["run-name"],
+    [
+      "${{ github.event_name == 'pull_request_target' &&",
+      "format('Vercel preview controller event | id={0} | number={1} | pr={2} | sha={3} | before={4} | action={5} | receipt={6}', github.run_id, github.run_number, github.event.pull_request.number, github.event.pull_request.head.sha, github.event.action == 'synchronize' && github.event.before || 'none', github.event.action, github.event.pull_request.user.login != 'dependabot[bot]' && github.event.pull_request.head.ref != 'dependabot' && !startsWith(github.event.pull_request.head.ref, 'dependabot/') && (github.event.action != 'edited' || github.event.changes.base != null)) ||",
+      "format('Vercel Preview Controller | event={0} | id={1}', github.event_name, github.run_id) }}",
+    ].join(" "),
+  );
   assert.match(
     controller.jobs["snapshot-event"].if,
     /action != 'edited'.*changes\.base != null/,
   );
   const raw = read(controllerPath);
+  assert.match(raw, /runNumber:\s*context\.runNumber/);
   assert.doesNotMatch(raw, /workflow_dispatch|\binputs\./);
+});
+
+test("controller run title marks exactly the receipt-producing PR events", () => {
+  const cases = [
+    ["Dependabot author", { author: "dependabot[bot]" }, false],
+    ["exact Dependabot ref", { headRef: "dependabot" }, false],
+    ["Dependabot ref prefix", { headRef: "dependabot/npm/pnpm" }, false],
+    [
+      "mixed-case Dependabot ref prefix",
+      { headRef: "Dependabot/npm/pnpm" },
+      false,
+    ],
+    ["trusted branch", {}, true],
+    ["fork branch", { headRef: "contributor/change" }, true],
+    ["unsupported ref", { headRef: "refs/change" }, true],
+    ["unrelated edit", { action: "edited" }, false],
+    ["base edit", { action: "edited", baseChanged: true }, true],
+  ];
+  for (const [label, inputs, expected] of cases) {
+    assert.equal(controllerTitleReceiptRequired(inputs), expected, label);
+  }
 });
 
 test("controller mode is canonical and reaches every reconciliation call", () => {


### PR DESCRIPTION
## The Problem

The race-hardened preview controller needs an authenticated, ordered Actions audit source before it can enforce missing-receipt admission. Existing controller runs and receipts do not expose a strict machine identity or workflow-monotonic run number, so enabling enforcement in the same merge would make existing v2 journals ambiguous.

## The Solution

- Stamp every `pull_request_target` run with a strict machine-readable identity containing its run ID, run number, PR, head SHA, synchronize predecessor, action, and receipt expectation.
- Persist the optional controller run number in event and bootstrap receipts while preserving legacy receipt digests and reconciliation keys.
- Mark Dependabot and unrelated edit runs as receipt-free, with controller classification aligned to GitHub Actions' case-insensitive string semantics.
- Document the evidence contract and staged migration sequence without changing reconciliation or dispatch behavior yet.

This is the evidence-only precursor for #520. The admission scanner remains in the follow-up PR so this change can be proven live before enforcement starts.

## Validation

- `pnpm vercel:preview:test` (199 tests)
- `node --test scripts/vercel-preview-controller.test.mjs scripts/vercel-preview-workflows.test.mjs` (170 tests)
- `pnpm adr:check`
- `pnpm ci:action-pins`
- `trunk check --upstream=HEAD`
- `git diff --check`
- Fresh-context semantic autoreview: clean, no findings

## Architecture

Updates ADR 0002 and the Vercel deployment runbook to describe the new evidence fields and staged activation order; no new architectural decision is introduced.
