### PR TITLE
test(ui): prove v2 target-local shadow preview

### DIFF
--- a/apps/ui.mento.org/vercel-shadow-canary-20260722.md
+++ b/apps/ui.mento.org/vercel-shadow-canary-20260722.md
@@ -1,0 +1,4 @@
+<!-- GitHub-driven Vercel shadow canary
+Date: 2026-07-22
+Target: ui
+Purpose: path-scoped deployment verification -->


### PR DESCRIPTION
## The Problem

Issue #520 requires fresh, target-local shadow evidence before any production cutover. The UI target must prove that a change confined to `apps/ui.mento.org` produces exactly one GitHub-owned preview without waking unrelated targets or Vercel's native Git integration.

## The Solution

Add one inert canary marker under `apps/ui.mento.org` so the v2 controller can exercise the UI-only path on a fresh pull request.

This pull request is evidence-only: do not merge it. After the preview, deployment record, smoke test, journal state, and close cleanup are verified, it will be closed and its branch deleted.

Refs #520
