### PR TITLE
test(governance): prove post-cutover preview ownership

### DIFF
--- a/apps/governance.mento.org/vercel-cutover-canary-20260722.md
+++ b/apps/governance.mento.org/vercel-cutover-canary-20260722.md
@@ -1,0 +1,4 @@
+<!-- GitHub-driven Vercel post-cutover canary
+Date: 2026-07-22
+Target: governance
+Purpose: path-scoped single-owner deployment verification -->


### PR DESCRIPTION
## The Problem

Issue #520 requires fresh post-merge proof that Governance preview ownership is fully cut over after `main@a0ca137383fd8d1fec3d24541e039775009f5c15`. A Governance-only runtime change must produce exactly one GitHub-owned Governance preview and no native Vercel duplicate.

## The Solution

Add one inert HTML comment under `apps/governance.mento.org` so the exact-SHA controller exercises only the Governance path without changing rendered behavior.

This pull request is evidence-only: do not merge it. After the controller plan, worker/deployment ownership, browser smoke, journal state, and close cleanup are verified, it will be closed and its branch deleted.

Refs #520

## Validation

- `pnpm vercel:plan --base a0ca137383fd8d1fec3d24541e039775009f5c15 --head f78cab6cdeb8bf156d0705bea1733c76ca76e293`
- `trunk check apps/governance.mento.org/vercel-cutover-canary-20260722.md`
- `pnpm adr:check`
- `pnpm pr:description:check < /private/tmp/pr-governance-postmerge-canary-body.md`

## Ship Checklist

- [x] ship skill used
- [x] local review run
- [x] validation run
