### PR TITLE
fix(ci): validate repo-linked Vercel pull settings

### DIFF
--- a/docs/vercel-deployments.md
+++ b/docs/vercel-deployments.md
@@ -246,9 +246,13 @@ The production-shadow workflow uses a separate runner-owned staging boundary.
 monorepo root, but first materializes a trusted root `.vercel/repo.json` mapping
 and selects the literal project with `--project`. Pinned CLI 56.2.0 then writes
 the pulled environment and project settings below `apps/<target>/.vercel`, so
-the checker passes the literal `apps/<target>` directory. Both the local mapping
-and the project's configured Root Directory are verified, with the latter also
-checked through the Vercel project API. The checker loads
+the checker passes the literal `apps/<target>` directory. In this repo-linked
+mode, identity lives only in the exact root `.vercel/repo.json` mapping;
+app-root `project.json` must be settings-only and must not duplicate standalone
+project, organization, or project-name identity. The controller verifies that
+mapping and the configured Root Directory locally, then the following read-only
+Vercel project API check independently verifies the literal project ID, name,
+and Root Directory. The checker loads
 `$PROJECT_DIRECTORY/.vercel/.env.<environment>.local`, then overlays explicit
 workflow constants and scoped GitHub secrets so they take precedence. A missing
 or invalid pulled file fails closed. Its machine-readable inventory is available

--- a/scripts/vercel-production-shadow-workflow.test.mjs
+++ b/scripts/vercel-production-shadow-workflow.test.mjs
@@ -474,6 +474,41 @@ test("sanitized Vercel build child receives the exact Git identity tuple", () =>
   }
 });
 
