### PR TITLE
fix(ci): close burst preview verification gaps

### DIFF
--- a/scripts/vercel-preview-browser-smoke.mjs
+++ b/scripts/vercel-preview-browser-smoke.mjs
@@ -132,6 +132,14 @@ export function reserveTabStateMatches({
   }
 }
 
+function reserveSupplyTabState(expectedOrigin) {
+  return {
+    expectedOrigin,
+    expectedTabLabel: "Supply",
+    expectedTabValue: "stablecoins",
+  };
+}
+
 async function runTargetInteraction(page, target, deploymentUrl) {
   if (target === "reserve") {
     const overview = page.getByRole("tab", { name: "Overview", exact: true });
@@ -144,11 +152,10 @@ async function runTargetInteraction(page, target, deploymentUrl) {
       .waitFor({ state: "visible" });
     const supply = page.getByRole("tab", { name: "Supply", exact: true });
     await supply.click();
-    await page.waitForFunction(reserveTabStateMatches, {
-      expectedOrigin: deploymentUrl.origin,
-      expectedTabLabel: "Supply",
-      expectedTabValue: "stablecoins",
-    });
+    await page.waitForFunction(
+      reserveTabStateMatches,
+      reserveSupplyTabState(deploymentUrl.origin),
+    );
     if (new URL(page.url()).searchParams.get("tab") !== "stablecoins") {
       throw new Error("Reserve Supply tab URL state did not persist");
     }
@@ -209,6 +216,17 @@ export async function runBrowserSmoke({
     if (new URL(page.url()).origin !== baseUrl.origin) {
       throw new Error(
         "Browser smoke escaped the immutable preview origin after interaction",
+      );
+    }
+    if (
+      tuple.logicalTarget === "reserve" &&
+      !(await page.evaluate(
+        reserveTabStateMatches,
+        reserveSupplyTabState(baseUrl.origin),
+      ))
+    ) {
+      throw new Error(
+        "Reserve Supply tab state did not persist after interaction settle",
       );
     }
     monitor.assertClean();

--- a/scripts/vercel-preview-browser-smoke.mjs
+++ b/scripts/vercel-preview-browser-smoke.mjs
@@ -111,6 +111,27 @@ function requireSecurityHeaders(response) {
   }
 }
 
+export function reserveTabStateMatches({
+  currentHref = window.location.href,
+  expectedOrigin,
+  expectedTabLabel,
+  expectedTabValue,
+  selectedTabLabel = document
+    .querySelector('[role="tab"][aria-selected="true"]')
+    ?.textContent?.trim(),
+}) {
+  try {
+    const currentUrl = new URL(currentHref);
+    return (
+      currentUrl.origin === expectedOrigin &&
+      currentUrl.searchParams.get("tab") === expectedTabValue &&
+      selectedTabLabel === expectedTabLabel
+    );
+  } catch {
+    return false;
+  }
+}
+
 async function runTargetInteraction(page, target, deploymentUrl) {
   if (target === "reserve") {
     const overview = page.getByRole("tab", { name: "Overview", exact: true });
@@ -123,12 +144,11 @@ async function runTargetInteraction(page, target, deploymentUrl) {
       .waitFor({ state: "visible" });
     const supply = page.getByRole("tab", { name: "Supply", exact: true });
     await supply.click();
-    await page.waitForURL(
-      (currentUrl) =>
-        currentUrl.origin === deploymentUrl.origin &&
-        currentUrl.searchParams.get("tab") === "stablecoins",
-      { waitUntil: "commit" },
-    );
+    await page.waitForFunction(reserveTabStateMatches, {
+      expectedOrigin: deploymentUrl.origin,
+      expectedTabLabel: "Supply",
+      expectedTabValue: "stablecoins",
+    });
     if (new URL(page.url()).searchParams.get("tab") !== "stablecoins") {
       throw new Error("Reserve Supply tab URL state did not persist");
     }
@@ -177,13 +197,20 @@ export async function runBrowserSmoke({
       throw new Error("Browser smoke escaped the immutable preview origin");
     }
     requireSecurityHeaders(response);
+    // The tab shell is server rendered. Wait for all deferred client scripts
+    // before clicking so the first interaction cannot race React hydration.
+    await page.waitForLoadState("load");
     const interaction = await runTargetInteraction(
       page,
       tuple.logicalTarget,
       baseUrl,
     );
-    await page.waitForLoadState("load");
     await page.waitForTimeout(250);
+    if (new URL(page.url()).origin !== baseUrl.origin) {
+      throw new Error(
+        "Browser smoke escaped the immutable preview origin after interaction",
+      );
+    }
     monitor.assertClean();
     return {
       logicalTarget: tuple.logicalTarget,

--- a/scripts/vercel-preview-browser-smoke.test.mjs
+++ b/scripts/vercel-preview-browser-smoke.test.mjs
@@ -5,6 +5,7 @@ import { test } from "node:test";
 import {
   createBrowserFailureMonitor,
   loadTrustedChromium,
+  reserveTabStateMatches,
   runBrowserSmoke,
 } from "./vercel-preview-browser-smoke.mjs";
 
@@ -39,11 +40,13 @@ function controllerTuple(target) {
 }
 
 class FakePage extends EventEmitter {
-  constructor(values, { afterInteraction } = {}) {
+  constructor(values, { afterInteraction, competingNavigation = false } = {}) {
     super();
     this.values = values;
     this.afterInteraction = afterInteraction;
+    this.competingNavigation = competingNavigation;
     this.currentUrl = values.deploymentUrl;
+    this.loadComplete = false;
     this.supplySelected = false;
     this.calls = [];
   }
@@ -118,11 +121,18 @@ class FakePage extends EventEmitter {
     if (options.name === "Supply") {
       return {
         click: async () => {
+          if (!this.loadComplete) {
+            this.calls.push(["supply-click-before-load"]);
+            return;
+          }
           this.supplySelected = true;
-          this.currentUrl = new URL(
+          this.pendingSupplyUrl = new URL(
             "/?tab=stablecoins",
             this.values.deploymentUrl,
           ).toString();
+          if (!this.competingNavigation) {
+            this.currentUrl = this.pendingSupplyUrl;
+          }
           this.calls.push(["supply-click"]);
         },
         getAttribute: async (attribute) => {
@@ -134,14 +144,31 @@ class FakePage extends EventEmitter {
     throw new Error(`Unexpected role ${options.name}`);
   }
 
-  async waitForURL(matcher, options) {
-    assert.equal(matcher(new URL(this.currentUrl)), true);
-    assert.deepEqual(options, { waitUntil: "commit" });
-    this.calls.push(["wait-for-url", this.currentUrl]);
+  async waitForFunction(predicate, argument) {
+    assert.deepEqual(argument, {
+      expectedOrigin: new URL(this.values.deploymentUrl).origin,
+      expectedTabLabel: "Supply",
+      expectedTabValue: "stablecoins",
+    });
+    assert.equal(this.supplySelected, true);
+    const stateMatches = () =>
+      predicate({
+        ...argument,
+        currentHref: this.currentUrl,
+        selectedTabLabel: this.supplySelected ? "Supply" : "Overview",
+      });
+    if (this.competingNavigation) {
+      assert.equal(stateMatches(), false);
+      this.calls.push(["competing-navigation", this.currentUrl]);
+      this.currentUrl = this.pendingSupplyUrl;
+    }
+    assert.equal(stateMatches(), true);
+    this.calls.push(["wait-for-function", this.currentUrl]);
   }
 
   async waitForLoadState(state) {
     assert.equal(state, "load");
+    this.loadComplete = true;
     this.calls.push(["load"]);
   }
 
@@ -184,6 +211,49 @@ test("Reserve browser smoke renders runtime data and changes the Supply tab stat
   assert.equal(result.interaction, "overview-data-and-supply-tab");
   assert.equal(page.supplySelected, true);
   assert.ok(page.calls.some(([name]) => name === "supply-data"));
+  assert.ok(
+    page.calls.findIndex(([name]) => name === "load") <
+      page.calls.findIndex(([name]) => name === "supply-click"),
+  );
+});
+
+test("Reserve browser smoke does not latch onto a competing root navigation", async () => {
+  const values = controllerTuple("reserve");
+  const page = new FakePage(values, { competingNavigation: true });
+  const result = await runBrowserSmoke({
+    chromium: fakeChromium(page).chromium,
+    values,
+  });
+
+  assert.equal(result.interaction, "overview-data-and-supply-tab");
+  assert.ok(page.calls.some(([name]) => name === "competing-navigation"));
+  assert.ok(page.calls.some(([name]) => name === "wait-for-function"));
+  assert.equal(new URL(page.url()).searchParams.get("tab"), "stablecoins");
+});
+
+test("Reserve tab matcher binds the immutable origin, URL state, and selected tab", () => {
+  const expectedOrigin = "https://reservemento-abc123-mentolabs.vercel.app";
+  const validState = {
+    currentHref: `${expectedOrigin}/?tab=stablecoins`,
+    expectedOrigin,
+    expectedTabLabel: "Supply",
+    expectedTabValue: "stablecoins",
+    selectedTabLabel: "Supply",
+  };
+
+  assert.equal(reserveTabStateMatches(validState), true);
+  for (const invalidState of [
+    { currentHref: "https://example.com/?tab=stablecoins" },
+    { currentHref: `${expectedOrigin}/?tab=collateral` },
+    { currentHref: "not a URL" },
+    { selectedTabLabel: "Overview" },
+    { selectedTabLabel: null },
+  ]) {
+    assert.equal(
+      reserveTabStateMatches({ ...validState, ...invalidState }),
+      false,
+    );
+  }
 });
 
 test("App browser smoke uses system Chrome when explicitly requested", async () => {
@@ -284,6 +354,22 @@ test("browser smoke closes Chromium after an interaction-time failure", async ()
   await assert.rejects(
     runBrowserSmoke({ chromium: fake.chromium, values }),
     /late hydration failure/,
+  );
+  assert.equal(fake.state.closed, true);
+});
+
+test("browser smoke rejects a late cross-origin redirect after interaction", async () => {
+  const values = controllerTuple("reserve");
+  const page = new FakePage(values, {
+    afterInteraction(currentPage) {
+      currentPage.currentUrl = "https://example.com/?tab=stablecoins";
+    },
+  });
+  const fake = fakeChromium(page);
+
+  await assert.rejects(
+    runBrowserSmoke({ chromium: fake.chromium, values }),
+    /escaped the immutable preview origin after interaction/,
   );
   assert.equal(fake.state.closed, true);
 });

--- a/scripts/vercel-preview-browser-smoke.test.mjs
+++ b/scripts/vercel-preview-browser-smoke.test.mjs
@@ -145,18 +145,9 @@ class FakePage extends EventEmitter {
   }
 
   async waitForFunction(predicate, argument) {
-    assert.deepEqual(argument, {
-      expectedOrigin: new URL(this.values.deploymentUrl).origin,
-      expectedTabLabel: "Supply",
-      expectedTabValue: "stablecoins",
-    });
+    this.assertSupplyTabArgument(argument);
     assert.equal(this.supplySelected, true);
-    const stateMatches = () =>
-      predicate({
-        ...argument,
-        currentHref: this.currentUrl,
-        selectedTabLabel: this.supplySelected ? "Supply" : "Overview",
-      });
+    const stateMatches = () => this.supplyTabStateMatches(predicate, argument);
     if (this.competingNavigation) {
       assert.equal(stateMatches(), false);
       this.calls.push(["competing-navigation", this.currentUrl]);
@@ -164,6 +155,28 @@ class FakePage extends EventEmitter {
     }
     assert.equal(stateMatches(), true);
     this.calls.push(["wait-for-function", this.currentUrl]);
+  }
+
+  assertSupplyTabArgument(argument) {
+    assert.deepEqual(argument, {
+      expectedOrigin: new URL(this.values.deploymentUrl).origin,
+      expectedTabLabel: "Supply",
+      expectedTabValue: "stablecoins",
+    });
+  }
+
+  supplyTabStateMatches(predicate, argument) {
+    return predicate({
+      ...argument,
+      currentHref: this.currentUrl,
+      selectedTabLabel: this.supplySelected ? "Supply" : "Overview",
+    });
+  }
+
+  async evaluate(predicate, argument) {
+    this.assertSupplyTabArgument(argument);
+    this.calls.push(["evaluate-supply-state", this.currentUrl]);
+    return this.supplyTabStateMatches(predicate, argument);
   }
 
   async waitForLoadState(state) {
@@ -229,6 +242,26 @@ test("Reserve browser smoke does not latch onto a competing root navigation", as
   assert.ok(page.calls.some(([name]) => name === "competing-navigation"));
   assert.ok(page.calls.some(([name]) => name === "wait-for-function"));
   assert.equal(new URL(page.url()).searchParams.get("tab"), "stablecoins");
+});
+
+test("Reserve browser smoke rejects a late same-origin return to Overview", async () => {
+  const values = controllerTuple("reserve");
+  const page = new FakePage(values, {
+    afterInteraction: (currentPage) => {
+      currentPage.currentUrl = values.deploymentUrl;
+      currentPage.supplySelected = false;
+      currentPage.calls.push(["late-overview-navigation"]);
+    },
+  });
+  const fake = fakeChromium(page);
+
+  await assert.rejects(
+    runBrowserSmoke({ chromium: fake.chromium, values }),
+    /Reserve Supply tab state did not persist after interaction settle/,
+  );
+  assert.equal(fake.state.closed, true);
+  assert.ok(page.calls.some(([name]) => name === "late-overview-navigation"));
+  assert.ok(page.calls.some(([name]) => name === "evaluate-supply-state"));
 });
 
 test("Reserve tab matcher binds the immutable origin, URL state, and selected tab", () => {

--- a/scripts/vercel-preview-controller.mjs
+++ b/scripts/vercel-preview-controller.mjs
@@ -2706,6 +2706,15 @@ function targetStatusDecision({
         target_url: terminalResultUrl(priorResult, controllerUrl),
       };
     }
+    const priorCoalescedTo = coalescedToByRun.get(priorRuntime.event_run_id);
+    if (priorCoalescedTo) {
+      return {
+        state: "success",
+        outcome: "coalesced",
+        description: `${target}: coalesced to ${priorCoalescedTo.head_sha.slice(0, 7)}`,
+        target_url: controllerUrl,
+      };
+    }
     return {
       state: "pending",
       outcome: "pending",

--- a/scripts/vercel-preview-controller.test.mjs
+++ b/scripts/vercel-preview-controller.test.mjs
@@ -1417,6 +1417,125 @@ test("coalescing needs an immutable later selection receipt", () => {
   assert.match(withProof.state.status_decisions[1].description, /ui=coalesced/);
 });
 
+test("an unaffected target inherits its prior runtime coalescing proof", () => {
+  const events = [
+    event({
+      run: 60,
+      action: "opened",
+      head: SHA.A,
+      targets: PREVIEW_TARGETS,
+      updated: timestamp(1),
+    }),
+    event({
+      run: 61,
+      action: "synchronize",
+      before: SHA.A,
+      head: SHA.B,
+      targets: PREVIEW_TARGETS,
+      updated: timestamp(2),
+    }),
+    event({
+      run: 62,
+      action: "synchronize",
+      before: SHA.B,
+      head: SHA.C,
+      targets: ["app", "governance", "reserve"],
+      updated: timestamp(3),
+    }),
+    event({
+      run: 63,
+      action: "synchronize",
+      before: SHA.C,
+      head: SHA.D,
+      targets: ["ui"],
+      updated: timestamp(4),
+    }),
+    event({
+      run: 64,
+      action: "synchronize",
+      before: SHA.D,
+      head: SHA.E,
+      runtime: false,
+      updated: timestamp(5),
+    }),
+  ];
+  const pullRequest = pull({ head: SHA.E, updated: timestamp(5) });
+  const selectedA = reconcile({ events, pullRequest });
+  const activeA = persistAllIntents(selectedA);
+  const resultsA = selectedA.nextDispatches.map((dispatch, index) =>
+    result(dispatch, { runId: 8_060 + index }),
+  );
+  const selectionsA = PREVIEW_TARGETS.map((target) =>
+    selectionReceiptFromDispatch(activeA.targets[target].active),
+  );
+
+  const selectedLatest = reconcile({
+    events,
+    results: resultsA,
+    selections: selectionsA,
+    pullRequest,
+    existingState: activeA,
+  });
+  assert.deepEqual(
+    selectedLatest.nextDispatches.map(({ target, sha }) => ({ target, sha })),
+    [
+      { target: "app", sha: SHA.C },
+      { target: "governance", sha: SHA.C },
+      { target: "reserve", sha: SHA.C },
+      { target: "ui", sha: SHA.D },
+    ],
+  );
+  const activeLatest = persistAllIntents(selectedLatest);
+  const selectionsLatest = PREVIEW_TARGETS.map((target) =>
+    selectionReceiptFromDispatch(activeLatest.targets[target].active),
+  );
+  const resultsLatest = selectedLatest.nextDispatches.map((dispatch, index) =>
+    result(dispatch, { runId: 8_070 + index }),
+  );
+
+  const terminal = reconcile({
+    events,
+    results: [...resultsA, ...resultsLatest],
+    selections: [...selectionsA, ...selectionsLatest],
+    pullRequest,
+    existingState: activeLatest,
+  });
+  const decisions = new Map(
+    terminal.state.status_decisions.map((decision) => [decision.sha, decision]),
+  );
+  assert.deepEqual(decisions.get(SHA.A).targets, {
+    app: "deployed",
+    governance: "deployed",
+    reserve: "deployed",
+    ui: "deployed",
+  });
+  assert.deepEqual(decisions.get(SHA.B).targets, {
+    app: "coalesced",
+    governance: "coalesced",
+    reserve: "coalesced",
+    ui: "coalesced",
+  });
+  assert.deepEqual(decisions.get(SHA.C).targets, {
+    app: "deployed",
+    governance: "deployed",
+    reserve: "deployed",
+    ui: "coalesced",
+  });
+  assert.equal(decisions.get(SHA.C).state, "success");
+  assert.deepEqual(decisions.get(SHA.D).targets, {
+    app: "runtime-equivalent",
+    governance: "runtime-equivalent",
+    reserve: "runtime-equivalent",
+    ui: "deployed",
+  });
+  assert.deepEqual(decisions.get(SHA.E).targets, {
+    app: "runtime-equivalent",
+    governance: "runtime-equivalent",
+    reserve: "runtime-equivalent",
+    ui: "runtime-equivalent",
+  });
+});
+
 test("more than 25 pushes converge from first preview to latest with compact proof", () => {
   const shas = Array.from({ length: 31 }, (_, index) =>
     (index + 16).toString(16).padStart(40, "0"),


### PR DESCRIPTION
## The Problem

The five-SHA, multi-target preview burst on #599 exposed two correctness gaps before the remaining target cutovers:

1. An unaffected target could remain `pending` forever when its inherited runtime had already been coalesced to a later selection. In #599, SHA `00b8a1833cfae0720ef3b52b25347d395eb1117d` correctly inherited UI runtime history, but the controller ignored that runtime's persisted coalescing proof and continued publishing `ui=pending`.
2. Reserve's browser smoke could race the server-rendered tab shell before React hydration, and a later same-origin navigation back to Overview could pass after the first Supply assertion. The bounded smoke retry recovered #599 without rebuilding, but the initial false failure and the late-navigation gap made the verification less deterministic than the deployment contract requires.

## The Solution

- Settle an unaffected target as `coalesced` when its validated inherited runtime carries `coalescedToByRun`, while preserving terminal worker results as the higher-priority outcome.
- Add an exact five-SHA regression covering the mixed affected/unaffected lineage observed in #599.
- Wait for the Reserve page load before clicking the server-rendered Supply tab.
- Bind Reserve success to one reusable invariant: the immutable deployment origin, `tab=stablecoins`, and the selected `Supply` tab must all agree.
- Re-evaluate that full invariant after the interaction settle window so a late same-origin return to Overview fails closed.
- Add regressions for the hydration ordering, a competing root navigation, and a stable-then-root navigation during settle.

## Verification

- `node --test scripts/vercel-preview-browser-smoke.test.mjs` — 12/12 passed
- `pnpm vercel:preview:test` — 243/243 passed
- `pnpm vercel:workflow:test` — 91/91 passed
- `pnpm vercel:primitives:test` — 60/60 passed
- `pnpm quality:budgets:test` — 30/30 passed
- `trunk fmt scripts/vercel-preview-browser-smoke.mjs scripts/vercel-preview-browser-smoke.test.mjs`
- `trunk check` — four modified files clean
- `pnpm adr:check`
- `git diff --check`

The final code also passed the exact immutable #599 Reserve tuple in headless system Chrome:

- Deployment: https://reservemento-1pv1usqzn-mentolabs.vercel.app/
- SHA: `00b8a1833cfae0720ef3b52b25347d395eb1117d`
- GitHub Deployment: `5554102585`
- Result: `overview-data-and-supply-tab`
- Assets: 13 JavaScript, 2 CSS, 3 fonts

## Risk and rollback

This changes only controller status reconciliation and Reserve preview verification; it does not change application runtime code, deployment ownership, credentials, or build/upload behavior. The controller remains fail-closed, and terminal worker evidence still wins over inherited coalescing evidence. Roll back by reverting this PR's merge commit; the existing serialized controller reconcile and bounded smoke retry paths remain available.

Refs #520
