### PR TITLE
test(reserve): prove v2 target-local shadow preview

### DIFF
--- a/apps/reserve.mento.org/vercel-shadow-canary-20260722.md
+++ b/apps/reserve.mento.org/vercel-shadow-canary-20260722.md
@@ -1,0 +1,4 @@
+<!-- GitHub-driven Vercel shadow canary
+Date: 2026-07-22
+Target: reserve
+Purpose: path-scoped deployment verification -->


### PR DESCRIPTION
## The Problem

Issue #520 requires fresh, target-local shadow evidence before any production cutover. The Reserve target must prove that a change confined to `apps/reserve.mento.org` produces exactly the intended GitHub-owned preview while Vercel's native integration remains available as the shadow comparator.

## The Solution

Add one inert canary marker under `apps/reserve.mento.org` so the v2 controller can exercise the Reserve-only path on a fresh pull request.

This pull request is evidence-only: do not merge it. After the GitHub and native deployment records, browser smoke, journal state, duplicate-prevention evidence, and close cleanup are verified, it will be closed and its branch deleted.

Refs #520
