### PR TITLE
docs(vercel): clarify preview adapter transition

### DIFF
--- a/.github/workflows/preview-smoke.yml
+++ b/.github/workflows/preview-smoke.yml
@@ -1,10 +1,10 @@
 name: Native Vercel Preview Smoke Adapter
 
-# Temporary bridge while Vercel Git owns App branch previews. Governance also
-# enters this adapter while its native previews remain shadowed before cutover,
-# and only through a bounded target-local rollback path afterward. Every exact
-# qualifying Vercel success runs the full secretless reusable smoke; no prior
-# status is trusted for dedupe.
+# Transition bridge: before App cutover, it smokes App's still-native shadow
+# previews; Governance enters only during bounded target-local rollback. After
+# App cutover, both App and Governance enter only during such rollbacks. Every
+# exact qualifying Vercel success runs the full secretless reusable smoke; no
+# prior status is trusted for dedupe.
 on:
   deployment_status:
 

--- a/docs/vercel-deployments.md
+++ b/docs/vercel-deployments.md
@@ -831,10 +831,13 @@ console/page errors, and same-origin failures, then runs the target interaction:
 - Reserve: Overview data plus Supply tab and URL/state transition;
 - UI: exact build/asset identity, navigation, and hydrated control interaction.
 
-The temporary `.github/workflows/preview-smoke.yml` native adapter classifies
+The transitional `.github/workflows/preview-smoke.yml` native adapter classifies
 only exact successful `Preview – app.mento.org` and
 `Preview – governance.mento.org` events created by Vercel's fixed bot identity
-on the exact project-slug team host. Production/v3, inactive/skipped, main,
+on the exact project-slug team host. Before App cutover, it handles App's
+still-native shadow-preview events; Governance enters only during bounded
+target-local rollback. After App cutover, both App and Governance enter only
+during those bounded rollback paths. Production/v3, inactive/skipped, main,
 controller-payload, actor-lookalike, Reserve, and UI events do not call smoke.
 Every qualifying event runs the full reusable workflow. No historical status
 is listed or trusted for dedupe, and the adapter deliberately declares no
@@ -842,8 +845,8 @@ workflow or job concurrency group: GitHub replaces an older pending run in a
 shared group even when `cancel-in-progress` is false, which would violate the
 one-full-smoke-per-event contract. The appended terminal status is bounded,
 run-specific evidence only. The adapter receives no PAT, Vercel token, Turbo
-token, or application secret and is deleted after all native consumers leave
-the observation window.
+token, or application secret and remains available only for the bounded
+rollback paths above after App cutover.
 
 ## Automatic trusted four-target previews (current v2 controller)
 
@@ -1891,9 +1894,11 @@ unsupported-trust, failure, cancellation, and old-epoch evidence.
 ## UI Vercel Git cutover (Phase B)
 
 Phase B established UI's GitHub-owned branch-preview state, which remains part
-of the current ownership map alongside Governance and Reserve. Its completed
-precondition was that every Phase A dual-path canary above passed and its
-GitHub-built/native-preview evidence was recorded. This separate merge paired
+of the current ownership map alongside Governance and Reserve. App remains
+shadowed until its separate cutover; after that cutover, App joins the map and
+all four targets are GitHub-owned. Phase B's completed precondition was that
+every Phase A dual-path canary above passed and its GitHub-built/native-preview
+evidence was recorded. This separate merge paired
 `VERCEL_PREVIEW_CONTROLLER_MODE: active` in
 `.github/workflows/vercel-preview-controller.yml` with the following exact
 `apps/ui.mento.org/vercel.json`, preserving its schema and unrelated keys:

--- a/docs/wallet-testing.md
+++ b/docs/wallet-testing.md
@@ -234,15 +234,15 @@ deployed bundle lists the real wallet options and that the mock wallet can
 connect only on an allowlisted team preview host.
 
 GitHub-built workers call the reusable workflow directly before posting a
-successful canonical Deployment status. While native Vercel Git still owns App
-branch previews, `.github/workflows/preview-smoke.yml` is its temporary
-`deployment_status` adapter. Governance enters the same adapter while its native
-previews remain shadowed before cutover; after cutover, that route is retained
-only for a bounded target-local rollback. It accepts only the exact Vercel bot,
-exact `Preview – <project>` environment, successful status, empty native
-Deployment payload, and exact project-slug team hostname. Every qualifying
-event runs the full smoke; the adapter does not query or reuse earlier statuses
-or use a lossy shared concurrency group, and has no PAT or Vercel credential.
+successful canonical Deployment status. Before App cutover,
+`.github/workflows/preview-smoke.yml` handles App's still-native shadow-preview
+events; Governance enters it only during a bounded target-local rollback. After
+App cutover, both App and Governance enter only through those bounded rollback
+paths. The adapter accepts only the exact Vercel bot, exact
+`Preview – <project>` environment, successful status, empty native Deployment
+payload, and exact project-slug team hostname. Every qualifying event runs the
+full smoke; the adapter does not query or reuse earlier statuses or use a lossy
+shared concurrency group, and has no PAT or Vercel credential.
 
 Run the wallet-specific portion locally against any live App or Governance
 preview URL:


### PR DESCRIPTION
## The Problem

The native preview-smoke adapter spans two rollout states: App still uses its
native shadow-preview route before the final App ownership cutover, while
Governance is already GitHub-owned and should enter the adapter only during a
bounded target-local rollback. Existing wording describes Governance's old
pre-cutover state and would become misleading again when App cuts over.

Because `.github/workflows/preview-smoke.yml` is a fail-closed global build
input, this transition wording must land separately from the App-target-local
ownership change.

## The Solution

Describe the adapter contract in state-independent terms across its workflow
comment, wallet-testing guide, and canonical Vercel runbook:

- before App cutover, App's still-native shadow previews use the adapter and
  Governance uses it only during bounded target-local rollback;
- after App cutover, App and Governance use it only during those rollback
  paths; and
- the UI Phase-B history records that App joins Governance, Reserve, and UI
  after its separate cutover, yielding four GitHub-owned preview targets.

This is wording-only: it does not change workflow execution, ownership modes,
Vercel project configuration, production paths, or the deleted Governance QA
environment.

## Validation

- `pnpm vercel:preview:test`
- `node --test scripts/vercel-preview-smoke-workflows.test.mjs`
- `trunk check --ci --all`
- `pnpm adr:check`
- `pnpm adr:check:test`
- `pnpm pr:description:test`

## Architecture decision

Not applicable — this precursor clarifies the already accepted adapter and
target-local rollback boundaries in ADR 0001 and ADR 0003 without changing
them.

## Rollout

Do not publish while the Governance post-merge canary is open. The workflow
comment is a global planner input even though it does not change executable
behavior, so its exact-head preview fan-out must start only after the prior
canary is closed and quiescent.

Progresses #520.
Part of #515.

## Ship Checklist

- [x] ship skill used
- [x] local review run
- [x] validation run
