### PR TITLE
fix(ci): isolate production shadow runtime

### DIFF
--- a/.github/actions/vercel-candidate-build/action.yml
+++ b/.github/actions/vercel-candidate-build/action.yml
@@ -8,17 +8,41 @@ inputs:
   source-path:
     description: Runner-owned exact-SHA source checkout
     required: true
+  runtime-root:
+    description: Root-owned run- and target-bound protected runtime root
+    required: true
+  isolation-root:
+    description: Runner-owned protected work root
+    required: true
+  runtime-marker:
+    description: Root-owned protected runtime identity marker
+    required: true
+  tools-path:
+    description: Runner-owned protected runtime tools root
+    required: true
+  build-environment-path:
+    description: Fixed runner-owned materialized build-environment path
+    required: true
   candidate-source-path:
-    description: Fresh candidate-owned source path under RUNNER_TEMP
+    description: Fresh candidate-owned source path under the protected work root
+    required: true
+  provenance-path:
+    description: Fixed runner-owned exact-SHA provenance path
     required: true
   candidate-home-path:
-    description: Fresh candidate-owned HOME path under RUNNER_TEMP
+    description: Fresh candidate-owned HOME path under the protected work root
     required: true
   pull-staging-path:
-    description: Validated runner-owned Vercel pull staging under RUNNER_TEMP
+    description: Validated runner-owned Vercel pull staging under the protected work root
     required: true
   upload-source-path:
-    description: Fresh runner-owned upload handoff under RUNNER_TEMP
+    description: Fresh runner-owned upload handoff under the protected work root
+    required: true
+  candidate-identity-marker:
+    description: Fixed runner-owned pending or bound candidate identity marker
+    required: true
+  build-log-path:
+    description: Fixed runner-owned candidate build log path
     required: true
   node-bin:
     description: Canonical protected Node executable
@@ -73,13 +97,16 @@ runs:
       env:
         CONTROLLER_PATH: ${{ inputs.controller-path }}
         EXPECTED_ROOT_DIRECTORY: ${{ inputs.expected-root-directory }}
+        ISOLATION_ROOT: ${{ inputs.isolation-root }}
         LOGICAL_TARGET: ${{ inputs.logical-target }}
         MENTO_NEXT_DEPLOYMENT_ID: ${{ inputs.next-deployment-id }}
         NODE_BIN: ${{ inputs.node-bin }}
         PULL_STAGING_PATH: ${{ inputs.pull-staging-path }}
       run: |
         set -euo pipefail
-        "$NODE_BIN" "$CONTROLLER_PATH/scripts/vercel-production-shadow.mjs" check-build-inputs
+        VERCEL_ISOLATION_ROOT="$ISOLATION_ROOT" \
+          "$NODE_BIN" "$CONTROLLER_PATH/scripts/vercel-production-shadow.mjs" \
+          check-build-inputs
         case "$LOGICAL_TARGET" in
           app) build_environment=v3 ;;
           governance|reserve|ui) build_environment=production ;;
@@ -95,31 +122,182 @@ runs:
       id: isolation
       shell: bash
       env:
+        BUILD_ENVIRONMENT_PATH: ${{ inputs.build-environment-path }}
+        BUILD_LOG_PATH: ${{ inputs.build-log-path }}
         CANDIDATE_HOME_PATH: ${{ inputs.candidate-home-path }}
+        CANDIDATE_IDENTITY_MARKER: ${{ inputs.candidate-identity-marker }}
         CANDIDATE_SOURCE_PATH: ${{ inputs.candidate-source-path }}
         CONTROLLER_PATH: ${{ inputs.controller-path }}
         DEPLOY_SHA: ${{ inputs.deploy-sha }}
+        ISOLATION_ROOT: ${{ inputs.isolation-root }}
+        LOGICAL_TARGET: ${{ inputs.logical-target }}
         NODE_BIN: ${{ inputs.node-bin }}
         PNPM_BIN: ${{ inputs.pnpm-bin }}
+        PROVENANCE_PATH: ${{ inputs.provenance-path }}
+        PULL_STAGING_PATH: ${{ inputs.pull-staging-path }}
+        RUNTIME_MARKER: ${{ inputs.runtime-marker }}
+        RUNTIME_ROOT: ${{ inputs.runtime-root }}
         SOURCE_PATH: ${{ inputs.source-path }}
+        TOOLS_PATH: ${{ inputs.tools-path }}
         TRUSTED_VERCEL_CLI_PATH: ${{ inputs.vercel-cli }}
+        UPLOAD_SOURCE_PATH: ${{ inputs.upload-source-path }}
       run: |
         set -euo pipefail
         umask 077
