### PR TITLE
test(reserve): prove post-cutover preview ownership

### DIFF
--- a/apps/reserve.mento.org/vercel-cutover-canary-20260722.md
+++ b/apps/reserve.mento.org/vercel-cutover-canary-20260722.md
@@ -1,0 +1,4 @@
+<!-- GitHub-driven Vercel post-cutover canary
+Date: 2026-07-22
+Target: reserve
+Purpose: path-scoped single-owner deployment verification -->


### PR DESCRIPTION
## The Problem

Issue #520 requires fresh post-merge proof that Reserve preview ownership is fully cut over after `main@2a91a3545d28f878a9b07164ec3cc0338dd2cd8f`. A Reserve-only runtime change must produce exactly one GitHub-owned Reserve preview and no native Vercel duplicate.

## The Solution

Add one inert HTML comment under `apps/reserve.mento.org` so the exact-SHA controller exercises only the Reserve path without changing rendered behavior.

This pull request is evidence-only: do not merge it. After the controller plan, worker/deployment ownership, browser smoke, journal state, and close cleanup are verified, it will be closed and its branch deleted.

Refs #520
