### PR TITLE
fix(pools): make Monad liquidity provision reliable

### DIFF
--- a/apps/app.mento.org/app/components/pools/add-liquidity-form.test.tsx
+++ b/apps/app.mento.org/app/components/pools/add-liquidity-form.test.tsx
@@ -1,0 +1,449 @@
+// @vitest-environment jsdom
+import React from "react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { parseUnits } from "viem";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { PoolDisplay } from "@repo/web3";
+
+type TransactionParams = {
+  to: string;
+  data: string;
+  value?: string;
+};
+
+type TestFlowStep = {
+  id: string;
+  buildTx: () => Promise<TransactionParams> | TransactionParams;
+};
+
+const mocks = vi.hoisted(() => ({
+  useLiquidityQuote: vi.fn(),
+  refetchLiquidityQuote: vi.fn(),
+  useAddLiquidityTransaction: vi.fn(),
+  buildAddLiquidityTransaction: vi.fn(),
+  useZapInTransaction: vi.fn(),
+  buildZapInTransaction: vi.fn(),
+  executeLiquidityFlow: vi.fn(),
+  useReadContract: vi.fn(),
+  toastError: vi.fn(),
+  showLiquiditySuccessToast: vi.fn(),
+  setFlow: vi.fn(),
+  balances: new Map<string, bigint>(),
+  allowances: new Map<string, bigint>(),
+}));
+
+vi.mock("@mento-protocol/ui", () => ({
+  Button: ({
+    children,
+    size: _size,
+    ...props
+  }: React.ButtonHTMLAttributes<HTMLButtonElement> & { size?: string }) => (
+    <button {...props}>{children}</button>
+  ),
+  CoinInput: (props: React.InputHTMLAttributes<HTMLInputElement>) => (
+    <input {...props} />
+  ),
+  Select: ({
+    value,
+    onValueChange,
+    children,
+  }: {
+    value: string;
+    onValueChange: (value: string) => void;
+    children: React.ReactNode;
+  }) => (
+    <select
+      data-testid={value.startsWith("0x") ? "token-select" : "slippage-select"}
+      value={value}
+      onChange={(event) => onValueChange(event.target.value)}
+    >
+      {children}
+    </select>
+  ),
+  SelectContent: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+  SelectItem: ({ value }: { value: string; children: React.ReactNode }) => (
+    <option value={value}>{value}</option>
+  ),
+  SelectTrigger: () => null,
+  SelectValue: () => null,
+  TokenIcon: () => null,
+  toast: { error: mocks.toastError },
+}));
+
+vi.mock("@repo/web3", () => ({
+  SLIPPAGE_OPTIONS: [0.3, 0.5, 1],
+  useLiquidityQuote: (params: unknown) => mocks.useLiquidityQuote(params),
+  useAddLiquidityTransaction: (...args: unknown[]) =>
+    mocks.useAddLiquidityTransaction(...args),
+  useZapInQuote: () => ({ isFetching: false }),
+  useZapInTransaction: (...args: unknown[]) =>
+    mocks.useZapInTransaction(...args),
+  ConnectButton: () => null,
+  tryParseUnits: (amount: string, decimals: number) => {
+    if (!amount) return null;
+    const [integer = "0", fraction = ""] = amount.split(".");
+    const paddedFraction = fraction.padEnd(decimals, "0").slice(0, decimals);
+    return (
+      BigInt(integer) * 10n ** BigInt(decimals) + BigInt(paddedFraction || "0")
+    );
+  },
+  formatCompactBalance: (balance: string) => balance,
+  executeLiquidityFlow: (...args: unknown[]) =>
+    mocks.executeLiquidityFlow(...args),
+  liquidityFlowAtom: {},
+  showLiquiditySuccessToast: mocks.showLiquiditySuccessToast,
+  getPoolDisplayOrder: (pool: PoolDisplay) => ({
+    displayToken0: pool.token0,
+    displayToken1: pool.token1,
+    isSwapped: false,
+  }),
+  isUserRejection: () => false,
+}));
+
+vi.mock("@repo/web3/wagmi", () => ({
+  useAccount: () => ({
+    address: "0x00000000000000000000000000000000000000aa",
+  }),
+  useConfig: () => ({}),
+  useBlockNumber: () => ({ data: undefined }),
+  useReadContract: (params: unknown) => mocks.useReadContract(params),
+}));
+
+vi.mock("@mento-protocol/mento-sdk", () => ({
+  getContractAddress: () => "0x00000000000000000000000000000000000000bb",
+}));
+
+vi.mock("jotai", () => ({
+  useSetAtom: () => mocks.setFlow,
+}));
+
+vi.mock("@tanstack/react-query", () => ({
+  useQueryClient: () => ({
+    invalidateQueries: vi.fn(),
+    refetchQueries: vi.fn(),
+  }),
+}));
+
+vi.mock("lucide-react", () => ({ AlertTriangle: () => null }));
+
+import { AddLiquidityForm } from "./add-liquidity-form";
+
+const EURM = "0x0000000000000000000000000000000000000002";
+const USDM = "0x0000000000000000000000000000000000000003";
+const OWNER = "0x00000000000000000000000000000000000000aa";
+
+const pool: PoolDisplay = {
+  poolAddr: "0x0000000000000000000000000000000000000001",
+  chainId: 143,
+  poolType: "FPMM",
+  token0: { symbol: "EURm", address: EURM, decimals: 18, name: "Euro Mento" },
+  token1: {
+    symbol: "USDm",
+    address: USDM,
+    decimals: 18,
+    name: "Dollar Mento",
+  },
+  reserves: {
+    token0: "0",
+    token1: "0",
+    token0Ratio: 0.5,
+    hasLiquidity: true,
+  },
+  fees: { total: 0.3, lp: 0.2, protocol: 0.1, label: "fee" },
+  priceAlignment: { status: "in-band" },
+  tvl: 0,
+};
+
+const walletEURm = parseUnits("2199.275594139894034278", 18);
+const walletUSDm = parseUnits("1677.027867285683156092", 18);
+const canonicalEURm = parseUnits("1938.824449465635730703", 18);
+const canonicalUSDm = parseUnits("1677.027867285683156092", 18);
+
+let currentQuote: Record<string, unknown>;
+let currentAddBuild: Record<string, unknown>;
+let currentZapPreviewBuild: Record<string, unknown>;
+let sentTransactions: TransactionParams[];
+let flowEvents: string[];
+
+function minimumAmount(amount: bigint): bigint {
+  return (amount * 9_970n) / 10_000n;
+}
+
+function makeAddBuild({ approvals }: { approvals: boolean }) {
+  return {
+    approvalA: approvals
+      ? { params: { to: EURM, data: "0xapprove-eurm", value: "0" } }
+      : undefined,
+    approvalB: approvals
+      ? { params: { to: USDM, data: "0xapprove-usdm", value: "0" } }
+      : undefined,
+    addLiquidity: {
+      amountADesired: canonicalEURm,
+      amountBDesired: canonicalUSDm,
+      amountAMin: minimumAmount(canonicalEURm),
+      amountBMin: minimumAmount(canonicalUSDm),
+      params: {
+        to: "0x00000000000000000000000000000000000000bb",
+        data: "0xcanonical-add-liquidity",
+        value: "0",
+      },
+    },
+  };
+}
+
+function makeZapBuild({
+  token,
+  approvalData,
+  zapData,
+}: {
+  token: string;
+  approvalData?: string;
+  zapData: string;
+}) {
+  return {
+    approval: approvalData
+      ? { params: { to: token, data: approvalData, value: "0" } }
+      : undefined,
+    zapIn: {
+      params: {
+        to: "0x00000000000000000000000000000000000000bb",
+        data: zapData,
+        value: "0",
+      },
+    },
+  };
+}
+
+describe("AddLiquidityForm canonical transaction flows", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    sentTransactions = [];
+    flowEvents = [];
+    mocks.balances.clear();
+    mocks.allowances.clear();
+    mocks.balances.set(EURM, walletEURm);
+    mocks.balances.set(USDM, walletUSDm);
+    mocks.allowances.set(EURM, 0n);
+    mocks.allowances.set(USDM, 0n);
+
+    currentQuote = {
+      amountA: canonicalEURm,
+      amountB: canonicalUSDm,
+      liquidity: 1n,
+      totalSupply: 10_000n,
+      reserve0: parseUnits("2000", 18),
+      reserve1: parseUnits("1730", 18),
+      requestId: 1,
+      requestKind: "max",
+      surplus0: walletEURm - canonicalEURm,
+      surplus1: walletUSDm - canonicalUSDm,
+    };
+    currentAddBuild = makeAddBuild({ approvals: true });
+    currentZapPreviewBuild = makeZapBuild({
+      token: EURM,
+      approvalData: "0xold-preview-approval",
+      zapData: "0xold-preview-zap",
+    });
+
+    mocks.refetchLiquidityQuote.mockImplementation(async () => ({
+      data: currentQuote,
+      error: null,
+    }));
+    mocks.useLiquidityQuote.mockImplementation(
+      ({ request }: { request: { id: number } | null }) => ({
+        data: request ? currentQuote : null,
+        isFetching: false,
+        isDebouncing: false,
+        refetch: mocks.refetchLiquidityQuote,
+      }),
+    );
+    mocks.useAddLiquidityTransaction.mockImplementation(() => ({
+      buildTransaction: mocks.buildAddLiquidityTransaction,
+      buildResult: currentAddBuild,
+      isBuilding: false,
+    }));
+    mocks.useZapInTransaction.mockImplementation(() => ({
+      buildTransaction: mocks.buildZapInTransaction,
+      buildResult: currentZapPreviewBuild,
+      buildError: null,
+      isBuilding: false,
+    }));
+    mocks.useReadContract.mockImplementation(
+      ({
+        address,
+        functionName,
+      }: {
+        address: string;
+        functionName: string;
+      }) => {
+        const data =
+          functionName === "balanceOf"
+            ? mocks.balances.get(address)
+            : mocks.allowances.get(address);
+        return {
+          data,
+          refetch: vi.fn().mockResolvedValue({ data }),
+        };
+      },
+    );
+    mocks.executeLiquidityFlow.mockImplementation(
+      async (...args: unknown[]) => {
+        const steps = args[3] as TestFlowStep[];
+        for (const step of steps) {
+          flowEvents.push(`step:${step.id}`);
+          const transaction = await step.buildTx();
+          sentTransactions.push(transaction);
+          flowEvents.push(`send:${transaction.data}`);
+        }
+        return { success: false, txHashes: [] };
+      },
+    );
+  });
+
+  afterEach(() => cleanup());
+
+  it("uses one Router-clipped MAX quote for inputs, summary, approvals, and calldata", async () => {
+    const previewBuild = makeAddBuild({ approvals: true });
+    const capturedBuild = makeAddBuild({ approvals: true });
+    const freshBuild = makeAddBuild({ approvals: false });
+    mocks.buildAddLiquidityTransaction
+      .mockResolvedValueOnce(previewBuild)
+      .mockResolvedValueOnce(capturedBuild)
+      .mockResolvedValueOnce(freshBuild);
+
+    render(<AddLiquidityForm pool={pool} />);
+    fireEvent.click(screen.getByRole("button", { name: "MAX EURm" }));
+
+    await waitFor(() => {
+      expect(
+        (screen.getByLabelText("Deposit amount in EURm") as HTMLInputElement)
+          .value,
+      ).toBe("1938.824449465635730703");
+      expect(
+        (screen.getByLabelText("Deposit amount in USDm") as HTMLInputElement)
+          .value,
+      ).toBe("1677.027867285683156092");
+    });
+    expect(screen.getByText("1,938.824449465635730703")).toBeTruthy();
+    expect(screen.getByText("1,677.027867285683156092")).toBeTruthy();
+    expect(mocks.useLiquidityQuote).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        request: expect.objectContaining({
+          kind: "max",
+          token: 0,
+          token0Balance: walletEURm,
+          token1Balance: walletUSDm,
+        }),
+      }),
+    );
+    await waitFor(() =>
+      expect(mocks.buildAddLiquidityTransaction).toHaveBeenCalledTimes(1),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Add Liquidity" }));
+
+    await waitFor(() =>
+      expect(mocks.buildAddLiquidityTransaction).toHaveBeenCalledTimes(3),
+    );
+    for (const call of mocks.buildAddLiquidityTransaction.mock.calls) {
+      expect(call).toEqual([canonicalEURm, canonicalUSDm, OWNER, 0.3]);
+    }
+    expect(sentTransactions).toEqual([
+      capturedBuild.approvalA?.params,
+      capturedBuild.approvalB?.params,
+      freshBuild.addLiquidity.params,
+    ]);
+  });
+
+  it.each([
+    ["EURm", EURM],
+    ["USDm", USDM],
+  ])(
+    "uses the click-time %s approval and refuses a zap whose fresh build still needs approval",
+    async (symbol, selectedToken) => {
+      const otherToken = selectedToken === EURM ? USDM : EURM;
+      const amount = parseUnits("1", 18);
+      mocks.balances.set(EURM, parseUnits("10", 18));
+      mocks.balances.set(USDM, parseUnits("10", 18));
+      mocks.allowances.set(selectedToken, 0n);
+      mocks.allowances.set(otherToken, amount + 1n);
+
+      const oldPreview = makeZapBuild({
+        token: selectedToken,
+        approvalData: `0xold-${symbol.toLowerCase()}`,
+        zapData: "0xold-zap",
+      });
+      const clickTimeBuild = makeZapBuild({
+        token: selectedToken,
+        approvalData: `0xcaptured-${symbol.toLowerCase()}`,
+        zapData: "0xcaptured-zap",
+      });
+      const stillNeedsApproval = makeZapBuild({
+        token: selectedToken,
+        approvalData: `0xstill-${symbol.toLowerCase()}`,
+        zapData: "0xfresh-zap-must-not-send",
+      });
+      currentZapPreviewBuild = oldPreview;
+
+      let buildCall = 0;
+      mocks.buildZapInTransaction.mockImplementation(async () => {
+        buildCall += 1;
+        if (buildCall === 1) return oldPreview;
+        if (buildCall === 2) {
+          flowEvents.push("click-time-build");
+          return clickTimeBuild;
+        }
+        flowEvents.push("fresh-zap-build");
+        return stillNeedsApproval;
+      });
+
+      render(<AddLiquidityForm pool={pool} />);
+      fireEvent.click(screen.getByRole("button", { name: "Single token" }));
+      if (selectedToken === USDM) {
+        fireEvent.change(screen.getByTestId("token-select"), {
+          target: { value: USDM },
+        });
+      }
+      fireEvent.change(screen.getByLabelText(`Deposit amount in ${symbol}`), {
+        target: { value: "1" },
+      });
+      await waitFor(() =>
+        expect(mocks.buildZapInTransaction).toHaveBeenCalledTimes(1),
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: "Add Liquidity" }));
+
+      await waitFor(() =>
+        expect(mocks.buildZapInTransaction).toHaveBeenCalledTimes(3),
+      );
+      expect(mocks.buildZapInTransaction.mock.calls[1]).toEqual([
+        selectedToken,
+        amount,
+        OWNER,
+        0.3,
+      ]);
+      expect(mocks.buildZapInTransaction.mock.calls[2]).toEqual([
+        selectedToken,
+        amount,
+        OWNER,
+        0.3,
+      ]);
+      expect(sentTransactions).toEqual([clickTimeBuild.approval?.params]);
+      expect(sentTransactions).not.toContainEqual(oldPreview.approval?.params);
+      expect(sentTransactions).not.toContainEqual(
+        stillNeedsApproval.zapIn.params,
+      );
+      expect(flowEvents.indexOf("step:approve-token")).toBeLessThan(
+        flowEvents.indexOf("fresh-zap-build"),
+      );
+    },
+  );
+});

