### PR TITLE
fix(ci): recover terminal closed preview ownership

### DIFF
--- a/docs/adr/0002-single-comment-preview-controller-journal.md
+++ b/docs/adr/0002-single-comment-preview-controller-journal.md
@@ -224,20 +224,44 @@ legacy admission fallback.
 
 One explicit closed-bootstrap path exists for recovery of a legacy cursorless
 closed journal during the admission-cursor cutover. It can update only an
-existing canonical v2 journal whose live PR is closed and whose durable state
-proves that no worker, selection, result, or dispatch ownership remains
-unfinished. The journal is cursorless unless this is an exact rerun of its
-already-recorded bootstrap. It authenticates the exact repository,
-numeric workflow ID/path, `repository_dispatch` run ID and run number, strict
-title, and receipt before mutation. It records a terminal closed anchor/state
-and admission floor without planning, worker dispatch, Deployment mutation, or
-a pending preview status. A rerun of that same Actions run is idempotent and can
-repair a post-commit witness or reconciliation failure; a second distinct
-closed-bootstrap run cannot replace the cursor. A missing journal fails rather
-than being created. Delayed events at or below that floor are exact-run-
-authenticated write-free no-ops, while every later run remains part of the
-global admission interval. A subsequent valid `reopened` event starts a new
-epoch from the terminal anchor.
+existing canonical v2 journal whose live PR is closed. Normally its durable
+state proves that no ownership remains unfinished. One narrowly bounded legacy
+case may instead fold stale current-active slots only when the journal is
+cursorless, has no checkpoint pending owner or `retired_active` entry, and every
+active slot has one exact selection, one compatible persisted
+terminal result, and one distinct completed worker run and attempt
+authenticated through the Actions API. Intended owners, worker search, result
+synthesis, Deployment inspection or mutation, ambiguous evidence, nonterminal
+evidence, a changed live PR, or a later controller run all fail before mutation.
+Terminal non-pending retired history retains the pre-existing drained semantics
+and does not use this exception.
+
+The journal is cursorless unless this is an exact rerun of its already-recorded
+bootstrap. The path authenticates the exact repository, numeric workflow
+ID/path, `repository_dispatch` run ID and run number, strict title, and receipt
+before mutation. The authenticated bootstrap must be the complete quiescent
+frontier. It records the admission floor without planning, worker dispatch,
+Deployment mutation, or a pending preview status; the same run's existing
+reconciliation job then consumes only the already-persisted terminal results,
+drains the active slots, and records terminal closed state. No second operation,
+reader, or compatibility mode exists. Active-capacity compaction is deferred only
+between that receipt and same-run drain, while the ordinary 60 KB guard remains
+fail-closed. Until drain and compaction commit, the durable admission cursor
+remains pinned to the bootstrap: a later Actions frontier fails before its
+cursor or any journal mutation is persisted, and a distinct reconciliation run
+cannot consume the pending state. A central writer barrier covers event,
+selection, worker-evidence, result, cursor, and state mutations; only the exact
+bootstrap's idempotent receipt replay and its same-run terminal
+state-and-compaction write are authorized. `state.closed` alone is not
+terminality for this barrier: unfinished authenticated ownership keeps recovery
+pending until the same run records a closed-and-drained state. Later PR receipts fail before
+admission refresh. A rerun of that same Actions run is
+idempotent and can repair a post-commit witness or reconciliation failure; a
+second distinct closed-bootstrap run cannot replace the cursor. A missing
+journal fails rather than being created. Delayed events at or below that floor
+are exact-run-authenticated write-free no-ops, while every later run remains
+part of the global admission interval. A subsequent valid `reopened` event
+starts a new epoch from the terminal anchor.
 
 During the historical precursor phase, every `pull_request_target` run began
 using a strict machine-readable title that binds run ID, workflow-monotonic run
@@ -407,6 +431,11 @@ cost, retention policy, and operator dependency for preview deployment.
 - Cutover and rollback require explicit run draining and fresh bootstrap. They
   intentionally abandon persistence continuity across journal versions rather
   than carrying compatibility code indefinitely.
+- The closed-bootstrap terminal-active exception is deliberately narrower than
+  general worker recovery: only exact current active slots with already-durable
+  terminal results qualify. Checkpoint owners, all retired owners, and intended
+  owners remain fail-closed, and there is no alternate operation or
+  second journal reader to maintain.
 - The decision should be reconsidered after any lost journal entry, duplicate
   worker or Deployment caused by journal state, repeated approach to the body
   limit, queue pressure near the 100-pending platform bound, material preview

--- a/docs/vercel-deployments.md
+++ b/docs/vercel-deployments.md
@@ -1419,15 +1419,56 @@ gh api --method POST \
 
 A closed bootstrap is an exceptional recovery reset, not a way to create a
 journal. It is accepted only when the exact PR is live-closed, exactly one
-canonical v2 journal already exists, and that journal has no unfinished worker,
-selection, result, or dispatch ownership. The journal must be cursorless unless
-this is an exact rerun of its already-recorded bootstrap. The numbered
-`repository_dispatch` run must authenticate the exact repository, numeric
-controller workflow ID and path, run ID, run number, strict title, and durable
-receipt. The reset records a terminal closed anchor/state and the new admission
-floor without invoking the planner, dispatching a worker, creating or updating
-a Deployment, or publishing a pending preview status. A later `reopened` event
-starts normally from that terminal anchor.
+canonical v2 journal already exists, and that journal either has no unfinished
+ownership or matches the narrow terminal-active legacy case below. The journal
+must be cursorless unless this is an exact rerun of its already-recorded
+bootstrap. The numbered `repository_dispatch` run must authenticate the exact
+repository, numeric controller workflow ID and path, run ID, run number, strict
+title, and durable receipt. Its receipt establishes the new admission floor;
+the same run's existing reconciliation job then folds the state and records the
+terminal closed anchor/state. Neither step invokes the planner, dispatches a
+worker, creates or updates a Deployment, or publishes a pending preview status.
+A later `reopened` event starts normally from that terminal anchor.
+
+The terminal-active legacy case exists only for a cursorless closed journal
+whose mutable state failed to fold already-durable terminal results. It permits
+current `active` slots only: no intended owner, any `retired_active` entry, or
+checkpoint pending owner is recoverable through this exception. Every active
+slot must bind exactly one canonical selection, one compatible terminal result,
+and one distinct exact worker run and attempt. The controller
+reads that exact attempt through the authenticated Actions API and validates
+the trusted worker path, repository, default ref, authorized workflow SHA,
+strict title, run URL, completed status, terminal conclusion, and
+result/conclusion compatibility. It does not search for a worker, synthesize a
+result, call worker recovery, or read or mutate a Deployment. Missing,
+duplicate, nonterminal, contradictory, or changed evidence fails before
+journal mutation. The live PR is queried again after proof and must still match
+the closed bootstrap snapshot exactly.
+
+The authenticated bootstrap run must also be the complete quiescent admission
+frontier. Its receipt establishes that one floor; the existing
+`reconcile-bootstrap` job in the same workflow run then consumes the already
+persisted results, clears the stale current-active slots, and compacts the
+journal. This is not another operation, reader, or compatibility mode. A
+terminal-recovery receipt deliberately defers active-capacity checkpointing so
+the old owner lineage survives until that reconcile; the ordinary 60 KB
+comment guard still rejects an oversized body before any write. While that
+drain is pending, the durable admission cursor remains pinned to the bootstrap
+run. If a later controller run appears at the Actions frontier before the drain
+and compaction write commits, same-run reconciliation fails before persisting
+that later cursor or mutating journal state. A centralized journal-write barrier
+also rejects event, selection, worker-evidence, result, cursor, and nonterminal
+state writes during this interval. Its only capabilities are an idempotent
+replay of the exact admitted bootstrap receipt and the exact same run's terminal
+drain-and-compaction state write. `state.closed` alone does not clear this
+barrier: recovery remains pending while authenticated ownership is unfinished,
+and only a terminal closed-and-drained state clears it.
+A later PR event fails before admission refresh, even when its live pull-request
+snapshot has already changed.
+A distinct reconciliation run is rejected before admission refresh or state
+mutation. A
+terminal non-pending retired entry remains part of the pre-existing drained
+contract and does not enter terminal-active recovery.
 
 If a closed bootstrap partially fails after committing its receipt or terminal
 witness, rerun the failed job(s) on that same Actions run. Reruns retain the
@@ -1435,7 +1476,34 @@ same run ID and run number and repair missing witness or reconciliation work
 idempotently. Never send a second bootstrap dispatch for the same closed
 journal: a distinct run cannot replace its established admission cursor. A
 closed bootstrap against a missing journal or unfinished ownership fails before
-mutation.
+mutation unless the unfinished state is exactly the authenticated
+terminal-active legacy case above.
+
+For a terminal-active cursorless closed journal, recovery after the corrective
+change reaches `main` has exactly two operator steps:
+
+1. Freeze lifecycle mutations and confirm the PR is still closed, exactly one
+   canonical v2 journal exists with no admission cursor, no checkpoint pending
+   owner or `retired_active` entry exists, every current active slot has one
+   matching terminal result, every exact worker attempt is completed, and no
+   later controller run is in flight. Do not edit the journal, run a standalone
+   reconcile, or redispatch a worker.
+2. Dispatch one closed bootstrap and wait for both its receipt and same-run
+   reconciliation jobs. Verify the journal has the exact bootstrap run
+   ID/number as its admission cursor, is terminal-closed with all active and
+   retired slots empty, and the run emitted no planner execution, worker
+   dispatch, Deployment mutation, or pending `Vercel Preview` status:
+
+   ```bash
+   PR_NUMBER="<closed-pr-number>"
+   gh api --method POST \
+     repos/mento-protocol/frontend-monorepo/dispatches \
+     -f event_type=vercel-preview-bootstrap \
+     -F "client_payload[pr_number]=$PR_NUMBER"
+   ```
+
+If step 2 fails after its receipt commits, rerun the failed job on that same
+Actions run. Never dispatch another distinct closed bootstrap.
 
 Do not invent an opened event, manually edit or delete a journal, invent journal
 entries, or re-dispatch the worker directly. Missing repository names must be

