### PR TITLE
fix(ci): always reconcile closed bootstraps

### DIFF
--- a/.github/workflows/vercel-preview-controller.yml
+++ b/.github/workflows/vercel-preview-controller.yml
@@ -411,7 +411,7 @@ jobs:
   reconcile-bootstrap:
     name: Reconcile bootstrapped preview state
     needs: receipt-bootstrap
-    if: needs.receipt-bootstrap.result == 'success'
+    if: always() && needs.receipt-bootstrap.result == 'success'
     concurrency:
       group: vercel-preview-state-pr-${{ needs.receipt-bootstrap.outputs.pr_number }}
       cancel-in-progress: false

--- a/scripts/vercel-preview-workflows.test.mjs
+++ b/scripts/vercel-preview-workflows.test.mjs
@@ -452,6 +452,27 @@ test("event receipts explicitly gate whether reconciliation is required", () => 
   );
 });
 
+test("closed bootstrap reconciliation survives an intentionally skipped planner", () => {
+  const planner = controller.jobs["plan-bootstrap"];
+  const receipt = controller.jobs["receipt-bootstrap"];
+  const reconcile = controller.jobs["reconcile-bootstrap"];
+
+  assert.equal(
+    planner.if,
+    "needs.snapshot-bootstrap.outputs.plan_required == 'true'",
+  );
+  assert.deepEqual(receipt.needs, ["snapshot-bootstrap", "plan-bootstrap"]);
+  assert.equal(
+    receipt.if,
+    "always() && needs.snapshot-bootstrap.result == 'success'",
+  );
+  assert.equal(reconcile.needs, "receipt-bootstrap");
+  assert.equal(
+    reconcile.if,
+    "always() && needs.receipt-bootstrap.result == 'success'",
+  );
+});
+
 test("every PR comment writer uses the pull-request resource permission", () => {
   const controllerCommentWriters = [
     ["receipt-event", "recordEventReceipt"],


### PR DESCRIPTION
## The Problem

The first live closed-bootstrap migration after #586 exposed GitHub Actions' transitive skipped-needs behavior. For a closed pull request, `plan-bootstrap` intentionally skips. `receipt-bootstrap` correctly survives that skip with `always()` and persisted the authenticated bootstrap receipt/cursor, but `reconcile-bootstrap` had only:

```yaml
if: needs.receipt-bootstrap.result == 'success'
```

GitHub therefore skipped reconciliation even though the direct receipt dependency succeeded. Live run `29903977469` / controller run number `684` left PR #586 with a valid admission floor but `state.closed=false`; the documented one-time reconcile fallback in run `29904149987` / `685` repaired it. The event route already uses the correct `always() && ...` pattern, but the structural workflow suite did not pin the equivalent bootstrap chain.

## The Solution

- make `reconcile-bootstrap` evaluate explicitly with `always()` while still requiring `receipt-bootstrap` to succeed;
- add a structural regression test covering the complete closed-bootstrap dependency chain: intentionally skipped planner, always-run receipt persistence, and always-evaluated reconciliation; and
- leave the ADR/runbook unchanged because they already describe reconciliation as required after a successful bootstrap receipt—this restores the workflow to that documented contract.

This is the reviewed corrective follow-up to #586 and part of #520.

## Live Evidence

- bootstrap run [29903977469](https://github.com/mento-protocol/frontend-monorepo/actions/runs/29903977469) persisted cursor `workflow_id=314322381`, run `684`, but skipped `Reconcile bootstrapped preview state`;
- reconcile run [29904149987](https://github.com/mento-protocol/frontend-monorepo/actions/runs/29904149987) terminalized the same journal without another bootstrap, worker, Deployment, upload, or pending preview status; and
- PR #586's journal is now terminal closed at revision `88`, anchored to bootstrap run `684`, with admission proven through reconcile run `685`.

## Validation

- `node --test scripts/vercel-preview-workflows.test.mjs` — 24/24 passed
- `pnpm vercel:preview:test` — 238/238 passed
- `npm_config_store_dir=/private/tmp/frontend-586-test-store pnpm vercel:workflow:test` — 91/91 passed
- `pnpm quality:budgets:test` — 30/30 passed
- `pnpm check-types` — 8/8 workspaces passed
- `pnpm knip` — passed (pre-existing Tailwind ignore hint only)
- `pnpm adr:check:test` — 9/9 passed
- `pnpm adr:check` — passed
- `pnpm ci:action-pins` — all 23 workflow/action files pinned
- `trunk check` — passed
- `git diff --check` — passed
- deterministic autoreview — clean
- fresh-context semantic review — clean, confidence 0.98

## Risk and Rollback

The change affects only the bootstrap reconciliation job condition. Receipt persistence must still succeed, so a failed receipt cannot unlock reconciliation. Rollback is the one-line condition revert; the documented explicit reconcile remains the operational repair for any already-persisted bootstrap receipt.
