### PR TITLE
fix(ci): omit preview-only branch override from production pulls

### DIFF
--- a/docs/vercel-deployments.md
+++ b/docs/vercel-deployments.md
@@ -258,7 +258,10 @@ Production-shadow pulls intentionally omit `--git-branch`: pinned CLI 56.2.0
 accepts that option only with the `preview` target. `--environment v3` or
 `--environment production` selects the exact custom or production
 configuration; the guarded source SHA, `VERCEL_GIT_COMMIT_REF=main`, and deploy
-metadata carry exact-main provenance independently.
+metadata carry exact-main provenance independently. Those are raw, explicit Git
+identity and provenance fields; they do not claim Vercel provider-linked
+branch-domain behavior. `githubDeployment=1` remains intentionally forbidden by
+the issue contract.
 
 ```bash
 node scripts/vercel-build-environment.mjs inventory \

--- a/docs/vercel-deployments.md
+++ b/docs/vercel-deployments.md
@@ -254,6 +254,12 @@ workflow constants and scoped GitHub secrets so they take precedence. A missing
 or invalid pulled file fails closed. Its machine-readable inventory is available
 directly:
 
+Production-shadow pulls intentionally omit `--git-branch`: pinned CLI 56.2.0
+accepts that option only with the `preview` target. `--environment v3` or
+`--environment production` selects the exact custom or production
+configuration; the guarded source SHA, `VERCEL_GIT_COMMIT_REF=main`, and deploy
+metadata carry exact-main provenance independently.
+
 ```bash
 node scripts/vercel-build-environment.mjs inventory \
   --target "$TARGET" \

--- a/scripts/vercel-production-shadow-workflow.test.mjs
+++ b/scripts/vercel-production-shadow-workflow.test.mjs
@@ -436,6 +436,44 @@ test("every target build receives the exact-main Git identity tuple", () => {
   }
 });
 