--- a/apps/app.mento.org/app/components/pools/add-liquidity-form.test.tsx
+++ b/apps/app.mento.org/app/components/pools/add-liquidity-form.test.tsx
@@ -29,6 +29,7 @@ const mocks = vi.hoisted(() => ({
   buildAddLiquidityTransaction: vi.fn(),
   useZapInTransaction: vi.fn(),
   buildZapInTransaction: vi.fn(),
+  buildZapInTransactionAttempt: vi.fn(),
   executeLiquidityFlow: vi.fn(),
   useReadContract: vi.fn(),
   toastError: vi.fn(),
@@ -43,9 +44,10 @@ vi.mock("@mento-protocol/ui", () => ({
     children,
     size: _size,
     ...props
-  }: React.ButtonHTMLAttributes<HTMLButtonElement> & { size?: string }) => (
-    <button {...props}>{children}</button>
-  ),
+  }: React.ButtonHTMLAttributes<HTMLButtonElement> & { size?: string }) => {
+    void _size;
+    return <button {...props}>{children}</button>;
+  },
   CoinInput: (props: React.InputHTMLAttributes<HTMLInputElement>) => (
     <input {...props} />
   ),
@@ -272,10 +274,17 @@ describe("AddLiquidityForm canonical transaction flows", () => {
     }));
     mocks.useZapInTransaction.mockImplementation(() => ({
       buildTransaction: mocks.buildZapInTransaction,
+      buildTransactionAttempt: mocks.buildZapInTransactionAttempt,
       buildResult: currentZapPreviewBuild,
       buildError: null,
       isBuilding: false,
     }));
+    mocks.buildZapInTransactionAttempt.mockImplementation(
+      async (...args: unknown[]) => ({
+        build: await mocks.buildZapInTransaction(...args),
+        error: null,
+      }),
+    );
     mocks.useReadContract.mockImplementation(
       ({
         address,
@@ -446,4 +455,43 @@ describe("AddLiquidityForm canonical transaction flows", () => {
       );
     },
   );
+
+  it("shows the exact fresh click-time liquidity failure", async () => {
+    const amount = parseUnits("1", 18);
+    mocks.balances.set(EURM, parseUnits("10", 18));
+    mocks.balances.set(USDM, parseUnits("10", 18));
+    currentZapPreviewBuild = makeZapBuild({
+      token: EURM,
+      zapData: "0xpreview-zap",
+    });
+    mocks.buildZapInTransaction.mockResolvedValue(currentZapPreviewBuild);
+    mocks.buildZapInTransactionAttempt.mockResolvedValue({
+      build: null,
+      error: "Pool liquidity is insufficient for this single-token amount.",
+    });
+
+    render(<AddLiquidityForm pool={pool} />);
+    fireEvent.click(screen.getByRole("button", { name: "Single token" }));
+    fireEvent.change(screen.getByLabelText("Deposit amount in EURm"), {
+      target: { value: "1" },
+    });
+    await waitFor(() =>
+      expect(mocks.buildZapInTransaction).toHaveBeenCalledTimes(1),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Add Liquidity" }));
+
+    await waitFor(() =>
+      expect(mocks.toastError).toHaveBeenCalledWith(
+        "This pool cannot convert enough EURm into the other token for this single-token amount. Try a smaller amount or use balanced mode.",
+      ),
+    );
+    expect(mocks.buildZapInTransactionAttempt).toHaveBeenCalledWith(
+      EURM,
+      amount,
+      OWNER,
+      0.3,
+    );
+    expect(mocks.executeLiquidityFlow).not.toHaveBeenCalled();
+  });
 });

--- a/apps/app.mento.org/app/components/pools/add-liquidity-form.tsx
+++ b/apps/app.mento.org/app/components/pools/add-liquidity-form.tsx
@@ -13,7 +13,6 @@ import type { PoolDisplay, SlippageOption } from "@repo/web3";
 import {
   SLIPPAGE_OPTIONS,
   useLiquidityQuote,
-  getProportionalAmount,
   useAddLiquidityTransaction,
   useZapInQuote,
   useZapInTransaction,
@@ -26,6 +25,7 @@ import {
   type LiquidityFlowStepDefinition,
   getPoolDisplayOrder,
   isUserRejection,
+  type LiquidityQuoteRequest,
 } from "@repo/web3";
 import {
   useAccount,
@@ -39,6 +39,10 @@ import { AlertTriangle } from "lucide-react";
 import { getContractAddress } from "@mento-protocol/mento-sdk";
 import { useSetAtom } from "jotai";
 import { useQueryClient } from "@tanstack/react-query";
+import {
+  formatLiquiditySummaryAmount,
+  getBalancedLiquidityDisplayState,
+} from "./balanced-liquidity-display";
 
 function isSingleTokenLiquidityLimitError(message: string): boolean {
   return /pool liquidity is insufficient|insufficient liquidity|insufficient reserves|insufficient output amount|bb55fd27/i.test(
@@ -144,18 +148,6 @@ function TokenAmountInput({
   );
 }
 
-function formatSummaryAmount(amount: string): string {
-  if (amount === "—") return amount;
-
-  const value = Number(amount);
-  if (!Number.isFinite(value)) return "0.0000";
-
-  return value.toLocaleString(undefined, {
-    minimumFractionDigits: 4,
-    maximumFractionDigits: 4,
-  });
-}
-
 interface AddLiquidityFormProps {
   pool: PoolDisplay;
   onLiquidityUpdated?: (txHash?: string) => void | Promise<void>;
@@ -188,16 +180,15 @@ export function AddLiquidityForm({
   const [mode, setMode] = useState<"balanced" | "single">("balanced");
   const [token0Amount, setToken0Amount] = useState("");
   const [token1Amount, setToken1Amount] = useState("");
-  const [lastEditedToken, setLastEditedToken] = useState<0 | 1>(0);
+  const [liquidityQuoteRequest, setLiquidityQuoteRequest] =
+    useState<LiquidityQuoteRequest | null>(null);
   const [slippage, setSlippage] = useState<SlippageOption>(0.3);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const liquidityQuoteRequestId = useRef(0);
 
   // Single-token (zap) state
   const [zapTokenIn, setZapTokenIn] = useState<string>(pool.token0.address);
   const [zapAmount, setZapAmount] = useState("");
-
-  // Track whether the auto-fill should be suppressed (during programmatic updates)
-  const isAutoFilling = useRef(false);
 
   // Fetch token balances
   const { data: token0Balance, refetch: refetchToken0Balance } =
@@ -281,30 +272,38 @@ export function AddLiquidityForm({
 
   // === Balanced mode hooks ===
 
-  const { data: quote, isFetching: isQuoting } = useLiquidityQuote({
+  const {
+    data: quote,
+    isFetching: isFetchingQuote,
+    isDebouncing: isQuoteDebouncing,
+  } = useLiquidityQuote({
     pool,
-    token0Amount: mode === "balanced" ? token0Amount : "",
-    token1Amount: mode === "balanced" ? token1Amount : "",
-    lastEditedToken,
+    request: mode === "balanced" ? liquidityQuoteRequest : null,
     chainId,
   });
+  const isQuoting = isFetchingQuote || isQuoteDebouncing;
 
-  // Auto-fill proportional amount when quote returns
+  const currentQuote =
+    quote && quote.requestId === liquidityQuoteRequest?.id ? quote : null;
+  const balancedDisplay = getBalancedLiquidityDisplayState({
+    quote: currentQuote,
+    pool,
+    rawToken0Amount: token0Amount,
+    rawToken1Amount: token1Amount,
+  });
+
+  // Persist the Router-authoritative pair without changing the user request.
+  // Keeping those states separate prevents a quote/input feedback loop.
   useEffect(() => {
-    if (mode !== "balanced" || !quote || isAutoFilling.current) return;
-    const proportional = getProportionalAmount(quote, lastEditedToken, pool);
-    if (!proportional) return;
-
-    isAutoFilling.current = true;
-    if (lastEditedToken === 0) {
-      setToken1Amount(proportional);
-    } else {
-      setToken0Amount(proportional);
-    }
-    requestAnimationFrame(() => {
-      isAutoFilling.current = false;
-    });
-  }, [quote, lastEditedToken, pool, mode]);
+    if (mode !== "balanced" || !currentQuote) return;
+    setToken0Amount(balancedDisplay.token0Amount);
+    setToken1Amount(balancedDisplay.token1Amount);
+  }, [
+    balancedDisplay.token0Amount,
+    balancedDisplay.token1Amount,
+    currentQuote,
+    mode,
+  ]);
 
   const { buildTransaction, buildResult, isBuilding } =
     useAddLiquidityTransaction(pool, chainId);
@@ -312,10 +311,20 @@ export function AddLiquidityForm({
   // Build transaction when we have a valid quote and wallet
   useEffect(() => {
     if (mode !== "balanced") return;
-    if (!address || !quote || quote.amountA === 0n || quote.amountB === 0n)
+    if (
+      !address ||
+      !currentQuote ||
+      currentQuote.amountA === 0n ||
+      currentQuote.amountB === 0n
+    )
       return;
-    buildTransaction(quote.amountA, quote.amountB, address, slippage);
-  }, [quote, address, slippage, buildTransaction, mode]);
+    buildTransaction(
+      currentQuote.amountA,
+      currentQuote.amountB,
+      address,
+      slippage,
+    );
+  }, [currentQuote, address, slippage, buildTransaction, mode]);
 
   // === Single-token (zap) hooks ===
 
@@ -362,37 +371,77 @@ export function AddLiquidityForm({
 
   const handleToken0Change = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
-      if (isAutoFilling.current) return;
-      setLastEditedToken(0);
-      setToken0Amount(e.target.value);
+      const amount = e.target.value;
+      const requestId = ++liquidityQuoteRequestId.current;
+      setToken0Amount(amount);
+      setToken1Amount("");
+      setLiquidityQuoteRequest(
+        amount ? { id: requestId, kind: "manual", token: 0, amount } : null,
+      );
     },
     [],
   );
 
   const handleToken1Change = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
-      if (isAutoFilling.current) return;
-      setLastEditedToken(1);
-      setToken1Amount(e.target.value);
+      const amount = e.target.value;
+      const requestId = ++liquidityQuoteRequestId.current;
+      setToken0Amount("");
+      setToken1Amount(amount);
+      setLiquidityQuoteRequest(
+        amount ? { id: requestId, kind: "manual", token: 1, amount } : null,
+      );
     },
     [],
   );
 
   const handleMax0 = useCallback(() => {
-    setLastEditedToken(0);
-    setToken0Amount(formattedToken0Balance);
-  }, [formattedToken0Balance]);
+    if (
+      token0Balance === undefined ||
+      token1Balance === undefined ||
+      token0Balance === 0n ||
+      token1Balance === 0n
+    )
+      return;
+
+    const requestId = ++liquidityQuoteRequestId.current;
+    setToken0Amount("");
+    setToken1Amount("");
+    setLiquidityQuoteRequest({
+      id: requestId,
+      kind: "max",
+      token: 0,
+      token0Balance,
+      token1Balance,
+    });
+  }, [token0Balance, token1Balance]);
 
   const handleMax1 = useCallback(() => {
-    setLastEditedToken(1);
-    setToken1Amount(formattedToken1Balance);
-  }, [formattedToken1Balance]);
+    if (
+      token0Balance === undefined ||
+      token1Balance === undefined ||
+      token0Balance === 0n ||
+      token1Balance === 0n
+    )
+      return;
+
+    const requestId = ++liquidityQuoteRequestId.current;
+    setToken0Amount("");
+    setToken1Amount("");
+    setLiquidityQuoteRequest({
+      id: requestId,
+      kind: "max",
+      token: 1,
+      token0Balance,
+      token1Balance,
+    });
+  }, [token0Balance, token1Balance]);
 
   // === Validation ===
 
   // Balanced mode
-  const parsedToken0 = tryParseUnits(token0Amount, pool.token0.decimals);
-  const parsedToken1 = tryParseUnits(token1Amount, pool.token1.decimals);
+  const parsedToken0 = currentQuote?.amountA ?? null;
+  const parsedToken1 = currentQuote?.amountB ?? null;
   const hasAmounts =
     parsedToken0 !== null &&
     parsedToken0 > 0n &&
@@ -597,19 +646,29 @@ export function AddLiquidityForm({
           await refreshLiquidityState(lastTxHash);
           setZapAmount("");
         }
-      } else if (mode === "balanced" && quote && buildResult) {
+      } else if (mode === "balanced" && currentQuote && buildResult) {
         // --- Balanced add flow ---
-        const capturedQuote = quote;
+        const capturedQuote = currentQuote;
         const capturedSlippage = slippage;
+
+        // Rebuild at click time and use this exact result for approvals. The
+        // stateful preview build may still belong to a previous quote.
+        const capturedBuild = await buildTransaction(
+          capturedQuote.amountA,
+          capturedQuote.amountB,
+          address,
+          capturedSlippage,
+        );
+        if (!capturedBuild) throw new Error("Failed to build transaction");
 
         const steps: LiquidityFlowStepDefinition[] = [];
         const allowances = await getLatestAllowances();
 
         if (
-          buildResult.approvalA &&
+          capturedBuild.approvalA &&
           capturedQuote.amountA > allowances.token0
         ) {
-          const approvalParams = buildResult.approvalA.params;
+          const approvalParams = capturedBuild.approvalA.params;
           steps.push({
             id: "approve-a",
             label: `Approve ${pool.token0.symbol}`,
@@ -618,10 +677,10 @@ export function AddLiquidityForm({
         }
 
         if (
-          buildResult.approvalB &&
+          capturedBuild.approvalB &&
           capturedQuote.amountB > allowances.token1
         ) {
-          const approvalParams = buildResult.approvalB.params;
+          const approvalParams = capturedBuild.approvalB.params;
           steps.push({
             id: "approve-b",
             label: `Approve ${pool.token1.symbol}`,
@@ -666,6 +725,7 @@ export function AddLiquidityForm({
           await refreshLiquidityState(lastTxHash);
           setToken0Amount("");
           setToken1Amount("");
+          setLiquidityQuoteRequest(null);
         }
       }
     } catch (err) {
@@ -710,16 +770,25 @@ export function AddLiquidityForm({
   // Summary display values
   const summaryToken0Amount =
     mode === "balanced"
-      ? formatSummaryAmount(token0Amount || "0")
+      ? balancedDisplay.summaryToken0Amount
       : zapTokenIn === pool.token0.address
-        ? formatSummaryAmount(zapAmount || "0")
+        ? formatLiquiditySummaryAmount(zapAmount || "0")
         : "—";
   const summaryToken1Amount =
     mode === "balanced"
-      ? formatSummaryAmount(token1Amount || "0")
+      ? balancedDisplay.summaryToken1Amount
       : zapTokenIn === pool.token1.address
-        ? formatSummaryAmount(zapAmount || "0")
+        ? formatLiquiditySummaryAmount(zapAmount || "0")
         : "—";
+
+  const maxSurplus0 =
+    currentQuote?.requestKind === "max" && currentQuote.surplus0 > 0n
+      ? formatUnits(currentQuote.surplus0, pool.token0.decimals)
+      : null;
+  const maxSurplus1 =
+    currentQuote?.requestKind === "max" && currentQuote.surplus1 > 0n
+      ? formatUnits(currentQuote.surplus1, pool.token1.decimals)
+      : null;
 
   return (
     <div className="gap-4 md:grid-cols-[2fr_1fr] grid grid-cols-1">
@@ -759,7 +828,7 @@ export function AddLiquidityForm({
                       key="t1"
                       token={pool.token1}
                       balance={formattedToken1Balance}
-                      amount={token1Amount}
+                      amount={balancedDisplay.token1Amount}
                       onChange={handleToken1Change}
                       onMax={handleMax1}
                       insufficient={insufficientToken1}
@@ -769,7 +838,7 @@ export function AddLiquidityForm({
                       key="t0"
                       token={pool.token0}
                       balance={formattedToken0Balance}
-                      amount={token0Amount}
+                      amount={balancedDisplay.token0Amount}
                       onChange={handleToken0Change}
                       onMax={handleMax0}
                       insufficient={insufficientToken0}
@@ -781,7 +850,7 @@ export function AddLiquidityForm({
                       key="t0"
                       token={pool.token0}
                       balance={formattedToken0Balance}
-                      amount={token0Amount}
+                      amount={balancedDisplay.token0Amount}
                       onChange={handleToken0Change}
                       onMax={handleMax0}
                       insufficient={insufficientToken0}
@@ -791,7 +860,7 @@ export function AddLiquidityForm({
                       key="t1"
                       token={pool.token1}
                       balance={formattedToken1Balance}
-                      amount={token1Amount}
+                      amount={balancedDisplay.token1Amount}
                       onChange={handleToken1Change}
                       onMax={handleMax1}
                       insufficient={insufficientToken1}
@@ -799,6 +868,23 @@ export function AddLiquidityForm({
                     />,
                   ]
               ).map((input) => input)}
+              <div className="gap-1.5 p-3 text-xs leading-5 flex flex-col rounded-lg border border-border bg-muted/30 text-muted-foreground">
+                <span>
+                  Balanced liquidity follows the pool&apos;s current reserve
+                  ratio, which may differ from equal USD value.
+                </span>
+                {(maxSurplus0 || maxSurplus1) && (
+                  <span className="text-foreground">
+                    Estimated surplus:{" "}
+                    {maxSurplus0 &&
+                      `${formatCompactBalance(maxSurplus0)} ${pool.token0.symbol}`}
+                    {maxSurplus0 && maxSurplus1 && ", "}
+                    {maxSurplus1 &&
+                      `${formatCompactBalance(maxSurplus1)} ${pool.token1.symbol}`}{" "}
+                    stays in your wallet.
+                  </span>
+                )}
+              </div>
             </>
           ) : (
             <>

--- a/apps/app.mento.org/app/components/pools/add-liquidity-form.tsx
+++ b/apps/app.mento.org/app/components/pools/add-liquidity-form.tsx
@@ -373,6 +373,7 @@ export function AddLiquidityForm({
 
   const {
     buildTransaction: buildZapTransaction,
+    buildTransactionAttempt: buildZapTransactionAttempt,
     buildResult: zapBuildResult,
     buildError: zapBuildError,
     isBuilding: isZapBuilding,
@@ -607,15 +608,16 @@ export function AddLiquidityForm({
         if (!capturedZapAmount || capturedZapAmount <= 0n) {
           throw new Error("Invalid single-token amount");
         }
-        const capturedZapBuild = await buildZapTransaction(
+        const capturedZapAttempt = await buildZapTransactionAttempt(
           capturedZapTokenIn as Address,
           capturedZapAmount,
           address,
           capturedSlippage,
         );
+        const capturedZapBuild = capturedZapAttempt.build;
         if (!capturedZapBuild) {
           throw new Error(
-            singleTokenLiquidityError ||
+            capturedZapAttempt.error ||
               "No single-token route is available for this amount. Try a smaller amount or use balanced mode.",
           );
         }
@@ -646,18 +648,19 @@ export function AddLiquidityForm({
           id: "zap-in",
           label: "Add Liquidity",
           buildTx: async () => {
-            const freshBuild =
+            const freshBuildAttempt =
               hasApprovalStep || capturedZapBuild.approval
-                ? await buildZapTransaction(
+                ? await buildZapTransactionAttempt(
                     capturedZapTokenIn as Address,
                     capturedZapAmount,
                     address,
                     capturedSlippage,
                   )
-                : capturedZapBuild;
+                : { build: capturedZapBuild, error: null };
+            const freshBuild = freshBuildAttempt.build;
             if (!freshBuild) {
               throw new Error(
-                singleTokenLiquidityError ||
+                freshBuildAttempt.error ||
                   "No single-token route is available for this amount. Try a smaller amount or use balanced mode.",
               );
             }

--- a/apps/app.mento.org/app/components/pools/add-liquidity-form.tsx
+++ b/apps/app.mento.org/app/components/pools/add-liquidity-form.tsx
@@ -9,7 +9,11 @@ import {
   CoinInput,
   toast,
 } from "@mento-protocol/ui";
-import type { PoolDisplay, SlippageOption } from "@repo/web3";
+import type {
+  LiquidityQuoteResult,
+  PoolDisplay,
+  SlippageOption,
+} from "@repo/web3";
 import {
   SLIPPAGE_OPTIONS,
   useLiquidityQuote,
@@ -36,7 +40,10 @@ import {
 import { erc20Abi, formatUnits, type Address } from "viem";
 import { useState, useEffect, useCallback, useRef } from "react";
 import { AlertTriangle } from "lucide-react";
-import { getContractAddress } from "@mento-protocol/mento-sdk";
+import {
+  getContractAddress,
+  type AddLiquidityTransaction,
+} from "@mento-protocol/mento-sdk";
 import { useSetAtom } from "jotai";
 import { useQueryClient } from "@tanstack/react-query";
 import {
@@ -79,6 +86,38 @@ function getSingleTokenLiquidityErrorMessage(
   }
 
   return message.replace(/zap-?in/gi, "single-token liquidity");
+}
+
+const POOL_RATIO_CHANGED_ERROR =
+  "Pool ratio changed. Review the updated amounts before submitting.";
+
+function isWithinOneWei(actual: bigint, expected: bigint): boolean {
+  return actual >= expected ? actual - expected <= 1n : expected - actual <= 1n;
+}
+
+function getMinimumAmount(amount: bigint, slippage: SlippageOption): bigint {
+  const basisPoints = BigInt(Math.floor(slippage * 100));
+  return (amount * (10_000n - basisPoints)) / 10_000n;
+}
+
+function isBuildAlignedWithQuote(
+  build: AddLiquidityTransaction,
+  quote: LiquidityQuoteResult,
+  slippage: SlippageOption,
+): boolean {
+  const details = build.addLiquidity;
+  return (
+    isWithinOneWei(details.amountADesired, quote.amountA) &&
+    isWithinOneWei(details.amountBDesired, quote.amountB) &&
+    isWithinOneWei(
+      details.amountAMin,
+      getMinimumAmount(quote.amountA, slippage),
+    ) &&
+    isWithinOneWei(
+      details.amountBMin,
+      getMinimumAmount(quote.amountB, slippage),
+    )
+  );
 }
 
 function TokenAmountInput({
@@ -276,6 +315,7 @@ export function AddLiquidityForm({
     data: quote,
     isFetching: isFetchingQuote,
     isDebouncing: isQuoteDebouncing,
+    refetch: refetchLiquidityQuote,
   } = useLiquidityQuote({
     pool,
     request: mode === "balanced" ? liquidityQuoteRequest : null,
@@ -291,19 +331,6 @@ export function AddLiquidityForm({
     rawToken0Amount: token0Amount,
     rawToken1Amount: token1Amount,
   });
-
-  // Persist the Router-authoritative pair without changing the user request.
-  // Keeping those states separate prevents a quote/input feedback loop.
-  useEffect(() => {
-    if (mode !== "balanced" || !currentQuote) return;
-    setToken0Amount(balancedDisplay.token0Amount);
-    setToken1Amount(balancedDisplay.token1Amount);
-  }, [
-    balancedDisplay.token0Amount,
-    balancedDisplay.token1Amount,
-    currentQuote,
-    mode,
-  ]);
 
   const { buildTransaction, buildResult, isBuilding } =
     useAddLiquidityTransaction(pool, chainId);
@@ -580,8 +607,17 @@ export function AddLiquidityForm({
         if (!capturedZapAmount || capturedZapAmount <= 0n) {
           throw new Error("Invalid single-token amount");
         }
-        if (zapBuildError) {
-          throw new Error(zapBuildError);
+        const capturedZapBuild = await buildZapTransaction(
+          capturedZapTokenIn as Address,
+          capturedZapAmount,
+          address,
+          capturedSlippage,
+        );
+        if (!capturedZapBuild) {
+          throw new Error(
+            singleTokenLiquidityError ||
+              "No single-token route is available for this amount. Try a smaller amount or use balanced mode.",
+          );
         }
 
         const steps: LiquidityFlowStepDefinition[] = [];
@@ -593,10 +629,10 @@ export function AddLiquidityForm({
             : allowances.token1;
 
         if (
-          zapBuildResult.approval &&
+          capturedZapBuild.approval &&
           capturedZapAmount > currentZapAllowance
         ) {
-          const approvalParams = zapBuildResult.approval.params;
+          const approvalParams = capturedZapBuild.approval.params;
           steps.push({
             id: "approve-token",
             label: `Approve ${zapToken.symbol}`,
@@ -604,20 +640,30 @@ export function AddLiquidityForm({
           });
         }
 
+        const hasApprovalStep = steps.length > 0;
+
         steps.push({
           id: "zap-in",
           label: "Add Liquidity",
           buildTx: async () => {
-            const freshBuild = await buildZapTransaction(
-              capturedZapTokenIn as Address,
-              capturedZapAmount,
-              address,
-              capturedSlippage,
-            );
+            const freshBuild =
+              hasApprovalStep || capturedZapBuild.approval
+                ? await buildZapTransaction(
+                    capturedZapTokenIn as Address,
+                    capturedZapAmount,
+                    address,
+                    capturedSlippage,
+                  )
+                : capturedZapBuild;
             if (!freshBuild) {
               throw new Error(
                 singleTokenLiquidityError ||
                   "No single-token route is available for this amount. Try a smaller amount or use balanced mode.",
+              );
+            }
+            if (freshBuild.approval) {
+              throw new Error(
+                "Token approval is still required. Please try again.",
               );
             }
             return freshBuild.zapIn.params;
@@ -651,6 +697,20 @@ export function AddLiquidityForm({
         const capturedQuote = currentQuote;
         const capturedSlippage = slippage;
 
+        const refreshedQuoteResult = await refetchLiquidityQuote();
+        if (refreshedQuoteResult.error) {
+          throw new Error("Unable to refresh liquidity quote.");
+        }
+        const refreshedQuote = refreshedQuoteResult.data;
+        if (
+          !refreshedQuote ||
+          refreshedQuote.requestId !== capturedQuote.requestId ||
+          refreshedQuote.amountA !== capturedQuote.amountA ||
+          refreshedQuote.amountB !== capturedQuote.amountB
+        ) {
+          throw new Error(POOL_RATIO_CHANGED_ERROR);
+        }
+
         // Rebuild at click time and use this exact result for approvals. The
         // stateful preview build may still belong to a previous quote.
         const capturedBuild = await buildTransaction(
@@ -660,6 +720,15 @@ export function AddLiquidityForm({
           capturedSlippage,
         );
         if (!capturedBuild) throw new Error("Failed to build transaction");
+        if (
+          !isBuildAlignedWithQuote(
+            capturedBuild,
+            capturedQuote,
+            capturedSlippage,
+          )
+        ) {
+          throw new Error(POOL_RATIO_CHANGED_ERROR);
+        }
 
         const steps: LiquidityFlowStepDefinition[] = [];
         const allowances = await getLatestAllowances();
@@ -688,10 +757,30 @@ export function AddLiquidityForm({
           });
         }
 
+        const hasApprovalSteps = steps.length > 0;
+
         steps.push({
           id: "add-liquidity",
           label: "Add Liquidity",
           buildTx: async () => {
+            if (!hasApprovalSteps) {
+              return capturedBuild.addLiquidity.params;
+            }
+
+            const postApprovalQuoteResult = await refetchLiquidityQuote();
+            if (postApprovalQuoteResult.error) {
+              throw new Error("Unable to refresh liquidity quote.");
+            }
+            const postApprovalQuote = postApprovalQuoteResult.data;
+            if (
+              !postApprovalQuote ||
+              postApprovalQuote.requestId !== capturedQuote.requestId ||
+              postApprovalQuote.amountA !== capturedQuote.amountA ||
+              postApprovalQuote.amountB !== capturedQuote.amountB
+            ) {
+              throw new Error(POOL_RATIO_CHANGED_ERROR);
+            }
+
             const freshBuild = await buildTransaction(
               capturedQuote.amountA,
               capturedQuote.amountB,
@@ -699,6 +788,20 @@ export function AddLiquidityForm({
               capturedSlippage,
             );
             if (!freshBuild) throw new Error("Failed to build transaction");
+            if (freshBuild.approvalA || freshBuild.approvalB) {
+              throw new Error(
+                "Token approval is still required. Please try again.",
+              );
+            }
+            if (
+              !isBuildAlignedWithQuote(
+                freshBuild,
+                capturedQuote,
+                capturedSlippage,
+              )
+            ) {
+              throw new Error(POOL_RATIO_CHANGED_ERROR);
+            }
             return freshBuild.addLiquidity.params;
           },
         });
@@ -743,6 +846,8 @@ export function AddLiquidityForm({
           toast.error(
             getSingleTokenLiquidityErrorMessage(msg, zapToken.symbol),
           );
+        } else if (msg === POOL_RATIO_CHANGED_ERROR) {
+          toast.error(POOL_RATIO_CHANGED_ERROR);
         } else {
           toast.error("Something went wrong. Please try again.");
         }

--- a/apps/app.mento.org/app/components/pools/balanced-liquidity-display.test.ts
+++ b/apps/app.mento.org/app/components/pools/balanced-liquidity-display.test.ts
@@ -25,8 +25,8 @@ describe("getBalancedLiquidityDisplayState", () => {
     ).toEqual({
       token0Amount: "1938.824449465635730703",
       token1Amount: "1677.027867285683156092",
-      summaryToken0Amount: "1,938.8244",
-      summaryToken1Amount: "1,677.0279",
+      summaryToken0Amount: "1,938.824449465635730703",
+      summaryToken1Amount: "1,677.027867285683156092",
     });
   });
 
@@ -41,8 +41,8 @@ describe("getBalancedLiquidityDisplayState", () => {
     ).toEqual({
       token0Amount: "10",
       token1Amount: "",
-      summaryToken0Amount: "0.0000",
-      summaryToken1Amount: "0.0000",
+      summaryToken0Amount: "0",
+      summaryToken1Amount: "0",
     });
   });
 });

--- a/apps/app.mento.org/app/components/pools/balanced-liquidity-display.test.ts
+++ b/apps/app.mento.org/app/components/pools/balanced-liquidity-display.test.ts
@@ -1,0 +1,48 @@
+import type { LiquidityQuoteResult, PoolDisplay } from "@repo/web3";
+import { parseUnits } from "viem";
+import { describe, expect, it } from "vitest";
+import { getBalancedLiquidityDisplayState } from "./balanced-liquidity-display";
+
+const pool = {
+  token0: { decimals: 18 },
+  token1: { decimals: 18 },
+} as PoolDisplay;
+
+describe("getBalancedLiquidityDisplayState", () => {
+  it("uses the Router-clipped pair for both visible inputs and the summary", () => {
+    const quote = {
+      amountA: parseUnits("1938.824449465635730703", 18),
+      amountB: parseUnits("1677.027867285683156092", 18),
+    } as LiquidityQuoteResult;
+
+    expect(
+      getBalancedLiquidityDisplayState({
+        quote,
+        pool,
+        rawToken0Amount: "2199.275594139894034278",
+        rawToken1Amount: "1677.027867285683156092",
+      }),
+    ).toEqual({
+      token0Amount: "1938.824449465635730703",
+      token1Amount: "1677.027867285683156092",
+      summaryToken0Amount: "1,938.8244",
+      summaryToken1Amount: "1,677.0279",
+    });
+  });
+
+  it("does not present an unquoted raw amount as the transaction summary", () => {
+    expect(
+      getBalancedLiquidityDisplayState({
+        quote: null,
+        pool,
+        rawToken0Amount: "10",
+        rawToken1Amount: "",
+      }),
+    ).toEqual({
+      token0Amount: "10",
+      token1Amount: "",
+      summaryToken0Amount: "0.0000",
+      summaryToken1Amount: "0.0000",
+    });
+  });
+});

--- a/apps/app.mento.org/app/components/pools/balanced-liquidity-display.ts
+++ b/apps/app.mento.org/app/components/pools/balanced-liquidity-display.ts
@@ -4,13 +4,16 @@ import { formatUnits } from "viem";
 export function formatLiquiditySummaryAmount(amount: string): string {
   if (amount === "—") return amount;
 
-  const value = Number(amount);
-  if (!Number.isFinite(value)) return "0.0000";
+  const match = amount.trim().match(/^(-?)(\d*)(?:\.(\d*))?$/);
+  if (!match || (!match[2] && !match[3])) return "0";
 
-  return value.toLocaleString(undefined, {
-    minimumFractionDigits: 4,
-    maximumFractionDigits: 4,
-  });
+  const [, sign, integer, fraction] = match;
+  const normalizedInteger = (integer || "0").replace(/^0+(?=\d)/, "");
+  const groupedInteger = normalizedInteger.replace(
+    /\B(?=(\d{3})+(?!\d))/g,
+    ",",
+  );
+  return `${sign}${groupedInteger}${fraction === undefined ? "" : `.${fraction}`}`;
 }
 
 export interface BalancedLiquidityDisplayState {

--- a/apps/app.mento.org/app/components/pools/balanced-liquidity-display.ts
+++ b/apps/app.mento.org/app/components/pools/balanced-liquidity-display.ts
@@ -1,0 +1,56 @@
+import type { LiquidityQuoteResult, PoolDisplay } from "@repo/web3";
+import { formatUnits } from "viem";
+
+export function formatLiquiditySummaryAmount(amount: string): string {
+  if (amount === "—") return amount;
+
+  const value = Number(amount);
+  if (!Number.isFinite(value)) return "0.0000";
+
+  return value.toLocaleString(undefined, {
+    minimumFractionDigits: 4,
+    maximumFractionDigits: 4,
+  });
+}
+
+export interface BalancedLiquidityDisplayState {
+  token0Amount: string;
+  token1Amount: string;
+  summaryToken0Amount: string;
+  summaryToken1Amount: string;
+}
+
+/**
+ * Keeps both balanced inputs and the summary on the same Router quote. Raw
+ * input is shown only while there is no executable canonical quote yet.
+ */
+export function getBalancedLiquidityDisplayState({
+  quote,
+  pool,
+  rawToken0Amount,
+  rawToken1Amount,
+}: {
+  quote: LiquidityQuoteResult | null | undefined;
+  pool: PoolDisplay;
+  rawToken0Amount: string;
+  rawToken1Amount: string;
+}): BalancedLiquidityDisplayState {
+  if (!quote) {
+    return {
+      token0Amount: rawToken0Amount,
+      token1Amount: rawToken1Amount,
+      summaryToken0Amount: formatLiquiditySummaryAmount("0"),
+      summaryToken1Amount: formatLiquiditySummaryAmount("0"),
+    };
+  }
+
+  const token0Amount = formatUnits(quote.amountA, pool.token0.decimals);
+  const token1Amount = formatUnits(quote.amountB, pool.token1.decimals);
+
+  return {
+    token0Amount,
+    token1Amount,
+    summaryToken0Amount: formatLiquiditySummaryAmount(token0Amount),
+    summaryToken1Amount: formatLiquiditySummaryAmount(token1Amount),
+  };
+}

--- a/packages/web3/src/features/pools/flow-engine.test.ts
+++ b/packages/web3/src/features/pools/flow-engine.test.ts
@@ -351,6 +351,60 @@ describe("executeLiquidityFlow", () => {
     );
   });
 
+  it("preserves actionable copy when the pool ratio changes after approval", async () => {
+    const recorder = createFlowRecorder();
+    const ratioChangedMessage =
+      "Pool ratio changed. Review the updated amounts before submitting.";
+
+    estimateGasMock.mockResolvedValueOnce(100n);
+    sendTransactionMock.mockResolvedValueOnce(firstHash as never);
+    waitForTransactionReceiptMock.mockResolvedValueOnce({
+      status: "success",
+    } as never);
+
+    const result = await executeLiquidityFlow(
+      wagmiConfig,
+      recorder.setFlowAtom,
+      "Add liquidity",
+      [
+        {
+          id: "approve",
+          label: "Approve",
+          buildTx: vi.fn().mockResolvedValue({
+            to: "0x0000000000000000000000000000000000000001",
+            data: "0x01",
+            value: 0n,
+          }),
+        },
+        {
+          id: "deposit",
+          label: "Deposit",
+          buildTx: vi.fn().mockRejectedValue(new Error(ratioChangedMessage)),
+        },
+      ],
+    );
+
+    expect(result).toEqual({ success: false, txHashes: [firstHash] });
+    expect(recorder.getState()).toEqual({
+      operation: "Add liquidity",
+      currentStepIndex: 1,
+      steps: [
+        {
+          id: "approve",
+          label: "Approve",
+          status: "confirmed",
+          txHash: firstHash,
+        },
+        {
+          id: "deposit",
+          label: "Deposit",
+          status: "error",
+          error: { message: ratioChangedMessage },
+        },
+      ],
+    });
+  });
+
   it("surfaces reverted receipts while preserving the pools-friendly error copy", async () => {
     const recorder = createFlowRecorder();
 

--- a/packages/web3/src/features/pools/flow.ts
+++ b/packages/web3/src/features/pools/flow.ts
@@ -74,21 +74,23 @@ function formatLiquidityFlowStepError(error: unknown): { message: string } {
       rawMessage,
     )
       ? "Pool liquidity is insufficient for this amount. Try a smaller amount."
-      : /current pool ratio|cannot be added|insufficient amount[ab]?|insufficient amount[ab] desired|0x8f66ec14|0x34c90624|0xdc6b2ef2|0xacee0513|0x5945ea56/i.test(
-            rawMessage,
-          )
-        ? "Pool ratio shifted during the transaction. Try a smaller amount or higher slippage."
-        : /no viable zap-(in|out) route|no route for this amount|route unavailable|unable to prepare single-token|unable to quote single-token|no single-token route/i.test(
+      : /pool ratio changed/i.test(rawMessage)
+        ? "Pool ratio changed. Review the updated amounts before submitting."
+        : /current pool ratio|cannot be added|insufficient amount[ab]?|insufficient amount[ab] desired|0x8f66ec14|0x34c90624|0xdc6b2ef2|0xacee0513|0x5945ea56/i.test(
               rawMessage,
             )
-          ? "No single-token route is available for this amount. Try a smaller amount or use balanced mode."
-          : /reverted/i.test(rawMessage)
-            ? "Transaction was reverted. Please check your inputs and try again."
-            : /insufficient\s+funds/i.test(rawMessage)
-              ? "Insufficient funds to complete this transaction."
-              : /nonce/i.test(rawMessage)
-                ? "Transaction conflict. Please try again."
-                : "Something went wrong. Please try again.";
+          ? "Pool ratio shifted during the transaction. Try a smaller amount or higher slippage."
+          : /no viable zap-(in|out) route|no route for this amount|route unavailable|unable to prepare single-token|unable to quote single-token|no single-token route/i.test(
+                rawMessage,
+              )
+            ? "No single-token route is available for this amount. Try a smaller amount or use balanced mode."
+            : /reverted/i.test(rawMessage)
+              ? "Transaction was reverted. Please check your inputs and try again."
+              : /insufficient\s+funds/i.test(rawMessage)
+                ? "Insufficient funds to complete this transaction."
+                : /nonce/i.test(rawMessage)
+                  ? "Transaction conflict. Please try again."
+                  : "Something went wrong. Please try again.";
 
   return { message };
 }

--- a/packages/web3/src/features/pools/hooks/use-liquidity-quote.test.tsx
+++ b/packages/web3/src/features/pools/hooks/use-liquidity-quote.test.tsx
@@ -24,11 +24,8 @@ vi.mock("wagmi", () => ({
   useChainId: () => 143,
 }));
 
-const {
-  getCanonicalLiquidityAmounts,
-  getDesiredBalancedLiquidityAmounts,
-  useLiquidityQuote,
-} = await import("./use-liquidity-quote");
+const { getDesiredBalancedLiquidityAmounts, useLiquidityQuote } =
+  await import("./use-liquidity-quote");
 
 const pool: PoolDisplay = {
   poolAddr: "0x0000000000000000000000000000000000000001",
@@ -208,9 +205,9 @@ describe("useLiquidityQuote", () => {
 
     await waitFor(() => expect(result.current.data).toBeTruthy());
 
-    expect(getCanonicalLiquidityAmounts(result.current.data, pool)).toEqual({
-      token0: "8",
-      token1: "4",
+    expect(result.current.data).toMatchObject({
+      amountA: 8n * 10n ** 18n,
+      amountB: 4n * 10n ** 18n,
     });
   });
 

--- a/packages/web3/src/features/pools/hooks/use-liquidity-quote.test.tsx
+++ b/packages/web3/src/features/pools/hooks/use-liquidity-quote.test.tsx
@@ -54,10 +54,9 @@ const pool: PoolDisplay = {
   tvl: 0,
 };
 
+let queryClient: QueryClient;
+
 function wrapper({ children }: { children: React.ReactNode }) {
-  const queryClient = new QueryClient({
-    defaultOptions: { queries: { retry: false } },
-  });
   return (
     <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
   );
@@ -86,6 +85,9 @@ describe("useLiquidityQuote", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
     liveReserves = [2_000n, 1_000n, 0n];
 
     mocks.getBlockNumber.mockResolvedValue(777n);
@@ -113,7 +115,10 @@ describe("useLiquidityQuote", () => {
     });
   });
 
-  afterEach(() => cleanup());
+  afterEach(() => {
+    cleanup();
+    queryClient.clear();
+  });
 
   it("uses a current-block reserve read instead of the primed SDK details cache", async () => {
     const { result } = renderHook(
@@ -148,6 +153,48 @@ describe("useLiquidityQuote", () => {
       reserve1: 1_000n,
       surplus0: 0n,
       surplus1: 500n,
+    });
+  });
+
+  it("uses live reserves to derive the manual pair sent to the Router", async () => {
+    liveReserves = [2n * 10n ** 18n, 1n * 10n ** 18n, 0n] as const;
+
+    const { result } = renderHook(
+      () =>
+        useLiquidityQuote({
+          pool,
+          chainId: 143,
+          request: {
+            id: 4,
+            kind: "manual",
+            token: 0,
+            amount: "10",
+          },
+        }),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.data).toBeTruthy());
+
+    expect(mocks.getPoolDetails).not.toHaveBeenCalled();
+    expect(mocks.readContract).toHaveBeenCalledWith(
+      expect.objectContaining({
+        functionName: "getReserves",
+        blockNumber: 777n,
+      }),
+    );
+    expect(mocks.quoteAddLiquidity).toHaveBeenCalledWith(
+      pool.poolAddr,
+      pool.token0.address,
+      10n * 10n ** 18n,
+      pool.token1.address,
+      5n * 10n ** 18n,
+    );
+    expect(result.current.data).toMatchObject({
+      amountA: 10n * 10n ** 18n,
+      amountB: 5n * 10n ** 18n,
+      reserve0: 2n * 10n ** 18n,
+      reserve1: 1n * 10n ** 18n,
     });
   });
 

--- a/packages/web3/src/features/pools/hooks/use-liquidity-quote.test.tsx
+++ b/packages/web3/src/features/pools/hooks/use-liquidity-quote.test.tsx
@@ -1,0 +1,316 @@
+// @vitest-environment jsdom
+import React from "react";
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { PoolDisplay } from "../types";
+
+const mocks = vi.hoisted(() => ({
+  getMentoSdk: vi.fn(),
+  getPublicClient: vi.fn(),
+  getBlockNumber: vi.fn(),
+  readContract: vi.fn(),
+  quoteAddLiquidity: vi.fn(),
+  getLPTokenBalance: vi.fn(),
+  getPoolDetails: vi.fn(),
+}));
+
+vi.mock("@/features/sdk", () => ({
+  getMentoSdk: mocks.getMentoSdk,
+  getPublicClient: mocks.getPublicClient,
+}));
+
+vi.mock("wagmi", () => ({
+  useChainId: () => 143,
+}));
+
+const {
+  getCanonicalLiquidityAmounts,
+  getDesiredBalancedLiquidityAmounts,
+  useLiquidityQuote,
+} = await import("./use-liquidity-quote");
+
+const pool: PoolDisplay = {
+  poolAddr: "0x0000000000000000000000000000000000000001",
+  chainId: 143,
+  poolType: "FPMM",
+  token0: {
+    symbol: "EURm",
+    address: "0x0000000000000000000000000000000000000002",
+    decimals: 18,
+    name: "Euro Mento",
+  },
+  token1: {
+    symbol: "USDm",
+    address: "0x0000000000000000000000000000000000000003",
+    decimals: 18,
+    name: "Dollar Mento",
+  },
+  reserves: {
+    token0: "0",
+    token1: "0",
+    token0Ratio: 0.5,
+    hasLiquidity: true,
+  },
+  fees: { total: 0.3, lp: 0.2, protocol: 0.1, label: "fee" },
+  priceAlignment: { status: "in-band" },
+  tvl: 0,
+};
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+function quoteAtRatio(
+  reserve0: bigint,
+  reserve1: bigint,
+  amount0: bigint,
+  amount1: bigint,
+) {
+  const amount1Optimal = (amount0 * reserve1) / reserve0;
+  if (amount1Optimal <= amount1) {
+    return { amountA: amount0, amountB: amount1Optimal, liquidity: 1n };
+  }
+
+  return {
+    amountA: (amount1 * reserve0) / reserve1,
+    amountB: amount1,
+    liquidity: 1n,
+  };
+}
+
+describe("useLiquidityQuote", () => {
+  let liveReserves: readonly [bigint, bigint, bigint];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    liveReserves = [2_000n, 1_000n, 0n];
+
+    mocks.getBlockNumber.mockResolvedValue(777n);
+    mocks.readContract.mockImplementation(async () => liveReserves);
+    mocks.getPublicClient.mockReturnValue({
+      getBlockNumber: mocks.getBlockNumber,
+      readContract: mocks.readContract,
+    });
+    mocks.getPoolDetails.mockResolvedValue({
+      // Deliberately stale 1:1 reserves. Transaction quotes must never read it.
+      reserve0: 1_000n,
+      reserve1: 1_000n,
+    });
+    mocks.quoteAddLiquidity.mockImplementation(
+      async (_pool, _token0, amount0: bigint, _token1, amount1: bigint) =>
+        quoteAtRatio(liveReserves[0], liveReserves[1], amount0, amount1),
+    );
+    mocks.getLPTokenBalance.mockResolvedValue({ totalSupply: 10_000n });
+    mocks.getMentoSdk.mockResolvedValue({
+      pools: { getPoolDetails: mocks.getPoolDetails },
+      liquidity: {
+        quoteAddLiquidity: mocks.quoteAddLiquidity,
+        getLPTokenBalance: mocks.getLPTokenBalance,
+      },
+    });
+  });
+
+  afterEach(() => cleanup());
+
+  it("uses a current-block reserve read instead of the primed SDK details cache", async () => {
+    const { result } = renderHook(
+      () =>
+        useLiquidityQuote({
+          pool,
+          chainId: 143,
+          request: {
+            id: 1,
+            kind: "max",
+            token: 0,
+            token0Balance: 1_000n,
+            token1Balance: 1_000n,
+          },
+        }),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.data).toBeTruthy());
+
+    expect(mocks.getPoolDetails).not.toHaveBeenCalled();
+    expect(mocks.readContract).toHaveBeenCalledWith(
+      expect.objectContaining({
+        functionName: "getReserves",
+        blockNumber: 777n,
+      }),
+    );
+    expect(result.current.data).toMatchObject({
+      amountA: 1_000n,
+      amountB: 500n,
+      reserve0: 2_000n,
+      reserve1: 1_000n,
+      surplus0: 0n,
+      surplus1: 500n,
+    });
+  });
+
+  it("lets the Router choose token1 as the limiting MAX side", async () => {
+    liveReserves = [1_000n, 2_000n, 0n];
+
+    const { result } = renderHook(
+      () =>
+        useLiquidityQuote({
+          pool,
+          chainId: 143,
+          request: {
+            id: 2,
+            kind: "max",
+            token: 1,
+            token0Balance: 1_000n,
+            token1Balance: 1_000n,
+          },
+        }),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.data).toBeTruthy());
+
+    expect(result.current.data).toMatchObject({
+      amountA: 500n,
+      amountB: 1_000n,
+      surplus0: 500n,
+      surplus1: 0n,
+    });
+  });
+
+  it("keeps a Router-clipped driver amount canonical", async () => {
+    mocks.quoteAddLiquidity.mockResolvedValue({
+      amountA: 8n * 10n ** 18n,
+      amountB: 4n * 10n ** 18n,
+      liquidity: 1n,
+    });
+
+    const { result } = renderHook(
+      () =>
+        useLiquidityQuote({
+          pool,
+          chainId: 143,
+          request: {
+            id: 3,
+            kind: "max",
+            token: 0,
+            token0Balance: 10n * 10n ** 18n,
+            token1Balance: 10n * 10n ** 18n,
+          },
+        }),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.data).toBeTruthy());
+
+    expect(getCanonicalLiquidityAmounts(result.current.data, pool)).toEqual({
+      token0: "8",
+      token1: "4",
+    });
+  });
+
+  it("does not let an older MAX response replace a newer request", async () => {
+    let resolveFirstQuote!: (quote: {
+      amountA: bigint;
+      amountB: bigint;
+      liquidity: bigint;
+    }) => void;
+    mocks.quoteAddLiquidity
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveFirstQuote = resolve;
+          }),
+      )
+      .mockResolvedValueOnce({ amountA: 900n, amountB: 450n, liquidity: 2n });
+
+    const { result, rerender } = renderHook(
+      ({ requestId }) =>
+        useLiquidityQuote({
+          pool,
+          chainId: 143,
+          request: {
+            id: requestId,
+            kind: "max",
+            token: 0,
+            token0Balance: 1_000n,
+            token1Balance: 1_000n,
+          },
+        }),
+      { initialProps: { requestId: 10 }, wrapper },
+    );
+
+    await waitFor(() =>
+      expect(mocks.quoteAddLiquidity).toHaveBeenCalledTimes(1),
+    );
+    rerender({ requestId: 11 });
+
+    await waitFor(() =>
+      expect(result.current.data).toMatchObject({
+        requestId: 11,
+        amountA: 900n,
+        amountB: 450n,
+      }),
+    );
+
+    await act(async () => {
+      resolveFirstQuote({ amountA: 100n, amountB: 50n, liquidity: 1n });
+    });
+
+    expect(result.current.data).toMatchObject({
+      requestId: 11,
+      amountA: 900n,
+      amountB: 450n,
+    });
+  });
+});
+
+describe("getDesiredBalancedLiquidityAmounts", () => {
+  it("calculates the fresh reserve-ratio counterpart for either manual driver", () => {
+    expect(
+      getDesiredBalancedLiquidityAmounts(
+        { id: 1, kind: "manual", token: 0, amount: "10" },
+        pool,
+        20n * 10n ** 18n,
+        10n * 10n ** 18n,
+      ),
+    ).toEqual({
+      amount0: 10n * 10n ** 18n,
+      amount1: 5n * 10n ** 18n,
+    });
+
+    expect(
+      getDesiredBalancedLiquidityAmounts(
+        { id: 2, kind: "manual", token: 1, amount: "5" },
+        pool,
+        20n * 10n ** 18n,
+        10n * 10n ** 18n,
+      ),
+    ).toEqual({
+      amount0: 10n * 10n ** 18n,
+      amount1: 5n * 10n ** 18n,
+    });
+  });
+
+  it("passes both wallet balances to the live Router for MAX", () => {
+    expect(
+      getDesiredBalancedLiquidityAmounts(
+        {
+          id: 3,
+          kind: "max",
+          token: 0,
+          token0Balance: 123n,
+          token1Balance: 456n,
+        },
+        pool,
+        999n,
+        1n,
+      ),
+    ).toEqual({ amount0: 123n, amount1: 456n });
+  });
+});

--- a/packages/web3/src/features/pools/hooks/use-liquidity-quote.ts
+++ b/packages/web3/src/features/pools/hooks/use-liquidity-quote.ts
@@ -1,108 +1,207 @@
-import { getMentoSdk } from "@/features/sdk";
+import type { ChainId } from "@/config/chains";
+import { getMentoSdk, getPublicClient } from "@/features/sdk";
 import { fromWei, toWei } from "@/utils/amount";
 import { useDebounce } from "@/utils/debounce";
+import { FPMM_ABI } from "@mento-protocol/mento-sdk";
 import { useQuery } from "@tanstack/react-query";
 import type { Address } from "viem";
 import { useChainId } from "wagmi";
-import type { ChainId } from "@/config/chains";
 import type { PoolDisplay } from "../types";
 import { LP_TOTAL_SUPPLY_HOLDER } from "../types";
+
+export type LiquidityQuoteRequest =
+  | {
+      id: number;
+      kind: "manual";
+      token: 0 | 1;
+      amount: string;
+    }
+  | {
+      id: number;
+      kind: "max";
+      token: 0 | 1;
+      token0Balance: bigint;
+      token1Balance: bigint;
+    };
 
 export interface LiquidityQuoteResult {
   amountA: bigint;
   amountB: bigint;
   liquidity: bigint;
   totalSupply: bigint;
+  reserve0: bigint;
+  reserve1: bigint;
+  requestId: number;
+  requestKind: LiquidityQuoteRequest["kind"];
+  surplus0: bigint;
+  surplus1: bigint;
 }
 
 interface UseLiquidityQuoteParams {
   pool: PoolDisplay;
-  token0Amount: string;
-  token1Amount: string;
-  lastEditedToken: 0 | 1;
+  request: LiquidityQuoteRequest | null;
   chainId?: ChainId;
+}
+
+export interface BalancedLiquidityAmounts {
+  amount0: bigint;
+  amount1: bigint;
+}
+
+/**
+ * Calculates the desired pair in pool contract order. MAX deliberately sends
+ * both balances to the Router so its live quote, including integer rounding,
+ * chooses the largest feasible pair and the limiting token.
+ */
+export function getDesiredBalancedLiquidityAmounts(
+  request: LiquidityQuoteRequest,
+  pool: PoolDisplay,
+  reserve0: bigint,
+  reserve1: bigint,
+): BalancedLiquidityAmounts {
+  if (request.kind === "max") {
+    return {
+      amount0: request.token0Balance,
+      amount1: request.token1Balance,
+    };
+  }
+
+  const driverDecimals =
+    request.token === 0 ? pool.token0.decimals : pool.token1.decimals;
+  const driverWei = BigInt(toWei(request.amount, driverDecimals).toFixed(0));
+
+  if (request.token === 0) {
+    return {
+      amount0: driverWei,
+      amount1: reserve0 > 0n ? (driverWei * reserve1) / reserve0 : 0n,
+    };
+  }
+
+  return {
+    amount0: reserve1 > 0n ? (driverWei * reserve0) / reserve1 : 0n,
+    amount1: driverWei,
+  };
 }
 
 export function useLiquidityQuote({
   pool,
-  token0Amount,
-  token1Amount,
-  lastEditedToken,
+  request,
   chainId,
 }: UseLiquidityQuoteParams) {
   const walletChainId = useChainId() as ChainId;
   const resolvedChainId = chainId ?? walletChainId;
 
-  const driverAmount = lastEditedToken === 0 ? token0Amount : token1Amount;
-  const debouncedAmount = useDebounce(driverAmount, 350);
-  const isValidAmount = !!debouncedAmount && Number(debouncedAmount) > 0;
+  const manualAmount = request?.kind === "manual" ? request.amount : "";
+  const debouncedManualAmount = useDebounce(manualAmount, 350);
+  const isManualRequestSettled =
+    request?.kind !== "manual" || manualAmount === debouncedManualAmount;
+  const isValidRequest =
+    request?.kind === "max"
+      ? request.token0Balance > 0n && request.token1Balance > 0n
+      : request?.kind === "manual"
+        ? !!manualAmount && Number(manualAmount) > 0
+        : false;
 
-  return useQuery<LiquidityQuoteResult | null>({
+  const query = useQuery<LiquidityQuoteResult | null>({
     queryKey: [
       "liquidity-quote",
       pool.poolAddr,
-      debouncedAmount,
-      lastEditedToken,
       resolvedChainId,
+      request?.id ?? 0,
+      request?.kind ?? "none",
+      request?.token ?? 0,
+      request?.kind === "manual" ? request.amount : "",
+      request?.kind === "max" ? request.token0Balance.toString() : "",
+      request?.kind === "max" ? request.token1Balance.toString() : "",
     ],
     queryFn: async () => {
-      if (!isValidAmount) return null;
+      if (!request || !isValidRequest || !isManualRequestSettled) return null;
 
-      const sdk = await getMentoSdk(resolvedChainId);
+      const [sdk, publicClient] = await Promise.all([
+        getMentoSdk(resolvedChainId),
+        Promise.resolve(getPublicClient(resolvedChainId)),
+      ]);
 
-      // Get raw pool reserves for proportional calculation
-      const details = await sdk.pools.getPoolDetails(pool.poolAddr);
-      const reserve0 = details.reserve0;
-      const reserve1 = details.reserve1;
+      // PoolService caches details for the SDK lifetime. Read reserves directly
+      // at one captured latest block so same-session swaps cannot leave this
+      // transaction-critical ratio stale.
+      const blockNumber = await publicClient.getBlockNumber();
+      const [reserve0, reserve1] = (await publicClient.readContract({
+        address: pool.poolAddr as Address,
+        abi: FPMM_ABI,
+        functionName: "getReserves",
+        blockNumber,
+      })) as readonly [bigint, bigint, bigint];
 
-      const driverDecimals =
-        lastEditedToken === 0 ? pool.token0.decimals : pool.token1.decimals;
-      const driverWei = toWei(debouncedAmount, driverDecimals);
-
-      // Calculate proportional amount using reserves ratio
-      let amount0: bigint;
-      let amount1: bigint;
-
-      if (lastEditedToken === 0) {
-        amount0 = BigInt(driverWei.toFixed(0));
-        // amount1 = amount0 * reserve1 / reserve0
-        amount1 = reserve0 > 0n ? (amount0 * reserve1) / reserve0 : 0n;
-      } else {
-        amount1 = BigInt(driverWei.toFixed(0));
-        // amount0 = amount1 * reserve0 / reserve1
-        amount0 = reserve1 > 0n ? (amount1 * reserve0) / reserve1 : 0n;
-      }
-
-      // Get quote from the Router on-chain for exact LP token estimate
-      const quote = await sdk.liquidity.quoteAddLiquidity(
-        pool.poolAddr as Address,
-        pool.token0.address as Address,
-        amount0,
-        pool.token1.address as Address,
-        amount1,
+      const { amount0, amount1 } = getDesiredBalancedLiquidityAmounts(
+        request,
+        pool,
+        reserve0,
+        reserve1,
       );
 
-      // Get LP token total supply for share calculation
-      const lpBalance = await sdk.liquidity.getLPTokenBalance(
-        pool.poolAddr,
-        LP_TOTAL_SUPPLY_HOLDER,
-      );
+      // The Router is authoritative: it applies the current reserve ratio and
+      // can clip either desired amount. Everything downstream uses its result.
+      const [quote, lpBalance] = await Promise.all([
+        sdk.liquidity.quoteAddLiquidity(
+          pool.poolAddr as Address,
+          pool.token0.address as Address,
+          amount0,
+          pool.token1.address as Address,
+          amount1,
+        ),
+        sdk.liquidity.getLPTokenBalance(pool.poolAddr, LP_TOTAL_SUPPLY_HOLDER),
+      ]);
+
+      const token0Balance =
+        request.kind === "max" ? request.token0Balance : quote.amountA;
+      const token1Balance =
+        request.kind === "max" ? request.token1Balance : quote.amountB;
 
       return {
         amountA: quote.amountA,
         amountB: quote.amountB,
         liquidity: quote.liquidity,
         totalSupply: lpBalance.totalSupply,
+        reserve0,
+        reserve1,
+        requestId: request.id,
+        requestKind: request.kind,
+        surplus0:
+          token0Balance > quote.amountA ? token0Balance - quote.amountA : 0n,
+        surplus1:
+          token1Balance > quote.amountB ? token1Balance - quote.amountB : 0n,
       };
     },
-    enabled: isValidAmount,
-    staleTime: 5000,
+    enabled: isValidRequest && isManualRequestSettled,
+    staleTime: 0,
     gcTime: 30_000,
+    refetchOnMount: "always",
   });
+
+  return {
+    ...query,
+    isDebouncing:
+      request?.kind === "manual" && isValidRequest && !isManualRequestSettled,
+  };
+}
+
+/** Formats both Router-authoritative amounts in pool contract order. */
+export function getCanonicalLiquidityAmounts(
+  quote: LiquidityQuoteResult | null | undefined,
+  pool: PoolDisplay,
+): { token0: string; token1: string } | null {
+  if (!quote) return null;
+
+  return {
+    token0: fromWei(quote.amountA.toString(), pool.token0.decimals),
+    token1: fromWei(quote.amountB.toString(), pool.token1.decimals),
+  };
 }
 
 /**
  * Formats the proportional amount from a quote result for the non-edited token input.
+ * Kept for consumers outside the add-liquidity form; new code should canonicalize both sides.
  */
 export function getProportionalAmount(
   quote: LiquidityQuoteResult | null | undefined,

--- a/packages/web3/src/features/pools/hooks/use-liquidity-quote.ts
+++ b/packages/web3/src/features/pools/hooks/use-liquidity-quote.ts
@@ -1,6 +1,6 @@
 import type { ChainId } from "@/config/chains";
 import { getMentoSdk, getPublicClient } from "@/features/sdk";
-import { fromWei, toWei } from "@/utils/amount";
+import { toWei } from "@/utils/amount";
 import { useDebounce } from "@/utils/debounce";
 import { FPMM_ABI } from "@mento-protocol/mento-sdk";
 import { useQuery } from "@tanstack/react-query";
@@ -184,34 +184,4 @@ export function useLiquidityQuote({
     isDebouncing:
       request?.kind === "manual" && isValidRequest && !isManualRequestSettled,
   };
-}
-
-/** Formats both Router-authoritative amounts in pool contract order. */
-export function getCanonicalLiquidityAmounts(
-  quote: LiquidityQuoteResult | null | undefined,
-  pool: PoolDisplay,
-): { token0: string; token1: string } | null {
-  if (!quote) return null;
-
-  return {
-    token0: fromWei(quote.amountA.toString(), pool.token0.decimals),
-    token1: fromWei(quote.amountB.toString(), pool.token1.decimals),
-  };
-}
-
-/**
- * Formats the proportional amount from a quote result for the non-edited token input.
- * Kept for consumers outside the add-liquidity form; new code should canonicalize both sides.
- */
-export function getProportionalAmount(
-  quote: LiquidityQuoteResult | null | undefined,
-  lastEditedToken: 0 | 1,
-  pool: PoolDisplay,
-): string {
-  if (!quote) return "";
-  const amount = lastEditedToken === 0 ? quote.amountB : quote.amountA;
-  const decimals =
-    lastEditedToken === 0 ? pool.token1.decimals : pool.token0.decimals;
-  if (amount === 0n) return "";
-  return fromWei(amount.toString(), decimals);
 }

--- a/packages/web3/src/features/pools/hooks/use-zap-in-transaction.test.tsx
+++ b/packages/web3/src/features/pools/hooks/use-zap-in-transaction.test.tsx
@@ -140,7 +140,7 @@ describe("useZapInTransaction build preflight", () => {
     expect(build).toBe(approvalBuild);
     expect(hook.result.current.buildResult).toBe(approvalBuild);
     expect(hook.result.current.buildError).toBeNull();
-    expect(mocks.estimateGas).not.toHaveBeenCalled();
+    expect(mocks.estimateGas).toHaveBeenCalledTimes(1);
   });
 
   it("runs the fail-closed estimate on a fresh build after approval", async () => {
@@ -153,10 +153,10 @@ describe("useZapInTransaction build preflight", () => {
     const hook = renderHook(() => useZapInTransaction(pool, 143));
 
     expect(await buildTransaction(hook)).toBe(approvalBuild);
-    expect(mocks.estimateGas).not.toHaveBeenCalled();
+    expect(mocks.estimateGas).toHaveBeenCalledTimes(1);
 
     expect(await buildTransaction(hook)).toBe(freshBuild);
-    expect(mocks.estimateGas).toHaveBeenCalledTimes(1);
+    expect(mocks.estimateGas).toHaveBeenCalledTimes(2);
     expect(hook.result.current.buildResult).toBe(freshBuild);
     expect(hook.result.current.buildError).toBeNull();
   });
@@ -174,6 +174,21 @@ describe("useZapInTransaction build preflight", () => {
     expect(hook.result.current.buildResult).toBeNull();
     expect(hook.result.current.buildError).toBe(
       "This single-token amount cannot be simulated right now. Try a smaller amount, higher slippage, or balanced mode.",
+    );
+  });
+
+  it("blocks a known liquidity failure even when approval is required", async () => {
+    const approvalBuild = makeBuild({ approval: true });
+    mocks.buildZapInTransaction.mockResolvedValueOnce(approvalBuild);
+    mocks.estimateGas.mockRejectedValueOnce(
+      new Error("execution reverted: insufficient liquidity"),
+    );
+    const hook = renderHook(() => useZapInTransaction(pool, 143));
+
+    expect(await buildTransaction(hook)).toBeNull();
+    expect(mocks.readContract).not.toHaveBeenCalled();
+    expect(hook.result.current.buildError).toBe(
+      "Pool liquidity is insufficient for this single-token amount.",
     );
   });
 });

--- a/packages/web3/src/features/pools/hooks/use-zap-in-transaction.test.tsx
+++ b/packages/web3/src/features/pools/hooks/use-zap-in-transaction.test.tsx
@@ -1,0 +1,179 @@
+// @vitest-environment jsdom
+import { act, renderHook, type RenderHookResult } from "@testing-library/react";
+import type { ZapInTransaction } from "@mento-protocol/mento-sdk";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Address } from "viem";
+import type { PoolDisplay } from "../types";
+
+const mocks = vi.hoisted(() => ({
+  buildZapInTransaction: vi.fn(),
+  estimateGas: vi.fn(),
+  getBlock: vi.fn(),
+  readContract: vi.fn(),
+  waitForTransactionReceipt: vi.fn(),
+}));
+
+vi.mock("@/features/sdk", () => ({
+  getMentoSdk: vi.fn().mockResolvedValue({
+    liquidity: { buildZapInTransaction: mocks.buildZapInTransaction },
+  }),
+}));
+
+vi.mock("wagmi", () => ({
+  useChainId: () => 143,
+  usePublicClient: () => ({
+    estimateGas: mocks.estimateGas,
+    getBlock: mocks.getBlock,
+    readContract: mocks.readContract,
+    waitForTransactionReceipt: mocks.waitForTransactionReceipt,
+  }),
+  useSendTransaction: () => ({
+    isPending: false,
+    reset: vi.fn(),
+    sendTransactionAsync: vi.fn(),
+  }),
+}));
+
+vi.mock("@tanstack/react-query", () => ({
+  useQueryClient: () => ({ invalidateQueries: vi.fn() }),
+}));
+
+vi.mock("@mento-protocol/ui", () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+}));
+
+vi.mock("@mento-protocol/mento-sdk", () => ({
+  FPMM_ABI: [],
+  ROUTER_ABI: [],
+}));
+
+vi.mock("@/utils/logger", () => ({
+  logger: { error: vi.fn(), info: vi.fn() },
+}));
+
+vi.mock("../liquidity-toast", () => ({
+  showLiquiditySuccessToast: vi.fn(),
+}));
+
+const { useZapInTransaction } = await import("./use-zap-in-transaction");
+
+const POOL_ADDRESS = "0x0000000000000000000000000000000000000001";
+const TOKEN_IN = "0x0000000000000000000000000000000000000002";
+const RECIPIENT = "0x0000000000000000000000000000000000000003";
+const ROUTER = "0x0000000000000000000000000000000000000004";
+
+const pool: PoolDisplay = {
+  poolAddr: POOL_ADDRESS,
+  chainId: 143,
+  poolType: "FPMM",
+  token0: { symbol: "EURm", address: TOKEN_IN, decimals: 18, name: "EURm" },
+  token1: {
+    symbol: "USDm",
+    address: "0x0000000000000000000000000000000000000005",
+    decimals: 18,
+    name: "USDm",
+  },
+  reserves: {
+    token0: "1",
+    token1: "1",
+    token0Ratio: 0.5,
+    hasLiquidity: true,
+  },
+  fees: { total: 0.3, lp: 0.25, protocol: 0.05, label: "fee" },
+  priceAlignment: { status: "in-band" },
+  tvl: 2,
+};
+
+function makeBuild({ approval }: { approval: boolean }): ZapInTransaction {
+  return {
+    approval: approval
+      ? {
+          params: { to: TOKEN_IN, data: "0xapproval", value: "0" },
+        }
+      : undefined,
+    zapIn: {
+      params: { to: ROUTER, data: "0xzap", value: "0" },
+      routesA: [],
+      routesB: [],
+      amountInA: 1n,
+      amountInB: 0n,
+    },
+  } as unknown as ZapInTransaction;
+}
+
+async function buildTransaction(
+  hook: RenderHookResult<ReturnType<typeof useZapInTransaction>, unknown>,
+) {
+  let build: ZapInTransaction | null = null;
+  await act(async () => {
+    build = await hook.result.current.buildTransaction(
+      TOKEN_IN as Address,
+      1n,
+      RECIPIENT as Address,
+      0.5,
+    );
+  });
+  return build;
+}
+
+describe("useZapInTransaction build preflight", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.buildZapInTransaction.mockReset();
+    mocks.estimateGas.mockReset();
+    mocks.getBlock.mockReset();
+    mocks.readContract.mockReset();
+    mocks.waitForTransactionReceipt.mockReset();
+    mocks.getBlock.mockResolvedValue({ timestamp: 1_000n });
+  });
+
+  it("preserves a build requiring approval without running the zap estimate", async () => {
+    const approvalBuild = makeBuild({ approval: true });
+    mocks.buildZapInTransaction.mockResolvedValueOnce(approvalBuild);
+    mocks.estimateGas.mockRejectedValueOnce(
+      new Error("execution reverted: Transfer failed"),
+    );
+    const hook = renderHook(() => useZapInTransaction(pool, 143));
+
+    const build = await buildTransaction(hook);
+
+    expect(build).toBe(approvalBuild);
+    expect(hook.result.current.buildResult).toBe(approvalBuild);
+    expect(hook.result.current.buildError).toBeNull();
+    expect(mocks.estimateGas).not.toHaveBeenCalled();
+  });
+
+  it("runs the fail-closed estimate on a fresh build after approval", async () => {
+    const approvalBuild = makeBuild({ approval: true });
+    const freshBuild = makeBuild({ approval: false });
+    mocks.buildZapInTransaction
+      .mockResolvedValueOnce(approvalBuild)
+      .mockResolvedValueOnce(freshBuild);
+    mocks.estimateGas.mockResolvedValueOnce(250_000n);
+    const hook = renderHook(() => useZapInTransaction(pool, 143));
+
+    expect(await buildTransaction(hook)).toBe(approvalBuild);
+    expect(mocks.estimateGas).not.toHaveBeenCalled();
+
+    expect(await buildTransaction(hook)).toBe(freshBuild);
+    expect(mocks.estimateGas).toHaveBeenCalledTimes(1);
+    expect(hook.result.current.buildResult).toBe(freshBuild);
+    expect(hook.result.current.buildError).toBeNull();
+  });
+
+  it("blocks a generic transfer failure when no approval is required", async () => {
+    const buildWithoutApproval = makeBuild({ approval: false });
+    mocks.buildZapInTransaction.mockResolvedValueOnce(buildWithoutApproval);
+    mocks.estimateGas.mockRejectedValueOnce(
+      new Error("execution reverted: Transfer failed"),
+    );
+    const hook = renderHook(() => useZapInTransaction(pool, 143));
+
+    expect(await buildTransaction(hook)).toBeNull();
+    expect(mocks.estimateGas).toHaveBeenCalledTimes(1);
+    expect(hook.result.current.buildResult).toBeNull();
+    expect(hook.result.current.buildError).toBe(
+      "This single-token amount cannot be simulated right now. Try a smaller amount, higher slippage, or balanced mode.",
+    );
+  });
+});

--- a/packages/web3/src/features/pools/hooks/use-zap-in-transaction.test.tsx
+++ b/packages/web3/src/features/pools/hooks/use-zap-in-transaction.test.tsx
@@ -191,4 +191,19 @@ describe("useZapInTransaction build preflight", () => {
       "Pool liquidity is insufficient for this single-token amount.",
     );
   });
+
+  it("blocks an unrelated estimate failure even when approval is required", async () => {
+    const approvalBuild = makeBuild({ approval: true });
+    mocks.buildZapInTransaction.mockResolvedValueOnce(approvalBuild);
+    mocks.estimateGas.mockRejectedValueOnce(
+      new Error("execution reverted: token paused"),
+    );
+    const hook = renderHook(() => useZapInTransaction(pool, 143));
+
+    expect(await buildTransaction(hook)).toBeNull();
+    expect(mocks.readContract).not.toHaveBeenCalled();
+    expect(hook.result.current.buildError).toBe(
+      "This single-token amount cannot be simulated right now. Try a smaller amount, higher slippage, or balanced mode.",
+    );
+  });
 });

--- a/packages/web3/src/features/pools/hooks/use-zap-in-transaction.test.tsx
+++ b/packages/web3/src/features/pools/hooks/use-zap-in-transaction.test.tsx
@@ -127,21 +127,25 @@ describe("useZapInTransaction build preflight", () => {
     mocks.getBlock.mockResolvedValue({ timestamp: 1_000n });
   });
 
-  it("preserves a build requiring approval without running the zap estimate", async () => {
-    const approvalBuild = makeBuild({ approval: true });
-    mocks.buildZapInTransaction.mockResolvedValueOnce(approvalBuild);
-    mocks.estimateGas.mockRejectedValueOnce(
-      new Error("execution reverted: Transfer failed"),
-    );
-    const hook = renderHook(() => useZapInTransaction(pool, 143));
+  it.each([
+    "execution reverted: Transfer failed",
+    "ERC20: transfer amount exceeds allowance",
+  ])(
+    "preserves a build for an approval preflight failure: %s",
+    async (error) => {
+      const approvalBuild = makeBuild({ approval: true });
+      mocks.buildZapInTransaction.mockResolvedValueOnce(approvalBuild);
+      mocks.estimateGas.mockRejectedValueOnce(new Error(error));
+      const hook = renderHook(() => useZapInTransaction(pool, 143));
 
-    const build = await buildTransaction(hook);
+      const build = await buildTransaction(hook);
 
-    expect(build).toBe(approvalBuild);
-    expect(hook.result.current.buildResult).toBe(approvalBuild);
-    expect(hook.result.current.buildError).toBeNull();
-    expect(mocks.estimateGas).toHaveBeenCalledTimes(1);
-  });
+      expect(build).toBe(approvalBuild);
+      expect(hook.result.current.buildResult).toBe(approvalBuild);
+      expect(hook.result.current.buildError).toBeNull();
+      expect(mocks.estimateGas).toHaveBeenCalledTimes(1);
+    },
+  );
 
   it("runs the fail-closed estimate on a fresh build after approval", async () => {
     const approvalBuild = makeBuild({ approval: true });

--- a/packages/web3/src/features/pools/hooks/use-zap-in-transaction.tsx
+++ b/packages/web3/src/features/pools/hooks/use-zap-in-transaction.tsx
@@ -198,16 +198,6 @@ export function useZapInTransaction(pool: PoolDisplay, chainId?: ChainId) {
           options: { slippageTolerance: slippage, deadline },
         });
 
-        // A zap that still needs approval cannot be simulated successfully:
-        // the router's transferFrom runs before the approval transaction has
-        // granted allowance. Preserve the build so callers can send approval,
-        // then use their existing fresh build to run this estimate fail-closed.
-        if (result.approval) {
-          setBuildResult(result);
-          setBuildError(null);
-          return result;
-        }
-
         try {
           await publicClient.estimateGas({
             account: recipient,
@@ -247,6 +237,15 @@ export function useZapInTransaction(pool: PoolDisplay, chainId?: ChainId) {
               parsedError =
                 getZapInBuildError(validationMessage) || validationMessage;
             }
+          }
+
+          // A missing allowance can surface as a generic transfer failure on
+          // Monad. Only waive that generic estimate after the route itself has
+          // passed read-only liquidity validation.
+          if (result.approval && !parsedError) {
+            setBuildResult(result);
+            setBuildError(null);
+            return result;
           }
 
           setBuildError(

--- a/packages/web3/src/features/pools/hooks/use-zap-in-transaction.tsx
+++ b/packages/web3/src/features/pools/hooks/use-zap-in-transaction.tsx
@@ -21,6 +21,11 @@ const FPMM_FACTORY_POOL_ABI = parseAbi([
 
 type ZapRoute = ZapInTransaction["zapIn"]["routesA"];
 
+export interface ZapInBuildAttempt {
+  build: ZapInTransaction | null;
+  error: string | null;
+}
+
 function getZapInBuildError(message: string): string | null {
   if (/no viable zap-in route|no single-token route/i.test(message)) {
     return "No route for this amount. Reduce amount or use balanced mode.";
@@ -47,6 +52,12 @@ function getZapInBuildError(message: string): string | null {
   }
 
   return null;
+}
+
+function isApprovalPreflightEstimateError(message: string): boolean {
+  return /erc20insufficientallowance|insufficient allowance|0xfb8f41b2|transfer failed/i.test(
+    message,
+  );
 }
 
 function isSameAddress(addressA: string, addressB: string): boolean {
@@ -172,13 +183,13 @@ export function useZapInTransaction(pool: PoolDisplay, chainId?: ChainId) {
       });
   }, [txHash, publicClient, pool, resolvedChainId, queryClient]);
 
-  const buildTransaction = useCallback(
+  const buildTransactionAttempt = useCallback(
     async (
       tokenIn: Address,
       amountIn: bigint,
       recipient: Address,
       slippage: SlippageOption,
-    ): Promise<ZapInTransaction | null> => {
+    ): Promise<ZapInBuildAttempt> => {
       setIsBuilding(true);
       setBuildError(null);
       try {
@@ -212,8 +223,12 @@ export function useZapInTransaction(pool: PoolDisplay, chainId?: ChainId) {
               : String(estimateErr);
 
           let parsedError = getZapInBuildError(estimateMessage);
+          const canBeMissingAllowance =
+            Boolean(result.approval) &&
+            !parsedError &&
+            isApprovalPreflightEstimateError(estimateMessage);
 
-          if (!parsedError) {
+          if (canBeMissingAllowance) {
             try {
               await Promise.all([
                 validateZapRouteLiquidity({
@@ -239,40 +254,52 @@ export function useZapInTransaction(pool: PoolDisplay, chainId?: ChainId) {
             }
           }
 
-          // A missing allowance can surface as a generic transfer failure on
-          // Monad. Only waive that generic estimate after the route itself has
-          // passed read-only liquidity validation.
-          if (result.approval && !parsedError) {
+          // Missing allowance can surface as a generic transfer failure on
+          // Monad. Waive only that recognized approval failure after the route
+          // itself has passed read-only liquidity validation.
+          if (canBeMissingAllowance && !parsedError) {
             setBuildResult(result);
             setBuildError(null);
-            return result;
+            return { build: result, error: null };
           }
 
-          setBuildError(
+          const error =
             parsedError ||
-              "This single-token amount cannot be simulated right now. Try a smaller amount, higher slippage, or balanced mode.",
-          );
+            "This single-token amount cannot be simulated right now. Try a smaller amount, higher slippage, or balanced mode.";
+          setBuildError(error);
           setBuildResult(null);
-          return null;
+          return { build: null, error };
         }
 
         setBuildResult(result);
         setBuildError(null);
-        return result;
+        return { build: result, error: null };
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
         const parsedError = getZapInBuildError(message);
-        setBuildError(
-          parsedError || "Unable to prepare single-token liquidity right now.",
-        );
+        const error =
+          parsedError || "Unable to prepare single-token liquidity right now.";
+        setBuildError(error);
         logger.error("Failed to build zap-in transaction:", err);
         setBuildResult(null);
-        return null;
+        return { build: null, error };
       } finally {
         setIsBuilding(false);
       }
     },
     [resolvedChainId, pool, publicClient],
+  );
+
+  const buildTransaction = useCallback(
+    async (
+      tokenIn: Address,
+      amountIn: bigint,
+      recipient: Address,
+      slippage: SlippageOption,
+    ): Promise<ZapInTransaction | null> =>
+      (await buildTransactionAttempt(tokenIn, amountIn, recipient, slippage))
+        .build,
+    [buildTransactionAttempt],
   );
 
   const sendZapIn = useCallback(
@@ -313,6 +340,7 @@ export function useZapInTransaction(pool: PoolDisplay, chainId?: ChainId) {
 
   return {
     buildTransaction,
+    buildTransactionAttempt,
     buildResult,
     buildError,
     isBuilding,

--- a/packages/web3/src/features/pools/hooks/use-zap-in-transaction.tsx
+++ b/packages/web3/src/features/pools/hooks/use-zap-in-transaction.tsx
@@ -55,9 +55,7 @@ function getZapInBuildError(message: string): string | null {
 }
 
 function isApprovalPreflightEstimateError(message: string): boolean {
-  return /erc20insufficientallowance|insufficient allowance|0xfb8f41b2|transfer failed/i.test(
-    message,
-  );
+  return /allowance|0xfb8f41b2|transfer failed/i.test(message);
 }
 
 function isSameAddress(addressA: string, addressB: string): boolean {

--- a/packages/web3/src/features/pools/hooks/use-zap-in-transaction.tsx
+++ b/packages/web3/src/features/pools/hooks/use-zap-in-transaction.tsx
@@ -53,10 +53,6 @@ function isSameAddress(addressA: string, addressB: string): boolean {
   return addressA.toLowerCase() === addressB.toLowerCase();
 }
 
-function isAllowanceError(message: string): boolean {
-  return /allowance|insufficient allowance|exceeds allowance/i.test(message);
-}
-
 async function validateZapRouteLiquidity({
   publicClient,
   routerAddress,
@@ -202,6 +198,16 @@ export function useZapInTransaction(pool: PoolDisplay, chainId?: ChainId) {
           options: { slippageTolerance: slippage, deadline },
         });
 
+        // A zap that still needs approval cannot be simulated successfully:
+        // the router's transferFrom runs before the approval transaction has
+        // granted allowance. Preserve the build so callers can send approval,
+        // then use their existing fresh build to run this estimate fail-closed.
+        if (result.approval) {
+          setBuildResult(result);
+          setBuildError(null);
+          return result;
+        }
+
         try {
           await publicClient.estimateGas({
             account: recipient,
@@ -214,19 +220,6 @@ export function useZapInTransaction(pool: PoolDisplay, chainId?: ChainId) {
             estimateErr instanceof Error
               ? estimateErr.message
               : String(estimateErr);
-
-          // Pre-approval simulations legitimately fail with allowance errors
-          // because the wallet hasn't granted the allowance yet. That doesn't
-          // mean the zap is invalid — let the build through so the approval
-          // step can run; a fresh preflight after approval will catch any
-          // real issues. All other failures (bad route, ratio shift, etc.)
-          // still gate the build to avoid prompting an approval for a zap
-          // we already know will revert.
-          if (result.approval && isAllowanceError(estimateMessage)) {
-            setBuildResult(result);
-            setBuildError(null);
-            return result;
-          }
 
           let parsedError = getZapInBuildError(estimateMessage);
 


### PR DESCRIPTION
## The Problem

- Monad single-token liquidity provision could fail before approval because gas estimation simulated the zap against a zero Router allowance.
- Balanced MAX could mix stale or non-canonical reserve quotes across the form, approvals, and submitted calldata, leaving an unexpectedly large remainder and forcing users through repeated deposits.

## The Solution

- Preserve approval-required zap builds when Monad simulation reports an allowance/transfer failure, while continuing to block real liquidity, ratio, deadline, or unrelated execution failures.
- Rebuild from the exact click-time token, amount, slippage, and approval state; require a clean post-approval rebuild before submitting.
- Use fresh on-chain reserves and the Router quote as the canonical balanced pair for both visible inputs and transaction calldata.
- Revalidate the quote at submission boundaries, abort on pool-ratio drift, show the estimated surplus, and preserve exact token precision in the summary.

## Validation

- Added 19 focused regression tests across the zap hook, liquidity quote hook, balanced display, and add-liquidity form.
- `pnpm quality:budgets:test` — 30 passed.
- `pnpm quality:coverage` — all four measured workspaces passed (536 tests total).
- `pnpm check-types`, `trunk check`, `pnpm adr:check`, `pnpm pr:description:test`, and pre-push Knip — passed.
- Full `pnpm build` and `pnpm quality:bundle:check` — passed for all four applications.
- Chrome + local Monad fork:
  - Balanced MAX submitted the exact displayed `1050.000000000000000710 EURm` and `829.344780256867576724 USDm` in one flow, leaving the displayed `415.95 USDm` surplus.
  - `1 EURm` and `1 USDm` single-token deposits each succeeded from zero Router allowance with one approval followed by the zap.
  - All transaction receipts succeeded and both Router allowances ended at zero.
  - Lighthouse snapshot scores: 100 accessibility, 100 best practices, 100 SEO.

Closes #593
Closes #596

## Ship Checklist

- [x] PR title follows the conventions.
- [x] Performed a self-review, multi-lens review, and fresh-context semantic review.
- [x] Relevant automated checks and browser/fork smoke tests pass.
- [x] Architecture decision: Not applicable — this fixes transaction quoting and approval sequencing within the existing pool architecture.