--- a/scripts/vercel-preview-controller.mjs
+++ b/scripts/vercel-preview-controller.mjs
@@ -118,6 +118,27 @@ const TERMINAL_WORKFLOW_RUN_CONCLUSIONS = new Set([
   "stale",
   "startup_failure",
 ]);
+const RESULT_BEARING_WORKER_CONCLUSIONS = new Set([
+  "success",
+  "failure",
+  "cancelled",
+  "timed_out",
+  "startup_failure",
+  "action_required",
+  "stale",
+]);
+const FAILURE_CONCLUSION_FAILURE_REASONS = new Set([
+  "build-failed-retriable",
+  "build-failed-final",
+  "smoke-failed-retriable",
+  "smoke-failed-final",
+  "worker-failure",
+  "worker-failure-recovered",
+]);
+const FAILURE_CONCLUSION_ERROR_REASONS = new Set([
+  "upload-ambiguous",
+  "verification-ambiguous",
+]);
 const WORKER_RECOVERY_BEFORE_MS = 2 * 60 * 1_000;
 const WORKER_RECOVERY_AFTER_MS = 15 * 60 * 1_000;
 const UPLOAD_STARTED_DESCRIPTION = "Prebuilt preview upload starting";
@@ -4798,6 +4819,7 @@ async function mutatePreviewJournal({
   allowCreate = false,
   assertCanCreate,
   expectedComment = null,
+  closedBootstrapRecoveryCapability = null,
   mutate,
 }) {
   const pr = pullRequestNumber(rawPr);
@@ -4810,10 +4832,28 @@ async function mutatePreviewJournal({
       "Preview journal identity changed",
     );
   }
+  const pendingClosedBootstrapRecovery = loaded
+    ? pendingClosedBootstrapTerminalRecovery(loaded)
+    : null;
+  if (pendingClosedBootstrapRecovery) {
+    assertClosedBootstrapTerminalRecoveryWriteAuthorized({
+      recovery: pendingClosedBootstrapRecovery,
+      context,
+      capability: closedBootstrapRecoveryCapability,
+    });
+  }
   if (!loaded && assertCanCreate) await assertCanCreate();
   const current = loaded?.journal ?? createPreviewJournal({ pr, revision: 1 });
   const candidate = structuredClone(current);
   mutate(candidate);
+  if (pendingClosedBootstrapRecovery) {
+    assertClosedBootstrapTerminalRecoveryWriteResult({
+      current,
+      candidate,
+      recovery: pendingClosedBootstrapRecovery,
+      capability: closedBootstrapRecoveryCapability,
+    });
+  }
   candidate.journal_digest = previewJournalDigest(
     candidate.receipts,
     candidate.state,
@@ -4933,6 +4973,7 @@ function journalHasUnfinishedOwnership(journal, state) {
     const pendingKey =
       journal.checkpoint?.targets[target].pending_owner_key_digest ?? null;
     return (
+      pendingKey !== null ||
       targetState.active !== null ||
       targetState.retired_active.some(
         (selection) =>
@@ -4941,6 +4982,255 @@ function journalHasUnfinishedOwnership(journal, state) {
       )
     );
   });
+}
+
+function closedBootstrapOwnershipClaims(journal, state) {
+  const claims = new Map();
+  for (const target of PREVIEW_TARGETS) {
+    const targetState = state.targets[target];
+    invariant(
+      targetState.retired_active.length === 0 &&
+        (journal.checkpoint?.targets[target].pending_owner_key_digest ??
+          null) === null,
+      "Closed bootstrap terminal recovery rejects retired or checkpoint ownership",
+    );
+    const dispatch = targetState.active;
+    if (!dispatch) continue;
+    invariant(
+      !claims.has(dispatch.key_digest),
+      "Closed bootstrap terminal ownership is duplicated",
+    );
+    claims.set(dispatch.key_digest, { target, dispatch });
+  }
+  return [...claims.entries()].map(([keyDigest, claim]) => ({
+    keyDigest,
+    ...claim,
+  }));
+}
+
+function workerConclusionMatchesTerminalResult(conclusion, result) {
+  if (conclusion === "success") {
+    return (
+      (result.state === "success" && result.terminal_reason === "verified") ||
+      (result.state === "error" &&
+        result.terminal_reason === "missing-success-evidence")
+    );
+  }
+  if (conclusion === "failure") {
+    return (
+      (result.state === "failure" &&
+        FAILURE_CONCLUSION_FAILURE_REASONS.has(result.terminal_reason)) ||
+      (result.state === "error" &&
+        FAILURE_CONCLUSION_ERROR_REASONS.has(result.terminal_reason))
+    );
+  }
+  return (
+    result.state === "error" &&
+    result.terminal_reason === `worker-${conclusion}`
+  );
+}
+
+async function authenticateClosedBootstrapTerminalOwnership({
+  github,
+  context,
+  parsed,
+  state,
+  bootstrap,
+  alreadyRepresented,
+  waitForRetry,
+}) {
+  const admission = validateControllerAdmissionCursor(parsed.admission);
+  const exactBootstrapRerun =
+    alreadyRepresented &&
+    admission?.through_run_id === bootstrap.event_run_id &&
+    admission.through_run_number === bootstrap.event_run_number;
+  invariant(
+    admission === null || exactBootstrapRerun,
+    "Closed bootstrap terminal recovery requires a cursorless journal or its exact admitted rerun",
+  );
+  const claims = closedBootstrapOwnershipClaims(parsed.journal, state);
+  invariant(
+    claims.length > 0,
+    "Closed bootstrap terminal recovery has no stale ownership",
+  );
+  const workerRunIds = new Set();
+  for (const { keyDigest, target, dispatch } of claims) {
+    const selections = parsed.selections.filter(
+      (selection) => selection.key_digest === keyDigest,
+    );
+    invariant(
+      selections.length === 1 && selections[0].target === target,
+      "Closed bootstrap terminal recovery selection is missing or ambiguous",
+    );
+    const [selection] = selections;
+    invariant(
+      dispatch.dispatch_state === "dispatched" &&
+        dispatch.workflow_run_id !== null &&
+        dispatch.workflow_run_attempt !== null &&
+        dispatch.run_url !== null &&
+        dispatch.html_url !== null &&
+        canonicalJson(selection) ===
+          canonicalJson(selectionReceiptFromDispatch(dispatch)),
+      "Closed bootstrap terminal recovery owner is not an exact dispatched selection",
+    );
+    const results = parsed.results.filter(
+      (result) => result.key_digest === keyDigest,
+    );
+    invariant(
+      results.length === 1 && sameAttemptBinding(results[0], selection),
+      "Closed bootstrap terminal recovery result is missing or ambiguous",
+    );
+    const [result] = results;
+    invariant(
+      dispatch.workflow_run_id === result.worker_run_id &&
+        dispatch.workflow_run_attempt === result.worker_run_attempt &&
+        !workerRunIds.has(result.worker_run_id),
+      "Closed bootstrap terminal recovery worker ownership is ambiguous",
+    );
+    workerRunIds.add(result.worker_run_id);
+    const worker = await getValidatedWorkerRun(
+      github,
+      context,
+      result.worker_run_id,
+      dispatch,
+      { waitForRetry },
+    );
+    invariant(
+      worker.workflow_run_id === result.worker_run_id &&
+        worker.workflow_run_attempt === result.worker_run_attempt &&
+        worker.status === "completed" &&
+        RESULT_BEARING_WORKER_CONCLUSIONS.has(worker.conclusion) &&
+        workerConclusionMatchesTerminalResult(worker.conclusion, result),
+      "Closed bootstrap terminal recovery worker evidence is nonterminal or mismatched",
+    );
+    invariant(
+      worker.workflow_sha === dispatch.workflow_sha &&
+        worker.run_url === dispatch.run_url &&
+        worker.html_url === dispatch.html_url,
+      "Closed bootstrap terminal recovery worker identity changed",
+    );
+  }
+  return claims.length;
+}
+
+function closedBootstrapTerminalRecoveryBootstrap({ parsed, state }) {
+  const admission = validateControllerAdmissionCursor(parsed.admission);
+  if (
+    admission === null ||
+    !journalHasUnfinishedOwnership(parsed.journal, state)
+  ) {
+    return null;
+  }
+  const bootstrap = controllerAdmissionEvents(
+    parsed.events,
+    parsed.checkpoint,
+  ).find((event) => event.event_run_id === admission.through_run_id);
+  if (
+    bootstrap?.event_action !== "bootstrap" ||
+    bootstrap.pr_state !== "closed" ||
+    bootstrap.event_run_number !== admission.through_run_number
+  ) {
+    return null;
+  }
+  return closedBootstrapOwnershipClaims(parsed.journal, state).length > 0
+    ? bootstrap
+    : null;
+}
+
+function isSameRunClosedBootstrapTerminalRecovery({ bootstrap, context }) {
+  return (
+    context.runNumber !== null &&
+    context.runNumber !== undefined &&
+    bootstrap.event_run_id === exactRunId(context.runId) &&
+    bootstrap.event_run_number === exactRunId(context.runNumber)
+  );
+}
+
+const CLOSED_BOOTSTRAP_RECOVERY_EXACT_RECEIPT = "exact-bootstrap-receipt";
+const CLOSED_BOOTSTRAP_RECOVERY_TERMINAL_STATE =
+  "exact-same-run-terminal-state";
+
+function pendingClosedBootstrapTerminalRecovery(parsed) {
+  if (parsed.state === null) return null;
+  const state = normalizeExistingState(parsed.state, parsed.journal.pr);
+  const bootstrap = closedBootstrapTerminalRecoveryBootstrap({
+    parsed,
+    state,
+  });
+  return bootstrap ? { bootstrap, state } : null;
+}
+
+function assertClosedBootstrapTerminalRecoveryWriteAuthorized({
+  recovery,
+  context,
+  capability,
+}) {
+  invariant(
+    isSameRunClosedBootstrapTerminalRecovery({
+      bootstrap: recovery.bootstrap,
+      context,
+    }),
+    "Closed bootstrap terminal recovery rejects journal writes outside its exact run",
+  );
+  invariant(
+    capability?.type === CLOSED_BOOTSTRAP_RECOVERY_EXACT_RECEIPT ||
+      capability?.type === CLOSED_BOOTSTRAP_RECOVERY_TERMINAL_STATE,
+    "Closed bootstrap terminal recovery rejects journal writes before same-run drain",
+  );
+  if (capability.type === CLOSED_BOOTSTRAP_RECOVERY_EXACT_RECEIPT) {
+    const receipt = validateEventReceipt(capability.receipt);
+    invariant(
+      canonicalJson(receipt) === canonicalJson(recovery.bootstrap),
+      "Closed bootstrap terminal recovery receipt capability is not exact",
+    );
+  }
+}
+
+function assertClosedBootstrapTerminalRecoveryWriteResult({
+  current,
+  candidate,
+  recovery,
+  capability,
+}) {
+  if (capability.type === CLOSED_BOOTSTRAP_RECOVERY_EXACT_RECEIPT) {
+    invariant(
+      canonicalJson(candidate) === canonicalJson(current),
+      "Closed bootstrap terminal recovery bootstrap replay mutated the journal",
+    );
+    return;
+  }
+
+  const currentAdmission = validateControllerAdmissionCursor(current.admission);
+  const candidateAdmission = validateControllerAdmissionCursor(
+    candidate.admission,
+  );
+  invariant(
+    currentAdmission?.through_run_id === recovery.bootstrap.event_run_id &&
+      currentAdmission.through_run_number ===
+        recovery.bootstrap.event_run_number &&
+      canonicalJson(candidateAdmission) === canonicalJson(currentAdmission),
+    "Closed bootstrap terminal recovery state write changed its admission floor",
+  );
+  const representedBootstrap = controllerAdmissionEvents(
+    candidate.receipts.events,
+    candidate.checkpoint,
+  ).find((event) => event.event_run_id === recovery.bootstrap.event_run_id);
+  invariant(
+    representedBootstrap &&
+      canonicalJson(representedBootstrap) === canonicalJson(recovery.bootstrap),
+    "Closed bootstrap terminal recovery state write lost its bootstrap receipt",
+  );
+  const terminalState = normalizeExistingState(candidate.state, candidate.pr);
+  invariant(
+    terminalState.closed &&
+      !journalHasUnfinishedOwnership(candidate, terminalState) &&
+      PREVIEW_TARGETS.every(
+        (target) =>
+          terminalState.targets[target].active === null &&
+          terminalState.targets[target].retired_active.length === 0,
+      ),
+    "Closed bootstrap terminal recovery state write is not terminal and drained",
+  );
 }
 
 function foldCheckpointSemanticEvent(journal, event) {
@@ -4986,17 +5276,35 @@ async function appendJournalReceipt({
   allowCreate = false,
   assertCanCreate,
   eventAdmissionProof = null,
+  deferCompaction = false,
 }) {
   const definition = RECEIPT_COLLECTION[kind];
   invariant(definition, "Preview journal receipt kind is invalid");
   const value = definition.validate(rawValue);
   invariant(value.pr === pullRequestNumber(pr), "Preview receipt PR mismatch");
+  invariant(
+    deferCompaction === false ||
+      (kind === "event" &&
+        value.event_action === "bootstrap" &&
+        value.pr_state === "closed" &&
+        eventAdmissionProof?.complete === true),
+    "Preview receipt compaction deferral is not authorized",
+  );
   return mutatePreviewJournal({
     github,
     context,
     pr,
     allowCreate,
     assertCanCreate,
+    closedBootstrapRecoveryCapability:
+      kind === "event" &&
+      value.event_action === "bootstrap" &&
+      value.pr_state === "closed"
+        ? {
+            type: CLOSED_BOOTSTRAP_RECOVERY_EXACT_RECEIPT,
+            receipt: value,
+          }
+        : null,
     mutate(journal) {
       const priorAdmissionRunNumber =
         journal.admission?.through_run_number ?? null;
@@ -5122,6 +5430,13 @@ async function appendJournalReceipt({
         kind === "event" ? structuredClone(journal.receipts.events) : null;
       entries.push(structuredClone(value));
       persistAdmission();
+      if (deferCompaction) {
+        // This one authenticated legacy drain must preserve the old active
+        // owner lineage until the same run reconciles the persisted results.
+        // Rendering here enforces the 60 KB comment headroom before any write.
+        renderPreviewJournalBody(journal);
+        return;
+      }
       if (
         kind === "event" &&
         journal.state !== null &&
@@ -5206,14 +5521,31 @@ async function writeControllerState({
   pr,
   state,
   stateComment,
+  compactClosedBootstrapRecovery = false,
 }) {
   const updated = await mutatePreviewJournal({
     github,
     context,
     pr,
     expectedComment: stateComment,
+    closedBootstrapRecoveryCapability: compactClosedBootstrapRecovery
+      ? { type: CLOSED_BOOTSTRAP_RECOVERY_TERMINAL_STATE }
+      : null,
     mutate(journal) {
       journal.state = structuredClone(state);
+      if (compactClosedBootstrapRecovery) {
+        invariant(
+          state.closed,
+          "Closed bootstrap recovery compaction requires terminal state",
+        );
+        journal.journal_digest = previewJournalDigest(
+          journal.receipts,
+          journal.state,
+          journal.checkpoint,
+          journal.admission,
+        );
+        compactPreviewJournal(journal, { expectedPullNumber: pr });
+      }
     },
   });
   return updated.journalComment;
@@ -5572,6 +5904,7 @@ export async function recordEventReceipt({
   const receipt = validateEventReceipt({ ...validatedSnapshot, plan });
   const firstAttempt = exactRunAttempt(context.runAttempt ?? 1) === 1;
   const operatorBootstrap = receipt.event_action === "bootstrap";
+  let closedBootstrapTerminalRecoveryState = null;
   const currentBefore = normalizePullRequest(
     await pullFromApi(github, context, receipt.pr),
   );
@@ -5607,6 +5940,34 @@ export async function recordEventReceipt({
       allowMissing: firstAttempt,
     });
   }
+  const representedEvent = existing
+    ? (controllerAdmissionEvents(existing.events, existing.checkpoint).find(
+        (event) => event.event_run_id === receipt.event_run_id,
+      ) ?? null)
+    : null;
+  const alreadyRepresented = representedEvent !== null;
+  if (operatorBootstrap && representedEvent) {
+    invariant(
+      canonicalJson(representedEvent) === canonicalJson(receipt),
+      "Conflicting bootstrap receipt in preview journal",
+    );
+  }
+  const pendingClosedBootstrapRecovery = existing
+    ? pendingClosedBootstrapTerminalRecovery(existing)
+    : null;
+  if (pendingClosedBootstrapRecovery) {
+    invariant(
+      operatorBootstrap &&
+        alreadyRepresented &&
+        isSameRunClosedBootstrapTerminalRecovery({
+          bootstrap: pendingClosedBootstrapRecovery.bootstrap,
+          context,
+        }) &&
+        canonicalJson(receipt) ===
+          canonicalJson(pendingClosedBootstrapRecovery.bootstrap),
+      "Closed bootstrap terminal recovery rejects later event receipts before same-run drain",
+    );
+  }
   if (operatorBootstrap && receipt.pr_state === "closed") {
     invariant(
       existing && currentBefore.state === "closed",
@@ -5616,14 +5977,36 @@ export async function recordEventReceipt({
       existing.state === null
         ? null
         : normalizeExistingState(existing.state, receipt.pr);
-    invariant(
-      existingState
-        ? !journalHasUnfinishedOwnership(existing.journal, existingState)
-        : existing.selections.length === 0 &&
-            existing.workerEvidence.length === 0 &&
-            existing.results.length === 0,
-      "Closed bootstrap requires all preview ownership to be drained",
-    );
+    if (existingState) {
+      if (journalHasUnfinishedOwnership(existing.journal, existingState)) {
+        const staleClaims = closedBootstrapOwnershipClaims(
+          existing.journal,
+          existingState,
+        );
+        const priorAdmission = validateControllerAdmissionCursor(
+          existing.admission,
+        );
+        const exactBootstrapRerun =
+          alreadyRepresented &&
+          priorAdmission?.through_run_id === receipt.event_run_id &&
+          priorAdmission.through_run_number === receipt.event_run_number;
+        invariant(
+          staleClaims.length > 0 &&
+            (priorAdmission === null || exactBootstrapRerun),
+          staleClaims.length > 0
+            ? "Closed bootstrap terminal recovery requires a cursorless journal or its exact admitted rerun"
+            : "Closed bootstrap requires all preview ownership to be drained",
+        );
+        closedBootstrapTerminalRecoveryState = existingState;
+      }
+    } else {
+      invariant(
+        existing.selections.length === 0 &&
+          existing.workerEvidence.length === 0 &&
+          existing.results.length === 0,
+        "Closed bootstrap requires all preview ownership to be drained",
+      );
+    }
   }
   const representedEvents = [
     ...(existing?.events ?? []),
@@ -5633,11 +6016,6 @@ export async function recordEventReceipt({
       ? []
       : [receipt]),
   ];
-  const alreadyRepresented = existing
-    ? controllerAdmissionEvents(existing.events, existing.checkpoint).some(
-        (event) => event.event_run_id === receipt.event_run_id,
-      )
-    : false;
   const admissionSession = await createControllerAdmissionSession({
     github,
     context,
@@ -5663,6 +6041,49 @@ export async function recordEventReceipt({
     pull: currentBefore,
   });
   if (preFloorEvent) eventAdmissionProof.preFloorEvent = preFloorEvent;
+  if (closedBootstrapTerminalRecoveryState !== null) {
+    const authenticatedFloor = validateControllerAdmissionCursor(
+      eventAdmissionProof.cursor,
+    );
+    invariant(
+      eventAdmissionProof.complete &&
+        authenticatedFloor?.through_run_id === receipt.event_run_id &&
+        authenticatedFloor.through_run_number === receipt.event_run_number,
+      "Closed bootstrap terminal recovery requires an exact quiescent admission floor",
+    );
+    const recoveredOwners = await authenticateClosedBootstrapTerminalOwnership({
+      github,
+      context,
+      parsed: existing,
+      state: closedBootstrapTerminalRecoveryState,
+      bootstrap: receipt,
+      alreadyRepresented,
+      waitForRetry: waitForAdmission,
+    });
+    const confirmedClosedPull = normalizePullRequest(
+      await pullFromApi(github, context, receipt.pr),
+    );
+    invariant(
+      confirmedClosedPull.number === receipt.pr &&
+        confirmedClosedPull.state === "closed" &&
+        confirmedClosedPull.baseSha === receipt.trusted_base_sha &&
+        (receipt.base_ref === undefined ||
+          confirmedClosedPull.baseRef === receipt.base_ref) &&
+        confirmedClosedPull.headSha === receipt.head_sha &&
+        confirmedClosedPull.headRef === receipt.head_ref &&
+        confirmedClosedPull.headRepository === receipt.head_repository &&
+        confirmedClosedPull.author === receipt.pr_author &&
+        confirmedClosedPull.trust === receipt.trust &&
+        confirmedClosedPull.updatedAt === receipt.pr_updated_at &&
+        confirmedClosedPull.closedAt === receipt.pr_closed_at,
+      "Closed bootstrap terminal recovery PR state changed before mutation",
+    );
+    core.setOutput("closed_bootstrap_terminal_recovery", "true");
+    core.setOutput(
+      "closed_bootstrap_terminal_owner_count",
+      String(recoveredOwners),
+    );
+  }
   await appendJournalReceipt({
     github,
     context,
@@ -5676,6 +6097,7 @@ export async function recordEventReceipt({
         ? () => assertPreviewJournalIsUninitialized(github, context, receipt)
         : undefined,
     eventAdmissionProof,
+    deferCompaction: closedBootstrapTerminalRecoveryState !== null,
   });
   const controllerRunUrl = `https://github.com/${PREVIEW_REPOSITORY}/actions/runs/${context.runId}`;
   await ensurePreviewInitializationWitness({
@@ -6784,7 +7206,11 @@ export async function reconcilePreview({
     core.setOutput("reconcile_deferred", "true");
     core.setOutput("pr_number", String(pr));
   };
-  const deferIfBacklogged = async (currentPull, parsed) => {
+  const deferIfBacklogged = async (
+    currentPull,
+    parsed,
+    { pinnedAdmissionEvent = null } = {},
+  ) => {
     admissionSession ??= await createControllerAdmissionSession({
       github,
       context,
@@ -6804,12 +7230,23 @@ export async function reconcilePreview({
         pull: currentPull,
       }))
     ) {
-      await persistControllerAdmissionCursor({
-        github,
-        context,
-        pr,
-        admission: admissionSession.cursor(),
-      });
+      const refreshedCursor = admissionSession.cursor();
+      if (pinnedAdmissionEvent) {
+        invariant(
+          refreshedCursor?.through_run_id ===
+            pinnedAdmissionEvent.event_run_id &&
+            refreshedCursor.through_run_number ===
+              pinnedAdmissionEvent.event_run_number,
+          "Closed bootstrap terminal recovery requires an exact quiescent admission floor",
+        );
+      } else {
+        await persistControllerAdmissionCursor({
+          github,
+          context,
+          pr,
+          admission: refreshedCursor,
+        });
+      }
       return false;
     }
     recordBacklogDeferral();
@@ -6845,7 +7282,29 @@ export async function reconcilePreview({
       const pull = await pullFromApi(github, context, pr);
       const currentPull = normalizePullRequest(pull);
       const parsed = await loadPreviewJournal(github, context, pr);
-      if (await deferIfBacklogged(currentPull, parsed)) {
+      const parsedState =
+        parsed.state === null ? null : normalizeExistingState(parsed.state, pr);
+      const pendingClosedBootstrapRecovery = parsedState
+        ? closedBootstrapTerminalRecoveryBootstrap({
+            parsed,
+            state: parsedState,
+          })
+        : null;
+      invariant(
+        pendingClosedBootstrapRecovery === null ||
+          isSameRunClosedBootstrapTerminalRecovery({
+            bootstrap: pendingClosedBootstrapRecovery,
+            context,
+          }),
+        "Closed bootstrap terminal recovery requires its exact admitted run",
+      );
+      const compactClosedBootstrapRecovery =
+        pendingClosedBootstrapRecovery !== null;
+      if (
+        await deferIfBacklogged(currentPull, parsed, {
+          pinnedAdmissionEvent: pendingClosedBootstrapRecovery,
+        })
+      ) {
         return parsed.state;
       }
       const previewOwners = await candidatePreviewOwners(github, context, pull);
@@ -6887,7 +7346,11 @@ export async function reconcilePreview({
         await pullFromApi(github, context, pr),
       );
       const mutationComments = await loadPreviewJournal(github, context, pr);
-      if (await deferIfBacklogged(mutationPull, mutationComments)) {
+      if (
+        await deferIfBacklogged(mutationPull, mutationComments, {
+          pinnedAdmissionEvent: pendingClosedBootstrapRecovery,
+        })
+      ) {
         return mutationComments.state;
       }
 
@@ -6923,6 +7386,7 @@ export async function reconcilePreview({
           pr,
           state,
           stateComment,
+          compactClosedBootstrapRecovery,
         });
         if (headDecision) {
           await github.rest.repos.createCommitStatus({
@@ -6992,6 +7456,7 @@ export async function reconcilePreview({
           pr,
           state,
           stateComment,
+          compactClosedBootstrapRecovery,
         });
       }
 
@@ -8102,15 +8567,7 @@ export async function recoverWorkerResult({
     32,
   );
   invariant(
-    [
-      "success",
-      "failure",
-      "cancelled",
-      "timed_out",
-      "startup_failure",
-      "action_required",
-      "stale",
-    ].includes(conclusion),
+    RESULT_BEARING_WORKER_CONCLUSIONS.has(conclusion),
     "Worker conclusion is unsupported",
   );
   const existingResult = evidence.results.find(

--- a/scripts/vercel-preview-controller.test.mjs
+++ b/scripts/vercel-preview-controller.test.mjs
@@ -315,6 +315,25 @@ function persistAllIntents(reconciled) {
   return state;
 }
 
+function persistTargetDispatches(reconciled, runIdsByTarget) {
+  const state = structuredClone(reconciled.state);
+  for (const dispatch of reconciled.nextDispatches) {
+    const runId = runIdsByTarget[dispatch.target];
+    if (runId === undefined) continue;
+    state.targets[dispatch.target].active = {
+      ...structuredClone(dispatch),
+      dispatch_started_at: timestamp(0),
+      dispatch_state: "dispatched",
+      workflow_run_id: runId,
+      workflow_sha: dispatch.expected_workflow_sha,
+      workflow_run_attempt: 1,
+      run_url: `https://api.github.com/repos/mento-protocol/frontend-monorepo/actions/runs/${runId}`,
+      html_url: `https://github.com/mento-protocol/frontend-monorepo/actions/runs/${runId}`,
+    };
+  }
+  return state;
+}
+
 function result(
   dispatch,
   {
@@ -4923,7 +4942,957 @@ test("closed bootstrap recovers one drained legacy journal and pre-floor reruns 
   assert.equal(fixture.comments[0].body, beforeDelayedRerun);
 });
 
-test("closed bootstrap never creates a missing journal or accepts unfinished ownership", async () => {
+function closedBootstrapTerminalRecoverySetup() {
+  const opened = event({
+    run: 70_001,
+    action: "opened",
+    head: SHA.A,
+    targets: ["app", "governance", "reserve"],
+    updated: timestamp(1),
+  });
+  const selected = reconcile({
+    events: [opened],
+    pullRequest: pull({ head: SHA.A, updated: timestamp(1) }),
+  });
+  const runIdsByTarget = {
+    app: 80_001,
+    governance: 80_002,
+    reserve: 80_003,
+  };
+  const state = persistTargetDispatches(selected, runIdsByTarget);
+  const selections = Object.keys(runIdsByTarget).map((target) =>
+    selectionReceiptFromDispatch(state.targets[target].active),
+  );
+  const results = Object.entries(runIdsByTarget).map(([target, runId]) =>
+    result(state.targets[target].active, {
+      runId,
+      state: "failure",
+      reason: target === "reserve" ? "worker-failure" : "build-failed-final",
+    }),
+  );
+  const workerRuns = Object.entries(runIdsByTarget).map(([target, runId]) =>
+    workerRun(state.targets[target].active, {
+      id: runId,
+      status: "completed",
+      conclusion: "failure",
+    }),
+  );
+  const bootstrap = closedBootstrapEvent({
+    run: 70_010,
+    runNumber: 10,
+    head: SHA.A,
+    updated: timestamp(2),
+  });
+  const closedPull = pull({
+    head: SHA.A,
+    state: "closed",
+    updated: timestamp(2),
+    closed: timestamp(2),
+  });
+  const inputs = {
+    context: fakeContext({
+      runId: bootstrap.event_run_id,
+      runNumber: bootstrap.event_run_number,
+    }),
+    core: fakeCore(),
+    snapshotRaw: JSON.stringify(
+      Object.fromEntries(
+        Object.entries(bootstrap).filter(([key]) => key !== "plan"),
+      ),
+    ),
+    planRaw: "",
+    plannerOutcome: "skipped",
+    waitForAdmission: async () => {},
+  };
+  return {
+    bootstrap,
+    closedPull,
+    inputs,
+    opened,
+    results,
+    runIdsByTarget,
+    selections,
+    state,
+    workerRuns,
+  };
+}
+
+function assertClosedBootstrapRecoveryStayedWriteFree(fixture, before) {
+  assert.equal(fixture.comments[0].body, before);
+  assert.equal(fixture.commentUpdates.length, 0);
+  assert.equal(fixture.commitStatuses.length, 0);
+  assert.equal(fixture.dispatches.length, 0);
+  assert.equal(fixture.workerDispatchRequests.length, 0);
+  assert.equal(fixture.deployments.length, 0);
+  assert.equal(fixture.createdDeploymentStatuses.length, 0);
+}
+
+test("closed bootstrap authenticates terminal stale owners before its one reconcile path drains them", async () => {
+  const setup = closedBootstrapTerminalRecoverySetup();
+  const fixture = fakeGitHub({
+    pullRequest: setup.closedPull,
+    comments: [
+      journalComment({
+        events: [setup.opened],
+        state: setup.state,
+        selections: setup.selections,
+        results: setup.results,
+        admission: null,
+      }),
+    ],
+    runs: [
+      controllerInertRun({
+        id: setup.bootstrap.event_run_id,
+        runNumber: setup.bootstrap.event_run_number,
+      }),
+      ...setup.workerRuns,
+    ],
+    includeDefaultControllerFloor: false,
+  });
+
+  await recordEventReceipt({ github: fixture.github, ...setup.inputs });
+
+  const admitted = journalFromComment(fixture.comments[0]);
+  assert.deepEqual(admitted.admission, {
+    schema: "vercel-preview-controller-admission:v1",
+    workflow_id: CONTROLLER_WORKFLOW_ID,
+    through_run_id: setup.bootstrap.event_run_id,
+    through_run_number: setup.bootstrap.event_run_number,
+  });
+  assert.equal(
+    setup.inputs.core.outputs.get("closed_bootstrap_terminal_recovery"),
+    "true",
+  );
+  assert.equal(
+    setup.inputs.core.outputs.get("closed_bootstrap_terminal_owner_count"),
+    "3",
+  );
+  assert.deepEqual(
+    fixture.workflowRunAttemptRequests.map(({ run_id: runId }) => runId),
+    Object.values(setup.runIdsByTarget),
+  );
+  assert.equal(fixture.workflowRunListRequests.length, 0);
+  assert.equal(fixture.dispatches.length, 0);
+  assert.equal(fixture.workerDispatchRequests.length, 0);
+  assert.equal(fixture.deployments.length, 0);
+  assert.equal(fixture.createdDeploymentStatuses.length, 0);
+  assert.ok(fixture.commitStatuses.every(({ state }) => state !== "pending"));
+
+  const state = await reconcilePreview({
+    github: fixture.github,
+    context: setup.inputs.context,
+    core: fakeCore(),
+    prNumber: 519,
+    waitForRecovery: async () => {},
+  });
+  assert.equal(state.closed, true);
+  assert.equal(state.epoch.anchor_run_id, setup.bootstrap.event_run_id);
+  for (const target of PREVIEW_TARGETS) {
+    assert.equal(state.targets[target].active, null);
+    assert.deepEqual(state.targets[target].retired_active, []);
+  }
+  assert.equal(fixture.dispatches.length, 0);
+  assert.equal(fixture.workerDispatchRequests.length, 0);
+  assert.equal(fixture.deployments.length, 0);
+  assert.equal(fixture.createdDeploymentStatuses.length, 0);
+  assert.ok(fixture.commitStatuses.every(({ state }) => state !== "pending"));
+});
+
+test("closed bootstrap accepts a successful worker with durable missing-success evidence", async () => {
+  const setup = closedBootstrapTerminalRecoverySetup();
+  const active = setup.state.targets.app.active;
+  const results = setup.results.map((candidate) =>
+    candidate.target === "app"
+      ? controllerResult(active, {
+          runId: active.workflow_run_id,
+          reason: "missing-success-evidence",
+        })
+      : candidate,
+  );
+  const workerRuns = setup.workerRuns.map((run) =>
+    run.id === active.workflow_run_id
+      ? workerRun(active, {
+          id: active.workflow_run_id,
+          status: "completed",
+          conclusion: "success",
+        })
+      : run,
+  );
+  const fixture = fakeGitHub({
+    pullRequest: setup.closedPull,
+    comments: [
+      journalComment({
+        events: [setup.opened],
+        state: setup.state,
+        selections: setup.selections,
+        results,
+        admission: null,
+      }),
+    ],
+    runs: [
+      controllerInertRun({
+        id: setup.bootstrap.event_run_id,
+        runNumber: setup.bootstrap.event_run_number,
+      }),
+      ...workerRuns,
+    ],
+    includeDefaultControllerFloor: false,
+  });
+
+  await recordEventReceipt({ github: fixture.github, ...setup.inputs });
+  const state = await reconcilePreview({
+    github: fixture.github,
+    context: setup.inputs.context,
+    core: fakeCore(),
+    prNumber: 519,
+    waitForRecovery: async () => {},
+  });
+
+  assert.equal(state.closed, true);
+  assert.equal(state.targets.app.active, null);
+  assert.equal(fixture.dispatches.length, 0);
+  assert.equal(fixture.deployments.length, 0);
+  assert.ok(fixture.commitStatuses.every(({ state }) => state !== "pending"));
+});
+
+test("closed bootstrap drains a near-capacity closed state with terminal active owners only in the same run", async () => {
+  const setup = closedBootstrapTerminalRecoverySetup();
+  const closed = event({
+    run: 70_005,
+    runNumber: 5,
+    action: "closed",
+    head: SHA.A,
+    updated: timestamp(2),
+  });
+  const closedBeforeTerminalFold = reconcile({
+    events: [setup.opened, closed],
+    pullRequest: setup.closedPull,
+    existingState: setup.state,
+  });
+  assert.equal(closedBeforeTerminalFold.state.closed, true);
+  for (const target of ["app", "governance", "reserve"]) {
+    assert.ok(closedBeforeTerminalFold.state.targets[target].active);
+  }
+  const events = [setup.opened, closed];
+  let comment = journalComment({
+    events,
+    state: closedBeforeTerminalFold.state,
+    selections: setup.selections,
+    results: setup.results,
+    admission: null,
+  });
+  for (
+    let index = 1;
+    Buffer.byteLength(comment.body, "utf8") <= 41_000;
+    index += 1
+  ) {
+    events.push(
+      event({
+        run: 72_000 + index,
+        action: "opened",
+        head: SHA.A,
+        targets: ["app", "governance", "reserve"],
+        updated: timestamp(1),
+      }),
+    );
+    comment = journalComment({
+      events,
+      state: closedBeforeTerminalFold.state,
+      selections: setup.selections,
+      results: setup.results,
+      admission: null,
+    });
+  }
+  assert.ok(Buffer.byteLength(comment.body, "utf8") > 40_000);
+  assert.ok(Buffer.byteLength(comment.body, "utf8") < 60_000);
+  const appSelection = setup.state.targets.app.active;
+  const appDeployment = {
+    id: 9_000,
+    ref: appSelection.sha,
+    sha: appSelection.sha,
+    environment: "preview/app/pr-519",
+    payload: {
+      ...canonicalDeploymentBinding(),
+      idempotency_key: appSelection.key,
+      sha: appSelection.sha,
+      logical_target: "app",
+    },
+  };
+  const fixture = fakeGitHub({
+    pullRequest: setup.closedPull,
+    comments: [comment],
+    runs: [
+      controllerInertRun({
+        id: setup.bootstrap.event_run_id,
+        runNumber: setup.bootstrap.event_run_number,
+      }),
+      ...setup.workerRuns,
+    ],
+    deployments: [appDeployment],
+    includeDefaultControllerFloor: false,
+  });
+
+  await recordEventReceipt({ github: fixture.github, ...setup.inputs });
+  const admitted = journalFromComment(fixture.comments[0]);
+  assert.equal(admitted.checkpoint, null);
+  assert.equal(admitted.state.closed, true);
+  for (const target of ["app", "governance", "reserve"]) {
+    assert.ok(admitted.state.targets[target].active);
+  }
+  assert.deepEqual(admitted.admission, {
+    schema: "vercel-preview-controller-admission:v1",
+    workflow_id: CONTROLLER_WORKFLOW_ID,
+    through_run_id: setup.bootstrap.event_run_id,
+    through_run_number: setup.bootstrap.event_run_number,
+  });
+  assert.ok(Buffer.byteLength(fixture.comments[0].body, "utf8") > 40_000);
+
+  const beforeBlockedWriters = fixture.comments[0].body;
+  const mutationCounts = () => ({
+    comments: fixture.commentUpdates.length,
+    statuses: fixture.commitStatuses.length,
+    dispatches: fixture.dispatches.length,
+    workerDispatches: fixture.workerDispatchRequests.length,
+    deployments: fixture.deployments.length,
+    deploymentStatuses: fixture.createdDeploymentStatuses.length,
+  });
+  const initialMutationCounts = mutationCounts();
+  await assert.rejects(
+    recordWorkerEvidence({
+      github: fixture.github,
+      context: fakeContext({ runId: appSelection.workflow_run_id }),
+      core: fakeCore(),
+      inputs: {
+        ...workerInputs(appSelection),
+        execution_mode: "build",
+        build_duration_ms: "1234",
+        verified_upload_url: "https://app-terminal-recovery.vercel.app",
+        vercel_deployment_id: "dpl_TerminalRecovery",
+        next_deployment_id: "m-app-terminal-recovery",
+      },
+    }),
+    /rejects journal writes outside its exact run/,
+  );
+  assert.equal(fixture.comments[0].body, beforeBlockedWriters);
+  assert.deepEqual(mutationCounts(), initialMutationCounts);
+
+  for (const [index, action] of ["reopened", "synchronize"].entries()) {
+    const laterReceipt = event({
+      run: 70_012 + index,
+      runNumber: 12 + index,
+      action,
+      before: action === "synchronize" ? SHA.A : null,
+      head: action === "synchronize" ? SHA.B : SHA.A,
+      targets: ["app"],
+      updated: timestamp(3 + index),
+    });
+    fixture.runs.push(
+      controllerEventRun({
+        id: laterReceipt.event_run_id,
+        runNumber: laterReceipt.event_run_number,
+        action,
+        before: laterReceipt.before_sha,
+        sha: laterReceipt.head_sha,
+        createdAt: timestamp(3 + index),
+      }),
+    );
+    const admissionScans = fixture.controllerEventRunListRequests.length;
+    await assert.rejects(
+      recordEventReceipt({
+        github: fixture.github,
+        context: fakeContext({
+          runId: laterReceipt.event_run_id,
+          runNumber: laterReceipt.event_run_number,
+        }),
+        core: fakeCore(),
+        ...eventRecordInputs(laterReceipt),
+      }),
+      /rejects later event receipts before same-run drain/,
+      action,
+    );
+    assert.equal(fixture.comments[0].body, beforeBlockedWriters);
+    assert.equal(
+      fixture.controllerEventRunListRequests.length,
+      admissionScans,
+      `${action} must fail before admission refresh`,
+    );
+    assert.deepEqual(mutationCounts(), initialMutationCounts);
+    fixture.runs.pop();
+  }
+
+  const beforeDistinctReconcile = fixture.comments[0].body;
+  await assert.rejects(
+    reconcilePreview({
+      github: fixture.github,
+      context: fakeContext({ runId: 70_011, runNumber: 11 }),
+      core: fakeCore(),
+      prNumber: 519,
+      waitForRecovery: async () => {},
+    }),
+    /requires its exact admitted run/,
+  );
+  assert.equal(fixture.comments[0].body, beforeDistinctReconcile);
+  const stillPending = journalFromComment(fixture.comments[0]);
+  assert.equal(stillPending.checkpoint, null);
+  assert.equal(stillPending.state.closed, true);
+  for (const target of ["app", "governance", "reserve"]) {
+    assert.ok(stillPending.state.targets[target].active);
+  }
+
+  fixture.runs.push(
+    controllerInertRun({
+      id: 70_011,
+      runNumber: 11,
+      event: "workflow_run",
+    }),
+  );
+  const beforeAdvancedFrontier = fixture.comments[0].body;
+  await assert.rejects(
+    reconcilePreview({
+      github: fixture.github,
+      context: setup.inputs.context,
+      core: fakeCore(),
+      prNumber: 519,
+      waitForRecovery: async () => {},
+    }),
+    /requires an exact quiescent admission floor/,
+  );
+  assert.equal(fixture.comments[0].body, beforeAdvancedFrontier);
+  const pinned = journalFromComment(fixture.comments[0]);
+  assert.deepEqual(pinned.admission, admitted.admission);
+  assert.equal(pinned.checkpoint, null);
+  assert.equal(pinned.state.closed, true);
+  fixture.runs.pop();
+
+  const state = await reconcilePreview({
+    github: fixture.github,
+    context: setup.inputs.context,
+    core: fakeCore(),
+    prNumber: 519,
+    waitForRecovery: async () => {},
+  });
+  const compacted = journalFromComment(fixture.comments[0]);
+  assert.equal(state.closed, true);
+  assert.ok(compacted.checkpoint);
+  assert.equal(compacted.state.closed, true);
+  assert.ok(Buffer.byteLength(fixture.comments[0].body, "utf8") < 40_000);
+  for (const target of PREVIEW_TARGETS) {
+    assert.equal(compacted.state.targets[target].active, null);
+    assert.deepEqual(compacted.state.targets[target].retired_active, []);
+  }
+  assert.equal(fixture.dispatches.length, 0);
+  assert.equal(fixture.workerDispatchRequests.length, 0);
+  assert.deepEqual(fixture.deployments, [appDeployment]);
+  assert.equal(fixture.createdDeploymentStatuses.length, 0);
+  assert.ok(fixture.commitStatuses.every(({ state }) => state !== "pending"));
+
+  fixture.runs.push(
+    controllerInertRun({
+      id: 70_011,
+      runNumber: 11,
+      event: "workflow_run",
+    }),
+  );
+  await recordEventReceipt({ github: fixture.github, ...setup.inputs });
+  assert.deepEqual(journalFromComment(fixture.comments[0]).admission, {
+    schema: "vercel-preview-controller-admission:v1",
+    workflow_id: CONTROLLER_WORKFLOW_ID,
+    through_run_id: 70_011,
+    through_run_number: 11,
+  });
+  assert.equal(fixture.dispatches.length, 0);
+  assert.deepEqual(fixture.deployments, [appDeployment]);
+  assert.equal(fixture.createdDeploymentStatuses.length, 0);
+});
+
+test("closed bootstrap terminal recovery resumes only the exact admitted run after a partial failure", async () => {
+  const setup = closedBootstrapTerminalRecoverySetup();
+  const fixture = fakeGitHub({
+    pullRequest: setup.closedPull,
+    comments: [
+      journalComment({
+        events: [setup.opened],
+        state: setup.state,
+        selections: setup.selections,
+        results: setup.results,
+        admission: null,
+      }),
+    ],
+    runs: [
+      controllerInertRun({
+        id: setup.bootstrap.event_run_id,
+        runNumber: setup.bootstrap.event_run_number,
+      }),
+      ...setup.workerRuns,
+    ],
+    includeDefaultControllerFloor: false,
+    commitStatusFailures: [503],
+  });
+
+  await assert.rejects(
+    recordEventReceipt({ github: fixture.github, ...setup.inputs }),
+    /fixture commit status write failed/,
+  );
+  const afterPartialFailure = journalFromComment(fixture.comments[0]);
+  assert.deepEqual(afterPartialFailure.admission, {
+    schema: "vercel-preview-controller-admission:v1",
+    workflow_id: CONTROLLER_WORKFLOW_ID,
+    through_run_id: setup.bootstrap.event_run_id,
+    through_run_number: setup.bootstrap.event_run_number,
+  });
+  assert.equal(
+    afterPartialFailure.receipts.events.some(
+      (candidate) => candidate.event_run_id === setup.bootstrap.event_run_id,
+    ) ||
+      afterPartialFailure.checkpoint?.event.event_run_id ===
+        setup.bootstrap.event_run_id,
+    true,
+  );
+  assert.equal(afterPartialFailure.state.closed, false);
+
+  const rerunCore = fakeCore();
+  await recordEventReceipt({
+    github: fixture.github,
+    ...setup.inputs,
+    context: fakeContext({
+      runId: setup.bootstrap.event_run_id,
+      runNumber: setup.bootstrap.event_run_number,
+      runAttempt: 2,
+    }),
+    core: rerunCore,
+  });
+  const afterRerun = journalFromComment(fixture.comments[0]);
+  assert.equal(afterRerun.revision, afterPartialFailure.revision);
+  assert.equal(
+    rerunCore.outputs.get("closed_bootstrap_terminal_recovery"),
+    "true",
+  );
+  assert.equal(rerunCore.outputs.get("reconcile_required"), "true");
+  assert.equal(fixture.commentUpdates.length, 1);
+  assert.equal(fixture.workflowRunListRequests.length, 0);
+  assert.equal(fixture.dispatches.length, 0);
+  assert.equal(fixture.workerDispatchRequests.length, 0);
+  assert.equal(fixture.deployments.length, 0);
+  assert.equal(fixture.createdDeploymentStatuses.length, 0);
+  assert.ok(fixture.commitStatuses.every(({ state }) => state !== "pending"));
+
+  const state = await reconcilePreview({
+    github: fixture.github,
+    context: fakeContext({
+      runId: setup.bootstrap.event_run_id,
+      runNumber: setup.bootstrap.event_run_number,
+      runAttempt: 2,
+    }),
+    core: fakeCore(),
+    prNumber: 519,
+    waitForRecovery: async () => {},
+  });
+  assert.equal(state.closed, true);
+  for (const target of PREVIEW_TARGETS) {
+    assert.equal(state.targets[target].active, null);
+    assert.deepEqual(state.targets[target].retired_active, []);
+  }
+});
+
+test("closed bootstrap terminal recovery fails before mutation on missing, ambiguous, or mismatched results", async () => {
+  for (const scenario of ["missing", "ambiguous", "wrong-run"]) {
+    const setup = closedBootstrapTerminalRecoverySetup();
+    const active = setup.state.targets.app.active;
+    let results = setup.results;
+    if (scenario === "missing") {
+      results = results.filter((candidate) => candidate.target !== "app");
+    } else if (scenario === "ambiguous") {
+      results = [
+        ...results,
+        result(active, {
+          runId: 80_011,
+          state: "failure",
+          reason: "worker-failure",
+        }),
+      ];
+    } else {
+      results = results.map((candidate) =>
+        candidate.target === "app"
+          ? result(active, {
+              runId: 80_011,
+              state: "failure",
+              reason: "worker-failure",
+            })
+          : candidate,
+      );
+    }
+    const fixture = fakeGitHub({
+      pullRequest: setup.closedPull,
+      comments: [
+        journalComment({
+          events: [setup.opened],
+          state: setup.state,
+          selections: setup.selections,
+          results,
+          admission: null,
+        }),
+      ],
+      runs: [
+        controllerInertRun({
+          id: setup.bootstrap.event_run_id,
+          runNumber: setup.bootstrap.event_run_number,
+        }),
+        ...setup.workerRuns,
+        workerRun(active, {
+          id: 80_011,
+          status: "completed",
+          conclusion: "failure",
+        }),
+      ],
+      includeDefaultControllerFloor: false,
+    });
+    const before = fixture.comments[0].body;
+
+    await assert.rejects(
+      recordEventReceipt({ github: fixture.github, ...setup.inputs }),
+      scenario === "wrong-run"
+        ? /worker ownership is ambiguous/
+        : /result is missing or ambiguous/,
+      scenario,
+    );
+    assertClosedBootstrapRecoveryStayedWriteFree(fixture, before);
+  }
+});
+
+test("closed bootstrap terminal recovery rejects nonterminal or contradictory worker evidence", async () => {
+  for (const scenario of ["queued", "success-vs-failure", "wrong-workflow"]) {
+    const setup = closedBootstrapTerminalRecoverySetup();
+    const active = setup.state.targets.app.active;
+    const workerRuns = setup.workerRuns.map((run) => {
+      if (run.id !== active.workflow_run_id) return run;
+      if (scenario === "queued") {
+        return { ...run, status: "queued", conclusion: null };
+      }
+      if (scenario === "success-vs-failure") {
+        return { ...run, status: "completed", conclusion: "success" };
+      }
+      return { ...run, head_sha: SHA.D };
+    });
+    const fixture = fakeGitHub({
+      pullRequest: setup.closedPull,
+      comments: [
+        journalComment({
+          events: [setup.opened],
+          state: setup.state,
+          selections: setup.selections,
+          results: setup.results,
+          admission: null,
+        }),
+      ],
+      runs: [
+        controllerInertRun({
+          id: setup.bootstrap.event_run_id,
+          runNumber: setup.bootstrap.event_run_number,
+        }),
+        ...workerRuns,
+      ],
+      includeDefaultControllerFloor: false,
+    });
+    const before = fixture.comments[0].body;
+
+    await assert.rejects(
+      recordEventReceipt({ github: fixture.github, ...setup.inputs }),
+      scenario === "wrong-workflow"
+        ? /does not match controller-authorized SHA/
+        : /worker evidence is nonterminal or mismatched/,
+      scenario,
+    );
+    assertClosedBootstrapRecoveryStayedWriteFree(fixture, before);
+  }
+});
+
+test("closed bootstrap rejects terminal results with a contradictory conclusion reason", async () => {
+  for (const scenario of [
+    {
+      conclusion: "success",
+      reason: "worker-cancelled",
+    },
+    {
+      conclusion: "failure",
+      reason: "missing-success-evidence",
+    },
+    {
+      conclusion: "cancelled",
+      reason: "upload-ambiguous",
+    },
+  ]) {
+    const setup = closedBootstrapTerminalRecoverySetup();
+    const active = setup.state.targets.app.active;
+    const results = setup.results.map((candidate) =>
+      candidate.target === "app"
+        ? controllerResult(active, {
+            runId: active.workflow_run_id,
+            reason: scenario.reason,
+          })
+        : candidate,
+    );
+    const workerRuns = setup.workerRuns.map((run) =>
+      run.id === active.workflow_run_id
+        ? workerRun(active, {
+            id: active.workflow_run_id,
+            status: "completed",
+            conclusion: scenario.conclusion,
+          })
+        : run,
+    );
+    const fixture = fakeGitHub({
+      pullRequest: setup.closedPull,
+      comments: [
+        journalComment({
+          events: [setup.opened],
+          state: setup.state,
+          selections: setup.selections,
+          results,
+          admission: null,
+        }),
+      ],
+      runs: [
+        controllerInertRun({
+          id: setup.bootstrap.event_run_id,
+          runNumber: setup.bootstrap.event_run_number,
+        }),
+        ...workerRuns,
+      ],
+      includeDefaultControllerFloor: false,
+    });
+    const before = fixture.comments[0].body;
+
+    await assert.rejects(
+      recordEventReceipt({ github: fixture.github, ...setup.inputs }),
+      /worker evidence is nonterminal or mismatched/,
+      `${scenario.conclusion}:${scenario.reason}`,
+    );
+    assertClosedBootstrapRecoveryStayedWriteFree(fixture, before);
+  }
+});
+
+test("closed bootstrap terminal recovery cannot replace a cursor or race another controller run", async () => {
+  for (const scenario of ["cursor", "later-run"]) {
+    const setup = closedBootstrapTerminalRecoverySetup();
+    const admission =
+      scenario === "cursor" ? DEFAULT_CONTROLLER_ADMISSION : null;
+    const runs = [
+      controllerInertRun({
+        id: setup.bootstrap.event_run_id,
+        runNumber: setup.bootstrap.event_run_number,
+      }),
+      ...setup.workerRuns,
+    ];
+    if (scenario === "later-run") {
+      runs.push(
+        controllerInertRun({
+          id: 70_011,
+          runNumber: 11,
+          event: "workflow_run",
+        }),
+      );
+    }
+    const fixture = fakeGitHub({
+      pullRequest: setup.closedPull,
+      comments: [
+        journalComment({
+          events: [setup.opened],
+          state: setup.state,
+          selections: setup.selections,
+          results: setup.results,
+          admission,
+        }),
+      ],
+      runs,
+      includeDefaultControllerFloor: false,
+    });
+    const before = fixture.comments[0].body;
+
+    await assert.rejects(
+      recordEventReceipt({ github: fixture.github, ...setup.inputs }),
+      scenario === "cursor"
+        ? /requires a cursorless journal/
+        : /requires an exact quiescent admission floor/,
+      scenario,
+    );
+    assertClosedBootstrapRecoveryStayedWriteFree(fixture, before);
+  }
+});
+
+test("closed bootstrap terminal recovery rejects unfinished retired and checkpoint ownership", async () => {
+  for (const scenario of ["retired", "checkpoint"]) {
+    const setup = closedBootstrapTerminalRecoverySetup();
+    let comment;
+    if (scenario === "retired") {
+      const state = structuredClone(setup.state);
+      state.targets.app.retired_active = [state.targets.app.active];
+      state.targets.app.active = null;
+      comment = journalComment({
+        events: [setup.opened],
+        state,
+        selections: setup.selections,
+        results: setup.results.filter(
+          (candidate) => candidate.target !== "app",
+        ),
+        admission: null,
+      });
+    } else {
+      const events = [setup.opened];
+      let previousHead = setup.opened.head_sha;
+      let journal = createPreviewJournal({
+        pr: 519,
+        events,
+        selections: setup.selections,
+        results: setup.results,
+        state: setup.state,
+      });
+      for (
+        let index = 1;
+        Buffer.byteLength(previewJournalBody(journal), "utf8") < 41_000;
+        index += 1
+      ) {
+        const head = (1_000 + index).toString(16).padStart(40, "0");
+        events.push(
+          event({
+            run: 71_000 + index,
+            action: "synchronize",
+            before: previousHead,
+            head,
+            targets: ["app", "governance", "reserve"],
+            updated: new Date(
+              Date.UTC(2026, 6, 15, 10, 0, index + 2),
+            ).toISOString(),
+          }),
+        );
+        previousHead = head;
+        journal = createPreviewJournal({
+          pr: 519,
+          events,
+          selections: setup.selections,
+          results: setup.results,
+          state: setup.state,
+        });
+      }
+      const compacted = compactPreviewJournal(journal);
+      assert.ok(
+        PREVIEW_TARGETS.some(
+          (target) =>
+            compacted.checkpoint.targets[target].pending_owner_key_digest !==
+            null,
+        ),
+      );
+      comment = {
+        id: 1,
+        user: { type: "Bot", login: "github-actions[bot]" },
+        body: previewJournalBody(compacted),
+      };
+    }
+    const fixture = fakeGitHub({
+      pullRequest: setup.closedPull,
+      comments: [comment],
+      runs: [
+        controllerInertRun({
+          id: setup.bootstrap.event_run_id,
+          runNumber: setup.bootstrap.event_run_number,
+        }),
+        ...setup.workerRuns,
+      ],
+      includeDefaultControllerFloor: false,
+    });
+    const before = fixture.comments[0].body;
+
+    await assert.rejects(
+      recordEventReceipt({ github: fixture.github, ...setup.inputs }),
+      /rejects retired or checkpoint ownership/,
+      scenario,
+    );
+    assertClosedBootstrapRecoveryStayedWriteFree(fixture, before);
+  }
+});
+
+test("closed bootstrap preserves the drained contract for terminal non-pending retired history", async () => {
+  const setup = closedBootstrapTerminalRecoverySetup();
+  const state = structuredClone(setup.state);
+  state.targets.app.retired_active = [state.targets.app.active];
+  state.targets.app.active = null;
+  for (const target of ["governance", "reserve"]) {
+    state.targets[target].active = null;
+  }
+  const fixture = fakeGitHub({
+    pullRequest: setup.closedPull,
+    comments: [
+      journalComment({
+        events: [setup.opened],
+        state,
+        selections: setup.selections,
+        results: setup.results,
+        admission: null,
+      }),
+    ],
+    runs: [
+      controllerInertRun({
+        id: setup.bootstrap.event_run_id,
+        runNumber: setup.bootstrap.event_run_number,
+      }),
+    ],
+    includeDefaultControllerFloor: false,
+  });
+
+  await recordEventReceipt({ github: fixture.github, ...setup.inputs });
+
+  assert.equal(
+    journalFromComment(fixture.comments[0]).admission.through_run_id,
+    setup.bootstrap.event_run_id,
+  );
+  assert.equal(
+    setup.inputs.core.outputs.has("closed_bootstrap_terminal_recovery"),
+    false,
+  );
+  assert.equal(fixture.workflowRunAttemptRequests.length, 0);
+  assert.equal(fixture.dispatches.length, 0);
+  assert.equal(fixture.deployments.length, 0);
+  assert.ok(fixture.commitStatuses.every(({ state }) => state !== "pending"));
+});
+
+test("closed bootstrap terminal recovery rechecks that the PR stayed closed before mutation", async () => {
+  const setup = closedBootstrapTerminalRecoverySetup();
+  const reopenedPull = pull({
+    head: SHA.A,
+    state: "open",
+    updated: timestamp(3),
+    closed: null,
+  });
+  const fixture = fakeGitHub({
+    pullRequest: setup.closedPull,
+    pullRequests: [setup.closedPull, reopenedPull],
+    comments: [
+      journalComment({
+        events: [setup.opened],
+        state: setup.state,
+        selections: setup.selections,
+        results: setup.results,
+        admission: null,
+      }),
+    ],
+    runs: [
+      controllerInertRun({
+        id: setup.bootstrap.event_run_id,
+        runNumber: setup.bootstrap.event_run_number,
+      }),
+      ...setup.workerRuns,
+    ],
+    includeDefaultControllerFloor: false,
+  });
+  const before = fixture.comments[0].body;
+
+  await assert.rejects(
+    recordEventReceipt({ github: fixture.github, ...setup.inputs }),
+    /PR state changed before mutation/,
+  );
+  assertClosedBootstrapRecoveryStayedWriteFree(fixture, before);
+});
+
+test("closed bootstrap never creates a missing journal or accepts an owner without a worker", async () => {
   const bootstrap = closedBootstrapEvent({
     run: 70_020,
     runNumber: 20,
@@ -5000,7 +5969,7 @@ test("closed bootstrap never creates a missing journal or accepts unfinished own
   const before = unfinished.comments[0].body;
   await assert.rejects(
     recordEventReceipt({ github: unfinished.github, ...inputs }),
-    /ownership to be drained/,
+    /owner is not an exact dispatched selection/,
   );
   assert.equal(unfinished.comments[0].body, before);
   assert.equal(unfinished.commitStatuses.length, 0);

--- a/scripts/vercel-preview-workflows.test.mjs
+++ b/scripts/vercel-preview-workflows.test.mjs
@@ -471,6 +471,18 @@ test("closed bootstrap reconciliation survives an intentionally skipped planner"
     reconcile.if,
     "always() && needs.receipt-bootstrap.result == 'success'",
   );
+  assert.equal(Object.hasOwn(receipt.permissions, "deployments"), false);
+  assert.match(JSON.stringify(receipt), /recordEventReceipt/);
+  assert.doesNotMatch(
+    JSON.stringify(receipt),
+    /recoverWorkerResult|createDeployment|createDeploymentStatus/,
+  );
+  assert.match(JSON.stringify(reconcile), /reconcilePreview/);
+  assert.doesNotMatch(JSON.stringify(reconcile), /recoverWorkerResult/);
+  assert.deepEqual(controller.on.repository_dispatch.types, [
+    "vercel-preview-bootstrap",
+    "vercel-preview-reconcile",
+  ]);
 });
 
 test("every PR comment writer uses the pull-request resource permission", () => {
@@ -928,6 +940,18 @@ test("runbook covers v2 migration, four-target canaries, cutover, and exact roll
     "vercel-preview-worker.yml",
     "vercel-preview-intake.yml",
     "queued requested waiting pending in_progress",
+    "terminal-active legacy case",
+    "current `active` slots only",
+    "does not search for a worker",
+    "complete quiescent admission",
+    "defers active-capacity checkpointing",
+    "admission cursor remains pinned to the bootstrap",
+    "later controller run appears at the Actions frontier",
+    "centralized journal-write barrier",
+    "only a terminal closed-and-drained state clears it",
+    "later PR event fails before admission refresh",
+    "distinct reconciliation run is rejected",
+    "exactly two operator steps",
     "gh api --paginate",
     "set -euo pipefail",
     "SHA",


### PR DESCRIPTION
## The Problem

PR #585 is live-closed with one canonical v2 preview journal, but that legacy journal predates the controller admission cursor and still records three current active owners. Each owner already has a durable terminal worker result and an exact completed Actions run. The ordinary reconcile path correctly rejects a cursorless journal, while the closed-bootstrap path correctly rejects unfinished ownership, leaving the journal unable to establish its authenticated floor or fold the terminal results.

The recovery must not introduce a second journal reader or operation, search for workers, synthesize results, dispatch work, touch GitHub Deployments, or publish pending preview statuses.

## The Solution

Permit the existing closed-bootstrap receipt and same-run reconciliation path to recover one narrowly authenticated legacy state:

- the PR is queried as closed before proof and rechecked unchanged before mutation;
- the existing canonical v2 journal is cursorless, except for an idempotent rerun of the exact admitted bootstrap;
- only current `active` slots may remain—checkpoint pending owners, any `retired_active` entry, and intended slots fail closed;
- every active slot must bind one canonical selection, one compatible terminal result, and one distinct exact completed worker run attempt;
- result compatibility follows the controller's exact terminal mappings, including `success` plus durable `missing-success-evidence`, while contradictory conclusion/reason pairs fail closed;
- the controller reads each exact run attempt from the Actions API and validates its repository, workflow path, default ref, workflow SHA, strict title, URLs, status, conclusion, and immutable selection identity;
- the bootstrap must be the complete quiescent admission frontier;
- capacity checkpointing is deferred only until the same-run reconcile drains stale active ownership, while the existing 60 KB guard still rejects an oversized receipt before mutation;
- the durable admission cursor stays pinned to the bootstrap until drain and compaction commit, so a later Actions frontier fails before its cursor or any journal mutation is persisted;
- a centralized journal-writer barrier blocks later event, selection, worker-evidence, result, cursor, and nonterminal state writes; only exact bootstrap replay and exact same-run terminal state/compaction are authorized, and later PR events fail before admission refresh;
- `state.closed` alone does not clear the barrier: authenticated ownership remains pending until the admitted run records a closed-and-drained state;
- while that drain is pending, any distinct reconciliation run fails before admission refresh or state mutation;
- the existing `reconcile-bootstrap` job alone folds the persisted results and drains ownership.

A partially completed bootstrap can retry only the same run ID and run number. A second distinct bootstrap cannot replace the floor. The normal drained closed-bootstrap behavior remains unchanged, including terminal non-pending retired history.

## Verification

- `node --test scripts/vercel-preview-controller.test.mjs` (197 passing)
- `node --test scripts/vercel-preview-workflows.test.mjs` (24 passing)
- `pnpm vercel:primitives:test` (60 passing)
- `pnpm quality:budgets:test`
- `pnpm ci:action-pins`
- `pnpm ci:action-pins:test`
- `pnpm adr:check`
- `pnpm adr:check:test`
- `pnpm pr:description:test`
- `trunk check`
- `trunk fmt`
- `git diff --check`

The broader preview/workflow suites otherwise pass locally but the checkout cannot resolve its pinned `@playwright/test`, and the isolated offline pnpm-layout test cannot find `@eslint/js` in the local pnpm store. No dependency install or network fetch was performed; CI remains the clean-environment proof for those dependency-hydration checks.

## Architecture decision

ADR 0002 is updated in place because this is a refinement of the existing single-comment, single-reader controller decision. It records the terminal-active exception, exact authentication boundary, same-run-only retry, unchanged drained semantics, and prohibition on alternate recovery paths.

## Operator recovery after merge

Freeze lifecycle mutations and reverify the closed PR has exactly one canonical cursorless v2 journal, no pending checkpoint or unfinished retired owner, exact terminal result/run evidence for every current active slot, and no later controller run. Then dispatch exactly one `vercel-preview-bootstrap` and wait for that run's receipt and reconciliation jobs. If the receipt commits but reconciliation fails, rerun only the failed job on that same Actions run; never dispatch another distinct bootstrap.