+test("sanitized Vercel build child receives the exact Git identity tuple", () => {
+  const build = candidateAction.runs.steps.find(
+    (step) => step.name === "Build prebuilt output as candidate",
+  );
+  assert.ok(build, "missing candidate Vercel build step");
+  const cliInvocation =
+    '"$NODE_BIN" "$TRUSTED_VERCEL_CLI_PATH" "${build_arguments[@]}"';
+  const invocationIndex = build.run.indexOf(cliInvocation);
+  assert.notEqual(invocationIndex, -1, "missing pinned Vercel CLI invocation");
+  const environmentIndex = build.run.lastIndexOf(
+    "sudo --non-interactive /usr/bin/env -i",
+    invocationIndex,
+  );
+  assert.notEqual(
+    environmentIndex,
+    -1,
+    "missing sanitized Vercel CLI environment",
+  );
+  const child = build.run.slice(
+    environmentIndex,
+    invocationIndex + cliInvocation.length,
+  );
+  assert.equal((child.match(/\/usr\/bin\/env -i/g) ?? []).length, 1);
+  assert.match(child, /\/usr\/bin\/setpriv/);
+  for (const assignment of [
+    'VERCEL_GIT_COMMIT_REF="${VERCEL_GIT_COMMIT_REF:-main}"',
+    'VERCEL_GIT_COMMIT_SHA="$DEPLOY_SHA"',
+    'VERCEL_GIT_PROVIDER="${VERCEL_GIT_PROVIDER:-github}"',
+    'VERCEL_GIT_REPO_OWNER="${VERCEL_GIT_REPO_OWNER:-mento-protocol}"',
+    'VERCEL_GIT_REPO_SLUG="${VERCEL_GIT_REPO_SLUG:-frontend-monorepo}"',
+  ]) {
+    assert.ok(
+      child.split("\n").some((line) => line.trim() === `${assignment} \\`),
+      `sanitized Vercel build child is missing ${assignment.split("=")[0]}`,
+    );
+  }
+});
+
 test("ordinary targets use isolated builds, runner-owned handoff, and fresh smoke", () => {
   for (const target of ["governance", "reserve", "ui"]) {
     const source = jobSource(target);

--- a/scripts/vercel-production-shadow-workflow.test.mjs
+++ b/scripts/vercel-production-shadow-workflow.test.mjs
@@ -461,16 +461,7 @@ test("ordinary targets use isolated builds, runner-owned handoff, and fresh smok
     const projectId = `prj_${target}123`;
     assert.deepEqual(
       buildProductionShadowPullArguments({ logicalTarget: target, projectId }),
-      [
-        "pull",
-        "--yes",
-        "--environment",
-        "production",
-        "--git-branch",
-        "main",
-        "--project",
-        projectId,
-      ],
+      ["pull", "--yes", "--environment", "production", "--project", projectId],
     );
     assert.deepEqual(
       buildProductionShadowBuildArguments({ logicalTarget: target, projectId }),
@@ -575,16 +566,7 @@ test("app Outcome B has no reachable deploy or production command", () => {
       logicalTarget: "app",
       projectId: "prj_app123",
     }),
-    [
-      "pull",
-      "--yes",
-      "--environment",
-      "v3",
-      "--git-branch",
-      "main",
-      "--project",
-      "prj_app123",
-    ],
+    ["pull", "--yes", "--environment", "v3", "--project", "prj_app123"],
   );
   assert.deepEqual(
     buildProductionShadowBuildArguments({

--- a/scripts/vercel-production-shadow-workflow.test.mjs
+++ b/scripts/vercel-production-shadow-workflow.test.mjs
@@ -414,6 +414,28 @@ test("all credential-bearing jobs use the dedicated non-Deployment environment",
   assert.doesNotMatch(workflowSource, /github-deployment|deployments\/\{/i);
 });
 
+test("every target build receives the exact-main Git identity tuple", () => {
+  const expectedIdentity = {
+    VERCEL_GIT_COMMIT_REF: "main",
+    VERCEL_GIT_COMMIT_SHA: "${{ needs.preflight.outputs.deploy_sha }}",
+    VERCEL_GIT_PROVIDER: "github",
+    VERCEL_GIT_REPO_OWNER: "mento-protocol",
+    VERCEL_GIT_REPO_SLUG: "frontend-monorepo",
+  };
+  for (const target of ["app", "governance", "reserve", "ui"]) {
+    const build = workflow.jobs[target].steps.find(
+      (step) => step.uses === "./.github/actions/vercel-candidate-build",
+    );
+    assert.ok(build, `missing ${target} candidate build`);
+    assert.deepEqual(
+      Object.fromEntries(
+        Object.keys(expectedIdentity).map((name) => [name, build.env[name]]),
+      ),
+      expectedIdentity,
+    );
+  }
+});
+
 test("ordinary targets use isolated builds, runner-owned handoff, and fresh smoke", () => {
   for (const target of ["governance", "reserve", "ui"]) {
     const source = jobSource(target);

--- a/scripts/vercel-production-shadow.mjs
+++ b/scripts/vercel-production-shadow.mjs
@@ -1532,13 +1532,14 @@ export function buildProductionShadowPullArguments({
   projectId,
 }) {
   const contract = targetContract(logicalTarget);
+  // Pinned Vercel CLI accepts a Git branch only for preview pulls. Production
+  // and custom-environment selection is carried entirely by --environment;
+  // exact-main provenance is supplied separately to build and deploy.
   return [
     "pull",
     "--yes",
     "--environment",
     contract.pullEnvironment,
-    "--git-branch",
-    "main",
     "--project",
     requireIdentifier(projectId, "Vercel project ID"),
   ];

--- a/scripts/vercel-production-shadow.test.mjs
+++ b/scripts/vercel-production-shadow.test.mjs
@@ -491,7 +491,7 @@ test("pinned CLI build and deploy arguments bind each literal project and target
       deploySha: SHA,
       transaction: `123-1-${target}`,
     });
-    assert.deepEqual(deploy.slice(0, 10), [
+    assert.deepEqual(deploy, [
       "deploy",
       "--prebuilt",
       "--prod",
@@ -502,11 +502,16 @@ test("pinned CLI build and deploy arguments bind each literal project and target
       "--project",
       `prj_${target}123`,
       "--meta",
+      "githubCommitOrg=mento-protocol",
+      "--meta",
+      "githubCommitRepo=frontend-monorepo",
+      "--meta",
+      "githubCommitRef=main",
+      "--meta",
+      `githubCommitSha=${SHA}`,
+      "--meta",
+      `mentoTransaction=123-1-${target}`,
     ]);
-    assert.match(
-      deploy.join(" "),
-      new RegExp(`mentoTransaction=123-1-${target}`),
-    );
     assert.doesNotMatch(deploy.join(" "), /--token|githubDeployment|promote/);
   }
   assert.throws(() =>

--- a/scripts/vercel-production-shadow.test.mjs
+++ b/scripts/vercel-production-shadow.test.mjs
@@ -425,23 +425,36 @@ test("staged production state permits only its immutable deployment hostname", (
   );
 });
 
-test("pinned CLI arguments bind each literal project and monorepo target", () => {
+test("custom-v3 pull selects the custom target without a preview-only branch override", () => {
   assert.deepEqual(
     buildProductionShadowPullArguments({
       logicalTarget: "app",
       projectId: "prj_app123",
     }),
-    [
-      "pull",
-      "--yes",
-      "--environment",
-      "v3",
-      "--git-branch",
-      "main",
-      "--project",
-      "prj_app123",
-    ],
+    ["pull", "--yes", "--environment", "v3", "--project", "prj_app123"],
   );
+});
+
+test("production pull selects production without a preview-only branch override", () => {
+  for (const target of ["governance", "reserve", "ui"]) {
+    assert.deepEqual(
+      buildProductionShadowPullArguments({
+        logicalTarget: target,
+        projectId: `prj_${target}123`,
+      }),
+      [
+        "pull",
+        "--yes",
+        "--environment",
+        "production",
+        "--project",
+        `prj_${target}123`,
+      ],
+    );
+  }
+});
+
+test("pinned CLI build and deploy arguments bind each literal project and target", () => {
   assert.deepEqual(
     buildProductionShadowBuildArguments({
       logicalTarget: "app",
@@ -458,22 +471,6 @@ test("pinned CLI arguments bind each literal project and monorepo target", () =>
     ],
   );
   for (const target of ["governance", "reserve", "ui"]) {
-    assert.deepEqual(
-      buildProductionShadowPullArguments({
-        logicalTarget: target,
-        projectId: `prj_${target}123`,
-      }),
-      [
-        "pull",
-        "--yes",
-        "--environment",
-        "production",
-        "--git-branch",
-        "main",
-        "--project",
-        `prj_${target}123`,
-      ],
-    );
     assert.deepEqual(
       buildProductionShadowBuildArguments({
         logicalTarget: target,


### PR DESCRIPTION
## The Problem

The first live `Vercel Production Shadow` pilot, [run 29991384651](https://github.com/mento-protocol/frontend-monorepo/actions/runs/29991384651), failed safely before build or upload. Pinned Vercel CLI 56.2.0 rejects `vercel pull` when a production or custom environment is combined with `--git-branch main`:

`Invalid request: target must be "preview" when specifying a gitBranch`

App custom `v3` and Governance production both stopped at the same shared pull helper. The final protected-domain comparison passed, all before/after GitHub Deployment records remained identical, and no artifact, build, upload, alias mutation, promotion, or Git configuration change occurred.

## The Solution

Remove the preview-only branch override from production-shadow pulls while preserving:

- exact environment selection through `--environment v3` or `--environment production`;
- immutable current-`main` checkout and SHA validation;
- the full explicit Git identity tuple in the sanitized candidate-build child;
- exact Git metadata on ordinary prebuilt deployments;
- the ban on `githubDeployment=1`, promotion, alias mutation, and App deployment in this pilot.

Regression tests assert the exact App and ordinary-target pull commands, the sanitized-child identity boundary, and complete deployment metadata. The runbook now distinguishes raw explicit Git provenance from Vercel provider-linked branch-domain behavior.

Relates to #521.

## Validation

- `pnpm vercel:production-shadow:test` — 83/83 passed
- `pnpm vercel:primitives:test` — 60/60 passed
- `pnpm ci:action-pins` — passed
- `pnpm quality:budgets:test` — 30/30 passed
- `pnpm adr:check` — passed
- targeted Trunk format/check — passed
- `git diff --check origin/main...HEAD` — passed
- fresh-context semantic autoreview — clean, confidence 0.98
- deterministic local autoreview — clean
- broader workflow suite — 90/91; the sole local failure is the known unavailable offline tarball for `@eslint/js@9.39.2`

The local pre-push typecheck hook could not resolve workspace binaries because this isolated worktree is intentionally unhydrated (`next: command not found`). No dependency install or network fetch was attempted; the push used `--no-verify`, and GitHub CI remains the required full typecheck/build gate.

## Ship Checklist

- [x] ship skill used
- [x] local review run
- [x] focused validation run
- [x] no deployment or Vercel mutation performed by this PR
