### PR TITLE
ci(vercel): cut over App preview ownership

### DIFF
--- a/README.md
+++ b/README.md
@@ -454,12 +454,12 @@ The repository is set up with GitHub Actions for CI:
   PRs remain credential-free. A dedicated repository-scoped GitHub credential
   performs only the worker-dispatch POST so terminal `workflow_run` callbacks
   are created; the normal job token still owns all state and recovery calls.
-  GitHub Actions is the sole automatic branch-preview owner for Governance,
-  Reserve, and UI. App remains in shadow mode, where its existing native Vercel
-  branch preview stays enabled alongside the GitHub-built canary. The
-  Governance configuration change is not an accepted live cutover until its
-  exact-head and post-merge canary gates pass; publishing this change also
-  requires the prior Reserve post-merge canary to pass.
+  GitHub Actions is the sole automatic branch-preview owner for App,
+  Governance, Reserve, and UI. The App configuration change is not an accepted
+  live cutover until its exact-head and post-merge canary gates pass; publishing
+  this change also requires the prior Governance post-merge canary to pass.
+  Vercel Git still owns every `main`/production deployment and App `v2`; App's
+  custom `v3` deployment semantics are unchanged.
   The version-controlled controller mode is `active`; per-target ownership and
   exact expected Vercel configurations are executable invariants. The trusted
   controller reads every selected target's bounded exact-head Vercel

--- a/apps/app.mento.org/vercel.json
+++ b/apps/app.mento.org/vercel.json
@@ -2,7 +2,9 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "git": {
     "deploymentEnabled": {
-      "dependabot/**": false
+      "**": false,
+      "main": true,
+      "v2": true
     }
   }
 }

--- a/docs/adr/0001-github-actions-vercel-deployment-orchestration.md
+++ b/docs/adr/0001-github-actions-vercel-deployment-orchestration.md
@@ -137,10 +137,9 @@ guarantee which event runs first.
 Each worker creates or reuses one GitHub Deployment whose `ref` is the selected
 40-character SHA, then reports queued, in-progress, and a truthful terminal
 status. Every selected target runs direct smoke against its immutable URL before
-success. App and governance additionally retain the temporary native
-`deployment_status` adapter only while Vercel Git still produces those events;
-a status created with the repository `GITHUB_TOKEN` is evidence, not a trigger
-contract.
+success. App and governance retain a rollback-only native `deployment_status`
+adapter for bounded target-local recovery; a status created with the repository
+`GITHUB_TOKEN` is evidence, not a trigger contract.
 
 The direct smoke is one credential-free reusable workflow shared by all four
 targets and the temporary native adapter. Its input is an already verified,
@@ -221,12 +220,11 @@ evidence. Preview paths cut over before `main`; the three ordinary production
 targets prove no-domain staging, and app `v3` proves its activation semantics,
 before the final reviewed ownership change.
 
-The current version-controlled preview map assigns Governance, Reserve, and UI
-to GitHub Actions while App remains in shadow mode. Governance's configuration
-change is accepted only after its exact-head and fresh post-merge canaries pass,
-and it may not be published until the earlier Reserve post-merge canary has
-passed. The later App cutover remains independently gated; App `main`, `v2`,
-and custom-`v3` semantics do not change in this step.
+The current version-controlled preview map assigns App, Governance, Reserve,
+and UI to GitHub Actions. App's configuration change is accepted only after its
+exact-head and fresh post-merge canaries pass, and it may not be published until
+the earlier Governance post-merge canary has passed. App `main`, `v2`, and
+custom-`v3` semantics do not change in this step.
 
 `git.deploymentEnabled` branch rules disable only replaced native paths. The app
 configuration always retains `v2: true`. Outside a bounded shadow canary or

--- a/docs/adr/0003-preview-worker-dispatch-authentication.md
+++ b/docs/adr/0003-preview-worker-dispatch-authentication.md
@@ -102,10 +102,10 @@ the primary client.
 
 A target-local ownership rollback keeps the controller `active`, atomically
 restores only that target's native Vercel Git configuration and `shadow` mode,
