### PR TITLE
feat(ci): add Vercel production-shadow pilot

### DIFF
--- a/.github/actions/pnpm-install/action.yml
+++ b/.github/actions/pnpm-install/action.yml
@@ -17,6 +17,10 @@ inputs:
     description: Whether actions/setup-node should cache the pnpm store
     required: false
     default: "true"
+  working-directory:
+    description: Repository directory containing package.json and pnpm-lock.yaml
+    required: false
+    default: .
 
 runs:
   using: composite
@@ -30,6 +34,7 @@ runs:
       with:
         node-version: ${{ inputs.node-version }}
         cache: pnpm
+        cache-dependency-path: ${{ inputs.working-directory }}/pnpm-lock.yaml
         registry-url: ${{ inputs.registry-url }}
 
     - name: Set up Node.js without package-manager cache
@@ -42,4 +47,7 @@ runs:
 
     - name: Install dependencies
       shell: bash
-      run: pnpm install --frozen-lockfile
+      working-directory: ${{ inputs.working-directory }}
+      run: >-
+        env -u GITHUB_ENV -u GITHUB_OUTPUT -u GITHUB_PATH -u GITHUB_STATE
+        -u GITHUB_STEP_SUMMARY pnpm install --frozen-lockfile

--- a/.github/actions/vercel-candidate-build/action.yml
+++ b/.github/actions/vercel-candidate-build/action.yml
@@ -1,0 +1,601 @@
+name: Build isolated Vercel candidate
+description: Run candidate install and build under a dedicated UID, then hand off immutable output
+
+inputs:
+  controller-path:
+    description: Trusted workflow-controller checkout
+    required: true
+  source-path:
+    description: Runner-owned exact-SHA source checkout
+    required: true
+  candidate-source-path:
+    description: Fresh candidate-owned source path under RUNNER_TEMP
+    required: true
+  candidate-home-path:
+    description: Fresh candidate-owned HOME path under RUNNER_TEMP
+    required: true
+  pull-staging-path:
+    description: Validated runner-owned Vercel pull staging under RUNNER_TEMP
+    required: true
+  upload-source-path:
+    description: Fresh runner-owned upload handoff under RUNNER_TEMP
+    required: true
+  node-bin:
+    description: Canonical protected Node executable
+    required: true
+  pnpm-bin:
+    description: Canonical protected pnpm executable
+    required: true
+  vercel-cli:
+    description: Canonical protected Vercel CLI entry point
+    required: true
+  deploy-sha:
+    description: Exact candidate commit SHA
+    required: true
+  next-deployment-id:
+    description: Deterministic build identity embedded in the prebuilt output
+    required: true
+  logical-target:
+    description: Literal app, governance, reserve, or ui target
+    required: true
+  expected-root-directory:
+    description: Literal reviewed Vercel Root Directory
+    required: true
+  vercel-org-id:
+    description: Literal reviewed Vercel organization ID
+    required: true
+  vercel-project-id:
+    description: Literal reviewed Vercel project ID
+    required: true
+
+outputs:
+  build_duration_ms:
+    description: Candidate Vercel build duration
+    value: ${{ steps.build.outputs.build_duration_ms }}
+  turbo_cache_hits:
+    description: Tasks restored from the canonical Turbo cache summary
+    value: ${{ steps.build.outputs.turbo_cache_hits }}
+  turbo_cache_misses:
+    description: Tasks not restored from the canonical Turbo cache summary
+    value: ${{ steps.build.outputs.turbo_cache_misses }}
+  upload_uid:
+    description: Runner UID owning the immutable upload handoff
+    value: ${{ steps.handoff.outputs.upload_uid }}
+  upload_gid:
+    description: Runner GID owning the immutable upload handoff
+    value: ${{ steps.handoff.outputs.upload_gid }}
+
+runs:
+  using: composite
+  steps:
+    - name: Validate runner-owned build inputs
+      shell: bash
+      env:
+        CONTROLLER_PATH: ${{ inputs.controller-path }}
+        EXPECTED_ROOT_DIRECTORY: ${{ inputs.expected-root-directory }}
+        LOGICAL_TARGET: ${{ inputs.logical-target }}
+        MENTO_NEXT_DEPLOYMENT_ID: ${{ inputs.next-deployment-id }}
+        NODE_BIN: ${{ inputs.node-bin }}
+        PULL_STAGING_PATH: ${{ inputs.pull-staging-path }}
+      run: |
+        set -euo pipefail
+        "$NODE_BIN" "$CONTROLLER_PATH/scripts/vercel-production-shadow.mjs" check-build-inputs
+        case "$LOGICAL_TARGET" in
+          app) build_environment=v3 ;;
+          governance|reserve|ui) build_environment=production ;;
+          *) echo "Unknown production-shadow target" >&2; exit 1 ;;
+        esac
+        "$NODE_BIN" "$CONTROLLER_PATH/scripts/vercel-build-environment.mjs" \
+          check \
+          --target "$LOGICAL_TARGET" \
+          --environment "$build_environment" \
+          --project-directory "$PULL_STAGING_PATH/$EXPECTED_ROOT_DIRECTORY"
+
+    - name: Prepare isolated exact-SHA candidate source
+      id: isolation
+      shell: bash
+      env:
+        CANDIDATE_HOME_PATH: ${{ inputs.candidate-home-path }}
+        CANDIDATE_SOURCE_PATH: ${{ inputs.candidate-source-path }}
+        CONTROLLER_PATH: ${{ inputs.controller-path }}
+        DEPLOY_SHA: ${{ inputs.deploy-sha }}
+        NODE_BIN: ${{ inputs.node-bin }}
+        PNPM_BIN: ${{ inputs.pnpm-bin }}
+        SOURCE_PATH: ${{ inputs.source-path }}
+        TRUSTED_VERCEL_CLI_PATH: ${{ inputs.vercel-cli }}
+      run: |
+        set -euo pipefail
+        umask 077
+        build_user=mento-vercel-build
+        identity_marker="$RUNNER_TEMP/mento-vercel-production-candidate-identity"
+        if /usr/bin/getent passwd "$build_user" >/dev/null || /usr/bin/getent group "$build_user" >/dev/null; then
+          echo "Dedicated candidate identity already exists" >&2
+          exit 1
+        fi
+        if [ -e "$identity_marker" ] || [ -L "$identity_marker" ]; then
+          echo "Candidate identity marker must be fresh" >&2
+          exit 1
+        fi
+        set -o noclobber
+        printf 'pending\n' > "$identity_marker"
+        set +o noclobber
+        /bin/chmod 0600 "$identity_marker"
+        sudo --non-interactive /usr/sbin/useradd \
+          --system \
+          --no-create-home \
+          --home-dir /nonexistent \
+          --shell /usr/sbin/nologin \
+          --user-group \
+          "$build_user"
+        build_uid="$(/usr/bin/id -u "$build_user")"
+        build_gid="$(/usr/bin/id -g "$build_user")"
+        printf '%s:%s\n' "$build_uid" "$build_gid" > "$identity_marker"
+        /bin/chmod 0600 "$identity_marker"
+        if sudo --non-interactive /usr/bin/pgrep -u "$build_uid" >/dev/null 2>&1; then
+          echo "Dedicated candidate identity unexpectedly owns a process" >&2
+          exit 1
+        fi
+        candidate_can_write() {
+          sudo --non-interactive /usr/bin/env -i PATH=/usr/bin:/bin \
+            /usr/bin/setpriv \
+            --reuid="$build_uid" \
+            --regid="$build_gid" \
+            --clear-groups \
+            --no-new-privs \
+            -- \
+            /usr/bin/test -w "$1"
+        }
+        for protected_path in \
+          "$GITHUB_WORKSPACE" \
+          "$CONTROLLER_PATH" \
+          "$RUNNER_TEMP" \
+          "$SOURCE_PATH" \
+          "$SOURCE_PATH/.git" \
+          "$SOURCE_PATH/package.json" \
+          "$SOURCE_PATH/pnpm-lock.yaml" \
+          "$NODE_BIN" \
+          "$PNPM_BIN" \
+          "$TRUSTED_VERCEL_CLI_PATH"; do
+          if [ ! -e "$protected_path" ] || candidate_can_write "$protected_path"; then
+            echo "Candidate can modify a protected runner path" >&2
+            exit 1
+          fi
+        done
+        case "$CANDIDATE_SOURCE_PATH:$CANDIDATE_HOME_PATH" in
+          "$RUNNER_TEMP"/mento-vercel-*:"$RUNNER_TEMP"/mento-vercel-*) ;;
+          *) echo "Candidate isolation path is outside RUNNER_TEMP" >&2; exit 1 ;;
+        esac
+        if [ -e "$CANDIDATE_SOURCE_PATH" ] || [ -e "$CANDIDATE_HOME_PATH" ]; then
+          echo "Candidate isolation paths must be fresh" >&2
+          exit 1
+        fi
+        "$NODE_BIN" \
+          "$CONTROLLER_PATH/scripts/vercel-production-shadow.mjs" \
+          materialize-source
+        sudo --non-interactive /bin/chown \
+          -R --no-dereference "$build_uid:$build_gid" "$CANDIDATE_SOURCE_PATH"
+        sudo --non-interactive /usr/bin/install \
+          -d -o "$build_uid" -g "$build_gid" -m 0700 \
+          "$CANDIDATE_HOME_PATH" \
+          "$CANDIDATE_HOME_PATH/cache" \
+          "$CANDIDATE_HOME_PATH/config" \
+          "$CANDIDATE_HOME_PATH/data" \
+          "$CANDIDATE_HOME_PATH/pnpm-store" \
+          "$CANDIDATE_HOME_PATH/tmp"
+        printf '{"commitSha":"%s"}\n' "$DEPLOY_SHA" > "${CANDIDATE_SOURCE_PATH}.provenance.json"
+        /bin/chmod 0600 "${CANDIDATE_SOURCE_PATH}.provenance.json"
+        echo "build_uid=$build_uid" >> "$GITHUB_OUTPUT"
+        echo "build_gid=$build_gid" >> "$GITHUB_OUTPUT"
+
+    - name: Install frozen dependencies as candidate
+      shell: bash
+      env:
+        BUILD_GID: ${{ steps.isolation.outputs.build_gid }}
+        BUILD_UID: ${{ steps.isolation.outputs.build_uid }}
+        CANDIDATE_HOME_PATH: ${{ inputs.candidate-home-path }}
+        CANDIDATE_SOURCE_PATH: ${{ inputs.candidate-source-path }}
+        NODE_BIN: ${{ inputs.node-bin }}
+        PNPM_BIN: ${{ inputs.pnpm-bin }}
+      run: |
+        set -euo pipefail
+        terminate_candidate() {
+          sudo --non-interactive /usr/bin/pkill -KILL -u "$BUILD_UID" >/dev/null 2>&1 || true
+          for _ in $(seq 1 50); do
+            if ! sudo --non-interactive /usr/bin/pgrep -u "$BUILD_UID" >/dev/null 2>&1; then return 0; fi
+            /bin/sleep 0.1
+          done
+          sudo --non-interactive /usr/bin/pgrep -a -u "$BUILD_UID" >&2 || true
+          echo "Candidate processes survived the UID-wide kill" >&2
+          return 1
+        }
+        command_token=""
+        trap 'status=$?; terminate_candidate || status=1; if [ -n "$command_token" ]; then echo "::$command_token::"; fi; exit "$status"' EXIT
+        if sudo --non-interactive /usr/bin/pgrep -u "$BUILD_UID" >/dev/null 2>&1; then
+          echo "Candidate identity owns a process before dependency installation" >&2
+          exit 1
+        fi
+        safe_path="$(dirname "$NODE_BIN"):$(dirname "$PNPM_BIN"):/usr/local/bin:/usr/bin:/bin"
+        command_token="mento-$(/usr/bin/openssl rand -hex 16)"
+        echo "::stop-commands::$command_token"
+        set +e
+        sudo --non-interactive /usr/bin/env -i \
+          CI=1 \
+          HOME="$CANDIDATE_HOME_PATH" \
+          HTTP_PROXY="${HTTP_PROXY:-}" \
+          HTTPS_PROXY="${HTTPS_PROXY:-}" \
+          LANG="${LANG:-C.UTF-8}" \
+          LC_ALL="${LC_ALL:-C.UTF-8}" \
+          NODE_EXTRA_CA_CERTS="${NODE_EXTRA_CA_CERTS:-}" \
+          NO_PROXY="${NO_PROXY:-}" \
+          PATH="$safe_path" \
+          PNPM_HOME="$CANDIDATE_HOME_PATH/pnpm" \
+          SSL_CERT_FILE="${SSL_CERT_FILE:-}" \
+          TMPDIR="$CANDIDATE_HOME_PATH/tmp" \
+          XDG_CACHE_HOME="$CANDIDATE_HOME_PATH/cache" \
+          XDG_CONFIG_HOME="$CANDIDATE_HOME_PATH/config" \
+          XDG_DATA_HOME="$CANDIDATE_HOME_PATH/data" \
+          /usr/bin/setpriv \
+          --reuid="$BUILD_UID" \
+          --regid="$BUILD_GID" \
+          --clear-groups \
+          --no-new-privs \
+          -- \
+          "$PNPM_BIN" --dir "$CANDIDATE_SOURCE_PATH" install \
+          --frozen-lockfile \
+          --ignore-scripts \
+          --store-dir "$CANDIDATE_HOME_PATH/pnpm-store" \
+          2>&1
+        candidate_status=$?
+        set -e
+        terminate_candidate
+        echo "::$command_token::"
+        command_token=""
+        if [ "$candidate_status" -ne 0 ]; then exit "$candidate_status"; fi
+
+    - name: Stage validated runner-owned Vercel settings
+      shell: bash
+      env:
+        BUILD_GID: ${{ steps.isolation.outputs.build_gid }}
+        BUILD_UID: ${{ steps.isolation.outputs.build_uid }}
+        CANDIDATE_SOURCE_PATH: ${{ inputs.candidate-source-path }}
+        CONTROLLER_PATH: ${{ inputs.controller-path }}
+        EXPECTED_ROOT_DIRECTORY: ${{ inputs.expected-root-directory }}
+        LOGICAL_TARGET: ${{ inputs.logical-target }}
+        MENTO_NEXT_DEPLOYMENT_ID: ${{ inputs.next-deployment-id }}
+        NODE_BIN: ${{ inputs.node-bin }}
+        PULL_STAGING_PATH: ${{ inputs.pull-staging-path }}
+        VERCEL_ORG_ID: ${{ inputs.vercel-org-id }}
+        VERCEL_PROJECT_ID: ${{ inputs.vercel-project-id }}
+      run: |
+        set -euo pipefail
+        if sudo --non-interactive /usr/bin/pgrep -u "$BUILD_UID" >/dev/null 2>&1; then
+          echo "Candidate identity owns a process before settings staging" >&2
+          exit 1
+        fi
+        sudo --non-interactive /usr/bin/env -i \
+          BUILD_GID="$BUILD_GID" \
+          BUILD_UID="$BUILD_UID" \
+          CANDIDATE_SOURCE_PATH="$CANDIDATE_SOURCE_PATH" \
+          EXPECTED_ROOT_DIRECTORY="$EXPECTED_ROOT_DIRECTORY" \
+          LOGICAL_TARGET="$LOGICAL_TARGET" \
+          PATH="$(dirname "$NODE_BIN"):/usr/bin:/bin" \
+          PULL_STAGING_GID="$(id -g)" \
+          PULL_STAGING_PATH="$PULL_STAGING_PATH" \
+          PULL_STAGING_UID="$(id -u)" \
+          RUNNER_TEMP="$RUNNER_TEMP" \
+          VERCEL_ORG_ID="$VERCEL_ORG_ID" \
+          VERCEL_PROJECT_ID="$VERCEL_PROJECT_ID" \
+          "$NODE_BIN" "$CONTROLLER_PATH/scripts/vercel-production-shadow.mjs" stage-pull
+        if sudo --non-interactive /usr/bin/pgrep -u "$BUILD_UID" >/dev/null 2>&1; then
+          echo "Candidate identity acquired a process while settings were staged" >&2
+          exit 1
+        fi
+
+    - name: Build prebuilt output as candidate
+      id: build
+      shell: bash
+      env:
+        BUILD_GID: ${{ steps.isolation.outputs.build_gid }}
+        BUILD_UID: ${{ steps.isolation.outputs.build_uid }}
+        CANDIDATE_HOME_PATH: ${{ inputs.candidate-home-path }}
+        CANDIDATE_SOURCE_PATH: ${{ inputs.candidate-source-path }}
+        CONTROLLER_PATH: ${{ inputs.controller-path }}
+        DEPLOY_SHA: ${{ inputs.deploy-sha }}
+        EXPECTED_ROOT_DIRECTORY: ${{ inputs.expected-root-directory }}
+        LOGICAL_TARGET: ${{ inputs.logical-target }}
+        NODE_BIN: ${{ inputs.node-bin }}
+        PNPM_BIN: ${{ inputs.pnpm-bin }}
+        TRUSTED_VERCEL_CLI_PATH: ${{ inputs.vercel-cli }}
+        VERCEL_ORG_ID: ${{ inputs.vercel-org-id }}
+        VERCEL_PROJECT_ID: ${{ inputs.vercel-project-id }}
+      run: |
+        set -euo pipefail
+        terminate_candidate() {
+          sudo --non-interactive /usr/bin/pkill -KILL -u "$BUILD_UID" >/dev/null 2>&1 || true
+          for _ in $(seq 1 50); do
+            if ! sudo --non-interactive /usr/bin/pgrep -u "$BUILD_UID" >/dev/null 2>&1; then return 0; fi
+            /bin/sleep 0.1
+          done
+          sudo --non-interactive /usr/bin/pgrep -a -u "$BUILD_UID" >&2 || true
+          echo "Candidate processes survived the UID-wide kill" >&2
+          return 1
+        }
+        command_token=""
+        trap 'status=$?; terminate_candidate || status=1; if [ -n "$command_token" ]; then echo "::$command_token::"; fi; exit "$status"' EXIT
+        if sudo --non-interactive /usr/bin/pgrep -u "$BUILD_UID" >/dev/null 2>&1; then
+          echo "Candidate identity owns a process before the build" >&2
+          exit 1
+        fi
+        sudo --non-interactive /usr/bin/env -i \
+          BUILD_GID="$BUILD_GID" \
+          BUILD_UID="$BUILD_UID" \
+          CANDIDATE_SOURCE_PATH="$CANDIDATE_SOURCE_PATH" \
+          EXPECTED_ROOT_DIRECTORY="$EXPECTED_ROOT_DIRECTORY" \
+          LOGICAL_TARGET="$LOGICAL_TARGET" \
+          PATH="$(dirname "$NODE_BIN"):/usr/bin:/bin" \
+          PULL_STAGING_GID="$(id -g)" \
+          PULL_STAGING_UID="$(id -u)" \
+          RUNNER_TEMP="$RUNNER_TEMP" \
+          VERCEL_ORG_ID="$VERCEL_ORG_ID" \
+          VERCEL_PROJECT_ID="$VERCEL_PROJECT_ID" \
+          "$NODE_BIN" "$CONTROLLER_PATH/scripts/vercel-production-shadow.mjs" validate-candidate-pull
+        case "$LOGICAL_TARGET" in
+          app) build_arguments=(build --yes --standalone --target v3 --project "$VERCEL_PROJECT_ID") ;;
+          governance|reserve|ui) build_arguments=(build --yes --standalone --prod --project "$VERCEL_PROJECT_ID") ;;
+          *) echo "Unknown production-shadow target" >&2; exit 1 ;;
+        esac
+        safe_path="$(dirname "$NODE_BIN"):$(dirname "$PNPM_BIN"):/usr/local/bin:/usr/bin:/bin"
+        started_at_ms="$(date +%s%3N)"
+        build_log="$RUNNER_TEMP/mento-vercel-production-${LOGICAL_TARGET}-build.log"
+        if [ -e "$build_log" ] || [ -L "$build_log" ]; then
+          echo "Candidate build log path must be fresh" >&2
+          exit 1
+        fi
+        cd "$CANDIDATE_SOURCE_PATH"
+        command_token="mento-$(/usr/bin/openssl rand -hex 16)"
+        echo "::stop-commands::$command_token"
+        set +e
+        sudo --non-interactive /usr/bin/env -i \
+          CI=1 \
+          ETHERSCAN_API_KEY="${ETHERSCAN_API_KEY:-}" \
+          HOME="$CANDIDATE_HOME_PATH" \
+          HTTP_PROXY="${HTTP_PROXY:-}" \
+          HTTPS_PROXY="${HTTPS_PROXY:-}" \
+          LANG="${LANG:-C.UTF-8}" \
+          LC_ALL="${LC_ALL:-C.UTF-8}" \
+          MENTO_NEXT_DEPLOYMENT_ID="${MENTO_NEXT_DEPLOYMENT_ID:-}" \
+          NEXT_PUBLIC_VERCEL_ENV="${NEXT_PUBLIC_VERCEL_ENV:-}" \
+          NODE_EXTRA_CA_CERTS="${NODE_EXTRA_CA_CERTS:-}" \
+          NO_PROXY="${NO_PROXY:-}" \
+          PATH="$safe_path" \
+          SENTRY_AUTH_TOKEN="${SENTRY_AUTH_TOKEN:-}" \
+          SSL_CERT_FILE="${SSL_CERT_FILE:-}" \
+          TMPDIR="$CANDIDATE_HOME_PATH/tmp" \
+          TURBO_REMOTE_CACHE_SIGNATURE_KEY="${TURBO_REMOTE_CACHE_SIGNATURE_KEY:-}" \
+          TURBO_TEAM="${TURBO_TEAM:-}" \
+          TURBO_TOKEN="${TURBO_TOKEN:-}" \
+          VERCEL="${VERCEL:-1}" \
+          VERCEL_ENV="${VERCEL_ENV:-}" \
+          VERCEL_GIT_COMMIT_REF="${VERCEL_GIT_COMMIT_REF:-main}" \
+          VERCEL_GIT_COMMIT_SHA="$DEPLOY_SHA" \
+          VERCEL_GIT_PROVIDER="${VERCEL_GIT_PROVIDER:-github}" \
+          VERCEL_GIT_REPO_OWNER="${VERCEL_GIT_REPO_OWNER:-mento-protocol}" \
+          VERCEL_GIT_REPO_SLUG="${VERCEL_GIT_REPO_SLUG:-frontend-monorepo}" \
+          VERCEL_TARGET_ENV="${VERCEL_TARGET_ENV:-}" \
+          XDG_CACHE_HOME="$CANDIDATE_HOME_PATH/cache" \
+          XDG_CONFIG_HOME="$CANDIDATE_HOME_PATH/config" \
+          XDG_DATA_HOME="$CANDIDATE_HOME_PATH/data" \
+          /usr/bin/setpriv \
+          --reuid="$BUILD_UID" \
+          --regid="$BUILD_GID" \
+          --clear-groups \
+          --no-new-privs \
+          -- \
+          "$NODE_BIN" "$TRUSTED_VERCEL_CLI_PATH" "${build_arguments[@]}" \
+          2>&1 | /usr/bin/tee "$build_log"
+        pipeline_status=("${PIPESTATUS[@]}")
+        candidate_status="${pipeline_status[0]}"
+        tee_status="${pipeline_status[1]}"
+        set -e
+        terminate_candidate
+        echo "::$command_token::"
+        command_token=""
+        if [ "$tee_status" -ne 0 ]; then exit "$tee_status"; fi
+        if [ "$candidate_status" -ne 0 ]; then exit "$candidate_status"; fi
+        "$NODE_BIN" "$CONTROLLER_PATH/scripts/vercel-production-shadow.mjs" \
+          cache-summary --input "$build_log"
+        /bin/rm -f "$build_log"
+        trap - EXIT
+        echo "build_duration_ms=$(($(date +%s%3N) - started_at_ms))" >> "$GITHUB_OUTPUT"
+
+    - name: Validate candidate-owned prebuilt output
+      shell: bash
+      env:
+        BUILD_GID: ${{ steps.isolation.outputs.build_gid }}
+        BUILD_UID: ${{ steps.isolation.outputs.build_uid }}
+        CANDIDATE_SOURCE_PATH: ${{ inputs.candidate-source-path }}
+        CONTROLLER_PATH: ${{ inputs.controller-path }}
+        DEPLOY_SHA: ${{ inputs.deploy-sha }}
+        EXPECTED_ROOT_DIRECTORY: ${{ inputs.expected-root-directory }}
+        LOGICAL_TARGET: ${{ inputs.logical-target }}
+        MENTO_NEXT_DEPLOYMENT_ID: ${{ inputs.next-deployment-id }}
+        NODE_BIN: ${{ inputs.node-bin }}
+        VERCEL_ORG_ID: ${{ inputs.vercel-org-id }}
+        VERCEL_PROJECT_ID: ${{ inputs.vercel-project-id }}
+      run: |
+        set -euo pipefail
+        if sudo --non-interactive /usr/bin/pgrep -u "$BUILD_UID" >/dev/null 2>&1; then
+          echo "Candidate identity owns a process before output validation" >&2
+          exit 1
+        fi
+        sudo --non-interactive /usr/bin/env -i \
+          DEPLOY_SHA="$DEPLOY_SHA" \
+          EXPECTED_OUTPUT_GID="$BUILD_GID" \
+          EXPECTED_OUTPUT_UID="$BUILD_UID" \
+          EXPECTED_PROVENANCE_UID="$(id -u)" \
+          EXPECTED_ROOT_DIRECTORY="$EXPECTED_ROOT_DIRECTORY" \
+          LOGICAL_TARGET="$LOGICAL_TARGET" \
+          MENTO_NEXT_DEPLOYMENT_ID="$MENTO_NEXT_DEPLOYMENT_ID" \
+          PATH="$(dirname "$NODE_BIN"):/usr/bin:/bin" \
+          SOURCE_PATH="$CANDIDATE_SOURCE_PATH" \
+          VERCEL_ORG_ID="$VERCEL_ORG_ID" \
+          VERCEL_PROJECT_ID="$VERCEL_PROJECT_ID" \
+          "$NODE_BIN" "$CONTROLLER_PATH/scripts/vercel-production-shadow.mjs" assert-output
+
+    - name: Create immutable runner-owned output handoff
+      id: handoff
+      shell: bash
+      env:
+        BUILD_GID: ${{ steps.isolation.outputs.build_gid }}
+        BUILD_UID: ${{ steps.isolation.outputs.build_uid }}
+        CANDIDATE_SOURCE_PATH: ${{ inputs.candidate-source-path }}
+        CONTROLLER_PATH: ${{ inputs.controller-path }}
+        DEPLOY_SHA: ${{ inputs.deploy-sha }}
+        LOGICAL_TARGET: ${{ inputs.logical-target }}
+        MENTO_NEXT_DEPLOYMENT_ID: ${{ inputs.next-deployment-id }}
+        NODE_BIN: ${{ inputs.node-bin }}
+        PULL_STAGING_PATH: ${{ inputs.pull-staging-path }}
+        UPLOAD_SOURCE_PATH: ${{ inputs.upload-source-path }}
+        VERCEL_ORG_ID: ${{ inputs.vercel-org-id }}
+        VERCEL_PROJECT_ID: ${{ inputs.vercel-project-id }}
+      run: |
+        set -euo pipefail
+        umask 077
+        if sudo --non-interactive /usr/bin/pgrep -u "$BUILD_UID" >/dev/null 2>&1; then
+          echo "Candidate identity still owns a process before handoff" >&2
+          exit 1
+        fi
+        runner_uid="$(/usr/bin/id -u)"
+        runner_gid="$(/usr/bin/id -g)"
+        sudo --non-interactive /usr/bin/env -i \
+          PATH=/usr/bin:/bin \
+          BUILD_GID="$BUILD_GID" \
+          BUILD_UID="$BUILD_UID" \
+          CANDIDATE_SOURCE_PATH="$CANDIDATE_SOURCE_PATH" \
+          DEPLOY_SHA="$DEPLOY_SHA" \
+          LOGICAL_TARGET="$LOGICAL_TARGET" \
+          MENTO_NEXT_DEPLOYMENT_ID="$MENTO_NEXT_DEPLOYMENT_ID" \
+          PULL_STAGING_PATH="$PULL_STAGING_PATH" \
+          RUNNER_GID="$runner_gid" \
+          RUNNER_TEMP="$RUNNER_TEMP" \
+          RUNNER_UID="$runner_uid" \
+          UPLOAD_SOURCE_PATH="$UPLOAD_SOURCE_PATH" \
+          VERCEL_ORG_ID="$VERCEL_ORG_ID" \
+          VERCEL_PROJECT_ID="$VERCEL_PROJECT_ID" \
+          "$NODE_BIN" \
+          "$CONTROLLER_PATH/scripts/vercel-production-shadow.mjs" \
+          create-handoff
+        echo "upload_uid=$runner_uid" >> "$GITHUB_OUTPUT"
+        echo "upload_gid=$runner_gid" >> "$GITHUB_OUTPUT"
+
+    - name: Remove candidate execution boundary
+      if: always()
+      shell: bash
+      env:
+        CANDIDATE_HOME_PATH: ${{ inputs.candidate-home-path }}
+        CANDIDATE_SOURCE_PATH: ${{ inputs.candidate-source-path }}
+        PULL_STAGING_PATH: ${{ inputs.pull-staging-path }}
+      run: |
+        set -euo pipefail
+        identity_marker="$RUNNER_TEMP/mento-vercel-production-candidate-identity"
+        if [ -e "$identity_marker" ] || [ -L "$identity_marker" ]; then
+          if [ -L "$identity_marker" ] || [ ! -f "$identity_marker" ] || \
+            [ "$(/usr/bin/stat -c '%u' "$identity_marker")" != "$(id -u)" ] || \
+            [ "$(/usr/bin/stat -c '%g' "$identity_marker")" != "$(id -g)" ] || \
+            [ "$(/usr/bin/stat -c '%h' "$identity_marker")" != 1 ] || \
+            [ "$(/usr/bin/stat -c '%a' "$identity_marker")" != 600 ]; then
+            echo "Candidate identity marker is unsafe" >&2
+            exit 1
+          fi
+          identity="$(< "$identity_marker")"
+          if [ "$identity" = pending ]; then
+            if /usr/bin/getent passwd mento-vercel-build >/dev/null || \
+              /usr/bin/getent group mento-vercel-build >/dev/null; then
+              echo "Candidate identity ownership was not bound before teardown" >&2
+              exit 1
+            fi
+            /bin/rm -f -- "$identity_marker"
+          elif [[ "$identity" =~ ^([0-9]+):([0-9]+)$ ]]; then
+            build_uid="${BASH_REMATCH[1]}"
+            build_gid="${BASH_REMATCH[2]}"
+            if ! /usr/bin/getent passwd mento-vercel-build >/dev/null || \
+              ! /usr/bin/getent group mento-vercel-build >/dev/null || \
+              [ "$(/usr/bin/id -u mento-vercel-build)" != "$build_uid" ] || \
+              [ "$(/usr/bin/id -g mento-vercel-build)" != "$build_gid" ] || \
+              [ "$(/usr/bin/getent group mento-vercel-build | /usr/bin/cut -d: -f3)" != "$build_gid" ]; then
+              echo "Candidate identity no longer matches its runner-owned marker" >&2
+              exit 1
+            fi
+            sudo --non-interactive /usr/bin/pkill -KILL -u "$build_uid" >/dev/null 2>&1 || true
+            for _ in $(/usr/bin/seq 1 50); do
+              if ! sudo --non-interactive /usr/bin/pgrep -u "$build_uid" >/dev/null 2>&1; then break; fi
+              /bin/sleep 0.1
+            done
+            if sudo --non-interactive /usr/bin/pgrep -u "$build_uid" >/dev/null 2>&1; then
+              sudo --non-interactive /usr/bin/pgrep -a -u "$build_uid" >&2 || true
+              echo "Candidate processes survived final boundary teardown" >&2
+              exit 1
+            fi
+            sudo --non-interactive /usr/sbin/userdel mento-vercel-build
+            if /usr/bin/getent group mento-vercel-build >/dev/null; then
+              if [ "$(/usr/bin/getent group mento-vercel-build | /usr/bin/cut -d: -f3)" != "$build_gid" ]; then
+                echo "Candidate group changed during teardown" >&2
+                exit 1
+              fi
+              sudo --non-interactive /usr/sbin/groupdel mento-vercel-build
+            fi
+            /bin/rm -f -- "$identity_marker"
+          else
+            echo "Candidate identity marker is malformed" >&2
+            exit 1
+          fi
+        fi
+        materialized_environment_path="$RUNNER_TEMP/mento-vercel-production-build-environment"
+        for path in "$CANDIDATE_HOME_PATH" "$CANDIDATE_SOURCE_PATH" "$PULL_STAGING_PATH" "$materialized_environment_path"; do
+          case "$path" in
+            "$RUNNER_TEMP"/mento-vercel-*) ;;
+            *) echo "Refusing to clean an unexpected path" >&2; exit 1 ;;
+          esac
+        done
+        sudo --non-interactive /bin/rm -rf -- \
+          "$CANDIDATE_HOME_PATH" \
+          "$CANDIDATE_SOURCE_PATH" \
+          "$PULL_STAGING_PATH" \
+          "$materialized_environment_path"
+        /bin/rm -f -- "${CANDIDATE_SOURCE_PATH}.provenance.json"
+
+    - name: Assert immutable runner-owned upload handoff
+      if: steps.build.outcome == 'success' && steps.handoff.outcome == 'success'
+      shell: bash
+      env:
+        CONTROLLER_PATH: ${{ inputs.controller-path }}
+        DEPLOY_SHA: ${{ inputs.deploy-sha }}
+        EXPECTED_OUTPUT_GID: ${{ steps.handoff.outputs.upload_gid }}
+        EXPECTED_OUTPUT_UID: ${{ steps.handoff.outputs.upload_uid }}
+        EXPECTED_ROOT_DIRECTORY: ${{ inputs.expected-root-directory }}
+        LOGICAL_TARGET: ${{ inputs.logical-target }}
+        MENTO_NEXT_DEPLOYMENT_ID: ${{ inputs.next-deployment-id }}
+        NODE_BIN: ${{ inputs.node-bin }}
+        SOURCE_PATH: ${{ inputs.upload-source-path }}
+        VERCEL_ORG_ID: ${{ inputs.vercel-org-id }}
+        VERCEL_PROJECT_ID: ${{ inputs.vercel-project-id }}
+      run: |
+        set -euo pipefail
+        if [ -e "$RUNNER_TEMP/mento-vercel-production-candidate-identity" ] || \
+          [ -L "$RUNNER_TEMP/mento-vercel-production-candidate-identity" ] || \
+          /usr/bin/getent passwd mento-vercel-build >/dev/null || \
+          /usr/bin/getent group mento-vercel-build >/dev/null; then
+          echo "Candidate identity survived the upload handoff" >&2
+          exit 1
+        fi
+        DEPLOY_SHA="$DEPLOY_SHA" \
+        EXPECTED_OUTPUT_GID="$EXPECTED_OUTPUT_GID" \
+        EXPECTED_OUTPUT_UID="$EXPECTED_OUTPUT_UID" \
+        EXPECTED_PROVENANCE_UID="$(id -u)" \
+        EXPECTED_ROOT_DIRECTORY="$EXPECTED_ROOT_DIRECTORY" \
+        LOGICAL_TARGET="$LOGICAL_TARGET" \
+        MENTO_NEXT_DEPLOYMENT_ID="$MENTO_NEXT_DEPLOYMENT_ID" \
+        SOURCE_PATH="$SOURCE_PATH" \
+        VERCEL_ORG_ID="$VERCEL_ORG_ID" \
+        VERCEL_PROJECT_ID="$VERCEL_PROJECT_ID" \
+          "$NODE_BIN" "$CONTROLLER_PATH/scripts/vercel-production-shadow.mjs" assert-output

--- a/.github/actions/vercel-protected-runtime/action.yml
+++ b/.github/actions/vercel-protected-runtime/action.yml
@@ -1,0 +1,100 @@
+name: Prepare protected Vercel runtime
+description: Install pinned Node, pnpm, and Vercel CLI files outside candidate control
+
+inputs:
+  controller-path:
+    description: Trusted workflow-controller checkout
+    required: true
+  source-path:
+    description: Runner-owned exact-SHA source checkout used only for cache provenance
+    required: true
+  tools-path:
+    description: Fresh runner-owned path under RUNNER_TEMP for the pinned Vercel CLI
+    required: true
+
+outputs:
+  node-bin:
+    description: Canonical protected Node executable
+    value: ${{ steps.runtime.outputs.node_bin }}
+  pnpm-bin:
+    description: Canonical protected pnpm executable
+    value: ${{ steps.runtime.outputs.pnpm_bin }}
+  vercel-cli:
+    description: Canonical protected Vercel CLI entry point
+    value: ${{ steps.runtime.outputs.vercel_cli }}
+
+runs:
+  using: composite
+  steps:
+    - name: Set up pinned pnpm
+      uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v4
+      with:
+        version: 10.34.4
+
+    - name: Set up pinned Node.js and pnpm cache
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      with:
+        node-version: 22
+        cache: pnpm
+        cache-dependency-path: ${{ inputs.source-path }}/pnpm-lock.yaml
+
+    - name: Materialize protected pinned Vercel CLI
+      id: runtime
+      shell: bash
+      env:
+        CONTROLLER_PATH: ${{ inputs.controller-path }}
+        SOURCE_PATH: ${{ inputs.source-path }}
+        TRUSTED_VERCEL_TOOLS_PATH: ${{ inputs.tools-path }}
+      run: |
+        set -euo pipefail
+        umask 077
+        controller_path="$(realpath "$CONTROLLER_PATH")"
+        source_path="$(realpath "$SOURCE_PATH")"
+        case "$TRUSTED_VERCEL_TOOLS_PATH" in
+          "$RUNNER_TEMP"/mento-vercel-*) ;;
+          *) echo "Protected Vercel tools path is outside RUNNER_TEMP" >&2; exit 1 ;;
+        esac
+        if [ -e "$TRUSTED_VERCEL_TOOLS_PATH" ]; then
+          echo "Protected Vercel tools path must be fresh" >&2
+          exit 1
+        fi
+        /usr/bin/install -d -m 0755 "$TRUSTED_VERCEL_TOOLS_PATH"
+        node_bin="$(realpath "$(command -v node)")"
+        pnpm_bin="$(realpath "$(command -v pnpm)")"
+        for path in "$controller_path" "$source_path" "$node_bin" "$pnpm_bin"; do
+          if [ ! -e "$path" ] || [ -L "$path" ]; then
+            echo "Protected runtime prerequisite is missing or symbolic" >&2
+            exit 1
+          fi
+        done
+        trusted_modules_dir="$(
+          /usr/bin/realpath -m \
+            --relative-to="$controller_path" \
+            "$TRUSTED_VERCEL_TOOLS_PATH/node_modules"
+        )"
+        if [ -z "$trusted_modules_dir" ] || [[ "$trusted_modules_dir" = /* ]]; then
+          echo "Protected pnpm modules path is not relative" >&2
+          exit 1
+        fi
+        env -u GITHUB_ENV -u GITHUB_OUTPUT -u GITHUB_PATH -u GITHUB_STATE \
+          -u GITHUB_STEP_SUMMARY \
+          "$pnpm_bin" --dir "$controller_path" --filter frontend-monorepo install \
+          --frozen-lockfile \
+          --ignore-scripts \
+          --modules-dir "$trusted_modules_dir" \
+          --package-import-method copy \
+          --virtual-store-dir "$trusted_modules_dir/.pnpm"
+        /bin/chmod -R a+rX,go-w "$TRUSTED_VERCEL_TOOLS_PATH"
+        vercel_cli="$(realpath "$TRUSTED_VERCEL_TOOLS_PATH/node_modules/vercel/dist/index.js")"
+        case "$vercel_cli" in
+          "$TRUSTED_VERCEL_TOOLS_PATH"/*) ;;
+          *) echo "Pinned Vercel CLI escaped its protected directory" >&2; exit 1 ;;
+        esac
+        if [ ! -f "$vercel_cli" ] || [ -L "$vercel_cli" ]; then
+          echo "Pinned Vercel CLI is not a regular file" >&2
+          exit 1
+        fi
+        "$node_bin" "$vercel_cli" --version >/dev/null
+        echo "node_bin=$node_bin" >> "$GITHUB_OUTPUT"
+        echo "pnpm_bin=$pnpm_bin" >> "$GITHUB_OUTPUT"
+        echo "vercel_cli=$vercel_cli" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ci-failure-notifier.yml
+++ b/.github/workflows/ci-failure-notifier.yml
@@ -11,6 +11,7 @@ on:
       - Quality Budgets
       - Scorecard supply-chain security
       - Supply Chain
+      - Vercel Production Shadow
       - Visual Regression
     types: [completed]
 

--- a/.github/workflows/vercel-production-shadow.yml
+++ b/.github/workflows/vercel-production-shadow.yml
@@ -908,7 +908,7 @@ jobs:
           PRODUCTION_SHADOW_URL: ${{ needs.governance.outputs.deployment_url }}
         run: |
           node scripts/vercel-production-shadow.mjs health --url "$PRODUCTION_SHADOW_URL"
-          env -u GITHUB_ENV -u GITHUB_OUTPUT -u GITHUB_PATH -u GITHUB_STATE -u GITHUB_STEP_SUMMARY pnpm --filter app.mento.org exec playwright test -c apps/app.mento.org/playwright.production-shadow.config.ts
+          env -u GITHUB_ENV -u GITHUB_OUTPUT -u GITHUB_PATH -u GITHUB_STATE -u GITHUB_STEP_SUMMARY pnpm --filter app.mento.org exec playwright test -c playwright.production-shadow.config.ts
       - name: Upload governance browser diagnostics on failure
         if: failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -954,7 +954,7 @@ jobs:
           PRODUCTION_SHADOW_URL: ${{ needs.reserve.outputs.deployment_url }}
         run: |
           node scripts/vercel-production-shadow.mjs health --url "$PRODUCTION_SHADOW_URL"
-          env -u GITHUB_ENV -u GITHUB_OUTPUT -u GITHUB_PATH -u GITHUB_STATE -u GITHUB_STEP_SUMMARY pnpm --filter app.mento.org exec playwright test -c apps/app.mento.org/playwright.production-shadow.config.ts
+          env -u GITHUB_ENV -u GITHUB_OUTPUT -u GITHUB_PATH -u GITHUB_STATE -u GITHUB_STEP_SUMMARY pnpm --filter app.mento.org exec playwright test -c playwright.production-shadow.config.ts
       - name: Upload reserve browser diagnostics on failure
         if: failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -1000,7 +1000,7 @@ jobs:
           PRODUCTION_SHADOW_URL: ${{ needs.ui.outputs.deployment_url }}
         run: |
           node scripts/vercel-production-shadow.mjs health --url "$PRODUCTION_SHADOW_URL"
-          env -u GITHUB_ENV -u GITHUB_OUTPUT -u GITHUB_PATH -u GITHUB_STATE -u GITHUB_STEP_SUMMARY pnpm --filter app.mento.org exec playwright test -c apps/app.mento.org/playwright.production-shadow.config.ts
+          env -u GITHUB_ENV -u GITHUB_OUTPUT -u GITHUB_PATH -u GITHUB_STATE -u GITHUB_STEP_SUMMARY pnpm --filter app.mento.org exec playwright test -c playwright.production-shadow.config.ts
       - name: Upload UI browser diagnostics on failure
         if: failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/vercel-production-shadow.yml
+++ b/.github/workflows/vercel-production-shadow.yml
@@ -1,0 +1,1157 @@
+name: Vercel Production Shadow
+
+# Manual, non-activating production pilot. Ordinary projects upload unaliased
+# production artifacts; app custom v3 is build-only because the pinned CLI has
+# no documented no-alias custom-environment deploy.
+#checkov:skip=CKV_GHA_7:Immutable SHA and reviewed alias inputs are mandatory for this manual pilot.
+on:
+  workflow_dispatch:
+    inputs:
+      deploy_sha:
+        description: Full immutable current-main commit SHA to build
+        required: true
+        type: string
+      app_v3_aliases_json:
+        description: Reviewed JSON array of every intentional app v3 alias
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+env:
+  SOURCE_PATH: source
+  TRUSTED_POST_BUILD_PATH: trusted-after-build
+
+concurrency:
+  group: vercel-production-shadow
+  cancel-in-progress: false
+
+jobs:
+  preflight:
+    name: Validate immutable main source
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      deploy_sha: ${{ steps.source.outputs.deploy_sha }}
+      started_at_ms: ${{ steps.timing.outputs.started_at_ms }}
+    steps:
+      - name: Start workflow timing
+        id: timing
+        run: echo "started_at_ms=$(date +%s%3N)" >> "$GITHUB_OUTPUT"
+
+      - name: Check out trusted workflow controller
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+          ref: ${{ github.workflow_sha }}
+
+      - name: Validate trusted dispatch context
+        env:
+          DEPLOY_SHA: ${{ inputs.deploy_sha }}
+        run: node scripts/vercel-production-shadow.mjs validate-context
+
+      - name: Check out exact requested source
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+          path: source
+          persist-credentials: false
+          ref: ${{ inputs.deploy_sha }}
+
+      - name: Fetch main and prove immutable source
+        id: source
+        env:
+          DEPLOY_SHA: ${{ inputs.deploy_sha }}
+          GITHUB_WORKFLOW_SHA: ${{ github.workflow_sha }}
+        run: |
+          git -C "$SOURCE_PATH" fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
+          node scripts/vercel-production-shadow.mjs validate-source
+
+  baseline:
+    name: Capture protected-domain baseline
+    needs: [preflight]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment:
+      name: vercel-cli-production
+      deployment: false
+    outputs:
+      snapshot: ${{ steps.emit.outputs.snapshot }}
+    steps:
+      - name: Check out trusted workflow controller
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+          ref: ${{ needs.preflight.outputs.deploy_sha }}
+
+      - name: Check out exact deployment source
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+          path: source
+          persist-credentials: false
+          ref: ${{ needs.preflight.outputs.deploy_sha }}
+
+      - name: Prove exact checked-out source
+        env:
+          DEPLOY_SHA: ${{ needs.preflight.outputs.deploy_sha }}
+          GITHUB_WORKFLOW_SHA: ${{ needs.preflight.outputs.deploy_sha }}
+        run: |
+          git -C "$SOURCE_PATH" fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
+          node scripts/vercel-production-shadow.mjs validate-source
+
+      - name: Materialize reviewed protected-alias specification
+        env:
+          APP_V3_ALIASES_JSON: ${{ inputs.app_v3_aliases_json }}
+          VERCEL_PROJECT_ID_APP: ${{ vars.VERCEL_PROJECT_ID_APP }}
+          VERCEL_PROJECT_ID_GOVERNANCE: ${{ vars.VERCEL_PROJECT_ID_GOVERNANCE }}
+          VERCEL_PROJECT_ID_RESERVE: ${{ vars.VERCEL_PROJECT_ID_RESERVE }}
+          VERCEL_PROJECT_ID_UI: ${{ vars.VERCEL_PROJECT_ID_UI }}
+        run: node scripts/vercel-production-shadow.mjs create-spec --output "$RUNNER_TEMP/protected-spec.json"
+
+      - name: Capture canonical Vercel state
+        env:
+          VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN_PRODUCTION }}
+        run: >-
+          node scripts/vercel-deployment-state.mjs snapshot
+          --spec "$RUNNER_TEMP/protected-spec.json"
+          --output "$RUNNER_TEMP/baseline.json"
+
+      - name: Verify every protected public hostname is healthy
+        run: node scripts/vercel-production-shadow.mjs health --spec "$RUNNER_TEMP/protected-spec.json"
+
+      - name: Scan canonical evidence for forbidden fields
+        run: |
+          set -o noclobber
+          printf '["%s"]\n' "$RUNNER_TEMP/baseline.json" > "$RUNNER_TEMP/evidence-files.json"
+          node scripts/vercel-production-shadow.mjs evidence --files "$RUNNER_TEMP/evidence-files.json"
+
+      - name: Emit canonical baseline
+        id: emit
+        run: node scripts/vercel-production-shadow.mjs emit-output --name snapshot --input "$RUNNER_TEMP/baseline.json"
+
+  app:
+    name: Build app custom v3 (Outcome B)
+    needs: [preflight, baseline]
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    environment:
+      name: vercel-cli-production
+      deployment: false
+    outputs:
+      next_deployment_id: ${{ steps.identity.outputs.next_deployment_id }}
+      build_duration_ms: ${{ steps.build.outputs.build_duration_ms }}
+      turbo_cache_hits: ${{ steps.build.outputs.turbo_cache_hits }}
+      turbo_cache_misses: ${{ steps.build.outputs.turbo_cache_misses }}
+      total_duration_ms: ${{ steps.total.outputs.total_duration_ms }}
+    steps:
+      - name: Start app job timing
+        id: timing
+        run: echo "started_at_ms=$(date +%s%3N)" >> "$GITHUB_OUTPUT"
+
+      - name: Check out trusted workflow controller
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+          ref: ${{ needs.preflight.outputs.deploy_sha }}
+
+      - name: Check out exact deployment source
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+          path: source
+          persist-credentials: false
+          ref: ${{ needs.preflight.outputs.deploy_sha }}
+
+      - name: Prove exact checked-out source
+        env:
+          DEPLOY_SHA: ${{ needs.preflight.outputs.deploy_sha }}
+          GITHUB_WORKFLOW_SHA: ${{ needs.preflight.outputs.deploy_sha }}
+        run: |
+          git -C "$SOURCE_PATH" fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
+          node scripts/vercel-production-shadow.mjs validate-source
+
+      - name: Prepare protected app build runtime
+        id: runtime
+        uses: ./.github/actions/vercel-protected-runtime
+        with:
+          controller-path: ${{ github.workspace }}
+          source-path: ${{ github.workspace }}/source
+          tools-path: ${{ runner.temp }}/mento-vercel-production-tools
+
+      - name: Verify pinned Vercel prerequisites
+        run: ${{ steps.runtime.outputs.node-bin }} scripts/vercel-prebuilt.mjs check-versions --repo-root "$SOURCE_PATH"
+
+      - name: Prepare runner-owned app pull staging
+        env:
+          LOGICAL_TARGET: app
+          PULL_STAGING_PATH: ${{ runner.temp }}/mento-vercel-production-pull-staging
+          SOURCE_PATH: ${{ runner.temp }}/mento-vercel-production-pull-staging
+          VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ vars.VERCEL_PROJECT_ID_APP }}
+        run: ${{ steps.runtime.outputs.node-bin }} scripts/vercel-production-shadow.mjs prepare-pull-staging
+
+      - name: Pull app custom-v3 configuration
+        env:
+          LOGICAL_TARGET: app
+          SOURCE_PATH: ${{ runner.temp }}/mento-vercel-production-pull-staging
+          TRUSTED_NODE_PATH: ${{ steps.runtime.outputs.node-bin }}
+          TRUSTED_VERCEL_CLI_PATH: ${{ steps.runtime.outputs.vercel-cli }}
+          VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ vars.VERCEL_PROJECT_ID_APP }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN_PRODUCTION }}
+        run: ${{ steps.runtime.outputs.node-bin }} scripts/vercel-production-shadow.mjs pull
+
+      - name: Validate app project link and Root Directory
+        env:
+          LOGICAL_TARGET: app
+          PULL_STAGING_PATH: ${{ runner.temp }}/mento-vercel-production-pull-staging
+          SOURCE_PATH: ${{ runner.temp }}/mento-vercel-production-pull-staging
+          VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ vars.VERCEL_PROJECT_ID_APP }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN_PRODUCTION }}
+        run: |
+          "${{ steps.runtime.outputs.node-bin }}" scripts/vercel-production-shadow.mjs validate-pull-staging
+          "${{ steps.runtime.outputs.node-bin }}" scripts/vercel-deployment-state.mjs project --project-id "$VERCEL_PROJECT_ID" --project-name app.mento.org --root-directory apps/app.mento.org
+
+      - name: Generate exact app build deployment ID
+        id: identity
+        env:
+          DEPLOY_SHA: ${{ needs.preflight.outputs.deploy_sha }}
+        run: |
+          next_deployment_id="$("${{ steps.runtime.outputs.node-bin }}" scripts/vercel-prebuilt.mjs deployment-id --target app --sha "$DEPLOY_SHA" --run-id "$GITHUB_RUN_ID" --run-attempt "$GITHUB_RUN_ATTEMPT")"
+          echo "next_deployment_id=$next_deployment_id" >> "$GITHUB_OUTPUT"
+
+      - name: Build app custom v3 and assert output
+        id: build
+        env:
+          CI: 1
+          LOGICAL_TARGET: app
+          MENTO_NEXT_DEPLOYMENT_ID: ${{ steps.identity.outputs.next_deployment_id }}
+          NEXT_PUBLIC_VERCEL_ENV: preview
+          TURBO_REMOTE_CACHE_SIGNATURE_KEY: ${{ secrets.TURBO_REMOTE_CACHE_SIGNATURE_KEY }}
+          TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+          TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+          VERCEL: 1
+          VERCEL_ENV: preview
+          VERCEL_GIT_COMMIT_REF: main
+          VERCEL_GIT_COMMIT_SHA: ${{ needs.preflight.outputs.deploy_sha }}
+          VERCEL_GIT_PROVIDER: github
+          VERCEL_GIT_REPO_OWNER: mento-protocol
+          VERCEL_GIT_REPO_SLUG: frontend-monorepo
+          VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ vars.VERCEL_PROJECT_ID_APP }}
+          VERCEL_TARGET_ENV: v3
+        uses: ./.github/actions/vercel-candidate-build
+        with:
+          controller-path: ${{ github.workspace }}
+          source-path: ${{ github.workspace }}/source
+          candidate-source-path: ${{ runner.temp }}/mento-vercel-production-candidate-source
+          candidate-home-path: ${{ runner.temp }}/mento-vercel-production-candidate-home
+          pull-staging-path: ${{ runner.temp }}/mento-vercel-production-pull-staging
+          upload-source-path: ${{ runner.temp }}/mento-vercel-production-upload-source
+          node-bin: ${{ steps.runtime.outputs.node-bin }}
+          pnpm-bin: ${{ steps.runtime.outputs.pnpm-bin }}
+          vercel-cli: ${{ steps.runtime.outputs.vercel-cli }}
+          deploy-sha: ${{ needs.preflight.outputs.deploy_sha }}
+          next-deployment-id: ${{ steps.identity.outputs.next_deployment_id }}
+          logical-target: app
+          expected-root-directory: apps/app.mento.org
+          vercel-org-id: ${{ vars.VERCEL_ORG_ID }}
+          vercel-project-id: ${{ vars.VERCEL_PROJECT_ID_APP }}
+
+      - name: Restore trusted controller after candidate build
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 1
+          path: trusted-after-build
+          persist-credentials: false
+          ref: ${{ needs.preflight.outputs.deploy_sha }}
+
+      - name: Record static app Outcome B proof
+        env:
+          DEPLOY_SHA: ${{ needs.preflight.outputs.deploy_sha }}
+          MENTO_NEXT_DEPLOYMENT_ID: ${{ steps.identity.outputs.next_deployment_id }}
+        run: |
+          node "$TRUSTED_POST_BUILD_PATH/scripts/vercel-production-shadow.mjs" app-proof --output "$RUNNER_TEMP/app-proof.json"
+          set -o noclobber
+          printf '["%s"]\n' "$RUNNER_TEMP/app-proof.json" > "$RUNNER_TEMP/evidence-files.json"
+          node "$TRUSTED_POST_BUILD_PATH/scripts/vercel-production-shadow.mjs" evidence --files "$RUNNER_TEMP/evidence-files.json"
+
+      - name: Measure app job duration
+        id: total
+        env:
+          STARTED_AT_MS: ${{ steps.timing.outputs.started_at_ms }}
+        run: echo "total_duration_ms=$(($(date +%s%3N) - STARTED_AT_MS))" >> "$GITHUB_OUTPUT"
+
+  governance:
+    name: Stage governance production
+    needs: [preflight, baseline]
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+    environment:
+      name: vercel-cli-production
+      deployment: false
+    outputs:
+      deployment_id: ${{ steps.deploy.outputs.vercel_deployment_id }}
+      deployment_url: ${{ steps.deploy.outputs.vercel_deployment_url }}
+      next_deployment_id: ${{ steps.identity.outputs.next_deployment_id }}
+      build_duration_ms: ${{ steps.build.outputs.build_duration_ms }}
+      turbo_cache_hits: ${{ steps.build.outputs.turbo_cache_hits }}
+      turbo_cache_misses: ${{ steps.build.outputs.turbo_cache_misses }}
+      deploy_duration_ms: ${{ steps.deploy.outputs.deploy_duration_ms }}
+      total_duration_ms: ${{ steps.total.outputs.total_duration_ms }}
+    steps:
+      - name: Start governance job timing
+        id: timing
+        run: echo "started_at_ms=$(date +%s%3N)" >> "$GITHUB_OUTPUT"
+
+      - name: Check out trusted workflow controller
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+          ref: ${{ needs.preflight.outputs.deploy_sha }}
+      - name: Check out exact deployment source
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+          path: source
+          persist-credentials: false
+          ref: ${{ needs.preflight.outputs.deploy_sha }}
+      - name: Prove exact checked-out source
+        env:
+          DEPLOY_SHA: ${{ needs.preflight.outputs.deploy_sha }}
+          GITHUB_WORKFLOW_SHA: ${{ needs.preflight.outputs.deploy_sha }}
+        run: |
+          git -C "$SOURCE_PATH" fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
+          node scripts/vercel-production-shadow.mjs validate-source
+      - name: Prepare protected governance build runtime
+        id: runtime
+        uses: ./.github/actions/vercel-protected-runtime
+        with:
+          controller-path: ${{ github.workspace }}
+          source-path: ${{ github.workspace }}/source
+          tools-path: ${{ runner.temp }}/mento-vercel-production-tools
+      - name: Verify pinned Vercel prerequisites
+        run: ${{ steps.runtime.outputs.node-bin }} scripts/vercel-prebuilt.mjs check-versions --repo-root "$SOURCE_PATH"
+      - name: Prepare runner-owned governance pull staging
+        env:
+          LOGICAL_TARGET: governance
+          PULL_STAGING_PATH: ${{ runner.temp }}/mento-vercel-production-pull-staging
+          SOURCE_PATH: ${{ runner.temp }}/mento-vercel-production-pull-staging
+          VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ vars.VERCEL_PROJECT_ID_GOVERNANCE }}
+        run: ${{ steps.runtime.outputs.node-bin }} scripts/vercel-production-shadow.mjs prepare-pull-staging
+      - name: Pull governance production configuration
+        env:
+          LOGICAL_TARGET: governance
+          SOURCE_PATH: ${{ runner.temp }}/mento-vercel-production-pull-staging
+          TRUSTED_NODE_PATH: ${{ steps.runtime.outputs.node-bin }}
+          TRUSTED_VERCEL_CLI_PATH: ${{ steps.runtime.outputs.vercel-cli }}
+          VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ vars.VERCEL_PROJECT_ID_GOVERNANCE }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN_PRODUCTION }}
+        run: ${{ steps.runtime.outputs.node-bin }} scripts/vercel-production-shadow.mjs pull
+      - name: Validate governance project link and Root Directory
+        env:
+          LOGICAL_TARGET: governance
+          PULL_STAGING_PATH: ${{ runner.temp }}/mento-vercel-production-pull-staging
+          SOURCE_PATH: ${{ runner.temp }}/mento-vercel-production-pull-staging
+          VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ vars.VERCEL_PROJECT_ID_GOVERNANCE }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN_PRODUCTION }}
+        run: |
+          "${{ steps.runtime.outputs.node-bin }}" scripts/vercel-production-shadow.mjs validate-pull-staging
+          "${{ steps.runtime.outputs.node-bin }}" scripts/vercel-deployment-state.mjs project --project-id "$VERCEL_PROJECT_ID" --project-name governance.mento.org --root-directory apps/governance.mento.org
+      - name: Generate exact governance build deployment ID
+        id: identity
+        env:
+          DEPLOY_SHA: ${{ needs.preflight.outputs.deploy_sha }}
+        run: |
+          next_deployment_id="$("${{ steps.runtime.outputs.node-bin }}" scripts/vercel-prebuilt.mjs deployment-id --target governance --sha "$DEPLOY_SHA" --run-id "$GITHUB_RUN_ID" --run-attempt "$GITHUB_RUN_ATTEMPT")"
+          echo "next_deployment_id=$next_deployment_id" >> "$GITHUB_OUTPUT"
+      - name: Build governance production and assert output
+        id: build
+        env:
+          CI: 1
+          ETHERSCAN_API_KEY: ${{ secrets.ETHERSCAN_API_KEY }}
+          LOGICAL_TARGET: governance
+          MENTO_NEXT_DEPLOYMENT_ID: ${{ steps.identity.outputs.next_deployment_id }}
+          NEXT_PUBLIC_VERCEL_ENV: production
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          TURBO_REMOTE_CACHE_SIGNATURE_KEY: ${{ secrets.TURBO_REMOTE_CACHE_SIGNATURE_KEY }}
+          TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+          TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+          VERCEL: 1
+          VERCEL_ENV: production
+          VERCEL_GIT_COMMIT_REF: main
+          VERCEL_GIT_COMMIT_SHA: ${{ needs.preflight.outputs.deploy_sha }}
+          VERCEL_GIT_PROVIDER: github
+          VERCEL_GIT_REPO_OWNER: mento-protocol
+          VERCEL_GIT_REPO_SLUG: frontend-monorepo
+          VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ vars.VERCEL_PROJECT_ID_GOVERNANCE }}
+          VERCEL_TARGET_ENV: production
+        uses: ./.github/actions/vercel-candidate-build
+        with:
+          controller-path: ${{ github.workspace }}
+          source-path: ${{ github.workspace }}/source
+          candidate-source-path: ${{ runner.temp }}/mento-vercel-production-candidate-source
+          candidate-home-path: ${{ runner.temp }}/mento-vercel-production-candidate-home
+          pull-staging-path: ${{ runner.temp }}/mento-vercel-production-pull-staging
+          upload-source-path: ${{ runner.temp }}/mento-vercel-production-upload-source
+          node-bin: ${{ steps.runtime.outputs.node-bin }}
+          pnpm-bin: ${{ steps.runtime.outputs.pnpm-bin }}
+          vercel-cli: ${{ steps.runtime.outputs.vercel-cli }}
+          deploy-sha: ${{ needs.preflight.outputs.deploy_sha }}
+          next-deployment-id: ${{ steps.identity.outputs.next_deployment_id }}
+          logical-target: governance
+          expected-root-directory: apps/governance.mento.org
+          vercel-org-id: ${{ vars.VERCEL_ORG_ID }}
+          vercel-project-id: ${{ vars.VERCEL_PROJECT_ID_GOVERNANCE }}
+      - name: Restore trusted controller after candidate build
+        id: trusted
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 1
+          path: trusted-after-build
+          persist-credentials: false
+          ref: ${{ needs.preflight.outputs.deploy_sha }}
+      - name: Upload unchanged governance output without domains
+        id: deploy
+        env:
+          DEPLOY_SHA: ${{ needs.preflight.outputs.deploy_sha }}
+          LOGICAL_TARGET: governance
+          SOURCE_PATH: ${{ runner.temp }}/mento-vercel-production-upload-source
+          TRUSTED_NODE_PATH: ${{ steps.runtime.outputs.node-bin }}
+          TRUSTED_VERCEL_CLI_PATH: ${{ steps.runtime.outputs.vercel-cli }}
+          VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ vars.VERCEL_PROJECT_ID_GOVERNANCE }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN_PRODUCTION }}
+        run: node "$TRUSTED_POST_BUILD_PATH/scripts/vercel-production-shadow.mjs" deploy --expected "$RUNNER_TEMP/governance-expected.json"
+      - name: Fail read-only on protected alias drift after governance deploy
+        if: ${{ always() && steps.build.outcome == 'success' && steps.trusted.outcome == 'success' }}
+        env:
+          BASELINE_JSON: ${{ needs.baseline.outputs.snapshot }}
+          VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN_PRODUCTION }}
+        run: >-
+          node "$TRUSTED_POST_BUILD_PATH/scripts/vercel-production-shadow.mjs"
+          check-aliases
+      - name: Prove every protected mapping remains unchanged
+        env:
+          APP_V3_ALIASES_JSON: ${{ inputs.app_v3_aliases_json }}
+          BASELINE_JSON: ${{ needs.baseline.outputs.snapshot }}
+          VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID_APP: ${{ vars.VERCEL_PROJECT_ID_APP }}
+          VERCEL_PROJECT_ID_GOVERNANCE: ${{ vars.VERCEL_PROJECT_ID_GOVERNANCE }}
+          VERCEL_PROJECT_ID_RESERVE: ${{ vars.VERCEL_PROJECT_ID_RESERVE }}
+          VERCEL_PROJECT_ID_UI: ${{ vars.VERCEL_PROJECT_ID_UI }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN_PRODUCTION }}
+        run: |
+          umask 077
+          set -o noclobber
+          printf '%s\n' "$BASELINE_JSON" > "$RUNNER_TEMP/governance-compare-baseline.json"
+          node "$TRUSTED_POST_BUILD_PATH/scripts/vercel-production-shadow.mjs" create-spec --output "$RUNNER_TEMP/protected-spec.json"
+          node "$TRUSTED_POST_BUILD_PATH/scripts/vercel-deployment-state.mjs" snapshot --spec "$RUNNER_TEMP/protected-spec.json" --output "$RUNNER_TEMP/current.json"
+          node "$TRUSTED_POST_BUILD_PATH/scripts/vercel-deployment-state.mjs" compare --before "$RUNNER_TEMP/governance-compare-baseline.json" --after "$RUNNER_TEMP/current.json"
+      - name: Verify governance deployment provenance and readiness
+        env:
+          VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN_PRODUCTION }}
+        run: |
+          verified=false
+          for attempt in {1..12}; do
+            echo "Verifying governance deployment (attempt $attempt/12)"
+            if node "$TRUSTED_POST_BUILD_PATH/scripts/vercel-deployment-state.mjs" deployment --expected "$RUNNER_TEMP/governance-expected.json" --output "$RUNNER_TEMP/governance-state.json"; then verified=true; break; fi
+            sleep 5
+          done
+          "$verified"
+          node "$TRUSTED_POST_BUILD_PATH/scripts/vercel-production-shadow.mjs" assert-unaliased --input "$RUNNER_TEMP/governance-state.json"
+      - name: Scan governance canonical evidence
+        run: |
+          set -o noclobber
+          printf '["%s","%s"]\n' "$RUNNER_TEMP/governance-state.json" "$RUNNER_TEMP/current.json" > "$RUNNER_TEMP/evidence-files.json"
+          node "$TRUSTED_POST_BUILD_PATH/scripts/vercel-production-shadow.mjs" evidence --files "$RUNNER_TEMP/evidence-files.json"
+      - name: Measure governance job duration
+        id: total
+        env:
+          STARTED_AT_MS: ${{ steps.timing.outputs.started_at_ms }}
+        run: echo "total_duration_ms=$(($(date +%s%3N) - STARTED_AT_MS))" >> "$GITHUB_OUTPUT"
+  reserve:
+    name: Stage reserve production
+    needs: [preflight, baseline, governance, smoke-governance]
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+    environment:
+      name: vercel-cli-production
+      deployment: false
+    outputs:
+      deployment_id: ${{ steps.deploy.outputs.vercel_deployment_id }}
+      deployment_url: ${{ steps.deploy.outputs.vercel_deployment_url }}
+      next_deployment_id: ${{ steps.identity.outputs.next_deployment_id }}
+      build_duration_ms: ${{ steps.build.outputs.build_duration_ms }}
+      turbo_cache_hits: ${{ steps.build.outputs.turbo_cache_hits }}
+      turbo_cache_misses: ${{ steps.build.outputs.turbo_cache_misses }}
+      deploy_duration_ms: ${{ steps.deploy.outputs.deploy_duration_ms }}
+      total_duration_ms: ${{ steps.total.outputs.total_duration_ms }}
+    steps:
+      - name: Start reserve job timing
+        id: timing
+        run: echo "started_at_ms=$(date +%s%3N)" >> "$GITHUB_OUTPUT"
+
+      - name: Check out trusted workflow controller
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+          ref: ${{ needs.preflight.outputs.deploy_sha }}
+      - name: Check out exact deployment source
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+          path: source
+          persist-credentials: false
+          ref: ${{ needs.preflight.outputs.deploy_sha }}
+      - name: Prove exact checked-out source
+        env:
+          DEPLOY_SHA: ${{ needs.preflight.outputs.deploy_sha }}
+          GITHUB_WORKFLOW_SHA: ${{ needs.preflight.outputs.deploy_sha }}
+        run: |
+          git -C "$SOURCE_PATH" fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
+          node scripts/vercel-production-shadow.mjs validate-source
+      - name: Prepare protected reserve build runtime
+        id: runtime
+        uses: ./.github/actions/vercel-protected-runtime
+        with:
+          controller-path: ${{ github.workspace }}
+          source-path: ${{ github.workspace }}/source
+          tools-path: ${{ runner.temp }}/mento-vercel-production-tools
+      - name: Verify pinned Vercel prerequisites
+        run: ${{ steps.runtime.outputs.node-bin }} scripts/vercel-prebuilt.mjs check-versions --repo-root "$SOURCE_PATH"
+      - name: Prepare runner-owned reserve pull staging
+        env:
+          LOGICAL_TARGET: reserve
+          PULL_STAGING_PATH: ${{ runner.temp }}/mento-vercel-production-pull-staging
+          SOURCE_PATH: ${{ runner.temp }}/mento-vercel-production-pull-staging
+          VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ vars.VERCEL_PROJECT_ID_RESERVE }}
+        run: ${{ steps.runtime.outputs.node-bin }} scripts/vercel-production-shadow.mjs prepare-pull-staging
+      - name: Pull reserve production configuration
+        env:
+          LOGICAL_TARGET: reserve
+          SOURCE_PATH: ${{ runner.temp }}/mento-vercel-production-pull-staging
+          TRUSTED_NODE_PATH: ${{ steps.runtime.outputs.node-bin }}
+          TRUSTED_VERCEL_CLI_PATH: ${{ steps.runtime.outputs.vercel-cli }}
+          VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ vars.VERCEL_PROJECT_ID_RESERVE }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN_PRODUCTION }}
+        run: ${{ steps.runtime.outputs.node-bin }} scripts/vercel-production-shadow.mjs pull
+      - name: Validate reserve project link and Root Directory
+        env:
+          LOGICAL_TARGET: reserve
+          PULL_STAGING_PATH: ${{ runner.temp }}/mento-vercel-production-pull-staging
+          SOURCE_PATH: ${{ runner.temp }}/mento-vercel-production-pull-staging
+          VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ vars.VERCEL_PROJECT_ID_RESERVE }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN_PRODUCTION }}
+        run: |
+          "${{ steps.runtime.outputs.node-bin }}" scripts/vercel-production-shadow.mjs validate-pull-staging
+          "${{ steps.runtime.outputs.node-bin }}" scripts/vercel-deployment-state.mjs project --project-id "$VERCEL_PROJECT_ID" --project-name reserve.mento.org --root-directory apps/reserve.mento.org
+      - name: Generate exact reserve build deployment ID
+        id: identity
+        env:
+          DEPLOY_SHA: ${{ needs.preflight.outputs.deploy_sha }}
+        run: |
+          next_deployment_id="$("${{ steps.runtime.outputs.node-bin }}" scripts/vercel-prebuilt.mjs deployment-id --target reserve --sha "$DEPLOY_SHA" --run-id "$GITHUB_RUN_ID" --run-attempt "$GITHUB_RUN_ATTEMPT")"
+          echo "next_deployment_id=$next_deployment_id" >> "$GITHUB_OUTPUT"
+      - name: Build reserve production and assert output
+        id: build
+        env:
+          CI: 1
+          LOGICAL_TARGET: reserve
+          MENTO_NEXT_DEPLOYMENT_ID: ${{ steps.identity.outputs.next_deployment_id }}
+          NEXT_PUBLIC_VERCEL_ENV: production
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          TURBO_REMOTE_CACHE_SIGNATURE_KEY: ${{ secrets.TURBO_REMOTE_CACHE_SIGNATURE_KEY }}
+          TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+          TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+          VERCEL: 1
+          VERCEL_ENV: production
+          VERCEL_GIT_COMMIT_REF: main
+          VERCEL_GIT_COMMIT_SHA: ${{ needs.preflight.outputs.deploy_sha }}
+          VERCEL_GIT_PROVIDER: github
+          VERCEL_GIT_REPO_OWNER: mento-protocol
+          VERCEL_GIT_REPO_SLUG: frontend-monorepo
+          VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ vars.VERCEL_PROJECT_ID_RESERVE }}
+          VERCEL_TARGET_ENV: production
+        uses: ./.github/actions/vercel-candidate-build
+        with:
+          controller-path: ${{ github.workspace }}
+          source-path: ${{ github.workspace }}/source
+          candidate-source-path: ${{ runner.temp }}/mento-vercel-production-candidate-source
+          candidate-home-path: ${{ runner.temp }}/mento-vercel-production-candidate-home
+          pull-staging-path: ${{ runner.temp }}/mento-vercel-production-pull-staging
+          upload-source-path: ${{ runner.temp }}/mento-vercel-production-upload-source
+          node-bin: ${{ steps.runtime.outputs.node-bin }}
+          pnpm-bin: ${{ steps.runtime.outputs.pnpm-bin }}
+          vercel-cli: ${{ steps.runtime.outputs.vercel-cli }}
+          deploy-sha: ${{ needs.preflight.outputs.deploy_sha }}
+          next-deployment-id: ${{ steps.identity.outputs.next_deployment_id }}
+          logical-target: reserve
+          expected-root-directory: apps/reserve.mento.org
+          vercel-org-id: ${{ vars.VERCEL_ORG_ID }}
+          vercel-project-id: ${{ vars.VERCEL_PROJECT_ID_RESERVE }}
+      - name: Restore trusted controller after candidate build
+        id: trusted
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 1
+          path: trusted-after-build
+          persist-credentials: false
+          ref: ${{ needs.preflight.outputs.deploy_sha }}
+      - name: Upload unchanged reserve output without domains
+        id: deploy
+        env:
+          DEPLOY_SHA: ${{ needs.preflight.outputs.deploy_sha }}
+          LOGICAL_TARGET: reserve
+          SOURCE_PATH: ${{ runner.temp }}/mento-vercel-production-upload-source
+          TRUSTED_NODE_PATH: ${{ steps.runtime.outputs.node-bin }}
+          TRUSTED_VERCEL_CLI_PATH: ${{ steps.runtime.outputs.vercel-cli }}
+          VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ vars.VERCEL_PROJECT_ID_RESERVE }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN_PRODUCTION }}
+        run: node "$TRUSTED_POST_BUILD_PATH/scripts/vercel-production-shadow.mjs" deploy --expected "$RUNNER_TEMP/reserve-expected.json"
+      - name: Fail read-only on protected alias drift after reserve deploy
+        if: ${{ always() && steps.build.outcome == 'success' && steps.trusted.outcome == 'success' }}
+        env:
+          BASELINE_JSON: ${{ needs.baseline.outputs.snapshot }}
+          VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN_PRODUCTION }}
+        run: >-
+          node "$TRUSTED_POST_BUILD_PATH/scripts/vercel-production-shadow.mjs"
+          check-aliases
+      - name: Prove every protected mapping remains unchanged
+        env:
+          APP_V3_ALIASES_JSON: ${{ inputs.app_v3_aliases_json }}
+          BASELINE_JSON: ${{ needs.baseline.outputs.snapshot }}
+          VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID_APP: ${{ vars.VERCEL_PROJECT_ID_APP }}
+          VERCEL_PROJECT_ID_GOVERNANCE: ${{ vars.VERCEL_PROJECT_ID_GOVERNANCE }}
+          VERCEL_PROJECT_ID_RESERVE: ${{ vars.VERCEL_PROJECT_ID_RESERVE }}
+          VERCEL_PROJECT_ID_UI: ${{ vars.VERCEL_PROJECT_ID_UI }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN_PRODUCTION }}
+        run: |
+          umask 077
+          set -o noclobber
+          printf '%s\n' "$BASELINE_JSON" > "$RUNNER_TEMP/reserve-compare-baseline.json"
+          node "$TRUSTED_POST_BUILD_PATH/scripts/vercel-production-shadow.mjs" create-spec --output "$RUNNER_TEMP/protected-spec.json"
+          node "$TRUSTED_POST_BUILD_PATH/scripts/vercel-deployment-state.mjs" snapshot --spec "$RUNNER_TEMP/protected-spec.json" --output "$RUNNER_TEMP/current.json"
+          node "$TRUSTED_POST_BUILD_PATH/scripts/vercel-deployment-state.mjs" compare --before "$RUNNER_TEMP/reserve-compare-baseline.json" --after "$RUNNER_TEMP/current.json"
+      - name: Verify reserve deployment provenance and readiness
+        env:
+          VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN_PRODUCTION }}
+        run: |
+          verified=false
+          for attempt in {1..12}; do
+            echo "Verifying reserve deployment (attempt $attempt/12)"
+            if node "$TRUSTED_POST_BUILD_PATH/scripts/vercel-deployment-state.mjs" deployment --expected "$RUNNER_TEMP/reserve-expected.json" --output "$RUNNER_TEMP/reserve-state.json"; then verified=true; break; fi
+            sleep 5
+          done
+          "$verified"
+          node "$TRUSTED_POST_BUILD_PATH/scripts/vercel-production-shadow.mjs" assert-unaliased --input "$RUNNER_TEMP/reserve-state.json"
+      - name: Scan reserve canonical evidence
+        run: |
+          set -o noclobber
+          printf '["%s","%s"]\n' "$RUNNER_TEMP/reserve-state.json" "$RUNNER_TEMP/current.json" > "$RUNNER_TEMP/evidence-files.json"
+          node "$TRUSTED_POST_BUILD_PATH/scripts/vercel-production-shadow.mjs" evidence --files "$RUNNER_TEMP/evidence-files.json"
+      - name: Measure reserve job duration
+        id: total
+        env:
+          STARTED_AT_MS: ${{ steps.timing.outputs.started_at_ms }}
+        run: echo "total_duration_ms=$(($(date +%s%3N) - STARTED_AT_MS))" >> "$GITHUB_OUTPUT"
+  ui:
+    name: Stage UI production
+    needs: [preflight, baseline, governance, reserve, smoke-reserve]
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+    environment:
+      name: vercel-cli-production
+      deployment: false
+    outputs:
+      deployment_id: ${{ steps.deploy.outputs.vercel_deployment_id }}
+      deployment_url: ${{ steps.deploy.outputs.vercel_deployment_url }}
+      next_deployment_id: ${{ steps.identity.outputs.next_deployment_id }}
+      build_duration_ms: ${{ steps.build.outputs.build_duration_ms }}
+      turbo_cache_hits: ${{ steps.build.outputs.turbo_cache_hits }}
+      turbo_cache_misses: ${{ steps.build.outputs.turbo_cache_misses }}
+      deploy_duration_ms: ${{ steps.deploy.outputs.deploy_duration_ms }}
+      total_duration_ms: ${{ steps.total.outputs.total_duration_ms }}
+    steps:
+      - name: Start UI job timing
+        id: timing
+        run: echo "started_at_ms=$(date +%s%3N)" >> "$GITHUB_OUTPUT"
+
+      - name: Check out trusted workflow controller
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+          ref: ${{ needs.preflight.outputs.deploy_sha }}
+      - name: Check out exact deployment source
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+          path: source
+          persist-credentials: false
+          ref: ${{ needs.preflight.outputs.deploy_sha }}
+      - name: Prove exact checked-out source
+        env:
+          DEPLOY_SHA: ${{ needs.preflight.outputs.deploy_sha }}
+          GITHUB_WORKFLOW_SHA: ${{ needs.preflight.outputs.deploy_sha }}
+        run: |
+          git -C "$SOURCE_PATH" fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
+          node scripts/vercel-production-shadow.mjs validate-source
+      - name: Prepare protected UI build runtime
+        id: runtime
+        uses: ./.github/actions/vercel-protected-runtime
+        with:
+          controller-path: ${{ github.workspace }}
+          source-path: ${{ github.workspace }}/source
+          tools-path: ${{ runner.temp }}/mento-vercel-production-tools
+      - name: Verify pinned Vercel prerequisites
+        run: ${{ steps.runtime.outputs.node-bin }} scripts/vercel-prebuilt.mjs check-versions --repo-root "$SOURCE_PATH"
+      - name: Prepare runner-owned UI pull staging
+        env:
+          LOGICAL_TARGET: ui
+          PULL_STAGING_PATH: ${{ runner.temp }}/mento-vercel-production-pull-staging
+          SOURCE_PATH: ${{ runner.temp }}/mento-vercel-production-pull-staging
+          VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ vars.VERCEL_PROJECT_ID_UI }}
+        run: ${{ steps.runtime.outputs.node-bin }} scripts/vercel-production-shadow.mjs prepare-pull-staging
+      - name: Pull UI production configuration
+        env:
+          LOGICAL_TARGET: ui
+          SOURCE_PATH: ${{ runner.temp }}/mento-vercel-production-pull-staging
+          TRUSTED_NODE_PATH: ${{ steps.runtime.outputs.node-bin }}
+          TRUSTED_VERCEL_CLI_PATH: ${{ steps.runtime.outputs.vercel-cli }}
+          VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ vars.VERCEL_PROJECT_ID_UI }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN_PRODUCTION }}
+        run: ${{ steps.runtime.outputs.node-bin }} scripts/vercel-production-shadow.mjs pull
+      - name: Validate UI project link and Root Directory
+        env:
+          LOGICAL_TARGET: ui
+          PULL_STAGING_PATH: ${{ runner.temp }}/mento-vercel-production-pull-staging
+          SOURCE_PATH: ${{ runner.temp }}/mento-vercel-production-pull-staging
+          VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ vars.VERCEL_PROJECT_ID_UI }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN_PRODUCTION }}
+        run: |
+          "${{ steps.runtime.outputs.node-bin }}" scripts/vercel-production-shadow.mjs validate-pull-staging
+          "${{ steps.runtime.outputs.node-bin }}" scripts/vercel-deployment-state.mjs project --project-id "$VERCEL_PROJECT_ID" --project-name ui.mento.org --root-directory apps/ui.mento.org
+      - name: Generate exact UI build deployment ID
+        id: identity
+        env:
+          DEPLOY_SHA: ${{ needs.preflight.outputs.deploy_sha }}
+        run: |
+          next_deployment_id="$("${{ steps.runtime.outputs.node-bin }}" scripts/vercel-prebuilt.mjs deployment-id --target ui --sha "$DEPLOY_SHA" --run-id "$GITHUB_RUN_ID" --run-attempt "$GITHUB_RUN_ATTEMPT")"
+          echo "next_deployment_id=$next_deployment_id" >> "$GITHUB_OUTPUT"
+      - name: Build UI production and assert output
+        id: build
+        env:
+          CI: 1
+          LOGICAL_TARGET: ui
+          MENTO_NEXT_DEPLOYMENT_ID: ${{ steps.identity.outputs.next_deployment_id }}
+          NEXT_PUBLIC_VERCEL_ENV: production
+          TURBO_REMOTE_CACHE_SIGNATURE_KEY: ${{ secrets.TURBO_REMOTE_CACHE_SIGNATURE_KEY }}
+          TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+          TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+          VERCEL: 1
+          VERCEL_ENV: production
+          VERCEL_GIT_COMMIT_REF: main
+          VERCEL_GIT_COMMIT_SHA: ${{ needs.preflight.outputs.deploy_sha }}
+          VERCEL_GIT_PROVIDER: github
+          VERCEL_GIT_REPO_OWNER: mento-protocol
+          VERCEL_GIT_REPO_SLUG: frontend-monorepo
+          VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ vars.VERCEL_PROJECT_ID_UI }}
+          VERCEL_TARGET_ENV: production
+        uses: ./.github/actions/vercel-candidate-build
+        with:
+          controller-path: ${{ github.workspace }}
+          source-path: ${{ github.workspace }}/source
+          candidate-source-path: ${{ runner.temp }}/mento-vercel-production-candidate-source
+          candidate-home-path: ${{ runner.temp }}/mento-vercel-production-candidate-home
+          pull-staging-path: ${{ runner.temp }}/mento-vercel-production-pull-staging
+          upload-source-path: ${{ runner.temp }}/mento-vercel-production-upload-source
+          node-bin: ${{ steps.runtime.outputs.node-bin }}
+          pnpm-bin: ${{ steps.runtime.outputs.pnpm-bin }}
+          vercel-cli: ${{ steps.runtime.outputs.vercel-cli }}
+          deploy-sha: ${{ needs.preflight.outputs.deploy_sha }}
+          next-deployment-id: ${{ steps.identity.outputs.next_deployment_id }}
+          logical-target: ui
+          expected-root-directory: apps/ui.mento.org
+          vercel-org-id: ${{ vars.VERCEL_ORG_ID }}
+          vercel-project-id: ${{ vars.VERCEL_PROJECT_ID_UI }}
+      - name: Restore trusted controller after candidate build
+        id: trusted
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 1
+          path: trusted-after-build
+          persist-credentials: false
+          ref: ${{ needs.preflight.outputs.deploy_sha }}
+      - name: Upload unchanged UI output without domains
+        id: deploy
+        env:
+          DEPLOY_SHA: ${{ needs.preflight.outputs.deploy_sha }}
+          LOGICAL_TARGET: ui
+          SOURCE_PATH: ${{ runner.temp }}/mento-vercel-production-upload-source
+          TRUSTED_NODE_PATH: ${{ steps.runtime.outputs.node-bin }}
+          TRUSTED_VERCEL_CLI_PATH: ${{ steps.runtime.outputs.vercel-cli }}
+          VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ vars.VERCEL_PROJECT_ID_UI }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN_PRODUCTION }}
+        run: node "$TRUSTED_POST_BUILD_PATH/scripts/vercel-production-shadow.mjs" deploy --expected "$RUNNER_TEMP/ui-expected.json"
+      - name: Fail read-only on protected alias drift after UI deploy
+        if: ${{ always() && steps.build.outcome == 'success' && steps.trusted.outcome == 'success' }}
+        env:
+          BASELINE_JSON: ${{ needs.baseline.outputs.snapshot }}
+          VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN_PRODUCTION }}
+        run: >-
+          node "$TRUSTED_POST_BUILD_PATH/scripts/vercel-production-shadow.mjs"
+          check-aliases
+      - name: Prove every protected mapping remains unchanged
+        env:
+          APP_V3_ALIASES_JSON: ${{ inputs.app_v3_aliases_json }}
+          BASELINE_JSON: ${{ needs.baseline.outputs.snapshot }}
+          VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID_APP: ${{ vars.VERCEL_PROJECT_ID_APP }}
+          VERCEL_PROJECT_ID_GOVERNANCE: ${{ vars.VERCEL_PROJECT_ID_GOVERNANCE }}
+          VERCEL_PROJECT_ID_RESERVE: ${{ vars.VERCEL_PROJECT_ID_RESERVE }}
+          VERCEL_PROJECT_ID_UI: ${{ vars.VERCEL_PROJECT_ID_UI }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN_PRODUCTION }}
+        run: |
+          umask 077
+          set -o noclobber
+          printf '%s\n' "$BASELINE_JSON" > "$RUNNER_TEMP/ui-compare-baseline.json"
+          node "$TRUSTED_POST_BUILD_PATH/scripts/vercel-production-shadow.mjs" create-spec --output "$RUNNER_TEMP/protected-spec.json"
+          node "$TRUSTED_POST_BUILD_PATH/scripts/vercel-deployment-state.mjs" snapshot --spec "$RUNNER_TEMP/protected-spec.json" --output "$RUNNER_TEMP/current.json"
+          node "$TRUSTED_POST_BUILD_PATH/scripts/vercel-deployment-state.mjs" compare --before "$RUNNER_TEMP/ui-compare-baseline.json" --after "$RUNNER_TEMP/current.json"
+      - name: Verify UI deployment provenance and readiness
+        env:
+          VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN_PRODUCTION }}
+        run: |
+          verified=false
+          for attempt in {1..12}; do
+            echo "Verifying UI deployment (attempt $attempt/12)"
+            if node "$TRUSTED_POST_BUILD_PATH/scripts/vercel-deployment-state.mjs" deployment --expected "$RUNNER_TEMP/ui-expected.json" --output "$RUNNER_TEMP/ui-state.json"; then verified=true; break; fi
+            sleep 5
+          done
+          "$verified"
+          node "$TRUSTED_POST_BUILD_PATH/scripts/vercel-production-shadow.mjs" assert-unaliased --input "$RUNNER_TEMP/ui-state.json"
+      - name: Scan UI canonical evidence
+        run: |
+          set -o noclobber
+          printf '["%s","%s"]\n' "$RUNNER_TEMP/ui-state.json" "$RUNNER_TEMP/current.json" > "$RUNNER_TEMP/evidence-files.json"
+          node "$TRUSTED_POST_BUILD_PATH/scripts/vercel-production-shadow.mjs" evidence --files "$RUNNER_TEMP/evidence-files.json"
+      - name: Measure UI job duration
+        id: total
+        env:
+          STARTED_AT_MS: ${{ steps.timing.outputs.started_at_ms }}
+        run: echo "total_duration_ms=$(($(date +%s%3N) - STARTED_AT_MS))" >> "$GITHUB_OUTPUT"
+
+  smoke-governance:
+    name: Smoke governance from fresh trusted state
+    needs: [preflight, governance]
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Check out fresh trusted governance smoke source
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+          ref: ${{ needs.preflight.outputs.deploy_sha }}
+      - name: Prove exact fresh governance smoke source
+        env:
+          DEPLOY_SHA: ${{ needs.preflight.outputs.deploy_sha }}
+          GITHUB_WORKFLOW_SHA: ${{ needs.preflight.outputs.deploy_sha }}
+          SOURCE_PATH: ${{ github.workspace }}
+        run: |
+          git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
+          node scripts/vercel-production-shadow.mjs validate-source
+      - name: Install fresh trusted governance smoke dependencies
+        uses: ./.github/actions/pnpm-install
+      - name: Install governance smoke Chromium
+        run: >-
+          env -u GITHUB_ENV -u GITHUB_OUTPUT -u GITHUB_PATH -u GITHUB_STATE
+          -u GITHUB_STEP_SUMMARY pnpm --filter app.mento.org exec playwright
+          install --with-deps chromium
+      - name: Run direct governance production-shadow smoke
+        env:
+          PRODUCTION_SHADOW_EXPECTED_DEPLOYMENT_ID: ${{ needs.governance.outputs.next_deployment_id }}
+          PRODUCTION_SHADOW_EXPECTED_SHA: ${{ needs.preflight.outputs.deploy_sha }}
+          PRODUCTION_SHADOW_OUTPUT_DIR: ${{ github.workspace }}/apps/app.mento.org/test-results
+          PRODUCTION_SHADOW_TARGET: governance
+          PRODUCTION_SHADOW_URL: ${{ needs.governance.outputs.deployment_url }}
+        run: |
+          node scripts/vercel-production-shadow.mjs health --url "$PRODUCTION_SHADOW_URL"
+          env -u GITHUB_ENV -u GITHUB_OUTPUT -u GITHUB_PATH -u GITHUB_STATE -u GITHUB_STEP_SUMMARY pnpm --filter app.mento.org exec playwright test -c apps/app.mento.org/playwright.production-shadow.config.ts
+      - name: Upload governance browser diagnostics on failure
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: production-shadow-governance-${{ github.run_id }}-${{ github.run_attempt }}
+          path: apps/app.mento.org/test-results/
+          if-no-files-found: ignore
+          retention-days: 7
+
+  smoke-reserve:
+    name: Smoke reserve from fresh trusted state
+    needs: [preflight, reserve]
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Check out fresh trusted reserve smoke source
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+          ref: ${{ needs.preflight.outputs.deploy_sha }}
+      - name: Prove exact fresh reserve smoke source
+        env:
+          DEPLOY_SHA: ${{ needs.preflight.outputs.deploy_sha }}
+          GITHUB_WORKFLOW_SHA: ${{ needs.preflight.outputs.deploy_sha }}
+          SOURCE_PATH: ${{ github.workspace }}
+        run: |
+          git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
+          node scripts/vercel-production-shadow.mjs validate-source
+      - name: Install fresh trusted reserve smoke dependencies
+        uses: ./.github/actions/pnpm-install
+      - name: Install reserve smoke Chromium
+        run: >-
+          env -u GITHUB_ENV -u GITHUB_OUTPUT -u GITHUB_PATH -u GITHUB_STATE
+          -u GITHUB_STEP_SUMMARY pnpm --filter app.mento.org exec playwright
+          install --with-deps chromium
+      - name: Run direct reserve production-shadow smoke
+        env:
+          PRODUCTION_SHADOW_EXPECTED_DEPLOYMENT_ID: ${{ needs.reserve.outputs.next_deployment_id }}
+          PRODUCTION_SHADOW_EXPECTED_SHA: ${{ needs.preflight.outputs.deploy_sha }}
+          PRODUCTION_SHADOW_OUTPUT_DIR: ${{ github.workspace }}/apps/app.mento.org/test-results
+          PRODUCTION_SHADOW_TARGET: reserve
+          PRODUCTION_SHADOW_URL: ${{ needs.reserve.outputs.deployment_url }}
+        run: |
+          node scripts/vercel-production-shadow.mjs health --url "$PRODUCTION_SHADOW_URL"
+          env -u GITHUB_ENV -u GITHUB_OUTPUT -u GITHUB_PATH -u GITHUB_STATE -u GITHUB_STEP_SUMMARY pnpm --filter app.mento.org exec playwright test -c apps/app.mento.org/playwright.production-shadow.config.ts
+      - name: Upload reserve browser diagnostics on failure
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: production-shadow-reserve-${{ github.run_id }}-${{ github.run_attempt }}
+          path: apps/app.mento.org/test-results/
+          if-no-files-found: ignore
+          retention-days: 7
+
+  smoke-ui:
+    name: Smoke UI from fresh trusted state
+    needs: [preflight, ui]
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Check out fresh trusted UI smoke source
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+          ref: ${{ needs.preflight.outputs.deploy_sha }}
+      - name: Prove exact fresh UI smoke source
+        env:
+          DEPLOY_SHA: ${{ needs.preflight.outputs.deploy_sha }}
+          GITHUB_WORKFLOW_SHA: ${{ needs.preflight.outputs.deploy_sha }}
+          SOURCE_PATH: ${{ github.workspace }}
+        run: |
+          git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
+          node scripts/vercel-production-shadow.mjs validate-source
+      - name: Install fresh trusted UI smoke dependencies
+        uses: ./.github/actions/pnpm-install
+      - name: Install UI smoke Chromium
+        run: >-
+          env -u GITHUB_ENV -u GITHUB_OUTPUT -u GITHUB_PATH -u GITHUB_STATE
+          -u GITHUB_STEP_SUMMARY pnpm --filter app.mento.org exec playwright
+          install --with-deps chromium
+      - name: Run direct UI production-shadow smoke
+        env:
+          PRODUCTION_SHADOW_EXPECTED_DEPLOYMENT_ID: ${{ needs.ui.outputs.next_deployment_id }}
+          PRODUCTION_SHADOW_EXPECTED_SHA: ${{ needs.preflight.outputs.deploy_sha }}
+          PRODUCTION_SHADOW_OUTPUT_DIR: ${{ github.workspace }}/apps/app.mento.org/test-results
+          PRODUCTION_SHADOW_TARGET: ui
+          PRODUCTION_SHADOW_URL: ${{ needs.ui.outputs.deployment_url }}
+        run: |
+          node scripts/vercel-production-shadow.mjs health --url "$PRODUCTION_SHADOW_URL"
+          env -u GITHUB_ENV -u GITHUB_OUTPUT -u GITHUB_PATH -u GITHUB_STATE -u GITHUB_STEP_SUMMARY pnpm --filter app.mento.org exec playwright test -c apps/app.mento.org/playwright.production-shadow.config.ts
+      - name: Upload UI browser diagnostics on failure
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: production-shadow-ui-${{ github.run_id }}-${{ github.run_attempt }}
+          path: apps/app.mento.org/test-results/
+          if-no-files-found: ignore
+          retention-days: 7
+
+  final-alias-comparison:
+    name: Final protected-domain comparison
+    needs:
+      - preflight
+      - baseline
+      - app
+      - governance
+      - smoke-governance
+      - reserve
+      - smoke-reserve
+      - ui
+      - smoke-ui
+    if: ${{ always() && needs.preflight.result == 'success' && needs.baseline.result == 'success' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment:
+      name: vercel-cli-production
+      deployment: false
+    steps:
+      - name: Check out trusted workflow controller
+        id: trusted
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+          ref: ${{ needs.preflight.outputs.deploy_sha }}
+      - name: Prove exact final-comparison source
+        id: source
+        env:
+          DEPLOY_SHA: ${{ needs.preflight.outputs.deploy_sha }}
+          GITHUB_WORKFLOW_SHA: ${{ needs.preflight.outputs.deploy_sha }}
+          SOURCE_PATH: ${{ github.workspace }}
+        run: |
+          git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
+          node scripts/vercel-production-shadow.mjs validate-source
+      - name: Fail read-only on final protected alias drift
+        if: ${{ always() && steps.trusted.outcome == 'success' && steps.source.outcome == 'success' }}
+        env:
+          BASELINE_JSON: ${{ needs.baseline.outputs.snapshot }}
+          VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN_PRODUCTION }}
+        run: >-
+          node scripts/vercel-production-shadow.mjs
+          check-aliases
+      - name: Capture and compare final protected mappings
+        env:
+          APP_V3_ALIASES_JSON: ${{ inputs.app_v3_aliases_json }}
+          BASELINE_JSON: ${{ needs.baseline.outputs.snapshot }}
+          VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID_APP: ${{ vars.VERCEL_PROJECT_ID_APP }}
+          VERCEL_PROJECT_ID_GOVERNANCE: ${{ vars.VERCEL_PROJECT_ID_GOVERNANCE }}
+          VERCEL_PROJECT_ID_RESERVE: ${{ vars.VERCEL_PROJECT_ID_RESERVE }}
+          VERCEL_PROJECT_ID_UI: ${{ vars.VERCEL_PROJECT_ID_UI }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN_PRODUCTION }}
+        run: |
+          umask 077
+          set -o noclobber
+          printf '%s\n' "$BASELINE_JSON" > "$RUNNER_TEMP/final-compare-baseline.json"
+          node scripts/vercel-production-shadow.mjs create-spec --output "$RUNNER_TEMP/protected-spec.json"
+          node scripts/vercel-deployment-state.mjs snapshot --spec "$RUNNER_TEMP/protected-spec.json" --output "$RUNNER_TEMP/final.json"
+          node scripts/vercel-deployment-state.mjs compare --before "$RUNNER_TEMP/final-compare-baseline.json" --after "$RUNNER_TEMP/final.json"
+          set -o noclobber
+          printf '["%s"]\n' "$RUNNER_TEMP/final.json" > "$RUNNER_TEMP/evidence-files.json"
+          node scripts/vercel-production-shadow.mjs evidence --files "$RUNNER_TEMP/evidence-files.json"
+
+      - name: Record complete pilot evidence
+        if: >-
+          needs.app.result == 'success' &&
+          needs.governance.result == 'success' &&
+          needs.smoke-governance.result == 'success' &&
+          needs.reserve.result == 'success' &&
+          needs.smoke-reserve.result == 'success' &&
+          needs.ui.result == 'success' &&
+          needs.smoke-ui.result == 'success'
+        env:
+          APP_BUILD_DURATION_MS: ${{ needs.app.outputs.build_duration_ms }}
+          APP_TURBO_CACHE_HITS: ${{ needs.app.outputs.turbo_cache_hits }}
+          APP_TURBO_CACHE_MISSES: ${{ needs.app.outputs.turbo_cache_misses }}
+          APP_NEXT_DEPLOYMENT_ID: ${{ needs.app.outputs.next_deployment_id }}
+          APP_TOTAL_DURATION_MS: ${{ needs.app.outputs.total_duration_ms }}
+          BASELINE_JSON: ${{ needs.baseline.outputs.snapshot }}
+          DEPLOY_SHA: ${{ needs.preflight.outputs.deploy_sha }}
+          GOVERNANCE_BUILD_DURATION_MS: ${{ needs.governance.outputs.build_duration_ms }}
+          GOVERNANCE_DEPLOY_DURATION_MS: ${{ needs.governance.outputs.deploy_duration_ms }}
+          GOVERNANCE_DEPLOYMENT_ID: ${{ needs.governance.outputs.deployment_id }}
+          GOVERNANCE_DEPLOYMENT_URL: ${{ needs.governance.outputs.deployment_url }}
+          GOVERNANCE_TOTAL_DURATION_MS: ${{ needs.governance.outputs.total_duration_ms }}
+          GOVERNANCE_TURBO_CACHE_HITS: ${{ needs.governance.outputs.turbo_cache_hits }}
+          GOVERNANCE_TURBO_CACHE_MISSES: ${{ needs.governance.outputs.turbo_cache_misses }}
+          RESERVE_BUILD_DURATION_MS: ${{ needs.reserve.outputs.build_duration_ms }}
+          RESERVE_DEPLOY_DURATION_MS: ${{ needs.reserve.outputs.deploy_duration_ms }}
+          RESERVE_DEPLOYMENT_ID: ${{ needs.reserve.outputs.deployment_id }}
+          RESERVE_DEPLOYMENT_URL: ${{ needs.reserve.outputs.deployment_url }}
+          RESERVE_TOTAL_DURATION_MS: ${{ needs.reserve.outputs.total_duration_ms }}
+          RESERVE_TURBO_CACHE_HITS: ${{ needs.reserve.outputs.turbo_cache_hits }}
+          RESERVE_TURBO_CACHE_MISSES: ${{ needs.reserve.outputs.turbo_cache_misses }}
+          UI_BUILD_DURATION_MS: ${{ needs.ui.outputs.build_duration_ms }}
+          UI_DEPLOY_DURATION_MS: ${{ needs.ui.outputs.deploy_duration_ms }}
+          UI_DEPLOYMENT_ID: ${{ needs.ui.outputs.deployment_id }}
+          UI_DEPLOYMENT_URL: ${{ needs.ui.outputs.deployment_url }}
+          UI_TOTAL_DURATION_MS: ${{ needs.ui.outputs.total_duration_ms }}
+          UI_TURBO_CACHE_HITS: ${{ needs.ui.outputs.turbo_cache_hits }}
+          UI_TURBO_CACHE_MISSES: ${{ needs.ui.outputs.turbo_cache_misses }}
+          WORKFLOW_STARTED_AT_MS: ${{ needs.preflight.outputs.started_at_ms }}
+          WORKFLOW_RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}
+        run: |
+          export WORKFLOW_DURATION_MS="$(($(date +%s%3N) - WORKFLOW_STARTED_AT_MS))"
+          node scripts/vercel-production-shadow.mjs summary
+
+  result:
+    name: Vercel Production Shadow
+    needs:
+      - preflight
+      - baseline
+      - app
+      - governance
+      - smoke-governance
+      - reserve
+      - smoke-reserve
+      - ui
+      - smoke-ui
+      - final-alias-comparison
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Enforce complete shadow-pilot success
+        env:
+          PREFLIGHT_RESULT: ${{ needs.preflight.result }}
+          BASELINE_RESULT: ${{ needs.baseline.result }}
+          APP_RESULT: ${{ needs.app.result }}
+          GOVERNANCE_RESULT: ${{ needs.governance.result }}
+          GOVERNANCE_SMOKE_RESULT: ${{ needs.smoke-governance.result }}
+          RESERVE_RESULT: ${{ needs.reserve.result }}
+          RESERVE_SMOKE_RESULT: ${{ needs.smoke-reserve.result }}
+          UI_RESULT: ${{ needs.ui.result }}
+          UI_SMOKE_RESULT: ${{ needs.smoke-ui.result }}
+          FINAL_ALIAS_RESULT: ${{ needs.final-alias-comparison.result }}
+        run: |
+          for result in "$PREFLIGHT_RESULT" "$BASELINE_RESULT" "$APP_RESULT" "$GOVERNANCE_RESULT" "$GOVERNANCE_SMOKE_RESULT" "$RESERVE_RESULT" "$RESERVE_SMOKE_RESULT" "$UI_RESULT" "$UI_SMOKE_RESULT" "$FINAL_ALIAS_RESULT"; do
+            if [[ "$result" != "success" ]]; then
+              echo "A required production-shadow job did not succeed" >&2
+              exit 1
+            fi
+          done

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -42,6 +42,11 @@ lint:
         - pnpm-lock.yaml
         - scripts/vercel-pnpm-bootstrap/package-lock.json
         - scripts/vercel-pnpm-runtime/pnpm-lock.yaml
+    - linters: [actionlint]
+      paths:
+        # actionlint 1.7.8 predates GitHub's environment.deployment key. The
+        # production-shadow structural suite validates this workflow instead.
+        - .github/workflows/vercel-production-shadow.yml
     - linters: [ALL]
       paths:
         - scripts/ralph/** # Ralph autonomous agent tooling — externally managed

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,27 @@ When adding or renaming an operational workflow, update its static allowlist and
 the structural test in the same PR. Never execute a triggering head SHA from
 this privileged `workflow_run` workflow.
 
+`.github/workflows/vercel-production-shadow.yml` is manual-only and
+non-activating. Candidate dependency installation and builds must run under its
+dedicated UID boundary with exact protected tools, private-umask runner-owned
+pull staging, raw Git-object materialization of the exact commit (never
+archive/checkout filters), and a runner-owned verified output handoff. Browser
+smoke must use a fresh trusted checkout and dependencies, never candidate
+`node_modules`; tear down every candidate boundary before upload or later
+production-token checks. Preserve App custom `v3` as build-only, preserve the
+App `v2` alias, and keep Governance, Reserve, and UI deployments unaliased.
+Every candidate Vercel build must use `--standalone`; reject invalid, oversized,
+or non-empty-`filePathMap` `.vc-config.json` files before handoff and again on
+the runner-owned upload tree.
+Never copy a raw Vercel-pulled `.env.*.local` into candidate storage. One-way
+materialize only the exact `vercel-pull` allowlist, prove the raw source is
+unchanged, reassert candidate canonical bytes, and clean both protected roots.
+Preflight must bind workflow, requested, fetched-main, and source SHAs before
+downstream jobs consume its single SHA output. Reachable browser smokes must
+verify both the custom build ID and exact deployed-SHA response header. Candidate
+builds must emit one canonical Turbo cache summary for per-target evidence.
+The full contract and commands live in `docs/vercel-deployments.md`.
+
 ## Pull request descriptions
 
 Every non-draft, non-Dependabot pull request body must start with the exact

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,8 @@ pnpm vercel:deployment-state:test    # Test canonical read-only Vercel state and
 pnpm vercel:primitives:test          # Test affected planning, custom deployment IDs, and build-env contracts
 pnpm vercel:workflow:test            # Test the manual prebuilt pilot, REST lifecycle, CLI args, and HTTP/browser smoke
 pnpm vercel:preview:test             # Test preview state plus reusable smoke trust, native-adapter, and Git-ownership boundaries
+pnpm vercel:production-shadow:test   # Test state allowlisting, shadow helpers, and workflow invariants
+pnpm --filter app.mento.org test:production-shadow:routing  # Prove bypass headers do not cross Chromium redirects
 pnpm vercel:versions:check           # Verify pinned Next.js/Vercel CLI custom-ID prerequisites
 pnpm vercel:plan --base <sha> --head <sha>  # Emit the fail-closed Vercel target plan
 gh pr view --json body --jq .body | pnpm pr:description:check  # Validate the current PR body
@@ -143,6 +145,10 @@ cutover and required observation period. GitHub-built workers call the reusable
 workflow directly because a `GITHUB_TOKEN` Deployment status is evidence, not
 a downstream trigger contract. The automatic exact-SHA controller, bootstrap,
 canary, cutover, and rollback contract is in `docs/vercel-deployments.md`.
+
+Manual staged production URLs use the separate target-aware
+`test:production-shadow` command documented in `docs/vercel-deployments.md`; it
+never enables the mock wallet.
 
 ## Coding Conventions
 

--- a/README.md
+++ b/README.md
@@ -149,6 +149,12 @@ pnpm vercel:workflow:test
 # Test preview state, reusable smoke trust, native-adapter, and Git ownership
 pnpm vercel:preview:test
 
+# Test production-shadow state, workflow, and runtime-smoke invariants
+pnpm vercel:production-shadow:test
+
+# Run the real two-origin Chromium protection-header isolation regression
+pnpm --filter app.mento.org test:production-shadow:routing
+
 # Verify exact Next.js and Vercel CLI custom deployment-ID prerequisites
 pnpm vercel:versions:check
 
@@ -491,11 +497,21 @@ The repository is set up with GitHub Actions for CI:
   v2 bootstrap, activation canaries, per-target cutover, and rollback
   procedures.
 
+  The manual `Vercel Production Shadow` workflow can build App custom `v3`
+  without deploying it and upload unaliased Governance, Reserve, and UI
+  production artifacts for verification; it never activates a domain or changes
+  ownership. Its exact-SHA contract, read-only protected-domain drift checks,
+  guarded manual operator recovery, and direct smoke are documented in the same
+  runbook.
+
 Dependency-installing jobs use `.github/actions/pnpm-install`, which pins the
 Node/pnpm bootstrap, relies on `actions/setup-node` as the single pnpm-store
-cache owner, and enforces `pnpm install --frozen-lockfile`. Publishing overrides
-the composite's Node version and disables its cache; zero-dependency jobs may
-set up Node directly.
+cache owner, and enforces `pnpm install --frozen-lockfile`.
+Production-shadow candidate builds instead use the dedicated-UID
+`.github/actions/vercel-candidate-build` boundary documented in the deployment
+runbook; fresh browser-smoke jobs return to the trusted pnpm action. Publishing
+overrides the trusted composite's Node version and disables its cache;
+zero-dependency jobs may set up Node directly.
 
 The docs-only decision is implemented by `scripts/ci-change-plan.mjs` and
 covered by `pnpm ci:change-plan:test`, which the Unit tests job runs before the

--- a/apps/app.mento.org/e2e/production-shadow/request-policy.mjs
+++ b/apps/app.mento.org/e2e/production-shadow/request-policy.mjs
@@ -1,0 +1,30 @@
+export function productionShadowRequestHeaders({ existingHeaders = {} }) {
+  const headers = { ...existingHeaders };
+  for (const name of Object.keys(headers)) {
+    if (name.toLowerCase() === "x-vercel-protection-bypass") {
+      throw new Error(
+        "Production-shadow request contained a forbidden protection header",
+      );
+    }
+  }
+  return headers;
+}
+
+export async function fulfillProductionShadowRequest({ route }) {
+  const response = await route.fetch({
+    headers: productionShadowRequestHeaders({
+      existingHeaders: route.request().headers(),
+    }),
+    // Fulfill each redirect response so Chromium creates a new request that
+    // passes through the header-validation policy independently.
+    maxRedirects: 0,
+  });
+  await route.fulfill({ response });
+}
+
+export function assertProductionShadowOrigin(value, allowedOrigin) {
+  if (new URL(value).origin !== new URL(allowedOrigin).origin) {
+    throw new Error("Production-shadow navigation left its immutable origin");
+  }
+  return true;
+}

--- a/apps/app.mento.org/e2e/production-shadow/smoke.spec.ts
+++ b/apps/app.mento.org/e2e/production-shadow/smoke.spec.ts
@@ -1,0 +1,203 @@
+/* eslint-disable turbo/no-undeclared-env-vars -- The direct Actions smoke does not run through Turbo. */
+
+import { expect, test, type Page, type Response } from "@playwright/test";
+
+import {
+  assertProductionShadowOrigin,
+  fulfillProductionShadowRequest,
+} from "./request-policy.mjs";
+
+const TARGETS = ["governance", "reserve", "ui"] as const;
+type Target = (typeof TARGETS)[number];
+
+interface RuntimeErrors {
+  console: string[];
+  origins: string[];
+  page: string[];
+  requests: string[];
+  responses: string[];
+}
+
+function requiredInputs() {
+  const target = process.env.PRODUCTION_SHADOW_TARGET;
+  const url = process.env.PRODUCTION_SHADOW_URL;
+  const expectedDeploymentId =
+    process.env.PRODUCTION_SHADOW_EXPECTED_DEPLOYMENT_ID;
+  const expectedSha = process.env.PRODUCTION_SHADOW_EXPECTED_SHA;
+  if (!TARGETS.includes(target as Target)) {
+    throw new Error(
+      "PRODUCTION_SHADOW_TARGET must be governance, reserve, or ui",
+    );
+  }
+  if (!url) throw new Error("PRODUCTION_SHADOW_URL is required");
+  const parsedUrl = new URL(url);
+  if (
+    parsedUrl.protocol !== "https:" ||
+    !parsedUrl.hostname.endsWith(".vercel.app") ||
+    parsedUrl.username ||
+    parsedUrl.password ||
+    parsedUrl.port ||
+    parsedUrl.pathname !== "/" ||
+    parsedUrl.search ||
+    parsedUrl.hash
+  ) {
+    throw new Error(
+      "PRODUCTION_SHADOW_URL must be an immutable HTTPS Vercel URL",
+    );
+  }
+  if (
+    !expectedDeploymentId ||
+    !new RegExp(`^m-${target}-[a-f0-9]{19}$`).test(expectedDeploymentId)
+  ) {
+    throw new Error(
+      "PRODUCTION_SHADOW_EXPECTED_DEPLOYMENT_ID must match the exact target build ID",
+    );
+  }
+  if (!expectedSha || !/^[a-f0-9]{40}$/.test(expectedSha)) {
+    throw new Error(
+      "PRODUCTION_SHADOW_EXPECTED_SHA must be the exact lowercase deployment SHA",
+    );
+  }
+  return {
+    target: target as Target,
+    url: parsedUrl,
+    expectedDeploymentId,
+    expectedSha,
+  };
+}
+
+function observeRuntimeErrors(page: Page, origin: string): RuntimeErrors {
+  const errors: RuntimeErrors = {
+    console: [],
+    origins: [],
+    page: [],
+    requests: [],
+    responses: [],
+  };
+  page.on("console", (message) => {
+    if (message.type() === "error") errors.console.push(message.text());
+  });
+  page.on("pageerror", (error) => errors.page.push(error.message));
+  page.on("framenavigated", (frame) => {
+    if (frame !== page.mainFrame() || frame.url() === "about:blank") return;
+    try {
+      assertProductionShadowOrigin(frame.url(), origin);
+    } catch {
+      errors.origins.push(frame.url());
+    }
+  });
+  page.on("requestfailed", (request) => {
+    const resourceType = request.resourceType();
+    if (["document", "script", "stylesheet"].includes(resourceType)) {
+      errors.requests.push(
+        `${resourceType} ${request.url()} ${request.failure()?.errorText ?? "failed"}`,
+      );
+    }
+  });
+  page.on("response", (response) => {
+    const resourceType = response.request().resourceType();
+    if (
+      ["document", "script", "stylesheet"].includes(resourceType) &&
+      response.status() >= 400
+    ) {
+      errors.responses.push(
+        `${resourceType} ${response.url()} HTTP ${response.status()}`,
+      );
+    }
+  });
+  return errors;
+}
+
+function assertSecurityHeaders(response: Response) {
+  const headers = response.headers();
+  expect(headers["x-frame-options"]).toBe("DENY");
+  expect(headers["content-security-policy"]).toBe("frame-ancestors 'none'");
+  expect(headers["x-content-type-options"]).toBe("nosniff");
+  expect(headers["referrer-policy"]).toBe("strict-origin-when-cross-origin");
+  expect(headers["permissions-policy"]).toBe(
+    "camera=(), microphone=(), geolocation=()",
+  );
+  expect(headers["content-security-policy-report-only"]).toBeTruthy();
+}
+
+async function verifyTarget(page: Page, target: Target, origin: string) {
+  if (target === "governance") {
+    await expect(
+      page.getByRole("heading", { name: "Mento Governance" }),
+    ).toBeVisible({ timeout: 30_000 });
+    await page.getByRole("link", { name: "My Voting Power" }).click();
+    await expect(page).toHaveURL(/\/voting-power$/);
+    expect(() =>
+      assertProductionShadowOrigin(page.url(), origin),
+    ).not.toThrow();
+    return;
+  }
+  if (target === "reserve") {
+    await expect(page.getByText("Mento Reserve").first()).toBeVisible({
+      timeout: 30_000,
+    });
+    const supplyTab = page.getByRole("tab", { name: "Supply" });
+    await supplyTab.click();
+    await expect(supplyTab).toHaveAttribute("data-state", "active");
+    await expect(page).toHaveURL(/[?&]tab=stablecoins(?:&|$)/);
+    expect(() =>
+      assertProductionShadowOrigin(page.url(), origin),
+    ).not.toThrow();
+    return;
+  }
+
+  await expect(
+    page.getByRole("heading", { name: "Basic Components" }),
+  ).toBeVisible({ timeout: 30_000 });
+  const search = page.getByPlaceholder("Search components...");
+  await search.fill("Dialog");
+  await expect(
+    page.getByRole("button", { name: /Interactive Components/ }),
+  ).toBeVisible();
+  expect(() => assertProductionShadowOrigin(page.url(), origin)).not.toThrow();
+}
+
+test("staged production artifact is healthy, secure, and interactive", async ({
+  page,
+}) => {
+  const { target, url, expectedDeploymentId, expectedSha } = requiredInputs();
+  await page.route("**/*", async (route) => {
+    await fulfillProductionShadowRequest({ route });
+  });
+  const errors = observeRuntimeErrors(page, url.origin);
+  const response = await page.goto("/", {
+    waitUntil: "domcontentloaded",
+    timeout: 45_000,
+  });
+  expect(response, "document response must exist").not.toBeNull();
+  expect(response?.status()).toBeGreaterThanOrEqual(200);
+  expect(response?.status()).toBeLessThan(300);
+  expect(() =>
+    assertProductionShadowOrigin(page.url(), url.origin),
+  ).not.toThrow();
+  assertSecurityHeaders(response as Response);
+  expect(response?.headers()["x-mento-deployment-sha"]).toBe(expectedSha);
+  await expect(page.locator("html")).toHaveAttribute(
+    "data-dpl-id",
+    expectedDeploymentId,
+  );
+
+  await verifyTarget(page, target, url.origin);
+  await page.waitForLoadState("networkidle", { timeout: 30_000 }).catch(() => {
+    // Live data polling may keep the network active. The tracked document,
+    // script, stylesheet, page, and console failures remain authoritative.
+  });
+
+  expect(errors.origins, "cross-origin main-frame navigations").toEqual([]);
+  expect(errors.page, "uncaught page errors").toEqual([]);
+  expect(
+    errors.console,
+    "console errors (reviewed allowlist is empty)",
+  ).toEqual([]);
+  expect(errors.requests, "failed critical requests from any origin").toEqual(
+    [],
+  );
+  expect(errors.responses, "critical HTTP failures from any origin").toEqual(
+    [],
+  );
+});

--- a/apps/app.mento.org/package.json
+++ b/apps/app.mento.org/package.json
@@ -16,6 +16,8 @@
     "test:connected:monad": "playwright test --project=connected-monad --workers=1",
     "test:coverage": "vitest run --coverage",
     "test:preview": "playwright test -c playwright.preview.config.ts",
+    "test:production-shadow": "playwright test -c playwright.production-shadow.config.ts",
+    "test:production-shadow:routing": "node --test production-shadow-routing.test.mjs",
     "test:visual": "playwright test --project=desktop --project=mobile",
     "test:watch": "vitest"
   },

--- a/apps/app.mento.org/playwright.config.ts
+++ b/apps/app.mento.org/playwright.config.ts
@@ -29,17 +29,18 @@ export default defineConfig({
   use: { baseURL: `http://localhost:${PORT}`, deviceScaleFactor: 1 },
   projects: [
     {
-      // `preview/` runs only via playwright.preview.config.ts (needs
-      // PREVIEW_URL, has no webServer) — ignore it here or these projects
-      // would pick it up against the local webServer below and fail fast on
-      // the missing env var.
+      // `preview/` and `production-shadow/` each run only through their
+      // dedicated configs (they need deployment-specific environment and
+      // have no local webServer). Ignore them here or the visual projects
+      // would collect the smoke specs against the local webServer and fail
+      // fast on missing env vars.
       name: "desktop",
-      testIgnore: [/connected\//, /preview\//],
+      testIgnore: [/connected\//, /preview\//, /production-shadow\//],
       use: { viewport: { width: 1280, height: 900 } },
     },
     {
       name: "mobile",
-      testIgnore: [/connected\//, /preview\//],
+      testIgnore: [/connected\//, /preview\//, /production-shadow\//],
       use: { viewport: { width: 375, height: 812 } },
     },
     {

--- a/apps/app.mento.org/playwright.production-shadow.config.ts
+++ b/apps/app.mento.org/playwright.production-shadow.config.ts
@@ -1,0 +1,24 @@
+/* eslint-disable turbo/no-undeclared-env-vars -- The direct Actions smoke does not run through Turbo. */
+
+import { defineConfig } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./e2e/production-shadow",
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: 0,
+  timeout: 90_000,
+  outputDir: process.env.PRODUCTION_SHADOW_OUTPUT_DIR ?? "test-results",
+  reporter: [[process.env.CI ? "github" : "list"]],
+  use: {
+    baseURL: process.env.PRODUCTION_SHADOW_URL,
+    serviceWorkers: "block",
+    viewport: { width: 1280, height: 900 },
+    // Traces capture request headers, including a deployment-protection
+    // bypass when configured. Keep only visual diagnostics safe to upload.
+    trace: "off",
+    screenshot: "only-on-failure",
+    video: "retain-on-failure",
+  },
+  projects: [{ name: "production-shadow" }],
+});

--- a/apps/app.mento.org/production-shadow-routing.test.mjs
+++ b/apps/app.mento.org/production-shadow-routing.test.mjs
@@ -1,0 +1,87 @@
+import assert from "node:assert/strict";
+import { createServer } from "node:http";
+import { test } from "node:test";
+
+import { chromium } from "@playwright/test";
+
+import { fulfillProductionShadowRequest } from "./e2e/production-shadow/request-policy.mjs";
+
+const BYPASS_HEADER = "x-vercel-protection-bypass";
+
+function listen(server) {
+  return new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+}
+
+function close(server) {
+  return new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+function origin(server) {
+  const address = server.address();
+  assert.ok(address && typeof address === "object");
+  return `http://127.0.0.1:${address.port}`;
+}
+
+test(
+  "Chromium sends no protection header across a cross-origin redirect",
+  { timeout: 30_000 },
+  async () => {
+    const received = { source: [], destination: [] };
+    const destination = createServer((request, response) => {
+      received.destination.push(request.headers[BYPASS_HEADER]);
+      response.writeHead(200, { "content-type": "text/html" });
+      response.end("<!doctype html><title>destination</title><h1>safe</h1>");
+    });
+    await listen(destination);
+    const destinationOrigin = origin(destination);
+
+    const source = createServer((request, response) => {
+      received.source.push(request.headers[BYPASS_HEADER]);
+      response.writeHead(302, {
+        location: `${destinationOrigin}/landing`,
+      });
+      response.end();
+    });
+    await listen(source);
+    const sourceOrigin = origin(source);
+
+    let browser;
+    try {
+      browser = await chromium.launch({ headless: true });
+      assert.equal(browser.browserType().name(), "chromium");
+      assert.match(browser.version(), /^\d+\./);
+
+      const page = await browser.newPage();
+      const requested = [];
+      page.on("request", (request) => requested.push(request.url()));
+      await page.route("**/*", async (route) => {
+        await fulfillProductionShadowRequest({
+          route,
+        });
+      });
+
+      const response = await page.goto(`${sourceOrigin}/start`, {
+        waitUntil: "domcontentloaded",
+      });
+      assert.equal(response?.status(), 200);
+      assert.equal(page.url(), `${destinationOrigin}/landing`);
+      assert.deepEqual(requested, [
+        `${sourceOrigin}/start`,
+        `${destinationOrigin}/landing`,
+      ]);
+      assert.deepEqual(received.source, [undefined]);
+      assert.deepEqual(received.destination, [undefined]);
+    } finally {
+      await browser?.close();
+      await Promise.all([close(source), close(destination)]);
+    }
+  },
+);

--- a/apps/app.mento.org/production-shadow-routing.test.mjs
+++ b/apps/app.mento.org/production-shadow-routing.test.mjs
@@ -5,6 +5,8 @@ import { test } from "node:test";
 import { chromium } from "@playwright/test";
 
 import { fulfillProductionShadowRequest } from "./e2e/production-shadow/request-policy.mjs";
+import defaultConfig from "./playwright.config.ts";
+import productionShadowConfig from "./playwright.production-shadow.config.ts";
 
 const BYPASS_HEADER = "x-vercel-protection-bypass";
 
@@ -29,6 +31,36 @@ function origin(server) {
   assert.ok(address && typeof address === "object");
   return `http://127.0.0.1:${address.port}`;
 }
+
+test("only the dedicated config collects production-shadow smoke specs", () => {
+  for (const projectName of ["desktop", "mobile"]) {
+    const project = defaultConfig.projects?.find(
+      ({ name }) => name === projectName,
+    );
+    assert.ok(project, `${projectName} project must exist`);
+    const ignored = Array.isArray(project.testIgnore)
+      ? project.testIgnore
+      : [project.testIgnore];
+    assert.ok(
+      ignored.some(
+        (pattern) =>
+          pattern instanceof RegExp &&
+          pattern.test("production-shadow/smoke.spec.ts"),
+      ),
+      `${projectName} must not collect the production-shadow smoke`,
+    );
+  }
+
+  assert.equal(
+    productionShadowConfig.testDir,
+    "./e2e/production-shadow",
+    "the dedicated config must keep collecting the production-shadow smoke",
+  );
+  assert.deepEqual(
+    productionShadowConfig.projects?.map(({ name }) => name),
+    ["production-shadow"],
+  );
+});
 
 test(
   "Chromium sends no protection header across a cross-origin redirect",

--- a/apps/governance.mento.org/next.config.ts
+++ b/apps/governance.mento.org/next.config.ts
@@ -13,6 +13,12 @@ const sentryAuthToken = env.SENTRY_AUTH_TOKEN;
 // Declared in this app's turbo.json so deployment attempts do not invalidate shared-package caches.
 // eslint-disable-next-line turbo/no-undeclared-env-vars
 const deploymentId = process.env.MENTO_NEXT_DEPLOYMENT_ID;
+// Vercel provides this in hosted builds; the production-shadow workflow binds it to preflight's exact main SHA.
+// eslint-disable-next-line turbo/no-undeclared-env-vars
+const deploymentSha = process.env.VERCEL_GIT_COMMIT_SHA;
+if (deploymentSha && !/^[a-f0-9]{40}$/i.test(deploymentSha)) {
+  throw new Error("VERCEL_GIT_COMMIT_SHA must be a full commit SHA");
+}
 
 if (uploadSentrySourceMaps && !sentryAuthToken) {
   throw new Error("SENTRY_AUTH_TOKEN is required for production builds");
@@ -101,7 +107,17 @@ const nextConfig: NextConfig = {
     return [
       {
         source: "/:path*",
-        headers: buildSecurityHeaders({ reportOnlyCsp }),
+        headers: [
+          ...buildSecurityHeaders({ reportOnlyCsp }),
+          ...(deploymentSha
+            ? [
+                {
+                  key: "X-Mento-Deployment-Sha",
+                  value: deploymentSha.toLowerCase(),
+                },
+              ]
+            : []),
+        ],
       },
     ];
   },

--- a/apps/governance.mento.org/turbo.json
+++ b/apps/governance.mento.org/turbo.json
@@ -3,7 +3,12 @@
   "extends": ["//"],
   "tasks": {
     "build": {
-      "env": ["$TURBO_EXTENDS$", "MENTO_NEXT_DEPLOYMENT_ID", "VERCEL_ENV"],
+      "env": [
+        "$TURBO_EXTENDS$",
+        "MENTO_NEXT_DEPLOYMENT_ID",
+        "VERCEL_ENV",
+        "VERCEL_GIT_COMMIT_SHA"
+      ],
       "inputs": ["$TURBO_EXTENDS$", "$TURBO_ROOT$/scripts/security-headers.mjs"]
     }
   }

--- a/apps/reserve.mento.org/next.config.ts
+++ b/apps/reserve.mento.org/next.config.ts
@@ -13,6 +13,12 @@ const sentryAuthToken = env.SENTRY_AUTH_TOKEN;
 // Declared in this app's turbo.json so deployment attempts do not invalidate shared-package caches.
 // eslint-disable-next-line turbo/no-undeclared-env-vars
 const deploymentId = process.env.MENTO_NEXT_DEPLOYMENT_ID;
+// Vercel provides this in hosted builds; the production-shadow workflow binds it to preflight's exact main SHA.
+// eslint-disable-next-line turbo/no-undeclared-env-vars
+const deploymentSha = process.env.VERCEL_GIT_COMMIT_SHA;
+if (deploymentSha && !/^[a-f0-9]{40}$/i.test(deploymentSha)) {
+  throw new Error("VERCEL_GIT_COMMIT_SHA must be a full commit SHA");
+}
 
 if (uploadSentrySourceMaps && !sentryAuthToken) {
   throw new Error("SENTRY_AUTH_TOKEN is required for production builds");
@@ -63,7 +69,17 @@ const nextConfig: NextConfig = {
     return [
       {
         source: "/:path*",
-        headers: buildSecurityHeaders({ reportOnlyCsp }),
+        headers: [
+          ...buildSecurityHeaders({ reportOnlyCsp }),
+          ...(deploymentSha
+            ? [
+                {
+                  key: "X-Mento-Deployment-Sha",
+                  value: deploymentSha.toLowerCase(),
+                },
+              ]
+            : []),
+        ],
       },
     ];
   },

--- a/apps/reserve.mento.org/turbo.json
+++ b/apps/reserve.mento.org/turbo.json
@@ -3,7 +3,12 @@
   "extends": ["//"],
   "tasks": {
     "build": {
-      "env": ["$TURBO_EXTENDS$", "MENTO_NEXT_DEPLOYMENT_ID", "VERCEL_ENV"],
+      "env": [
+        "$TURBO_EXTENDS$",
+        "MENTO_NEXT_DEPLOYMENT_ID",
+        "VERCEL_ENV",
+        "VERCEL_GIT_COMMIT_SHA"
+      ],
       "inputs": ["$TURBO_EXTENDS$", "$TURBO_ROOT$/scripts/security-headers.mjs"]
     }
   }

--- a/apps/ui.mento.org/next.config.ts
+++ b/apps/ui.mento.org/next.config.ts
@@ -6,6 +6,12 @@ import { sharpOutputFileTracingConfig } from "../../scripts/next-sharp-output-tr
 // Declared in this app's turbo.json so deployment attempts do not invalidate shared-package caches.
 // eslint-disable-next-line turbo/no-undeclared-env-vars
 const deploymentId = process.env.MENTO_NEXT_DEPLOYMENT_ID;
+// Vercel provides this in hosted builds; the production-shadow workflow binds it to preflight's exact main SHA.
+// eslint-disable-next-line turbo/no-undeclared-env-vars
+const deploymentSha = process.env.VERCEL_GIT_COMMIT_SHA;
+if (deploymentSha && !/^[a-f0-9]{40}$/i.test(deploymentSha)) {
+  throw new Error("VERCEL_GIT_COMMIT_SHA must be a full commit SHA");
+}
 const storageHostname = env.NEXT_PUBLIC_STORAGE_URL.replace(
   /^https?:\/\/([^/]+)\/?.*$/,
   "$1",
@@ -44,7 +50,17 @@ const nextConfig: NextConfig = {
     return [
       {
         source: "/:path*",
-        headers: buildSecurityHeaders({ reportOnlyCsp }),
+        headers: [
+          ...buildSecurityHeaders({ reportOnlyCsp }),
+          ...(deploymentSha
+            ? [
+                {
+                  key: "X-Mento-Deployment-Sha",
+                  value: deploymentSha.toLowerCase(),
+                },
+              ]
+            : []),
+        ],
       },
     ];
   },

--- a/apps/ui.mento.org/turbo.json
+++ b/apps/ui.mento.org/turbo.json
@@ -3,7 +3,12 @@
   "extends": ["//"],
   "tasks": {
     "build": {
-      "env": ["$TURBO_EXTENDS$", "MENTO_NEXT_DEPLOYMENT_ID", "VERCEL_ENV"],
+      "env": [
+        "$TURBO_EXTENDS$",
+        "MENTO_NEXT_DEPLOYMENT_ID",
+        "VERCEL_ENV",
+        "VERCEL_GIT_COMMIT_SHA"
+      ],
       "inputs": ["$TURBO_EXTENDS$", "$TURBO_ROOT$/scripts/security-headers.mjs"]
     }
   }

--- a/docs/vercel-deployments.md
+++ b/docs/vercel-deployments.md
@@ -27,6 +27,10 @@ per-target `shadow` or `github` mode live together in
 guards, and ownership tests import or structurally verify that source; do not
 copy a second ownership table into executable code.
 
+The guarded manual production-shadow pilot does not activate a domain or change
+deployment ownership. Until the later production cutover issues ship, the
+Vercel Git integration remains the production deployment owner.
+
 ## Pinned prerequisites
 
 - Vercel CLI: exactly `56.2.0` in the root `devDependencies`. The project owner
@@ -164,16 +168,18 @@ After `vercel build`, verify the build-bound ID before uploading anything:
 ```bash
 pnpm vercel:prebuilt:assert \
   --expected "$MENTO_NEXT_DEPLOYMENT_ID" \
-  --output .vercel/output
+  --output "$PROJECT_DIRECTORY/.vercel/output"
 ```
 
-The assertion reads `.vercel/output/config.json` and fails when `deploymentId`
-is missing or different. Next.js first writes the custom ID to its
+The assertion reads the selected project's
+`apps/<target>/.vercel/output/config.json` and fails when `deploymentId` is
+missing or different. Next.js first writes the custom ID to its
 `routes-manifest.json`; the pinned Vercel CLI carries that value into the final
 Build Output API `config.json` that `--prebuilt` uploads. `vercel deploy
---prebuilt` must upload that exact, unchanged `.vercel/output` directory in the
-same job. Do not regenerate the ID, rebuild, transfer an unverified artifact, or
-pass an invented deployment-ID option to `vercel deploy`.
+--prebuilt` must upload that exact, unchanged app-root `.vercel/output`
+directory in the same job. Do not regenerate the ID, rebuild, transfer an
+unverified artifact, or pass an invented deployment-ID option to
+`vercel deploy`.
 
 ## Build-environment contract
 
@@ -232,7 +238,21 @@ source for a Sensitive value without depending on a denylist of names that may
 appear in Vercel's raw file. A missing, empty, oversized, controlled, or
 unrepresentable required value, missing scoped secret, or cross-target
 Sensitive name fails closed. The checker prints variable names on failure but
-never values. Its machine-readable inventory is available directly:
+never values.
+
+The production-shadow workflow uses a separate runner-owned staging boundary.
+`PROJECT_DIRECTORY` must be the directory in which the Vercel CLI writes its
+`.vercel` state. The production-shadow workflow launches the CLI from the
+monorepo root, but first materializes a trusted root `.vercel/repo.json` mapping
+and selects the literal project with `--project`. Pinned CLI 56.2.0 then writes
+the pulled environment and project settings below `apps/<target>/.vercel`, so
+the checker passes the literal `apps/<target>` directory. Both the local mapping
+and the project's configured Root Directory are verified, with the latter also
+checked through the Vercel project API. The checker loads
+`$PROJECT_DIRECTORY/.vercel/.env.<environment>.local`, then overlays explicit
+workflow constants and scoped GitHub secrets so they take precedence. A missing
+or invalid pulled file fails closed. Its machine-readable inventory is available
+directly:
 
 ```bash
 node scripts/vercel-build-environment.mjs inventory \
@@ -322,6 +342,249 @@ are maintainer-entered. Automation must not discover, export, recover, or print
 them, and a Vercel Sensitive value must never be assumed to appear in
 `vercel pull` output.
 
+## Manual production-shadow pilot
+
+`.github/workflows/vercel-production-shadow.yml` is a manual-only,
+non-activating pilot. Dispatch it from `main` with:
+
+- `deploy_sha`: a full 40-character commit SHA that exactly equals the fetched
+  `refs/remotes/origin/main` tip;
+- `app_v3_aliases_json`: the exact reviewed JSON array
+  `["app.mento.org","appmentoorg-env-v3-mentolabs.vercel.app"]` for the app
+  project's custom `v3` deployment. It must not omit either entry, add another
+  alias, or contain `v2-app.mento.org`.
+
+Do not guess the alias list. Capture it read-only, review it, then use the exact
+literal array for the pilot and record it for the activation issue. The workflow
+will not read a credential manager or attempt to recover a missing credential.
+
+Every credential-bearing job uses the dedicated `vercel-cli-production` GitHub
+Environment with `deployment: false`. This prevents an implicit GitHub
+Deployment whose ref could differ from `deploy_sha`. The token-free preflight
+also verifies the canonical repository, the workflow definition on `main`, and
+first proves `deploy_sha` is an ancestor of the freshly fetched `origin/main`.
+It then requires exact equality among `${{ github.workflow_sha }}`, `deploy_sha`,
+the fetched `origin/main` tip, and the checked-out `HEAD` before any job can
+reference production credentials. That validated SHA is the preflight output;
+every later trusted controller, source, post-build, smoke, and final-comparison
+checkout consumes only that output.
+Each fresh smoke checkout and the credential-bearing final comparison fetches
+`origin/main` and reruns the same ancestry, tip, workflow-SHA, and `HEAD` guard
+before installing dependencies or mapping a production token.
+
+Every source-consuming job separates the trusted controller, immutable source,
+candidate execution, and upload handoff. Preflight checks the workflow
+definition's `${{ github.workflow_sha }}` at the workspace root. After proving
+it is the requested current-main commit, downstream jobs check out the
+preflight-issued immutable SHA for validators, state readers, CLI orchestration,
+drift evidence, and the runner-owned `source/` build input. Before candidate
+code can run, the workflow materializes exact protected
+Node, pnpm, and Vercel CLI paths outside candidate control, pulls Vercel settings
+with the production token under a private `077` umask into a fresh runner-owned
+staging tree, and validates that tree's complete file set, ownership, project
+mapping, and Root Directory.
+
+The raw Vercel-pulled `.env.<target>.local` remains private and runner-owned.
+Before staging settings into candidate storage, the trusted controller parses
+that file, selects only the target/environment variables classified
+`vercel-pull` in `scripts/vercel-build-environment.mjs`, and serializes them into
+a fresh canonical `0600` file below a runner-owned `0700` materialization root.
+Unknown values and sensitive values such as `SENTRY_AUTH_TOKEN`,
+`ETHERSCAN_API_KEY`, or `CHAINALYSIS_API_KEY` are never copied into candidate
+storage. The controller proves the raw file's inode and bytes did not change,
+reasserts the materialized and candidate files are the exact canonical
+allowlist, rechecks the materialization before handoff, and deletes the raw and
+materialized roots during boundary teardown.
+
+`.github/actions/vercel-candidate-build/action.yml` then creates the dedicated
+system identity `mento-vercel-build`, binds its numeric UID/GID to a private
+runner-owned marker, and materializes the exact commit directly from bounded raw
+Git tree/blob objects into a fresh candidate-owned tree. This deliberately does
+not use `git archive` or checkout filters: candidate-controlled
+`.gitattributes` entries such as `export-ignore`, `export-subst`, `ident`, or
+line-ending conversion cannot omit or rewrite build input. Gitlinks and unsafe
+paths are rejected before any candidate source is written. Dependency
+installation and `vercel build` run through `env -i` plus `setpriv` with an
+isolated HOME, temporary directory, XDG directories, pnpm store, and an
+allowlisted PATH containing the exact protected executables. Lifecycle scripts
+are disabled. The action first proves that this UID cannot write the workspace,
+trusted controller, runner temp root, immutable checkout, lockfile, or protected
+runtime. GitHub command-file paths and the production Vercel token are absent
+from candidate processes. A UID-wide
+kill and process check runs after install, after build, before handoff, and
+during final teardown; teardown deletes the account only when its live UID/GID
+still matches that marker.
+
+The trusted controller validates candidate ownership, the exact output tree,
+custom deployment ID, project mapping, and source provenance. Every shadow
+build uses Vercel's `--standalone` mode so function inputs are copied into the
+output tree. Before handoff, and again on the runner-owned upload tree, the
+controller parses every `.vc-config.json` and rejects invalid or oversized
+configs plus every non-empty `filePathMap`; a candidate path such as
+`../../proc/self/environ` therefore cannot make the later token-bearing uploader
+read outside the handoff. Only then does it copy the prebuilt output and
+validated Vercel mapping into a fresh runner-owned, non-writable-by-candidate
+upload tree. The candidate UID/group and all candidate and pull-staging paths
+are deleted before any upload or later production-token step. A fresh
+`trusted-after-build/` checkout owns deploy, state, evidence, and read-only alias
+checks, and upload reads only the runner-owned handoff. Canonical temporary JSON
+uses exclusive, no-follow creation, and shell-created evidence files enable
+`noclobber`; a precreated file or symlink therefore fails the job instead of
+replacing controller or evidence content.
+
+Browser smokes run in separate jobs from fresh checkouts of the exact
+preflight-issued workflow/source SHA with freshly installed trusted dependencies
+and Chromium. They never reuse
+the candidate checkout, candidate `node_modules`, or candidate command files;
+they receive neither production credentials nor a protected GitHub Environment.
+
+### Protected-domain transaction boundary
+
+Before building, the workflow uses `scripts/vercel-deployment-state.mjs` to
+capture an allowlisted snapshot for the reviewed app-v3 aliases,
+`v2-app.mento.org`, and the governance, reserve, and UI production domains. The
+state helper calls only Vercel's read endpoints for aliases, deployments,
+deployment aliases, and projects. It emits only canonical project, deployment,
+readiness, environment, Git, and alias fields; raw API responses, protection
+bypass data, and environment arrays never enter logs or artifacts.
+The reviewed app-v3 input must exactly equal the deployment's complete,
+normalized alias set. The current reviewed topology has two entries:
+`app.mento.org` and `appmentoorg-env-v3-mentolabs.vercel.app`. An omitted or
+extra alias fails baseline capture.
+
+Governance, reserve, and UI each execute this staged sequence:
+
+```text
+runner:    vercel pull --yes --environment=production
+candidate: vercel build --yes --standalone --prod
+runner:    validate -> immutable handoff -> destroy candidate boundary
+runner:    vercel deploy --prebuilt --prod --skip-domain --archive=tgz --format=json
+```
+
+Each command is launched at the monorepo root with an explicit literal
+`--project` argument. The controller removes `VERCEL_ORG_ID` and
+`VERCEL_PROJECT_ID` only from the CLI child environment after validating them
+and writing the trusted repo mapping; CLI 56.2.0 otherwise gives those variables
+precedence and loses the Root Directory. Authentication remains in the narrowly
+scoped `VERCEL_TOKEN` environment for API, pull, deploy, and alias-check steps,
+but
+`vercel build` receives no production token. The non-exportable
+`SENTRY_AUTH_TOKEN` and `ETHERSCAN_API_KEY` mirrors exist only on the literal
+build step that needs them. Before every literal build, the trusted controller
+requires the names `TURBO_TEAM`, `TURBO_TOKEN`, and
+`TURBO_REMOTE_CACHE_SIGNATURE_KEY` without printing their values, then runs the
+target environment checker. No deployment-protection bypass is mapped; direct
+health and browser checks must succeed through the public immutable URLs. Pulled
+project state and prebuilt output must exist below the matching
+`apps/<target>/.vercel` path.
+
+The uploaded `apps/<target>/.vercel/output` is the exact output whose custom
+Next deployment ID was asserted and copied into the runner-owned handoff. It is
+never transferred as a GitHub artifact.
+Each immutable URL must prove the literal project, `production` target, `READY`
+state, exact repository/ref/SHA metadata, and an alias set containing only its
+immutable deployment hostname before smoke begins. The browser then proves
+critical security headers, a stable page marker, and a target-specific
+non-transaction interaction. Protected alias
+mappings are compared after each upload and once again at the end. Once the
+candidate build boundary and fresh trusted-controller checkout both succeed, an
+always-run read-only check executes immediately after every deploy attempt,
+including failed deploy attempts, before state polling, Chromium installation,
+or smoke checks. Candidate-boundary or trusted-checkout failure never exposes
+the production token to this check. Any drift fails the run without executing
+an alias, deploy, promotion, or rollback command. The failure contains only
+canonical alias plus before/current deployment IDs and immutable URLs, followed
+by manual operator instructions. The final all-target comparison has its own
+fresh trusted checkout and likewise cannot receive the production token when
+that checkout fails.
+
+On drift, stop all forward work. Confirm the change is not an intentional or
+concurrent activation, re-resolve every affected alias, and require it still to
+match the reported canonical current ID/URL. Only then may an operator run the
+listed `vercel alias set <captured-prior-immutable-url> <alias>` command
+manually. Capture and compare the complete protected snapshot afterward. Never
+automate this restoration and never restore by a mutable `latest` lookup. The
+final job repeats the same read-only check directly from the trusted workflow
+tree and does not install or execute candidate dependencies.
+
+### App custom v3: build-only Outcome B
+
+The app job runs only:
+
+```text
+vercel pull --yes --environment=v3
+vercel build --yes --standalone --target=v3
+```
+
+The pinned CLI documents `--skip-domain` only with `--prod`, so a custom-target
+deploy cannot be proven non-activating. The app job therefore has no reachable
+deploy, promotion, or alias command. It explicitly builds with
+`VERCEL_ENV=preview`, `VERCEL_TARGET_ENV=v3`,
+`NEXT_PUBLIC_VERCEL_ENV=preview`, and an empty `SENTRY_AUTH_TOKEN`.
+
+The composite caller deliberately omits `SENTRY_AUTH_TOKEN` so the trusted
+credential-boundary preflight sees no forbidden app-v3 source. Only the isolated
+Vercel build child materializes the required explicit empty override.
+
+The job then records the future activation shape for the next issue:
+
+```text
+vercel deploy --prebuilt --target=v3 --archive=tgz --format=json
+```
+
+That future command is live activation and must remain inside the later guarded
+coordinator. The production-shadow pilot never creates an app URL. The legacy
+`v2-app.mento.org` production mapping is inspected, health-checked, and left
+untouched.
+
+### Direct production-shadow smoke
+
+The `deployment_status`-driven preview smoke is not reused for production
+shadow artifacts. Staged governance, reserve, and UI URLs run the direct command
+below in separate fresh trusted smoke jobs:
+
+```bash
+PRODUCTION_SHADOW_TARGET=governance \
+PRODUCTION_SHADOW_URL=https://<immutable>.vercel.app \
+PRODUCTION_SHADOW_EXPECTED_DEPLOYMENT_ID=<generated-build-id> \
+PRODUCTION_SHADOW_EXPECTED_SHA=<40-character-current-main-sha> \
+pnpm --filter app.mento.org test:production-shadow
+```
+
+Before this smoke starts, the stage job's trusted state helper independently
+proves the immutable deployment's exact repository, ref, SHA, project,
+production target, transaction, and READY state against Vercel's API. The smoke
+job checks out the exact preflight-issued SHA into a fresh workspace, installs
+its own trusted dependencies and Chromium, and consumes only the canonical
+deployment URL, expected custom ID, and exact SHA from prior jobs. The browser
+smoke then checks
+bounded HTTP readiness, document status, stable target content, one
+safe interaction, critical security headers, uncaught page errors, console
+errors, failed document/script/style requests from any origin, critical HTTP
+responses with status 400 or higher from any origin, the exact custom Next
+build ID rendered as the document's `data-dpl-id`, and the exact deployed SHA
+from the build-bound `X-Mento-Deployment-Sha` response header. No deployment-protection header is
+supplied. The request policy rejects any ambient protection header, handles each
+redirect as a new browser request, and origin-checks main-frame navigation
+throughout the smoke and after every target interaction. HTTP readiness also
+uses manual redirects and rejects a cross-origin redirect. The fresh smoke job
+never links or executes candidate `node_modules`. Failure uploads only
+screenshots/video for seven days; tracing stays disabled to keep diagnostic
+artifacts bounded.
+
+Do not run the manual pilot until the required GitHub Environment, repository
+variables, production token, mirrored build-variable names, and reviewed app-v3
+alias list are confirmed present. The workflow itself performs no Vercel Git
+setting change, domain activation, promotion, or cleanup of a serving
+deployment.
+
+Each candidate build must emit exactly one canonical Turbo
+`Cached: X cached, Y total` line. Missing, duplicate, malformed, or impossible
+counts fail the job. The final summary records hits and misses for every target,
+per-target build/deploy/job timing, and whole-workflow duration measured from
+the first preflight step; the original cache summaries remain in their build
+logs.
+
 ## Tests
 
 The ADR, primitive, read-only state-inspector, reusable-workflow, and
@@ -333,6 +596,8 @@ pnpm vercel:primitives:test
 pnpm vercel:deployment-state:test
 pnpm vercel:workflow:test
 pnpm vercel:preview:test
+pnpm vercel:production-shadow:test
+pnpm --filter app.mento.org test:production-shadow:routing
 ```
 
 They are stages near the start of the canonical root `pnpm test` command. The
@@ -340,10 +605,18 @@ suites cover app/package graph fixtures, fail-closed cases, output ordering,
 every deployment-ID constraint, prebuilt-config matching, prerequisite versions,
 all target/environment classifications, canonical alias mappings, guarded
 rollback evidence, exclusive private-file output, and redaction-safe
-missing-variable and API-error handling.
+missing-variable and API-error handling. The production-shadow command adds
+canonical Vercel state fixtures, read-only protected mapping failures, workflow
+structure, and direct runtime-smoke structure. Those commands are offline and
+do not contact or mutate Vercel. The separate routing regression starts two
+loopback origins and the Playwright-pinned Chromium to prove a cross-origin
+redirect cannot inherit a protection header.
 
-The test commands perform no Vercel API call, build upload, deployment, alias
-mutation, environment mutation, or Git-ownership change.
+The test commands above perform no Vercel API call, build upload, deployment,
+alias mutation, environment mutation, or Git-ownership change. The manual
+production-shadow workflow described above does use read-only Vercel API checks
+and stages non-activating ordinary-project deployments; it still performs no
+alias mutation, environment mutation, or Git-ownership change.
 
 ## Cost validation preparation
 

--- a/docs/wallet-testing.md
+++ b/docs/wallet-testing.md
@@ -254,6 +254,32 @@ preview URL:
 PREVIEW_URL=https://appmento-<hash>-mentolabs.vercel.app pnpm --filter app.mento.org test:preview
 ```
 
+Staged governance, reserve, and UI production artifacts use a different
+walletless smoke, invoked directly by the manual production-shadow job rather
+than by `deployment_status`:
+
+```bash
+PRODUCTION_SHADOW_TARGET=reserve \
+PRODUCTION_SHADOW_URL=https://<immutable>.vercel.app \
+PRODUCTION_SHADOW_EXPECTED_DEPLOYMENT_ID=<generated-build-id> \
+PRODUCTION_SHADOW_EXPECTED_SHA=<40-character-current-main-sha> \
+pnpm --filter app.mento.org test:production-shadow
+```
+
+This target-aware suite checks production headers, stable content, and one safe
+interaction, fails critical document/script/style responses from any origin,
+keeps the main frame on the exact immutable origin throughout, and binds the
+rendered `data-dpl-id` and `X-Mento-Deployment-Sha` response header to the exact
+prebuilt output and commit. No deployment-protection
+bypass is supplied; the request policy rejects any ambient protection header
+and handles every redirect as a new browser request. The real two-origin
+Chromium regression is
+`pnpm --filter app.mento.org test:production-shadow:routing`. It does not enable
+the mock wallet and is not a replacement for the team-preview smoke above. See
+`docs/vercel-deployments.md` for the protected alias and deployment-provenance
+gates around it, including the independent Vercel state check that proves the
+exact repository, ref, and SHA before browser smoke starts.
+
 ## Activation flags
 
 Two equivalent activation paths. Env vars are read at build/dev-server start;

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "supply-chain:lockfile-lint:test": "node scripts/lockfile-lint.test.mjs",
     "supply-chain:version-skew": "node scripts/version-skew-check.mjs",
     "supply-chain:version-skew:test": "node scripts/version-skew-check.test.mjs",
-    "test": "pnpm adr:check:test && pnpm vercel:primitives:test && pnpm vercel:deployment-state:test && pnpm vercel:workflow:test && pnpm vercel:preview:test && pnpm vercel:cost:test && turbo run test",
+    "test": "pnpm adr:check:test && pnpm vercel:primitives:test && pnpm vercel:deployment-state:test && pnpm vercel:production-shadow:test && pnpm vercel:workflow:test && pnpm vercel:preview:test && pnpm vercel:cost:test && turbo run test",
     "test:coverage": "turbo run test:coverage",
     "vercel:cost:analyze": "node scripts/vercel-cost-analysis.mjs",
     "vercel:cost:test": "node --test scripts/vercel-cost-analysis.test.mjs",
@@ -52,6 +52,7 @@
     "vercel:prebuilt:assert": "node scripts/vercel-prebuilt.mjs assert-output",
     "vercel:preview:test": "node --test scripts/vercel-preview-controller.test.mjs scripts/vercel-preview-workflows.test.mjs scripts/vercel-preview-smoke.test.mjs scripts/vercel-preview-browser-smoke.test.mjs scripts/vercel-preview-smoke-workflows.test.mjs scripts/vercel-git-ownership.test.mjs",
     "vercel:primitives:test": "node --test scripts/plan-vercel-deployments.test.mjs scripts/vercel-build-environment.test.mjs scripts/vercel-prebuilt.test.mjs",
+    "vercel:production-shadow:test": "node --test scripts/vercel-deployment-state.test.mjs scripts/vercel-production-shadow.test.mjs scripts/vercel-production-shadow-workflow.test.mjs",
     "vercel:versions:check": "node scripts/vercel-prebuilt.mjs check-versions",
     "vercel:workflow:test": "node --test scripts/github-deployment.test.mjs scripts/vercel-prebuilt-workflow.test.mjs scripts/vercel-prebuilt-workflows.test.mjs apps/ui.mento.org/e2e/vercel-preview-browser-smoke.test.mjs"
   },

--- a/scripts/fixtures/vercel-production-shadow/unexpected-alias.json
+++ b/scripts/fixtures/vercel-production-shadow/unexpected-alias.json
@@ -1,0 +1,17 @@
+{
+  "alias": "governance-immutable.vercel.app",
+  "deploymentId": "dpl_governance123",
+  "deploymentUrl": "https://governance-immutable.vercel.app",
+  "projectId": "prj_governance123",
+  "projectName": "governance.mento.org",
+  "readyState": "READY",
+  "target": "production",
+  "customEnvironmentSlug": null,
+  "git": {
+    "org": "mento-protocol",
+    "repo": "frontend-monorepo",
+    "ref": "main",
+    "sha": "0123456789abcdef0123456789abcdef01234567"
+  },
+  "aliases": ["governance-immutable.vercel.app", "governance.mento.org"]
+}

--- a/scripts/quality-workflows.test.mjs
+++ b/scripts/quality-workflows.test.mjs
@@ -159,6 +159,7 @@ test("the notifier is loop-safe, secretless, and least privilege", () => {
     ".github/workflows/quality-budgets.yml",
     ".github/workflows/scorecard.yml",
     ".github/workflows/supply-chain.yml",
+    ".github/workflows/vercel-production-shadow.yml",
     ".github/workflows/visual.yml",
   ].map((path) => /^name: (.+)$/m.exec(read(path))?.[1]);
 
@@ -166,6 +167,7 @@ test("the notifier is loop-safe, secretless, and least privilege", () => {
   assert.match(workflow, /^ {2}workflow_run:$/m);
   assert.match(workflow, /^ {6}- Quality Budgets$/m);
   assert.match(workflow, /^ {6}- Supply Chain$/m);
+  assert.match(workflow, /^ {6}- Vercel Production Shadow$/m);
   assert.ok(
     monitoredNames.every(Boolean),
     "every monitored workflow must declare a top-level name",

--- a/scripts/vercel-prebuilt.mjs
+++ b/scripts/vercel-prebuilt.mjs
@@ -201,7 +201,11 @@ if (isCliEntrypoint()) {
     process.stdout.write("Prebuilt deployment ID verified\n");
   } else if (command === "check-versions") {
     process.stdout.write(
-      `${JSON.stringify(assertDeploymentIdPrerequisites(process.cwd()))}\n`,
+      `${JSON.stringify(
+        assertDeploymentIdPrerequisites(
+          resolve(options["repo-root"] ?? process.cwd()),
+        ),
+      )}\n`,
     );
   } else {
     throw new Error(

--- a/scripts/vercel-production-shadow-workflow.test.mjs
+++ b/scripts/vercel-production-shadow-workflow.test.mjs
@@ -1,0 +1,1034 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { test } from "node:test";
+import { parse } from "yaml";
+
+import { validateVercelBuildCredentialBoundary } from "./vercel-build-environment.mjs";
+import {
+  buildProductionShadowBuildArguments,
+  buildProductionShadowDeployArguments,
+  buildProductionShadowPullArguments,
+} from "./vercel-production-shadow.mjs";
+
+const SHA = "0123456789abcdef0123456789abcdef01234567";
+
+const workflowPath = ".github/workflows/vercel-production-shadow.yml";
+const workflowSource = readFileSync(
+  new URL(`../${workflowPath}`, import.meta.url),
+  "utf8",
+);
+const workflow = parse(workflowSource);
+
+function optionalShellEnvironmentAssignment(name) {
+  return new RegExp(`${name}="\\$\\{${name}:-\\}"`);
+}
+const candidateActionSource = readFileSync(
+  new URL(
+    "../.github/actions/vercel-candidate-build/action.yml",
+    import.meta.url,
+  ),
+  "utf8",
+);
+const candidateAction = parse(candidateActionSource);
+const protectedRuntimeAction = parse(
+  readFileSync(
+    new URL(
+      "../.github/actions/vercel-protected-runtime/action.yml",
+      import.meta.url,
+    ),
+    "utf8",
+  ),
+);
+const rootPackage = JSON.parse(
+  readFileSync(new URL("../package.json", import.meta.url), "utf8"),
+);
+
+function jobSource(name) {
+  const nextJob = /^ {2}[a-z0-9-]+:\n/gm;
+  const marker = `  ${name}:\n`;
+  const start = workflowSource.indexOf(marker);
+  assert.notEqual(start, -1, `missing job ${name}`);
+  nextJob.lastIndex = start + marker.length;
+  const match = nextJob.exec(workflowSource);
+  return workflowSource.slice(start, match?.index ?? workflowSource.length);
+}
+
+function allStrings(value, output = []) {
+  if (typeof value === "string") output.push(value);
+  if (Array.isArray(value)) value.forEach((item) => allStrings(item, output));
+  if (value && typeof value === "object") {
+    Object.values(value).forEach((item) => allStrings(item, output));
+  }
+  return output;
+}
+
+function stepNamed(jobName, name) {
+  const step = workflow.jobs[jobName].steps.find((item) => item.name === name);
+  assert.ok(step, `missing ${jobName} step: ${name}`);
+  return step;
+}
+
+function stepsMatching(jobName, pattern) {
+  return workflow.jobs[jobName].steps.filter((step) =>
+    pattern.test(step.name ?? ""),
+  );
+}
+
+test("workflow is manual-only and requires exact deployment identity", () => {
+  assert.equal(workflow.name, "Vercel Production Shadow");
+  assert.deepEqual(Object.keys(workflow.on), ["workflow_dispatch"]);
+  assert.equal(workflow.on.workflow_dispatch.inputs.deploy_sha.required, true);
+  assert.equal(
+    workflow.on.workflow_dispatch.inputs.app_v3_aliases_json.required,
+    true,
+  );
+  assert.deepEqual(workflow.permissions, { contents: "read" });
+  assert.doesNotMatch(workflowSource, /deployments:\s*write/);
+  assert.doesNotMatch(workflowSource, /pull_request|deployment_status|push:/);
+  assert.equal(
+    workflow.jobs.preflight.outputs.deploy_sha,
+    "${{ steps.source.outputs.deploy_sha }}",
+  );
+  assert.equal(
+    workflow.jobs.preflight.outputs.started_at_ms,
+    "${{ steps.timing.outputs.started_at_ms }}",
+  );
+  assert.equal(workflow.jobs.preflight.steps[0].id, "timing");
+});
+
+test("candidate source cannot replace trusted controllers or runner state", () => {
+  for (const name of [
+    "preflight",
+    "baseline",
+    "app",
+    "governance",
+    "reserve",
+    "ui",
+  ]) {
+    const job = workflow.jobs[name];
+    const checkouts = job.steps.filter((step) =>
+      step.uses?.startsWith("actions/checkout@"),
+    );
+    const expectedCheckoutCount = [
+      "app",
+      "governance",
+      "reserve",
+      "ui",
+    ].includes(name)
+      ? 3
+      : 2;
+    assert.equal(
+      checkouts.length,
+      expectedCheckoutCount,
+      `${name} checkout count`,
+    );
+    assert.deepEqual(checkouts[0].with, {
+      "fetch-depth": 1,
+      "persist-credentials": false,
+      ref:
+        name === "preflight"
+          ? "${{ github.workflow_sha }}"
+          : "${{ needs.preflight.outputs.deploy_sha }}",
+    });
+    assert.equal(checkouts[1].with["fetch-depth"], 0);
+    assert.equal(checkouts[1].with.path, "source");
+    assert.equal(checkouts[1].with["persist-credentials"], false);
+    assert.equal(
+      checkouts[1].with.ref,
+      name === "preflight"
+        ? "${{ inputs.deploy_sha }}"
+        : "${{ needs.preflight.outputs.deploy_sha }}",
+    );
+    for (const restored of checkouts.slice(2)) {
+      assert.equal(restored.with["fetch-depth"], 1);
+      assert.equal(restored.with.path, "trusted-after-build");
+      assert.equal(restored.with["persist-credentials"], false);
+      assert.equal(
+        restored.with.ref,
+        "${{ needs.preflight.outputs.deploy_sha }}",
+      );
+    }
+
+    const validationIndex = job.steps.findIndex((step) =>
+      step.run?.includes("vercel-production-shadow.mjs validate-source"),
+    );
+    const candidateCheckoutIndex = job.steps.indexOf(checkouts[1]);
+    assert.ok(validationIndex > candidateCheckoutIndex, `${name} validation`);
+    const validation = job.steps[validationIndex].run;
+    assert.match(validation, /git -C "\$SOURCE_PATH" fetch/);
+    assert.match(
+      validation,
+      /node scripts\/vercel-production-shadow\.mjs validate-source/,
+    );
+    assert.equal(
+      job.steps[validationIndex].env.GITHUB_WORKFLOW_SHA,
+      name === "preflight"
+        ? "${{ github.workflow_sha }}"
+        : "${{ needs.preflight.outputs.deploy_sha }}",
+    );
+
+    for (const [stepIndex, step] of job.steps.entries()) {
+      assert.doesNotMatch(
+        step.run ?? "",
+        /(?:\$SOURCE_PATH|source)\/scripts\//,
+      );
+      assert.notEqual(step["working-directory"], "source");
+      assert.doesNotMatch(step.uses ?? "", /^\.\/source\//);
+      const executesCandidate =
+        step.uses === "./.github/actions/vercel-candidate-build";
+      if (executesCandidate) {
+        assert.ok(
+          stepIndex > validationIndex,
+          `${name} candidate execution must follow validation`,
+        );
+      }
+    }
+  }
+
+  const preflight = workflow.jobs.preflight.steps;
+  assert.ok(
+    preflight.findIndex((step) => step.run?.includes("validate-context")) <
+      preflight.findIndex((step) => step.with?.path === "source"),
+  );
+  for (const name of ["app", "governance", "reserve", "ui"]) {
+    const job = workflow.jobs[name];
+    const validationIndex = job.steps.findIndex((step) =>
+      step.run?.includes("validate-source"),
+    );
+    const runtimeIndex = job.steps.findIndex(
+      (step) => step.uses === "./.github/actions/vercel-protected-runtime",
+    );
+    const pullIndex = job.steps.findIndex((step) =>
+      step.run?.includes("vercel-production-shadow.mjs pull"),
+    );
+    const installIndex = job.steps.findIndex(
+      (step) => step.uses === "./.github/actions/vercel-candidate-build",
+    );
+    assert.ok(
+      validationIndex < runtimeIndex &&
+        runtimeIndex < pullIndex &&
+        pullIndex < installIndex,
+      `${name} validates and pulls runner state before candidate execution`,
+    );
+    const build = job.steps[installIndex];
+    assert.equal(build.id, "build");
+    assert.equal(build.with["logical-target"], name);
+    assert.match(build.with["candidate-source-path"], /runner\.temp/);
+    assert.match(build.with["upload-source-path"], /runner\.temp/);
+    const restoredAfterBuild = job.steps[installIndex + 1];
+    assert.equal(
+      restoredAfterBuild.name,
+      "Restore trusted controller after candidate build",
+    );
+    if (name !== "app") {
+      assert.equal(restoredAfterBuild.id, "trusted");
+    }
+    assert.equal(restoredAfterBuild.with.path, "trusted-after-build");
+    assert.equal(
+      restoredAfterBuild.with.ref,
+      "${{ needs.preflight.outputs.deploy_sha }}",
+    );
+    for (const step of job.steps.slice(installIndex + 1)) {
+      assert.doesNotMatch(
+        step.run ?? "",
+        /node scripts\//,
+        `${name} must not reuse the pre-build controller tree`,
+      );
+    }
+  }
+  for (const target of ["governance", "reserve", "ui"]) {
+    const smoke = workflow.jobs[`smoke-${target}`];
+    const checkouts = smoke.steps.filter((step) =>
+      step.uses?.startsWith("actions/checkout@"),
+    );
+    assert.equal(checkouts.length, 1);
+    assert.equal(
+      checkouts[0].with.ref,
+      "${{ needs.preflight.outputs.deploy_sha }}",
+    );
+    assert.equal(
+      smoke.steps.some((step) => step.with?.path === "source"),
+      false,
+    );
+    assert.doesNotMatch(
+      jobSource(`smoke-${target}`),
+      /source\/node_modules|ln -s/,
+    );
+    const validation = smoke.steps.find((step) =>
+      step.run?.includes("vercel-production-shadow.mjs validate-source"),
+    );
+    assert.ok(validation, `${target} smoke must revalidate current main`);
+    assert.equal(validation.env.SOURCE_PATH, "${{ github.workspace }}");
+    assert.match(validation.run, /git fetch --no-tags origin/);
+  }
+  const finalJob = workflow.jobs["final-alias-comparison"];
+  const finalCheckouts = finalJob.steps.filter((step) =>
+    step.uses?.startsWith("actions/checkout@"),
+  );
+  assert.equal(finalCheckouts.length, 1);
+  assert.deepEqual(finalCheckouts[0].with, {
+    "fetch-depth": 1,
+    "persist-credentials": false,
+    ref: "${{ needs.preflight.outputs.deploy_sha }}",
+  });
+  assert.equal(
+    finalJob.steps.some((step) => step.with?.path === "source"),
+    false,
+  );
+  assert.equal(
+    finalJob.steps.some(
+      (step) => step.uses === "./.github/actions/pnpm-install",
+    ),
+    false,
+  );
+  const finalValidation = stepNamed(
+    "final-alias-comparison",
+    "Prove exact final-comparison source",
+  );
+  assert.equal(finalValidation.id, "source");
+  assert.equal(finalValidation.env.SOURCE_PATH, "${{ github.workspace }}");
+  assert.match(finalValidation.run, /git fetch --no-tags origin/);
+  assert.match(finalValidation.run, /validate-source/);
+  const guardedDriftCheck = stepNamed(
+    "final-alias-comparison",
+    "Fail read-only on final protected alias drift",
+  );
+  assert.match(guardedDriftCheck.if, /steps\.source\.outcome == 'success'/);
+  assert.match(workflowSource, /^env:\n {2}SOURCE_PATH: source$/m);
+  assert.match(workflowSource, /TRUSTED_POST_BUILD_PATH: trusted-after-build/);
+  assert.doesNotMatch(workflowSource, /node source\//);
+});
+
+test("trusted pnpm action installs and caches the fresh smoke tree", () => {
+  const action = parse(
+    readFileSync(
+      new URL("../.github/actions/pnpm-install/action.yml", import.meta.url),
+      "utf8",
+    ),
+  );
+  assert.equal(action.inputs["working-directory"].default, ".");
+  const setup = action.runs.steps.find((step) =>
+    step.uses?.startsWith("actions/setup-node@"),
+  );
+  assert.equal(
+    setup.with["cache-dependency-path"],
+    "${{ inputs.working-directory }}/pnpm-lock.yaml",
+  );
+  const install = action.runs.steps.find((step) =>
+    step.run?.includes("pnpm install --frozen-lockfile"),
+  );
+  assert.equal(install["working-directory"], "${{ inputs.working-directory }}");
+  for (const name of [
+    "GITHUB_ENV",
+    "GITHUB_OUTPUT",
+    "GITHUB_PATH",
+    "GITHUB_STATE",
+    "GITHUB_STEP_SUMMARY",
+  ]) {
+    assert.match(install.run, new RegExp(`-u ${name}`));
+  }
+});
+
+test("protected build runtime uses the repository package-manager version", () => {
+  const setup = protectedRuntimeAction.runs.steps.find((step) =>
+    step.uses?.startsWith("pnpm/action-setup@"),
+  );
+  assert.equal(
+    setup.with.version,
+    rootPackage.packageManager.replace(/^pnpm@/, ""),
+  );
+});
+
+test("fresh smoke jobs never reuse candidate dependencies or command files", () => {
+  for (const target of ["governance", "reserve", "ui"]) {
+    const job = workflow.jobs[`smoke-${target}`];
+    const steps = job.steps;
+    const installIndex = steps.findIndex(
+      (step) => step.uses === "./.github/actions/pnpm-install",
+    );
+    const chromiumIndex = steps.findIndex((step) =>
+      step.run?.includes("playwright install"),
+    );
+    const smokeIndex = steps.findIndex((step) =>
+      step.run?.includes("playwright test"),
+    );
+    assert.ok(installIndex < chromiumIndex && chromiumIndex < smokeIndex);
+    assert.equal(
+      steps[0].with.ref,
+      "${{ needs.preflight.outputs.deploy_sha }}",
+    );
+    assert.equal(steps[0].with["persist-credentials"], false);
+    assert.doesNotMatch(
+      jobSource(`smoke-${target}`),
+      /source\/node_modules|ln -s/,
+    );
+    for (const step of [steps[chromiumIndex], steps[smokeIndex]]) {
+      for (const name of [
+        "GITHUB_ENV",
+        "GITHUB_OUTPUT",
+        "GITHUB_PATH",
+        "GITHUB_STATE",
+        "GITHUB_STEP_SUMMARY",
+      ]) {
+        assert.match(step.run, new RegExp(`-u ${name}`));
+      }
+    }
+  }
+});
+
+test("all credential-bearing jobs use the dedicated non-Deployment environment", () => {
+  const credentialJobs = [
+    "baseline",
+    "app",
+    "governance",
+    "reserve",
+    "ui",
+    "final-alias-comparison",
+  ];
+  const tokenFreeSmokeJobs = ["smoke-governance", "smoke-reserve", "smoke-ui"];
+  assert.equal(workflow.jobs.preflight.environment, undefined);
+  assert.doesNotMatch(jobSource("preflight"), /secrets\.|vars\./);
+  for (const name of credentialJobs) {
+    assert.ok(
+      workflow.jobs[name].needs.includes("preflight"),
+      `${name} must wait for trusted preflight`,
+    );
+    assert.deepEqual(workflow.jobs[name].environment, {
+      name: "vercel-cli-production",
+      deployment: false,
+    });
+    assert.match(jobSource(name), /secrets\./);
+  }
+  for (const name of tokenFreeSmokeJobs) {
+    assert.ok(
+      workflow.jobs[name].needs.includes("preflight"),
+      `${name} must wait for trusted preflight`,
+    );
+    assert.equal(workflow.jobs[name].environment, undefined);
+    assert.doesNotMatch(jobSource(name), /secrets\./);
+  }
+  assert.doesNotMatch(workflowSource, /name: Production\b/);
+  assert.doesNotMatch(workflowSource, /secrets:\s*inherit/);
+  assert.doesNotMatch(workflowSource, /--token\b/);
+  assert.doesNotMatch(workflowSource, /githubDeployment/);
+  assert.doesNotMatch(workflowSource, /github-deployment|deployments\/\{/i);
+});
+
+test("ordinary targets use isolated builds, runner-owned handoff, and fresh smoke", () => {
+  for (const target of ["governance", "reserve", "ui"]) {
+    const source = jobSource(target);
+    assert.match(
+      source,
+      /vercel-production-shadow\.mjs"? prepare-pull-staging/,
+    );
+    assert.match(source, /vercel-production-shadow\.mjs"? pull/);
+    assert.match(
+      source,
+      /vercel-production-shadow\.mjs"? validate-pull-staging/,
+    );
+    assert.doesNotMatch(
+      source,
+      /vercel-production-shadow\.mjs"? assert-output/,
+    );
+    assert.match(source, /vercel-production-shadow\.mjs"? deploy --expected/);
+    assert.match(source, new RegExp(`LOGICAL_TARGET: ${target}`));
+    const build = stepNamed(
+      target,
+      `Build ${target === "ui" ? "UI" : target} production and assert output`,
+    );
+    assert.equal(build.uses, "./.github/actions/vercel-candidate-build");
+    assert.equal(build.with["logical-target"], target);
+    assert.equal(
+      build.with["expected-root-directory"],
+      `apps/${target}.mento.org`,
+    );
+    assert.match(build.with["candidate-source-path"], /runner\.temp/);
+    assert.match(build.with["pull-staging-path"], /runner\.temp/);
+    assert.match(build.with["upload-source-path"], /runner\.temp/);
+    assert.match(source, /vercel-deployment-state\.mjs"? deployment/);
+    assert.match(source, /vercel-deployment-state\.mjs"? compare/);
+    assert.match(source, /vercel-production-shadow\.mjs"? assert-unaliased/);
+    assert.match(source, /check-versions --repo-root "\$SOURCE_PATH"/);
+    assert.doesNotMatch(source, /playwright (?:install|test)/);
+
+    const smokeSource = jobSource(`smoke-${target}`);
+    assert.match(smokeSource, /playwright test -c/);
+    assert.match(smokeSource, /playwright[\s\S]*install --with-deps chromium/);
+    assert.match(smokeSource, /PRODUCTION_SHADOW_EXPECTED_DEPLOYMENT_ID/);
+    assert.match(smokeSource, /PRODUCTION_SHADOW_EXPECTED_SHA/);
+    assert.equal(workflow.jobs[`smoke-${target}`].needs.includes(target), true);
+
+    const projectId = `prj_${target}123`;
+    assert.deepEqual(
+      buildProductionShadowPullArguments({ logicalTarget: target, projectId }),
+      [
+        "pull",
+        "--yes",
+        "--environment",
+        "production",
+        "--git-branch",
+        "main",
+        "--project",
+        projectId,
+      ],
+    );
+    assert.deepEqual(
+      buildProductionShadowBuildArguments({ logicalTarget: target, projectId }),
+      ["build", "--yes", "--standalone", "--prod", "--project", projectId],
+    );
+    assert.deepEqual(
+      buildProductionShadowDeployArguments({
+        logicalTarget: target,
+        projectId,
+        deploySha: SHA,
+        transaction: `123-1-${target}`,
+      }).slice(0, 9),
+      [
+        "deploy",
+        "--prebuilt",
+        "--prod",
+        "--skip-domain",
+        "--archive=tgz",
+        "--format=json",
+        "--yes",
+        "--project",
+        projectId,
+      ],
+    );
+  }
+  assert.doesNotMatch(workflowSource, /vercel promote|vercel rollback/);
+  assert.deepEqual(workflow.jobs.governance.needs, ["preflight", "baseline"]);
+  assert.deepEqual(workflow.jobs.reserve.needs, [
+    "preflight",
+    "baseline",
+    "governance",
+    "smoke-governance",
+  ]);
+  assert.deepEqual(workflow.jobs.ui.needs, [
+    "preflight",
+    "baseline",
+    "governance",
+    "reserve",
+    "smoke-reserve",
+  ]);
+});
+
+test("ordinary uploads stop forward mutation after any prior drift failure", () => {
+  const sequence = ["governance", "reserve", "ui"];
+  for (const [index, target] of sequence.entries()) {
+    const steps = workflow.jobs[target].steps;
+    const targetLabel = target === "ui" ? "UI" : target;
+    const upload = stepNamed(
+      target,
+      `Upload unchanged ${targetLabel} output without domains`,
+    );
+    const drift = stepNamed(
+      target,
+      `Fail read-only on protected alias drift after ${targetLabel} deploy`,
+    );
+    const proof = stepNamed(
+      target,
+      "Prove every protected mapping remains unchanged",
+    );
+    assert.ok(steps.indexOf(upload) < steps.indexOf(drift));
+    assert.ok(steps.indexOf(drift) < steps.indexOf(proof));
+    assert.equal(
+      drift.if,
+      "${{ always() && steps.build.outcome == 'success' && steps.trusted.outcome == 'success' }}",
+    );
+    assert.match(drift.run, /vercel-production-shadow\.mjs" check-aliases/);
+    assert.match(proof.run, /vercel-deployment-state\.mjs" compare/);
+    assert.equal(workflow.jobs[target].if, undefined);
+
+    if (index === 0) continue;
+    const prior = sequence[index - 1];
+    assert.ok(workflow.jobs[target].needs.includes(prior));
+    assert.ok(workflow.jobs[target].needs.includes(`smoke-${prior}`));
+  }
+});
+
+test("app Outcome B has no reachable deploy or production command", () => {
+  const source = jobSource("app");
+  assert.match(source, /vercel-production-shadow\.mjs"? prepare-pull-staging/);
+  assert.match(source, /vercel-production-shadow\.mjs"? pull/);
+  assert.doesNotMatch(source, /vercel-production-shadow\.mjs"? assert-output/);
+  const build = stepNamed("app", "Build app custom v3 and assert output");
+  assert.equal(build.uses, "./.github/actions/vercel-candidate-build");
+  assert.equal(build.with["logical-target"], "app");
+  assert.equal(build.with["expected-root-directory"], "apps/app.mento.org");
+  assert.match(build.with["upload-source-path"], /runner\.temp/);
+  assert.match(source, /NEXT_PUBLIC_VERCEL_ENV: preview/);
+  assert.match(source, /VERCEL_ENV: preview/);
+  assert.match(source, /VERCEL_TARGET_ENV: v3/);
+  assert.doesNotMatch(source, /SENTRY_AUTH_TOKEN:/);
+  assert.match(
+    candidateActionSource,
+    /SENTRY_AUTH_TOKEN="\$\{SENTRY_AUTH_TOKEN:-\}"/,
+  );
+  assert.match(source, /app-proof/);
+  assert.doesNotMatch(
+    source,
+    /vercel-production-shadow\.mjs"? deploy|--prod|--skip-domain|promote|alias set/,
+  );
+  assert.deepEqual(
+    buildProductionShadowPullArguments({
+      logicalTarget: "app",
+      projectId: "prj_app123",
+    }),
+    [
+      "pull",
+      "--yes",
+      "--environment",
+      "v3",
+      "--git-branch",
+      "main",
+      "--project",
+      "prj_app123",
+    ],
+  );
+  assert.deepEqual(
+    buildProductionShadowBuildArguments({
+      logicalTarget: "app",
+      projectId: "prj_app123",
+    }),
+    [
+      "build",
+      "--yes",
+      "--standalone",
+      "--target",
+      "v3",
+      "--project",
+      "prj_app123",
+    ],
+  );
+  assert.throws(() =>
+    buildProductionShadowDeployArguments({
+      logicalTarget: "app",
+      projectId: "prj_app123",
+      deploySha: SHA,
+      transaction: "123-1-app",
+    }),
+  );
+});
+
+test("candidate builds are standalone and external references fail before handoff", () => {
+  const build = candidateAction.runs.steps.find(
+    (step) => step.name === "Build prebuilt output as candidate",
+  );
+  assert.match(
+    build.run,
+    /app\) build_arguments=\(build --yes --standalone --target v3 --project "\$VERCEL_PROJECT_ID"\)/,
+  );
+  assert.match(
+    build.run,
+    /governance\|reserve\|ui\) build_arguments=\(build --yes --standalone --prod --project "\$VERCEL_PROJECT_ID"\)/,
+  );
+  assert.ok(
+    build.run.indexOf("validate-candidate-pull") <
+      build.run.indexOf("build_arguments="),
+  );
+
+  const stagingIndex = candidateAction.runs.steps.findIndex(
+    (step) => step.name === "Stage validated runner-owned Vercel settings",
+  );
+  const buildIndex = candidateAction.runs.steps.findIndex(
+    (step) => step.name === "Build prebuilt output as candidate",
+  );
+  assert.ok(stagingIndex >= 0);
+  assert.ok(stagingIndex < buildIndex);
+  assert.match(candidateAction.runs.steps[stagingIndex].run, /stage-pull/);
+  assert.match(
+    candidateAction.runs.steps[stagingIndex].run,
+    /pgrep -u "\$BUILD_UID"/,
+  );
+
+  const candidateValidationIndex = candidateAction.runs.steps.findIndex(
+    (step) => step.name === "Validate candidate-owned prebuilt output",
+  );
+  const handoffIndex = candidateAction.runs.steps.findIndex(
+    (step) => step.name === "Create immutable runner-owned output handoff",
+  );
+  const uploadValidationIndex = candidateAction.runs.steps.findIndex(
+    (step) => step.name === "Assert immutable runner-owned upload handoff",
+  );
+  assert.ok(candidateValidationIndex >= 0);
+  assert.ok(candidateValidationIndex < handoffIndex);
+  assert.ok(handoffIndex < uploadValidationIndex);
+  assert.match(
+    candidateAction.runs.steps[candidateValidationIndex].run,
+    /vercel-production-shadow\.mjs" assert-output/,
+  );
+  assert.match(
+    candidateAction.runs.steps[handoffIndex].run,
+    /vercel-production-shadow\.mjs"[\s\\]+create-handoff/,
+  );
+  assert.match(
+    candidateAction.runs.steps[uploadValidationIndex].run,
+    /vercel-production-shadow\.mjs" assert-output/,
+  );
+  const cleanup = candidateAction.runs.steps.find(
+    (step) => step.name === "Remove candidate execution boundary",
+  );
+  assert.match(cleanup.run, /mento-vercel-production-build-environment/);
+  assert.match(cleanup.run, /"\$materialized_environment_path"/);
+});
+
+test("build-variable scopes preserve production Sentry behavior", () => {
+  const expectedBuildSecrets = {
+    app: {},
+    governance: {
+      ETHERSCAN_API_KEY: "${{ secrets.ETHERSCAN_API_KEY }}",
+      SENTRY_AUTH_TOKEN: "${{ secrets.SENTRY_AUTH_TOKEN }}",
+    },
+    reserve: {
+      SENTRY_AUTH_TOKEN: "${{ secrets.SENTRY_AUTH_TOKEN }}",
+    },
+    ui: {},
+  };
+  for (const [target, expected] of Object.entries(expectedBuildSecrets)) {
+    const buildSteps = stepsMatching(target, /^Build .+ and assert output$/);
+    assert.equal(buildSteps.length, 1);
+    const [build] = buildSteps;
+    assert.equal(build.env.VERCEL_TOKEN, undefined);
+    assert.equal(build.env.TURBO_TEAM, "${{ vars.TURBO_TEAM }}");
+    assert.equal(build.env.TURBO_TOKEN, "${{ secrets.TURBO_TOKEN }}");
+    assert.equal(
+      build.env.TURBO_REMOTE_CACHE_SIGNATURE_KEY,
+      "${{ secrets.TURBO_REMOTE_CACHE_SIGNATURE_KEY }}",
+    );
+    assert.equal(build.env.VERCEL_AUTOMATION_BYPASS_SECRET, undefined);
+    for (const key of ["SENTRY_AUTH_TOKEN", "ETHERSCAN_API_KEY"]) {
+      assert.equal(build.env[key], expected[key]);
+      for (const step of workflow.jobs[target].steps) {
+        if (step === build) continue;
+        assert.notEqual(
+          step.env?.[key],
+          `\${{ secrets.${key} }}`,
+          `${target} ${key} must exist only in its literal build step`,
+        );
+      }
+    }
+    assert.equal(build.uses, "./.github/actions/vercel-candidate-build");
+    if (target === "app") {
+      assert.doesNotThrow(() =>
+        validateVercelBuildCredentialBoundary({
+          target: "app",
+          environment: "v3",
+          pulledValues: {},
+          explicitValues: build.env,
+        }),
+      );
+    }
+  }
+  const validation = candidateAction.runs.steps.find(
+    (step) => step.name === "Validate runner-owned build inputs",
+  );
+  assert.match(
+    validation.run,
+    /vercel-production-shadow\.mjs" check-build-inputs/,
+  );
+  assert.match(validation.run, /vercel-build-environment\.mjs/);
+  assert.match(
+    validation.run,
+    /"\$PULL_STAGING_PATH\/\$EXPECTED_ROOT_DIRECTORY"/,
+  );
+  const install = candidateAction.runs.steps.find(
+    (step) => step.name === "Install frozen dependencies as candidate",
+  );
+  assert.match(install.run, /\/usr\/bin\/env -i/);
+  assert.match(
+    install.run,
+    /"\$PNPM_BIN" --dir "\$CANDIDATE_SOURCE_PATH" install/,
+  );
+  assert.match(install.run, /--ignore-scripts/);
+  const candidateBuild = candidateAction.runs.steps.find(
+    (step) => step.name === "Build prebuilt output as candidate",
+  );
+  assert.match(candidateBuild.run, /\/usr\/bin\/env -i/);
+  assert.match(
+    candidateBuild.run,
+    /SENTRY_AUTH_TOKEN="\$\{SENTRY_AUTH_TOKEN:-\}"/,
+  );
+  assert.match(
+    candidateBuild.run,
+    /"\$NODE_BIN" "\$TRUSTED_VERCEL_CLI_PATH" "\$\{build_arguments\[@\]\}"/,
+  );
+  assert.match(candidateBuild.run, /\/usr\/bin\/tee "\$build_log"/);
+  assert.match(candidateBuild.run, /PIPESTATUS/);
+  assert.match(candidateBuild.run, /cache-summary --input "\$build_log"/);
+  assert.equal(
+    candidateAction.outputs.turbo_cache_hits.value,
+    "${{ steps.build.outputs.turbo_cache_hits }}",
+  );
+  assert.equal(
+    candidateAction.outputs.turbo_cache_misses.value,
+    "${{ steps.build.outputs.turbo_cache_misses }}",
+  );
+  for (const target of ["app", "governance", "reserve", "ui"]) {
+    assert.equal(
+      workflow.jobs[target].outputs.turbo_cache_hits,
+      "${{ steps.build.outputs.turbo_cache_hits }}",
+    );
+    assert.equal(
+      workflow.jobs[target].outputs.turbo_cache_misses,
+      "${{ steps.build.outputs.turbo_cache_misses }}",
+    );
+  }
+  assert.match(
+    candidateBuild.run,
+    optionalShellEnvironmentAssignment("ETHERSCAN_API_KEY"),
+  );
+  assert.match(
+    candidateBuild.run,
+    optionalShellEnvironmentAssignment("SENTRY_AUTH_TOKEN"),
+  );
+  assert.doesNotMatch(candidateActionSource, /VERCEL_TOKEN/);
+  assert.equal(
+    (workflowSource.match(/secrets\.SENTRY_AUTH_TOKEN/g) ?? []).length,
+    2,
+  );
+  assert.equal(
+    (workflowSource.match(/secrets\.ETHERSCAN_API_KEY/g) ?? []).length,
+    1,
+  );
+});
+
+test("artifacts contain only failure-safe browser diagnostics", () => {
+  const uploadSteps = Object.values(workflow.jobs)
+    .flatMap((job) => job.steps ?? [])
+    .filter((step) => step.uses?.startsWith("actions/upload-artifact@"));
+  assert.equal(uploadSteps.length, 3);
+  for (const step of uploadSteps) {
+    assert.equal(step.if, "failure()");
+    assert.equal(step.with.path, "apps/app.mento.org/test-results/");
+    assert.equal(step.with["retention-days"], 7);
+    assert.doesNotMatch(step.with.path, /\.vercel|\.env/);
+  }
+  assert.doesNotMatch(
+    workflowSource,
+    /upload-artifact[\s\S]{0,500}\.vercel\/output/,
+  );
+});
+
+test("post-candidate evidence files fail closed on preexisting paths", () => {
+  for (const name of [
+    "app",
+    "governance",
+    "reserve",
+    "ui",
+    "final-alias-comparison",
+  ]) {
+    for (const step of workflow.jobs[name].steps) {
+      if ((step.run ?? "").includes("printf ")) {
+        assert.match(step.run, /set -o noclobber/);
+      }
+    }
+  }
+  for (const path of [
+    "../scripts/vercel-production-shadow.mjs",
+    "../scripts/vercel-deployment-state.mjs",
+  ]) {
+    const source = readFileSync(new URL(path, import.meta.url), "utf8");
+    assert.match(source, /constants\.O_EXCL/);
+    assert.match(source, /constants\.O_NOFOLLOW/);
+  }
+});
+
+test("every deploy is immediately checked for drift without automatic repair", () => {
+  for (const target of ["governance", "reserve", "ui"]) {
+    const steps = workflow.jobs[target].steps;
+    const deployIndex = steps.findIndex((step) => step.id === "deploy");
+    assert.notEqual(deployIndex, -1);
+    const check = steps[deployIndex + 1];
+    assert.equal(
+      check.name,
+      `Fail read-only on protected alias drift after ${target === "ui" ? "UI" : target} deploy`,
+    );
+    assert.equal(
+      check.if,
+      "${{ always() && steps.build.outcome == 'success' && steps.trusted.outcome == 'success' }}",
+    );
+    assert.match(check.run, /check-aliases/);
+    assert.doesNotMatch(
+      check.run,
+      /--baseline|--target|--deployment-id|printf/,
+    );
+    assert.equal(
+      check.env.VERCEL_TOKEN,
+      "${{ secrets.VERCEL_TOKEN_PRODUCTION }}",
+    );
+    const compareIndex = steps.findIndex(
+      (step) => step.name === "Prove every protected mapping remains unchanged",
+    );
+    const stateIndex = steps.findIndex(
+      (step) =>
+        step.name?.startsWith("Verify ") &&
+        step.name.endsWith(" deployment provenance and readiness"),
+    );
+    assert.ok(deployIndex < deployIndex + 1);
+    assert.ok(deployIndex + 1 < compareIndex);
+    assert.ok(compareIndex < stateIndex);
+    assert.equal(
+      steps.some((step) => step.run?.includes("playwright")),
+      false,
+    );
+
+    const smokeSteps = workflow.jobs[`smoke-${target}`].steps;
+    const chromiumIndex = smokeSteps.findIndex((step) =>
+      step.run?.includes("playwright install"),
+    );
+    const smokeIndex = smokeSteps.findIndex((step) =>
+      step.run?.includes("playwright test"),
+    );
+    assert.ok(chromiumIndex < smokeIndex);
+  }
+
+  const finalCheck = stepNamed(
+    "final-alias-comparison",
+    "Fail read-only on final protected alias drift",
+  );
+  const finalTrustedCheckout = workflow.jobs[
+    "final-alias-comparison"
+  ].steps.find(({ name }) => name === "Check out trusted workflow controller");
+  assert.equal(finalTrustedCheckout.id, "trusted");
+  assert.ok(finalTrustedCheckout.uses.startsWith("actions/checkout@"));
+  assert.equal(
+    finalCheck.if,
+    "${{ always() && steps.trusted.outcome == 'success' && steps.source.outcome == 'success' }}",
+  );
+  assert.match(finalCheck.run, /check-aliases/);
+  assert.doesNotMatch(finalCheck.run, /--baseline|--target|printf/);
+  assert.deepEqual(Object.keys(finalCheck.env).sort(), [
+    "BASELINE_JSON",
+    "VERCEL_ORG_ID",
+    "VERCEL_TOKEN",
+  ]);
+  const helperSource = readFileSync(
+    new URL("../scripts/vercel-production-shadow.mjs", import.meta.url),
+    "utf8",
+  );
+  assert.doesNotMatch(helperSource, /guardProtectedAliases/);
+  assert.doesNotMatch(helperSource, /environmentForProtectedAliasRepair/);
+  assert.doesNotMatch(helperSource, /\["exec", "vercel", "alias"/);
+  assert.doesNotMatch(workflowSource, /vercel-production-shadow\.mjs restore/);
+  assert.doesNotMatch(workflowSource, /vercel alias set/);
+  assert.doesNotMatch(workflowSource, /guard-aliases|promote|rollback/);
+});
+
+test("stable final status job fails closed over literal dependencies", () => {
+  const job = workflow.jobs.result;
+  assert.equal(job.name, "Vercel Production Shadow");
+  assert.equal(job.if, "${{ always() }}");
+  assert.deepEqual(job.needs, [
+    "preflight",
+    "baseline",
+    "app",
+    "governance",
+    "smoke-governance",
+    "reserve",
+    "smoke-reserve",
+    "ui",
+    "smoke-ui",
+    "final-alias-comparison",
+  ]);
+  const source = jobSource("result");
+  assert.match(source, /if \[\[ "\$result" != "success" \]\]/);
+});
+
+test("all external action references remain immutable full SHA pins", () => {
+  for (const value of allStrings(workflow)) {
+    if (!value.includes("@") || value.startsWith("./")) continue;
+    const [action, pin] = value.split("@");
+    if (!action.includes("/")) continue;
+    assert.match(pin, /^[a-f0-9]{40}$/i, value);
+  }
+});
+
+test("shadow smoke strips protection headers and disables traces", () => {
+  const config = readFileSync(
+    new URL(
+      "../apps/app.mento.org/playwright.production-shadow.config.ts",
+      import.meta.url,
+    ),
+    "utf8",
+  );
+  const spec = readFileSync(
+    new URL(
+      "../apps/app.mento.org/e2e/production-shadow/smoke.spec.ts",
+      import.meta.url,
+    ),
+    "utf8",
+  );
+  const requestPolicy = readFileSync(
+    new URL(
+      "../apps/app.mento.org/e2e/production-shadow/request-policy.mjs",
+      import.meta.url,
+    ),
+    "utf8",
+  );
+  const redirectRegression = readFileSync(
+    new URL(
+      "../apps/app.mento.org/production-shadow-routing.test.mjs",
+      import.meta.url,
+    ),
+    "utf8",
+  );
+  assert.match(config, /trace: "off"/);
+  assert.match(config, /serviceWorkers: "block"/);
+  assert.doesNotMatch(config, /extraHTTPHeaders/);
+  assert.match(spec, /page\.route\("\*\*\/\*"/);
+  assert.match(spec, /fulfillProductionShadowRequest/);
+  assert.doesNotMatch(spec, /route\.continue/);
+  assert.match(spec, /assertProductionShadowOrigin/);
+  assert.match(spec, /framenavigated/);
+  assert.match(spec, /frame !== page\.mainFrame\(\)/);
+  assert.match(spec, /errors\.origins/);
+  assert.match(spec, /X-Frame-Options|x-frame-options/);
+  assert.match(spec, /content-security-policy-report-only/);
+  assert.match(spec, /requestfailed/);
+  assert.match(spec, /page\.on\("response"/);
+  assert.match(spec, /response\.status\(\) >= 400/);
+  assert.doesNotMatch(
+    spec,
+    /new URL\((?:request|response)\.url\(\)\)\.origin === origin/,
+  );
+  assert.doesNotMatch(spec, /startsWith\(origin\)/);
+  assert.match(spec, /pageerror/);
+  assert.match(spec, /message\.type\(\) === "error"/);
+  assert.match(spec, /PRODUCTION_SHADOW_EXPECTED_DEPLOYMENT_ID/);
+  assert.match(spec, /PRODUCTION_SHADOW_EXPECTED_SHA|expectedSha/);
+  assert.match(workflowSource, /PRODUCTION_SHADOW_EXPECTED_SHA/);
+  assert.match(spec, /x-mento-deployment-sha/);
+  assert.match(spec, /data-dpl-id/);
+  assert.match(spec, /My Voting Power/);
+  assert.match(spec, /Supply/);
+  assert.match(spec, /Search components/);
+  assert.match(requestPolicy, /name\.toLowerCase\(\)/);
+  assert.match(requestPolicy, /forbidden protection header/);
+  assert.doesNotMatch(requestPolicy, /bypassSecret|fixture-bypass/);
+  assert.match(requestPolicy, /route\.fetch/);
+  assert.match(requestPolicy, /maxRedirects: 0/);
+  assert.match(requestPolicy, /route\.fulfill/);
+  assert.match(redirectRegression, /createServer/);
+  assert.match(redirectRegression, /chromium\.launch/);
+  assert.match(redirectRegression, /received\.source, \[undefined\]/);
+  assert.match(redirectRegression, /received\.destination, \[undefined\]/);
+  for (const target of ["governance", "reserve", "ui"]) {
+    const nextConfig = readFileSync(
+      new URL(`../apps/${target}.mento.org/next.config.ts`, import.meta.url),
+      "utf8",
+    );
+    const turbo = JSON.parse(
+      readFileSync(
+        new URL(`../apps/${target}.mento.org/turbo.json`, import.meta.url),
+        "utf8",
+      ),
+    );
+    assert.match(nextConfig, /X-Mento-Deployment-Sha/);
+    assert.match(nextConfig, /VERCEL_GIT_COMMIT_SHA/);
+    assert.ok(
+      turbo.tasks.build.env.includes("VERCEL_GIT_COMMIT_SHA"),
+      `${target} build cache identity`,
+    );
+  }
+});

--- a/scripts/vercel-production-shadow-workflow.test.mjs
+++ b/scripts/vercel-production-shadow-workflow.test.mjs
@@ -935,6 +935,23 @@ test("stable final status job fails closed over literal dependencies", () => {
   assert.match(source, /if \[\[ "\$result" != "success" \]\]/);
 });
 
+test("fresh smoke jobs resolve the Playwright config from the filtered workspace", () => {
+  for (const target of ["governance", "reserve", "ui"]) {
+    const smoke = workflow.jobs[`smoke-${target}`].steps.find((step) =>
+      step.name?.startsWith("Run direct "),
+    );
+    assert.ok(smoke, `${target} smoke step must exist`);
+    assert.match(
+      smoke.run,
+      /pnpm --filter app\.mento\.org exec playwright test -c playwright\.production-shadow\.config\.ts/,
+    );
+    assert.doesNotMatch(
+      smoke.run,
+      /-c apps\/app\.mento\.org\/playwright\.production-shadow\.config\.ts/,
+    );
+  }
+});
+
 test("all external action references remain immutable full SHA pins", () => {
   for (const value of allStrings(workflow)) {
     if (!value.includes("@") || value.startsWith("./")) continue;

--- a/scripts/vercel-production-shadow.mjs
+++ b/scripts/vercel-production-shadow.mjs
@@ -1,0 +1,2883 @@
+#!/usr/bin/env node
+
+/* eslint-disable turbo/no-undeclared-env-vars -- This direct Actions controller does not run through Turbo. */
+
+import { Buffer } from "node:buffer";
+import { execFileSync, spawnSync } from "node:child_process";
+import {
+  chmodSync,
+  chownSync,
+  closeSync,
+  cpSync,
+  copyFileSync,
+  constants,
+  existsSync,
+  fchmodSync,
+  fstatSync,
+  lstatSync,
+  mkdirSync,
+  openSync,
+  readdirSync,
+  readFileSync,
+  readSync,
+  realpathSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import process from "node:process";
+import {
+  basename,
+  dirname,
+  isAbsolute,
+  join,
+  relative,
+  resolve,
+  sep,
+} from "node:path";
+import { fileURLToPath } from "node:url";
+import { stripVTControlCharacters } from "node:util";
+
+import { assertPrebuiltDeploymentId } from "./vercel-prebuilt.mjs";
+import {
+  parseVercelPulledEnvironment,
+  selectVercelPulledEnvironment,
+  serializeVercelPulledEnvironment,
+} from "./vercel-build-environment.mjs";
+import {
+  assertCanonicalOutput,
+  canonicalizeDeploymentUrl,
+  canonicalizeHostname,
+  captureAliasMappings,
+  VercelStateClient,
+} from "./vercel-deployment-state.mjs";
+
+const SHA_PATTERN = /^[A-Fa-f0-9]{40}$/;
+const DEPLOYMENT_ID_PATTERN = /^dpl_[A-Za-z0-9]+$/;
+const EXPECTED_WORKFLOW_REF =
+  "mento-protocol/frontend-monorepo/.github/workflows/vercel-production-shadow.yml@refs/heads/main";
+const REVIEWED_APP_V3_ALIASES = Object.freeze([
+  "app.mento.org",
+  "appmentoorg-env-v3-mentolabs.vercel.app",
+]);
+const FORBIDDEN_EVIDENCE_PATTERN =
+  /protectionBypass|buildEnv|VERCEL_TOKEN|SENTRY_AUTH_TOKEN|ETHERSCAN_API_KEY|authorization|cookie/i;
+const PULL_STAGING_DIRECTORY = "mento-vercel-production-pull-staging";
+const BUILD_ENVIRONMENT_DIRECTORY = "mento-vercel-production-build-environment";
+const CANDIDATE_SOURCE_DIRECTORY = "mento-vercel-production-candidate-source";
+const UPLOAD_SOURCE_DIRECTORY = "mento-vercel-production-upload-source";
+const EXPLICIT_EMPTY = "explicit-empty";
+const MAX_SOURCE_ENTRIES = 20_000;
+const MAX_SOURCE_PATH_BYTES = 4_096;
+const MAX_SOURCE_BLOB_BYTES = 32 * 1_024 * 1_024;
+const MAX_SOURCE_TREE_BYTES = 16 * 1_024 * 1_024;
+const MAX_SOURCE_TOTAL_BYTES = 128 * 1_024 * 1_024;
+const MAX_PULLED_ENVIRONMENT_BYTES = 16 * 1_024 * 1_024;
+const MAX_MATERIALIZED_ENVIRONMENT_BYTES = 1_024 * 1_024;
+const MAX_PREBUILT_CONFIG_BYTES = 1_024 * 1_024;
+const VERCEL_CLI_ENVIRONMENT_NAMES = Object.freeze([
+  "CI",
+  "HTTP_PROXY",
+  "HTTPS_PROXY",
+  "LANG",
+  "LC_ALL",
+  "NODE_EXTRA_CA_CERTS",
+  "NO_PROXY",
+  "PATH",
+  "SSL_CERT_FILE",
+  "VERCEL_TOKEN",
+]);
+
+export const PRODUCTION_SHADOW_TARGETS = {
+  app: {
+    projectName: "app.mento.org",
+    rootDirectory: "apps/app.mento.org",
+    pullEnvironment: "v3",
+    buildArguments: ["build", "--yes", "--standalone", "--target", "v3"],
+    deployArguments: null,
+  },
+  governance: {
+    projectName: "governance.mento.org",
+    rootDirectory: "apps/governance.mento.org",
+    pullEnvironment: "production",
+    buildArguments: ["build", "--yes", "--standalone", "--prod"],
+    deployArguments: [
+      "deploy",
+      "--prebuilt",
+      "--prod",
+      "--skip-domain",
+      "--archive=tgz",
+      "--format=json",
+      "--yes",
+    ],
+  },
+  reserve: {
+    projectName: "reserve.mento.org",
+    rootDirectory: "apps/reserve.mento.org",
+    pullEnvironment: "production",
+    buildArguments: ["build", "--yes", "--standalone", "--prod"],
+    deployArguments: [
+      "deploy",
+      "--prebuilt",
+      "--prod",
+      "--skip-domain",
+      "--archive=tgz",
+      "--format=json",
+      "--yes",
+    ],
+  },
+  ui: {
+    projectName: "ui.mento.org",
+    rootDirectory: "apps/ui.mento.org",
+    pullEnvironment: "production",
+    buildArguments: ["build", "--yes", "--standalone", "--prod"],
+    deployArguments: [
+      "deploy",
+      "--prebuilt",
+      "--prod",
+      "--skip-domain",
+      "--archive=tgz",
+      "--format=json",
+      "--yes",
+    ],
+  },
+};
+
+function requireString(value, label, pattern) {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error(`${label} is required`);
+  }
+  if (pattern && !pattern.test(value)) {
+    throw new Error(`${label} is malformed`);
+  }
+  return value;
+}
+
+function requireIdentifier(value, label) {
+  return requireString(value, label, /^[A-Za-z0-9._-]+$/);
+}
+
+function targetContract(logicalTarget) {
+  if (!Object.hasOwn(PRODUCTION_SHADOW_TARGETS, logicalTarget)) {
+    throw new Error(
+      `Unknown production-shadow target: ${String(logicalTarget)}`,
+    );
+  }
+  return PRODUCTION_SHADOW_TARGETS[logicalTarget];
+}
+
+function numericIdentity(value, label) {
+  const numeric = typeof value === "string" ? Number(value) : value;
+  if (!Number.isSafeInteger(numeric) || numeric < 0) {
+    throw new Error(`${label} is invalid`);
+  }
+  return numeric;
+}
+
+function hasControlCharacters(value) {
+  return [...value].some((character) => {
+    const codePoint = character.codePointAt(0);
+    return codePoint <= 31 || codePoint === 127;
+  });
+}
+
+function optionalEntry(path) {
+  try {
+    return lstatSync(path);
+  } catch (error) {
+    if (error?.code === "ENOENT") return undefined;
+    throw error;
+  }
+}
+
+function pulledEnvironmentFile(logicalTarget) {
+  return `.env.${targetContract(logicalTarget).pullEnvironment}.local`;
+}
+
+function expectedPullTree(logicalTarget) {
+  const rootDirectory = targetContract(logicalTarget).rootDirectory;
+  const entries = [
+    ["", { type: "directory" }],
+    [".vercel", { type: "directory" }],
+    [join(".vercel", "repo.json"), { type: "file", maximumSize: 64 * 1_024 }],
+  ];
+  let current = "";
+  for (const component of rootDirectory.split("/")) {
+    current = join(current, component);
+    entries.push([current, { type: "directory" }]);
+  }
+  const appState = join(rootDirectory, ".vercel");
+  entries.push(
+    [appState, { type: "directory" }],
+    [
+      join(appState, "project.json"),
+      { type: "file", maximumSize: 256 * 1_024 },
+    ],
+    [
+      join(appState, pulledEnvironmentFile(logicalTarget)),
+      { type: "file", maximumSize: MAX_PULLED_ENVIRONMENT_BYTES },
+    ],
+  );
+  return entries;
+}
+
+function protectedFileIdentity(entry) {
+  return {
+    ctimeMs: entry.ctimeMs,
+    dev: entry.dev,
+    gid: entry.gid,
+    ino: entry.ino,
+    mode: entry.mode,
+    mtimeMs: entry.mtimeMs,
+    nlink: entry.nlink,
+    size: entry.size,
+    uid: entry.uid,
+  };
+}
+
+function sameProtectedFileIdentity(left, right) {
+  return Object.keys(left).every((name) => left[name] === right[name]);
+}
+
+function assertProtectedEnvironmentEntry(
+  entry,
+  { expectedUid, expectedGid, label },
+) {
+  if (
+    entry.isSymbolicLink() ||
+    !entry.isFile() ||
+    entry.uid !== expectedUid ||
+    entry.gid !== expectedGid ||
+    (entry.mode & 0o777) !== 0o600 ||
+    entry.nlink !== 1 ||
+    entry.size > MAX_PULLED_ENVIRONMENT_BYTES
+  ) {
+    throw new Error(`${label} has unsafe filesystem metadata`);
+  }
+}
+
+function readProtectedEnvironmentFile({
+  root,
+  filePath,
+  expectedUid,
+  expectedGid,
+  label,
+}) {
+  const resolvedRoot = resolve(root);
+  const resolvedFilePath = resolve(filePath);
+  const canonicalRoot = realpathSync(resolvedRoot);
+  const canonicalFilePath = realpathSync(resolvedFilePath);
+  const lexicalRelativePath = relative(resolvedRoot, resolvedFilePath);
+  if (
+    lexicalRelativePath === "" ||
+    lexicalRelativePath === ".." ||
+    lexicalRelativePath.startsWith(`..${sep}`) ||
+    isAbsolute(lexicalRelativePath) ||
+    canonicalFilePath !== join(canonicalRoot, lexicalRelativePath)
+  ) {
+    throw new Error(`${label} escapes its protected root`);
+  }
+  const beforeEntry = lstatSync(resolvedFilePath);
+  assertProtectedEnvironmentEntry(beforeEntry, {
+    expectedUid,
+    expectedGid,
+    label,
+  });
+  if (typeof constants.O_NOFOLLOW !== "number") {
+    throw new Error(`${label} cannot be opened without following links`);
+  }
+  const descriptor = openSync(
+    resolvedFilePath,
+    constants.O_RDONLY | constants.O_NOFOLLOW,
+  );
+  const beforeIdentity = protectedFileIdentity(beforeEntry);
+  let bytes;
+  try {
+    const openedEntry = fstatSync(descriptor);
+    assertProtectedEnvironmentEntry(openedEntry, {
+      expectedUid,
+      expectedGid,
+      label,
+    });
+    if (
+      !sameProtectedFileIdentity(
+        beforeIdentity,
+        protectedFileIdentity(openedEntry),
+      )
+    ) {
+      throw new Error(`${label} changed before it was opened`);
+    }
+    bytes = Buffer.alloc(openedEntry.size);
+    let offset = 0;
+    while (offset < bytes.length) {
+      const count = readSync(
+        descriptor,
+        bytes,
+        offset,
+        bytes.length - offset,
+        offset,
+      );
+      if (count === 0) throw new Error(`${label} was truncated while reading`);
+      offset += count;
+    }
+    const afterReadEntry = fstatSync(descriptor);
+    if (
+      !sameProtectedFileIdentity(
+        beforeIdentity,
+        protectedFileIdentity(afterReadEntry),
+      )
+    ) {
+      throw new Error(`${label} changed while it was read`);
+    }
+  } finally {
+    closeSync(descriptor);
+  }
+  const afterPathEntry = lstatSync(resolvedFilePath);
+  if (
+    !sameProtectedFileIdentity(
+      beforeIdentity,
+      protectedFileIdentity(afterPathEntry),
+    )
+  ) {
+    throw new Error(`${label} changed after it was read`);
+  }
+  return { bytes, identity: beforeIdentity };
+}
+
+function assertSameProtectedSource(before, after) {
+  if (
+    !sameProtectedFileIdentity(before.identity, after.identity) ||
+    !before.bytes.equals(after.bytes)
+  ) {
+    throw new Error(
+      "Vercel-pulled build environment changed during materialization",
+    );
+  }
+}
+
+function deriveProductionShadowBuildEnvironment({ logicalTarget, raw }) {
+  let text;
+  try {
+    text = new TextDecoder("utf-8", { fatal: true }).decode(raw);
+  } catch {
+    throw new Error("Vercel-pulled build environment is not valid UTF-8");
+  }
+  const contract = targetContract(logicalTarget);
+  const values = selectVercelPulledEnvironment({
+    target: logicalTarget,
+    environment: contract.pullEnvironment,
+    pulledValues: parseVercelPulledEnvironment(text),
+  });
+  return {
+    serialized: serializeVercelPulledEnvironment(values),
+    values,
+  };
+}
+
+function assertRunnerTempChild({
+  runnerTemp,
+  path,
+  expectedName,
+  expectedUid = process.getuid?.(),
+  expectedGid = process.getgid?.(),
+}) {
+  requireString(runnerTemp, "Runner temporary directory");
+  requireString(path, "Isolated path");
+  if (!isAbsolute(runnerTemp) || !isAbsolute(path)) {
+    throw new Error("Runner isolation paths must be absolute");
+  }
+  const uid = numericIdentity(expectedUid, "Expected runner UID");
+  const gid = numericIdentity(expectedGid, "Expected runner GID");
+  const canonicalRunnerTemp = realpathSync(runnerTemp);
+  const runnerEntry = lstatSync(canonicalRunnerTemp);
+  if (
+    runnerEntry.isSymbolicLink() ||
+    !runnerEntry.isDirectory() ||
+    runnerEntry.uid !== uid ||
+    runnerEntry.gid !== gid ||
+    (runnerEntry.mode & 0o7022) !== 0
+  ) {
+    throw new Error("Runner temporary directory is not protected");
+  }
+  if (
+    basename(path) !== expectedName ||
+    realpathSync(dirname(path)) !== canonicalRunnerTemp
+  ) {
+    throw new Error("Isolated path is not the expected RUNNER_TEMP child");
+  }
+  return join(canonicalRunnerTemp, expectedName);
+}
+
+function rawGitEnvironment() {
+  return {
+    GIT_CONFIG_GLOBAL: "/dev/null",
+    GIT_CONFIG_NOSYSTEM: "1",
+    GIT_NO_LAZY_FETCH: "1",
+    GIT_NO_REPLACE_OBJECTS: "1",
+    GIT_OPTIONAL_LOCKS: "0",
+    GIT_TERMINAL_PROMPT: "0",
+    HOME: "/nonexistent",
+    LANG: "C",
+    LC_ALL: "C",
+    PATH: "/usr/bin:/bin",
+  };
+}
+
+function rawGit(
+  repoRoot,
+  argumentsList,
+  { input, maximumOutput, run = spawnSync },
+) {
+  const result = run(
+    "/usr/bin/git",
+    ["--no-pager", "--no-replace-objects", "-C", repoRoot, ...argumentsList],
+    {
+      encoding: null,
+      env: rawGitEnvironment(),
+      input,
+      maxBuffer: maximumOutput,
+      stdio: ["pipe", "pipe", "pipe"],
+    },
+  );
+  if (result.error || result.status !== 0 || !Buffer.isBuffer(result.stdout)) {
+    throw new Error(`Unable to read exact Git ${argumentsList[0]} objects`);
+  }
+  return result.stdout;
+}
+
+function decodeGitPath(pathBytes) {
+  if (pathBytes.length === 0 || pathBytes.length > MAX_SOURCE_PATH_BYTES) {
+    throw new Error("Exact Git tree contains an invalid path length");
+  }
+  let path;
+  try {
+    path = new TextDecoder("utf-8", { fatal: true }).decode(pathBytes);
+  } catch {
+    throw new Error("Exact Git tree contains a non-UTF-8 path");
+  }
+  const components = path.split("/");
+  if (
+    isAbsolute(path) ||
+    components.some(
+      (component) =>
+        component.length === 0 ||
+        component === "." ||
+        component === ".." ||
+        component.toLowerCase() === ".git" ||
+        hasControlCharacters(component),
+    )
+  ) {
+    throw new Error("Exact Git tree contains an unsafe path");
+  }
+  return { components, path };
+}
+
+function parseExactGitTree(rawTree) {
+  const entries = [];
+  const paths = new Set();
+  let offset = 0;
+  while (offset < rawTree.length) {
+    const end = rawTree.indexOf(0, offset);
+    if (end === -1) {
+      throw new Error("Exact Git tree is not NUL terminated");
+    }
+    const record = rawTree.subarray(offset, end);
+    const separator = record.indexOf(0x09);
+    if (separator === -1) {
+      throw new Error("Exact Git tree entry has invalid metadata");
+    }
+    const metadata = record.subarray(0, separator).toString("ascii");
+    const match = /^(\d{6}) ([a-z]+) ([0-9a-f]{40})$/.exec(metadata);
+    if (!match) {
+      throw new Error("Exact Git tree entry has invalid metadata");
+    }
+    const [, mode, type, oid] = match;
+    if (
+      type !== "blob" ||
+      (mode !== "100644" && mode !== "100755" && mode !== "120000")
+    ) {
+      throw new Error("Exact Git tree contains an unsupported entry");
+    }
+    const { components, path } = decodeGitPath(record.subarray(separator + 1));
+    if (paths.has(path)) {
+      throw new Error("Exact Git tree contains a duplicate path");
+    }
+    paths.add(path);
+    entries.push({ components, mode, oid, path });
+    if (entries.length > MAX_SOURCE_ENTRIES) {
+      throw new Error("Exact Git tree contains too many entries");
+    }
+    offset = end + 1;
+  }
+  return entries;
+}
+
+function loadRawGitBlobs(repoRoot, entries, run) {
+  const objectIds = [...new Set(entries.map(({ oid }) => oid))];
+  if (objectIds.length === 0) return new Map();
+  const input = Buffer.from(`${objectIds.join("\n")}\n`, "ascii");
+  const rawSizes = rawGit(
+    repoRoot,
+    ["cat-file", "--batch-check=%(objectname) %(objecttype) %(objectsize)"],
+    { input, maximumOutput: MAX_SOURCE_TREE_BYTES, run },
+  );
+  const sizeLines = rawSizes.toString("ascii").split("\n");
+  if (sizeLines.at(-1) !== "") {
+    throw new Error("Raw Git blob size response is not newline terminated");
+  }
+  sizeLines.pop();
+  if (sizeLines.length !== objectIds.length) {
+    throw new Error("Raw Git blob size response is incomplete");
+  }
+  const sizes = new Map();
+  for (const [index, line] of sizeLines.entries()) {
+    const match = /^([0-9a-f]{40}) blob ([0-9]+)$/.exec(line);
+    const expectedOid = objectIds[index];
+    if (!match || match[1] !== expectedOid) {
+      throw new Error("Exact Git tree references a non-blob object");
+    }
+    const size = Number(match[2]);
+    if (!Number.isSafeInteger(size) || size > MAX_SOURCE_BLOB_BYTES) {
+      throw new Error("Exact Git tree contains an oversized blob");
+    }
+    sizes.set(expectedOid, size);
+  }
+  let totalBytes = 0;
+  for (const { oid } of entries) {
+    totalBytes += sizes.get(oid);
+    if (totalBytes > MAX_SOURCE_TOTAL_BYTES) {
+      throw new Error("Exact Git tree exceeds the source byte limit");
+    }
+  }
+
+  const rawBlobs = rawGit(repoRoot, ["cat-file", "--batch"], {
+    input,
+    maximumOutput: MAX_SOURCE_TOTAL_BYTES + MAX_SOURCE_TREE_BYTES,
+    run,
+  });
+  const blobs = new Map();
+  let offset = 0;
+  for (const expectedOid of objectIds) {
+    const headerEnd = rawBlobs.indexOf(0x0a, offset);
+    if (headerEnd === -1) {
+      throw new Error("Raw Git blob response is missing a header");
+    }
+    const header = rawBlobs.subarray(offset, headerEnd).toString("ascii");
+    const match = /^([0-9a-f]{40}) blob ([0-9]+)$/.exec(header);
+    const expectedSize = sizes.get(expectedOid);
+    if (
+      !match ||
+      match[1] !== expectedOid ||
+      Number(match[2]) !== expectedSize
+    ) {
+      throw new Error("Raw Git blob response does not match the exact tree");
+    }
+    const bodyStart = headerEnd + 1;
+    const bodyEnd = bodyStart + expectedSize;
+    if (bodyEnd >= rawBlobs.length || rawBlobs[bodyEnd] !== 0x0a) {
+      throw new Error("Raw Git blob response is truncated");
+    }
+    blobs.set(expectedOid, Buffer.from(rawBlobs.subarray(bodyStart, bodyEnd)));
+    offset = bodyEnd + 1;
+  }
+  if (offset !== rawBlobs.length) {
+    throw new Error("Raw Git blob response contains trailing data");
+  }
+  return blobs;
+}
+
+function ensureMaterializedParent(root, components) {
+  let current = root;
+  for (const component of components.slice(0, -1)) {
+    current = join(current, component);
+    const entry = optionalEntry(current);
+    if (entry) {
+      if (entry.isSymbolicLink() || !entry.isDirectory()) {
+        throw new Error("Exact Git tree has a non-directory path component");
+      }
+      continue;
+    }
+    mkdirSync(current, { mode: 0o755 });
+    chmodSync(current, 0o755);
+  }
+}
+
+export function materializeExactGitTree({
+  runnerTemp,
+  sourceRoot,
+  candidateRoot,
+  commitSha,
+  expectedUid = process.getuid?.(),
+  expectedGid = process.getgid?.(),
+  run = spawnSync,
+}) {
+  const sha = requireString(commitSha, "Commit SHA", SHA_PATTERN).toLowerCase();
+  requireString(sourceRoot, "Exact Git source path");
+  if (sourceRoot.length > MAX_SOURCE_PATH_BYTES) {
+    throw new Error("Exact Git source path is too long");
+  }
+  const canonicalSourceRoot = realpathSync(sourceRoot);
+  const sourceEntry = lstatSync(canonicalSourceRoot);
+  if (!sourceEntry.isDirectory()) {
+    throw new Error("Exact Git source must be a real directory");
+  }
+  const canonicalCandidateRoot = assertRunnerTempChild({
+    runnerTemp,
+    path: candidateRoot,
+    expectedName: CANDIDATE_SOURCE_DIRECTORY,
+    expectedUid,
+    expectedGid,
+  });
+  if (optionalEntry(canonicalCandidateRoot)) {
+    throw new Error("Candidate source path must be fresh");
+  }
+  const rawTree = rawGit(
+    canonicalSourceRoot,
+    ["ls-tree", "-r", "-z", "--full-tree", sha],
+    { maximumOutput: MAX_SOURCE_TREE_BYTES, run },
+  );
+  const entries = parseExactGitTree(rawTree);
+  const blobs = loadRawGitBlobs(canonicalSourceRoot, entries, run);
+
+  mkdirSync(canonicalCandidateRoot, { mode: 0o755 });
+  chmodSync(canonicalCandidateRoot, 0o755);
+  for (const entry of entries) {
+    ensureMaterializedParent(canonicalCandidateRoot, entry.components);
+    const destination = join(canonicalCandidateRoot, ...entry.components);
+    if (optionalEntry(destination)) {
+      throw new Error("Exact Git tree contains a filesystem collision");
+    }
+    const blob = blobs.get(entry.oid);
+    if (!blob) throw new Error("Exact Git tree blob was not loaded");
+    if (entry.mode === "120000") {
+      if (
+        blob.length === 0 ||
+        blob.length > MAX_SOURCE_PATH_BYTES ||
+        blob.includes(0)
+      ) {
+        throw new Error("Exact Git tree contains an invalid symbolic link");
+      }
+      symlinkSync(blob, destination);
+      continue;
+    }
+    if (typeof constants.O_NOFOLLOW !== "number") {
+      throw new Error("This platform cannot safely materialize Git blobs");
+    }
+    const descriptor = openSync(
+      destination,
+      constants.O_CREAT |
+        constants.O_EXCL |
+        constants.O_NOFOLLOW |
+        constants.O_WRONLY,
+      0o600,
+    );
+    try {
+      writeFileSync(descriptor, blob);
+      fchmodSync(descriptor, entry.mode === "100755" ? 0o755 : 0o644);
+    } finally {
+      closeSync(descriptor);
+    }
+  }
+  return {
+    bytes: entries.reduce((total, { oid }) => total + blobs.get(oid).length, 0),
+    entries: entries.length,
+    sourceRoot: canonicalCandidateRoot,
+  };
+}
+
+function assertExactFilesystemTree(
+  root,
+  expectedEntries,
+  { expectedUid = process.getuid?.(), expectedGid = process.getgid?.(), label },
+) {
+  const uid = numericIdentity(expectedUid, `Expected ${label} UID`);
+  const gid = numericIdentity(expectedGid, `Expected ${label} GID`);
+  const expected = new Map(expectedEntries);
+  const seen = new Set();
+  const pending = [root];
+  while (pending.length > 0) {
+    const path = pending.pop();
+    const relativePath = relative(root, path);
+    const specification = expected.get(relativePath);
+    if (!specification) {
+      throw new Error(`${label} contains an unexpected filesystem entry`);
+    }
+    const entry = lstatSync(path);
+    if (entry.uid !== uid || entry.gid !== gid || (entry.mode & 0o7077) !== 0) {
+      throw new Error(`${label} contains unsafe ownership or permissions`);
+    }
+    if (entry.isSymbolicLink()) {
+      throw new Error(`${label} contains a symbolic link`);
+    }
+    if (specification.type === "directory") {
+      if (!entry.isDirectory()) {
+        throw new Error(`${label} contains a non-directory component`);
+      }
+      for (const child of readdirSync(path)) pending.push(join(path, child));
+    } else {
+      if (!entry.isFile() || entry.nlink !== 1) {
+        throw new Error(`${label} contains a non-regular or hard-linked file`);
+      }
+      if (entry.size > specification.maximumSize) {
+        throw new Error(`${label} contains an oversized file`);
+      }
+    }
+    seen.add(relativePath);
+  }
+  if (seen.size !== expected.size) {
+    throw new Error(`${label} is missing a required filesystem entry`);
+  }
+  return root;
+}
+
+function readJson(path, label) {
+  try {
+    return JSON.parse(readFileSync(resolve(path), "utf8"));
+  } catch {
+    throw new Error(`${label} is missing or malformed`);
+  }
+}
+
+function readEnvironmentJson(name, label) {
+  try {
+    return JSON.parse(requireString(process.env[name], name));
+  } catch {
+    throw new Error(`${label} is missing or malformed`);
+  }
+}
+
+function writePrivateJson(path, value) {
+  const resolved = resolve(path);
+  const descriptor = openSync(
+    resolved,
+    constants.O_WRONLY |
+      constants.O_CREAT |
+      constants.O_EXCL |
+      constants.O_NOFOLLOW,
+    0o600,
+  );
+  try {
+    writeFileSync(descriptor, `${JSON.stringify(value)}\n`);
+    fchmodSync(descriptor, 0o600);
+  } finally {
+    closeSync(descriptor);
+  }
+}
+
+function assertPlainDirectory(path, label) {
+  if (!existsSync(path)) return;
+  const entry = lstatSync(path);
+  if (entry.isSymbolicLink() || !entry.isDirectory()) {
+    throw new Error(`${label} must be a real directory`);
+  }
+}
+
+function assertPlainFile(path, label) {
+  if (!existsSync(path)) return;
+  const entry = lstatSync(path);
+  if (entry.isSymbolicLink() || !entry.isFile()) {
+    throw new Error(`${label} must be a regular file`);
+  }
+}
+
+function appendOutput(name, value, outputPath = process.env.GITHUB_OUTPUT) {
+  if (typeof outputPath !== "string" || outputPath.length === 0) return;
+  if (!/^[a-z_]+$/.test(name) || /[\r\n]/.test(value)) {
+    throw new Error("GitHub output is malformed");
+  }
+  writeFileSync(outputPath, `${name}=${value}\n`, { flag: "a" });
+}
+
+export function validateDispatchContext({
+  repository,
+  ref,
+  workflowRef,
+  deploySha,
+}) {
+  if (repository !== "mento-protocol/frontend-monorepo") {
+    throw new Error("Production shadow runs only in the canonical repository");
+  }
+  if (ref !== "refs/heads/main") {
+    throw new Error("Production shadow must be dispatched from main");
+  }
+  if (workflowRef !== EXPECTED_WORKFLOW_REF) {
+    throw new Error("Production shadow workflow must come from main");
+  }
+  return requireString(deploySha, "deploy_sha", SHA_PATTERN).toLowerCase();
+}
+
+export function validateImmutableMainSource({
+  deploySha,
+  workflowSha,
+  sourcePath = process.cwd(),
+  execute = execFileSync,
+}) {
+  const normalizedSha = requireString(
+    deploySha,
+    "DEPLOY_SHA",
+    SHA_PATTERN,
+  ).toLowerCase();
+  const normalizedWorkflowSha = requireString(
+    workflowSha,
+    "GITHUB_WORKFLOW_SHA",
+    SHA_PATTERN,
+  ).toLowerCase();
+  if (normalizedWorkflowSha !== normalizedSha) {
+    throw new Error("GITHUB_WORKFLOW_SHA does not match DEPLOY_SHA");
+  }
+  const run = (argumentsList) =>
+    execute("git", ["-C", resolve(sourcePath), ...argumentsList], {
+      encoding: "utf8",
+      stdio: "pipe",
+    })
+      .trim()
+      .toLowerCase();
+  run(["cat-file", "-e", `${normalizedSha}^{commit}`]);
+  run([
+    "merge-base",
+    "--is-ancestor",
+    normalizedSha,
+    "refs/remotes/origin/main",
+  ]);
+  const fetchedMain = run(["rev-parse", "refs/remotes/origin/main"]);
+  if (fetchedMain !== normalizedSha) {
+    throw new Error("DEPLOY_SHA does not match fetched origin/main");
+  }
+  const head = run(["rev-parse", "HEAD"]);
+  if (head !== normalizedSha) {
+    throw new Error("Checked-out HEAD does not match DEPLOY_SHA");
+  }
+  return normalizedSha;
+}
+
+export function parseTurboCacheSummary(log) {
+  if (typeof log !== "string") {
+    throw new Error("Turbo build log must be a string");
+  }
+  const normalizedLog = stripVTControlCharacters(log);
+  const cacheLines = normalizedLog
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.startsWith("Cached:"));
+  if (cacheLines.length !== 1) {
+    throw new Error("Build log must contain exactly one Turbo cache summary");
+  }
+  const match = /^Cached:\s+([0-9]+) cached,\s+([0-9]+) total$/.exec(
+    cacheLines[0],
+  );
+  if (!match) {
+    throw new Error("Turbo cache summary is malformed");
+  }
+  const hits = Number.parseInt(match[1], 10);
+  const total = Number.parseInt(match[2], 10);
+  if (
+    !Number.isSafeInteger(hits) ||
+    !Number.isSafeInteger(total) ||
+    hits > total
+  ) {
+    throw new Error("Turbo cache summary values are invalid");
+  }
+  return { hits, misses: total - hits, total };
+}
+
+function trustedSourcePath() {
+  return resolve(requireString(process.env.SOURCE_PATH, "SOURCE_PATH"));
+}
+
+function expectedGit(ref) {
+  return {
+    org: "mento-protocol",
+    repo: "frontend-monorepo",
+    ref,
+  };
+}
+
+export function createProtectedAliasSpec({ appV3AliasesJson, projectIds }) {
+  let appAliases;
+  try {
+    appAliases = JSON.parse(appV3AliasesJson);
+  } catch {
+    throw new Error("APP_V3_ALIASES_JSON must be valid JSON");
+  }
+  if (!Array.isArray(appAliases) || appAliases.length === 0) {
+    throw new Error("APP_V3_ALIASES_JSON must be a non-empty array");
+  }
+  const normalizedAppAliases = appAliases.map(canonicalizeHostname);
+  if (new Set(normalizedAppAliases).size !== normalizedAppAliases.length) {
+    throw new Error("The reviewed v3 alias list contains duplicates");
+  }
+  const sortedAppAliases = normalizedAppAliases.toSorted();
+  if (
+    sortedAppAliases.length !== REVIEWED_APP_V3_ALIASES.length ||
+    sortedAppAliases.some(
+      (alias, index) => alias !== REVIEWED_APP_V3_ALIASES[index],
+    )
+  ) {
+    throw new Error(
+      "The reviewed v3 alias list must exactly match app.mento.org and appmentoorg-env-v3-mentolabs.vercel.app",
+    );
+  }
+
+  const appProjectId = requireString(projectIds.app, "App project ID");
+  const entries = sortedAppAliases.map((alias) => ({
+    alias,
+    projectId: appProjectId,
+    projectName: "app.mento.org",
+    target: null,
+    customEnvironmentSlug: "v3",
+    git: expectedGit("main"),
+  }));
+  entries.push({
+    alias: "v2-app.mento.org",
+    projectId: appProjectId,
+    projectName: "app.mento.org",
+    target: "production",
+    customEnvironmentSlug: null,
+    git: expectedGit("v2"),
+  });
+  for (const target of ["governance", "reserve", "ui"]) {
+    entries.push({
+      alias: `${target}.mento.org`,
+      projectId: requireString(projectIds[target], `${target} project ID`),
+      projectName: `${target}.mento.org`,
+      target: "production",
+      customEnvironmentSlug: null,
+      git: expectedGit("main"),
+    });
+  }
+  return entries.sort((left, right) => left.alias.localeCompare(right.alias));
+}
+
+export function materializeProductionShadowLink({
+  repoRoot,
+  logicalTarget,
+  orgId,
+  projectId,
+}) {
+  const contract = targetContract(logicalTarget);
+  const link = {
+    remoteName: "origin",
+    projects: [
+      {
+        id: requireIdentifier(projectId, "Vercel project ID"),
+        directory: contract.rootDirectory,
+        orgId: requireIdentifier(orgId, "Vercel organization ID"),
+      },
+    ],
+  };
+  const vercelDirectory = join(resolve(repoRoot), ".vercel");
+  assertPlainDirectory(vercelDirectory, "Repo-level Vercel state");
+  mkdirSync(vercelDirectory, { recursive: true });
+  const linkPath = join(vercelDirectory, "repo.json");
+  assertPlainFile(linkPath, "Repo-level Vercel link");
+  writePrivateJson(linkPath, link);
+  return link;
+}
+
+export function prepareProductionShadowPullStaging({
+  runnerTemp,
+  stagingRoot,
+  logicalTarget,
+  orgId,
+  projectId,
+}) {
+  const contract = targetContract(logicalTarget);
+  const canonicalStagingRoot = assertRunnerTempChild({
+    runnerTemp,
+    path: stagingRoot,
+    expectedName: PULL_STAGING_DIRECTORY,
+  });
+  if (existsSync(canonicalStagingRoot)) {
+    throw new Error("Production-shadow pull staging must be fresh");
+  }
+  mkdirSync(canonicalStagingRoot, { mode: 0o700 });
+  let current = canonicalStagingRoot;
+  for (const component of contract.rootDirectory.split("/")) {
+    current = join(current, component);
+    mkdirSync(current, { mode: 0o700 });
+  }
+  materializeProductionShadowLink({
+    repoRoot: canonicalStagingRoot,
+    logicalTarget,
+    orgId,
+    projectId,
+  });
+  chmodSync(join(canonicalStagingRoot, ".vercel"), 0o700);
+  chmodSync(join(canonicalStagingRoot, ".vercel", "repo.json"), 0o600);
+  return canonicalStagingRoot;
+}
+
+export function assertProductionShadowPullStaging({
+  runnerTemp,
+  stagingRoot,
+  logicalTarget,
+  orgId,
+  projectId,
+  expectedUid = process.getuid?.(),
+  expectedGid = process.getgid?.(),
+}) {
+  const canonicalStagingRoot = assertRunnerTempChild({
+    runnerTemp,
+    path: stagingRoot,
+    expectedName: PULL_STAGING_DIRECTORY,
+    expectedUid,
+    expectedGid,
+  });
+  if (realpathSync(stagingRoot) !== canonicalStagingRoot) {
+    throw new Error("Production-shadow pull staging escaped RUNNER_TEMP");
+  }
+  assertExactFilesystemTree(
+    canonicalStagingRoot,
+    expectedPullTree(logicalTarget),
+    {
+      expectedUid,
+      expectedGid,
+      label: "Production-shadow pull staging",
+    },
+  );
+  return assertPulledProductionShadowProject({
+    repoRoot: canonicalStagingRoot,
+    logicalTarget,
+    orgId,
+    projectId,
+  });
+}
+
+function materializedProductionShadowEnvironmentEntries(logicalTarget) {
+  return [
+    ["", { type: "directory" }],
+    [".vercel", { type: "directory" }],
+    [
+      join(".vercel", pulledEnvironmentFile(logicalTarget)),
+      { type: "file", maximumSize: MAX_MATERIALIZED_ENVIRONMENT_BYTES },
+    ],
+  ];
+}
+
+function inspectMaterializedProductionShadowBuildEnvironment({
+  runnerTemp,
+  stagingRoot,
+  materializationRoot,
+  logicalTarget,
+  orgId,
+  projectId,
+  expectedUid = process.getuid?.(),
+  expectedGid = process.getgid?.(),
+}) {
+  const uid = numericIdentity(expectedUid, "Expected runner UID");
+  const gid = numericIdentity(expectedGid, "Expected runner GID");
+  assertProductionShadowPullStaging({
+    runnerTemp,
+    stagingRoot,
+    logicalTarget,
+    orgId,
+    projectId,
+    expectedUid: uid,
+    expectedGid: gid,
+  });
+  const canonicalMaterializationRoot = assertRunnerTempChild({
+    runnerTemp,
+    path: materializationRoot,
+    expectedName: BUILD_ENVIRONMENT_DIRECTORY,
+    expectedUid: uid,
+    expectedGid: gid,
+  });
+  if (realpathSync(materializationRoot) !== canonicalMaterializationRoot) {
+    throw new Error(
+      "Materialized production-shadow build environment escaped RUNNER_TEMP",
+    );
+  }
+  assertExactFilesystemTree(
+    canonicalMaterializationRoot,
+    materializedProductionShadowEnvironmentEntries(logicalTarget),
+    {
+      expectedUid: uid,
+      expectedGid: gid,
+      label: "Materialized production-shadow build environment",
+    },
+  );
+  for (const path of [
+    canonicalMaterializationRoot,
+    join(canonicalMaterializationRoot, ".vercel"),
+  ]) {
+    if ((lstatSync(path).mode & 0o777) !== 0o700) {
+      throw new Error(
+        "Materialized production-shadow environment directory is not private",
+      );
+    }
+  }
+  const contract = targetContract(logicalTarget);
+  const environmentFile = pulledEnvironmentFile(logicalTarget);
+  const sourceSnapshot = readProtectedEnvironmentFile({
+    root: stagingRoot,
+    filePath: join(
+      stagingRoot,
+      contract.rootDirectory,
+      ".vercel",
+      environmentFile,
+    ),
+    expectedUid: uid,
+    expectedGid: gid,
+    label: "Vercel-pulled production-shadow build environment",
+  });
+  const expected = deriveProductionShadowBuildEnvironment({
+    logicalTarget,
+    raw: sourceSnapshot.bytes,
+  });
+  const environmentPath = join(
+    canonicalMaterializationRoot,
+    ".vercel",
+    environmentFile,
+  );
+  const materialized = readProtectedEnvironmentFile({
+    root: canonicalMaterializationRoot,
+    filePath: environmentPath,
+    expectedUid: uid,
+    expectedGid: gid,
+    label: "Materialized production-shadow build environment",
+  });
+  if (!materialized.bytes.equals(Buffer.from(expected.serialized, "utf8"))) {
+    throw new Error(
+      "Materialized production-shadow build environment is not the exact allowlist",
+    );
+  }
+  return {
+    checked: Object.keys(expected.values).length,
+    environmentPath,
+    sourceSnapshot,
+  };
+}
+
+export function materializeProductionShadowBuildEnvironment({
+  runnerTemp,
+  stagingRoot,
+  materializationRoot = join(resolve(runnerTemp), BUILD_ENVIRONMENT_DIRECTORY),
+  logicalTarget,
+  orgId,
+  projectId,
+  expectedUid = process.getuid?.(),
+  expectedGid = process.getgid?.(),
+}) {
+  const uid = numericIdentity(expectedUid, "Expected runner UID");
+  const gid = numericIdentity(expectedGid, "Expected runner GID");
+  assertProductionShadowPullStaging({
+    runnerTemp,
+    stagingRoot,
+    logicalTarget,
+    orgId,
+    projectId,
+    expectedUid: uid,
+    expectedGid: gid,
+  });
+  const canonicalMaterializationRoot = assertRunnerTempChild({
+    runnerTemp,
+    path: materializationRoot,
+    expectedName: BUILD_ENVIRONMENT_DIRECTORY,
+    expectedUid: uid,
+    expectedGid: gid,
+  });
+  if (optionalEntry(canonicalMaterializationRoot)) {
+    throw new Error(
+      "Materialized production-shadow build environment must be fresh",
+    );
+  }
+  const contract = targetContract(logicalTarget);
+  const environmentFile = pulledEnvironmentFile(logicalTarget);
+  const sourceBefore = readProtectedEnvironmentFile({
+    root: stagingRoot,
+    filePath: join(
+      stagingRoot,
+      contract.rootDirectory,
+      ".vercel",
+      environmentFile,
+    ),
+    expectedUid: uid,
+    expectedGid: gid,
+    label: "Vercel-pulled production-shadow build environment",
+  });
+  const derived = deriveProductionShadowBuildEnvironment({
+    logicalTarget,
+    raw: sourceBefore.bytes,
+  });
+
+  mkdirSync(canonicalMaterializationRoot, { mode: 0o700 });
+  chmodSync(canonicalMaterializationRoot, 0o700);
+  const vercelDirectory = join(canonicalMaterializationRoot, ".vercel");
+  mkdirSync(vercelDirectory, { mode: 0o700 });
+  chmodSync(vercelDirectory, 0o700);
+  const environmentPath = join(vercelDirectory, environmentFile);
+  if (typeof constants.O_NOFOLLOW !== "number") {
+    throw new Error(
+      "Materialized production-shadow environment cannot be created safely",
+    );
+  }
+  const descriptor = openSync(
+    environmentPath,
+    constants.O_CREAT |
+      constants.O_EXCL |
+      constants.O_NOFOLLOW |
+      constants.O_WRONLY,
+    0o600,
+  );
+  try {
+    writeFileSync(descriptor, derived.serialized, { encoding: "utf8" });
+    fchmodSync(descriptor, 0o600);
+  } finally {
+    closeSync(descriptor);
+  }
+  assignProductionShadowMaterializationOwnership({
+    materializationRoot: canonicalMaterializationRoot,
+    environmentPath,
+    expectedUid: uid,
+    expectedGid: gid,
+  });
+  chmodSync(canonicalMaterializationRoot, 0o700);
+  chmodSync(vercelDirectory, 0o700);
+  chmodSync(environmentPath, 0o600);
+
+  const inspected = inspectMaterializedProductionShadowBuildEnvironment({
+    runnerTemp,
+    stagingRoot,
+    materializationRoot: canonicalMaterializationRoot,
+    logicalTarget,
+    orgId,
+    projectId,
+    expectedUid: uid,
+    expectedGid: gid,
+  });
+  assertSameProtectedSource(sourceBefore, inspected.sourceSnapshot);
+  return {
+    checked: inspected.checked,
+    environmentPath: inspected.environmentPath,
+    materializationRoot: canonicalMaterializationRoot,
+  };
+}
+
+export function assertMaterializedProductionShadowBuildEnvironment(options) {
+  const inspected =
+    inspectMaterializedProductionShadowBuildEnvironment(options);
+  return {
+    checked: inspected.checked,
+    environmentPath: inspected.environmentPath,
+  };
+}
+
+export function assignProductionShadowMaterializationOwnership({
+  materializationRoot,
+  environmentPath,
+  expectedUid,
+  expectedGid,
+  changeOwner = chownSync,
+}) {
+  const uid = numericIdentity(expectedUid, "Expected runner UID");
+  const gid = numericIdentity(expectedGid, "Expected runner GID");
+  for (const path of [
+    materializationRoot,
+    join(materializationRoot, ".vercel"),
+    environmentPath,
+  ]) {
+    changeOwner(path, uid, gid);
+  }
+}
+
+function assertCandidateRootComponents({
+  runnerTemp,
+  candidateRoot,
+  logicalTarget,
+  buildUid,
+  buildGid,
+  runnerUid,
+  runnerGid,
+}) {
+  const contract = targetContract(logicalTarget);
+  const canonicalCandidateRoot = assertRunnerTempChild({
+    runnerTemp,
+    path: candidateRoot,
+    expectedName: CANDIDATE_SOURCE_DIRECTORY,
+    expectedUid: runnerUid,
+    expectedGid: runnerGid,
+  });
+  if (realpathSync(candidateRoot) !== canonicalCandidateRoot) {
+    throw new Error("Candidate source escaped RUNNER_TEMP");
+  }
+  let current = canonicalCandidateRoot;
+  for (const [path, label] of [
+    [canonicalCandidateRoot, "Candidate source"],
+    ...contract.rootDirectory.split("/").map((component) => {
+      current = join(current, component);
+      return [current, "Candidate Root Directory"];
+    }),
+  ]) {
+    const entry = lstatSync(path);
+    if (
+      entry.isSymbolicLink() ||
+      !entry.isDirectory() ||
+      entry.uid !== buildUid ||
+      entry.gid !== buildGid
+    ) {
+      throw new Error(`${label} contains an unsafe path component`);
+    }
+  }
+  return canonicalCandidateRoot;
+}
+
+export function assertCandidateProductionShadowPull({
+  runnerTemp,
+  candidateRoot,
+  logicalTarget,
+  orgId,
+  projectId,
+  buildUid,
+  buildGid,
+  runnerUid,
+  runnerGid,
+}) {
+  const candidateUid = numericIdentity(buildUid, "Candidate build UID");
+  const candidateGid = numericIdentity(buildGid, "Candidate build GID");
+  const trustedUid = numericIdentity(runnerUid, "Runner UID");
+  const trustedGid = numericIdentity(runnerGid, "Runner GID");
+  const canonicalCandidateRoot = assertCandidateRootComponents({
+    runnerTemp,
+    candidateRoot,
+    logicalTarget,
+    buildUid: candidateUid,
+    buildGid: candidateGid,
+    runnerUid: trustedUid,
+    runnerGid: trustedGid,
+  });
+  const contract = targetContract(logicalTarget);
+  const expected = expectedPullTree(logicalTarget);
+  for (const stateRoot of [
+    ".vercel",
+    join(contract.rootDirectory, ".vercel"),
+  ]) {
+    const stateEntries = expected
+      .filter(
+        ([path]) => path === stateRoot || path.startsWith(`${stateRoot}${sep}`),
+      )
+      .map(([path, specification]) => [
+        relative(stateRoot, path),
+        specification,
+      ]);
+    assertExactFilesystemTree(
+      join(canonicalCandidateRoot, stateRoot),
+      stateEntries,
+      {
+        expectedUid: candidateUid,
+        expectedGid: candidateGid,
+        label: "Candidate Vercel state",
+      },
+    );
+  }
+  const candidateEnvironment = readProtectedEnvironmentFile({
+    root: canonicalCandidateRoot,
+    filePath: join(
+      canonicalCandidateRoot,
+      contract.rootDirectory,
+      ".vercel",
+      pulledEnvironmentFile(logicalTarget),
+    ),
+    expectedUid: candidateUid,
+    expectedGid: candidateGid,
+    label: "Candidate production-shadow build environment",
+  });
+  const expectedEnvironment = deriveProductionShadowBuildEnvironment({
+    logicalTarget,
+    raw: candidateEnvironment.bytes,
+  });
+  if (
+    !candidateEnvironment.bytes.equals(
+      Buffer.from(expectedEnvironment.serialized, "utf8"),
+    )
+  ) {
+    throw new Error(
+      "Candidate production-shadow build environment is not the canonical exact allowlist",
+    );
+  }
+  return assertPulledProductionShadowProject({
+    repoRoot: canonicalCandidateRoot,
+    logicalTarget,
+    orgId,
+    projectId,
+  });
+}
+
+export function stageProductionShadowPullForCandidate({
+  runnerTemp,
+  stagingRoot,
+  candidateRoot,
+  logicalTarget,
+  orgId,
+  projectId,
+  buildUid,
+  buildGid,
+  runnerUid,
+  runnerGid,
+}) {
+  const candidateUid = numericIdentity(buildUid, "Candidate build UID");
+  const candidateGid = numericIdentity(buildGid, "Candidate build GID");
+  const trustedUid = numericIdentity(runnerUid, "Runner UID");
+  const trustedGid = numericIdentity(runnerGid, "Runner GID");
+  const materializationRoot = join(
+    resolve(runnerTemp),
+    BUILD_ENVIRONMENT_DIRECTORY,
+  );
+  const materializedEnvironment = materializeProductionShadowBuildEnvironment({
+    runnerTemp,
+    stagingRoot,
+    materializationRoot,
+    logicalTarget,
+    orgId,
+    projectId,
+    expectedUid: trustedUid,
+    expectedGid: trustedGid,
+  });
+  const canonicalCandidateRoot = assertCandidateRootComponents({
+    runnerTemp,
+    candidateRoot,
+    logicalTarget,
+    buildUid: candidateUid,
+    buildGid: candidateGid,
+    runnerUid: trustedUid,
+    runnerGid: trustedGid,
+  });
+  const contract = targetContract(logicalTarget);
+  for (const path of [
+    join(canonicalCandidateRoot, ".vercel"),
+    join(canonicalCandidateRoot, contract.rootDirectory, ".vercel"),
+  ]) {
+    rmSync(path, { force: true, recursive: true });
+    mkdirSync(path, { mode: 0o700 });
+    chownSync(path, candidateUid, candidateGid);
+    chmodSync(path, 0o700);
+  }
+  for (const relativePath of [
+    join(".vercel", "repo.json"),
+    join(contract.rootDirectory, ".vercel", "project.json"),
+  ]) {
+    const destination = join(canonicalCandidateRoot, relativePath);
+    copyFileSync(
+      join(stagingRoot, relativePath),
+      destination,
+      constants.COPYFILE_EXCL,
+    );
+    chownSync(destination, candidateUid, candidateGid);
+    chmodSync(destination, 0o600);
+  }
+  const candidateEnvironmentPath = join(
+    canonicalCandidateRoot,
+    contract.rootDirectory,
+    ".vercel",
+    pulledEnvironmentFile(logicalTarget),
+  );
+  copyFileSync(
+    materializedEnvironment.environmentPath,
+    candidateEnvironmentPath,
+    constants.COPYFILE_EXCL,
+  );
+  chownSync(candidateEnvironmentPath, candidateUid, candidateGid);
+  chmodSync(candidateEnvironmentPath, 0o600);
+  const candidateProject = assertCandidateProductionShadowPull({
+    runnerTemp,
+    candidateRoot: canonicalCandidateRoot,
+    logicalTarget,
+    orgId,
+    projectId,
+    buildUid: candidateUid,
+    buildGid: candidateGid,
+    runnerUid: trustedUid,
+    runnerGid: trustedGid,
+  });
+  assertMaterializedProductionShadowBuildEnvironment({
+    runnerTemp,
+    stagingRoot,
+    materializationRoot,
+    logicalTarget,
+    orgId,
+    projectId,
+    expectedUid: trustedUid,
+    expectedGid: trustedGid,
+  });
+  return candidateProject;
+}
+
+const GITHUB_COMMAND_FILE_NAMES = [
+  "GITHUB_ENV",
+  "GITHUB_OUTPUT",
+  "GITHUB_PATH",
+  "GITHUB_STATE",
+  "GITHUB_STEP_SUMMARY",
+];
+
+export function environmentForTrustedChild(environment) {
+  const cliEnvironment = { ...environment };
+  for (const name of GITHUB_COMMAND_FILE_NAMES) {
+    delete cliEnvironment[name];
+  }
+  return cliEnvironment;
+}
+
+export function environmentForVercelCli(environment) {
+  const cliEnvironment = {};
+  for (const name of VERCEL_CLI_ENVIRONMENT_NAMES) {
+    const value = environment[name];
+    if (value === undefined || value === "") continue;
+    cliEnvironment[name] = requireString(value, name);
+  }
+  return cliEnvironment;
+}
+
+export function buildProductionShadowPullArguments({
+  logicalTarget,
+  projectId,
+}) {
+  const contract = targetContract(logicalTarget);
+  return [
+    "pull",
+    "--yes",
+    "--environment",
+    contract.pullEnvironment,
+    "--git-branch",
+    "main",
+    "--project",
+    requireIdentifier(projectId, "Vercel project ID"),
+  ];
+}
+
+export function buildProductionShadowBuildArguments({
+  logicalTarget,
+  projectId,
+}) {
+  const contract = targetContract(logicalTarget);
+  return [
+    ...contract.buildArguments,
+    "--project",
+    requireIdentifier(projectId, "Vercel project ID"),
+  ];
+}
+
+function assertSafeProductionShadowArguments(argumentsList) {
+  for (const [index, argument] of argumentsList.entries()) {
+    if (argument === "--token" || argument.startsWith("--token=")) {
+      throw new Error(
+        "Vercel tokens must be passed only through the environment",
+      );
+    }
+    const metadata =
+      argument === "--meta"
+        ? argumentsList[index + 1]
+        : argument.startsWith("--meta=")
+          ? argument.slice("--meta=".length)
+          : undefined;
+    if (metadata?.split("=", 1)[0] === "githubDeployment") {
+      throw new Error("Forbidden Vercel metadata key: githubDeployment");
+    }
+  }
+  if (["promote", "alias"].includes(argumentsList[0])) {
+    throw new Error("Forbidden normal-path Vercel mutation command");
+  }
+  return argumentsList;
+}
+
+export function buildProductionShadowDeployArguments({
+  logicalTarget,
+  projectId,
+  deploySha,
+  transaction,
+}) {
+  const contract = targetContract(logicalTarget);
+  if (contract.deployArguments === null) {
+    throw new Error("The app v3 target is build-only in the production shadow");
+  }
+  const sha = requireString(
+    deploySha,
+    "Deployment SHA",
+    SHA_PATTERN,
+  ).toLowerCase();
+  const safeTransaction = requireString(
+    transaction,
+    "Production-shadow transaction",
+    /^(?:[1-9][0-9]*-[1-9][0-9]*-(?:governance|reserve|ui)|main-[0-9a-f]{40}-[1-9][0-9]*-[1-9][0-9]*)$/,
+  );
+  if (
+    !safeTransaction.startsWith("main-") &&
+    !safeTransaction.endsWith(`-${logicalTarget}`)
+  ) {
+    throw new Error("Production-shadow transaction target is inconsistent");
+  }
+  return assertSafeProductionShadowArguments([
+    ...contract.deployArguments,
+    "--project",
+    requireIdentifier(projectId, "Vercel project ID"),
+    "--meta",
+    "githubCommitOrg=mento-protocol",
+    "--meta",
+    "githubCommitRepo=frontend-monorepo",
+    "--meta",
+    "githubCommitRef=main",
+    "--meta",
+    `githubCommitSha=${sha}`,
+    "--meta",
+    `mentoTransaction=${safeTransaction}`,
+  ]);
+}
+
+export function assertPulledProductionShadowProject({
+  repoRoot,
+  logicalTarget,
+  orgId,
+  projectId,
+}) {
+  const contract = targetContract(logicalTarget);
+  const expectedLink = {
+    remoteName: "origin",
+    projects: [
+      {
+        id: requireIdentifier(projectId, "Vercel project ID"),
+        directory: contract.rootDirectory,
+        orgId: requireIdentifier(orgId, "Vercel organization ID"),
+      },
+    ],
+  };
+  const root = resolve(repoRoot);
+  const repoLinkPath = join(root, ".vercel", "repo.json");
+  const appVercelDirectory = join(root, contract.rootDirectory, ".vercel");
+  const projectPath = join(appVercelDirectory, "project.json");
+  assertPlainDirectory(join(root, ".vercel"), "Repo-level Vercel state");
+  assertPlainFile(repoLinkPath, "Repo-level Vercel link");
+  assertPlainDirectory(appVercelDirectory, "App-root Vercel state");
+  assertPlainFile(projectPath, "Pulled app-root Vercel project settings");
+  const repoLink = readJson(repoLinkPath, "Repo-level Vercel link");
+  const project = readJson(
+    projectPath,
+    "Pulled app-root Vercel project settings",
+  );
+  if (JSON.stringify(repoLink) !== JSON.stringify(expectedLink)) {
+    throw new Error(
+      "Repo-level Vercel mapping does not match the literal target",
+    );
+  }
+  if (project.settings?.rootDirectory !== contract.rootDirectory) {
+    throw new Error(
+      "Pulled Vercel Root Directory does not match the literal target",
+    );
+  }
+  if (project.projectId !== projectId || project.orgId !== orgId) {
+    throw new Error(
+      "Pulled Vercel project identity does not match the literal target",
+    );
+  }
+  return project;
+}
+
+export function assertProductionShadowOutput({
+  repoRoot,
+  logicalTarget,
+  deploymentId,
+  expectedUid = process.getuid?.(),
+  expectedGid = process.getgid?.(),
+}) {
+  const contract = targetContract(logicalTarget);
+  const outputDirectory = join(
+    resolve(repoRoot),
+    contract.rootDirectory,
+    ".vercel",
+    "output",
+  );
+  const configPath = join(outputDirectory, "config.json");
+  const buildsPath = join(outputDirectory, "builds.json");
+  const uid = numericIdentity(expectedUid, "Expected output UID");
+  const gid = numericIdentity(expectedGid, "Expected output GID");
+  const pending = [outputDirectory];
+  let entries = 0;
+  while (pending.length > 0) {
+    const path = pending.pop();
+    const entry = lstatSync(path);
+    entries += 1;
+    if (entries > 250_000) {
+      throw new Error("Prebuilt output contains too many filesystem entries");
+    }
+    if (entry.uid !== uid || entry.gid !== gid) {
+      throw new Error(
+        "Prebuilt output contains an entry with unsafe ownership",
+      );
+    }
+    if (
+      uid === process.getuid?.() &&
+      ((entry.mode & 0o022) !== 0 || (entry.mode & 0o7000) !== 0)
+    ) {
+      throw new Error("Runner-owned prebuilt output has unsafe permissions");
+    }
+    if (entry.isSymbolicLink()) {
+      throw new Error("Prebuilt output contains a symbolic link");
+    }
+    if (entry.isDirectory()) {
+      for (const child of readdirSync(path)) pending.push(join(path, child));
+    } else if (
+      !entry.isFile() ||
+      (uid === process.getuid?.() && entry.nlink !== 1)
+    ) {
+      throw new Error("Prebuilt output contains a special or hard-linked file");
+    } else {
+      assertStandaloneVercelConfig(path, entry);
+    }
+  }
+  if (!lstatSync(configPath).isFile() || !lstatSync(buildsPath).isFile()) {
+    throw new Error("Prebuilt app-root output is missing a required file");
+  }
+  const config = readJson(configPath, "Prebuilt output config");
+  const buildRecord = readJson(buildsPath, "Vercel CLI build record");
+  const expectedTarget = logicalTarget === "app" ? "v3" : "production";
+  if (config.version !== 3) {
+    throw new Error("Prebuilt output is not Build Output API version 3");
+  }
+  if (
+    buildRecord.target !== expectedTarget ||
+    buildRecord.cliVersion !== "56.2.0"
+  ) {
+    throw new Error("Prebuilt output target or Vercel CLI version is invalid");
+  }
+  assertPrebuiltDeploymentId(outputDirectory, deploymentId);
+  return outputDirectory;
+}
+
+function assertProductionShadowProvenance({
+  repoRoot,
+  deploySha,
+  expectedUid = process.getuid?.(),
+}) {
+  const path = `${resolve(repoRoot)}.provenance.json`;
+  const uid = numericIdentity(expectedUid, "Expected provenance UID");
+  let provenance;
+  try {
+    const entry = lstatSync(path);
+    if (
+      entry.isSymbolicLink() ||
+      !entry.isFile() ||
+      entry.uid !== uid ||
+      entry.nlink !== 1 ||
+      (entry.mode & 0o022) !== 0
+    ) {
+      throw new Error("unsafe provenance file");
+    }
+    provenance = JSON.parse(readFileSync(path, "utf8"));
+  } catch {
+    throw new Error(
+      "Production-shadow source provenance is missing or invalid",
+    );
+  }
+  const sha = requireString(
+    deploySha,
+    "Deployment SHA",
+    SHA_PATTERN,
+  ).toLowerCase();
+  if (
+    !provenance ||
+    typeof provenance !== "object" ||
+    Array.isArray(provenance) ||
+    Object.keys(provenance).length !== 1 ||
+    provenance.commitSha !== sha
+  ) {
+    throw new Error(
+      "Production-shadow source provenance does not match DEPLOY_SHA",
+    );
+  }
+  return provenance;
+}
+
+function assertOwnedMappingFile(path, uid, gid, label) {
+  const entry = lstatSync(path);
+  if (
+    entry.isSymbolicLink() ||
+    !entry.isFile() ||
+    entry.uid !== uid ||
+    entry.gid !== gid ||
+    entry.nlink !== 1 ||
+    (entry.mode & 0o077) !== 0
+  ) {
+    throw new Error(`${label} has unsafe ownership or permissions`);
+  }
+}
+
+function assertStandaloneVercelConfig(path, entry) {
+  if (basename(path) !== ".vc-config.json") return;
+  if (entry.size > MAX_PREBUILT_CONFIG_BYTES) {
+    throw new Error("Prebuilt output contains an oversized function config");
+  }
+  let config;
+  try {
+    config = JSON.parse(readFileSync(path, "utf8"));
+  } catch {
+    throw new Error("Prebuilt output contains an invalid function config");
+  }
+  if (!config || typeof config !== "object" || Array.isArray(config)) {
+    throw new Error("Prebuilt output contains an invalid function config");
+  }
+  if (!Object.hasOwn(config, "filePathMap")) return;
+  const { filePathMap } = config;
+  if (
+    !filePathMap ||
+    typeof filePathMap !== "object" ||
+    Array.isArray(filePathMap) ||
+    Object.keys(filePathMap).length > 0
+  ) {
+    throw new Error(
+      "Prebuilt output contains external function file references",
+    );
+  }
+}
+
+export function assertProductionShadowReadyForUpload({
+  repoRoot,
+  logicalTarget,
+  orgId,
+  projectId,
+  deploymentId,
+  deploySha,
+  expectedUid = process.getuid?.(),
+  expectedGid = process.getgid?.(),
+  expectedProvenanceUid = process.getuid?.(),
+}) {
+  const uid = numericIdentity(expectedUid, "Expected output UID");
+  const gid = numericIdentity(expectedGid, "Expected output GID");
+  const root = resolve(repoRoot);
+  const contract = targetContract(logicalTarget);
+  assertProductionShadowProvenance({
+    repoRoot: root,
+    deploySha,
+    expectedUid: expectedProvenanceUid,
+  });
+  assertOwnedMappingFile(
+    join(root, ".vercel", "repo.json"),
+    uid,
+    gid,
+    "Repo-level Vercel link",
+  );
+  assertOwnedMappingFile(
+    join(root, contract.rootDirectory, ".vercel", "project.json"),
+    uid,
+    gid,
+    "App-root Vercel project settings",
+  );
+  assertPulledProductionShadowProject({
+    repoRoot: root,
+    logicalTarget,
+    orgId,
+    projectId,
+  });
+  return assertProductionShadowOutput({
+    repoRoot: root,
+    logicalTarget,
+    deploymentId,
+    expectedUid: uid,
+    expectedGid: gid,
+  });
+}
+
+function normalizeRunnerOwnedHandoffTree(
+  root,
+  uid,
+  gid,
+  {
+    changeMode = chmodSync,
+    changeOwner = chownSync,
+    inspect = lstatSync,
+    list = readdirSync,
+  } = {},
+) {
+  const pending = [root];
+  let entries = 0;
+  while (pending.length > 0) {
+    const path = pending.pop();
+    const entry = inspect(path);
+    entries += 1;
+    if (entries > 250_000) {
+      throw new Error("Upload handoff contains too many filesystem entries");
+    }
+    if (entry.isSymbolicLink()) {
+      throw new Error("Upload handoff contains a symbolic link");
+    }
+    if (entry.isDirectory()) {
+      changeOwner(path, uid, gid);
+      changeMode(path, 0o755);
+      for (const child of list(path)) pending.push(join(path, child));
+      continue;
+    }
+    if (!entry.isFile() || entry.nlink !== 1) {
+      throw new Error("Upload handoff contains a special or hard-linked file");
+    }
+    changeOwner(path, uid, gid);
+    changeMode(path, (entry.mode & 0o111) === 0 ? 0o644 : 0o755);
+  }
+}
+
+export function createProductionShadowUploadHandoff({
+  runnerTemp,
+  stagingRoot,
+  candidateRoot,
+  uploadRoot,
+  logicalTarget,
+  orgId,
+  projectId,
+  deploymentId,
+  deploySha,
+  buildUid,
+  buildGid,
+  runnerUid,
+  runnerGid,
+  copyTree = cpSync,
+  changeMode = chmodSync,
+  changeOwner = chownSync,
+  inspect = lstatSync,
+  list = readdirSync,
+  validateCandidate = assertProductionShadowReadyForUpload,
+  validateMaterialized = assertMaterializedProductionShadowBuildEnvironment,
+  validateStaging = assertProductionShadowPullStaging,
+  validateUpload = assertProductionShadowReadyForUpload,
+}) {
+  const candidateUid = numericIdentity(buildUid, "Candidate build UID");
+  const candidateGid = numericIdentity(buildGid, "Candidate build GID");
+  const trustedUid = numericIdentity(runnerUid, "Runner UID");
+  const trustedGid = numericIdentity(runnerGid, "Runner GID");
+  const contract = targetContract(logicalTarget);
+  validateStaging({
+    runnerTemp,
+    stagingRoot,
+    logicalTarget,
+    orgId,
+    projectId,
+    expectedUid: trustedUid,
+    expectedGid: trustedGid,
+  });
+  validateMaterialized({
+    runnerTemp,
+    stagingRoot,
+    materializationRoot: join(resolve(runnerTemp), BUILD_ENVIRONMENT_DIRECTORY),
+    logicalTarget,
+    orgId,
+    projectId,
+    expectedUid: trustedUid,
+    expectedGid: trustedGid,
+  });
+  validateCandidate({
+    repoRoot: candidateRoot,
+    logicalTarget,
+    orgId,
+    projectId,
+    deploymentId,
+    deploySha,
+    expectedUid: candidateUid,
+    expectedGid: candidateGid,
+    expectedProvenanceUid: trustedUid,
+  });
+  const canonicalUploadRoot = assertRunnerTempChild({
+    runnerTemp,
+    path: uploadRoot,
+    expectedName: UPLOAD_SOURCE_DIRECTORY,
+    expectedUid: trustedUid,
+    expectedGid: trustedGid,
+  });
+  if (optionalEntry(canonicalUploadRoot)) {
+    throw new Error("Production-shadow upload handoff must be fresh");
+  }
+
+  const uploadAppState = join(
+    canonicalUploadRoot,
+    contract.rootDirectory,
+    ".vercel",
+  );
+  mkdirSync(join(canonicalUploadRoot, ".vercel"), {
+    mode: 0o755,
+    recursive: true,
+  });
+  mkdirSync(uploadAppState, { mode: 0o755, recursive: true });
+  copyTree(
+    join(candidateRoot, contract.rootDirectory, ".vercel", "output"),
+    join(uploadAppState, "output"),
+    {
+      dereference: false,
+      errorOnExist: true,
+      force: false,
+      preserveTimestamps: true,
+      recursive: true,
+    },
+  );
+  for (const relativePath of [
+    join(".vercel", "repo.json"),
+    join(contract.rootDirectory, ".vercel", "project.json"),
+  ]) {
+    copyFileSync(
+      join(stagingRoot, relativePath),
+      join(canonicalUploadRoot, relativePath),
+      constants.COPYFILE_EXCL,
+    );
+  }
+  normalizeRunnerOwnedHandoffTree(canonicalUploadRoot, trustedUid, trustedGid, {
+    changeMode,
+    changeOwner,
+    inspect,
+    list,
+  });
+  for (const relativePath of [
+    join(".vercel", "repo.json"),
+    join(contract.rootDirectory, ".vercel", "project.json"),
+  ]) {
+    changeMode(join(canonicalUploadRoot, relativePath), 0o600);
+  }
+  const provenancePath = `${canonicalUploadRoot}.provenance.json`;
+  writePrivateJson(provenancePath, {
+    commitSha: requireString(
+      deploySha,
+      "Deployment SHA",
+      SHA_PATTERN,
+    ).toLowerCase(),
+  });
+  changeOwner(provenancePath, trustedUid, trustedGid);
+  changeMode(provenancePath, 0o600);
+
+  validateUpload({
+    repoRoot: canonicalUploadRoot,
+    logicalTarget,
+    orgId,
+    projectId,
+    deploymentId,
+    deploySha,
+    expectedUid: trustedUid,
+    expectedGid: trustedGid,
+    expectedProvenanceUid: trustedUid,
+  });
+  return {
+    sourceRoot: canonicalUploadRoot,
+    uid: trustedUid,
+    gid: trustedGid,
+  };
+}
+
+export function runProductionShadowVercel({
+  repoRoot,
+  argumentsList,
+  environment = process.env,
+  captureStdout = false,
+  run = spawnSync,
+}) {
+  assertSafeProductionShadowArguments(argumentsList);
+  const nodeBin = environment.TRUSTED_NODE_PATH;
+  const vercelCli = environment.TRUSTED_VERCEL_CLI_PATH;
+  if ((nodeBin === undefined) !== (vercelCli === undefined)) {
+    throw new Error("Protected Vercel runtime paths must be provided together");
+  }
+  if (
+    nodeBin !== undefined &&
+    (!isAbsolute(nodeBin) || !isAbsolute(vercelCli))
+  ) {
+    throw new Error("Protected Vercel runtime paths must be absolute");
+  }
+  const command = nodeBin ?? "pnpm";
+  const commandArguments = nodeBin
+    ? [vercelCli, ...argumentsList]
+    : ["exec", "vercel", ...argumentsList];
+  const result = run(command, commandArguments, {
+    cwd: resolve(repoRoot),
+    encoding: "utf8",
+    env: environmentForVercelCli(environment),
+    stdio: captureStdout ? ["ignore", "pipe", "inherit"] : "inherit",
+  });
+  if (result.error || result.status !== 0) {
+    throw new Error("Pinned Vercel CLI command failed");
+  }
+  return captureStdout ? result.stdout : "";
+}
+
+export function pullProductionShadowProject({
+  repoRoot,
+  logicalTarget,
+  projectId,
+  environment = process.env,
+  executeVercel = runProductionShadowVercel,
+}) {
+  const previousUmask = process.umask(0o077);
+  try {
+    return executeVercel({
+      repoRoot,
+      argumentsList: buildProductionShadowPullArguments({
+        logicalTarget,
+        projectId,
+      }),
+      environment,
+    });
+  } finally {
+    process.umask(previousUmask);
+  }
+}
+
+export function buildProductionShadowArtifact({
+  repoRoot,
+  logicalTarget,
+  orgId,
+  projectId,
+  deploymentId,
+  environment = process.env,
+  executeVercel = runProductionShadowVercel,
+}) {
+  executeVercel({
+    repoRoot,
+    argumentsList: buildProductionShadowBuildArguments({
+      logicalTarget,
+      projectId,
+    }),
+    environment,
+  });
+  // The candidate build can mutate either Vercel link after the pre-build
+  // validation. Revalidate the exact trusted mapping before accepting output
+  // or allowing the workflow to advance to a deploy step.
+  assertPulledProductionShadowProject({
+    repoRoot,
+    logicalTarget,
+    orgId,
+    projectId,
+  });
+  return assertProductionShadowOutput({
+    repoRoot,
+    logicalTarget,
+    deploymentId,
+  });
+}
+
+export function parseDeployOutput(raw) {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+    throw new Error("Vercel deploy output is malformed");
+  }
+  if (raw.status !== undefined && raw.status !== "ok") {
+    throw new Error("Vercel deploy did not report a successful upload");
+  }
+  const deployment = raw.deployment ?? raw;
+  if (
+    !deployment ||
+    typeof deployment !== "object" ||
+    Array.isArray(deployment)
+  ) {
+    throw new Error("Vercel deploy output is malformed");
+  }
+  const deploymentId = deployment.id ?? deployment.deploymentId;
+  const deploymentUrl = deployment.url ?? deployment.deploymentUrl;
+  requireString(deploymentId, "Vercel deployment ID", DEPLOYMENT_ID_PATTERN);
+  return {
+    deploymentId,
+    deploymentUrl: canonicalizeDeploymentUrl(deploymentUrl),
+  };
+}
+
+export function createDeploymentExpectation({
+  deployment,
+  deploymentUrl,
+  projectId,
+  projectName,
+  sha,
+  transaction,
+  target = "production",
+  customEnvironmentSlug = null,
+}) {
+  return {
+    deployment: requireString(
+      deployment,
+      "Vercel deployment ID",
+      DEPLOYMENT_ID_PATTERN,
+    ),
+    deploymentUrl: canonicalizeDeploymentUrl(deploymentUrl),
+    projectId: requireString(projectId, "Vercel project ID"),
+    projectName: requireString(projectName, "Vercel project name"),
+    readyState: "READY",
+    target,
+    customEnvironmentSlug,
+    transaction: requireString(
+      transaction,
+      "Workflow transaction",
+      /^(?:[1-9][0-9]*-[1-9][0-9]*-(?:governance|reserve|ui)|main-[0-9a-f]{40}-[1-9][0-9]*-[1-9][0-9]*)$/,
+    ),
+    git: {
+      ...expectedGit("main"),
+      sha: requireString(sha, "Deployment SHA", SHA_PATTERN).toLowerCase(),
+    },
+  };
+}
+
+export function assertUnaliasedProductionShadowDeployment(state) {
+  assertCanonicalOutput(state);
+  if (Array.isArray(state)) {
+    throw new Error(
+      "Staged deployment state must describe exactly one deployment",
+    );
+  }
+  const immutableHostname = new URL(state.deploymentUrl).hostname;
+  if (
+    state.alias !== immutableHostname ||
+    JSON.stringify(state.aliases) !== JSON.stringify([immutableHostname])
+  ) {
+    throw new Error(
+      "Staged production deployment received an unexpected alias",
+    );
+  }
+  return state;
+}
+
+export function createAppBuildOnlyProof({ sha, deploymentId }) {
+  const normalizedSha = requireString(
+    sha,
+    "Deployment SHA",
+    SHA_PATTERN,
+  ).toLowerCase();
+  return {
+    target: "app",
+    sha: normalizedSha,
+    environment: "v3",
+    vercelEnv: "preview",
+    vercelTargetEnv: "v3",
+    nextPublicVercelEnv: "preview",
+    nextDeploymentId: requireString(deploymentId, "Next deployment ID"),
+    sentryAuthToken: EXPLICIT_EMPTY,
+    deployReachable: false,
+    futureActivationCommand:
+      "vercel deploy --prebuilt --target=v3 --archive=tgz --format=json",
+    futureMetadata: [
+      "githubCommitOrg=mento-protocol",
+      "githubCommitRepo=frontend-monorepo",
+      "githubCommitRef=main",
+      `githubCommitSha=${normalizedSha}`,
+      "mentoTransaction=<run_id>-<run_attempt>-app",
+    ],
+  };
+}
+
+export function writePilotSummary({
+  path,
+  baseline,
+  sha,
+  runUrl,
+  workflowDurationMs,
+  app,
+  governance,
+  reserve,
+  ui,
+}) {
+  const normalizedSha = requireString(
+    sha,
+    "Deployment SHA",
+    SHA_PATTERN,
+  ).toLowerCase();
+  const v3States = baseline
+    .filter((state) => state.customEnvironmentSlug === "v3")
+    .sort((left, right) => left.alias.localeCompare(right.alias));
+  const legacy = baseline.find((state) => state.alias === "v2-app.mento.org");
+  if (v3States.length === 0 || !legacy) {
+    throw new Error("Pilot baseline is missing app v3 or legacy v2 state");
+  }
+  if (new Set(v3States.map((state) => state.deploymentId)).size !== 1) {
+    throw new Error("Pilot baseline has divergent app-v3 deployments");
+  }
+  const checkedDeployment = (value, label) => ({
+    id: requireString(
+      value.id,
+      `${label} deployment ID`,
+      DEPLOYMENT_ID_PATTERN,
+    ),
+    url: canonicalizeDeploymentUrl(value.url),
+    buildDurationMs: requireString(
+      value.buildDurationMs,
+      `${label} build duration`,
+      /^[0-9]+$/,
+    ),
+    deployDurationMs: requireString(
+      value.deployDurationMs,
+      `${label} deploy duration`,
+      /^[0-9]+$/,
+    ),
+    totalDurationMs: requireString(
+      value.totalDurationMs,
+      `${label} total duration`,
+      /^[0-9]+$/,
+    ),
+    cacheHits: requireString(
+      value.cacheHits,
+      `${label} Turbo cache hits`,
+      /^[0-9]+$/,
+    ),
+    cacheMisses: requireString(
+      value.cacheMisses,
+      `${label} Turbo cache misses`,
+      /^[0-9]+$/,
+    ),
+  });
+  const deployments = {
+    governance: checkedDeployment(governance, "Governance"),
+    reserve: checkedDeployment(reserve, "Reserve"),
+    ui: checkedDeployment(ui, "UI"),
+  };
+  const appBuildDuration = requireString(
+    app.buildDurationMs,
+    "App build duration",
+    /^[0-9]+$/,
+  );
+  const appTotalDuration = requireString(
+    app.totalDurationMs,
+    "App total duration",
+    /^[0-9]+$/,
+  );
+  const appDeploymentId = requireString(
+    app.nextDeploymentId,
+    "App Next deployment ID",
+  );
+  const appCacheHits = requireString(
+    app.cacheHits,
+    "App Turbo cache hits",
+    /^[0-9]+$/,
+  );
+  const appCacheMisses = requireString(
+    app.cacheMisses,
+    "App Turbo cache misses",
+    /^[0-9]+$/,
+  );
+  const totalWorkflowDuration = requireString(
+    workflowDurationMs,
+    "Whole workflow duration",
+    /^[0-9]+$/,
+  );
+  const lines = [
+    "### Production-shadow pilot evidence",
+    "",
+    `- Workflow run: ${requireString(runUrl, "Workflow run URL")}`,
+    `- Exact deployment SHA: \`${normalizedSha}\``,
+    `- Whole workflow duration: ${totalWorkflowDuration} ms`,
+    "- Pinned Vercel CLI: `56.2.0`",
+    "- Project Root Directories verified: `apps/app.mento.org`, `apps/governance.mento.org`, `apps/reserve.mento.org`, `apps/ui.mento.org`",
+    "",
+    "| Target | Build target | Deployment ID / URL | Runtime/browser | Protected mappings | Turbo cache | Timing | Result |",
+    "|---|---|---|---|---|---|---|---|",
+    `| app | v3 | build-only Outcome B (Next ID \`${appDeploymentId}\`) | deferred by design | app/v2 unchanged | ${appCacheHits} hit / ${appCacheMisses} miss | build ${appBuildDuration} ms; job ${appTotalDuration} ms | pass |`,
+    `| governance | production | \`${deployments.governance.id}\` / ${deployments.governance.url} | pass | unchanged | ${deployments.governance.cacheHits} hit / ${deployments.governance.cacheMisses} miss | build ${deployments.governance.buildDurationMs} ms; deploy ${deployments.governance.deployDurationMs} ms; job ${deployments.governance.totalDurationMs} ms | pass |`,
+    `| reserve | production | \`${deployments.reserve.id}\` / ${deployments.reserve.url} | pass | unchanged | ${deployments.reserve.cacheHits} hit / ${deployments.reserve.cacheMisses} miss | build ${deployments.reserve.buildDurationMs} ms; deploy ${deployments.reserve.deployDurationMs} ms; job ${deployments.reserve.totalDurationMs} ms | pass |`,
+    `| ui | production | \`${deployments.ui.id}\` / ${deployments.ui.url} | pass | unchanged | ${deployments.ui.cacheHits} hit / ${deployments.ui.cacheMisses} miss | build ${deployments.ui.buildDurationMs} ms; deploy ${deployments.ui.deployDurationMs} ms; job ${deployments.ui.totalDurationMs} ms | pass |`,
+    `| legacy app | v2 production | \`${legacy.deploymentId}\` / ${canonicalizeDeploymentUrl(legacy.deploymentUrl)} | public health pass | unchanged | n/a | n/a | pass |`,
+    "",
+    `- Reviewed app-v3 aliases: ${v3States.map((state) => `\`${state.alias}\``).join(", ")}`,
+    `- Captured prior app-v3 deployment: \`${v3States[0].deploymentId}\` / ${canonicalizeDeploymentUrl(v3States[0].deploymentUrl)}`,
+    "- Copy-safe app-v3 rollback commands:",
+    ...v3States.map(
+      (state) =>
+        `  - \`vercel alias set ${canonicalizeDeploymentUrl(state.deploymentUrl)} ${state.alias}\``,
+    ),
+    "- Real required-variable names passed preflight; the synthetic `FIXTURE_REQUIRED_SECRET` failure is covered by the offline primitive suite.",
+    "- Turbo cache hit/miss counts are parsed fail-closed from each build's single canonical summary; the original summaries remain in the build logs.",
+    "- No raw Vercel response, pulled environment, `.vercel/output`, credential, or protection-bypass value was uploaded.",
+    "",
+  ];
+  writeFileSync(resolve(path), lines.join("\n"), { flag: "a" });
+}
+
+export function assertEvidenceFiles(files) {
+  if (!Array.isArray(files) || files.length === 0) {
+    throw new Error("Evidence file list must be non-empty");
+  }
+  for (const path of files) {
+    const evidence = readFileSync(resolve(path), "utf8");
+    if (FORBIDDEN_EVIDENCE_PATTERN.test(evidence)) {
+      throw new Error("Evidence contains a forbidden sensitive field name");
+    }
+  }
+}
+
+export function assertRequiredVariableNames(names, values = process.env) {
+  if (!Array.isArray(names) || names.length === 0) {
+    throw new Error("Required variable-name list must be non-empty");
+  }
+  const missing = names
+    .map((name) =>
+      requireString(name, "Required variable name", /^[A-Z0-9_]+$/),
+    )
+    .filter((name) => values[name] === undefined || values[name] === "")
+    .sort();
+  if (missing.length > 0) {
+    throw new Error(`Missing required variables: ${missing.join(", ")}`);
+  }
+  return names.length;
+}
+
+export const REQUIRED_BUILD_CACHE_VARIABLE_NAMES = Object.freeze([
+  "TURBO_REMOTE_CACHE_SIGNATURE_KEY",
+  "TURBO_TEAM",
+  "TURBO_TOKEN",
+]);
+
+export function assertProductionShadowBuildInputs(values = process.env) {
+  return assertRequiredVariableNames(
+    REQUIRED_BUILD_CACHE_VARIABLE_NAMES,
+    values,
+  );
+}
+
+export async function assertProtectedAliasesUnchanged({ baseline, client }) {
+  if (!Array.isArray(baseline) || baseline.length === 0) {
+    throw new Error("Protected alias baseline is malformed");
+  }
+  const baselineByAlias = new Map();
+  for (const state of baseline) {
+    const alias = canonicalizeHostname(state.alias);
+    if (baselineByAlias.has(alias)) {
+      throw new Error("Protected alias baseline contains duplicates");
+    }
+    baselineByAlias.set(alias, {
+      alias,
+      deploymentId: requireString(
+        state.deploymentId,
+        "Baseline deployment ID",
+        DEPLOYMENT_ID_PATTERN,
+      ),
+      deploymentUrl: canonicalizeDeploymentUrl(state.deploymentUrl),
+      projectId: requireIdentifier(state.projectId, "Baseline project ID"),
+    });
+  }
+  const current = await captureAliasMappings(client, [
+    ...baselineByAlias.keys(),
+  ]);
+  const drift = current.filter((mapping) => {
+    const before = baselineByAlias.get(mapping.alias);
+    return (
+      before.deploymentId !== mapping.deploymentId ||
+      before.deploymentUrl !== mapping.deploymentUrl ||
+      before.projectId !== mapping.projectId
+    );
+  });
+  if (drift.length === 0) return [];
+
+  const evidence = drift.map((mapping) => {
+    const before = baselineByAlias.get(mapping.alias);
+    return {
+      alias: mapping.alias,
+      before: {
+        deploymentId: before.deploymentId,
+        deploymentUrl: before.deploymentUrl,
+      },
+      current: {
+        deploymentId: mapping.deploymentId,
+        deploymentUrl: mapping.deploymentUrl,
+      },
+      restoreCommand: `vercel alias set ${before.deploymentUrl} ${mapping.alias}`,
+    };
+  });
+  throw new Error(
+    [
+      "Protected alias drift detected; the shadow pilot is read-only and attempted no repair.",
+      `Canonical drift: ${JSON.stringify(evidence)}`,
+      "Operator recovery: stop forward work; confirm there is no concurrent or intentional activation; re-resolve every alias and require it to still match the canonical current ID/URL above; only then run the listed restore command manually; finally capture and compare the full protected snapshot again.",
+    ].join(" "),
+  );
+}
+
+export function assertFinalJobResults(results) {
+  const required = [
+    "preflight",
+    "baseline",
+    "app",
+    "governance",
+    "smokeGovernance",
+    "reserve",
+    "smokeReserve",
+    "ui",
+    "smokeUi",
+    "finalAliasComparison",
+  ];
+  for (const name of required) {
+    if (results[name] !== "success") {
+      throw new Error(
+        `Required production-shadow job did not succeed: ${name}`,
+      );
+    }
+  }
+}
+
+export async function fetchWithOriginBoundRedirects({
+  url,
+  signal,
+  fetchImplementation = fetch,
+  maximumRedirects = 5,
+}) {
+  const allowedOrigin = new URL(url).origin;
+  let currentUrl = url;
+  for (
+    let redirectCount = 0;
+    redirectCount <= maximumRedirects;
+    redirectCount += 1
+  ) {
+    const response = await fetchImplementation(currentUrl, {
+      redirect: "manual",
+      signal,
+    });
+    if (response.status < 300 || response.status >= 400) return response;
+    const location = response.headers?.get("location");
+    if (!location || redirectCount === maximumRedirects) {
+      throw new Error("Protected host returned an invalid redirect");
+    }
+    const nextUrl = new URL(location, currentUrl);
+    if (nextUrl.origin !== allowedOrigin) {
+      throw new Error("Protected host redirected outside its immutable origin");
+    }
+    currentUrl = nextUrl.toString();
+  }
+  throw new Error("Protected host exceeded its redirect limit");
+}
+
+export async function waitForHealthyUrls({
+  urls,
+  attempts = 4,
+  delayMs = 2_000,
+  fetchImplementation = fetch,
+}) {
+  if (!Array.isArray(urls) || urls.length === 0) {
+    throw new Error("Health-check URL list must be non-empty");
+  }
+  await Promise.all(
+    urls.map(async (value) => {
+      const hostname = canonicalizeHostname(value);
+      const url = `https://${hostname}`;
+      let healthy = false;
+      for (let attempt = 1; attempt <= attempts; attempt += 1) {
+        const controller = new AbortController();
+        const timeout = setTimeout(() => controller.abort(), 15_000);
+        try {
+          const response = await fetchWithOriginBoundRedirects({
+            url,
+            signal: controller.signal,
+            fetchImplementation,
+          });
+          if (response.status >= 200 && response.status < 300) {
+            healthy = true;
+            break;
+          }
+        } catch {
+          // Retry only; response bodies and errors are intentionally not logged.
+        } finally {
+          clearTimeout(timeout);
+        }
+        if (attempt < attempts) {
+          await new Promise((resolveDelay) =>
+            setTimeout(resolveDelay, delayMs),
+          );
+        }
+      }
+      if (!healthy)
+        throw new Error(`Protected hostname is not healthy: ${hostname}`);
+    }),
+  );
+}
+
+function parseArguments(argv) {
+  const options = {};
+  for (let index = 1; index < argv.length; index += 1) {
+    if (!argv[index].startsWith("--")) continue;
+    options[argv[index].slice(2)] = argv[index + 1];
+    index += 1;
+  }
+  return { command: argv[0], options };
+}
+
+function isCliEntrypoint() {
+  return (
+    process.argv[1] !== undefined &&
+    fileURLToPath(import.meta.url) === resolve(process.argv[1])
+  );
+}
+
+if (isCliEntrypoint()) {
+  const { command, options } = parseArguments(process.argv.slice(2));
+  if (command === "validate-context") {
+    const sha = validateDispatchContext({
+      repository: process.env.GITHUB_REPOSITORY,
+      ref: process.env.GITHUB_REF,
+      workflowRef: process.env.GITHUB_WORKFLOW_REF,
+      deploySha: process.env.DEPLOY_SHA,
+    });
+    appendOutput("deploy_sha", sha);
+    process.stdout.write("Production-shadow dispatch context verified\n");
+  } else if (command === "validate-source") {
+    const sha = validateImmutableMainSource({
+      deploySha: process.env.DEPLOY_SHA,
+      workflowSha: process.env.GITHUB_WORKFLOW_SHA,
+      sourcePath: trustedSourcePath(),
+    });
+    appendOutput("deploy_sha", sha);
+    process.stdout.write("Immutable main source verified\n");
+  } else if (command === "create-spec") {
+    writePrivateJson(
+      options.output,
+      createProtectedAliasSpec({
+        appV3AliasesJson: process.env.APP_V3_ALIASES_JSON,
+        projectIds: {
+          app: process.env.VERCEL_PROJECT_ID_APP,
+          governance: process.env.VERCEL_PROJECT_ID_GOVERNANCE,
+          reserve: process.env.VERCEL_PROJECT_ID_RESERVE,
+          ui: process.env.VERCEL_PROJECT_ID_UI,
+        },
+      }),
+    );
+    process.stdout.write("Protected alias specification written\n");
+  } else if (command === "prepare-link") {
+    materializeProductionShadowLink({
+      repoRoot: trustedSourcePath(),
+      logicalTarget: process.env.LOGICAL_TARGET,
+      orgId: process.env.VERCEL_ORG_ID,
+      projectId: process.env.VERCEL_PROJECT_ID,
+    });
+    process.stdout.write("Trusted monorepo Vercel mapping written\n");
+  } else if (command === "prepare-pull-staging") {
+    prepareProductionShadowPullStaging({
+      runnerTemp: process.env.RUNNER_TEMP,
+      stagingRoot: process.env.PULL_STAGING_PATH,
+      logicalTarget: process.env.LOGICAL_TARGET,
+      orgId: process.env.VERCEL_ORG_ID,
+      projectId: process.env.VERCEL_PROJECT_ID,
+    });
+    process.stdout.write("Runner-owned Vercel pull staging prepared\n");
+  } else if (command === "pull") {
+    pullProductionShadowProject({
+      repoRoot: trustedSourcePath(),
+      logicalTarget: process.env.LOGICAL_TARGET,
+      projectId: process.env.VERCEL_PROJECT_ID,
+    });
+    process.stdout.write("Target Vercel configuration pulled\n");
+  } else if (command === "materialize-source") {
+    materializeExactGitTree({
+      runnerTemp: process.env.RUNNER_TEMP,
+      sourceRoot: process.env.SOURCE_PATH,
+      candidateRoot: process.env.CANDIDATE_SOURCE_PATH,
+      commitSha: process.env.DEPLOY_SHA,
+    });
+    process.stdout.write("Exact Git source materialized without filters\n");
+  } else if (command === "validate-pull-staging") {
+    assertProductionShadowPullStaging({
+      runnerTemp: process.env.RUNNER_TEMP,
+      stagingRoot: process.env.PULL_STAGING_PATH,
+      logicalTarget: process.env.LOGICAL_TARGET,
+      orgId: process.env.VERCEL_ORG_ID,
+      projectId: process.env.VERCEL_PROJECT_ID,
+    });
+    process.stdout.write("Runner-owned Vercel pull staging verified\n");
+  } else if (command === "stage-pull") {
+    stageProductionShadowPullForCandidate({
+      runnerTemp: process.env.RUNNER_TEMP,
+      stagingRoot: process.env.PULL_STAGING_PATH,
+      candidateRoot: process.env.CANDIDATE_SOURCE_PATH,
+      logicalTarget: process.env.LOGICAL_TARGET,
+      orgId: process.env.VERCEL_ORG_ID,
+      projectId: process.env.VERCEL_PROJECT_ID,
+      buildUid: process.env.BUILD_UID,
+      buildGid: process.env.BUILD_GID,
+      runnerUid: process.env.PULL_STAGING_UID,
+      runnerGid: process.env.PULL_STAGING_GID,
+    });
+    process.stdout.write("Runner-owned Vercel settings staged for candidate\n");
+  } else if (command === "validate-candidate-pull") {
+    assertCandidateProductionShadowPull({
+      runnerTemp: process.env.RUNNER_TEMP,
+      candidateRoot: process.env.CANDIDATE_SOURCE_PATH,
+      logicalTarget: process.env.LOGICAL_TARGET,
+      orgId: process.env.VERCEL_ORG_ID,
+      projectId: process.env.VERCEL_PROJECT_ID,
+      buildUid: process.env.BUILD_UID,
+      buildGid: process.env.BUILD_GID,
+      runnerUid: process.env.PULL_STAGING_UID,
+      runnerGid: process.env.PULL_STAGING_GID,
+    });
+    process.stdout.write("Candidate Vercel settings verified as root\n");
+  } else if (command === "validate-pull") {
+    assertPulledProductionShadowProject({
+      repoRoot: trustedSourcePath(),
+      logicalTarget: process.env.LOGICAL_TARGET,
+      orgId: process.env.VERCEL_ORG_ID,
+      projectId: process.env.VERCEL_PROJECT_ID,
+    });
+    process.stdout.write("Pulled app-root Vercel project mapping verified\n");
+  } else if (command === "check-build-inputs") {
+    assertProductionShadowBuildInputs();
+    process.stdout.write("Required build input names verified\n");
+  } else if (command === "build") {
+    assertProductionShadowBuildInputs();
+    const startedAt = Date.now();
+    const repoRoot = trustedSourcePath();
+    const logicalTarget = process.env.LOGICAL_TARGET;
+    buildProductionShadowArtifact({
+      repoRoot,
+      logicalTarget,
+      orgId: process.env.VERCEL_ORG_ID,
+      projectId: process.env.VERCEL_PROJECT_ID,
+      deploymentId: process.env.MENTO_NEXT_DEPLOYMENT_ID,
+    });
+    appendOutput("build_duration_ms", String(Date.now() - startedAt));
+    process.stdout.write("Target prebuilt output created and verified\n");
+  } else if (command === "create-handoff") {
+    createProductionShadowUploadHandoff({
+      runnerTemp: process.env.RUNNER_TEMP,
+      stagingRoot: process.env.PULL_STAGING_PATH,
+      candidateRoot: process.env.CANDIDATE_SOURCE_PATH,
+      uploadRoot: process.env.UPLOAD_SOURCE_PATH,
+      logicalTarget: process.env.LOGICAL_TARGET,
+      orgId: process.env.VERCEL_ORG_ID,
+      projectId: process.env.VERCEL_PROJECT_ID,
+      deploymentId: process.env.MENTO_NEXT_DEPLOYMENT_ID,
+      deploySha: process.env.DEPLOY_SHA,
+      buildUid: process.env.BUILD_UID,
+      buildGid: process.env.BUILD_GID,
+      runnerUid: process.env.RUNNER_UID,
+      runnerGid: process.env.RUNNER_GID,
+    });
+    process.stdout.write("Immutable runner-owned upload handoff created\n");
+  } else if (command === "assert-output") {
+    assertProductionShadowReadyForUpload({
+      repoRoot: trustedSourcePath(),
+      logicalTarget: process.env.LOGICAL_TARGET,
+      orgId: process.env.VERCEL_ORG_ID,
+      projectId: process.env.VERCEL_PROJECT_ID,
+      deploymentId: process.env.MENTO_NEXT_DEPLOYMENT_ID,
+      deploySha: process.env.DEPLOY_SHA,
+      expectedUid: process.env.EXPECTED_OUTPUT_UID,
+      expectedGid: process.env.EXPECTED_OUTPUT_GID,
+      expectedProvenanceUid: process.env.EXPECTED_PROVENANCE_UID,
+    });
+    process.stdout.write("Production-shadow upload handoff verified\n");
+  } else if (command === "deploy") {
+    const logicalTarget = process.env.LOGICAL_TARGET;
+    const transaction = `${process.env.GITHUB_RUN_ID}-${process.env.GITHUB_RUN_ATTEMPT}-${logicalTarget}`;
+    const startedAt = Date.now();
+    const raw = runProductionShadowVercel({
+      repoRoot: trustedSourcePath(),
+      argumentsList: buildProductionShadowDeployArguments({
+        logicalTarget,
+        projectId: process.env.VERCEL_PROJECT_ID,
+        deploySha: process.env.DEPLOY_SHA,
+        transaction,
+      }),
+      captureStdout: true,
+    });
+    let parsed;
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      throw new Error("Vercel deploy output is malformed");
+    }
+    const result = parseDeployOutput(parsed);
+    appendOutput("vercel_deployment_id", result.deploymentId);
+    appendOutput("vercel_deployment_url", result.deploymentUrl);
+    appendOutput("deploy_duration_ms", String(Date.now() - startedAt));
+    writePrivateJson(
+      options.expected,
+      createDeploymentExpectation({
+        deployment: result.deploymentId,
+        deploymentUrl: result.deploymentUrl,
+        projectId: process.env.VERCEL_PROJECT_ID,
+        projectName: targetContract(logicalTarget).projectName,
+        sha: process.env.DEPLOY_SHA,
+        transaction,
+      }),
+    );
+    process.stdout.write("Canonical deployment identity written\n");
+  } else if (command === "app-proof") {
+    writePrivateJson(
+      options.output,
+      createAppBuildOnlyProof({
+        sha: process.env.DEPLOY_SHA,
+        deploymentId: process.env.MENTO_NEXT_DEPLOYMENT_ID,
+      }),
+    );
+    process.stdout.write("App v3 build-only Outcome B verified\n");
+  } else if (command === "assert-unaliased") {
+    assertUnaliasedProductionShadowDeployment(
+      readJson(options.input, "Staged deployment state"),
+    );
+    process.stdout.write("Staged production deployment is unaliased\n");
+  } else if (command === "evidence") {
+    assertEvidenceFiles(readJson(options.files, "Evidence file list"));
+    process.stdout.write("Canonical evidence scan passed\n");
+  } else if (command === "check-aliases") {
+    await assertProtectedAliasesUnchanged({
+      baseline: options.baseline
+        ? readJson(options.baseline, "Baseline snapshot")
+        : readEnvironmentJson("BASELINE_JSON", "Baseline snapshot"),
+      client: new VercelStateClient({
+        token: process.env.VERCEL_TOKEN,
+        teamId: process.env.VERCEL_ORG_ID,
+      }),
+    });
+    process.stdout.write("Protected alias mappings remain unchanged\n");
+  } else if (command === "final") {
+    assertFinalJobResults(JSON.parse(process.env.JOB_RESULTS_JSON ?? "{}"));
+    process.stdout.write("All production-shadow jobs succeeded\n");
+  } else if (command === "emit-output") {
+    const value = JSON.stringify(readJson(options.input, "Canonical output"));
+    appendOutput(options.name, value);
+    process.stdout.write("Canonical GitHub output written\n");
+  } else if (command === "cache-summary") {
+    const cache = parseTurboCacheSummary(
+      readFileSync(resolve(options.input), "utf8"),
+    );
+    appendOutput("turbo_cache_hits", String(cache.hits));
+    appendOutput("turbo_cache_misses", String(cache.misses));
+    process.stdout.write("Canonical Turbo cache summary verified\n");
+  } else if (command === "summary") {
+    writePilotSummary({
+      path: process.env.GITHUB_STEP_SUMMARY,
+      baseline: JSON.parse(process.env.BASELINE_JSON ?? "[]"),
+      sha: process.env.DEPLOY_SHA,
+      runUrl: process.env.WORKFLOW_RUN_URL,
+      workflowDurationMs: process.env.WORKFLOW_DURATION_MS,
+      app: {
+        nextDeploymentId: process.env.APP_NEXT_DEPLOYMENT_ID,
+        buildDurationMs: process.env.APP_BUILD_DURATION_MS,
+        totalDurationMs: process.env.APP_TOTAL_DURATION_MS,
+        cacheHits: process.env.APP_TURBO_CACHE_HITS,
+        cacheMisses: process.env.APP_TURBO_CACHE_MISSES,
+      },
+      governance: {
+        id: process.env.GOVERNANCE_DEPLOYMENT_ID,
+        url: process.env.GOVERNANCE_DEPLOYMENT_URL,
+        buildDurationMs: process.env.GOVERNANCE_BUILD_DURATION_MS,
+        deployDurationMs: process.env.GOVERNANCE_DEPLOY_DURATION_MS,
+        totalDurationMs: process.env.GOVERNANCE_TOTAL_DURATION_MS,
+        cacheHits: process.env.GOVERNANCE_TURBO_CACHE_HITS,
+        cacheMisses: process.env.GOVERNANCE_TURBO_CACHE_MISSES,
+      },
+      reserve: {
+        id: process.env.RESERVE_DEPLOYMENT_ID,
+        url: process.env.RESERVE_DEPLOYMENT_URL,
+        buildDurationMs: process.env.RESERVE_BUILD_DURATION_MS,
+        deployDurationMs: process.env.RESERVE_DEPLOY_DURATION_MS,
+        totalDurationMs: process.env.RESERVE_TOTAL_DURATION_MS,
+        cacheHits: process.env.RESERVE_TURBO_CACHE_HITS,
+        cacheMisses: process.env.RESERVE_TURBO_CACHE_MISSES,
+      },
+      ui: {
+        id: process.env.UI_DEPLOYMENT_ID,
+        url: process.env.UI_DEPLOYMENT_URL,
+        buildDurationMs: process.env.UI_BUILD_DURATION_MS,
+        deployDurationMs: process.env.UI_DEPLOY_DURATION_MS,
+        totalDurationMs: process.env.UI_TOTAL_DURATION_MS,
+        cacheHits: process.env.UI_TURBO_CACHE_HITS,
+        cacheMisses: process.env.UI_TURBO_CACHE_MISSES,
+      },
+    });
+    process.stdout.write("Production-shadow pilot summary written\n");
+  } else if (command === "health") {
+    const urls = options.spec
+      ? readJson(options.spec, "Protected alias specification").map(
+          (entry) => entry.alias,
+        )
+      : options.url
+        ? [options.url]
+        : JSON.parse(process.env.HEALTH_URLS_JSON ?? "[]");
+    await waitForHealthyUrls({
+      urls,
+    });
+    process.stdout.write("Protected host health checks passed\n");
+  } else {
+    throw new Error(
+      "Usage: vercel-production-shadow.mjs validate-context|validate-source|create-spec|prepare-link|prepare-pull-staging|pull|materialize-source|validate-pull-staging|stage-pull|validate-candidate-pull|validate-pull|check-build-inputs|build|create-handoff|assert-output|deploy|app-proof|assert-unaliased|evidence|check-aliases|final|emit-output|cache-summary|summary|health",
+    );
+  }
+}

--- a/scripts/vercel-production-shadow.test.mjs
+++ b/scripts/vercel-production-shadow.test.mjs
@@ -1,0 +1,1892 @@
+import assert from "node:assert/strict";
+import { Buffer } from "node:buffer";
+import { execFileSync } from "node:child_process";
+import {
+  chmodSync,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readlinkSync,
+  realpathSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import process from "node:process";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+import {
+  assertEvidenceFiles,
+  assertCandidateProductionShadowPull,
+  assertFinalJobResults,
+  assertMaterializedProductionShadowBuildEnvironment,
+  assertProductionShadowBuildInputs,
+  assertProductionShadowOutput,
+  assertProductionShadowPullStaging,
+  assertProductionShadowReadyForUpload,
+  assertProtectedAliasesUnchanged,
+  assertPulledProductionShadowProject,
+  assertRequiredVariableNames,
+  assertUnaliasedProductionShadowDeployment,
+  assignProductionShadowMaterializationOwnership,
+  buildProductionShadowArtifact,
+  buildProductionShadowBuildArguments,
+  buildProductionShadowDeployArguments,
+  buildProductionShadowPullArguments,
+  createAppBuildOnlyProof,
+  createDeploymentExpectation,
+  createProtectedAliasSpec,
+  createProductionShadowUploadHandoff,
+  environmentForTrustedChild,
+  environmentForVercelCli,
+  fetchWithOriginBoundRedirects,
+  materializeExactGitTree,
+  materializeProductionShadowLink,
+  parseTurboCacheSummary,
+  parseDeployOutput,
+  prepareProductionShadowPullStaging,
+  PRODUCTION_SHADOW_TARGETS,
+  pullProductionShadowProject,
+  REQUIRED_BUILD_CACHE_VARIABLE_NAMES,
+  runProductionShadowVercel,
+  stageProductionShadowPullForCandidate,
+  validateDispatchContext,
+  validateImmutableMainSource,
+  waitForHealthyUrls,
+  writePilotSummary,
+} from "./vercel-production-shadow.mjs";
+import {
+  getVercelBuildRequirements,
+  parseVercelPulledEnvironment,
+  serializeVercelPulledEnvironment,
+} from "./vercel-build-environment.mjs";
+import {
+  assertProductionShadowOrigin,
+  productionShadowRequestHeaders,
+} from "../apps/app.mento.org/e2e/production-shadow/request-policy.mjs";
+
+const SHA = "0123456789abcdef0123456789abcdef01234567";
+const productionShadowScript = fileURLToPath(
+  new URL("./vercel-production-shadow.mjs", import.meta.url),
+);
+
+function projectIds() {
+  return {
+    app: "prj_app123",
+    governance: "prj_governance123",
+    reserve: "prj_reserve123",
+    ui: "prj_ui123",
+  };
+}
+
+function defaultPulledEnvironment(logicalTarget) {
+  const environment = PRODUCTION_SHADOW_TARGETS[logicalTarget].pullEnvironment;
+  return Object.fromEntries(
+    getVercelBuildRequirements(logicalTarget, environment)
+      .filter((requirement) => requirement.ciClassification === "vercel-pull")
+      .map((requirement) => [
+        requirement.name,
+        requirement.allowEmpty
+          ? ""
+          : requirement.name.includes("URL")
+            ? `https://${requirement.name.toLowerCase().replaceAll("_", "-")}.example`
+            : `fixture-${requirement.name.toLowerCase()}`,
+      ]),
+  );
+}
+
+test("materialized environment ownership is assigned to the runner identity", () => {
+  const calls = [];
+  assignProductionShadowMaterializationOwnership({
+    materializationRoot: "/runner/temp/materialized",
+    environmentPath: "/runner/temp/materialized/.vercel/.env.production.local",
+    expectedUid: 1_234,
+    expectedGid: 5_678,
+    changeOwner: (path, uid, gid) => calls.push({ path, uid, gid }),
+  });
+  assert.deepEqual(calls, [
+    { path: "/runner/temp/materialized", uid: 1_234, gid: 5_678 },
+    {
+      path: "/runner/temp/materialized/.vercel",
+      uid: 1_234,
+      gid: 5_678,
+    },
+    {
+      path: "/runner/temp/materialized/.vercel/.env.production.local",
+      uid: 1_234,
+      gid: 5_678,
+    },
+  ]);
+});
+
+test("dispatch context accepts only canonical main and immutable SHA", () => {
+  const input = {
+    repository: "mento-protocol/frontend-monorepo",
+    ref: "refs/heads/main",
+    workflowRef:
+      "mento-protocol/frontend-monorepo/.github/workflows/vercel-production-shadow.yml@refs/heads/main",
+    deploySha: SHA.toUpperCase(),
+  };
+  assert.equal(validateDispatchContext(input), SHA);
+  for (const override of [
+    { repository: "fork/frontend-monorepo" },
+    { ref: "refs/heads/feature" },
+    { workflowRef: input.workflowRef.replace("main", "feature") },
+    { deploySha: "main" },
+  ]) {
+    assert.throws(() => validateDispatchContext({ ...input, ...override }));
+  }
+});
+
+test("immutable-source validation requires the exact fetched main and HEAD", () => {
+  const calls = [];
+  const execute = (_command, argumentsList) => {
+    calls.push(argumentsList);
+    if (argumentsList[2] === "rev-parse") return `${SHA}\n`;
+    return "";
+  };
+  assert.equal(
+    validateImmutableMainSource({
+      deploySha: SHA,
+      workflowSha: SHA,
+      sourcePath: "/trusted/source",
+      execute,
+    }),
+    SHA,
+  );
+  assert.deepEqual(calls, [
+    ["-C", "/trusted/source", "cat-file", "-e", `${SHA}^{commit}`],
+    [
+      "-C",
+      "/trusted/source",
+      "merge-base",
+      "--is-ancestor",
+      SHA,
+      "refs/remotes/origin/main",
+    ],
+    ["-C", "/trusted/source", "rev-parse", "refs/remotes/origin/main"],
+    ["-C", "/trusted/source", "rev-parse", "HEAD"],
+  ]);
+  assert.throws(
+    () =>
+      validateImmutableMainSource({
+        deploySha: SHA,
+        workflowSha: SHA,
+        sourcePath: "/trusted/source",
+        execute: (_command, argumentsList) => {
+          if (argumentsList.includes("merge-base")) {
+            throw new Error("not an ancestor");
+          }
+          return `${SHA}\n`;
+        },
+      }),
+    /not an ancestor/,
+  );
+  assert.throws(
+    () =>
+      validateImmutableMainSource({
+        deploySha: SHA,
+        workflowSha: SHA,
+        sourcePath: "/trusted/source",
+        execute: (_command, argumentsList) =>
+          argumentsList.at(-1) === "refs/remotes/origin/main"
+            ? `${"e".repeat(40)}\n`
+            : `${SHA}\n`,
+      }),
+    /does not match fetched origin\/main/,
+  );
+  assert.throws(() =>
+    validateImmutableMainSource({
+      deploySha: SHA,
+      workflowSha: SHA,
+      sourcePath: "/trusted/source",
+      execute: (_command, argumentsList) => {
+        if (argumentsList.at(-1) === "refs/remotes/origin/main") {
+          return `${SHA}\n`;
+        }
+        return argumentsList.at(-1) === "HEAD" ? `${"f".repeat(40)}\n` : "";
+      },
+    }),
+  );
+});
+
+test("candidate-modified validators remain inert during trusted validation", () => {
+  const sourcePath = mkdtempSync(join(tmpdir(), "shadow-candidate-"));
+  const candidateScripts = join(sourcePath, "scripts");
+  const marker = join(sourcePath, "candidate-controller-ran");
+  try {
+    mkdirSync(candidateScripts);
+    writeFileSync(
+      join(candidateScripts, "vercel-production-shadow.mjs"),
+      `import { writeFileSync } from "node:fs"; writeFileSync(${JSON.stringify(marker)}, "unsafe");`,
+    );
+    assert.equal(
+      validateImmutableMainSource({
+        deploySha: SHA,
+        workflowSha: SHA,
+        sourcePath,
+        execute: (_command, argumentsList) =>
+          argumentsList[2] === "rev-parse" ? `${SHA}\n` : "",
+      }),
+      SHA,
+    );
+    assert.equal(existsSync(marker), false);
+  } finally {
+    rmSync(sourcePath, { recursive: true, force: true });
+  }
+});
+
+test("protected spec includes v3, v2, and every ordinary production alias", () => {
+  const spec = createProtectedAliasSpec({
+    appV3AliasesJson: JSON.stringify([
+      "app.mento.org",
+      "appmentoorg-env-v3-mentolabs.vercel.app",
+    ]),
+    projectIds: projectIds(),
+  });
+  assert.deepEqual(
+    spec.map((entry) => entry.alias),
+    [
+      "app.mento.org",
+      "appmentoorg-env-v3-mentolabs.vercel.app",
+      "governance.mento.org",
+      "reserve.mento.org",
+      "ui.mento.org",
+      "v2-app.mento.org",
+    ],
+  );
+  assert.equal(
+    spec.find((entry) => entry.alias === "app.mento.org").customEnvironmentSlug,
+    "v3",
+  );
+  assert.equal(
+    spec.find((entry) => entry.alias === "v2-app.mento.org").git.ref,
+    "v2",
+  );
+  assert.throws(
+    () =>
+      createProtectedAliasSpec({
+        appV3AliasesJson: '["appmentoorg-env-v3-mentolabs.vercel.app"]',
+        projectIds: projectIds(),
+      }),
+    /must exactly match/,
+  );
+  assert.throws(
+    () =>
+      createProtectedAliasSpec({
+        appV3AliasesJson: '["app.mento.org","v2-app.mento.org"]',
+        projectIds: projectIds(),
+      }),
+    /must exactly match/,
+  );
+  assert.throws(
+    () =>
+      createProtectedAliasSpec({
+        appV3AliasesJson:
+          '["app.mento.org","appmentoorg-env-v3-mentolabs.vercel.app","unexpected.vercel.app"]',
+        projectIds: projectIds(),
+      }),
+    /must exactly match/,
+  );
+});
+
+test("immutable-source validation binds workflow identity before Git reads", () => {
+  let executed = false;
+  assert.throws(
+    () =>
+      validateImmutableMainSource({
+        deploySha: SHA,
+        workflowSha: "f".repeat(40),
+        execute: () => {
+          executed = true;
+          return "";
+        },
+      }),
+    /GITHUB_WORKFLOW_SHA does not match DEPLOY_SHA/,
+  );
+  assert.equal(executed, false);
+});
+
+test("Turbo cache summary parsing is canonical and fail-closed", () => {
+  assert.deepEqual(
+    parseTurboCacheSummary("Tasks: 3 successful\nCached: 2 cached, 3 total\n"),
+    { hits: 2, misses: 1, total: 3 },
+  );
+  assert.deepEqual(
+    parseTurboCacheSummary("\u001b[32mCached: 0 cached, 4 total\u001b[0m\n"),
+    { hits: 0, misses: 4, total: 4 },
+  );
+  assert.throws(() => parseTurboCacheSummary("Tasks: 3 successful\n"));
+  assert.throws(() =>
+    parseTurboCacheSummary(
+      "Cached: 1 cached, 2 total\nCached: 1 cached, 2 total\n",
+    ),
+  );
+  assert.throws(() => parseTurboCacheSummary("Cached: x cached, 2 total\n"));
+  assert.throws(() => parseTurboCacheSummary("Cached: 3 cached, 2 total\n"));
+});
+
+test("deploy output parser emits only an immutable ID and URL", () => {
+  assert.deepEqual(
+    parseDeployOutput({
+      status: "ok",
+      deployment: {
+        id: "dpl_abc123",
+        url: "ordinary-immutable.vercel.app",
+      },
+      env: [{ key: "SECRET", value: "test-value-not-printed" }],
+    }),
+    {
+      deploymentId: "dpl_abc123",
+      deploymentUrl: "https://ordinary-immutable.vercel.app",
+    },
+  );
+  assert.throws(() =>
+    parseDeployOutput({ id: "dpl_abc123", url: "governance.mento.org" }),
+  );
+  assert.throws(() =>
+    parseDeployOutput({
+      status: "error",
+      deployment: { id: "dpl_abc123", url: "ordinary.vercel.app" },
+    }),
+  );
+});
+
+test("deployment expectation fixes production provenance and exact SHA", () => {
+  assert.deepEqual(
+    createDeploymentExpectation({
+      deployment: "dpl_abc123",
+      deploymentUrl: "https://ordinary-immutable.vercel.app",
+      projectId: "prj_governance123",
+      projectName: "governance.mento.org",
+      sha: SHA.toUpperCase(),
+      transaction: "123-1-governance",
+    }),
+    {
+      deployment: "dpl_abc123",
+      deploymentUrl: "https://ordinary-immutable.vercel.app",
+      projectId: "prj_governance123",
+      projectName: "governance.mento.org",
+      readyState: "READY",
+      target: "production",
+      customEnvironmentSlug: null,
+      transaction: "123-1-governance",
+      git: {
+        org: "mento-protocol",
+        repo: "frontend-monorepo",
+        ref: "main",
+        sha: SHA,
+      },
+    },
+  );
+});
+
+test("staged production state permits only its immutable deployment hostname", () => {
+  const unexpected = JSON.parse(
+    readFileSync(
+      new URL(
+        "./fixtures/vercel-production-shadow/unexpected-alias.json",
+        import.meta.url,
+      ),
+      "utf8",
+    ),
+  );
+  assert.throws(
+    () => assertUnaliasedProductionShadowDeployment(unexpected),
+    /unexpected alias/,
+  );
+
+  const immutableHostname = new URL(unexpected.deploymentUrl).hostname;
+  const unaliased = {
+    ...unexpected,
+    aliases: [immutableHostname],
+  };
+  assert.equal(assertUnaliasedProductionShadowDeployment(unaliased), unaliased);
+  assert.throws(
+    () =>
+      assertUnaliasedProductionShadowDeployment({
+        ...unaliased,
+        aliases: [],
+      }),
+    /unexpected alias/,
+  );
+  assert.throws(
+    () =>
+      assertUnaliasedProductionShadowDeployment({
+        ...unaliased,
+        alias: "governance.mento.org",
+      }),
+    /unexpected alias/,
+  );
+});
+
+test("pinned CLI arguments bind each literal project and monorepo target", () => {
+  assert.deepEqual(
+    buildProductionShadowPullArguments({
+      logicalTarget: "app",
+      projectId: "prj_app123",
+    }),
+    [
+      "pull",
+      "--yes",
+      "--environment",
+      "v3",
+      "--git-branch",
+      "main",
+      "--project",
+      "prj_app123",
+    ],
+  );
+  assert.deepEqual(
+    buildProductionShadowBuildArguments({
+      logicalTarget: "app",
+      projectId: "prj_app123",
+    }),
+    [
+      "build",
+      "--yes",
+      "--standalone",
+      "--target",
+      "v3",
+      "--project",
+      "prj_app123",
+    ],
+  );
+  for (const target of ["governance", "reserve", "ui"]) {
+    assert.deepEqual(
+      buildProductionShadowPullArguments({
+        logicalTarget: target,
+        projectId: `prj_${target}123`,
+      }),
+      [
+        "pull",
+        "--yes",
+        "--environment",
+        "production",
+        "--git-branch",
+        "main",
+        "--project",
+        `prj_${target}123`,
+      ],
+    );
+    assert.deepEqual(
+      buildProductionShadowBuildArguments({
+        logicalTarget: target,
+        projectId: `prj_${target}123`,
+      }),
+      [
+        "build",
+        "--yes",
+        "--standalone",
+        "--prod",
+        "--project",
+        `prj_${target}123`,
+      ],
+    );
+    const deploy = buildProductionShadowDeployArguments({
+      logicalTarget: target,
+      projectId: `prj_${target}123`,
+      deploySha: SHA,
+      transaction: `123-1-${target}`,
+    });
+    assert.deepEqual(deploy.slice(0, 10), [
+      "deploy",
+      "--prebuilt",
+      "--prod",
+      "--skip-domain",
+      "--archive=tgz",
+      "--format=json",
+      "--yes",
+      "--project",
+      `prj_${target}123`,
+      "--meta",
+    ]);
+    assert.match(
+      deploy.join(" "),
+      new RegExp(`mentoTransaction=123-1-${target}`),
+    );
+    assert.doesNotMatch(deploy.join(" "), /--token|githubDeployment|promote/);
+  }
+  assert.throws(() =>
+    buildProductionShadowDeployArguments({
+      logicalTarget: "app",
+      projectId: "prj_app123",
+      deploySha: SHA,
+      transaction: "123-1-app",
+    }),
+  );
+  const mainTransaction = `main-${SHA}-456-2`;
+  const mainDeploy = buildProductionShadowDeployArguments({
+    logicalTarget: "governance",
+    projectId: "prj_governance123",
+    deploySha: SHA,
+    transaction: mainTransaction,
+  });
+  assert.match(mainDeploy.join(" "), new RegExp(mainTransaction));
+  assert.doesNotMatch(mainDeploy.join(" "), /promote|rollback|alias set/);
+});
+
+test("trusted repo mapping and app-root output are exact for all four targets", () => {
+  for (const [target, contract] of Object.entries(PRODUCTION_SHADOW_TARGETS)) {
+    const directory = mkdtempSync(join(tmpdir(), `shadow-${target}-`));
+    const projectId = `prj_${target}123`;
+    const orgId = "team_fixture123";
+    const deploymentId = `m-${target}-0123456789abcdef012`;
+    const appVercel = join(directory, contract.rootDirectory, ".vercel");
+    const output = join(appVercel, "output");
+    try {
+      assert.deepEqual(
+        materializeProductionShadowLink({
+          repoRoot: directory,
+          logicalTarget: target,
+          orgId,
+          projectId,
+        }),
+        {
+          remoteName: "origin",
+          projects: [
+            { id: projectId, directory: contract.rootDirectory, orgId },
+          ],
+        },
+      );
+      mkdirSync(output, { recursive: true });
+      writeFileSync(
+        join(appVercel, "project.json"),
+        JSON.stringify({
+          orgId,
+          projectId,
+          settings: { rootDirectory: contract.rootDirectory },
+        }),
+      );
+      writeFileSync(
+        join(output, "config.json"),
+        JSON.stringify({ version: 3, deploymentId }),
+      );
+      writeFileSync(
+        join(output, "builds.json"),
+        JSON.stringify({
+          target: target === "app" ? "v3" : "production",
+          cliVersion: "56.2.0",
+        }),
+      );
+      assert.equal(
+        assertPulledProductionShadowProject({
+          repoRoot: directory,
+          logicalTarget: target,
+          orgId,
+          projectId,
+        }).settings.rootDirectory,
+        contract.rootDirectory,
+      );
+      assert.equal(
+        assertProductionShadowOutput({
+          repoRoot: directory,
+          logicalTarget: target,
+          deploymentId,
+        }),
+        output,
+      );
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  }
+});
+
+test("runner pull staging, candidate copy, and upload proof reject external references", () => {
+  for (const [target, contract] of Object.entries(PRODUCTION_SHADOW_TARGETS)) {
+    const runnerTemp = mkdtempSync(
+      join(tmpdir(), `shadow-boundary-${target}-`),
+    );
+    const stagingRoot = join(
+      runnerTemp,
+      "mento-vercel-production-pull-staging",
+    );
+    const candidateRoot = join(
+      runnerTemp,
+      "mento-vercel-production-candidate-source",
+    );
+    const uploadRoot = join(
+      runnerTemp,
+      "mento-vercel-production-upload-source",
+    );
+    const orgId = "team_fixture123";
+    const projectId = `prj_${target}123`;
+    const deploymentId = `m-${target}-0123456789abcdef012`;
+    try {
+      chmodSync(runnerTemp, 0o700);
+      prepareProductionShadowPullStaging({
+        runnerTemp,
+        stagingRoot,
+        logicalTarget: target,
+        orgId,
+        projectId,
+      });
+      const appState = join(stagingRoot, contract.rootDirectory, ".vercel");
+      mkdirSync(appState, { mode: 0o700 });
+      writeFileSync(
+        join(appState, "project.json"),
+        JSON.stringify({
+          orgId,
+          projectId,
+          settings: { rootDirectory: contract.rootDirectory },
+        }),
+        { mode: 0o600 },
+      );
+      const pulledValues = defaultPulledEnvironment(target);
+      if (target === "app") {
+        Object.assign(pulledValues, {
+          CHAINALYSIS_API_KEY: "raw-chainalysis-sentinel",
+          SENTRY_AUTH_TOKEN: "raw-sentry-sentinel",
+          UNKNOWN_VARIABLE: "raw-unknown-sentinel",
+        });
+      }
+      const rawEnvironment = serializeVercelPulledEnvironment(pulledValues);
+      const rawEnvironmentPath = join(
+        appState,
+        `.env.${contract.pullEnvironment}.local`,
+      );
+      writeFileSync(rawEnvironmentPath, rawEnvironment, { mode: 0o600 });
+      const rawEnvironmentBefore = lstatSync(rawEnvironmentPath);
+      assert.equal(
+        assertProductionShadowPullStaging({
+          runnerTemp,
+          stagingRoot,
+          logicalTarget: target,
+          orgId,
+          projectId,
+        }).projectId,
+        projectId,
+      );
+
+      mkdirSync(join(candidateRoot, contract.rootDirectory), {
+        recursive: true,
+        mode: 0o700,
+      });
+      stageProductionShadowPullForCandidate({
+        runnerTemp,
+        stagingRoot,
+        candidateRoot,
+        logicalTarget: target,
+        orgId,
+        projectId,
+        buildUid: process.getuid(),
+        buildGid: process.getgid(),
+        runnerUid: process.getuid(),
+        runnerGid: process.getgid(),
+      });
+      const rawEnvironmentAfter = lstatSync(rawEnvironmentPath);
+      assert.equal(readFileSync(rawEnvironmentPath, "utf8"), rawEnvironment);
+      for (const field of [
+        "dev",
+        "ino",
+        "mode",
+        "nlink",
+        "size",
+        "uid",
+        "gid",
+        "mtimeMs",
+        "ctimeMs",
+      ]) {
+        assert.equal(rawEnvironmentAfter[field], rawEnvironmentBefore[field]);
+      }
+      const candidateEnvironmentPath = join(
+        candidateRoot,
+        contract.rootDirectory,
+        ".vercel",
+        `.env.${contract.pullEnvironment}.local`,
+      );
+      const candidateEnvironment = readFileSync(
+        candidateEnvironmentPath,
+        "utf8",
+      );
+      assert.deepEqual(
+        parseVercelPulledEnvironment(candidateEnvironment),
+        defaultPulledEnvironment(target),
+      );
+      for (const forbidden of [
+        "CHAINALYSIS_API_KEY",
+        "SENTRY_AUTH_TOKEN",
+        "UNKNOWN_VARIABLE",
+        "raw-chainalysis-sentinel",
+        "raw-sentry-sentinel",
+        "raw-unknown-sentinel",
+      ]) {
+        assert.doesNotMatch(candidateEnvironment, new RegExp(forbidden));
+      }
+      const materializationRoot = join(
+        runnerTemp,
+        "mento-vercel-production-build-environment",
+      );
+      const materializedEnvironmentPath = join(
+        materializationRoot,
+        ".vercel",
+        `.env.${contract.pullEnvironment}.local`,
+      );
+      const materializedEnvironment = readFileSync(
+        materializedEnvironmentPath,
+        "utf8",
+      );
+      assert.equal(materializedEnvironment, candidateEnvironment);
+      if (target === "app") {
+        const pollutedEnvironment = serializeVercelPulledEnvironment({
+          ...defaultPulledEnvironment(target),
+          UNKNOWN_VARIABLE: "candidate-pollution-sentinel",
+        });
+        writeFileSync(candidateEnvironmentPath, pollutedEnvironment, {
+          mode: 0o600,
+        });
+        assert.throws(
+          () =>
+            assertCandidateProductionShadowPull({
+              runnerTemp,
+              candidateRoot,
+              logicalTarget: target,
+              orgId,
+              projectId,
+              buildUid: process.getuid(),
+              buildGid: process.getgid(),
+              runnerUid: process.getuid(),
+              runnerGid: process.getgid(),
+            }),
+          /canonical exact allowlist/,
+        );
+        writeFileSync(candidateEnvironmentPath, candidateEnvironment, {
+          mode: 0o600,
+        });
+
+        writeFileSync(materializedEnvironmentPath, pollutedEnvironment, {
+          mode: 0o600,
+        });
+        assert.throws(
+          () =>
+            assertMaterializedProductionShadowBuildEnvironment({
+              runnerTemp,
+              stagingRoot,
+              materializationRoot,
+              logicalTarget: target,
+              orgId,
+              projectId,
+            }),
+          /exact allowlist/,
+        );
+        writeFileSync(materializedEnvironmentPath, materializedEnvironment, {
+          mode: 0o600,
+        });
+      }
+      const output = join(
+        candidateRoot,
+        contract.rootDirectory,
+        ".vercel",
+        "output",
+      );
+      mkdirSync(output, { mode: 0o700 });
+      writeFileSync(
+        join(output, "config.json"),
+        JSON.stringify({ version: 3, deploymentId }),
+        { mode: 0o600 },
+      );
+      writeFileSync(
+        join(output, "builds.json"),
+        JSON.stringify({
+          target: target === "app" ? "v3" : "production",
+          cliVersion: "56.2.0",
+        }),
+        { mode: 0o600 },
+      );
+      writeFileSync(
+        `${candidateRoot}.provenance.json`,
+        `${JSON.stringify({ commitSha: SHA })}\n`,
+        { mode: 0o600 },
+      );
+      assert.equal(
+        assertProductionShadowReadyForUpload({
+          repoRoot: candidateRoot,
+          logicalTarget: target,
+          orgId,
+          projectId,
+          deploymentId,
+          deploySha: SHA,
+        }),
+        output,
+      );
+
+      if (target === "ui") {
+        const functionDirectory = join(output, "functions", "api.func");
+        const functionConfig = join(functionDirectory, ".vc-config.json");
+        mkdirSync(functionDirectory, { recursive: true, mode: 0o700 });
+        writeFileSync(
+          functionConfig,
+          JSON.stringify({
+            runtime: "nodejs22.x",
+            handler: "index.js",
+            filePathMap: {
+              "captured-environment": "../../proc/self/environ",
+            },
+          }),
+          { mode: 0o600 },
+        );
+        const readyForUpload = () =>
+          assertProductionShadowReadyForUpload({
+            repoRoot: candidateRoot,
+            logicalTarget: target,
+            orgId,
+            projectId,
+            deploymentId,
+            deploySha: SHA,
+          });
+        assert.throws(readyForUpload, /external function file references/);
+        assert.throws(
+          () =>
+            createProductionShadowUploadHandoff({
+              runnerTemp,
+              stagingRoot,
+              candidateRoot,
+              uploadRoot,
+              logicalTarget: target,
+              orgId,
+              projectId,
+              deploymentId,
+              deploySha: SHA,
+              buildUid: process.getuid(),
+              buildGid: process.getgid(),
+              runnerUid: process.getuid(),
+              runnerGid: process.getgid(),
+            }),
+          /external function file references/,
+        );
+        assert.equal(existsSync(uploadRoot), false);
+
+        writeFileSync(
+          functionConfig,
+          JSON.stringify({
+            runtime: "nodejs22.x",
+            handler: "index.js",
+            filePathMap: {},
+          }),
+          { mode: 0o600 },
+        );
+        assert.equal(readyForUpload(), output);
+
+        writeFileSync(functionConfig, "{", { mode: 0o600 });
+        assert.throws(readyForUpload, /invalid function config/);
+        writeFileSync(functionConfig, " ".repeat(1_024 * 1_024 + 1), {
+          mode: 0o600,
+        });
+        assert.throws(readyForUpload, /oversized function config/);
+      }
+
+      writeFileSync(join(stagingRoot, "candidate-extra"), "unsafe", {
+        mode: 0o600,
+      });
+      assert.throws(
+        () =>
+          assertProductionShadowPullStaging({
+            runnerTemp,
+            stagingRoot,
+            logicalTarget: target,
+            orgId,
+            projectId,
+          }),
+        /unexpected filesystem entry/,
+      );
+    } finally {
+      rmSync(runnerTemp, { recursive: true, force: true });
+    }
+  }
+});
+
+test("Vercel pull inherits a private umask and restores the runner umask", () => {
+  const runnerTemp = mkdtempSync(join(tmpdir(), "shadow-pull-umask-"));
+  const stagingRoot = join(runnerTemp, "mento-vercel-production-pull-staging");
+  const logicalTarget = "ui";
+  const contract = PRODUCTION_SHADOW_TARGETS[logicalTarget];
+  const orgId = "team_fixture123";
+  const projectId = "prj_ui123";
+  const priorUmask = process.umask();
+  try {
+    chmodSync(runnerTemp, 0o700);
+    prepareProductionShadowPullStaging({
+      runnerTemp,
+      stagingRoot,
+      logicalTarget,
+      orgId,
+      projectId,
+    });
+    const result = pullProductionShadowProject({
+      repoRoot: stagingRoot,
+      logicalTarget,
+      projectId,
+      executeVercel: ({ repoRoot, argumentsList }) => {
+        assert.equal(process.umask(), 0o077);
+        assert.equal(repoRoot, stagingRoot);
+        assert.deepEqual(
+          argumentsList,
+          buildProductionShadowPullArguments({ logicalTarget, projectId }),
+        );
+        const appState = join(stagingRoot, contract.rootDirectory, ".vercel");
+        mkdirSync(appState);
+        writeFileSync(
+          join(appState, "project.json"),
+          JSON.stringify({
+            orgId,
+            projectId,
+            settings: { rootDirectory: contract.rootDirectory },
+          }),
+        );
+        writeFileSync(
+          join(appState, `.env.${contract.pullEnvironment}.local`),
+          "FIXTURE_ONLY=1\n",
+        );
+        return "pulled";
+      },
+    });
+    assert.equal(result, "pulled");
+    assert.equal(process.umask(), priorUmask);
+    assert.equal(
+      assertProductionShadowPullStaging({
+        runnerTemp,
+        stagingRoot,
+        logicalTarget,
+        orgId,
+        projectId,
+      }).projectId,
+      projectId,
+    );
+  } finally {
+    process.umask(priorUmask);
+    rmSync(runnerTemp, { recursive: true, force: true });
+  }
+});
+
+test("handoff enforces distinct candidate and runner ownership contracts", () => {
+  const runnerTemp = mkdtempSync(join(tmpdir(), "shadow-handoff-owner-"));
+  const stagingRoot = join(runnerTemp, "mento-vercel-production-pull-staging");
+  const candidateRoot = join(
+    runnerTemp,
+    "mento-vercel-production-candidate-source",
+  );
+  const uploadRoot = join(runnerTemp, "mento-vercel-production-upload-source");
+  const logicalTarget = "ui";
+  const contract = PRODUCTION_SHADOW_TARGETS[logicalTarget];
+  const orgId = "team_fixture123";
+  const projectId = "prj_ui123";
+  const deploymentId = "m-ui-0123456789abcdef012";
+  const runnerUid = process.getuid();
+  const runnerGid = process.getgid();
+  const candidateUid = runnerUid + 10_000;
+  const candidateGid = runnerGid + 10_000;
+  const ownershipChanges = [];
+  const candidateValidations = [];
+  try {
+    chmodSync(runnerTemp, 0o700);
+    prepareProductionShadowPullStaging({
+      runnerTemp,
+      stagingRoot,
+      logicalTarget,
+      orgId,
+      projectId,
+    });
+    const stagedAppState = join(stagingRoot, contract.rootDirectory, ".vercel");
+    mkdirSync(stagedAppState, { mode: 0o700 });
+    writeFileSync(
+      join(stagedAppState, "project.json"),
+      JSON.stringify({
+        orgId,
+        projectId,
+        settings: { rootDirectory: contract.rootDirectory },
+      }),
+      { mode: 0o600 },
+    );
+    writeFileSync(
+      join(stagedAppState, `.env.${contract.pullEnvironment}.local`),
+      "FIXTURE_ONLY=1\n",
+      { mode: 0o600 },
+    );
+    const candidateOutput = join(
+      candidateRoot,
+      contract.rootDirectory,
+      ".vercel",
+      "output",
+    );
+    mkdirSync(candidateOutput, { mode: 0o700, recursive: true });
+    writeFileSync(
+      join(candidateOutput, "config.json"),
+      JSON.stringify({ version: 3, deploymentId }),
+      { mode: 0o600 },
+    );
+    writeFileSync(
+      join(candidateOutput, "builds.json"),
+      JSON.stringify({ target: "production", cliVersion: "56.2.0" }),
+      { mode: 0o600 },
+    );
+
+    const result = createProductionShadowUploadHandoff({
+      runnerTemp,
+      stagingRoot,
+      candidateRoot,
+      uploadRoot,
+      logicalTarget,
+      orgId,
+      projectId,
+      deploymentId,
+      deploySha: SHA,
+      buildUid: candidateUid,
+      buildGid: candidateGid,
+      runnerUid,
+      runnerGid,
+      changeOwner: (path, uid, gid) => {
+        ownershipChanges.push({ path, uid, gid });
+      },
+      validateCandidate: (values) => {
+        candidateValidations.push(values);
+      },
+      validateMaterialized: () => {},
+    });
+    assert.notEqual(candidateUid, runnerUid);
+    assert.notEqual(candidateGid, runnerGid);
+    assert.equal(candidateValidations.length, 1);
+    assert.equal(candidateValidations[0].expectedUid, candidateUid);
+    assert.equal(candidateValidations[0].expectedGid, candidateGid);
+    assert.equal(candidateValidations[0].expectedProvenanceUid, runnerUid);
+    assert.ok(ownershipChanges.length >= 8);
+    assert.ok(
+      ownershipChanges.some(({ path }) => path.endsWith("config.json")),
+    );
+    assert.ok(
+      ownershipChanges.some(({ path }) => path.endsWith(".provenance.json")),
+    );
+    for (const ownership of ownershipChanges) {
+      assert.equal(ownership.uid, runnerUid);
+      assert.equal(ownership.gid, runnerGid);
+    }
+    assert.equal(result.uid, runnerUid);
+    assert.equal(result.gid, runnerGid);
+    assert.equal(result.sourceRoot, realpathSync(uploadRoot));
+  } finally {
+    rmSync(runnerTemp, { recursive: true, force: true });
+  }
+});
+
+test("raw Git-object materialization bypasses archive and checkout filters", () => {
+  const repository = mkdtempSync(join(tmpdir(), "shadow-raw-source-"));
+  const runnerTemp = mkdtempSync(join(tmpdir(), "shadow-raw-runner-"));
+  const candidate = join(
+    runnerTemp,
+    "mento-vercel-production-candidate-source",
+  );
+  const checkoutCandidate = mkdtempSync(
+    join(tmpdir(), "shadow-filtered-candidate-"),
+  );
+  try {
+    chmodSync(runnerTemp, 0o700);
+    execFileSync("git", ["init", "--quiet"], { cwd: repository });
+    writeFileSync(
+      join(repository, ".gitattributes"),
+      [
+        "*.txt text eol=crlf ident",
+        "ignored.txt export-ignore",
+        "substituted.txt export-subst",
+        "",
+      ].join("\n"),
+    );
+    writeFileSync(join(repository, "ignored.txt"), "must remain\n");
+    writeFileSync(join(repository, "substituted.txt"), "$Format:%H$\n");
+    writeFileSync(join(repository, "identity.txt"), "$Id$\n");
+    writeFileSync(join(repository, "line-endings.txt"), "one\ntwo\n");
+    writeFileSync(join(repository, "executable.sh"), "#!/bin/sh\nexit 0\n");
+    chmodSync(join(repository, "executable.sh"), 0o755);
+    writeFileSync(join(repository, "plain.txt"), "plain\n");
+    chmodSync(join(repository, "plain.txt"), 0o644);
+    symlinkSync("ignored.txt", join(repository, "linked.txt"));
+    execFileSync("git", ["add", "."], { cwd: repository });
+    execFileSync(
+      "git",
+      [
+        "-c",
+        "user.name=Test",
+        "-c",
+        "user.email=test@example.com",
+        "commit",
+        "--quiet",
+        "-m",
+        "fixture",
+      ],
+      { cwd: repository },
+    );
+    const commitSha = execFileSync("git", ["rev-parse", "HEAD"], {
+      cwd: repository,
+      encoding: "utf8",
+    }).trim();
+
+    const result = materializeExactGitTree({
+      runnerTemp,
+      sourceRoot: repository,
+      candidateRoot: candidate,
+      commitSha,
+    });
+    assert.equal(result.sourceRoot, realpathSync(candidate));
+    assert.ok(result.entries >= 8);
+    execFileSync(
+      "git",
+      ["checkout-index", "--all", "--force", `--prefix=${checkoutCandidate}/`],
+      { cwd: repository },
+    );
+    for (const path of [
+      "ignored.txt",
+      "substituted.txt",
+      "identity.txt",
+      "line-endings.txt",
+    ]) {
+      const blob = execFileSync("git", ["cat-file", "blob", `HEAD:${path}`], {
+        cwd: repository,
+      });
+      assert.deepEqual(readFileSync(join(candidate, path)), blob);
+    }
+    assert.match(
+      readFileSync(join(checkoutCandidate, "identity.txt"), "utf8"),
+      /^\$Id: [0-9a-f]{40} \$\r\n$/,
+    );
+    assert.deepEqual(
+      readFileSync(join(checkoutCandidate, "line-endings.txt")),
+      Buffer.from("one\r\ntwo\r\n"),
+    );
+    assert.equal(
+      lstatSync(join(candidate, "linked.txt")).isSymbolicLink(),
+      true,
+    );
+    assert.equal(readlinkSync(join(candidate, "linked.txt")), "ignored.txt");
+    assert.notEqual(
+      lstatSync(join(candidate, "executable.sh")).mode & 0o111,
+      0,
+    );
+    assert.equal(lstatSync(join(candidate, "plain.txt")).mode & 0o111, 0);
+    assert.equal(existsSync(join(candidate, ".git")), false);
+    assert.throws(
+      () =>
+        materializeExactGitTree({
+          runnerTemp,
+          sourceRoot: repository,
+          candidateRoot: candidate,
+          commitSha,
+        }),
+      /must be fresh/,
+    );
+  } finally {
+    rmSync(repository, { force: true, recursive: true });
+    rmSync(runnerTemp, { force: true, recursive: true });
+    rmSync(checkoutCandidate, { force: true, recursive: true });
+  }
+});
+
+test("raw Git-object materialization rejects gitlinks before writing", () => {
+  const repository = mkdtempSync(join(tmpdir(), "shadow-gitlink-source-"));
+  const runnerTemp = mkdtempSync(join(tmpdir(), "shadow-gitlink-runner-"));
+  const candidate = join(
+    runnerTemp,
+    "mento-vercel-production-candidate-source",
+  );
+  try {
+    chmodSync(runnerTemp, 0o700);
+    execFileSync("git", ["init", "--quiet"], { cwd: repository });
+    writeFileSync(join(repository, "plain.txt"), "plain\n");
+    execFileSync("git", ["add", "."], { cwd: repository });
+    execFileSync(
+      "git",
+      [
+        "-c",
+        "user.name=Test",
+        "-c",
+        "user.email=test@example.com",
+        "commit",
+        "--quiet",
+        "-m",
+        "base",
+      ],
+      { cwd: repository },
+    );
+    const baseCommit = execFileSync("git", ["rev-parse", "HEAD"], {
+      cwd: repository,
+      encoding: "utf8",
+    }).trim();
+    execFileSync(
+      "git",
+      ["update-index", "--add", "--cacheinfo", `160000,${baseCommit},vendor`],
+      { cwd: repository },
+    );
+    const tree = execFileSync("git", ["write-tree"], {
+      cwd: repository,
+      encoding: "utf8",
+    }).trim();
+    const gitlinkCommit = execFileSync(
+      "git",
+      [
+        "-c",
+        "user.name=Test",
+        "-c",
+        "user.email=test@example.com",
+        "commit-tree",
+        tree,
+        "-p",
+        baseCommit,
+        "-m",
+        "gitlink",
+      ],
+      { cwd: repository, encoding: "utf8" },
+    ).trim();
+
+    assert.throws(
+      () =>
+        materializeExactGitTree({
+          runnerTemp,
+          sourceRoot: repository,
+          candidateRoot: candidate,
+          commitSha: gitlinkCommit,
+        }),
+      /unsupported entry/,
+    );
+    assert.equal(existsSync(candidate), false);
+  } finally {
+    rmSync(repository, { force: true, recursive: true });
+    rmSync(runnerTemp, { force: true, recursive: true });
+  }
+});
+
+test("trusted builds reject every post-build project-link mutation before deploy", () => {
+  const mutations = [
+    {
+      name: "missing repo link",
+      apply: ({ directory }) => rmSync(join(directory, ".vercel", "repo.json")),
+      error: /Repo-level Vercel link is missing or malformed/,
+    },
+    {
+      name: "wrong organization",
+      apply: ({ projectPath, project }) =>
+        writeFileSync(
+          projectPath,
+          JSON.stringify({ ...project, orgId: "team_other123" }),
+        ),
+      error: /project identity does not match the literal target/,
+    },
+    {
+      name: "missing organization",
+      apply: ({ projectPath, project }) =>
+        writeFileSync(
+          projectPath,
+          JSON.stringify({
+            projectId: project.projectId,
+            settings: project.settings,
+          }),
+        ),
+      error: /project identity does not match the literal target/,
+    },
+    {
+      name: "wrong project",
+      apply: ({ projectPath, project }) =>
+        writeFileSync(
+          projectPath,
+          JSON.stringify({ ...project, projectId: "prj_other123" }),
+        ),
+      error: /project identity does not match the literal target/,
+    },
+    {
+      name: "missing project",
+      apply: ({ projectPath, project }) =>
+        writeFileSync(
+          projectPath,
+          JSON.stringify({ orgId: project.orgId, settings: project.settings }),
+        ),
+      error: /project identity does not match the literal target/,
+    },
+    {
+      name: "wrong Root Directory",
+      apply: ({ projectPath, project }) =>
+        writeFileSync(
+          projectPath,
+          JSON.stringify({
+            ...project,
+            settings: { rootDirectory: "apps/other.mento.org" },
+          }),
+        ),
+      error: /Root Directory does not match the literal target/,
+    },
+  ];
+
+  for (const [target, contract] of Object.entries(PRODUCTION_SHADOW_TARGETS)) {
+    for (const mutation of mutations) {
+      const directory = mkdtempSync(
+        join(tmpdir(), `shadow-post-build-${target}-`),
+      );
+      const orgId = "team_fixture123";
+      const projectId = `prj_${target}123`;
+      const deploymentId = `m-${target}-0123456789abcdef012`;
+      const appVercel = join(directory, contract.rootDirectory, ".vercel");
+      const output = join(appVercel, "output");
+      const projectPath = join(appVercel, "project.json");
+      const project = {
+        orgId,
+        projectId,
+        settings: { rootDirectory: contract.rootDirectory },
+      };
+      const operations = [];
+      try {
+        materializeProductionShadowLink({
+          repoRoot: directory,
+          logicalTarget: target,
+          orgId,
+          projectId,
+        });
+        mkdirSync(output, { recursive: true });
+        writeFileSync(projectPath, JSON.stringify(project));
+        writeFileSync(
+          join(output, "config.json"),
+          JSON.stringify({ version: 3, deploymentId }),
+        );
+        writeFileSync(
+          join(output, "builds.json"),
+          JSON.stringify({
+            target: target === "app" ? "v3" : "production",
+            cliVersion: "56.2.0",
+          }),
+        );
+
+        assert.throws(
+          () => {
+            buildProductionShadowArtifact({
+              repoRoot: directory,
+              logicalTarget: target,
+              orgId,
+              projectId,
+              deploymentId,
+              executeVercel: () => {
+                operations.push("build");
+                mutation.apply({ directory, projectPath, project });
+              },
+            });
+            operations.push("deploy");
+          },
+          mutation.error,
+          `${target}: ${mutation.name}`,
+        );
+        assert.deepEqual(operations, ["build"], `${target}: ${mutation.name}`);
+      } finally {
+        rmSync(directory, { recursive: true, force: true });
+      }
+    }
+  }
+});
+
+test("Vercel subprocess keeps credentials in env but strips ID overrides", () => {
+  assert.deepEqual(
+    environmentForVercelCli({
+      CI: "1",
+      VERCEL_ORG_ID: "team_fixture123",
+      VERCEL_PROJECT_ID: "prj_ui123",
+      VERCEL_TOKEN: "fixture-token",
+      GITHUB_ENV: "/runner/command/env",
+      GITHUB_OUTPUT: "/runner/command/output",
+      GITHUB_PATH: "/runner/command/path",
+      GITHUB_STATE: "/runner/command/state",
+      GITHUB_STEP_SUMMARY: "/runner/command/summary",
+    }),
+    { CI: "1", VERCEL_TOKEN: "fixture-token" },
+  );
+  const calls = [];
+  assert.equal(
+    runProductionShadowVercel({
+      repoRoot: "/fixture/repo",
+      argumentsList: [
+        "build",
+        "--yes",
+        "--standalone",
+        "--prod",
+        "--project",
+        "prj_ui123",
+      ],
+      environment: {
+        VERCEL_ORG_ID: "team_fixture123",
+        VERCEL_PROJECT_ID: "prj_ui123",
+        VERCEL_TOKEN: "fixture-token",
+        GITHUB_ENV: "/runner/command/env",
+        GITHUB_OUTPUT: "/runner/command/output",
+        GITHUB_PATH: "/runner/command/path",
+        GITHUB_STATE: "/runner/command/state",
+        GITHUB_STEP_SUMMARY: "/runner/command/summary",
+      },
+      captureStdout: true,
+      run: (command, argumentsList, options) => {
+        calls.push({ command, argumentsList, options });
+        return { status: 0, stdout: '{"status":"ok"}' };
+      },
+    }),
+    '{"status":"ok"}',
+  );
+  assert.equal(calls[0].command, "pnpm");
+  assert.deepEqual(calls[0].argumentsList, [
+    "exec",
+    "vercel",
+    "build",
+    "--yes",
+    "--standalone",
+    "--prod",
+    "--project",
+    "prj_ui123",
+  ]);
+  assert.deepEqual(calls[0].options.env, { VERCEL_TOKEN: "fixture-token" });
+});
+
+test("every target build child denies adversarial command-file PATH poisoning", () => {
+  const commandFiles = {
+    GITHUB_ENV: "/runner/command/env",
+    GITHUB_OUTPUT: "/runner/command/output",
+    GITHUB_PATH: "/runner/command/path",
+    GITHUB_STATE: "/runner/command/state",
+    GITHUB_STEP_SUMMARY: "/runner/command/summary",
+  };
+  for (const target of Object.keys(PRODUCTION_SHADOW_TARGETS)) {
+    const calls = [];
+    runProductionShadowVercel({
+      repoRoot: "/fixture/repo",
+      argumentsList: buildProductionShadowBuildArguments({
+        logicalTarget: target,
+        projectId: `prj_${target}123`,
+      }),
+      environment: {
+        CI: "1",
+        PATH: "/trusted/node:/trusted/pnpm:/usr/bin",
+        VERCEL_ORG_ID: "team_fixture123",
+        VERCEL_PROJECT_ID: `prj_${target}123`,
+        ...commandFiles,
+      },
+      run: (command, argumentsList, options) => {
+        assert.deepEqual(
+          Object.keys(commandFiles).filter((name) => name in options.env),
+          [],
+          `${target} candidate can reach a GitHub command file`,
+        );
+        calls.push({ command, argumentsList, options });
+        return { status: 0 };
+      },
+    });
+    assert.equal(calls.length, 1, target);
+    assert.equal(calls[0].command, "pnpm", target);
+    assert.deepEqual(calls[0].options.env, {
+      CI: "1",
+      PATH: "/trusted/node:/trusted/pnpm:/usr/bin",
+    });
+    assert.deepEqual(
+      calls[0].argumentsList.slice(0, 3),
+      ["exec", "vercel", "build"],
+      target,
+    );
+  }
+});
+
+test("trusted child processes strip GitHub command files", () => {
+  assert.deepEqual(
+    environmentForTrustedChild({
+      VERCEL_ORG_ID: "team_fixture123",
+      VERCEL_TOKEN: "fixture-token",
+      GITHUB_ENV: "/runner/command/env",
+      GITHUB_OUTPUT: "/runner/command/output",
+    }),
+    {
+      VERCEL_ORG_ID: "team_fixture123",
+      VERCEL_TOKEN: "fixture-token",
+    },
+  );
+});
+
+test("app proof encodes Outcome B without a reachable deploy", () => {
+  const proof = createAppBuildOnlyProof({
+    sha: SHA,
+    deploymentId: "m-app-example123",
+  });
+  assert.equal(proof.environment, "v3");
+  assert.equal(proof.vercelEnv, "preview");
+  assert.equal(proof.sentryAuthToken, "explicit-empty");
+  assert.equal(proof.deployReachable, false);
+  assert.equal(
+    proof.futureActivationCommand,
+    "vercel deploy --prebuilt --target=v3 --archive=tgz --format=json",
+  );
+});
+
+test("canonical output creation refuses candidate-precreated symlinks", () => {
+  const directory = mkdtempSync(join(tmpdir(), "shadow-output-"));
+  const protectedTarget = join(directory, "protected-target.json");
+  const output = join(directory, "app-proof.json");
+  try {
+    writeFileSync(protectedTarget, "unchanged\n");
+    symlinkSync(protectedTarget, output);
+    assert.throws(() =>
+      execFileSync(
+        process.execPath,
+        [productionShadowScript, "app-proof", "--output", output],
+        {
+          env: {
+            ...process.env,
+            DEPLOY_SHA: SHA,
+            MENTO_NEXT_DEPLOYMENT_ID: "m-app-example123",
+          },
+          stdio: "pipe",
+        },
+      ),
+    );
+    assert.equal(readFileSync(protectedTarget, "utf8"), "unchanged\n");
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("pilot summary records exact build, staging, and rollback evidence", () => {
+  const directory = mkdtempSync(join(tmpdir(), "shadow-summary-"));
+  const summaryPath = join(directory, "summary.md");
+  const ordinary = (target) => ({
+    id: `dpl_${target}123`,
+    url: `https://${target}-immutable.vercel.app`,
+    buildDurationMs: "100",
+    deployDurationMs: "50",
+    totalDurationMs: "200",
+  });
+  try {
+    writePilotSummary({
+      path: summaryPath,
+      sha: SHA,
+      runUrl:
+        "https://github.com/mento-protocol/frontend-monorepo/actions/runs/123",
+      workflowDurationMs: "1000",
+      baseline: [
+        {
+          alias: "app.mento.org",
+          deploymentId: "dpl_appv3old123",
+          deploymentUrl: "https://app-v3-old.vercel.app",
+          customEnvironmentSlug: "v3",
+        },
+        {
+          alias: "appmentoorg-env-v3-mentolabs.vercel.app",
+          deploymentId: "dpl_appv3old123",
+          deploymentUrl: "https://app-v3-old.vercel.app",
+          customEnvironmentSlug: "v3",
+        },
+        {
+          alias: "v2-app.mento.org",
+          deploymentId: "dpl_appv2old123",
+          deploymentUrl: "https://app-v2-old.vercel.app",
+          customEnvironmentSlug: null,
+        },
+      ],
+      app: {
+        nextDeploymentId: "m-app-0123456789abcdef012",
+        buildDurationMs: "100",
+        totalDurationMs: "150",
+        cacheHits: "1",
+        cacheMisses: "2",
+      },
+      governance: {
+        ...ordinary("governance"),
+        cacheHits: "2",
+        cacheMisses: "1",
+      },
+      reserve: { ...ordinary("reserve"), cacheHits: "0", cacheMisses: "3" },
+      ui: { ...ordinary("ui"), cacheHits: "3", cacheMisses: "0" },
+    });
+    const summary = readFileSync(summaryPath, "utf8");
+    assert.match(summary, new RegExp(SHA));
+    assert.match(summary, /build-only Outcome B/);
+    assert.match(summary, /m-app-0123456789abcdef012/);
+    assert.match(
+      summary,
+      /vercel alias set https:\/\/app-v3-old\.vercel\.app app\.mento\.org/,
+    );
+    assert.match(summary, /dpl_governance123/);
+    assert.match(summary, /Whole workflow duration: 1000 ms/);
+    assert.match(summary, /2 hit \/ 1 miss/);
+    assert.doesNotMatch(summary, /fixture-token|test-value-not-printed/);
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("fixture variable failures reveal only the fake missing name", () => {
+  const secret = "test-value-not-printed";
+  assert.equal(
+    assertRequiredVariableNames(["REAL_NAME"], { REAL_NAME: secret }),
+    1,
+  );
+  assert.throws(
+    () =>
+      assertRequiredVariableNames(["REAL_NAME", "FIXTURE_REQUIRED_SECRET"], {
+        REAL_NAME: secret,
+      }),
+    (error) => {
+      assert.match(error.message, /FIXTURE_REQUIRED_SECRET/);
+      assert.doesNotMatch(error.message, new RegExp(secret));
+      return true;
+    },
+  );
+});
+
+test("every shadow build requires the exact remote-cache variable names", () => {
+  assert.deepEqual(REQUIRED_BUILD_CACHE_VARIABLE_NAMES, [
+    "TURBO_REMOTE_CACHE_SIGNATURE_KEY",
+    "TURBO_TEAM",
+    "TURBO_TOKEN",
+  ]);
+  const values = {
+    TURBO_REMOTE_CACHE_SIGNATURE_KEY: "signature-never-printed",
+    TURBO_TEAM: "fixture-team",
+    TURBO_TOKEN: "token-never-printed",
+  };
+  assert.equal(assertProductionShadowBuildInputs(values), 3);
+  for (const missing of REQUIRED_BUILD_CACHE_VARIABLE_NAMES) {
+    assert.throws(
+      () =>
+        assertProductionShadowBuildInputs(
+          Object.fromEntries(
+            Object.entries(values).filter(([name]) => name !== missing),
+          ),
+        ),
+      (error) => {
+        assert.match(error.message, new RegExp(missing));
+        assert.doesNotMatch(error.message, /never-printed/);
+        return true;
+      },
+    );
+  }
+  assert.doesNotThrow(() => assertProductionShadowBuildInputs(values));
+});
+
+test("evidence scanner rejects sensitive field names", () => {
+  const safe = fileURLToPath(
+    new URL(
+      "./fixtures/vercel-deployment-state/valid-production.json",
+      import.meta.url,
+    ),
+  );
+  const unsafe = fileURLToPath(
+    new URL(
+      "./fixtures/vercel-deployment-state/sensitive-response.json",
+      import.meta.url,
+    ),
+  );
+  assert.doesNotThrow(() => assertEvidenceFiles([safe]));
+  assert.throws(() => assertEvidenceFiles([unsafe]), /forbidden/);
+});
+
+function protectedAliasBaseline() {
+  return [
+    {
+      alias: "app.mento.org",
+      deploymentId: "dpl_appold123",
+      deploymentUrl: "https://app-old.vercel.app",
+      projectId: "prj_app123",
+    },
+    {
+      alias: "governance.mento.org",
+      deploymentId: "dpl_governanceold123",
+      deploymentUrl: "https://governance-old.vercel.app",
+      projectId: "prj_governance123",
+    },
+  ];
+}
+
+test("protected alias drift fails read-only with canonical operator evidence", async () => {
+  const baseline = protectedAliasBaseline();
+  const reads = [];
+  await assert.rejects(
+    () =>
+      assertProtectedAliasesUnchanged({
+        baseline,
+        client: {
+          aliasMapping: async (alias) => {
+            reads.push(alias);
+            if (alias === "governance.mento.org") {
+              return {
+                alias,
+                deploymentId: "dpl_governancenew123",
+                deploymentUrl: "https://governance-new.vercel.app",
+                projectId: "prj_governance123",
+              };
+            }
+            return {
+              alias,
+              deploymentId: "dpl_appold123",
+              deploymentUrl: "https://app-old.vercel.app",
+              projectId: "prj_app123",
+            };
+          },
+        },
+      }),
+    (error) => {
+      assert.match(error.message, /read-only and attempted no repair/);
+      assert.match(error.message, /dpl_governanceold123/);
+      assert.match(error.message, /governance-old\.vercel\.app/);
+      assert.match(error.message, /dpl_governancenew123/);
+      assert.match(error.message, /governance-new\.vercel\.app/);
+      assert.match(
+        error.message,
+        /vercel alias set https:\/\/governance-old\.vercel\.app governance\.mento\.org/,
+      );
+      assert.match(error.message, /confirm there is no concurrent/);
+      return true;
+    },
+  );
+  assert.deepEqual(reads, ["app.mento.org", "governance.mento.org"]);
+});
+
+test("protected alias check no-ops only for exact ID, URL, and project matches", async () => {
+  const baseline = protectedAliasBaseline();
+  assert.deepEqual(
+    await assertProtectedAliasesUnchanged({
+      baseline,
+      client: {
+        aliasMapping: async (alias) => {
+          const state = baseline.find((entry) => entry.alias === alias);
+          return { ...state };
+        },
+      },
+    }),
+    [],
+  );
+  await assert.rejects(
+    () =>
+      assertProtectedAliasesUnchanged({
+        baseline,
+        client: {
+          aliasMapping: async (alias) => {
+            const state = baseline.find((entry) => entry.alias === alias);
+            return alias === "app.mento.org"
+              ? { ...state, projectId: "prj_other123" }
+              : { ...state };
+          },
+        },
+      }),
+    /Protected alias drift detected/,
+  );
+});
+
+test("protected alias check propagates unreadable mappings without writes", async () => {
+  await assert.rejects(
+    () =>
+      assertProtectedAliasesUnchanged({
+        baseline: protectedAliasBaseline(),
+        client: {
+          aliasMapping: async () => {
+            throw new Error("missing mapping");
+          },
+        },
+      }),
+    /missing mapping/,
+  );
+});
+
+test("bounded health checks pass without logging response bodies", async () => {
+  const calls = [];
+  await waitForHealthyUrls({
+    urls: ["governance.mento.org"],
+    attempts: 2,
+    delayMs: 0,
+    fetchImplementation: async (url, options) => {
+      calls.push({ url, options });
+      return {
+        status: calls.length === 1 ? 503 : 204,
+        headers: { get: () => null },
+      };
+    },
+  });
+  assert.equal(calls.length, 2);
+  assert.equal(calls[0].options.headers, undefined);
+  assert.equal(calls[0].options.redirect, "manual");
+});
+
+test("health checks never follow a cross-origin redirect", async () => {
+  const calls = [];
+  await assert.rejects(
+    () =>
+      fetchWithOriginBoundRedirects({
+        url: "https://governance-immutable.vercel.app",
+        fetchImplementation: async (url, options) => {
+          calls.push({ url, options });
+          return {
+            status: 302,
+            headers: { get: () => "https://attacker.example/collect" },
+          };
+        },
+      }),
+    /redirected outside its immutable origin/,
+  );
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].url, "https://governance-immutable.vercel.app");
+  assert.equal(calls[0].options.headers, undefined);
+  assert.equal(calls[0].options.redirect, "manual");
+});
+
+test("browser request policy rejects protection headers", () => {
+  assert.deepEqual(
+    productionShadowRequestHeaders({
+      existingHeaders: { Accept: "text/javascript" },
+    }),
+    { Accept: "text/javascript" },
+  );
+  for (const name of [
+    "x-vercel-protection-bypass",
+    "X-Vercel-Protection-Bypass",
+  ]) {
+    assert.throws(
+      () =>
+        productionShadowRequestHeaders({
+          existingHeaders: { [name]: "must-be-rejected" },
+        }),
+      /forbidden protection header/,
+    );
+  }
+  assert.equal(
+    assertProductionShadowOrigin(
+      "https://governance-immutable.vercel.app/path",
+      "https://governance-immutable.vercel.app",
+    ),
+    true,
+  );
+  assert.throws(() =>
+    assertProductionShadowOrigin(
+      "https://attacker.example/collect",
+      "https://governance-immutable.vercel.app",
+    ),
+  );
+});
+
+test("stable final gate fails skipped, cancelled, or failed dependencies", () => {
+  const results = Object.fromEntries(
+    [
+      "preflight",
+      "baseline",
+      "app",
+      "governance",
+      "smokeGovernance",
+      "reserve",
+      "smokeReserve",
+      "ui",
+      "smokeUi",
+      "finalAliasComparison",
+    ].map((name) => [name, "success"]),
+  );
+  assert.doesNotThrow(() => assertFinalJobResults(results));
+  for (const result of ["skipped", "cancelled", "failure"]) {
+    assert.throws(() => assertFinalJobResults({ ...results, reserve: result }));
+  }
+});
+
+test("fixtures are themselves free of accidental credential material", () => {
+  for (const path of [
+    "./fixtures/vercel-deployment-state/valid-production.json",
+    "./fixtures/vercel-production-shadow/unexpected-alias.json",
+  ]) {
+    const content = readFileSync(new URL(path, import.meta.url), "utf8");
+    assert.doesNotMatch(content, /token|secret|authorization/i);
+  }
+});


### PR DESCRIPTION
## The Problem

Issue #521 needs a production-faithful proof that an exact current-`main` commit can be built on GitHub-hosted runners and uploaded to Vercel without activating a domain. The pilot must preserve App's custom `v3` semantics and legacy `v2`, fail closed on protected-alias drift, isolate build code from production credentials, and leave the existing Vercel Git production path unchanged.

## The Solution

- Add a manual `Vercel Production Shadow` workflow bound to one immutable SHA that every source-consuming job independently proves is the current `main`.
- Build App for custom `v3` only and record Outcome B without uploading it. Stage Governance, Reserve, and UI sequentially with `--prebuilt --prod --skip-domain`, stopping later uploads after any build, smoke, or alias-drift failure.
- Capture and compare the protected App v3, legacy v2, Governance, Reserve, and UI mappings before, after each upload, and at finalization. Staged candidates must be ready, match exact project/repository/ref/SHA/build identity, and have only their immutable hostname.
- Run target-specific Playwright smoke from fresh, token-free trusted jobs against the exact staged deployment IDs and URLs. These jobs preserve the issue's same-identity guarantee while more strongly isolating production credentials from browser execution.
- Harden the candidate boundary with a dedicated UID, exact allowlisted environment materialization, standalone output, fail-closed `filePathMap` rejection, immutable ownership/provenance checks, and fixed-path cleanup before the trusted token-bearing uploader runs.
- Add the operational-workflow notifier/action-pin coverage, structural and adversarial regressions, and the production-shadow runbook.

This PR introduces the manual non-activating workflow only. It does not dispatch it, change Vercel Git settings, move an alias, create a GitHub Deployment, deploy App, or touch legacy v2. The first live pilot remains gated on the final value-free #517 maintainer attestation and this workflow landing on `main`.

Validation:

- production-shadow tests: 78/78
- Vercel primitives: 60/60
- action-pin scanner: all 26 workflow/action YAML files pinned
- action-pin tests: 48/48 plus 11/11 REST materializer tests
- quality structural tests: 30/30
- ADR tests: 9/9
- PR-description tests: 25/25
- targeted typecheck: 6/6
- bundled-Chromium routing regression: 1/1
- Trunk and `git diff --check`: clean
- focused security review: all clear

The broader legacy Vercel workflow suite executes 90/91 locally; the sole non-executing case is an offline-store miss for `@eslint/js@9.39.2` (`ERR_PNPM_NO_OFFLINE_TARBALL`). No install or network fallback was used.

Part of #521 and #515.
