### PR TITLE
docs(vercel): update native adapter ownership wording

### DIFF
--- a/.github/workflows/preview-smoke.yml
+++ b/.github/workflows/preview-smoke.yml
@@ -1,8 +1,8 @@
 name: Native Vercel Preview Smoke Adapter
 
-# Temporary bridge while Vercel Git still owns App and Governance branch
-# previews. Every exact qualifying Vercel success runs the full secretless
-# reusable smoke; no prior status is queried or trusted as dedupe evidence.
+# Temporary bridge while Vercel Git owns App branch previews, retained for a
+# bounded Governance rollback/shadow path. Every exact qualifying Vercel success
+# runs the full secretless reusable smoke; no prior status is trusted for dedupe.
 on:
   deployment_status:
 

--- a/.github/workflows/preview-smoke.yml
+++ b/.github/workflows/preview-smoke.yml
@@ -1,8 +1,10 @@
 name: Native Vercel Preview Smoke Adapter
 
-# Temporary bridge while Vercel Git owns App branch previews, retained for a
-# bounded Governance rollback/shadow path. Every exact qualifying Vercel success
-# runs the full secretless reusable smoke; no prior status is trusted for dedupe.
+# Temporary bridge while Vercel Git owns App branch previews. Governance also
+# enters this adapter while its native previews remain shadowed before cutover,
+# and only through a bounded target-local rollback path afterward. Every exact
+# qualifying Vercel success runs the full secretless reusable smoke; no prior
+# status is trusted for dedupe.
 on:
   deployment_status:
 

--- a/docs/wallet-testing.md
+++ b/docs/wallet-testing.md
@@ -235,12 +235,13 @@ connect only on an allowlisted team preview host.
 
 GitHub-built workers call the reusable workflow directly before posting a
 successful canonical Deployment status. While native Vercel Git still owns App
-and Governance branch previews, `.github/workflows/preview-smoke.yml` is a
-temporary `deployment_status` adapter. It accepts only the exact Vercel bot,
-exact `Preview – <project>` environment, successful status, empty native
-Deployment payload, and exact project-slug team hostname. Every qualifying
-event runs the full smoke; the adapter does not query or reuse earlier statuses
-or use a lossy shared concurrency group, and has no PAT or Vercel credential.
+branch previews, `.github/workflows/preview-smoke.yml` is its temporary
+`deployment_status` adapter and remains available for a bounded Governance
+rollback/shadow path. It accepts only the exact Vercel bot, exact
+`Preview – <project>` environment, successful status, empty native Deployment
+payload, and exact project-slug team hostname. Every qualifying event runs the
+full smoke; the adapter does not query or reuse earlier statuses or use a lossy
+shared concurrency group, and has no PAT or Vercel credential.
 
 Run the wallet-specific portion locally against any live App or Governance
 preview URL:

--- a/docs/wallet-testing.md
+++ b/docs/wallet-testing.md
@@ -236,12 +236,13 @@ connect only on an allowlisted team preview host.
 GitHub-built workers call the reusable workflow directly before posting a
 successful canonical Deployment status. While native Vercel Git still owns App
 branch previews, `.github/workflows/preview-smoke.yml` is its temporary
-`deployment_status` adapter and remains available for a bounded Governance
-rollback/shadow path. It accepts only the exact Vercel bot, exact
-`Preview – <project>` environment, successful status, empty native Deployment
-payload, and exact project-slug team hostname. Every qualifying event runs the
-full smoke; the adapter does not query or reuse earlier statuses or use a lossy
-shared concurrency group, and has no PAT or Vercel credential.
+`deployment_status` adapter. Governance enters the same adapter while its native
+previews remain shadowed before cutover; after cutover, that route is retained
+only for a bounded target-local rollback. It accepts only the exact Vercel bot,
+exact `Preview – <project>` environment, successful status, empty native
+Deployment payload, and exact project-slug team hostname. Every qualifying
+event runs the full smoke; the adapter does not query or reuse earlier statuses
+or use a lossy shared concurrency group, and has no PAT or Vercel credential.
 
 Run the wallet-specific portion locally against any live App or Governance
 preview URL:


### PR DESCRIPTION
## The Problem

The native Vercel preview smoke adapter still says Vercel Git owns both App and Governance branch previews. That wording becomes stale before the target-local Governance ownership cutover can merge cleanly.

## The Solution

Update only the adapter comment and wallet-testing runbook wording to describe App as the active native owner while preserving Governance as a bounded rollback/shadow path.

## Validation

- `trunk check .github/workflows/preview-smoke.yml docs/wallet-testing.md`
- `pnpm vercel:preview:test`
- `pnpm vercel:workflow:test`
- `pnpm ci:change-plan:test`
- `pnpm adr:check`
- `git diff --check`
- `pnpm pr:description:check < /private/tmp/frontend-586-adapter-wording-pr-body.md`

## Ship Checklist

- [x] ship skill used
- [x] local review run
- [x] validation run