-and leaves the dispatch credential available for other GitHub-owned targets. A
-Governance rollback therefore leaves Reserve and UI GitHub-owned and App
-shadowed; it neither revokes the shared dispatch path nor recreates the deleted
-Governance QA environment. A
+and leaves the dispatch credential available for other GitHub-owned targets.
+An App rollback therefore leaves Governance, Reserve, and UI GitHub-owned; a
+Governance rollback leaves App, Reserve, and UI GitHub-owned. Neither revokes
+the shared dispatch path nor recreates the deleted Governance QA environment. A
 coordinated full-controller rollback may set the version-controlled controller
 mode to `observe-only` only in the same reviewed change that restores native
 ownership for every GitHub-owned target. In that full shutdown mode the

--- a/docs/vercel-deployments.md
+++ b/docs/vercel-deployments.md
@@ -6,14 +6,13 @@ four-target preview controller used by the GitHub Actions deployment migration t
 The ownership boundary and its trade-offs are recorded in
 [ADR 0001](adr/0001-github-actions-vercel-deployment-orchestration.md).
 The v2 controller builds App, Governance, Reserve, and UI independently from one
-target-ordered plan. Governance, Reserve, and UI branch-preview ownership is
-GitHub-only. App remains in shadow mode: its GitHub build runs alongside its
-native Vercel Git preview until App completes its own canary and separate atomic
-ownership cutover. The Governance configuration change is not an accepted live
-cutover until the exact-head and post-merge canary gates in
-[Governance Vercel Git cutover](#governance-vercel-git-cutover) pass. Publishing
-that change also requires the prior Reserve post-merge canary to have passed.
-Vercel Git continues to own every main and production deployment.
+target-ordered plan. All four branch-preview paths are GitHub-only. The App
+configuration change is not an accepted live cutover until the exact-head and
+post-merge canary gates in
+[App Vercel Git cutover](#app-vercel-git-cutover) pass. Publishing that change
+also requires the prior Governance post-merge canary to have passed. Vercel Git
+continues to own every main and production deployment plus App `v2`; App's
+custom `v3` deployment semantics are unchanged.
 
 The automatic controller's version-controlled
 `VERCEL_PREVIEW_CONTROLLER_MODE` is `active` in this ownership state. The only
@@ -379,8 +378,8 @@ secretless `_vercel-preview-smoke.yml` workflow with the complete verified
 target tuple before canonical Deployment success. The original v2 activation
 did not change any target's `vercel.json`; App, Governance, and Reserve
 therefore began as dual-run shadow canaries while UI was GitHub-owned. The
-current version-controlled map cuts Governance and Reserve over to GitHub
-ownership while App remains shadowed.
+current version-controlled map cuts App, Governance, and Reserve over to GitHub
+ownership, joining the already GitHub-owned UI target.
 
 The reusable declaration has the three common secrets
 (`VERCEL_TOKEN_PREVIEW`, `TURBO_TOKEN`, and
@@ -1710,10 +1709,11 @@ item until both the live cutover matrix and the post-merge canary pass.
 #### Independent Reserve rollback
 
 Rollback changes only Reserve and returns it to the pre-cutover shadow state;
-it does not roll back UI or pause the active controller globally. First establish
-a coordinated no-push window. Exhaustively drain controller, worker, and intake
-activity with this copy-safe command, repeating it until two consecutive
-inventories are empty after cancellations have settled:
+it does not roll back App, Governance, or UI or pause the active controller
+globally. App, Governance, and UI keep their GitHub preview owners. First
+establish a coordinated no-push window. Exhaustively drain controller, worker,
+and intake activity with this copy-safe command, repeating it until two
+consecutive inventories are empty after cancellations have settled:
 
 ```bash
 set -euo pipefail
@@ -1766,9 +1766,8 @@ In that same commit, change only the Reserve entry in
 ownershipMode: PREVIEW_OWNERSHIP_MODES.SHADOW,
 ```
 
-Do not change `VERCEL_PREVIEW_CONTROLLER_MODE`: it stays `active` so Governance
-and UI keep their GitHub preview owners and App keeps its existing shadow
-canary.
+Do not change `VERCEL_PREVIEW_CONTROLLER_MODE`: it stays `active` so App,
+Governance, and UI keep their GitHub preview owners.
 Do not split the two Reserve edits across commits or merges. Run the ownership,
 preview, primitives, and workflow structural tests, update the current-state
 text in this runbook and `README.md`, and re-inventory every active Reserve
@@ -1838,9 +1837,9 @@ browser proof.
 #### Independent Governance rollback
 
 Rollback changes only Governance and returns it to the pre-cutover shadow
-state. It does not roll back Reserve or UI, change App, or pause the active
-controller globally. Reserve and UI keep their GitHub preview owners. First
-establish a coordinated no-push window. Exhaustively
+state. It does not roll back App, Reserve, or UI or pause the active controller
+globally. App, Reserve, and UI keep their GitHub preview owners. First establish
+a coordinated no-push window. Exhaustively
 drain controller, worker, and intake activity with this copy-safe command,
 repeating it until two consecutive inventories are empty after cancellations
 have settled:
@@ -1896,12 +1895,12 @@ In that same commit, change only the Governance entry in
 ownershipMode: PREVIEW_OWNERSHIP_MODES.SHADOW,
 ```
 
-Do not change `VERCEL_PREVIEW_CONTROLLER_MODE`: it stays `active` so Reserve
-and UI keep their GitHub preview owners and App keeps its existing shadow
-canary. Do not split the two Governance edits across commits or merges. Run the
-ownership, preview, primitives, and workflow structural tests, update the
-current-state text in this runbook and `README.md`, and re-inventory every
-active Governance runtime branch carrying the GitHub-owned configuration.
+Do not change `VERCEL_PREVIEW_CONTROLLER_MODE`: it stays `active` so App,
+Reserve, and UI keep their GitHub preview owners. Do not split the two
+Governance edits across commits or merges. Run the ownership, preview,
+primitives, and workflow structural tests, update the current-state text in
+this runbook and `README.md`, and re-inventory every active Governance runtime
+branch carrying the GitHub-owned configuration.
 
 Before merging the rollback, require the native Vercel deployment/status for
 the rollback PR's exact head SHA and run the full Governance browser protocol
@@ -1916,6 +1915,143 @@ and the expected GitHub shadow canary. Keep Governance in shadow mode until a
 new independently reviewed cutover repeats the full acceptance matrix. Never
 touch App, Reserve, UI, production domains, or recreate Governance QA as part
 of this rollback.
+
+### App Vercel Git cutover
+
+This change is the third and final per-target ownership cutover. Governance's
+ownership change is already present in the base state, but this App change may
+be published only after the Governance cutover's fresh post-merge canary has
+passed. That precondition establishes ordering; Governance or earlier-target
+evidence must not be reused as proof for App. The App change atomically pairs
+`PREVIEW_TARGET_CONFIG.app.ownershipMode` set to `github` with this exact
+`apps/app.mento.org/vercel.json`:
+
+```json
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "git": {
+    "deploymentEnabled": {
+      "**": false,
+      "main": true,
+      "v2": true
+    }
+  }
+}
+```
+
+`main: true` and `v2: true` preserve the two native Vercel Git release paths
+after the catch-all branch rule disables ordinary native previews. Ordinary
+pull requests continue to use the standard `preview` target, never App's custom
+`v3` target. This PR does not change the custom-`v3` build, activation, domain,
+or rollback semantics. It must preserve Governance, Reserve, and UI GitHub
+ownership, every production domain, the active controller, and the deleted
+Governance QA environment.
+
+The version-controlled pair is preparation, not proof that App has cut over
+successfully. Before accepting the cutover, inventory and rebase every
+App-runtime validation branch that still carries the native configuration. On
+the cutover PR's exact head, then again on a fresh post-merge canary branched
+from the resulting `main`, record and verify every gate below.
+
+#### App target-local acceptance matrix
+
+| Gate                 | Exact evidence required                                                                                                                                                                                                        |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Plan and execution   | An App-local runtime delta selects only App, and its exact-SHA controller and worker complete successfully.                                                                                                                    |
+| Deployment identity  | One canonical GitHub Deployment points to exactly one corresponding prebuilt Vercel preview for the App target/key/SHA.                                                                                                        |
+| Browser protocol     | The immutable App URL renders the current swap shell, opens the real wallet list, permits the team-host-only mock-wallet connection, and passes primary-navigation, console, network, JS/CSS/font, and security-header checks. |
+| Single owner         | No native App branch preview or second Vercel Git deployment exists for the same exact SHA.                                                                                                                                    |
+| Durable state        | The aggregate `Vercel Preview` status and the single v2 journal agree with the exact App outcome and immutable URL.                                                                                                            |
+| Preserved boundaries | App `main` and `v2` still deploy natively; custom `v3` behavior and every production domain are unchanged; Governance, Reserve, and UI remain GitHub-owned; Governance QA remains deleted.                                     |
+
+Do not call App cut over or close the rollout item until both the exact-head
+matrix and the fresh post-merge App canary pass. Workflow logs, Governance or
+earlier-target evidence, a native `main`/`v2` deployment, a custom-`v3`
+deployment, or a mutable alias are not substitutes for App exact-SHA deployment
+and browser proof.
+
+#### Independent App rollback
+
+Rollback changes only App and returns it to the pre-cutover shadow state. It
+does not roll back Governance, Reserve, or UI, alter App's native release
+paths, or pause the active controller globally. Governance, Reserve, and UI
+keep their GitHub preview owners. First establish a coordinated no-push window.
+Exhaustively drain controller, worker, and intake activity with this copy-safe
+command, repeating it until two consecutive inventories are empty after
+cancellations have settled:
+
+```bash
+set -euo pipefail
+
+list_nonterminal_preview_runs() {
+  local workflow status
+  local -a workflows=(
+    vercel-preview-controller.yml
+    vercel-preview-worker.yml
+    vercel-preview-intake.yml
+  )
+  local -a statuses=(queued requested waiting pending in_progress)
+
+  for workflow in "${workflows[@]}"; do
+    for status in "${statuses[@]}"; do
+      gh api --paginate --method GET \
+        "repos/mento-protocol/frontend-monorepo/actions/workflows/${workflow}/runs" \
+        -f status="$status" \
+        -f per_page=100 \
+        --jq '.workflow_runs[] | [.id, .status, .path, .html_url] | @tsv'
+    done
+  done | sort -u
+}
+
+list_nonterminal_preview_runs
+list_nonterminal_preview_runs |
+  cut -f1 |
+  sort -u |
+  while read -r run_id; do gh run cancel "$run_id"; done
+```
+
+In one reviewed rollback PR, restore `apps/app.mento.org/vercel.json` exactly
+to:
+
+```json
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "git": {
+    "deploymentEnabled": {
+      "dependabot/**": false
+    }
+  }
+}
+```
+
+In that same commit, change only the App entry in
+`scripts/vercel-preview-targets.mjs` back to:
+
+```js
+ownershipMode: PREVIEW_OWNERSHIP_MODES.SHADOW,
+```
+
+Do not change `VERCEL_PREVIEW_CONTROLLER_MODE`: it stays `active` so
+Governance, Reserve, and UI keep their GitHub preview owners. Do not split the
+two App edits across commits or merges. Run the ownership, preview, primitives,
+and workflow structural tests, update the current-state text in this runbook
+and `README.md`, and re-inventory every active App runtime branch carrying the
+GitHub-owned configuration.
+
+Before merging the rollback, require the native Vercel deployment/status for
+the rollback PR's exact head SHA and run the full App browser protocol on its
+immutable URL. Prove the current swap shell, real wallet list, team-host-only
+mock-wallet connection, primary navigation, console and network health, assets,
+fonts, and security headers. The aggregate `Vercel Preview` status proves
+controller selection and journal drain only; it is not native deployment or
+browser evidence. After merge, rebase a fresh App-runtime canary onto the
+restored `main`, bootstrap or reconcile its v2 journal through the documented
+operator events if required, and prove both native-preview recovery and the
+expected GitHub shadow canary. Separately prove that native App `main` and `v2`
+remain healthy and that custom `v3` semantics did not change. Keep App in
+shadow mode until a new independently reviewed cutover repeats the full
+acceptance matrix. Never touch Governance, Reserve, UI, production domains, or
+recreate Governance QA as part of this rollback.
 
 ### Phase A canary evidence template
 
@@ -2019,9 +2155,9 @@ In that same commit, change only the UI entry in
 ownershipMode: PREVIEW_OWNERSHIP_MODES.SHADOW,
 ```
 
-Keep `VERCEL_PREVIEW_CONTROLLER_MODE` set to `active`; Governance and Reserve
-remain GitHub-owned and App retains its independent shadow canary. Do not
-split the two UI edits across commits or merges. A configuration-only or
+Keep `VERCEL_PREVIEW_CONTROLLER_MODE` set to `active`; App, Governance, and
+Reserve remain GitHub-owned. Do not split the two UI edits across commits or
+merges. A configuration-only or
 mode-only rollback is not a supported repository state, and
 `pnpm vercel:preview:test` rejects either mismatch. The exact-head runtime guard
 is additional pre-merge protection: as soon as the rollback PR contains the

--- a/scripts/vercel-git-ownership.test.mjs
+++ b/scripts/vercel-git-ownership.test.mjs
@@ -108,14 +108,14 @@ test("ownership configurations keep only their reviewed branch exceptions", () =
   }
 });
 