+test("every repo-linked pull validates local and remote project identity before build", () => {
+  for (const target of ["app", "governance", "reserve", "ui"]) {
+    const targetLabel = target === "ui" ? "UI" : target;
+    const validation = stepNamed(
+      target,
+      `Validate ${targetLabel} project link and Root Directory`,
+    );
+    const commands = validation.run.split("\n").map((line) => line.trim());
+    assert.ok(
+      commands.includes(
+        '"${{ steps.runtime.outputs.node-bin }}" scripts/vercel-production-shadow.mjs validate-pull-staging',
+      ),
+      `${target} must validate the exact local repo link`,
+    );
+    assert.ok(
+      commands.includes(
+        '"${{ steps.runtime.outputs.node-bin }}" scripts/vercel-deployment-state.mjs project --project-id "$VERCEL_PROJECT_ID" --project-name ' +
+          `${target}.mento.org --root-directory apps/${target}.mento.org`,
+      ),
+      `${target} must validate the literal remote project`,
+    );
+    assert.equal(
+      validation.env.VERCEL_PROJECT_ID,
+      `\${{ vars.VERCEL_PROJECT_ID_${target.toUpperCase()} }}`,
+    );
+    const buildIndex = workflow.jobs[target].steps.findIndex(
+      (step) => step.uses === "./.github/actions/vercel-candidate-build",
+    );
+    assert.ok(
+      workflow.jobs[target].steps.indexOf(validation) < buildIndex,
+      `${target} project validation must precede candidate execution`,
+    );
+  }
+});
+
 test("ordinary targets use isolated builds, runner-owned handoff, and fresh smoke", () => {
   for (const target of ["governance", "reserve", "ui"]) {
     const source = jobSource(target);

--- a/scripts/vercel-production-shadow.mjs
+++ b/scripts/vercel-production-shadow.mjs
@@ -1663,9 +1663,12 @@ export function assertPulledProductionShadowProject({
       "Pulled Vercel Root Directory does not match the literal target",
     );
   }
-  if (project.projectId !== projectId || project.orgId !== orgId) {
+  if (
+    Object.keys(project).length !== 1 ||
+    !Object.hasOwn(project, "settings")
+  ) {
     throw new Error(
-      "Pulled Vercel project identity does not match the literal target",
+      "Pulled repo-linked Vercel project file must contain only settings",
     );
   }
   return project;

--- a/scripts/vercel-production-shadow.test.mjs
+++ b/scripts/vercel-production-shadow.test.mjs
@@ -533,7 +533,7 @@ test("pinned CLI build and deploy arguments bind each literal project and target
   assert.doesNotMatch(mainDeploy.join(" "), /promote|rollback|alias set/);
 });
 
-test("trusted repo mapping and app-root output are exact for all four targets", () => {
+test("repo-linked settings use exact repo identity for all four targets", () => {
   for (const [target, contract] of Object.entries(PRODUCTION_SHADOW_TARGETS)) {
     const directory = mkdtempSync(join(tmpdir(), `shadow-${target}-`));
     const projectId = `prj_${target}123`;
@@ -560,8 +560,6 @@ test("trusted repo mapping and app-root output are exact for all four targets", 
       writeFileSync(
         join(appVercel, "project.json"),
         JSON.stringify({
-          orgId,
-          projectId,
           settings: { rootDirectory: contract.rootDirectory },
         }),
       );
@@ -576,14 +574,14 @@ test("trusted repo mapping and app-root output are exact for all four targets", 
           cliVersion: "56.2.0",
         }),
       );
-      assert.equal(
+      assert.deepEqual(
         assertPulledProductionShadowProject({
           repoRoot: directory,
           logicalTarget: target,
           orgId,
           projectId,
-        }).settings.rootDirectory,
-        contract.rootDirectory,
+        }),
+        { settings: { rootDirectory: contract.rootDirectory } },
       );
       assert.equal(
         assertProductionShadowOutput({
@@ -633,8 +631,6 @@ test("runner pull staging, candidate copy, and upload proof reject external refe
       writeFileSync(
         join(appState, "project.json"),
         JSON.stringify({
-          orgId,
-          projectId,
           settings: { rootDirectory: contract.rootDirectory },
         }),
         { mode: 0o600 },
@@ -654,15 +650,15 @@ test("runner pull staging, candidate copy, and upload proof reject external refe
       );
       writeFileSync(rawEnvironmentPath, rawEnvironment, { mode: 0o600 });
       const rawEnvironmentBefore = lstatSync(rawEnvironmentPath);
-      assert.equal(
+      assert.deepEqual(
         assertProductionShadowPullStaging({
           runnerTemp,
           stagingRoot,
           logicalTarget: target,
           orgId,
           projectId,
-        }).projectId,
-        projectId,
+        }),
+        { settings: { rootDirectory: contract.rootDirectory } },
       );
 
       mkdirSync(join(candidateRoot, contract.rootDirectory), {
@@ -935,8 +931,6 @@ test("Vercel pull inherits a private umask and restores the runner umask", () =>
         writeFileSync(
           join(appState, "project.json"),
           JSON.stringify({
-            orgId,
-            projectId,
             settings: { rootDirectory: contract.rootDirectory },
           }),
         );
@@ -949,15 +943,15 @@ test("Vercel pull inherits a private umask and restores the runner umask", () =>
     });
     assert.equal(result, "pulled");
     assert.equal(process.umask(), priorUmask);
-    assert.equal(
+    assert.deepEqual(
       assertProductionShadowPullStaging({
         runnerTemp,
         stagingRoot,
         logicalTarget,
         orgId,
         projectId,
-      }).projectId,
-      projectId,
+      }),
+      { settings: { rootDirectory: contract.rootDirectory } },
     );
   } finally {
     process.umask(priorUmask);
@@ -998,8 +992,6 @@ test("handoff enforces distinct candidate and runner ownership contracts", () =>
     writeFileSync(
       join(stagedAppState, "project.json"),
       JSON.stringify({
-        orgId,
-        projectId,
         settings: { rootDirectory: contract.rootDirectory },
       }),
       { mode: 0o600 },
@@ -1259,6 +1251,12 @@ test("raw Git-object materialization rejects gitlinks before writing", () => {
 });
 
 test("trusted builds reject every post-build project-link mutation before deploy", () => {
+  const updateRepoProject = (directory, update) => {
+    const linkPath = join(directory, ".vercel", "repo.json");
+    const link = JSON.parse(readFileSync(linkPath, "utf8"));
+    update(link.projects[0]);
+    writeFileSync(linkPath, JSON.stringify(link));
+  };
   const mutations = [
     {
       name: "missing repo link",
@@ -1267,43 +1265,49 @@ test("trusted builds reject every post-build project-link mutation before deploy
     },
     {
       name: "wrong organization",
-      apply: ({ projectPath, project }) =>
-        writeFileSync(
-          projectPath,
-          JSON.stringify({ ...project, orgId: "team_other123" }),
-        ),
-      error: /project identity does not match the literal target/,
+      apply: ({ directory }) =>
+        updateRepoProject(directory, (project) => {
+          project.orgId = "team_other123";
+        }),
+      error: /Repo-level Vercel mapping does not match the literal target/,
     },
     {
       name: "missing organization",
-      apply: ({ projectPath, project }) =>
-        writeFileSync(
-          projectPath,
-          JSON.stringify({
-            projectId: project.projectId,
-            settings: project.settings,
-          }),
-        ),
-      error: /project identity does not match the literal target/,
+      apply: ({ directory }) =>
+        updateRepoProject(directory, (project) => {
+          delete project.orgId;
+        }),
+      error: /Repo-level Vercel mapping does not match the literal target/,
     },
     {
       name: "wrong project",
-      apply: ({ projectPath, project }) =>
-        writeFileSync(
-          projectPath,
-          JSON.stringify({ ...project, projectId: "prj_other123" }),
-        ),
-      error: /project identity does not match the literal target/,
+      apply: ({ directory }) =>
+        updateRepoProject(directory, (project) => {
+          project.id = "prj_other123";
+        }),
+      error: /Repo-level Vercel mapping does not match the literal target/,
     },
     {
       name: "missing project",
+      apply: ({ directory }) =>
+        updateRepoProject(directory, (project) => {
+          delete project.id;
+        }),
+      error: /Repo-level Vercel mapping does not match the literal target/,
+    },
+    ...[
+      ["projectId", "prj_duplicate123"],
+      ["orgId", "team_duplicate123"],
+      ["projectName", "duplicate.mento.org"],
+    ].map(([name, value]) => ({
+      name: `standalone ${name}`,
       apply: ({ projectPath, project }) =>
         writeFileSync(
           projectPath,
-          JSON.stringify({ orgId: project.orgId, settings: project.settings }),
+          JSON.stringify({ ...project, [name]: value }),
         ),
-      error: /project identity does not match the literal target/,
-    },
+      error: /repo-linked Vercel project file must contain only settings/,
+    })),
     {
       name: "wrong Root Directory",
       apply: ({ projectPath, project }) =>
@@ -1330,8 +1334,6 @@ test("trusted builds reject every post-build project-link mutation before deploy
       const output = join(appVercel, "output");
       const projectPath = join(appVercel, "project.json");
       const project = {
-        orgId,
-        projectId,
         settings: { rootDirectory: contract.rootDirectory },
       };
       const operations = [];


### PR DESCRIPTION
## The Problem

The second live, non-activating production-shadow attempt (#521 run 29994593733) completed pinned Vercel pulls but failed before every build and upload. Our validator expected standalone-link project and organization IDs inside each app-local .vercel/project.json. Pinned vercel@56.2.0 deliberately omits those fields for a repo-linked monorepo and stores the authoritative identity in root .vercel/repo.json.

The workflow failed safely, but the false mismatch prevents the production-shadow pilot from reaching its actual build, staging, and browser checks.

## The Solution

- Keep the exact root repo.json mapping as the authoritative local organization/project/Root Directory identity.
- Require the pinned repo-linked app-local project.json shape to contain only settings and continue requiring the literal Root Directory.
- Preserve the independent read-only Vercel project API check for exact project ID, name, and Root Directory before candidate execution.
- Replace standalone-link fixtures with the real pinned-CLI shape, add all-target and mutation regressions, structurally lock the local-plus-remote validation order, and document the boundary.

## Verification

- pnpm vercel:production-shadow:test (84/84)
- pnpm ci:action-pins
- pnpm ci:action-pins:test (59/59)
- pnpm quality:budgets:test (30/30)
- pnpm adr:check
- pnpm adr:check:test (9/9)
- pnpm pr:description:test (25/25)
- targeted Trunk format/check and git diff --check
- independent pinned-CLI/security review: no blocking findings, confidence 0.97

The broad local workflow suite passed 90/91; its only failure was the existing unavailable offline tarball for @eslint/js@9.39.2. The isolated-worktree pre-push typecheck hook was bypassed because per-workspace node_modules links are not hydrated there, so full GitHub CI is required before merge.

Tracks #521.