### PR TITLE
test(app): verify GitHub-only post-cutover preview

### DIFF
--- a/apps/app.mento.org/vercel-cutover-canary-20260722.md
+++ b/apps/app.mento.org/vercel-cutover-canary-20260722.md
@@ -1,0 +1,4 @@
+<!-- GitHub-driven Vercel post-cutover canary
+Date: 2026-07-22
+Target: app
+Purpose: path-scoped single-owner deployment verification -->


### PR DESCRIPTION
## The Problem

App preview ownership was cut over in #609, but #520 still needs a fresh branch created from the resulting `main` to prove that new App branches receive one GitHub-built preview and no duplicate native Vercel preview.

## The Solution

Add a disposable App-scoped canary marker. The PR is intentionally opened once and will be closed without merging after exact-SHA controller, deployment, browser-smoke, and duplicate-owner evidence is captured.

## Validation

- `pnpm vercel:plan --base d647d33201189ffd4bfa2fbb0007def223bc04b9 --head deb769c17bec83a711f816ed668334f245856173` — selected only `app` with reason `affected-packages`
- `git diff --check origin/main...HEAD`

## Ship Checklist

- [x] ship skill used
- [x] planner verified locally
- [ ] live exact-SHA preview and browser smoke
- [ ] native-duplicate census and #520 evidence