-test("current rollout keeps only App shadowed while Governance, Reserve, and UI are GitHub-only", () => {
+test("current rollout keeps every branch-preview target GitHub-only", () => {
   assert.deepEqual(
     PREVIEW_TARGETS.filter(
       (target) =>
         PREVIEW_TARGET_CONFIG[target].ownershipMode ===
         PREVIEW_OWNERSHIP_MODES.SHADOW,
     ),
-    ["app"],
+    [],
   );
   assert.deepEqual(
     PREVIEW_TARGETS.filter(
@@ -123,7 +123,7 @@ test("current rollout keeps only App shadowed while Governance, Reserve, and UI 
         PREVIEW_TARGET_CONFIG[target].ownershipMode ===
         PREVIEW_OWNERSHIP_MODES.GITHUB,
     ),
-    ["governance", "reserve", "ui"],
+    PREVIEW_TARGETS,
   );
   assert.equal(controller.env.VERCEL_PREVIEW_CONTROLLER_MODE, "active");
 });

--- a/scripts/vercel-preview-controller.test.mjs
+++ b/scripts/vercel-preview-controller.test.mjs
@@ -8768,8 +8768,8 @@ test("worker preflight rejects expected A versus actual B before any API access"
   assert.equal(apiCalls, 0);
 });
 
-test("worker preflight permits a GitHub canary for the remaining native-owned App shadow target", async () => {
-  for (const [index, target] of ["app"].entries()) {
+test("worker preflight permits a GitHub canary for every GitHub-owned target", async () => {
+  for (const [index, target] of PREVIEW_TARGETS.entries()) {
     const opened = event({
       run: 116 + index,
       action: "opened",
@@ -10331,7 +10331,7 @@ test("observe-only mode durably attaches an in-progress crash-window worker and 
     target_url:
       "https://github.com/mento-protocol/frontend-monorepo/actions/runs/7001",
     targets: {
-      app: "not affected",
+      app: "native-owned",
       governance: "native-owned",
       reserve: "native-owned",
       ui: "pending",

--- a/scripts/vercel-preview-targets.mjs
+++ b/scripts/vercel-preview-targets.mjs
@@ -30,7 +30,7 @@ export const PREVIEW_TARGET_CONFIG = Object.freeze({
     workspacePackage: "app.mento.org",
     expectedRootDirectory: "apps/app.mento.org",
     projectVariable: "VERCEL_PROJECT_ID_APP",
-    ownershipMode: PREVIEW_OWNERSHIP_MODES.SHADOW,
+    ownershipMode: PREVIEW_OWNERSHIP_MODES.GITHUB,
     vercelConfigurationPath: "apps/app.mento.org/vercel.json",
     githubVercelConfiguration: APP_GITHUB_VERCEL_CONFIGURATION,
     nativeVercelConfiguration: NATIVE_VERCEL_CONFIGURATION,

--- a/scripts/vercel-preview-workflows.test.mjs
+++ b/scripts/vercel-preview-workflows.test.mjs
@@ -912,7 +912,14 @@ test("runbook covers v2 migration, four-target canaries, cutover, and exact roll
     "target-local acceptance matrix",
     "Independent Governance rollback",
     "Do not call Governance cut over, begin the App cutover",
-    "Reserve and UI keep their GitHub preview owners",
+    "App, Reserve, and UI keep their GitHub preview owners",
+    "App Vercel Git cutover",
+    "evidence must not be reused as proof for App",
+    "App target-local acceptance matrix",
+    "Independent App rollback",
+    "Governance, Reserve, and UI keep their GitHub preview owners",
+    "App `main` and `v2` still deploy natively",
+    "custom `v3` behavior",
     "Do not change `VERCEL_PREVIEW_CONTROLLER_MODE`",
     "live cutover matrix and the post-merge canary",
     "UI rollback is target-local",
@@ -969,6 +976,9 @@ test("runbook covers v2 migration, four-target canaries, cutover, and exact roll
     "### Governance Vercel Git cutover",
     "Do not call Governance cut over, begin the App cutover",
     "#### Independent Governance rollback",
+    "### App Vercel Git cutover",
+    "Do not call App cut over or close the rollout item",
+    "#### Independent App rollback",
   ];
   let previousOwnershipIndex = -1;
   for (const marker of orderedOwnershipCutovers) {


### PR DESCRIPTION
## The Problem

App is the final branch-preview target still in shadow mode. Each App runtime
change can therefore create both a native Vercel Git preview and the canonical
GitHub-built preview, preserving duplicate Vercel build-minute spend after the
other three targets have moved to GitHub ownership.

## The Solution

Atomically move App branch-preview ownership to GitHub Actions by pairing its
reviewed `github` ownership mode with the exact Vercel branch map that disables
ordinary native previews while keeping `main` and protected legacy `v2`
enabled. Preserve the active controller, Governance/Reserve/UI GitHub
ownership, all production domains, App custom-`v3` semantics, the deleted
Governance QA environment, and the terminal closed-preview recovery hardening
already present on `main`.

Update the executable ownership/controller tests, current-state documentation,
ADRs, and the App-specific acceptance and target-local rollback runbook. The
App configuration remains rollout preparation until both its exact-head
evidence matrix and a fresh post-merge App canary pass.

## Validation

- `node --test scripts/vercel-git-ownership.test.mjs`
- `pnpm vercel:preview:test`
- `pnpm vercel:primitives:test`
- `pnpm vercel:workflow:test` (90/91 locally; the sole offline-layout fixture
  requires an already-populated `@eslint/js@9.39.2` tarball)
- `node --test --test-name-pattern='app|v3' scripts/vercel-build-environment.test.mjs`
- `pnpm quality:budgets:test`
- `pnpm adr:check`
- `pnpm adr:check:test`
- `pnpm pr:description:test`
- `trunk check --ci --all`

## Architecture decision

Updates ADR 0001 and ADR 0003 to record the final target-local ownership state
and rollback boundary. No new direction is introduced beyond the accepted
ordered Reserve -> Governance -> App migration.

## Rollout

- Governance's fresh post-merge canary passed before this App cutover was
  prepared.
- On this PR's exact head, prove one App-only controller/worker path, one
  canonical GitHub Deployment, one corresponding prebuilt Vercel preview, no
  native App branch preview, the full immutable App browser protocol, truthful
  journal/status state, native `main` and `v2` continuity, and unchanged custom
  `v3` semantics.
- After merge, repeat the full App matrix on a fresh canary from resulting
  `main` before declaring the cutover complete.

Progresses #520.
Part of #515.

## Ship Checklist

- [x] ship skill used
- [x] local review run
- [x] validation run