+        runner_uid="$(/usr/bin/id -u)"
+        runner_gid="$(/usr/bin/id -g)"
+        expected_runtime_root="/var/lib/mento-vercel-runtime-$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT-$LOGICAL_TARGET"
+        expected_marker="$expected_runtime_root/.mento-vercel-runtime"
+        expected_isolation_root="$expected_runtime_root/work"
+        case "$LOGICAL_TARGET" in
+          app|governance|reserve|ui) ;;
+          *) echo "Unknown production-shadow target" >&2; exit 1 ;;
+        esac
+        if [[ ! "$GITHUB_RUN_ID" =~ ^[1-9][0-9]*$ ]] ||
+          [[ ! "$GITHUB_RUN_ATTEMPT" =~ ^[1-9][0-9]*$ ]]; then
+          echo "GitHub runtime identity is invalid" >&2
+          exit 1
+        fi
+        if [ "$RUNTIME_ROOT" != "$expected_runtime_root" ] ||
+          [ "$ISOLATION_ROOT" != "$expected_isolation_root" ] ||
+          [ "$RUNTIME_MARKER" != "$expected_marker" ] ||
+          [ "$TOOLS_PATH" != "$ISOLATION_ROOT/mento-vercel-trusted-tools" ] ||
+          [ "$PULL_STAGING_PATH" != "$ISOLATION_ROOT/mento-vercel-production-pull-staging" ] ||
+          [ "$BUILD_ENVIRONMENT_PATH" != "$ISOLATION_ROOT/mento-vercel-production-build-environment" ] ||
+          [ "$CANDIDATE_SOURCE_PATH" != "$ISOLATION_ROOT/mento-vercel-production-candidate-source" ] ||
+          [ "$PROVENANCE_PATH" != "$CANDIDATE_SOURCE_PATH.provenance.json" ] ||
+          [ "$CANDIDATE_HOME_PATH" != "$ISOLATION_ROOT/mento-vercel-production-candidate-home" ] ||
+          [ "$UPLOAD_SOURCE_PATH" != "$ISOLATION_ROOT/mento-vercel-production-upload-source" ] ||
+          [ "$CANDIDATE_IDENTITY_MARKER" != "$ISOLATION_ROOT/mento-vercel-production-candidate-identity" ] ||
+          [ "$BUILD_LOG_PATH" != "$ISOLATION_ROOT/mento-vercel-production-$LOGICAL_TARGET-build.log" ]; then
+          echo "Candidate runtime paths do not match the protected fixed contract" >&2
+          exit 1
+        fi
+        for ancestor in / /var /var/lib; do
+          if [ ! -d "$ancestor" ] ||
+            [ -L "$ancestor" ] ||
+            [ "$(/usr/bin/realpath "$ancestor")" != "$ancestor" ] ||
+            [ "$(/usr/bin/stat -c %u "$ancestor")" != 0 ] ||
+            [ "$(/usr/bin/stat -c %g "$ancestor")" != 0 ]; then
+            echo "Candidate runtime ancestor is not a canonical root-owned directory: $ancestor" >&2
+            exit 1
+          fi
+          ancestor_mode="$((8#$(/usr/bin/stat -c %a "$ancestor")))"
+          if (( (ancestor_mode & 0022) != 0 )); then
+            echo "Candidate runtime ancestor is group- or other-writable: $ancestor" >&2
+            exit 1
+          fi
+        done
+        if [ ! -d "$RUNTIME_ROOT" ] ||
+          [ -L "$RUNTIME_ROOT" ] ||
+          [ "$(sudo --non-interactive /usr/bin/realpath "$RUNTIME_ROOT")" != "$RUNTIME_ROOT" ] ||
+          [ "$(sudo --non-interactive /usr/bin/stat -c %u "$RUNTIME_ROOT")" != 0 ] ||
+          [ "$(sudo --non-interactive /usr/bin/stat -c %g "$RUNTIME_ROOT")" != 0 ] ||
+          [ "$(sudo --non-interactive /usr/bin/stat -c %a "$RUNTIME_ROOT")" != 711 ] ||
+          [ ! -f "$RUNTIME_MARKER" ] ||
+          [ -L "$RUNTIME_MARKER" ] ||
+          [ "$(sudo --non-interactive /usr/bin/stat -c %u "$RUNTIME_MARKER")" != 0 ] ||
+          [ "$(sudo --non-interactive /usr/bin/stat -c %g "$RUNTIME_MARKER")" != 0 ] ||
+          [ "$(sudo --non-interactive /usr/bin/stat -c %a "$RUNTIME_MARKER")" != 400 ] ||
+          [ "$(sudo --non-interactive /usr/bin/stat -c %h "$RUNTIME_MARKER")" != 1 ] ||
+          [ "$(sudo --non-interactive /bin/cat "$RUNTIME_MARKER")" != "$GITHUB_RUN_ID:$GITHUB_RUN_ATTEMPT:$LOGICAL_TARGET" ] ||
+          [ ! -d "$ISOLATION_ROOT" ] ||
+          [ -L "$ISOLATION_ROOT" ] ||
+          [ "$(/usr/bin/realpath "$ISOLATION_ROOT")" != "$ISOLATION_ROOT" ] ||
+          [ "$(/usr/bin/stat -c %u "$ISOLATION_ROOT")" != "$runner_uid" ] ||
+          [ "$(/usr/bin/stat -c %g "$ISOLATION_ROOT")" != "$runner_gid" ] ||
+          [ "$(/usr/bin/stat -c %a "$ISOLATION_ROOT")" != 711 ]; then
+          echo "Protected candidate runtime identity changed before user creation" >&2
+          exit 1
+        fi
+        while IFS= read -r -d '' entry; do
+          case "$entry" in
+            "$TOOLS_PATH"|"$PULL_STAGING_PATH") ;;
+            *) echo "Unexpected protected work entry before candidate creation: $entry" >&2; exit 1 ;;
+          esac
+        done < <(/usr/bin/find "$ISOLATION_ROOT" -mindepth 1 -maxdepth 1 -print0)
+        if [ ! -d "$TOOLS_PATH" ] || [ -L "$TOOLS_PATH" ] ||
+          [ "$(/usr/bin/realpath "$TOOLS_PATH")" != "$TOOLS_PATH" ] ||
+          [ ! -d "$PULL_STAGING_PATH" ] || [ -L "$PULL_STAGING_PATH" ] ||
+          [ "$(/usr/bin/realpath "$PULL_STAGING_PATH")" != "$PULL_STAGING_PATH" ]; then
+          echo "Protected tools and pull staging must be canonical directories" >&2
+          exit 1
+        fi
+        for fresh_path in \
+          "$BUILD_ENVIRONMENT_PATH" \
+          "$CANDIDATE_SOURCE_PATH" \
+          "$CANDIDATE_HOME_PATH" \
+          "$UPLOAD_SOURCE_PATH" \
+          "$CANDIDATE_IDENTITY_MARKER" \
+          "$BUILD_LOG_PATH" \
+          "$PROVENANCE_PATH"; do
+          if [ -e "$fresh_path" ] || [ -L "$fresh_path" ]; then
+            echo "Candidate runtime path must be fresh: $fresh_path" >&2
+            exit 1
+          fi
+        done
+        if [ -z "${RUNNER_TEMP:-}" ] || [[ "$RUNNER_TEMP" != /* ]] ||
+          [ ! -d "$RUNNER_TEMP" ] || [ -L "$RUNNER_TEMP" ] ||
+          [ "$(/usr/bin/realpath "$RUNNER_TEMP")" != "$RUNNER_TEMP" ] ||
+          [ "$(/usr/bin/stat -c %u "$RUNNER_TEMP")" != "$runner_uid" ] ||
+          [ "$(/usr/bin/stat -c %g "$RUNNER_TEMP")" != "$runner_gid" ]; then
+          echo "RUNNER_TEMP is not a canonical runner-owned directory" >&2
+          exit 1
+        fi
+        runner_temp_identity="$(
+          /usr/bin/stat -c '%d:%i:%u:%g' "$RUNNER_TEMP"
+        )"
+        /bin/chmod 0700 "$RUNNER_TEMP"
+        if [ -L "$RUNNER_TEMP" ] ||
+          [ "$(/usr/bin/realpath "$RUNNER_TEMP")" != "$RUNNER_TEMP" ] ||
+          [ "$(/usr/bin/stat -c '%d:%i:%u:%g' "$RUNNER_TEMP")" != "$runner_temp_identity" ] ||
+          [ "$(/usr/bin/stat -c %a "$RUNNER_TEMP")" != 700 ]; then
+          echo "RUNNER_TEMP identity or ownership changed while it was sealed" >&2
+          exit 1
+        fi
+        if [ "$NODE_BIN" != "$TOOLS_PATH/bin/node" ] ||
+          [ "$PNPM_BIN" != "$TOOLS_PATH/bin/pnpm" ]; then
+          echo "Protected Node or pnpm path is not the fixed staged executable" >&2
+          exit 1
+        fi
+        for protected_binary in "$NODE_BIN" "$PNPM_BIN"; do
+          if [ ! -f "$protected_binary" ] || [ -L "$protected_binary" ] ||
+            [ "$(/usr/bin/realpath "$protected_binary")" != "$protected_binary" ] ||
+            [ "$(/usr/bin/stat -c %u "$protected_binary")" != "$runner_uid" ] ||
+            [ "$(/usr/bin/stat -c %g "$protected_binary")" != "$runner_gid" ] ||
+            [ "$(/usr/bin/stat -c %h "$protected_binary")" != 1 ] ||
+            [ "$(/usr/bin/stat -c %a "$protected_binary")" != 555 ]; then
+            echo "Protected runtime executable changed: $protected_binary" >&2
+            exit 1
+          fi
+        done
+        if [ ! -f "$TRUSTED_VERCEL_CLI_PATH" ] ||
+          [ -L "$TRUSTED_VERCEL_CLI_PATH" ] ||
+          [ "$(/usr/bin/realpath "$TRUSTED_VERCEL_CLI_PATH")" != "$TRUSTED_VERCEL_CLI_PATH" ] ||
+          [ "$(/usr/bin/stat -c %u "$TRUSTED_VERCEL_CLI_PATH")" != "$runner_uid" ] ||
+          [ "$(/usr/bin/stat -c %g "$TRUSTED_VERCEL_CLI_PATH")" != "$runner_gid" ] ||
+          [ "$(/usr/bin/stat -c %h "$TRUSTED_VERCEL_CLI_PATH")" != 1 ]; then
+          echo "Protected Vercel CLI entry point changed" >&2
+          exit 1
+        fi
+        case "$TRUSTED_VERCEL_CLI_PATH" in
+          "$TOOLS_PATH"/*) ;;
+          *) echo "Protected Vercel CLI escaped the tools root" >&2; exit 1 ;;
+        esac
+        for protected_tool in "$TOOLS_PATH" "$NODE_BIN" "$PNPM_BIN" "$TRUSTED_VERCEL_CLI_PATH"; do
+          case "$protected_tool" in
+            /opt|/opt/*) echo "Candidate runtime must not depend on /opt: $protected_tool" >&2; exit 1 ;;
+          esac
+        done
         build_user=mento-vercel-build
-        identity_marker="$RUNNER_TEMP/mento-vercel-production-candidate-identity"
         if /usr/bin/getent passwd "$build_user" >/dev/null || /usr/bin/getent group "$build_user" >/dev/null; then
           echo "Dedicated candidate identity already exists" >&2
           exit 1
         fi
-        if [ -e "$identity_marker" ] || [ -L "$identity_marker" ]; then
-          echo "Candidate identity marker must be fresh" >&2
-          exit 1
-        fi
         set -o noclobber
-        printf 'pending\n' > "$identity_marker"
+        printf 'pending\n' > "$CANDIDATE_IDENTITY_MARKER"
         set +o noclobber
-        /bin/chmod 0600 "$identity_marker"
+        /bin/chmod 0600 "$CANDIDATE_IDENTITY_MARKER"
         sudo --non-interactive /usr/sbin/useradd \
           --system \
           --no-create-home \
@@ -129,8 +307,12 @@ runs:
           "$build_user"
         build_uid="$(/usr/bin/id -u "$build_user")"
         build_gid="$(/usr/bin/id -g "$build_user")"
-        printf '%s:%s\n' "$build_uid" "$build_gid" > "$identity_marker"
-        /bin/chmod 0600 "$identity_marker"
+        printf '%s:%s\n' "$build_uid" "$build_gid" > "$CANDIDATE_IDENTITY_MARKER"
+        /bin/chmod 0600 "$CANDIDATE_IDENTITY_MARKER"
+        if [ "$build_uid" = "$runner_uid" ] || [ "$build_gid" = "$runner_gid" ]; then
+          echo "Dedicated candidate identity overlaps the runner identity" >&2
+          exit 1
+        fi
         if sudo --non-interactive /usr/bin/pgrep -u "$build_uid" >/dev/null 2>&1; then
           echo "Dedicated candidate identity unexpectedly owns a process" >&2
           exit 1
@@ -146,6 +328,10 @@ runs:
             /usr/bin/test -w "$1"
         }
         for protected_path in \
+          /var/lib \
+          "$RUNTIME_ROOT" \
+          "$RUNTIME_MARKER" \
+          "$ISOLATION_ROOT" \
           "$GITHUB_WORKSPACE" \
           "$CONTROLLER_PATH" \
           "$RUNNER_TEMP" \
@@ -153,23 +339,61 @@ runs:
           "$SOURCE_PATH/.git" \
           "$SOURCE_PATH/package.json" \
           "$SOURCE_PATH/pnpm-lock.yaml" \
+          "$PULL_STAGING_PATH" \
+          "$TOOLS_PATH" \
+          "$TOOLS_PATH/bin" \
+          "$TOOLS_PATH/node_modules" \
+          "$TOOLS_PATH/pnpm-runtime" \
           "$NODE_BIN" \
           "$PNPM_BIN" \
           "$TRUSTED_VERCEL_CLI_PATH"; do
           if [ ! -e "$protected_path" ] || candidate_can_write "$protected_path"; then
-            echo "Candidate can modify a protected runner path" >&2
+            echo "Candidate can modify protected path: $protected_path" >&2
             exit 1
           fi
         done
-        case "$CANDIDATE_SOURCE_PATH:$CANDIDATE_HOME_PATH" in
-          "$RUNNER_TEMP"/mento-vercel-*:"$RUNNER_TEMP"/mento-vercel-*) ;;
-          *) echo "Candidate isolation path is outside RUNNER_TEMP" >&2; exit 1 ;;
-        esac
-        if [ -e "$CANDIDATE_SOURCE_PATH" ] || [ -e "$CANDIDATE_HOME_PATH" ]; then
-          echo "Candidate isolation paths must be fresh" >&2
+        if sudo --non-interactive /usr/bin/env -i PATH=/usr/bin:/bin \
+          /usr/bin/setpriv \
+          --reuid="$build_uid" \
+          --regid="$build_gid" \
+          --clear-groups \
+          --no-new-privs \
+          -- \
+          /usr/bin/test -x "$RUNNER_TEMP"; then
+          echo "Candidate can traverse protected path: $RUNNER_TEMP" >&2
           exit 1
         fi
-        "$NODE_BIN" \
+        safe_path="$(/usr/bin/dirname "$NODE_BIN"):/usr/local/bin:/usr/bin:/bin"
+        candidate_probe() {
+          sudo --non-interactive /usr/bin/env -i \
+            HOME=/nonexistent \
+            LANG=C \
+            LC_ALL=C \
+            PATH="$safe_path" \
+            /usr/bin/setpriv \
+            --reuid="$build_uid" \
+            --regid="$build_gid" \
+            --clear-groups \
+            --no-new-privs \
+            -- \
+            "$@"
+        }
+        if ! candidate_probe "$NODE_BIN" --version >/dev/null; then
+          echo "Candidate cannot execute protected path: $NODE_BIN" >&2
+          exit 1
+        fi
+        if ! candidate_probe "$PNPM_BIN" --version |
+          /usr/bin/grep -Fxq "10.34.4"; then
+          echo "Candidate cannot execute protected path: $PNPM_BIN" >&2
+          exit 1
+        fi
+        if ! candidate_probe \
+          "$NODE_BIN" "$TRUSTED_VERCEL_CLI_PATH" --version >/dev/null; then
+          echo "Candidate cannot execute protected path: $TRUSTED_VERCEL_CLI_PATH" >&2
+          exit 1
+        fi
+        VERCEL_ISOLATION_ROOT="$ISOLATION_ROOT" \
+          "$NODE_BIN" \
           "$CONTROLLER_PATH/scripts/vercel-production-shadow.mjs" \
           materialize-source
         sudo --non-interactive /bin/chown \
@@ -182,8 +406,8 @@ runs:
           "$CANDIDATE_HOME_PATH/data" \
           "$CANDIDATE_HOME_PATH/pnpm-store" \
           "$CANDIDATE_HOME_PATH/tmp"
-        printf '{"commitSha":"%s"}\n' "$DEPLOY_SHA" > "${CANDIDATE_SOURCE_PATH}.provenance.json"
-        /bin/chmod 0600 "${CANDIDATE_SOURCE_PATH}.provenance.json"
+        printf '{"commitSha":"%s"}\n' "$DEPLOY_SHA" > "$PROVENANCE_PATH"
+        /bin/chmod 0600 "$PROVENANCE_PATH"
         echo "build_uid=$build_uid" >> "$GITHUB_OUTPUT"
         echo "build_gid=$build_gid" >> "$GITHUB_OUTPUT"
 
@@ -260,6 +484,7 @@ runs:
         CANDIDATE_SOURCE_PATH: ${{ inputs.candidate-source-path }}
         CONTROLLER_PATH: ${{ inputs.controller-path }}
         EXPECTED_ROOT_DIRECTORY: ${{ inputs.expected-root-directory }}
+        ISOLATION_ROOT: ${{ inputs.isolation-root }}
         LOGICAL_TARGET: ${{ inputs.logical-target }}
         MENTO_NEXT_DEPLOYMENT_ID: ${{ inputs.next-deployment-id }}
         NODE_BIN: ${{ inputs.node-bin }}
@@ -277,12 +502,12 @@ runs:
           BUILD_UID="$BUILD_UID" \
           CANDIDATE_SOURCE_PATH="$CANDIDATE_SOURCE_PATH" \
           EXPECTED_ROOT_DIRECTORY="$EXPECTED_ROOT_DIRECTORY" \
+          VERCEL_ISOLATION_ROOT="$ISOLATION_ROOT" \
           LOGICAL_TARGET="$LOGICAL_TARGET" \
           PATH="$(dirname "$NODE_BIN"):/usr/bin:/bin" \
           PULL_STAGING_GID="$(id -g)" \
           PULL_STAGING_PATH="$PULL_STAGING_PATH" \
           PULL_STAGING_UID="$(id -u)" \
-          RUNNER_TEMP="$RUNNER_TEMP" \
           VERCEL_ORG_ID="$VERCEL_ORG_ID" \
           VERCEL_PROJECT_ID="$VERCEL_PROJECT_ID" \
           "$NODE_BIN" "$CONTROLLER_PATH/scripts/vercel-production-shadow.mjs" stage-pull
@@ -297,11 +522,13 @@ runs:
       env:
         BUILD_GID: ${{ steps.isolation.outputs.build_gid }}
         BUILD_UID: ${{ steps.isolation.outputs.build_uid }}
+        BUILD_LOG_PATH: ${{ inputs.build-log-path }}
         CANDIDATE_HOME_PATH: ${{ inputs.candidate-home-path }}
         CANDIDATE_SOURCE_PATH: ${{ inputs.candidate-source-path }}
         CONTROLLER_PATH: ${{ inputs.controller-path }}
         DEPLOY_SHA: ${{ inputs.deploy-sha }}
         EXPECTED_ROOT_DIRECTORY: ${{ inputs.expected-root-directory }}
+        ISOLATION_ROOT: ${{ inputs.isolation-root }}
         LOGICAL_TARGET: ${{ inputs.logical-target }}
         NODE_BIN: ${{ inputs.node-bin }}
         PNPM_BIN: ${{ inputs.pnpm-bin }}
@@ -335,7 +562,7 @@ runs:
           PATH="$(dirname "$NODE_BIN"):/usr/bin:/bin" \
           PULL_STAGING_GID="$(id -g)" \
           PULL_STAGING_UID="$(id -u)" \
-          RUNNER_TEMP="$RUNNER_TEMP" \
+          VERCEL_ISOLATION_ROOT="$ISOLATION_ROOT" \
           VERCEL_ORG_ID="$VERCEL_ORG_ID" \
           VERCEL_PROJECT_ID="$VERCEL_PROJECT_ID" \
           "$NODE_BIN" "$CONTROLLER_PATH/scripts/vercel-production-shadow.mjs" validate-candidate-pull
@@ -344,10 +571,9 @@ runs:
           governance|reserve|ui) build_arguments=(build --yes --standalone --prod --project "$VERCEL_PROJECT_ID") ;;
           *) echo "Unknown production-shadow target" >&2; exit 1 ;;
         esac
-        safe_path="$(dirname "$NODE_BIN"):$(dirname "$PNPM_BIN"):/usr/local/bin:/usr/bin:/bin"
+        safe_path="$(dirname "$NODE_BIN"):/usr/local/bin:/usr/bin:/bin"
         started_at_ms="$(date +%s%3N)"
-        build_log="$RUNNER_TEMP/mento-vercel-production-${LOGICAL_TARGET}-build.log"
-        if [ -e "$build_log" ] || [ -L "$build_log" ]; then
+        if [ -e "$BUILD_LOG_PATH" ] || [ -L "$BUILD_LOG_PATH" ]; then
           echo "Candidate build log path must be fresh" >&2
           exit 1
         fi
@@ -392,7 +618,7 @@ runs:
           --no-new-privs \
           -- \
           "$NODE_BIN" "$TRUSTED_VERCEL_CLI_PATH" "${build_arguments[@]}" \
-          2>&1 | /usr/bin/tee "$build_log"
+          2>&1 | /usr/bin/tee "$BUILD_LOG_PATH"
         pipeline_status=("${PIPESTATUS[@]}")
         candidate_status="${pipeline_status[0]}"
         tee_status="${pipeline_status[1]}"
@@ -402,9 +628,10 @@ runs:
         command_token=""
         if [ "$tee_status" -ne 0 ]; then exit "$tee_status"; fi
         if [ "$candidate_status" -ne 0 ]; then exit "$candidate_status"; fi
-        "$NODE_BIN" "$CONTROLLER_PATH/scripts/vercel-production-shadow.mjs" \
-          cache-summary --input "$build_log"
-        /bin/rm -f "$build_log"
+        VERCEL_ISOLATION_ROOT="$ISOLATION_ROOT" \
+          "$NODE_BIN" "$CONTROLLER_PATH/scripts/vercel-production-shadow.mjs" \
+          cache-summary --input "$BUILD_LOG_PATH"
+        /bin/rm -f -- "$BUILD_LOG_PATH"
         trap - EXIT
         echo "build_duration_ms=$(($(date +%s%3N) - started_at_ms))" >> "$GITHUB_OUTPUT"
 
@@ -417,6 +644,7 @@ runs:
         CONTROLLER_PATH: ${{ inputs.controller-path }}
         DEPLOY_SHA: ${{ inputs.deploy-sha }}
         EXPECTED_ROOT_DIRECTORY: ${{ inputs.expected-root-directory }}
+        ISOLATION_ROOT: ${{ inputs.isolation-root }}
         LOGICAL_TARGET: ${{ inputs.logical-target }}
         MENTO_NEXT_DEPLOYMENT_ID: ${{ inputs.next-deployment-id }}
         NODE_BIN: ${{ inputs.node-bin }}
@@ -438,6 +666,7 @@ runs:
           MENTO_NEXT_DEPLOYMENT_ID="$MENTO_NEXT_DEPLOYMENT_ID" \
           PATH="$(dirname "$NODE_BIN"):/usr/bin:/bin" \
           SOURCE_PATH="$CANDIDATE_SOURCE_PATH" \
+          VERCEL_ISOLATION_ROOT="$ISOLATION_ROOT" \
           VERCEL_ORG_ID="$VERCEL_ORG_ID" \
           VERCEL_PROJECT_ID="$VERCEL_PROJECT_ID" \
           "$NODE_BIN" "$CONTROLLER_PATH/scripts/vercel-production-shadow.mjs" assert-output
@@ -451,6 +680,7 @@ runs:
         CANDIDATE_SOURCE_PATH: ${{ inputs.candidate-source-path }}
         CONTROLLER_PATH: ${{ inputs.controller-path }}
         DEPLOY_SHA: ${{ inputs.deploy-sha }}
+        ISOLATION_ROOT: ${{ inputs.isolation-root }}
         LOGICAL_TARGET: ${{ inputs.logical-target }}
         MENTO_NEXT_DEPLOYMENT_ID: ${{ inputs.next-deployment-id }}
         NODE_BIN: ${{ inputs.node-bin }}
@@ -477,9 +707,9 @@ runs:
           MENTO_NEXT_DEPLOYMENT_ID="$MENTO_NEXT_DEPLOYMENT_ID" \
           PULL_STAGING_PATH="$PULL_STAGING_PATH" \
           RUNNER_GID="$runner_gid" \
-          RUNNER_TEMP="$RUNNER_TEMP" \
           RUNNER_UID="$runner_uid" \
           UPLOAD_SOURCE_PATH="$UPLOAD_SOURCE_PATH" \
+          VERCEL_ISOLATION_ROOT="$ISOLATION_ROOT" \
           VERCEL_ORG_ID="$VERCEL_ORG_ID" \
           VERCEL_PROJECT_ID="$VERCEL_PROJECT_ID" \
           "$NODE_BIN" \
@@ -492,87 +722,235 @@ runs:
       if: always()
       shell: bash
       env:
+        BUILD_ENVIRONMENT_PATH: ${{ inputs.build-environment-path }}
+        BUILD_LOG_PATH: ${{ inputs.build-log-path }}
         CANDIDATE_HOME_PATH: ${{ inputs.candidate-home-path }}
+        CANDIDATE_IDENTITY_MARKER: ${{ inputs.candidate-identity-marker }}
         CANDIDATE_SOURCE_PATH: ${{ inputs.candidate-source-path }}
+        ISOLATION_ROOT: ${{ inputs.isolation-root }}
+        LOGICAL_TARGET: ${{ inputs.logical-target }}
+        PROVENANCE_PATH: ${{ inputs.provenance-path }}
         PULL_STAGING_PATH: ${{ inputs.pull-staging-path }}
+        RUNTIME_MARKER: ${{ inputs.runtime-marker }}
+        RUNTIME_ROOT: ${{ inputs.runtime-root }}
+        TOOLS_PATH: ${{ inputs.tools-path }}
+        UPLOAD_SOURCE_PATH: ${{ inputs.upload-source-path }}
       run: |
         set -euo pipefail
-        identity_marker="$RUNNER_TEMP/mento-vercel-production-candidate-identity"
-        if [ -e "$identity_marker" ] || [ -L "$identity_marker" ]; then
-          if [ -L "$identity_marker" ] || [ ! -f "$identity_marker" ] || \
-            [ "$(/usr/bin/stat -c '%u' "$identity_marker")" != "$(id -u)" ] || \
-            [ "$(/usr/bin/stat -c '%g' "$identity_marker")" != "$(id -g)" ] || \
-            [ "$(/usr/bin/stat -c '%h' "$identity_marker")" != 1 ] || \
-            [ "$(/usr/bin/stat -c '%a' "$identity_marker")" != 600 ]; then
+        runner_uid="$(/usr/bin/id -u)"
+        runner_gid="$(/usr/bin/id -g)"
+        expected_runtime_root="/var/lib/mento-vercel-runtime-$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT-$LOGICAL_TARGET"
+        case "$LOGICAL_TARGET" in
+          app|governance|reserve|ui) ;;
+          *) echo "Unknown production-shadow target during candidate cleanup" >&2; exit 1 ;;
+        esac
+        if [[ ! "$GITHUB_RUN_ID" =~ ^[1-9][0-9]*$ ]] ||
+          [[ ! "$GITHUB_RUN_ATTEMPT" =~ ^[1-9][0-9]*$ ]] ||
+          [ "$RUNTIME_ROOT" != "$expected_runtime_root" ] ||
+          [ "$ISOLATION_ROOT" != "$RUNTIME_ROOT/work" ] ||
+          [ "$RUNTIME_MARKER" != "$RUNTIME_ROOT/.mento-vercel-runtime" ] ||
+          [ "$TOOLS_PATH" != "$ISOLATION_ROOT/mento-vercel-trusted-tools" ] ||
+          [ "$BUILD_ENVIRONMENT_PATH" != "$ISOLATION_ROOT/mento-vercel-production-build-environment" ] ||
+          [ "$CANDIDATE_HOME_PATH" != "$ISOLATION_ROOT/mento-vercel-production-candidate-home" ] ||
+          [ "$CANDIDATE_IDENTITY_MARKER" != "$ISOLATION_ROOT/mento-vercel-production-candidate-identity" ] ||
+          [ "$CANDIDATE_SOURCE_PATH" != "$ISOLATION_ROOT/mento-vercel-production-candidate-source" ] ||
+          [ "$PROVENANCE_PATH" != "$CANDIDATE_SOURCE_PATH.provenance.json" ] ||
+          [ "$PULL_STAGING_PATH" != "$ISOLATION_ROOT/mento-vercel-production-pull-staging" ] ||
+          [ "$UPLOAD_SOURCE_PATH" != "$ISOLATION_ROOT/mento-vercel-production-upload-source" ] ||
+          [ "$BUILD_LOG_PATH" != "$ISOLATION_ROOT/mento-vercel-production-$LOGICAL_TARGET-build.log" ]; then
+          echo "Candidate cleanup paths do not match the protected fixed contract" >&2
+          exit 1
+        fi
+        upload_provenance_path="$UPLOAD_SOURCE_PATH.provenance.json"
+        for ancestor in / /var /var/lib; do
+          if [ ! -d "$ancestor" ] ||
+            [ -L "$ancestor" ] ||
+            [ "$(/usr/bin/realpath "$ancestor")" != "$ancestor" ] ||
+            [ "$(/usr/bin/stat -c %u "$ancestor")" != 0 ] ||
+            [ "$(/usr/bin/stat -c %g "$ancestor")" != 0 ]; then
+            echo "Candidate cleanup ancestor changed: $ancestor" >&2
+            exit 1
+          fi
+          ancestor_mode="$((8#$(/usr/bin/stat -c %a "$ancestor")))"
+          if (( (ancestor_mode & 0022) != 0 )); then
+            echo "Candidate cleanup ancestor is writable: $ancestor" >&2
+            exit 1
+          fi
+        done
+        if [ ! -d "$RUNTIME_ROOT" ] ||
+          [ -L "$RUNTIME_ROOT" ] ||
+          [ "$(sudo --non-interactive /usr/bin/realpath "$RUNTIME_ROOT")" != "$RUNTIME_ROOT" ] ||
+          [ "$(sudo --non-interactive /usr/bin/stat -c %u "$RUNTIME_ROOT")" != 0 ] ||
+          [ "$(sudo --non-interactive /usr/bin/stat -c %g "$RUNTIME_ROOT")" != 0 ] ||
+          [ "$(sudo --non-interactive /usr/bin/stat -c %a "$RUNTIME_ROOT")" != 711 ] ||
+          [ ! -f "$RUNTIME_MARKER" ] ||
+          [ -L "$RUNTIME_MARKER" ] ||
+          [ "$(sudo --non-interactive /usr/bin/stat -c %u "$RUNTIME_MARKER")" != 0 ] ||
+          [ "$(sudo --non-interactive /usr/bin/stat -c %g "$RUNTIME_MARKER")" != 0 ] ||
+          [ "$(sudo --non-interactive /usr/bin/stat -c %a "$RUNTIME_MARKER")" != 400 ] ||
+          [ "$(sudo --non-interactive /usr/bin/stat -c %h "$RUNTIME_MARKER")" != 1 ] ||
+          [ "$(sudo --non-interactive /bin/cat "$RUNTIME_MARKER")" != "$GITHUB_RUN_ID:$GITHUB_RUN_ATTEMPT:$LOGICAL_TARGET" ] ||
+          [ ! -d "$ISOLATION_ROOT" ] ||
+          [ -L "$ISOLATION_ROOT" ] ||
+          [ "$(/usr/bin/realpath "$ISOLATION_ROOT")" != "$ISOLATION_ROOT" ] ||
+          [ "$(/usr/bin/stat -c %u "$ISOLATION_ROOT")" != "$runner_uid" ] ||
+          [ "$(/usr/bin/stat -c %g "$ISOLATION_ROOT")" != "$runner_gid" ] ||
+          [ "$(/usr/bin/stat -c %a "$ISOLATION_ROOT")" != 711 ]; then
+          echo "Protected runtime identity changed before candidate teardown" >&2
+          exit 1
+        fi
+        while IFS= read -r -d '' entry; do
+          case "$entry" in
+            "$TOOLS_PATH"|"$UPLOAD_SOURCE_PATH"|"$upload_provenance_path"|\
+            "$BUILD_ENVIRONMENT_PATH"|"$BUILD_LOG_PATH"|\
+            "$CANDIDATE_HOME_PATH"|"$CANDIDATE_IDENTITY_MARKER"|"$CANDIDATE_SOURCE_PATH"|\
+            "$PROVENANCE_PATH"|"$PULL_STAGING_PATH") ;;
+            *) echo "Unexpected protected work entry during candidate cleanup: $entry" >&2; exit 1 ;;
+          esac
+        done < <(/usr/bin/find "$ISOLATION_ROOT" -mindepth 1 -maxdepth 1 -print0)
+
+        build_user=mento-vercel-build
+        kill_candidate_uid() {
+          local uid="$1"
+          sudo --non-interactive /usr/bin/pkill -KILL -u "$uid" >/dev/null 2>&1 || true
+          for _ in $(/usr/bin/seq 1 50); do
+            if ! sudo --non-interactive /usr/bin/pgrep -u "$uid" >/dev/null 2>&1; then
+              return 0
+            fi
+            /bin/sleep 0.1
+          done
+          sudo --non-interactive /usr/bin/pgrep -a -u "$uid" >&2 || true
+          echo "Candidate processes survived final boundary teardown" >&2
+          return 1
+        }
+        validate_group() {
+          local expected_gid="$1"
+          local group_entry group_name group_password group_gid group_members
+          group_entry="$(/usr/bin/getent group "$build_user")"
+          IFS=: read -r group_name group_password group_gid group_members <<< "$group_entry"
+          if [ "$group_name" != "$build_user" ] ||
+            [[ ! "$group_gid" =~ ^[0-9]+$ ]] ||
+            [ -n "$group_members" ] ||
+            { [ -n "$expected_gid" ] && [ "$group_gid" != "$expected_gid" ]; }; then
+            echo "Candidate group changed during teardown" >&2
+            exit 1
+          fi
+          printf '%s\n' "$group_gid"
+        }
+        validate_user() {
+          local expected_uid="$1"
+          local expected_gid="$2"
+          local passwd_entry user_name user_password user_uid user_gid user_gecos user_home user_shell
+          passwd_entry="$(/usr/bin/getent passwd "$build_user")"
+          IFS=: read -r user_name user_password user_uid user_gid user_gecos user_home user_shell <<< "$passwd_entry"
+          if [ "$user_name" != "$build_user" ] ||
+            [[ ! "$user_uid" =~ ^[0-9]+$ ]] ||
+            [[ ! "$user_gid" =~ ^[0-9]+$ ]] ||
+            [ "$user_uid" = "$runner_uid" ] ||
+            [ "$user_gid" = "$runner_gid" ] ||
+            [ "$user_home" != /nonexistent ] ||
+            [ "$user_shell" != /usr/sbin/nologin ] ||
+            { [ -n "$expected_uid" ] && [ "$user_uid" != "$expected_uid" ]; } ||
+            { [ -n "$expected_gid" ] && [ "$user_gid" != "$expected_gid" ]; }; then
+            echo "Candidate user changed during teardown" >&2
+            exit 1
+          fi
+          printf '%s:%s\n' "$user_uid" "$user_gid"
+        }
+
+        if [ -e "$CANDIDATE_IDENTITY_MARKER" ] ||
+          [ -L "$CANDIDATE_IDENTITY_MARKER" ]; then
+          if [ -L "$CANDIDATE_IDENTITY_MARKER" ] ||
+            [ ! -f "$CANDIDATE_IDENTITY_MARKER" ] ||
+            [ "$(/usr/bin/stat -c %u "$CANDIDATE_IDENTITY_MARKER")" != "$runner_uid" ] ||
+            [ "$(/usr/bin/stat -c %g "$CANDIDATE_IDENTITY_MARKER")" != "$runner_gid" ] ||
+            [ "$(/usr/bin/stat -c %h "$CANDIDATE_IDENTITY_MARKER")" != 1 ] ||
+            [ "$(/usr/bin/stat -c %a "$CANDIDATE_IDENTITY_MARKER")" != 600 ]; then
             echo "Candidate identity marker is unsafe" >&2
             exit 1
           fi
-          identity="$(< "$identity_marker")"
+          identity="$(< "$CANDIDATE_IDENTITY_MARKER")"
           if [ "$identity" = pending ]; then
-            if /usr/bin/getent passwd mento-vercel-build >/dev/null || \
-              /usr/bin/getent group mento-vercel-build >/dev/null; then
-              echo "Candidate identity ownership was not bound before teardown" >&2
-              exit 1
+            if /usr/bin/getent passwd "$build_user" >/dev/null; then
+              user_identity="$(validate_user "" "")"
+              build_uid="${user_identity%%:*}"
+              build_gid="${user_identity##*:}"
+              if /usr/bin/getent group "$build_user" >/dev/null; then
+                validate_group "$build_gid" >/dev/null
+              fi
+              kill_candidate_uid "$build_uid"
+              sudo --non-interactive /usr/sbin/userdel "$build_user"
             fi
-            /bin/rm -f -- "$identity_marker"
+            if /usr/bin/getent group "$build_user" >/dev/null; then
+              validate_group "" >/dev/null
+              sudo --non-interactive /usr/sbin/groupdel "$build_user"
+            fi
           elif [[ "$identity" =~ ^([0-9]+):([0-9]+)$ ]]; then
             build_uid="${BASH_REMATCH[1]}"
             build_gid="${BASH_REMATCH[2]}"
-            if ! /usr/bin/getent passwd mento-vercel-build >/dev/null || \
-              ! /usr/bin/getent group mento-vercel-build >/dev/null || \
-              [ "$(/usr/bin/id -u mento-vercel-build)" != "$build_uid" ] || \
-              [ "$(/usr/bin/id -g mento-vercel-build)" != "$build_gid" ] || \
-              [ "$(/usr/bin/getent group mento-vercel-build | /usr/bin/cut -d: -f3)" != "$build_gid" ]; then
+            if ! /usr/bin/getent passwd "$build_user" >/dev/null ||
+              ! /usr/bin/getent group "$build_user" >/dev/null; then
               echo "Candidate identity no longer matches its runner-owned marker" >&2
               exit 1
             fi
-            sudo --non-interactive /usr/bin/pkill -KILL -u "$build_uid" >/dev/null 2>&1 || true
-            for _ in $(/usr/bin/seq 1 50); do
-              if ! sudo --non-interactive /usr/bin/pgrep -u "$build_uid" >/dev/null 2>&1; then break; fi
-              /bin/sleep 0.1
-            done
-            if sudo --non-interactive /usr/bin/pgrep -u "$build_uid" >/dev/null 2>&1; then
-              sudo --non-interactive /usr/bin/pgrep -a -u "$build_uid" >&2 || true
-              echo "Candidate processes survived final boundary teardown" >&2
-              exit 1
+            validate_user "$build_uid" "$build_gid" >/dev/null
+            validate_group "$build_gid" >/dev/null
+            kill_candidate_uid "$build_uid"
+            sudo --non-interactive /usr/sbin/userdel "$build_user"
+            if /usr/bin/getent group "$build_user" >/dev/null; then
+              validate_group "$build_gid" >/dev/null
+              sudo --non-interactive /usr/sbin/groupdel "$build_user"
             fi
-            sudo --non-interactive /usr/sbin/userdel mento-vercel-build
-            if /usr/bin/getent group mento-vercel-build >/dev/null; then
-              if [ "$(/usr/bin/getent group mento-vercel-build | /usr/bin/cut -d: -f3)" != "$build_gid" ]; then
-                echo "Candidate group changed during teardown" >&2
-                exit 1
-              fi
-              sudo --non-interactive /usr/sbin/groupdel mento-vercel-build
-            fi
-            /bin/rm -f -- "$identity_marker"
           else
             echo "Candidate identity marker is malformed" >&2
             exit 1
           fi
+          /bin/rm -f -- "$CANDIDATE_IDENTITY_MARKER"
+        elif /usr/bin/getent passwd "$build_user" >/dev/null ||
+          /usr/bin/getent group "$build_user" >/dev/null; then
+          echo "Candidate identity exists without its runner-owned marker" >&2
+          exit 1
         fi
-        materialized_environment_path="$RUNNER_TEMP/mento-vercel-production-build-environment"
-        for path in "$CANDIDATE_HOME_PATH" "$CANDIDATE_SOURCE_PATH" "$PULL_STAGING_PATH" "$materialized_environment_path"; do
-          case "$path" in
-            "$RUNNER_TEMP"/mento-vercel-*) ;;
-            *) echo "Refusing to clean an unexpected path" >&2; exit 1 ;;
-          esac
-        done
-        sudo --non-interactive /bin/rm -rf -- \
+        if /usr/bin/getent passwd "$build_user" >/dev/null ||
+          /usr/bin/getent group "$build_user" >/dev/null ||
+          [ -e "$CANDIDATE_IDENTITY_MARKER" ] ||
+          [ -L "$CANDIDATE_IDENTITY_MARKER" ]; then
+          echo "Candidate identity survived final boundary teardown" >&2
+          exit 1
+        fi
+        sudo --non-interactive /bin/rm -rf --one-file-system -- \
           "$CANDIDATE_HOME_PATH" \
           "$CANDIDATE_SOURCE_PATH" \
           "$PULL_STAGING_PATH" \
-          "$materialized_environment_path"
-        /bin/rm -f -- "${CANDIDATE_SOURCE_PATH}.provenance.json"
+          "$BUILD_ENVIRONMENT_PATH"
+        sudo --non-interactive /bin/rm -f -- \
+          "$BUILD_LOG_PATH" \
+          "$PROVENANCE_PATH"
+        for removed_path in \
+          "$BUILD_ENVIRONMENT_PATH" \
+          "$BUILD_LOG_PATH" \
+          "$CANDIDATE_HOME_PATH" \
+          "$CANDIDATE_IDENTITY_MARKER" \
+          "$CANDIDATE_SOURCE_PATH" \
+          "$PROVENANCE_PATH" \
+          "$PULL_STAGING_PATH"; do
+          if [ -e "$removed_path" ] || [ -L "$removed_path" ]; then
+            echo "Candidate cleanup did not remove exact path: $removed_path" >&2
+            exit 1
+          fi
+        done
 
     - name: Assert immutable runner-owned upload handoff
       if: steps.build.outcome == 'success' && steps.handoff.outcome == 'success'
       shell: bash
       env:
+        CANDIDATE_IDENTITY_MARKER: ${{ inputs.candidate-identity-marker }}
         CONTROLLER_PATH: ${{ inputs.controller-path }}
         DEPLOY_SHA: ${{ inputs.deploy-sha }}
         EXPECTED_OUTPUT_GID: ${{ steps.handoff.outputs.upload_gid }}
         EXPECTED_OUTPUT_UID: ${{ steps.handoff.outputs.upload_uid }}
         EXPECTED_ROOT_DIRECTORY: ${{ inputs.expected-root-directory }}
+        ISOLATION_ROOT: ${{ inputs.isolation-root }}
         LOGICAL_TARGET: ${{ inputs.logical-target }}
         MENTO_NEXT_DEPLOYMENT_ID: ${{ inputs.next-deployment-id }}
         NODE_BIN: ${{ inputs.node-bin }}
@@ -581,8 +959,8 @@ runs:
         VERCEL_PROJECT_ID: ${{ inputs.vercel-project-id }}
       run: |
         set -euo pipefail
-        if [ -e "$RUNNER_TEMP/mento-vercel-production-candidate-identity" ] || \
-          [ -L "$RUNNER_TEMP/mento-vercel-production-candidate-identity" ] || \
+        if [ -e "$CANDIDATE_IDENTITY_MARKER" ] || \
+          [ -L "$CANDIDATE_IDENTITY_MARKER" ] || \
           /usr/bin/getent passwd mento-vercel-build >/dev/null || \
           /usr/bin/getent group mento-vercel-build >/dev/null; then
           echo "Candidate identity survived the upload handoff" >&2
@@ -596,6 +974,7 @@ runs:
         LOGICAL_TARGET="$LOGICAL_TARGET" \
         MENTO_NEXT_DEPLOYMENT_ID="$MENTO_NEXT_DEPLOYMENT_ID" \
         SOURCE_PATH="$SOURCE_PATH" \
+        VERCEL_ISOLATION_ROOT="$ISOLATION_ROOT" \
         VERCEL_ORG_ID="$VERCEL_ORG_ID" \
         VERCEL_PROJECT_ID="$VERCEL_PROJECT_ID" \
           "$NODE_BIN" "$CONTROLLER_PATH/scripts/vercel-production-shadow.mjs" assert-output

--- a/.github/actions/vercel-protected-runtime/action.yml
+++ b/.github/actions/vercel-protected-runtime/action.yml
@@ -1,100 +1,561 @@
 name: Prepare protected Vercel runtime
-description: Install pinned Node, pnpm, and Vercel CLI files outside candidate control
+description: Prepare or remove a run- and target-bound runtime outside candidate control
 
 inputs:
+  operation:
+    description: Literal prepare or cleanup operation
+    required: false
+    default: prepare
+  logical-target:
+    description: Literal app, governance, reserve, or ui target
+    required: true
   controller-path:
-    description: Trusted workflow-controller checkout
-    required: true
+    description: Trusted workflow-controller checkout, required for prepare
+    required: false
   source-path:
-    description: Runner-owned exact-SHA source checkout used only for cache provenance
-    required: true
-  tools-path:
-    description: Fresh runner-owned path under RUNNER_TEMP for the pinned Vercel CLI
-    required: true
+    description: Runner-owned exact-SHA source checkout, required for prepare
+    required: false
 
 outputs:
+  runtime-root:
+    description: Root-owned run- and target-bound runtime root
+    value: ${{ steps.contract.outputs.runtime_root }}
+  isolation-root:
+    description: Runner-owned cross-identity work directory
+    value: ${{ steps.contract.outputs.isolation_root }}
+  runtime-marker:
+    description: Root-owned authenticated runtime marker
+    value: ${{ steps.contract.outputs.runtime_marker }}
+  tools-path:
+    description: Runner-owned protected Node, pnpm, and Vercel CLI root
+    value: ${{ steps.contract.outputs.tools_path }}
+  pull-staging-path:
+    description: Fixed runner-owned Vercel pull staging path
+    value: ${{ steps.contract.outputs.pull_staging_path }}
+  build-environment-path:
+    description: Fixed runner-owned derived build-environment path
+    value: ${{ steps.contract.outputs.build_environment_path }}
+  candidate-source-path:
+    description: Fixed candidate-owned exact-SHA source path
+    value: ${{ steps.contract.outputs.candidate_source_path }}
+  provenance-path:
+    description: Fixed runner-owned exact-SHA candidate provenance path
+    value: ${{ steps.contract.outputs.provenance_path }}
+  candidate-home-path:
+    description: Fixed candidate-owned home path
+    value: ${{ steps.contract.outputs.candidate_home_path }}
+  upload-source-path:
+    description: Fixed runner-owned immutable upload handoff path
+    value: ${{ steps.contract.outputs.upload_source_path }}
+  candidate-identity-marker:
+    description: Fixed runner-owned candidate identity marker
+    value: ${{ steps.contract.outputs.candidate_identity_marker }}
+  build-log-path:
+    description: Fixed runner-owned candidate build log path
+    value: ${{ steps.contract.outputs.build_log_path }}
   node-bin:
-    description: Canonical protected Node executable
+    description: Independent protected Node executable
     value: ${{ steps.runtime.outputs.node_bin }}
   pnpm-bin:
-    description: Canonical protected pnpm executable
+    description: Protected launcher for the pinned pnpm runtime
     value: ${{ steps.runtime.outputs.pnpm_bin }}
   vercel-cli:
-    description: Canonical protected Vercel CLI entry point
+    description: Protected pinned Vercel CLI entry point
     value: ${{ steps.runtime.outputs.vercel_cli }}
 
 runs:
   using: composite
   steps:
-    - name: Set up pinned pnpm
-      uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v4
-      with:
-        version: 10.34.4
+    - name: Resolve protected runtime contract
+      id: contract
+      shell: bash
+      env:
+        LOGICAL_TARGET: ${{ inputs.logical-target }}
+        OPERATION: ${{ inputs.operation }}
+      run: |
+        set -euo pipefail
+        case "$OPERATION" in
+          prepare|cleanup) ;;
+          *) echo "Protected runtime operation must be prepare or cleanup" >&2; exit 1 ;;
+        esac
+        case "$LOGICAL_TARGET" in
+          app|governance|reserve|ui) ;;
+          *) echo "Unknown protected runtime target" >&2; exit 1 ;;
+        esac
+        if [[ ! "$GITHUB_RUN_ID" =~ ^[1-9][0-9]*$ ]] ||
+          [[ ! "$GITHUB_RUN_ATTEMPT" =~ ^[1-9][0-9]*$ ]]; then
+          echo "GitHub runtime identity is invalid" >&2
+          exit 1
+        fi
+        runtime_root="/var/lib/mento-vercel-runtime-$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT-$LOGICAL_TARGET"
+        isolation_root="$runtime_root/work"
+        runtime_marker="$runtime_root/.mento-vercel-runtime"
+        tools_path="$isolation_root/mento-vercel-trusted-tools"
+        {
+          echo "runtime_root=$runtime_root"
+          echo "isolation_root=$isolation_root"
+          echo "runtime_marker=$runtime_marker"
+          echo "tools_path=$tools_path"
+          echo "pull_staging_path=$isolation_root/mento-vercel-production-pull-staging"
+          echo "build_environment_path=$isolation_root/mento-vercel-production-build-environment"
+          echo "candidate_source_path=$isolation_root/mento-vercel-production-candidate-source"
+          echo "provenance_path=$isolation_root/mento-vercel-production-candidate-source.provenance.json"
+          echo "candidate_home_path=$isolation_root/mento-vercel-production-candidate-home"
+          echo "upload_source_path=$isolation_root/mento-vercel-production-upload-source"
+          echo "candidate_identity_marker=$isolation_root/mento-vercel-production-candidate-identity"
+          echo "build_log_path=$isolation_root/mento-vercel-production-$LOGICAL_TARGET-build.log"
+        } >> "$GITHUB_OUTPUT"
 
-    - name: Set up pinned Node.js and pnpm cache
-      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+    - name: Create protected cross-identity runtime root
+      if: ${{ inputs.operation == 'prepare' }}
+      shell: bash
+      env:
+        ISOLATION_ROOT: ${{ steps.contract.outputs.isolation_root }}
+        LOGICAL_TARGET: ${{ inputs.logical-target }}
+        RUNTIME_MARKER: ${{ steps.contract.outputs.runtime_marker }}
+        RUNTIME_ROOT: ${{ steps.contract.outputs.runtime_root }}
+      run: |
+        set -euo pipefail
+        umask 077
+        expected_root="/var/lib/mento-vercel-runtime-$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT-$LOGICAL_TARGET"
+        if [ "$RUNTIME_ROOT" != "$expected_root" ] ||
+          [ "$ISOLATION_ROOT" != "$expected_root/work" ] ||
+          [ "$RUNTIME_MARKER" != "$expected_root/.mento-vercel-runtime" ]; then
+          echo "Protected runtime paths do not match the trusted identity" >&2
+          exit 1
+        fi
+        if [ -e "$RUNTIME_ROOT" ] || [ -L "$RUNTIME_ROOT" ]; then
+          echo "Protected runtime root must be fresh" >&2
+          exit 1
+        fi
+        for ancestor in / /var /var/lib; do
+          if [ ! -d "$ancestor" ] ||
+            [ -L "$ancestor" ] ||
+            [ "$(/usr/bin/realpath "$ancestor")" != "$ancestor" ] ||
+            [ "$(/usr/bin/stat -c %u "$ancestor")" != 0 ] ||
+            [ "$(/usr/bin/stat -c %g "$ancestor")" != 0 ]; then
+            echo "Protected runtime ancestor is not a real root-owned directory: $ancestor" >&2
+            exit 1
+          fi
+          mode="$((8#$(/usr/bin/stat -c %a "$ancestor")))"
+          if (( (mode & 07022) != 0 || (mode & 0001) == 0 )); then
+            echo "Protected runtime ancestor has unsafe permissions: $ancestor" >&2
+            exit 1
+          fi
+        done
+        sudo --non-interactive /usr/bin/install \
+          -d -o root -g root -m 0711 -- "$RUNTIME_ROOT"
+        sudo --non-interactive /usr/bin/install \
+          -d -o "$(/usr/bin/id -u)" -g "$(/usr/bin/id -g)" -m 0711 -- \
+          "$ISOLATION_ROOT"
+        /usr/bin/printf '%s\n' \
+          "$GITHUB_RUN_ID:$GITHUB_RUN_ATTEMPT:$LOGICAL_TARGET" |
+          sudo --non-interactive /usr/bin/tee "$RUNTIME_MARKER" >/dev/null
+        sudo --non-interactive /bin/chown root:root "$RUNTIME_MARKER"
+        sudo --non-interactive /bin/chmod 0400 "$RUNTIME_MARKER"
+        if [ ! -d "$RUNTIME_ROOT" ] ||
+          [ -L "$RUNTIME_ROOT" ] ||
+          [ "$(sudo --non-interactive /usr/bin/realpath "$RUNTIME_ROOT")" != "$RUNTIME_ROOT" ] ||
+          [ "$(sudo --non-interactive /usr/bin/stat -c %u "$RUNTIME_ROOT")" != 0 ] ||
+          [ "$(sudo --non-interactive /usr/bin/stat -c %g "$RUNTIME_ROOT")" != 0 ] ||
+          [ "$(sudo --non-interactive /usr/bin/stat -c %a "$RUNTIME_ROOT")" != 711 ] ||
+          [ ! -d "$ISOLATION_ROOT" ] ||
+          [ -L "$ISOLATION_ROOT" ] ||
+          [ "$(/usr/bin/realpath "$ISOLATION_ROOT")" != "$ISOLATION_ROOT" ] ||
+          [ "$(/usr/bin/stat -c %u "$ISOLATION_ROOT")" != "$(/usr/bin/id -u)" ] ||
+          [ "$(/usr/bin/stat -c %g "$ISOLATION_ROOT")" != "$(/usr/bin/id -g)" ] ||
+          [ "$(/usr/bin/stat -c %a "$ISOLATION_ROOT")" != 711 ] ||
+          [ ! -f "$RUNTIME_MARKER" ] ||
+          [ -L "$RUNTIME_MARKER" ] ||
+          [ "$(sudo --non-interactive /usr/bin/stat -c %u "$RUNTIME_MARKER")" != 0 ] ||
+          [ "$(sudo --non-interactive /usr/bin/stat -c %g "$RUNTIME_MARKER")" != 0 ] ||
+          [ "$(sudo --non-interactive /usr/bin/stat -c %a "$RUNTIME_MARKER")" != 400 ] ||
+          [ "$(sudo --non-interactive /usr/bin/stat -c %h "$RUNTIME_MARKER")" != 1 ] ||
+          [ "$(sudo --non-interactive /bin/cat "$RUNTIME_MARKER")" != "$GITHUB_RUN_ID:$GITHUB_RUN_ATTEMPT:$LOGICAL_TARGET" ]; then
+          echo "Protected runtime root was not created with the reviewed contract" >&2
+          exit 1
+        fi
+
+    - name: Set up pinned Node.js staging source
+      if: ${{ inputs.operation == 'prepare' }}
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
       with:
         node-version: 22
-        cache: pnpm
-        cache-dependency-path: ${{ inputs.source-path }}/pnpm-lock.yaml
+        package-manager-cache: false
 
-    - name: Materialize protected pinned Vercel CLI
+    - name: Materialize authenticated protected runtime
+      if: ${{ inputs.operation == 'prepare' }}
       id: runtime
       shell: bash
       env:
         CONTROLLER_PATH: ${{ inputs.controller-path }}
+        EXPECTED_PNPM_LINUX_X64_SHA256: e02c01738ce850754cf00111fd97bec24de550e1e963690486f02d9dae1a2193
+        ISOLATION_ROOT: ${{ steps.contract.outputs.isolation_root }}
         SOURCE_PATH: ${{ inputs.source-path }}
-        TRUSTED_VERCEL_TOOLS_PATH: ${{ inputs.tools-path }}
+        TOOLS_PATH: ${{ steps.contract.outputs.tools_path }}
       run: |
         set -euo pipefail
         umask 077
-        controller_path="$(realpath "$CONTROLLER_PATH")"
-        source_path="$(realpath "$SOURCE_PATH")"
-        case "$TRUSTED_VERCEL_TOOLS_PATH" in
-          "$RUNNER_TEMP"/mento-vercel-*) ;;
-          *) echo "Protected Vercel tools path is outside RUNNER_TEMP" >&2; exit 1 ;;
-        esac
-        if [ -e "$TRUSTED_VERCEL_TOOLS_PATH" ]; then
-          echo "Protected Vercel tools path must be fresh" >&2
+        if [ -z "$CONTROLLER_PATH" ] || [ -z "$SOURCE_PATH" ]; then
+          echo "Protected runtime prepare requires controller and source paths" >&2
           exit 1
         fi
-        /usr/bin/install -d -m 0755 "$TRUSTED_VERCEL_TOOLS_PATH"
-        node_bin="$(realpath "$(command -v node)")"
-        pnpm_bin="$(realpath "$(command -v pnpm)")"
-        for path in "$controller_path" "$source_path" "$node_bin" "$pnpm_bin"; do
-          if [ ! -e "$path" ] || [ -L "$path" ]; then
-            echo "Protected runtime prerequisite is missing or symbolic" >&2
+        controller_path="$(/usr/bin/realpath "$CONTROLLER_PATH")"
+        source_path="$(/usr/bin/realpath "$SOURCE_PATH")"
+        if [ -L "$CONTROLLER_PATH" ] || [ ! -d "$controller_path" ] ||
+          [ -L "$SOURCE_PATH" ] || [ ! -d "$source_path" ]; then
+          echo "Protected runtime source paths must be real directories" >&2
+          exit 1
+        fi
+        bootstrap_cache="$ISOLATION_ROOT/mento-vercel-npm-cache"
+        bootstrap_home="$ISOLATION_ROOT/mento-vercel-npm-home"
+        bootstrap_root="$ISOLATION_ROOT/mento-vercel-pnpm-bootstrap"
+        bootstrap_tmp="$ISOLATION_ROOT/mento-vercel-npm-tmp"
+        for path in \
+          "$bootstrap_cache" \
+          "$bootstrap_home" \
+          "$bootstrap_root" \
+          "$bootstrap_tmp" \
+          "$TOOLS_PATH"; do
+          if [ -e "$path" ] || [ -L "$path" ]; then
+            echo "Protected runtime staging path must be fresh: $path" >&2
             exit 1
           fi
         done
+        /usr/bin/install -d -m 0700 \
+          "$bootstrap_cache" \
+          "$bootstrap_home" \
+          "$bootstrap_tmp"
+        /usr/bin/install -m 0600 /dev/null \
+          "$bootstrap_home/global.npmrc"
+        /usr/bin/install -m 0600 /dev/null \
+          "$bootstrap_home/user.npmrc"
+
+        setup_node_bin="$(/usr/bin/realpath "$(type -P node)")"
+        setup_node_bin_dir="$(/usr/bin/dirname "$setup_node_bin")"
+        setup_node_root="$(/usr/bin/realpath "$setup_node_bin_dir/..")"
+        npm_cli="$(/usr/bin/realpath "$(type -P npm)")"
+        case "$npm_cli" in
+          "$setup_node_root"/*) ;;
+          *) echo "Pinned npm CLI escaped the setup-node tool root" >&2; exit 1 ;;
+        esac
+        if [ ! -f "$setup_node_bin" ] || [ -L "$setup_node_bin" ] ||
+          [ ! -f "$npm_cli" ] || [ -L "$npm_cli" ]; then
+          echo "Pinned Node/npm staging source is not a regular file" >&2
+          exit 1
+        fi
+        staged_bootstrap="$(
+          CONTROLLER_PATH="$controller_path" \
+          PNPM_BOOTSTRAP_PATH="$bootstrap_root" \
+          VERCEL_ISOLATION_ROOT="$ISOLATION_ROOT" \
+            "$setup_node_bin" \
+            "$controller_path/scripts/vercel-prebuilt-workflow.mjs" \
+            stage-pnpm-bootstrap
+        )"
+        if [ "$staged_bootstrap" != "$bootstrap_root" ]; then
+          echo "Pinned pnpm bootstrap escaped its fixed staging root" >&2
+          exit 1
+        fi
+        /usr/bin/env -i \
+          HOME="$bootstrap_home" \
+          HTTPS_PROXY="${HTTPS_PROXY:-}" \
+          HTTP_PROXY="${HTTP_PROXY:-}" \
+          LANG="${LANG:-C.UTF-8}" \
+          LC_ALL="${LC_ALL:-C.UTF-8}" \
+          NODE_EXTRA_CA_CERTS="${NODE_EXTRA_CA_CERTS:-}" \
+          NO_PROXY="${NO_PROXY:-}" \
+          NPM_CONFIG_AUDIT=false \
+          NPM_CONFIG_CACHE="$bootstrap_cache" \
+          NPM_CONFIG_FUND=false \
+          NPM_CONFIG_GLOBALCONFIG="$bootstrap_home/global.npmrc" \
+          NPM_CONFIG_IGNORE_SCRIPTS=true \
+          NPM_CONFIG_REGISTRY=https://registry.npmjs.org/ \
+          NPM_CONFIG_UPDATE_NOTIFIER=false \
+          NPM_CONFIG_USERCONFIG="$bootstrap_home/user.npmrc" \
+          PATH="$setup_node_bin_dir:/usr/bin:/bin" \
+          SSL_CERT_FILE="${SSL_CERT_FILE:-}" \
+          TMPDIR="$bootstrap_tmp" \
+          "$setup_node_bin" "$npm_cli" ci \
+            --prefix "$bootstrap_root" \
+            --ignore-scripts \
+            --no-audit \
+            --no-fund \
+            --omit=dev
+        /bin/chmod -R a+rX,go-w "$bootstrap_root"
+        NODE_SOURCE_PATH="$setup_node_bin" \
+        PNPM_BOOTSTRAP_PATH="$bootstrap_root" \
+        VERCEL_ISOLATION_ROOT="$ISOLATION_ROOT" \
+        TRUSTED_VERCEL_TOOLS_PATH="$TOOLS_PATH" \
+          "$setup_node_bin" \
+          "$controller_path/scripts/vercel-prebuilt-workflow.mjs" \
+          stage-runtime
+
+        node_bin="$TOOLS_PATH/bin/node"
+        pnpm_bootstrap="$TOOLS_PATH/bootstrap-bin/pnpm"
+        if [ "$(/usr/bin/sha256sum "$pnpm_bootstrap" | /usr/bin/cut -d ' ' -f1)" != "$EXPECTED_PNPM_LINUX_X64_SHA256" ] ||
+          [ "$("$pnpm_bootstrap" --version)" != 10.34.4 ]; then
+          echo "Protected pnpm bootstrap does not match the reviewed release" >&2
+          exit 1
+        fi
+        pnpm_runtime_root="$(
+          CONTROLLER_PATH="$controller_path" \
+          TRUSTED_VERCEL_TOOLS_PATH="$TOOLS_PATH" \
+            "$node_bin" \
+            "$controller_path/scripts/vercel-prebuilt-workflow.mjs" \
+            stage-pnpm-runtime
+        )"
+        if [ "$pnpm_runtime_root" != "$TOOLS_PATH/pnpm-runtime" ]; then
+          echo "Pinned pnpm runtime escaped the protected tools root" >&2
+          exit 1
+        fi
         trusted_modules_dir="$(
-          /usr/bin/realpath -m \
-            --relative-to="$controller_path" \
-            "$TRUSTED_VERCEL_TOOLS_PATH/node_modules"
+          CONTROLLER_PATH="$controller_path" \
+          TRUSTED_VERCEL_TOOLS_PATH="$TOOLS_PATH" \
+            "$node_bin" \
+            "$controller_path/scripts/vercel-prebuilt-workflow.mjs" \
+            trusted-install-modules-dir
         )"
         if [ -z "$trusted_modules_dir" ] || [[ "$trusted_modules_dir" = /* ]]; then
-          echo "Protected pnpm modules path is not relative" >&2
+          echo "Protected Vercel modules path is not relative" >&2
           exit 1
         fi
         env -u GITHUB_ENV -u GITHUB_OUTPUT -u GITHUB_PATH -u GITHUB_STATE \
           -u GITHUB_STEP_SUMMARY \
-          "$pnpm_bin" --dir "$controller_path" --filter frontend-monorepo install \
-          --frozen-lockfile \
-          --ignore-scripts \
-          --modules-dir "$trusted_modules_dir" \
-          --package-import-method copy \
-          --virtual-store-dir "$trusted_modules_dir/.pnpm"
-        /bin/chmod -R a+rX,go-w "$TRUSTED_VERCEL_TOOLS_PATH"
-        vercel_cli="$(realpath "$TRUSTED_VERCEL_TOOLS_PATH/node_modules/vercel/dist/index.js")"
+          NPM_CONFIG_MANAGE_PACKAGE_MANAGER_VERSIONS=false \
+          NPM_CONFIG_PACKAGE_MANAGER_STRICT_VERSION=false \
+          "$pnpm_bootstrap" --dir "$controller_path" --filter frontend-monorepo install \
+            --frozen-lockfile \
+            --ignore-scripts \
+            --modules-dir "$trusted_modules_dir" \
+            --package-import-method copy \
+            --virtual-store-dir "$trusted_modules_dir/.pnpm"
+        env -u GITHUB_ENV -u GITHUB_OUTPUT -u GITHUB_PATH -u GITHUB_STATE \
+          -u GITHUB_STEP_SUMMARY \
+          NPM_CONFIG_MANAGE_PACKAGE_MANAGER_VERSIONS=false \
+          NPM_CONFIG_PACKAGE_MANAGER_STRICT_VERSION=false \
+          "$pnpm_bootstrap" --dir "$pnpm_runtime_root" install \
+            --frozen-lockfile \
+            --ignore-scripts \
+            --ignore-workspace \
+            --package-import-method copy
+        /bin/chmod -R a+rX,go-w "$TOOLS_PATH"
+        pnpm_bin="$(
+          TRUSTED_VERCEL_TOOLS_PATH="$TOOLS_PATH" \
+            "$node_bin" \
+            "$controller_path/scripts/vercel-prebuilt-workflow.mjs" \
+            stage-pnpm-launcher
+        )"
+        /bin/chmod -R a+rX,go-w "$TOOLS_PATH"
+        vercel_cli="$(
+          /usr/bin/realpath \
+            "$TOOLS_PATH/node_modules/vercel/dist/index.js"
+        )"
         case "$vercel_cli" in
-          "$TRUSTED_VERCEL_TOOLS_PATH"/*) ;;
-          *) echo "Pinned Vercel CLI escaped its protected directory" >&2; exit 1 ;;
+          "$TOOLS_PATH"/*) ;;
+          *) echo "Pinned Vercel CLI escaped the protected tools root" >&2; exit 1 ;;
         esac
-        if [ ! -f "$vercel_cli" ] || [ -L "$vercel_cli" ]; then
-          echo "Pinned Vercel CLI is not a regular file" >&2
+        while IFS= read -r -d '' link_path; do
+          link_target="$(/usr/bin/realpath "$link_path")"
+          case "$link_target" in
+            "$TOOLS_PATH"/*) ;;
+            *) echo "Protected runtime symbolic link escaped the tools root: $link_path" >&2; exit 1 ;;
+          esac
+        done < <(
+          /usr/bin/find "$TOOLS_PATH" -xdev -type l -print0
+        )
+        writable_entry="$(
+          /usr/bin/find "$TOOLS_PATH" \
+            -xdev \
+            \( -type f -o -type d \) \
+            -perm /0022 \
+            -print \
+            -quit
+        )"
+        if [ -n "$writable_entry" ]; then
+          echo "Protected runtime entry is group- or other-writable: $writable_entry" >&2
           exit 1
         fi
+        for directory in \
+          "$TOOLS_PATH" \
+          "$TOOLS_PATH/bin" \
+          "$TOOLS_PATH/bootstrap-bin" \
+          "$TOOLS_PATH/pnpm-runtime"; do
+          if [ ! -d "$directory" ] || [ -L "$directory" ] ||
+            [ "$(/usr/bin/stat -c %u "$directory")" != "$(/usr/bin/id -u)" ] ||
+            [ "$(/usr/bin/stat -c %g "$directory")" != "$(/usr/bin/id -g)" ] ||
+            (( 8#$(/usr/bin/stat -c %a "$directory") & 0022 )); then
+            echo "Protected runtime directory is unsafe: $directory" >&2
+            exit 1
+          fi
+        done
+        for executable in "$node_bin" "$pnpm_bin"; do
+          if [ ! -f "$executable" ] || [ -L "$executable" ] ||
+            [ "$(/usr/bin/stat -c %u "$executable")" != "$(/usr/bin/id -u)" ] ||
+            [ "$(/usr/bin/stat -c %g "$executable")" != "$(/usr/bin/id -g)" ] ||
+            [ "$(/usr/bin/stat -c %h "$executable")" != 1 ] ||
+            [ "$(/usr/bin/stat -c %a "$executable")" != 555 ]; then
+            echo "Protected runtime executable is unsafe: $executable" >&2
+            exit 1
+          fi
+        done
+        if [ ! -f "$vercel_cli" ] || [ -L "$vercel_cli" ] ||
+          [ "$(/usr/bin/stat -c %u "$vercel_cli")" != "$(/usr/bin/id -u)" ] ||
+          [ "$(/usr/bin/stat -c %h "$vercel_cli")" != 1 ] ||
+          (( 8#$(/usr/bin/stat -c %a "$vercel_cli") & 0022 )); then
+          echo "Pinned Vercel CLI entry point is unsafe" >&2
+          exit 1
+        fi
+        "$node_bin" "$controller_path/scripts/vercel-prebuilt.mjs" \
+          check-versions --repo-root "$source_path"
+        [ "$("$pnpm_bin" --version)" = 10.34.4 ]
         "$node_bin" "$vercel_cli" --version >/dev/null
-        echo "node_bin=$node_bin" >> "$GITHUB_OUTPUT"
-        echo "pnpm_bin=$pnpm_bin" >> "$GITHUB_OUTPUT"
-        echo "vercel_cli=$vercel_cli" >> "$GITHUB_OUTPUT"
+
+        /bin/rm -rf -- \
+          "$bootstrap_cache" \
+          "$bootstrap_home" \
+          "$bootstrap_root" \
+          "$bootstrap_tmp"
+        printf '%s\n' "$TOOLS_PATH/bin" >> "$GITHUB_PATH"
+        {
+          echo "node_bin=$node_bin"
+          echo "pnpm_bin=$pnpm_bin"
+          echo "vercel_cli=$vercel_cli"
+        } >> "$GITHUB_OUTPUT"
+
+    - name: Remove authenticated protected runtime
+      if: ${{ inputs.operation == 'cleanup' }}
+      shell: bash
+      env:
+        BUILD_ENVIRONMENT_PATH: ${{ steps.contract.outputs.build_environment_path }}
+        BUILD_LOG_PATH: ${{ steps.contract.outputs.build_log_path }}
+        CANDIDATE_HOME_PATH: ${{ steps.contract.outputs.candidate_home_path }}
+        CANDIDATE_IDENTITY_MARKER: ${{ steps.contract.outputs.candidate_identity_marker }}
+        CANDIDATE_SOURCE_PATH: ${{ steps.contract.outputs.candidate_source_path }}
+        ISOLATION_ROOT: ${{ steps.contract.outputs.isolation_root }}
+        LOGICAL_TARGET: ${{ inputs.logical-target }}
+        PULL_STAGING_PATH: ${{ steps.contract.outputs.pull_staging_path }}
+        RUNTIME_MARKER: ${{ steps.contract.outputs.runtime_marker }}
+        RUNTIME_ROOT: ${{ steps.contract.outputs.runtime_root }}
+        TOOLS_PATH: ${{ steps.contract.outputs.tools_path }}
+        UPLOAD_SOURCE_PATH: ${{ steps.contract.outputs.upload_source_path }}
+      run: |
+        set -euo pipefail
+        if [ ! -e "$RUNTIME_ROOT" ] && [ ! -L "$RUNTIME_ROOT" ]; then
+          echo "Protected runtime root was not created; skipping cleanup"
+          exit 0
+        fi
+        expected_root="/var/lib/mento-vercel-runtime-$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT-$LOGICAL_TARGET"
+        if [ "$RUNTIME_ROOT" != "$expected_root" ] ||
+          [ "$ISOLATION_ROOT" != "$expected_root/work" ] ||
+          [ "$RUNTIME_MARKER" != "$expected_root/.mento-vercel-runtime" ]; then
+          echo "Refusing to clean unexpected protected runtime paths" >&2
+          exit 1
+        fi
+        for ancestor in / /var /var/lib; do
+          if [ ! -d "$ancestor" ] ||
+            [ -L "$ancestor" ] ||
+            [ "$(/usr/bin/realpath "$ancestor")" != "$ancestor" ] ||
+            [ "$(/usr/bin/stat -c %u "$ancestor")" != 0 ] ||
+            [ "$(/usr/bin/stat -c %g "$ancestor")" != 0 ]; then
+            echo "Protected runtime ancestor changed before cleanup: $ancestor" >&2
+            exit 1
+          fi
+          mode="$((8#$(/usr/bin/stat -c %a "$ancestor")))"
+          if (( (mode & 07022) != 0 || (mode & 0001) == 0 )); then
+            echo "Protected runtime ancestor permissions changed before cleanup: $ancestor" >&2
+            exit 1
+          fi
+        done
+        if [ ! -d "$RUNTIME_ROOT" ] ||
+          [ -L "$RUNTIME_ROOT" ] ||
+          [ "$(sudo --non-interactive /usr/bin/realpath "$RUNTIME_ROOT")" != "$RUNTIME_ROOT" ] ||
+          [ "$(sudo --non-interactive /usr/bin/stat -c %u "$RUNTIME_ROOT")" != 0 ] ||
+          [ "$(sudo --non-interactive /usr/bin/stat -c %g "$RUNTIME_ROOT")" != 0 ] ||
+          [ "$(sudo --non-interactive /usr/bin/stat -c %a "$RUNTIME_ROOT")" != 711 ] ||
+          [ ! -d "$ISOLATION_ROOT" ] ||
+          [ -L "$ISOLATION_ROOT" ] ||
+          [ "$(/usr/bin/realpath "$ISOLATION_ROOT")" != "$ISOLATION_ROOT" ] ||
+          [ "$(/usr/bin/stat -c %u "$ISOLATION_ROOT")" != "$(/usr/bin/id -u)" ] ||
+          [ "$(/usr/bin/stat -c %g "$ISOLATION_ROOT")" != "$(/usr/bin/id -g)" ] ||
+          [ "$(/usr/bin/stat -c %a "$ISOLATION_ROOT")" != 711 ] ||
+          [ ! -f "$RUNTIME_MARKER" ] ||
+          [ -L "$RUNTIME_MARKER" ] ||
+          [ "$(sudo --non-interactive /usr/bin/stat -c %u "$RUNTIME_MARKER")" != 0 ] ||
+          [ "$(sudo --non-interactive /usr/bin/stat -c %g "$RUNTIME_MARKER")" != 0 ] ||
+          [ "$(sudo --non-interactive /usr/bin/stat -c %a "$RUNTIME_MARKER")" != 400 ] ||
+          [ "$(sudo --non-interactive /usr/bin/stat -c %h "$RUNTIME_MARKER")" != 1 ] ||
+          [ "$(sudo --non-interactive /bin/cat "$RUNTIME_MARKER")" != "$GITHUB_RUN_ID:$GITHUB_RUN_ATTEMPT:$LOGICAL_TARGET" ]; then
+          echo "Protected runtime root failed cleanup authentication" >&2
+          exit 1
+        fi
+        top_entries="$(
+          sudo --non-interactive /usr/bin/find "$RUNTIME_ROOT" \
+            -mindepth 1 -maxdepth 1 -printf '%f\n' |
+            LC_ALL=C /usr/bin/sort
+        )"
+        if [ "$top_entries" != $'.mento-vercel-runtime\nwork' ]; then
+          echo "Protected runtime root contains unexpected top-level state" >&2
+          exit 1
+        fi
+        if /usr/bin/getent passwd mento-vercel-build >/dev/null; then
+          candidate_uid="$(/usr/bin/id -u mento-vercel-build)"
+          if sudo --non-interactive /usr/bin/pgrep -u "$candidate_uid" >/dev/null 2>&1; then
+            echo "Candidate processes survived before runtime cleanup" >&2
+          fi
+          echo "Candidate user survived before runtime cleanup" >&2
+          exit 1
+        fi
+        if /usr/bin/getent group mento-vercel-build >/dev/null ||
+          [ -e "$CANDIDATE_IDENTITY_MARKER" ] ||
+          [ -L "$CANDIDATE_IDENTITY_MARKER" ]; then
+          echo "Candidate execution boundary survived before runtime cleanup" >&2
+          exit 1
+        fi
+        while IFS= read -r entry; do
+          case "$entry" in
+            mento-vercel-trusted-tools|\
+            mento-vercel-npm-cache|\
+            mento-vercel-npm-home|\
+            mento-vercel-pnpm-bootstrap|\
+            mento-vercel-npm-tmp|\
+            mento-vercel-production-pull-staging|\
+            mento-vercel-production-build-environment|\
+            mento-vercel-production-candidate-source|\
+            mento-vercel-production-candidate-source.provenance.json|\
+            mento-vercel-production-candidate-home|\
+            mento-vercel-production-upload-source|\
+            mento-vercel-production-upload-source.provenance.json|\
+            "mento-vercel-production-$LOGICAL_TARGET-build.log") ;;
+            *) echo "Protected work root contains unexpected state: $entry" >&2; exit 1 ;;
+          esac
+        done < <(
+          sudo --non-interactive /usr/bin/find "$ISOLATION_ROOT" \
+            -mindepth 1 -maxdepth 1 -printf '%f\n' |
+            LC_ALL=C /usr/bin/sort
+        )
+        sudo --non-interactive /bin/rm \
+          -rf \
+          --one-file-system \
+          -- \
+          "$ISOLATION_ROOT/mento-vercel-npm-cache" \
+          "$ISOLATION_ROOT/mento-vercel-npm-home" \
+          "$ISOLATION_ROOT/mento-vercel-pnpm-bootstrap" \
+          "$ISOLATION_ROOT/mento-vercel-npm-tmp" \
+          "$TOOLS_PATH" \
+          "$PULL_STAGING_PATH" \
+          "$BUILD_ENVIRONMENT_PATH" \
+          "$CANDIDATE_SOURCE_PATH" \
+          "$CANDIDATE_HOME_PATH" \
+          "$UPLOAD_SOURCE_PATH"
+        sudo --non-interactive /bin/rm -f -- \
+          "${CANDIDATE_SOURCE_PATH}.provenance.json" \
+          "${UPLOAD_SOURCE_PATH}.provenance.json" \
+          "$BUILD_LOG_PATH"
+        sudo --non-interactive /bin/rmdir "$ISOLATION_ROOT"
+        sudo --non-interactive /bin/rm -f -- "$RUNTIME_MARKER"
+        sudo --non-interactive /bin/rmdir "$RUNTIME_ROOT"
+        if sudo --non-interactive /usr/bin/test -e "$RUNTIME_ROOT" ||
+          sudo --non-interactive /usr/bin/test -L "$RUNTIME_ROOT"; then
+          echo "Protected runtime root survived cleanup" >&2
+          exit 1
+        fi

--- a/.github/workflows/vercel-production-shadow.yml
+++ b/.github/workflows/vercel-production-shadow.yml
@@ -180,9 +180,10 @@ jobs:
         id: runtime
         uses: ./.github/actions/vercel-protected-runtime
         with:
+          operation: prepare
+          logical-target: app
           controller-path: ${{ github.workspace }}
           source-path: ${{ github.workspace }}/source
-          tools-path: ${{ runner.temp }}/mento-vercel-production-tools
 
       - name: Verify pinned Vercel prerequisites
         run: ${{ steps.runtime.outputs.node-bin }} scripts/vercel-prebuilt.mjs check-versions --repo-root "$SOURCE_PATH"
@@ -190,8 +191,9 @@ jobs:
       - name: Prepare runner-owned app pull staging
         env:
           LOGICAL_TARGET: app
-          PULL_STAGING_PATH: ${{ runner.temp }}/mento-vercel-production-pull-staging
-          SOURCE_PATH: ${{ runner.temp }}/mento-vercel-production-pull-staging
+          PULL_STAGING_PATH: ${{ steps.runtime.outputs.pull-staging-path }}
+          SOURCE_PATH: ${{ steps.runtime.outputs.pull-staging-path }}
+          VERCEL_ISOLATION_ROOT: ${{ steps.runtime.outputs.isolation-root }}
           VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ vars.VERCEL_PROJECT_ID_APP }}
         run: ${{ steps.runtime.outputs.node-bin }} scripts/vercel-production-shadow.mjs prepare-pull-staging
@@ -199,7 +201,7 @@ jobs:
       - name: Pull app custom-v3 configuration
         env:
           LOGICAL_TARGET: app
-          SOURCE_PATH: ${{ runner.temp }}/mento-vercel-production-pull-staging
+          SOURCE_PATH: ${{ steps.runtime.outputs.pull-staging-path }}
           TRUSTED_NODE_PATH: ${{ steps.runtime.outputs.node-bin }}
           TRUSTED_VERCEL_CLI_PATH: ${{ steps.runtime.outputs.vercel-cli }}
           VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
@@ -210,8 +212,9 @@ jobs:
       - name: Validate app project link and Root Directory
         env:
           LOGICAL_TARGET: app
-          PULL_STAGING_PATH: ${{ runner.temp }}/mento-vercel-production-pull-staging
-          SOURCE_PATH: ${{ runner.temp }}/mento-vercel-production-pull-staging
+          PULL_STAGING_PATH: ${{ steps.runtime.outputs.pull-staging-path }}
+          SOURCE_PATH: ${{ steps.runtime.outputs.pull-staging-path }}
+          VERCEL_ISOLATION_ROOT: ${{ steps.runtime.outputs.isolation-root }}
           VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ vars.VERCEL_PROJECT_ID_APP }}
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN_PRODUCTION }}
@@ -251,10 +254,18 @@ jobs:
         with:
           controller-path: ${{ github.workspace }}
           source-path: ${{ github.workspace }}/source
-          candidate-source-path: ${{ runner.temp }}/mento-vercel-production-candidate-source
-          candidate-home-path: ${{ runner.temp }}/mento-vercel-production-candidate-home
-          pull-staging-path: ${{ runner.temp }}/mento-vercel-production-pull-staging
-          upload-source-path: ${{ runner.temp }}/mento-vercel-production-upload-source
+          runtime-root: ${{ steps.runtime.outputs.runtime-root }}
+          isolation-root: ${{ steps.runtime.outputs.isolation-root }}
+          runtime-marker: ${{ steps.runtime.outputs.runtime-marker }}
+          tools-path: ${{ steps.runtime.outputs.tools-path }}
+          build-environment-path: ${{ steps.runtime.outputs.build-environment-path }}
+          candidate-source-path: ${{ steps.runtime.outputs.candidate-source-path }}
+          candidate-home-path: ${{ steps.runtime.outputs.candidate-home-path }}
+          pull-staging-path: ${{ steps.runtime.outputs.pull-staging-path }}
+          candidate-identity-marker: ${{ steps.runtime.outputs.candidate-identity-marker }}
+          build-log-path: ${{ steps.runtime.outputs.build-log-path }}
+          provenance-path: ${{ steps.runtime.outputs.provenance-path }}
+          upload-source-path: ${{ steps.runtime.outputs.upload-source-path }}
           node-bin: ${{ steps.runtime.outputs.node-bin }}
           pnpm-bin: ${{ steps.runtime.outputs.pnpm-bin }}
           vercel-cli: ${{ steps.runtime.outputs.vercel-cli }}
@@ -278,16 +289,23 @@ jobs:
           DEPLOY_SHA: ${{ needs.preflight.outputs.deploy_sha }}
           MENTO_NEXT_DEPLOYMENT_ID: ${{ steps.identity.outputs.next_deployment_id }}
         run: |
-          node "$TRUSTED_POST_BUILD_PATH/scripts/vercel-production-shadow.mjs" app-proof --output "$RUNNER_TEMP/app-proof.json"
+          "${{ steps.runtime.outputs.node-bin }}" "$TRUSTED_POST_BUILD_PATH/scripts/vercel-production-shadow.mjs" app-proof --output "$RUNNER_TEMP/app-proof.json"
           set -o noclobber
           printf '["%s"]\n' "$RUNNER_TEMP/app-proof.json" > "$RUNNER_TEMP/evidence-files.json"
-          node "$TRUSTED_POST_BUILD_PATH/scripts/vercel-production-shadow.mjs" evidence --files "$RUNNER_TEMP/evidence-files.json"
+          "${{ steps.runtime.outputs.node-bin }}" "$TRUSTED_POST_BUILD_PATH/scripts/vercel-production-shadow.mjs" evidence --files "$RUNNER_TEMP/evidence-files.json"
 
       - name: Measure app job duration
         id: total
         env:
           STARTED_AT_MS: ${{ steps.timing.outputs.started_at_ms }}
         run: echo "total_duration_ms=$(($(date +%s%3N) - STARTED_AT_MS))" >> "$GITHUB_OUTPUT"
+
+      - name: Remove authenticated app runtime
+        if: ${{ always() }}
+        uses: ./.github/actions/vercel-protected-runtime
+        with:
+          operation: cleanup
+          logical-target: app
 
   governance:
     name: Stage governance production
@@ -335,23 +353,25 @@ jobs:
         id: runtime
         uses: ./.github/actions/vercel-protected-runtime
         with:
+          operation: prepare
+          logical-target: governance
           controller-path: ${{ github.workspace }}
           source-path: ${{ github.workspace }}/source
-          tools-path: ${{ runner.temp }}/mento-vercel-production-tools
       - name: Verify pinned Vercel prerequisites
         run: ${{ steps.runtime.outputs.node-bin }} scripts/vercel-prebuilt.mjs check-versions --repo-root "$SOURCE_PATH"
       - name: Prepare runner-owned governance pull staging
         env:
           LOGICAL_TARGET: governance
-          PULL_STAGING_PATH: ${{ runner.temp }}/mento-vercel-production-pull-staging
-          SOURCE_PATH: ${{ runner.temp }}/mento-vercel-production-pull-staging
+          PULL_STAGING_PATH: ${{ steps.runtime.outputs.pull-staging-path }}
+          SOURCE_PATH: ${{ steps.runtime.outputs.pull-staging-path }}
+          VERCEL_ISOLATION_ROOT: ${{ steps.runtime.outputs.isolation-root }}
           VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ vars.VERCEL_PROJECT_ID_GOVERNANCE }}
         run: ${{ steps.runtime.outputs.node-bin }} scripts/vercel-production-shadow.mjs prepare-pull-staging
       - name: Pull governance production configuration
         env:
           LOGICAL_TARGET: governance
-          SOURCE_PATH: ${{ runner.temp }}/mento-vercel-production-pull-staging
+          SOURCE_PATH: ${{ steps.runtime.outputs.pull-staging-path }}
           TRUSTED_NODE_PATH: ${{ steps.runtime.outputs.node-bin }}
           TRUSTED_VERCEL_CLI_PATH: ${{ steps.runtime.outputs.vercel-cli }}
           VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
@@ -361,8 +381,9 @@ jobs:
       - name: Validate governance project link and Root Directory
         env:
           LOGICAL_TARGET: governance
-          PULL_STAGING_PATH: ${{ runner.temp }}/mento-vercel-production-pull-staging
-          SOURCE_PATH: ${{ runner.temp }}/mento-vercel-production-pull-staging
+          PULL_STAGING_PATH: ${{ steps.runtime.outputs.pull-staging-path }}
+          SOURCE_PATH: ${{ steps.runtime.outputs.pull-staging-path }}
+          VERCEL_ISOLATION_ROOT: ${{ steps.runtime.outputs.isolation-root }}
           VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ vars.VERCEL_PROJECT_ID_GOVERNANCE }}
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN_PRODUCTION }}
@@ -402,10 +423,18 @@ jobs:
         with:
           controller-path: ${{ github.workspace }}
           source-path: ${{ github.workspace }}/source
-          candidate-source-path: ${{ runner.temp }}/mento-vercel-production-candidate-source
-          candidate-home-path: ${{ runner.temp }}/mento-vercel-production-candidate-home
-          pull-staging-path: ${{ runner.temp }}/mento-vercel-production-pull-staging
-          upload-source-path: ${{ runner.temp }}/mento-vercel-production-upload-source
+          runtime-root: ${{ steps.runtime.outputs.runtime-root }}
+          isolation-root: ${{ steps.runtime.outputs.isolation-root }}
+          runtime-marker: ${{ steps.runtime.outputs.runtime-marker }}
+          tools-path: ${{ steps.runtime.outputs.tools-path }}
+          build-environment-path: ${{ steps.runtime.outputs.build-environment-path }}
+          candidate-source-path: ${{ steps.runtime.outputs.candidate-source-path }}
+          candidate-home-path: ${{ steps.runtime.outputs.candidate-home-path }}
+          pull-staging-path: ${{ steps.runtime.outputs.pull-staging-path }}
+          candidate-identity-marker: ${{ steps.runtime.outputs.candidate-identity-marker }}
+          build-log-path: ${{ steps.runtime.outputs.build-log-path }}
+          provenance-path: ${{ steps.runtime.outputs.provenance-path }}
+          upload-source-path: ${{ steps.runtime.outputs.upload-source-path }}
           node-bin: ${{ steps.runtime.outputs.node-bin }}
           pnpm-bin: ${{ steps.runtime.outputs.pnpm-bin }}
           vercel-cli: ${{ steps.runtime.outputs.vercel-cli }}
@@ -428,13 +457,13 @@ jobs:
         env:
           DEPLOY_SHA: ${{ needs.preflight.outputs.deploy_sha }}
           LOGICAL_TARGET: governance
-          SOURCE_PATH: ${{ runner.temp }}/mento-vercel-production-upload-source
+          SOURCE_PATH: ${{ steps.runtime.outputs.upload-source-path }}
           TRUSTED_NODE_PATH: ${{ steps.runtime.outputs.node-bin }}
           TRUSTED_VERCEL_CLI_PATH: ${{ steps.runtime.outputs.vercel-cli }}
           VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ vars.VERCEL_PROJECT_ID_GOVERNANCE }}
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN_PRODUCTION }}
-        run: node "$TRUSTED_POST_BUILD_PATH/scripts/vercel-production-shadow.mjs" deploy --expected "$RUNNER_TEMP/governance-expected.json"
+        run: ${{ steps.runtime.outputs.node-bin }} "$TRUSTED_POST_BUILD_PATH/scripts/vercel-production-shadow.mjs" deploy --expected "$RUNNER_TEMP/governance-expected.json"
       - name: Fail read-only on protected alias drift after governance deploy
         if: ${{ always() && steps.build.outcome == 'success' && steps.trusted.outcome == 'success' }}
         env:
@@ -442,7 +471,7 @@ jobs:
           VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN_PRODUCTION }}
         run: >-
-          node "$TRUSTED_POST_BUILD_PATH/scripts/vercel-production-shadow.mjs"
+          "${{ steps.runtime.outputs.node-bin }}" "$TRUSTED_POST_BUILD_PATH/scripts/vercel-production-shadow.mjs"
           check-aliases
       - name: Prove every protected mapping remains unchanged
         env:
@@ -458,9 +487,9 @@ jobs:
           umask 077
           set -o noclobber
           printf '%s\n' "$BASELINE_JSON" > "$RUNNER_TEMP/governance-compare-baseline.json"
-          node "$TRUSTED_POST_BUILD_PATH/scripts/vercel-production-shadow.mjs" create-spec --output "$RUNNER_TEMP/protected-spec.json"
-          node "$TRUSTED_POST_BUILD_PATH/scripts/vercel-deployment-state.mjs" snapshot --spec "$RUNNER_TEMP/protected-spec.json" --output "$RUNNER_TEMP/current.json"
-          node "$TRUSTED_POST_BUILD_PATH/scripts/vercel-deployment-state.mjs" compare --before "$RUNNER_TEMP/governance-compare-baseline.json" --after "$RUNNER_TEMP/current.json"
+          "${{ steps.runtime.outputs.node-bin }}" "$TRUSTED_POST_BUILD_PATH/scripts/vercel-production-shadow.mjs" create-spec --output "$RUNNER_TEMP/protected-spec.json"
+          "${{ steps.runtime.outputs.node-bin }}" "$TRUSTED_POST_BUILD_PATH/scripts/vercel-deployment-state.mjs" snapshot --spec "$RUNNER_TEMP/protected-spec.json" --output "$RUNNER_TEMP/current.json"
+          "${{ steps.runtime.outputs.node-bin }}" "$TRUSTED_POST_BUILD_PATH/scripts/vercel-deployment-state.mjs" compare --before "$RUNNER_TEMP/governance-compare-baseline.json" --after "$RUNNER_TEMP/current.json"
       - name: Verify governance deployment provenance and readiness
         env:
           VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
@@ -469,21 +498,29 @@ jobs:
           verified=false
           for attempt in {1..12}; do
             echo "Verifying governance deployment (attempt $attempt/12)"
-            if node "$TRUSTED_POST_BUILD_PATH/scripts/vercel-deployment-state.mjs" deployment --expected "$RUNNER_TEMP/governance-expected.json" --output "$RUNNER_TEMP/governance-state.json"; then verified=true; break; fi
+            if "${{ steps.runtime.outputs.node-bin }}" "$TRUSTED_POST_BUILD_PATH/scripts/vercel-deployment-state.mjs" deployment --expected "$RUNNER_TEMP/governance-expected.json" --output "$RUNNER_TEMP/governance-state.json"; then verified=true; break; fi
             sleep 5
           done
           "$verified"
-          node "$TRUSTED_POST_BUILD_PATH/scripts/vercel-production-shadow.mjs" assert-unaliased --input "$RUNNER_TEMP/governance-state.json"
+          "${{ steps.runtime.outputs.node-bin }}" "$TRUSTED_POST_BUILD_PATH/scripts/vercel-production-shadow.mjs" assert-unaliased --input "$RUNNER_TEMP/governance-state.json"
       - name: Scan governance canonical evidence
         run: |
           set -o noclobber
           printf '["%s","%s"]\n' "$RUNNER_TEMP/governance-state.json" "$RUNNER_TEMP/current.json" > "$RUNNER_TEMP/evidence-files.json"
-          node "$TRUSTED_POST_BUILD_PATH/scripts/vercel-production-shadow.mjs" evidence --files "$RUNNER_TEMP/evidence-files.json"
+          "${{ steps.runtime.outputs.node-bin }}" "$TRUSTED_POST_BUILD_PATH/scripts/vercel-production-shadow.mjs" evidence --files "$RUNNER_TEMP/evidence-files.json"
       - name: Measure governance job duration
         id: total
         env:
           STARTED_AT_MS: ${{ steps.timing.outputs.started_at_ms }}
         run: echo "total_duration_ms=$(($(date +%s%3N) - STARTED_AT_MS))" >> "$GITHUB_OUTPUT"
+
+      - name: Remove authenticated governance runtime
+        if: ${{ always() }}
+        uses: ./.github/actions/vercel-protected-runtime
+        with:
+          operation: cleanup
+          logical-target: governance
+
   reserve:
     name: Stage reserve production
     needs: [preflight, baseline, governance, smoke-governance]
@@ -530,23 +567,25 @@ jobs:
         id: runtime
         uses: ./.github/actions/vercel-protected-runtime
         with:
+          operation: prepare
+          logical-target: reserve
           controller-path: ${{ github.workspace }}
           source-path: ${{ github.workspace }}/source
-          tools-path: ${{ runner.temp }}/mento-vercel-production-tools
       - name: Verify pinned Vercel prerequisites
         run: ${{ steps.runtime.outputs.node-bin }} scripts/vercel-prebuilt.mjs check-versions --repo-root "$SOURCE_PATH"
       - name: Prepare runner-owned reserve pull staging
         env:
           LOGICAL_TARGET: reserve
-          PULL_STAGING_PATH: ${{ runner.temp }}/mento-vercel-production-pull-staging
-          SOURCE_PATH: ${{ runner.temp }}/mento-vercel-production-pull-staging
+          PULL_STAGING_PATH: ${{ steps.runtime.outputs.pull-staging-path }}
+          SOURCE_PATH: ${{ steps.runtime.outputs.pull-staging-path }}
+          VERCEL_ISOLATION_ROOT: ${{ steps.runtime.outputs.isolation-root }}
           VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ vars.VERCEL_PROJECT_ID_RESERVE }}
         run: ${{ steps.runtime.outputs.node-bin }} scripts/vercel-production-shadow.mjs prepare-pull-staging
       - name: Pull reserve production configuration
         env:
           LOGICAL_TARGET: reserve
-          SOURCE_PATH: ${{ runner.temp }}/mento-vercel-production-pull-staging
+          SOURCE_PATH: ${{ steps.runtime.outputs.pull-staging-path }}
           TRUSTED_NODE_PATH: ${{ steps.runtime.outputs.node-bin }}
           TRUSTED_VERCEL_CLI_PATH: ${{ steps.runtime.outputs.vercel-cli }}
           VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
@@ -556,8 +595,9 @@ jobs:
       - name: Validate reserve project link and Root Directory
         env:
           LOGICAL_TARGET: reserve
-          PULL_STAGING_PATH: ${{ runner.temp }}/mento-vercel-production-pull-staging
-          SOURCE_PATH: ${{ runner.temp }}/mento-vercel-production-pull-staging
+          PULL_STAGING_PATH: ${{ steps.runtime.outputs.pull-staging-path }}
+          SOURCE_PATH: ${{ steps.runtime.outputs.pull-staging-path }}
+          VERCEL_ISOLATION_ROOT: ${{ steps.runtime.outputs.isolation-root }}
           VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ vars.VERCEL_PROJECT_ID_RESERVE }}
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN_PRODUCTION }}
@@ -596,10 +636,18 @@ jobs:
         with:
           controller-path: ${{ github.workspace }}
           source-path: ${{ github.workspace }}/source
-          candidate-source-path: ${{ runner.temp }}/mento-vercel-production-candidate-source
-          candidate-home-path: ${{ runner.temp }}/mento-vercel-production-candidate-home
-          pull-staging-path: ${{ runner.temp }}/mento-vercel-production-pull-staging
-          upload-source-path: ${{ runner.temp }}/mento-vercel-production-upload-source
+          runtime-root: ${{ steps.runtime.outputs.runtime-root }}
+          isolation-root: ${{ steps.runtime.outputs.isolation-root }}
+          runtime-marker: ${{ steps.runtime.outputs.runtime-marker }}
+          tools-path: ${{ steps.runtime.outputs.tools-path }}
+          build-environment-path: ${{ steps.runtime.outputs.build-environment-path }}
+          candidate-source-path: ${{ steps.runtime.outputs.candidate-source-path }}
+          candidate-home-path: ${{ steps.runtime.outputs.candidate-home-path }}
+          pull-staging-path: ${{ steps.runtime.outputs.pull-staging-path }}
+          candidate-identity-marker: ${{ steps.runtime.outputs.candidate-identity-marker }}
+          build-log-path: ${{ steps.runtime.outputs.build-log-path }}
+          provenance-path: ${{ steps.runtime.outputs.provenance-path }}
+          upload-source-path: ${{ steps.runtime.outputs.upload-source-path }}
           node-bin: ${{ steps.runtime.outputs.node-bin }}
           pnpm-bin: ${{ steps.runtime.outputs.pnpm-bin }}
           vercel-cli: ${{ steps.runtime.outputs.vercel-cli }}
@@ -622,13 +670,13 @@ jobs:
         env:
           DEPLOY_SHA: ${{ needs.preflight.outputs.deploy_sha }}
           LOGICAL_TARGET: reserve
-          SOURCE_PATH: ${{ runner.temp }}/mento-vercel-production-upload-source
+          SOURCE_PATH: ${{ steps.runtime.outputs.upload-source-path }}
           TRUSTED_NODE_PATH: ${{ steps.runtime.outputs.node-bin }}
           TRUSTED_VERCEL_CLI_PATH: ${{ steps.runtime.outputs.vercel-cli }}
           VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ vars.VERCEL_PROJECT_ID_RESERVE }}
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN_PRODUCTION }}
-        run: node "$TRUSTED_POST_BUILD_PATH/scripts/vercel-production-shadow.mjs" deploy --expected "$RUNNER_TEMP/reserve-expected.json"
+        run: ${{ steps.runtime.outputs.node-bin }} "$TRUSTED_POST_BUILD_PATH/scripts/vercel-production-shadow.mjs" deploy --expected "$RUNNER_TEMP/reserve-expected.json"
       - name: Fail read-only on protected alias drift after reserve deploy
         if: ${{ always() && steps.build.outcome == 'success' && steps.trusted.outcome == 'success' }}
         env:
@@ -636,7 +684,7 @@ jobs:
           VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN_PRODUCTION }}
         run: >-
-          node "$TRUSTED_POST_BUILD_PATH/scripts/vercel-production-shadow.mjs"
+          "${{ steps.runtime.outputs.node-bin }}" "$TRUSTED_POST_BUILD_PATH/scripts/vercel-production-shadow.mjs"
           check-aliases
       - name: Prove every protected mapping remains unchanged
         env:
@@ -652,9 +700,9 @@ jobs:
           umask 077
           set -o noclobber
           printf '%s\n' "$BASELINE_JSON" > "$RUNNER_TEMP/reserve-compare-baseline.json"
-          node "$TRUSTED_POST_BUILD_PATH/scripts/vercel-production-shadow.mjs" create-spec --output "$RUNNER_TEMP/protected-spec.json"
-          node "$TRUSTED_POST_BUILD_PATH/scripts/vercel-deployment-state.mjs" snapshot --spec "$RUNNER_TEMP/protected-spec.json" --output "$RUNNER_TEMP/current.json"
-          node "$TRUSTED_POST_BUILD_PATH/scripts/vercel-deployment-state.mjs" compare --before "$RUNNER_TEMP/reserve-compare-baseline.json" --after "$RUNNER_TEMP/current.json"
+          "${{ steps.runtime.outputs.node-bin }}" "$TRUSTED_POST_BUILD_PATH/scripts/vercel-production-shadow.mjs" create-spec --output "$RUNNER_TEMP/protected-spec.json"
+          "${{ steps.runtime.outputs.node-bin }}" "$TRUSTED_POST_BUILD_PATH/scripts/vercel-deployment-state.mjs" snapshot --spec "$RUNNER_TEMP/protected-spec.json" --output "$RUNNER_TEMP/current.json"
+          "${{ steps.runtime.outputs.node-bin }}" "$TRUSTED_POST_BUILD_PATH/scripts/vercel-deployment-state.mjs" compare --before "$RUNNER_TEMP/reserve-compare-baseline.json" --after "$RUNNER_TEMP/current.json"
       - name: Verify reserve deployment provenance and readiness
         env:
           VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
@@ -663,21 +711,29 @@ jobs:
           verified=false
           for attempt in {1..12}; do
             echo "Verifying reserve deployment (attempt $attempt/12)"
-            if node "$TRUSTED_POST_BUILD_PATH/scripts/vercel-deployment-state.mjs" deployment --expected "$RUNNER_TEMP/reserve-expected.json" --output "$RUNNER_TEMP/reserve-state.json"; then verified=true; break; fi
+            if "${{ steps.runtime.outputs.node-bin }}" "$TRUSTED_POST_BUILD_PATH/scripts/vercel-deployment-state.mjs" deployment --expected "$RUNNER_TEMP/reserve-expected.json" --output "$RUNNER_TEMP/reserve-state.json"; then verified=true; break; fi
             sleep 5
           done
           "$verified"
-          node "$TRUSTED_POST_BUILD_PATH/scripts/vercel-production-shadow.mjs" assert-unaliased --input "$RUNNER_TEMP/reserve-state.json"
+          "${{ steps.runtime.outputs.node-bin }}" "$TRUSTED_POST_BUILD_PATH/scripts/vercel-production-shadow.mjs" assert-unaliased --input "$RUNNER_TEMP/reserve-state.json"
       - name: Scan reserve canonical evidence
         run: |
           set -o noclobber
           printf '["%s","%s"]\n' "$RUNNER_TEMP/reserve-state.json" "$RUNNER_TEMP/current.json" > "$RUNNER_TEMP/evidence-files.json"
-          node "$TRUSTED_POST_BUILD_PATH/scripts/vercel-production-shadow.mjs" evidence --files "$RUNNER_TEMP/evidence-files.json"
+          "${{ steps.runtime.outputs.node-bin }}" "$TRUSTED_POST_BUILD_PATH/scripts/vercel-production-shadow.mjs" evidence --files "$RUNNER_TEMP/evidence-files.json"
       - name: Measure reserve job duration
         id: total
         env:
           STARTED_AT_MS: ${{ steps.timing.outputs.started_at_ms }}
         run: echo "total_duration_ms=$(($(date +%s%3N) - STARTED_AT_MS))" >> "$GITHUB_OUTPUT"
+
+      - name: Remove authenticated reserve runtime
+        if: ${{ always() }}
+        uses: ./.github/actions/vercel-protected-runtime
+        with:
+          operation: cleanup
+          logical-target: reserve
+
   ui:
     name: Stage UI production
     needs: [preflight, baseline, governance, reserve, smoke-reserve]
@@ -724,23 +780,25 @@ jobs:
         id: runtime
         uses: ./.github/actions/vercel-protected-runtime
         with:
+          operation: prepare
+          logical-target: ui
           controller-path: ${{ github.workspace }}
           source-path: ${{ github.workspace }}/source
-          tools-path: ${{ runner.temp }}/mento-vercel-production-tools
       - name: Verify pinned Vercel prerequisites
         run: ${{ steps.runtime.outputs.node-bin }} scripts/vercel-prebuilt.mjs check-versions --repo-root "$SOURCE_PATH"
       - name: Prepare runner-owned UI pull staging
         env:
           LOGICAL_TARGET: ui
-          PULL_STAGING_PATH: ${{ runner.temp }}/mento-vercel-production-pull-staging
-          SOURCE_PATH: ${{ runner.temp }}/mento-vercel-production-pull-staging
+          PULL_STAGING_PATH: ${{ steps.runtime.outputs.pull-staging-path }}
+          SOURCE_PATH: ${{ steps.runtime.outputs.pull-staging-path }}
+          VERCEL_ISOLATION_ROOT: ${{ steps.runtime.outputs.isolation-root }}
           VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ vars.VERCEL_PROJECT_ID_UI }}
         run: ${{ steps.runtime.outputs.node-bin }} scripts/vercel-production-shadow.mjs prepare-pull-staging
       - name: Pull UI production configuration
         env:
           LOGICAL_TARGET: ui
-          SOURCE_PATH: ${{ runner.temp }}/mento-vercel-production-pull-staging
+          SOURCE_PATH: ${{ steps.runtime.outputs.pull-staging-path }}
           TRUSTED_NODE_PATH: ${{ steps.runtime.outputs.node-bin }}
           TRUSTED_VERCEL_CLI_PATH: ${{ steps.runtime.outputs.vercel-cli }}
           VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
@@ -750,8 +808,9 @@ jobs:
       - name: Validate UI project link and Root Directory
         env:
           LOGICAL_TARGET: ui
-          PULL_STAGING_PATH: ${{ runner.temp }}/mento-vercel-production-pull-staging
-          SOURCE_PATH: ${{ runner.temp }}/mento-vercel-production-pull-staging
+          PULL_STAGING_PATH: ${{ steps.runtime.outputs.pull-staging-path }}
+          SOURCE_PATH: ${{ steps.runtime.outputs.pull-staging-path }}
+          VERCEL_ISOLATION_ROOT: ${{ steps.runtime.outputs.isolation-root }}
           VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ vars.VERCEL_PROJECT_ID_UI }}
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN_PRODUCTION }}
@@ -789,10 +848,18 @@ jobs:
         with:
           controller-path: ${{ github.workspace }}
           source-path: ${{ github.workspace }}/source
-          candidate-source-path: ${{ runner.temp }}/mento-vercel-production-candidate-source
-          candidate-home-path: ${{ runner.temp }}/mento-vercel-production-candidate-home
-          pull-staging-path: ${{ runner.temp }}/mento-vercel-production-pull-staging
-          upload-source-path: ${{ runner.temp }}/mento-vercel-production-upload-source
+          runtime-root: ${{ steps.runtime.outputs.runtime-root }}
+          isolation-root: ${{ steps.runtime.outputs.isolation-root }}
+          runtime-marker: ${{ steps.runtime.outputs.runtime-marker }}
+          tools-path: ${{ steps.runtime.outputs.tools-path }}
+          build-environment-path: ${{ steps.runtime.outputs.build-environment-path }}
+          candidate-source-path: ${{ steps.runtime.outputs.candidate-source-path }}
+          candidate-home-path: ${{ steps.runtime.outputs.candidate-home-path }}
+          pull-staging-path: ${{ steps.runtime.outputs.pull-staging-path }}
+          candidate-identity-marker: ${{ steps.runtime.outputs.candidate-identity-marker }}
+          build-log-path: ${{ steps.runtime.outputs.build-log-path }}
+          provenance-path: ${{ steps.runtime.outputs.provenance-path }}
+          upload-source-path: ${{ steps.runtime.outputs.upload-source-path }}
           node-bin: ${{ steps.runtime.outputs.node-bin }}
           pnpm-bin: ${{ steps.runtime.outputs.pnpm-bin }}
           vercel-cli: ${{ steps.runtime.outputs.vercel-cli }}
@@ -815,13 +882,13 @@ jobs:
         env:
           DEPLOY_SHA: ${{ needs.preflight.outputs.deploy_sha }}
           LOGICAL_TARGET: ui
-          SOURCE_PATH: ${{ runner.temp }}/mento-vercel-production-upload-source
+          SOURCE_PATH: ${{ steps.runtime.outputs.upload-source-path }}
           TRUSTED_NODE_PATH: ${{ steps.runtime.outputs.node-bin }}
           TRUSTED_VERCEL_CLI_PATH: ${{ steps.runtime.outputs.vercel-cli }}
           VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ vars.VERCEL_PROJECT_ID_UI }}
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN_PRODUCTION }}
-        run: node "$TRUSTED_POST_BUILD_PATH/scripts/vercel-production-shadow.mjs" deploy --expected "$RUNNER_TEMP/ui-expected.json"
+        run: ${{ steps.runtime.outputs.node-bin }} "$TRUSTED_POST_BUILD_PATH/scripts/vercel-production-shadow.mjs" deploy --expected "$RUNNER_TEMP/ui-expected.json"
       - name: Fail read-only on protected alias drift after UI deploy
         if: ${{ always() && steps.build.outcome == 'success' && steps.trusted.outcome == 'success' }}
         env:
@@ -829,7 +896,7 @@ jobs:
           VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN_PRODUCTION }}
         run: >-
-          node "$TRUSTED_POST_BUILD_PATH/scripts/vercel-production-shadow.mjs"
+          "${{ steps.runtime.outputs.node-bin }}" "$TRUSTED_POST_BUILD_PATH/scripts/vercel-production-shadow.mjs"
           check-aliases
       - name: Prove every protected mapping remains unchanged
         env:
@@ -845,9 +912,9 @@ jobs:
           umask 077
           set -o noclobber
           printf '%s\n' "$BASELINE_JSON" > "$RUNNER_TEMP/ui-compare-baseline.json"
-          node "$TRUSTED_POST_BUILD_PATH/scripts/vercel-production-shadow.mjs" create-spec --output "$RUNNER_TEMP/protected-spec.json"
-          node "$TRUSTED_POST_BUILD_PATH/scripts/vercel-deployment-state.mjs" snapshot --spec "$RUNNER_TEMP/protected-spec.json" --output "$RUNNER_TEMP/current.json"
-          node "$TRUSTED_POST_BUILD_PATH/scripts/vercel-deployment-state.mjs" compare --before "$RUNNER_TEMP/ui-compare-baseline.json" --after "$RUNNER_TEMP/current.json"
+          "${{ steps.runtime.outputs.node-bin }}" "$TRUSTED_POST_BUILD_PATH/scripts/vercel-production-shadow.mjs" create-spec --output "$RUNNER_TEMP/protected-spec.json"
+          "${{ steps.runtime.outputs.node-bin }}" "$TRUSTED_POST_BUILD_PATH/scripts/vercel-deployment-state.mjs" snapshot --spec "$RUNNER_TEMP/protected-spec.json" --output "$RUNNER_TEMP/current.json"
+          "${{ steps.runtime.outputs.node-bin }}" "$TRUSTED_POST_BUILD_PATH/scripts/vercel-deployment-state.mjs" compare --before "$RUNNER_TEMP/ui-compare-baseline.json" --after "$RUNNER_TEMP/current.json"
       - name: Verify UI deployment provenance and readiness
         env:
           VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
@@ -856,21 +923,28 @@ jobs:
           verified=false
           for attempt in {1..12}; do
             echo "Verifying UI deployment (attempt $attempt/12)"
-            if node "$TRUSTED_POST_BUILD_PATH/scripts/vercel-deployment-state.mjs" deployment --expected "$RUNNER_TEMP/ui-expected.json" --output "$RUNNER_TEMP/ui-state.json"; then verified=true; break; fi
+            if "${{ steps.runtime.outputs.node-bin }}" "$TRUSTED_POST_BUILD_PATH/scripts/vercel-deployment-state.mjs" deployment --expected "$RUNNER_TEMP/ui-expected.json" --output "$RUNNER_TEMP/ui-state.json"; then verified=true; break; fi
             sleep 5
           done
           "$verified"
-          node "$TRUSTED_POST_BUILD_PATH/scripts/vercel-production-shadow.mjs" assert-unaliased --input "$RUNNER_TEMP/ui-state.json"
+          "${{ steps.runtime.outputs.node-bin }}" "$TRUSTED_POST_BUILD_PATH/scripts/vercel-production-shadow.mjs" assert-unaliased --input "$RUNNER_TEMP/ui-state.json"
       - name: Scan UI canonical evidence
         run: |
           set -o noclobber
           printf '["%s","%s"]\n' "$RUNNER_TEMP/ui-state.json" "$RUNNER_TEMP/current.json" > "$RUNNER_TEMP/evidence-files.json"
-          node "$TRUSTED_POST_BUILD_PATH/scripts/vercel-production-shadow.mjs" evidence --files "$RUNNER_TEMP/evidence-files.json"
+          "${{ steps.runtime.outputs.node-bin }}" "$TRUSTED_POST_BUILD_PATH/scripts/vercel-production-shadow.mjs" evidence --files "$RUNNER_TEMP/evidence-files.json"
       - name: Measure UI job duration
         id: total
         env:
           STARTED_AT_MS: ${{ steps.timing.outputs.started_at_ms }}
         run: echo "total_duration_ms=$(($(date +%s%3N) - STARTED_AT_MS))" >> "$GITHUB_OUTPUT"
+
+      - name: Remove authenticated UI runtime
+        if: ${{ always() }}
+        uses: ./.github/actions/vercel-protected-runtime
+        with:
+          operation: cleanup
+          logical-target: ui
 
   smoke-governance:
     name: Smoke governance from fresh trusted state

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,14 +62,19 @@ pull staging, raw Git-object materialization of the exact commit (never
 archive/checkout filters), and a runner-owned verified output handoff. Browser
 smoke must use a fresh trusted checkout and dependencies, never candidate
 `node_modules`; tear down every candidate boundary before upload or later
-production-token checks. Preserve App custom `v3` as build-only, preserve the
-App `v2` alias, and keep Governance, Reserve, and UI deployments unaliased.
+production-token checks. Keep all build-boundary state below the target-scoped,
+authenticated `/var/lib/mento-vercel-runtime-<run>-<attempt>-<target>/work`
+root, seal `RUNNER_TEMP` to runner-owned mode `0700` before candidate execution,
+and reauthenticate and remove the exact runtime in a final `if: always()` step.
+Preserve App custom `v3` as build-only, preserve the App `v2` alias, and keep
+Governance, Reserve, and UI deployments unaliased.
 Every candidate Vercel build must use `--standalone`; reject invalid, oversized,
 or non-empty-`filePathMap` `.vc-config.json` files before handoff and again on
 the runner-owned upload tree.
 Never copy a raw Vercel-pulled `.env.*.local` into candidate storage. One-way
 materialize only the exact `vercel-pull` allowlist, prove the raw source is
-unchanged, reassert candidate canonical bytes, and clean both protected roots.
+unchanged, reassert candidate canonical bytes, and remove raw pull and derived
+environment state during candidate teardown.
 Preflight must bind workflow, requested, fetched-main, and source SHAs before
 downstream jobs consume its single SHA output. Reachable browser smokes must
 verify both the custom build ID and exact deployed-SHA response header. Candidate

--- a/docs/vercel-deployments.md
+++ b/docs/vercel-deployments.md
@@ -397,6 +397,29 @@ with the production token under a private `077` umask into a fresh runner-owned
 staging tree, and validates that tree's complete file set, ownership, project
 mapping, and Root Directory.
 
+Each target job derives a distinct authenticated runtime from the immutable
+Actions identity:
+`/var/lib/mento-vercel-runtime-<run-id>-<run-attempt>-<target>`. The outer
+directory and its readiness marker are root-owned; the marker binds the exact
+run ID, attempt, and literal target. Its `work/` child is a runner-owned `0711`
+isolation root. Protected tools, pull staging, one-way build-environment
+materialization, candidate source and home, and the verified upload handoff use
+reviewed fixed children of that root. None of this build-boundary state lives
+under `RUNNER_TEMP`.
+
+Before the dedicated candidate UID starts, the candidate-build action seals
+`RUNNER_TEMP` to runner-owned mode `0700` and proves the directory remains
+canonical. This keeps GitHub command files such as `GITHUB_ENV`,
+`GITHUB_OUTPUT`, `GITHUB_PATH`, `GITHUB_STATE`, and `GITHUB_STEP_SUMMARY`
+outside candidate traversal even if the hosted image originally created the
+temporary root with broader permissions. Setup-provided Node and package
+manager paths are staging inputs only: the action copies and verifies the
+executables under the authenticated runtime, and every post-candidate Node
+command uses that protected copy. A final `if: always()` cleanup
+reauthenticates the root and marker before removing the exact target-scoped
+runtime after upload and evidence work; it refuses ambiguous or unexpected
+state.
+
 The raw Vercel-pulled `.env.<target>.local` remains private and runner-owned.
 Before staging settings into candidate storage, the trusted controller parses
 that file, selects only the target/environment variables classified
@@ -421,9 +444,10 @@ installation and `vercel build` run through `env -i` plus `setpriv` with an
 isolated HOME, temporary directory, XDG directories, pnpm store, and an
 allowlisted PATH containing the exact protected executables. Lifecycle scripts
 are disabled. The action first proves that this UID cannot write the workspace,
-trusted controller, runner temp root, immutable checkout, lockfile, or protected
-runtime. GitHub command-file paths and the production Vercel token are absent
-from candidate processes. A UID-wide
+trusted controller, sealed runner temporary root, immutable checkout, lockfile,
+authenticated runtime root, work directory, or protected tools. GitHub
+command-file paths and the production Vercel token are absent from candidate
+processes. A UID-wide
 kill and process check runs after install, after build, before handoff, and
 during final teardown; teardown deletes the account only when its live UID/GID
 still matches that marker.

--- a/scripts/vercel-production-shadow-workflow.test.mjs
+++ b/scripts/vercel-production-shadow-workflow.test.mjs
@@ -30,15 +30,14 @@ const candidateActionSource = readFileSync(
   "utf8",
 );
 const candidateAction = parse(candidateActionSource);
-const protectedRuntimeAction = parse(
-  readFileSync(
-    new URL(
-      "../.github/actions/vercel-protected-runtime/action.yml",
-      import.meta.url,
-    ),
-    "utf8",
+const protectedRuntimeActionSource = readFileSync(
+  new URL(
+    "../.github/actions/vercel-protected-runtime/action.yml",
+    import.meta.url,
   ),
+  "utf8",
 );
+const protectedRuntimeAction = parse(protectedRuntimeActionSource);
 const rootPackage = JSON.parse(
   readFileSync(new URL("../package.json", import.meta.url), "utf8"),
 );
@@ -213,8 +212,14 @@ test("candidate source cannot replace trusted controllers or runner state", () =
     const build = job.steps[installIndex];
     assert.equal(build.id, "build");
     assert.equal(build.with["logical-target"], name);
-    assert.match(build.with["candidate-source-path"], /runner\.temp/);
-    assert.match(build.with["upload-source-path"], /runner\.temp/);
+    assert.equal(
+      build.with["candidate-source-path"],
+      "${{ steps.runtime.outputs.candidate-source-path }}",
+    );
+    assert.equal(
+      build.with["upload-source-path"],
+      "${{ steps.runtime.outputs.upload-source-path }}",
+    );
     const restoredAfterBuild = job.steps[installIndex + 1];
     assert.equal(
       restoredAfterBuild.name,
@@ -330,12 +335,220 @@ test("trusted pnpm action installs and caches the fresh smoke tree", () => {
 });
 
 test("protected build runtime uses the repository package-manager version", () => {
-  const setup = protectedRuntimeAction.runs.steps.find((step) =>
-    step.uses?.startsWith("pnpm/action-setup@"),
+  const pinnedVersion = rootPackage.packageManager.replace(/^pnpm@/, "");
+  assert.doesNotMatch(protectedRuntimeActionSource, /pnpm\/action-setup@/);
+  assert.match(
+    protectedRuntimeActionSource,
+    new RegExp(`pnpm_bootstrap.*--version.*${pinnedVersion}`, "s"),
   );
-  assert.equal(
-    setup.with.version,
-    rootPackage.packageManager.replace(/^pnpm@/, ""),
+  assert.match(
+    protectedRuntimeActionSource,
+    /node_bin="\$TOOLS_PATH\/bin\/node"/,
+  );
+});
+
+test("each target uses one authenticated run-scoped runtime and always cleans it", () => {
+  const expectedRuntimeOutputs = [
+    "runtime-root",
+    "isolation-root",
+    "runtime-marker",
+    "tools-path",
+    "node-bin",
+    "pnpm-bin",
+    "vercel-cli",
+    "pull-staging-path",
+    "build-environment-path",
+    "candidate-source-path",
+    "provenance-path",
+    "candidate-home-path",
+    "candidate-identity-marker",
+    "build-log-path",
+    "upload-source-path",
+  ];
+  assert.deepEqual(
+    Object.keys(protectedRuntimeAction.outputs).sort(),
+    expectedRuntimeOutputs.sort(),
+  );
+  assert.match(
+    protectedRuntimeActionSource,
+    /\/var\/lib\/mento-vercel-runtime-\$GITHUB_RUN_ID-\$GITHUB_RUN_ATTEMPT-\$LOGICAL_TARGET/,
+  );
+  assert.doesNotMatch(
+    workflowSource,
+    /\$\{\{ runner\.temp \}\}\/mento-vercel-production-/,
+  );
+  assert.doesNotMatch(
+    candidateActionSource,
+    /\$RUNNER_TEMP\/mento-vercel-production-/,
+  );
+  assert.doesNotMatch(
+    protectedRuntimeActionSource,
+    /\$RUNNER_TEMP\/mento-vercel-production-/,
+  );
+
+  for (const target of ["app", "governance", "reserve", "ui"]) {
+    const steps = workflow.jobs[target].steps;
+    const runtimeCalls = steps.filter(
+      (step) => step.uses === "./.github/actions/vercel-protected-runtime",
+    );
+    assert.equal(runtimeCalls.length, 2, `${target} runtime action count`);
+    const [prepare, cleanup] = runtimeCalls;
+    assert.equal(prepare.id, "runtime");
+    assert.deepEqual(prepare.with, {
+      operation: "prepare",
+      "logical-target": target,
+      "controller-path": "${{ github.workspace }}",
+      "source-path": "${{ github.workspace }}/source",
+    });
+    assert.equal(cleanup, steps.at(-1), `${target} cleanup must be job-final`);
+    assert.equal(cleanup.if, "${{ always() }}");
+    assert.deepEqual(cleanup.with, {
+      operation: "cleanup",
+      "logical-target": target,
+    });
+
+    const targetLabel = target === "ui" ? "UI" : target;
+    const preparePull = steps.find(
+      (step) =>
+        step.name === `Prepare runner-owned ${targetLabel} pull staging`,
+    );
+    const validatePull = steps.find(
+      (step) =>
+        step.name === `Validate ${targetLabel} project link and Root Directory`,
+    );
+    for (const step of [preparePull, validatePull]) {
+      assert.equal(
+        step.env.VERCEL_ISOLATION_ROOT,
+        "${{ steps.runtime.outputs.isolation-root }}",
+      );
+      assert.equal(
+        step.env.PULL_STAGING_PATH,
+        "${{ steps.runtime.outputs.pull-staging-path }}",
+      );
+      assert.equal(
+        step.env.SOURCE_PATH,
+        "${{ steps.runtime.outputs.pull-staging-path }}",
+      );
+    }
+
+    const build = steps.find(
+      (step) => step.uses === "./.github/actions/vercel-candidate-build",
+    );
+    for (const name of [
+      "runtime-root",
+      "isolation-root",
+      "runtime-marker",
+      "tools-path",
+      "build-environment-path",
+      "candidate-source-path",
+      "candidate-home-path",
+      "pull-staging-path",
+      "candidate-identity-marker",
+      "build-log-path",
+      "provenance-path",
+      "upload-source-path",
+    ]) {
+      assert.equal(
+        build.with[name],
+        `\${{ steps.runtime.outputs.${name} }}`,
+        `${target} ${name}`,
+      );
+    }
+    assert.doesNotMatch(
+      jobSource(target),
+      /\$\{\{ runner\.temp \}\}\/mento-vercel-production-(?:tools|pull-staging|candidate|build-environment|upload-source)/,
+    );
+  }
+});
+
+test("trusted post-candidate commands use only protected runtime Node", () => {
+  for (const target of ["app", "governance", "reserve", "ui"]) {
+    const steps = workflow.jobs[target].steps;
+    const buildIndex = steps.findIndex(
+      (step) => step.uses === "./.github/actions/vercel-candidate-build",
+    );
+    assert.notEqual(buildIndex, -1);
+    for (const step of steps.slice(buildIndex + 1)) {
+      const run = step.run ?? "";
+      if (!run.includes("$TRUSTED_POST_BUILD_PATH/scripts/")) continue;
+      assert.match(
+        run,
+        /\$\{\{ steps\.runtime\.outputs\.node-bin \}\}/,
+        `${target} post-candidate command must use protected Node`,
+      );
+      assert.doesNotMatch(
+        run,
+        /(?:^|\s)node "\$TRUSTED_POST_BUILD_PATH/,
+        `${target} must not fall back to setup-node after candidate execution`,
+      );
+    }
+  }
+});
+
+test("protected runtime creation and cleanup authenticate the exact target root", () => {
+  const create = protectedRuntimeAction.runs.steps.find(
+    (step) => step.name === "Create protected cross-identity runtime root",
+  );
+  const cleanup = protectedRuntimeAction.runs.steps.find(
+    (step) => step.name === "Remove authenticated protected runtime",
+  );
+  assert.equal(create.if, "${{ inputs.operation == 'prepare' }}");
+  assert.equal(cleanup.if, "${{ inputs.operation == 'cleanup' }}");
+  for (const step of [create, cleanup]) {
+    assert.match(
+      step.run,
+      /\/var\/lib\/mento-vercel-runtime-\$GITHUB_RUN_ID-\$GITHUB_RUN_ATTEMPT-\$LOGICAL_TARGET/,
+    );
+    assert.match(
+      step.run,
+      /GITHUB_RUN_ID:\$GITHUB_RUN_ATTEMPT:\$LOGICAL_TARGET/,
+    );
+    assert.match(step.run, /for ancestor in \/ \/var \/var\/lib/);
+    assert.match(step.run, /stat -c %u/);
+    assert.match(step.run, /stat -c %g/);
+    assert.match(step.run, /stat -c %a/);
+  }
+  assert.match(create.run, /-o root -g root -m 0711/);
+  assert.match(create.run, /-m 0711[\s\\]+--[\s\\]+"\$ISOLATION_ROOT"/);
+  assert.match(create.run, /chmod 0400 "\$RUNTIME_MARKER"/);
+  assert.match(create.run, /stat -c %h "\$RUNTIME_MARKER"/);
+  assert.match(cleanup.run, /stat -c %h "\$RUNTIME_MARKER"/);
+  assert.match(cleanup.run, /failed cleanup authentication/);
+  assert.match(cleanup.run, /contains unexpected top-level state/);
+  assert.match(cleanup.run, /work root contains unexpected state/);
+  assert.match(cleanup.run, /Protected runtime root survived cleanup/);
+  assert.doesNotMatch(cleanup.run, /(?:^|\s)node(?:\s|$)/m);
+});
+
+test("candidate execution seals command files and rejects hosted tool paths", () => {
+  const isolation = candidateAction.runs.steps.find(
+    (step) => step.name === "Prepare isolated exact-SHA candidate source",
+  );
+  const sealIndex = isolation.run.indexOf('/bin/chmod 0700 "$RUNNER_TEMP"');
+  const identityIndex = isolation.run.indexOf("/usr/sbin/useradd", sealIndex);
+  assert.ok(sealIndex >= 0 && sealIndex < identityIndex);
+  assert.match(
+    isolation.run,
+    /RUNNER_TEMP is not a canonical runner-owned directory/,
+  );
+  assert.match(isolation.run, /stat -c '%d:%i:%u:%g' "\$RUNNER_TEMP"/);
+  assert.match(isolation.run, /stat -c %a "\$RUNNER_TEMP"\)" != 700/);
+  assert.match(
+    isolation.run,
+    /Candidate can traverse protected path: \$RUNNER_TEMP/,
+  );
+  assert.match(
+    isolation.run,
+    /\[ "\$NODE_BIN" != "\$TOOLS_PATH\/bin\/node" \]/,
+  );
+  assert.match(isolation.run, /Candidate runtime must not depend on \/opt/);
+  assert.match(
+    isolation.run,
+    /"\$SOURCE_PATH\/pnpm-lock\.yaml"[\s\\]+"\$PULL_STAGING_PATH"[\s\\]+"\$TOOLS_PATH"/,
+  );
+  assert.doesNotMatch(
+    candidateActionSource,
+    /\$RUNNER_TEMP\/mento-vercel-production-/,
   );
 });
 
@@ -537,9 +750,18 @@ test("ordinary targets use isolated builds, runner-owned handoff, and fresh smok
       build.with["expected-root-directory"],
       `apps/${target}.mento.org`,
     );
-    assert.match(build.with["candidate-source-path"], /runner\.temp/);
-    assert.match(build.with["pull-staging-path"], /runner\.temp/);
-    assert.match(build.with["upload-source-path"], /runner\.temp/);
+    assert.equal(
+      build.with["candidate-source-path"],
+      "${{ steps.runtime.outputs.candidate-source-path }}",
+    );
+    assert.equal(
+      build.with["pull-staging-path"],
+      "${{ steps.runtime.outputs.pull-staging-path }}",
+    );
+    assert.equal(
+      build.with["upload-source-path"],
+      "${{ steps.runtime.outputs.upload-source-path }}",
+    );
     assert.match(source, /vercel-deployment-state\.mjs"? deployment/);
     assert.match(source, /vercel-deployment-state\.mjs"? compare/);
     assert.match(source, /vercel-production-shadow\.mjs"? assert-unaliased/);
@@ -642,7 +864,10 @@ test("app Outcome B has no reachable deploy or production command", () => {
   assert.equal(build.uses, "./.github/actions/vercel-candidate-build");
   assert.equal(build.with["logical-target"], "app");
   assert.equal(build.with["expected-root-directory"], "apps/app.mento.org");
-  assert.match(build.with["upload-source-path"], /runner\.temp/);
+  assert.equal(
+    build.with["upload-source-path"],
+    "${{ steps.runtime.outputs.upload-source-path }}",
+  );
   assert.match(source, /NEXT_PUBLIC_VERCEL_ENV: preview/);
   assert.match(source, /VERCEL_ENV: preview/);
   assert.match(source, /VERCEL_TARGET_ENV: v3/);
@@ -747,7 +972,15 @@ test("candidate builds are standalone and external references fail before handof
     (step) => step.name === "Remove candidate execution boundary",
   );
   assert.match(cleanup.run, /mento-vercel-production-build-environment/);
-  assert.match(cleanup.run, /"\$materialized_environment_path"/);
+  assert.match(cleanup.run, /"\$BUILD_ENVIRONMENT_PATH"/);
+  assert.match(cleanup.run, /"\$PROVENANCE_PATH"/);
+  assert.match(
+    cleanup.run,
+    /upload_provenance_path="\$UPLOAD_SOURCE_PATH\.provenance\.json"/,
+  );
+  assert.match(cleanup.run, /"\$upload_provenance_path"/);
+  assert.doesNotMatch(cleanup.run, /rm[\s\S]{0,300}"\$TOOLS_PATH"/);
+  assert.doesNotMatch(cleanup.run, /rm[\s\S]{0,300}"\$UPLOAD_SOURCE_PATH"/);
 });
 
 test("build-variable scopes preserve production Sentry behavior", () => {
@@ -802,7 +1035,7 @@ test("build-variable scopes preserve production Sentry behavior", () => {
   );
   assert.match(
     validation.run,
-    /vercel-production-shadow\.mjs" check-build-inputs/,
+    /vercel-production-shadow\.mjs"[\s\\]+check-build-inputs/,
   );
   assert.match(validation.run, /vercel-build-environment\.mjs/);
   assert.match(
@@ -830,9 +1063,9 @@ test("build-variable scopes preserve production Sentry behavior", () => {
     candidateBuild.run,
     /"\$NODE_BIN" "\$TRUSTED_VERCEL_CLI_PATH" "\$\{build_arguments\[@\]\}"/,
   );
-  assert.match(candidateBuild.run, /\/usr\/bin\/tee "\$build_log"/);
+  assert.match(candidateBuild.run, /\/usr\/bin\/tee "\$BUILD_LOG_PATH"/);
   assert.match(candidateBuild.run, /PIPESTATUS/);
-  assert.match(candidateBuild.run, /cache-summary --input "\$build_log"/);
+  assert.match(candidateBuild.run, /cache-summary --input "\$BUILD_LOG_PATH"/);
   assert.equal(
     candidateAction.outputs.turbo_cache_hits.value,
     "${{ steps.build.outputs.turbo_cache_hits }}",

--- a/scripts/vercel-production-shadow.mjs
+++ b/scripts/vercel-production-shadow.mjs
@@ -374,38 +374,59 @@ function deriveProductionShadowBuildEnvironment({ logicalTarget, raw }) {
   };
 }
 
-function assertRunnerTempChild({
-  runnerTemp,
+export function assertProtectedIsolationChild({
+  isolationRoot,
   path,
   expectedName,
   expectedUid = process.getuid?.(),
   expectedGid = process.getgid?.(),
 }) {
-  requireString(runnerTemp, "Runner temporary directory");
+  requireString(isolationRoot, "Vercel isolation root");
   requireString(path, "Isolated path");
-  if (!isAbsolute(runnerTemp) || !isAbsolute(path)) {
-    throw new Error("Runner isolation paths must be absolute");
+  requireIdentifier(expectedName, "Expected isolated path name");
+  if (!isAbsolute(isolationRoot) || !isAbsolute(path)) {
+    throw new Error("Protected isolation paths must be absolute");
   }
-  const uid = numericIdentity(expectedUid, "Expected runner UID");
-  const gid = numericIdentity(expectedGid, "Expected runner GID");
-  const canonicalRunnerTemp = realpathSync(runnerTemp);
-  const runnerEntry = lstatSync(canonicalRunnerTemp);
+  const uid = numericIdentity(expectedUid, "Expected isolation owner UID");
+  const gid = numericIdentity(expectedGid, "Expected isolation owner GID");
+  const lexicalIsolationRoot = resolve(isolationRoot);
+  if (lexicalIsolationRoot !== isolationRoot) {
+    throw new Error("Vercel isolation root is not lexically canonical");
+  }
+  const isolationEntry = lstatSync(isolationRoot);
   if (
-    runnerEntry.isSymbolicLink() ||
-    !runnerEntry.isDirectory() ||
-    runnerEntry.uid !== uid ||
-    runnerEntry.gid !== gid ||
-    (runnerEntry.mode & 0o7022) !== 0
+    isolationEntry.isSymbolicLink() ||
+    !isolationEntry.isDirectory() ||
+    isolationEntry.uid !== uid ||
+    isolationEntry.gid !== gid ||
+    (isolationEntry.mode & 0o7777) !== 0o711
   ) {
-    throw new Error("Runner temporary directory is not protected");
+    throw new Error("Vercel isolation root is not protected");
+  }
+  const canonicalIsolationRoot = realpathSync(isolationRoot);
+  if (canonicalIsolationRoot !== isolationRoot) {
+    throw new Error("Vercel isolation root is not canonically stable");
+  }
+  const expectedPath = join(canonicalIsolationRoot, expectedName);
+  if (path !== expectedPath || basename(path) !== expectedName) {
+    throw new Error(
+      "Isolated path is not the expected protected-isolation direct child",
+    );
   }
   if (
-    basename(path) !== expectedName ||
-    realpathSync(dirname(path)) !== canonicalRunnerTemp
+    dirname(path) !== canonicalIsolationRoot ||
+    realpathSync(dirname(path)) !== canonicalIsolationRoot
   ) {
-    throw new Error("Isolated path is not the expected RUNNER_TEMP child");
+    throw new Error("Isolated path parent escaped the Vercel isolation root");
   }
-  return join(canonicalRunnerTemp, expectedName);
+  const pathEntry = optionalEntry(path);
+  if (pathEntry?.isSymbolicLink()) {
+    throw new Error("Isolated path must not be a symbolic link");
+  }
+  if (pathEntry && realpathSync(path) !== expectedPath) {
+    throw new Error("Isolated path is not canonically stable");
+  }
+  return expectedPath;
 }
 
 function rawGitEnvironment() {
@@ -603,7 +624,7 @@ function ensureMaterializedParent(root, components) {
 }
 
 export function materializeExactGitTree({
-  runnerTemp,
+  isolationRoot,
   sourceRoot,
   candidateRoot,
   commitSha,
@@ -621,8 +642,8 @@ export function materializeExactGitTree({
   if (!sourceEntry.isDirectory()) {
     throw new Error("Exact Git source must be a real directory");
   }
-  const canonicalCandidateRoot = assertRunnerTempChild({
-    runnerTemp,
+  const canonicalCandidateRoot = assertProtectedIsolationChild({
+    isolationRoot,
     path: candidateRoot,
     expectedName: CANDIDATE_SOURCE_DIRECTORY,
     expectedUid,
@@ -975,15 +996,15 @@ export function materializeProductionShadowLink({
 }
 
 export function prepareProductionShadowPullStaging({
-  runnerTemp,
+  isolationRoot,
   stagingRoot,
   logicalTarget,
   orgId,
   projectId,
 }) {
   const contract = targetContract(logicalTarget);
-  const canonicalStagingRoot = assertRunnerTempChild({
-    runnerTemp,
+  const canonicalStagingRoot = assertProtectedIsolationChild({
+    isolationRoot,
     path: stagingRoot,
     expectedName: PULL_STAGING_DIRECTORY,
   });
@@ -1008,7 +1029,7 @@ export function prepareProductionShadowPullStaging({
 }
 
 export function assertProductionShadowPullStaging({
-  runnerTemp,
+  isolationRoot,
   stagingRoot,
   logicalTarget,
   orgId,
@@ -1016,15 +1037,17 @@ export function assertProductionShadowPullStaging({
   expectedUid = process.getuid?.(),
   expectedGid = process.getgid?.(),
 }) {
-  const canonicalStagingRoot = assertRunnerTempChild({
-    runnerTemp,
+  const canonicalStagingRoot = assertProtectedIsolationChild({
+    isolationRoot,
     path: stagingRoot,
     expectedName: PULL_STAGING_DIRECTORY,
     expectedUid,
     expectedGid,
   });
   if (realpathSync(stagingRoot) !== canonicalStagingRoot) {
-    throw new Error("Production-shadow pull staging escaped RUNNER_TEMP");
+    throw new Error(
+      "Production-shadow pull staging escaped the Vercel isolation root",
+    );
   }
   assertExactFilesystemTree(
     canonicalStagingRoot,
@@ -1055,7 +1078,7 @@ function materializedProductionShadowEnvironmentEntries(logicalTarget) {
 }
 
 function inspectMaterializedProductionShadowBuildEnvironment({
-  runnerTemp,
+  isolationRoot,
   stagingRoot,
   materializationRoot,
   logicalTarget,
@@ -1067,7 +1090,7 @@ function inspectMaterializedProductionShadowBuildEnvironment({
   const uid = numericIdentity(expectedUid, "Expected runner UID");
   const gid = numericIdentity(expectedGid, "Expected runner GID");
   assertProductionShadowPullStaging({
-    runnerTemp,
+    isolationRoot,
     stagingRoot,
     logicalTarget,
     orgId,
@@ -1075,8 +1098,8 @@ function inspectMaterializedProductionShadowBuildEnvironment({
     expectedUid: uid,
     expectedGid: gid,
   });
-  const canonicalMaterializationRoot = assertRunnerTempChild({
-    runnerTemp,
+  const canonicalMaterializationRoot = assertProtectedIsolationChild({
+    isolationRoot,
     path: materializationRoot,
     expectedName: BUILD_ENVIRONMENT_DIRECTORY,
     expectedUid: uid,
@@ -1084,7 +1107,7 @@ function inspectMaterializedProductionShadowBuildEnvironment({
   });
   if (realpathSync(materializationRoot) !== canonicalMaterializationRoot) {
     throw new Error(
-      "Materialized production-shadow build environment escaped RUNNER_TEMP",
+      "Materialized production-shadow build environment escaped the Vercel isolation root",
     );
   }
   assertExactFilesystemTree(
@@ -1149,9 +1172,12 @@ function inspectMaterializedProductionShadowBuildEnvironment({
 }
 
 export function materializeProductionShadowBuildEnvironment({
-  runnerTemp,
+  isolationRoot,
   stagingRoot,
-  materializationRoot = join(resolve(runnerTemp), BUILD_ENVIRONMENT_DIRECTORY),
+  materializationRoot = join(
+    resolve(isolationRoot),
+    BUILD_ENVIRONMENT_DIRECTORY,
+  ),
   logicalTarget,
   orgId,
   projectId,
@@ -1161,7 +1187,7 @@ export function materializeProductionShadowBuildEnvironment({
   const uid = numericIdentity(expectedUid, "Expected runner UID");
   const gid = numericIdentity(expectedGid, "Expected runner GID");
   assertProductionShadowPullStaging({
-    runnerTemp,
+    isolationRoot,
     stagingRoot,
     logicalTarget,
     orgId,
@@ -1169,8 +1195,8 @@ export function materializeProductionShadowBuildEnvironment({
     expectedUid: uid,
     expectedGid: gid,
   });
-  const canonicalMaterializationRoot = assertRunnerTempChild({
-    runnerTemp,
+  const canonicalMaterializationRoot = assertProtectedIsolationChild({
+    isolationRoot,
     path: materializationRoot,
     expectedName: BUILD_ENVIRONMENT_DIRECTORY,
     expectedUid: uid,
@@ -1236,7 +1262,7 @@ export function materializeProductionShadowBuildEnvironment({
   chmodSync(environmentPath, 0o600);
 
   const inspected = inspectMaterializedProductionShadowBuildEnvironment({
-    runnerTemp,
+    isolationRoot,
     stagingRoot,
     materializationRoot: canonicalMaterializationRoot,
     logicalTarget,
@@ -1281,7 +1307,7 @@ export function assignProductionShadowMaterializationOwnership({
 }
 
 function assertCandidateRootComponents({
-  runnerTemp,
+  isolationRoot,
   candidateRoot,
   logicalTarget,
   buildUid,
@@ -1290,15 +1316,15 @@ function assertCandidateRootComponents({
   runnerGid,
 }) {
   const contract = targetContract(logicalTarget);
-  const canonicalCandidateRoot = assertRunnerTempChild({
-    runnerTemp,
+  const canonicalCandidateRoot = assertProtectedIsolationChild({
+    isolationRoot,
     path: candidateRoot,
     expectedName: CANDIDATE_SOURCE_DIRECTORY,
     expectedUid: runnerUid,
     expectedGid: runnerGid,
   });
   if (realpathSync(candidateRoot) !== canonicalCandidateRoot) {
-    throw new Error("Candidate source escaped RUNNER_TEMP");
+    throw new Error("Candidate source escaped the Vercel isolation root");
   }
   let current = canonicalCandidateRoot;
   for (const [path, label] of [
@@ -1322,7 +1348,7 @@ function assertCandidateRootComponents({
 }
 
 export function assertCandidateProductionShadowPull({
-  runnerTemp,
+  isolationRoot,
   candidateRoot,
   logicalTarget,
   orgId,
@@ -1337,7 +1363,7 @@ export function assertCandidateProductionShadowPull({
   const trustedUid = numericIdentity(runnerUid, "Runner UID");
   const trustedGid = numericIdentity(runnerGid, "Runner GID");
   const canonicalCandidateRoot = assertCandidateRootComponents({
-    runnerTemp,
+    isolationRoot,
     candidateRoot,
     logicalTarget,
     buildUid: candidateUid,
@@ -1403,7 +1429,7 @@ export function assertCandidateProductionShadowPull({
 }
 
 export function stageProductionShadowPullForCandidate({
-  runnerTemp,
+  isolationRoot,
   stagingRoot,
   candidateRoot,
   logicalTarget,
@@ -1419,11 +1445,11 @@ export function stageProductionShadowPullForCandidate({
   const trustedUid = numericIdentity(runnerUid, "Runner UID");
   const trustedGid = numericIdentity(runnerGid, "Runner GID");
   const materializationRoot = join(
-    resolve(runnerTemp),
+    resolve(isolationRoot),
     BUILD_ENVIRONMENT_DIRECTORY,
   );
   const materializedEnvironment = materializeProductionShadowBuildEnvironment({
-    runnerTemp,
+    isolationRoot,
     stagingRoot,
     materializationRoot,
     logicalTarget,
@@ -1433,7 +1459,7 @@ export function stageProductionShadowPullForCandidate({
     expectedGid: trustedGid,
   });
   const canonicalCandidateRoot = assertCandidateRootComponents({
-    runnerTemp,
+    isolationRoot,
     candidateRoot,
     logicalTarget,
     buildUid: candidateUid,
@@ -1478,7 +1504,7 @@ export function stageProductionShadowPullForCandidate({
   chownSync(candidateEnvironmentPath, candidateUid, candidateGid);
   chmodSync(candidateEnvironmentPath, 0o600);
   const candidateProject = assertCandidateProductionShadowPull({
-    runnerTemp,
+    isolationRoot,
     candidateRoot: canonicalCandidateRoot,
     logicalTarget,
     orgId,
@@ -1489,7 +1515,7 @@ export function stageProductionShadowPullForCandidate({
     runnerGid: trustedGid,
   });
   assertMaterializedProductionShadowBuildEnvironment({
-    runnerTemp,
+    isolationRoot,
     stagingRoot,
     materializationRoot,
     logicalTarget,
@@ -1916,7 +1942,7 @@ function normalizeRunnerOwnedHandoffTree(
 }
 
 export function createProductionShadowUploadHandoff({
-  runnerTemp,
+  isolationRoot,
   stagingRoot,
   candidateRoot,
   uploadRoot,
@@ -1944,8 +1970,20 @@ export function createProductionShadowUploadHandoff({
   const trustedUid = numericIdentity(runnerUid, "Runner UID");
   const trustedGid = numericIdentity(runnerGid, "Runner GID");
   const contract = targetContract(logicalTarget);
+  const canonicalCandidateRoot = assertProtectedIsolationChild({
+    isolationRoot,
+    path: candidateRoot,
+    expectedName: CANDIDATE_SOURCE_DIRECTORY,
+    expectedUid: trustedUid,
+    expectedGid: trustedGid,
+  });
+  if (realpathSync(candidateRoot) !== canonicalCandidateRoot) {
+    throw new Error(
+      "Candidate upload source escaped the Vercel isolation root",
+    );
+  }
   validateStaging({
-    runnerTemp,
+    isolationRoot,
     stagingRoot,
     logicalTarget,
     orgId,
@@ -1954,9 +1992,12 @@ export function createProductionShadowUploadHandoff({
     expectedGid: trustedGid,
   });
   validateMaterialized({
-    runnerTemp,
+    isolationRoot,
     stagingRoot,
-    materializationRoot: join(resolve(runnerTemp), BUILD_ENVIRONMENT_DIRECTORY),
+    materializationRoot: join(
+      resolve(isolationRoot),
+      BUILD_ENVIRONMENT_DIRECTORY,
+    ),
     logicalTarget,
     orgId,
     projectId,
@@ -1964,7 +2005,7 @@ export function createProductionShadowUploadHandoff({
     expectedGid: trustedGid,
   });
   validateCandidate({
-    repoRoot: candidateRoot,
+    repoRoot: canonicalCandidateRoot,
     logicalTarget,
     orgId,
     projectId,
@@ -1974,8 +2015,8 @@ export function createProductionShadowUploadHandoff({
     expectedGid: candidateGid,
     expectedProvenanceUid: trustedUid,
   });
-  const canonicalUploadRoot = assertRunnerTempChild({
-    runnerTemp,
+  const canonicalUploadRoot = assertProtectedIsolationChild({
+    isolationRoot,
     path: uploadRoot,
     expectedName: UPLOAD_SOURCE_DIRECTORY,
     expectedUid: trustedUid,
@@ -1996,7 +2037,7 @@ export function createProductionShadowUploadHandoff({
   });
   mkdirSync(uploadAppState, { mode: 0o755, recursive: true });
   copyTree(
-    join(candidateRoot, contract.rootDirectory, ".vercel", "output"),
+    join(canonicalCandidateRoot, contract.rootDirectory, ".vercel", "output"),
     join(uploadAppState, "output"),
     {
       dereference: false,
@@ -2633,7 +2674,7 @@ if (isCliEntrypoint()) {
     process.stdout.write("Trusted monorepo Vercel mapping written\n");
   } else if (command === "prepare-pull-staging") {
     prepareProductionShadowPullStaging({
-      runnerTemp: process.env.RUNNER_TEMP,
+      isolationRoot: process.env.VERCEL_ISOLATION_ROOT,
       stagingRoot: process.env.PULL_STAGING_PATH,
       logicalTarget: process.env.LOGICAL_TARGET,
       orgId: process.env.VERCEL_ORG_ID,
@@ -2649,7 +2690,7 @@ if (isCliEntrypoint()) {
     process.stdout.write("Target Vercel configuration pulled\n");
   } else if (command === "materialize-source") {
     materializeExactGitTree({
-      runnerTemp: process.env.RUNNER_TEMP,
+      isolationRoot: process.env.VERCEL_ISOLATION_ROOT,
       sourceRoot: process.env.SOURCE_PATH,
       candidateRoot: process.env.CANDIDATE_SOURCE_PATH,
       commitSha: process.env.DEPLOY_SHA,
@@ -2657,7 +2698,7 @@ if (isCliEntrypoint()) {
     process.stdout.write("Exact Git source materialized without filters\n");
   } else if (command === "validate-pull-staging") {
     assertProductionShadowPullStaging({
-      runnerTemp: process.env.RUNNER_TEMP,
+      isolationRoot: process.env.VERCEL_ISOLATION_ROOT,
       stagingRoot: process.env.PULL_STAGING_PATH,
       logicalTarget: process.env.LOGICAL_TARGET,
       orgId: process.env.VERCEL_ORG_ID,
@@ -2666,7 +2707,7 @@ if (isCliEntrypoint()) {
     process.stdout.write("Runner-owned Vercel pull staging verified\n");
   } else if (command === "stage-pull") {
     stageProductionShadowPullForCandidate({
-      runnerTemp: process.env.RUNNER_TEMP,
+      isolationRoot: process.env.VERCEL_ISOLATION_ROOT,
       stagingRoot: process.env.PULL_STAGING_PATH,
       candidateRoot: process.env.CANDIDATE_SOURCE_PATH,
       logicalTarget: process.env.LOGICAL_TARGET,
@@ -2680,7 +2721,7 @@ if (isCliEntrypoint()) {
     process.stdout.write("Runner-owned Vercel settings staged for candidate\n");
   } else if (command === "validate-candidate-pull") {
     assertCandidateProductionShadowPull({
-      runnerTemp: process.env.RUNNER_TEMP,
+      isolationRoot: process.env.VERCEL_ISOLATION_ROOT,
       candidateRoot: process.env.CANDIDATE_SOURCE_PATH,
       logicalTarget: process.env.LOGICAL_TARGET,
       orgId: process.env.VERCEL_ORG_ID,
@@ -2718,7 +2759,7 @@ if (isCliEntrypoint()) {
     process.stdout.write("Target prebuilt output created and verified\n");
   } else if (command === "create-handoff") {
     createProductionShadowUploadHandoff({
-      runnerTemp: process.env.RUNNER_TEMP,
+      isolationRoot: process.env.VERCEL_ISOLATION_ROOT,
       stagingRoot: process.env.PULL_STAGING_PATH,
       candidateRoot: process.env.CANDIDATE_SOURCE_PATH,
       uploadRoot: process.env.UPLOAD_SOURCE_PATH,

--- a/scripts/vercel-production-shadow.test.mjs
+++ b/scripts/vercel-production-shadow.test.mjs
@@ -25,6 +25,7 @@ import {
   assertCandidateProductionShadowPull,
   assertFinalJobResults,
   assertMaterializedProductionShadowBuildEnvironment,
+  assertProtectedIsolationChild,
   assertProductionShadowBuildInputs,
   assertProductionShadowOutput,
   assertProductionShadowPullStaging,
@@ -122,6 +123,127 @@ test("materialized environment ownership is assigned to the runner identity", ()
       gid: 5_678,
     },
   ]);
+});
+
+test("protected isolation paths require one canonical, owned direct child", () => {
+  const container = realpathSync(
+    mkdtempSync(join(tmpdir(), "shadow-isolation-contract-")),
+  );
+  const isolationRoot = join(container, "work");
+  const expectedName = "mento-vercel-production-pull-staging";
+  const expectedPath = join(isolationRoot, expectedName);
+  const uid = process.getuid();
+  const gid = process.getgid();
+  try {
+    mkdirSync(isolationRoot, { mode: 0o711 });
+    chmodSync(isolationRoot, 0o711);
+    assert.equal(
+      assertProtectedIsolationChild({
+        isolationRoot,
+        path: expectedPath,
+        expectedName,
+      }),
+      expectedPath,
+    );
+
+    for (const path of [
+      join(container, expectedName),
+      join(isolationRoot, "nested", expectedName),
+      `${isolationRoot}/nested/../${expectedName}`,
+      join(isolationRoot, "wrong-name"),
+    ]) {
+      assert.throws(
+        () =>
+          assertProtectedIsolationChild({
+            isolationRoot,
+            path,
+            expectedName,
+          }),
+        /direct child/,
+      );
+    }
+    assert.throws(
+      () =>
+        assertProtectedIsolationChild({
+          isolationRoot: `${isolationRoot}/.`,
+          path: expectedPath,
+          expectedName,
+        }),
+      /lexically canonical/,
+    );
+    assert.throws(
+      () =>
+        assertProtectedIsolationChild({
+          isolationRoot,
+          path: expectedPath,
+          expectedName,
+          expectedUid: uid + 1,
+        }),
+      /not protected/,
+    );
+    assert.throws(
+      () =>
+        assertProtectedIsolationChild({
+          isolationRoot,
+          path: expectedPath,
+          expectedName,
+          expectedGid: gid + 1,
+        }),
+      /not protected/,
+    );
+    chmodSync(isolationRoot, 0o700);
+    assert.throws(
+      () =>
+        assertProtectedIsolationChild({
+          isolationRoot,
+          path: expectedPath,
+          expectedName,
+        }),
+      /not protected/,
+    );
+    chmodSync(isolationRoot, 0o711);
+
+    const external = join(container, "external");
+    mkdirSync(external, { mode: 0o700 });
+    symlinkSync(external, expectedPath);
+    assert.throws(
+      () =>
+        assertProtectedIsolationChild({
+          isolationRoot,
+          path: expectedPath,
+          expectedName,
+        }),
+      /symbolic link/,
+    );
+    rmSync(expectedPath);
+
+    const linkedRoot = join(container, "linked-work");
+    symlinkSync(isolationRoot, linkedRoot);
+    assert.throws(
+      () =>
+        assertProtectedIsolationChild({
+          isolationRoot: linkedRoot,
+          path: join(linkedRoot, expectedName),
+          expectedName,
+        }),
+      /not protected/,
+    );
+  } finally {
+    rmSync(container, { recursive: true, force: true });
+  }
+});
+
+test("build-boundary CLI commands use the protected isolation root", () => {
+  const script = readFileSync(productionShadowScript, "utf8");
+  assert.equal(
+    script.match(/isolationRoot:\s*process\.env\.VERCEL_ISOLATION_ROOT/g)
+      ?.length,
+    6,
+  );
+  assert.doesNotMatch(
+    script,
+    /(?:runnerTemp|isolationRoot):\s*process\.env\.RUNNER_TEMP/,
+  );
 });
 
 test("dispatch context accepts only canonical main and immutable SHA", () => {
@@ -599,28 +721,28 @@ test("repo-linked settings use exact repo identity for all four targets", () => 
 
 test("runner pull staging, candidate copy, and upload proof reject external references", () => {
   for (const [target, contract] of Object.entries(PRODUCTION_SHADOW_TARGETS)) {
-    const runnerTemp = mkdtempSync(
-      join(tmpdir(), `shadow-boundary-${target}-`),
+    const isolationRoot = realpathSync(
+      mkdtempSync(join(tmpdir(), `shadow-boundary-${target}-`)),
     );
     const stagingRoot = join(
-      runnerTemp,
+      isolationRoot,
       "mento-vercel-production-pull-staging",
     );
     const candidateRoot = join(
-      runnerTemp,
+      isolationRoot,
       "mento-vercel-production-candidate-source",
     );
     const uploadRoot = join(
-      runnerTemp,
+      isolationRoot,
       "mento-vercel-production-upload-source",
     );
     const orgId = "team_fixture123";
     const projectId = `prj_${target}123`;
     const deploymentId = `m-${target}-0123456789abcdef012`;
     try {
-      chmodSync(runnerTemp, 0o700);
+      chmodSync(isolationRoot, 0o711);
       prepareProductionShadowPullStaging({
-        runnerTemp,
+        isolationRoot,
         stagingRoot,
         logicalTarget: target,
         orgId,
@@ -652,7 +774,7 @@ test("runner pull staging, candidate copy, and upload proof reject external refe
       const rawEnvironmentBefore = lstatSync(rawEnvironmentPath);
       assert.deepEqual(
         assertProductionShadowPullStaging({
-          runnerTemp,
+          isolationRoot,
           stagingRoot,
           logicalTarget: target,
           orgId,
@@ -666,7 +788,7 @@ test("runner pull staging, candidate copy, and upload proof reject external refe
         mode: 0o700,
       });
       stageProductionShadowPullForCandidate({
-        runnerTemp,
+        isolationRoot,
         stagingRoot,
         candidateRoot,
         logicalTarget: target,
@@ -717,7 +839,7 @@ test("runner pull staging, candidate copy, and upload proof reject external refe
         assert.doesNotMatch(candidateEnvironment, new RegExp(forbidden));
       }
       const materializationRoot = join(
-        runnerTemp,
+        isolationRoot,
         "mento-vercel-production-build-environment",
       );
       const materializedEnvironmentPath = join(
@@ -741,7 +863,7 @@ test("runner pull staging, candidate copy, and upload proof reject external refe
         assert.throws(
           () =>
             assertCandidateProductionShadowPull({
-              runnerTemp,
+              isolationRoot,
               candidateRoot,
               logicalTarget: target,
               orgId,
@@ -763,7 +885,7 @@ test("runner pull staging, candidate copy, and upload proof reject external refe
         assert.throws(
           () =>
             assertMaterializedProductionShadowBuildEnvironment({
-              runnerTemp,
+              isolationRoot,
               stagingRoot,
               materializationRoot,
               logicalTarget: target,
@@ -841,7 +963,7 @@ test("runner pull staging, candidate copy, and upload proof reject external refe
         assert.throws(
           () =>
             createProductionShadowUploadHandoff({
-              runnerTemp,
+              isolationRoot,
               stagingRoot,
               candidateRoot,
               uploadRoot,
@@ -884,7 +1006,7 @@ test("runner pull staging, candidate copy, and upload proof reject external refe
       assert.throws(
         () =>
           assertProductionShadowPullStaging({
-            runnerTemp,
+            isolationRoot,
             stagingRoot,
             logicalTarget: target,
             orgId,
@@ -893,23 +1015,28 @@ test("runner pull staging, candidate copy, and upload proof reject external refe
         /unexpected filesystem entry/,
       );
     } finally {
-      rmSync(runnerTemp, { recursive: true, force: true });
+      rmSync(isolationRoot, { recursive: true, force: true });
     }
   }
 });
 
 test("Vercel pull inherits a private umask and restores the runner umask", () => {
-  const runnerTemp = mkdtempSync(join(tmpdir(), "shadow-pull-umask-"));
-  const stagingRoot = join(runnerTemp, "mento-vercel-production-pull-staging");
+  const isolationRoot = realpathSync(
+    mkdtempSync(join(tmpdir(), "shadow-pull-umask-")),
+  );
+  const stagingRoot = join(
+    isolationRoot,
+    "mento-vercel-production-pull-staging",
+  );
   const logicalTarget = "ui";
   const contract = PRODUCTION_SHADOW_TARGETS[logicalTarget];
   const orgId = "team_fixture123";
   const projectId = "prj_ui123";
   const priorUmask = process.umask();
   try {
-    chmodSync(runnerTemp, 0o700);
+    chmodSync(isolationRoot, 0o711);
     prepareProductionShadowPullStaging({
-      runnerTemp,
+      isolationRoot,
       stagingRoot,
       logicalTarget,
       orgId,
@@ -945,7 +1072,7 @@ test("Vercel pull inherits a private umask and restores the runner umask", () =>
     assert.equal(process.umask(), priorUmask);
     assert.deepEqual(
       assertProductionShadowPullStaging({
-        runnerTemp,
+        isolationRoot,
         stagingRoot,
         logicalTarget,
         orgId,
@@ -955,18 +1082,26 @@ test("Vercel pull inherits a private umask and restores the runner umask", () =>
     );
   } finally {
     process.umask(priorUmask);
-    rmSync(runnerTemp, { recursive: true, force: true });
+    rmSync(isolationRoot, { recursive: true, force: true });
   }
 });
 
 test("handoff enforces distinct candidate and runner ownership contracts", () => {
-  const runnerTemp = mkdtempSync(join(tmpdir(), "shadow-handoff-owner-"));
-  const stagingRoot = join(runnerTemp, "mento-vercel-production-pull-staging");
+  const isolationRoot = realpathSync(
+    mkdtempSync(join(tmpdir(), "shadow-handoff-owner-")),
+  );
+  const stagingRoot = join(
+    isolationRoot,
+    "mento-vercel-production-pull-staging",
+  );
   const candidateRoot = join(
-    runnerTemp,
+    isolationRoot,
     "mento-vercel-production-candidate-source",
   );
-  const uploadRoot = join(runnerTemp, "mento-vercel-production-upload-source");
+  const uploadRoot = join(
+    isolationRoot,
+    "mento-vercel-production-upload-source",
+  );
   const logicalTarget = "ui";
   const contract = PRODUCTION_SHADOW_TARGETS[logicalTarget];
   const orgId = "team_fixture123";
@@ -979,9 +1114,9 @@ test("handoff enforces distinct candidate and runner ownership contracts", () =>
   const ownershipChanges = [];
   const candidateValidations = [];
   try {
-    chmodSync(runnerTemp, 0o700);
+    chmodSync(isolationRoot, 0o711);
     prepareProductionShadowPullStaging({
-      runnerTemp,
+      isolationRoot,
       stagingRoot,
       logicalTarget,
       orgId,
@@ -1020,7 +1155,7 @@ test("handoff enforces distinct candidate and runner ownership contracts", () =>
     );
 
     const result = createProductionShadowUploadHandoff({
-      runnerTemp,
+      isolationRoot,
       stagingRoot,
       candidateRoot,
       uploadRoot,
@@ -1062,22 +1197,24 @@ test("handoff enforces distinct candidate and runner ownership contracts", () =>
     assert.equal(result.gid, runnerGid);
     assert.equal(result.sourceRoot, realpathSync(uploadRoot));
   } finally {
-    rmSync(runnerTemp, { recursive: true, force: true });
+    rmSync(isolationRoot, { recursive: true, force: true });
   }
 });
 
 test("raw Git-object materialization bypasses archive and checkout filters", () => {
   const repository = mkdtempSync(join(tmpdir(), "shadow-raw-source-"));
-  const runnerTemp = mkdtempSync(join(tmpdir(), "shadow-raw-runner-"));
+  const isolationRoot = realpathSync(
+    mkdtempSync(join(tmpdir(), "shadow-raw-isolation-")),
+  );
   const candidate = join(
-    runnerTemp,
+    isolationRoot,
     "mento-vercel-production-candidate-source",
   );
   const checkoutCandidate = mkdtempSync(
     join(tmpdir(), "shadow-filtered-candidate-"),
   );
   try {
-    chmodSync(runnerTemp, 0o700);
+    chmodSync(isolationRoot, 0o711);
     execFileSync("git", ["init", "--quiet"], { cwd: repository });
     writeFileSync(
       join(repository, ".gitattributes"),
@@ -1118,7 +1255,7 @@ test("raw Git-object materialization bypasses archive and checkout filters", () 
     }).trim();
 
     const result = materializeExactGitTree({
-      runnerTemp,
+      isolationRoot,
       sourceRoot: repository,
       candidateRoot: candidate,
       commitSha,
@@ -1163,7 +1300,7 @@ test("raw Git-object materialization bypasses archive and checkout filters", () 
     assert.throws(
       () =>
         materializeExactGitTree({
-          runnerTemp,
+          isolationRoot,
           sourceRoot: repository,
           candidateRoot: candidate,
           commitSha,
@@ -1172,20 +1309,22 @@ test("raw Git-object materialization bypasses archive and checkout filters", () 
     );
   } finally {
     rmSync(repository, { force: true, recursive: true });
-    rmSync(runnerTemp, { force: true, recursive: true });
+    rmSync(isolationRoot, { force: true, recursive: true });
     rmSync(checkoutCandidate, { force: true, recursive: true });
   }
 });
 
 test("raw Git-object materialization rejects gitlinks before writing", () => {
   const repository = mkdtempSync(join(tmpdir(), "shadow-gitlink-source-"));
-  const runnerTemp = mkdtempSync(join(tmpdir(), "shadow-gitlink-runner-"));
+  const isolationRoot = realpathSync(
+    mkdtempSync(join(tmpdir(), "shadow-gitlink-isolation-")),
+  );
   const candidate = join(
-    runnerTemp,
+    isolationRoot,
     "mento-vercel-production-candidate-source",
   );
   try {
-    chmodSync(runnerTemp, 0o700);
+    chmodSync(isolationRoot, 0o711);
     execFileSync("git", ["init", "--quiet"], { cwd: repository });
     writeFileSync(join(repository, "plain.txt"), "plain\n");
     execFileSync("git", ["add", "."], { cwd: repository });
@@ -1236,7 +1375,7 @@ test("raw Git-object materialization rejects gitlinks before writing", () => {
     assert.throws(
       () =>
         materializeExactGitTree({
-          runnerTemp,
+          isolationRoot,
           sourceRoot: repository,
           candidateRoot: candidate,
           commitSha: gitlinkCommit,
@@ -1246,7 +1385,7 @@ test("raw Git-object materialization rejects gitlinks before writing", () => {
     assert.equal(existsSync(candidate), false);
   } finally {
     rmSync(repository, { force: true, recursive: true });
-    rmSync(runnerTemp, { force: true, recursive: true });
+    rmSync(isolationRoot, { force: true, recursive: true });
   }
 });
 


### PR DESCRIPTION
## The Problem

The production-shadow pilot stopped safely before source materialization because GitHub's hosted runner exposes setup-node tooling below writable `/opt`. The same candidate boundary also relied on `$RUNNER_TEMP`, whose GitHub command files must remain inaccessible to untrusted build code.

## The Solution

- create one authenticated, per-target runtime below `/var/lib` with a root-owned marker and exact cleanup contract;
- stage immutable Node, pnpm, and Vercel tooling inside that protected runtime before the candidate user exists;
- seal `$RUNNER_TEMP`, run repository build code as a dedicated unprivileged user, and preserve only a validated runner-owned upload handoff;
- authenticate and remove the candidate identity and every protected runtime path during job-final cleanup;
- move build-boundary helpers from `$RUNNER_TEMP` to the fixed isolation root and add adversarial path, ownership, mode, symlink, lifecycle, and workflow tests;
- document the protected runtime and command-file boundary.

The workflow remains manual and non-activating. App stays build-only under Outcome B; governance, reserve, and UI still use `--skip-domain`; no alias, promotion, Git setting, GitHub Deployment, governance QA, or legacy v2 behavior changes.

## Validation

- `pnpm vercel:production-shadow:test` — 90 passed
- `pnpm ci:action-pins` — 26 workflow/action files clean
- `pnpm ci:action-pins:test` — 59 passed
- `pnpm quality:budgets:test` — 30 passed
- `pnpm vercel:primitives:test` — 60 passed
- `pnpm vercel:workflow:test` — 90 passed; the offline-install fixture could not run because the local pnpm store lacks cached `@eslint/js@9.39.2`
- `pnpm check-types` — all eight tasks passed
- `pnpm adr:check`
- `pnpm exec prettier --check <8 changed files>`
- `trunk check <8 changed files>`
- Bash syntax validation — 84 embedded `run` blocks clean
- `git diff --check`
- Fresh-context semantic autoreview — one lifecycle finding fixed; second pass clean
- Deterministic autoreview — clean

No browser check applies to the local patch because it changes only CI/runtime isolation. The required hosted runtime and browser proof will come from the next manual production-shadow pilot after merge.

## Risk

The remaining material risk is hosted-runner behavior that cannot be reproduced faithfully under the local primary user. The next manual pilot remains fail-closed and non-activating, and must pass before #521 or any #522 cutover work can proceed.

Relates to #521.

## Ship Checklist

- [x] ship skill used
- [x] local review run
- [x] validation run
