### PR TITLE
test(ci): prove v2 multi-target burst convergence

### DIFF
--- a/apps/ui.mento.org/vercel-multitarget-burst-app-ui-20260722.md
+++ b/apps/ui.mento.org/vercel-multitarget-burst-app-ui-20260722.md
@@ -1,0 +1,4 @@
+<!--
+  Inert #520 canary marker: a UI application-local change must affect only
+  the ui.mento.org preview target.
+-->

--- a/docs/vercel-multitarget-burst-docs-20260722.md
+++ b/docs/vercel-multitarget-burst-docs-20260722.md
@@ -1,0 +1,4 @@
+<!--
+  Inert #520 canary marker: a proven documentation-only change must affect no
+  Vercel preview target.
+-->

--- a/packages/ui/vercel-multitarget-burst-ui-20260722.md
+++ b/packages/ui/vercel-multitarget-burst-ui-20260722.md
@@ -1,0 +1,4 @@
+<!--
+  Inert #520 canary marker: a shared UI package change must affect every
+  Vercel preview target.
+-->

--- a/packages/web3/vercel-multitarget-burst-web3-20260722.md
+++ b/packages/web3/vercel-multitarget-burst-web3-20260722.md
@@ -1,0 +1,4 @@
+<!--
+  Inert #520 canary marker: a shared web3 package change must affect App,
+  Governance, and Reserve previews, but not UI.
+-->

--- a/vercel-multitarget-burst-unknown-20260722.md
+++ b/vercel-multitarget-burst-unknown-20260722.md
@@ -1,0 +1,4 @@
+<!--
+  Inert #520 canary marker: unknown root paths must fail closed to every
+  Vercel preview target.
+-->


### PR DESCRIPTION
## The Problem

Issue #520 requires live proof that the v2 controller preserves each target's first eligible runtime SHA, converges independently to the latest desired SHA during a burst, coalesces redundant all-target work, and treats a final docs-only push as runtime-equivalent.

## The Solution

Exercise one disposable five-SHA burst with inert markers whose adjacent planner results are deliberately distinct: unknown root → all four, `packages/ui` → all four, `packages/web3` → App/Governance/Reserve, UI-local → UI, and docs-only → none.

This pull request is evidence-only: do not merge it. After worker counts, coalescing, exact deployment tuples, browser smokes, retry/reconciliation idempotence, and close cleanup are verified, it will be closed and its branch deleted.

Refs #520
