### PR TITLE
fix(ci): pin candidate pnpm working directory

### DIFF
--- a/.github/actions/vercel-candidate-build/action.yml
+++ b/.github/actions/vercel-candidate-build/action.yml
@@ -364,10 +364,35 @@ runs:
           echo "Candidate can traverse protected path: $RUNNER_TEMP" >&2
           exit 1
         fi
+        sudo --non-interactive /usr/bin/install \
+          -d -o "$build_uid" -g "$build_gid" -m 0700 \
+          "$CANDIDATE_HOME_PATH" \
+          "$CANDIDATE_HOME_PATH/cache" \
+          "$CANDIDATE_HOME_PATH/config" \
+          "$CANDIDATE_HOME_PATH/data" \
+          "$CANDIDATE_HOME_PATH/pnpm-store" \
+          "$CANDIDATE_HOME_PATH/tmp"
+        for candidate_home_entry in \
+          "$CANDIDATE_HOME_PATH" \
+          "$CANDIDATE_HOME_PATH/cache" \
+          "$CANDIDATE_HOME_PATH/config" \
+          "$CANDIDATE_HOME_PATH/data" \
+          "$CANDIDATE_HOME_PATH/pnpm-store" \
+          "$CANDIDATE_HOME_PATH/tmp"; do
+          if ! sudo --non-interactive /usr/bin/test -d "$candidate_home_entry" ||
+            sudo --non-interactive /usr/bin/test -L "$candidate_home_entry" ||
+            [ "$(sudo --non-interactive /usr/bin/realpath "$candidate_home_entry")" != "$candidate_home_entry" ] ||
+            [ "$(sudo --non-interactive /usr/bin/stat -c %u "$candidate_home_entry")" != "$build_uid" ] ||
+            [ "$(sudo --non-interactive /usr/bin/stat -c %g "$candidate_home_entry")" != "$build_gid" ] ||
+            [ "$(sudo --non-interactive /usr/bin/stat -c %a "$candidate_home_entry")" != 700 ]; then
+            echo "Candidate home entry is unsafe: $candidate_home_entry" >&2
+            exit 1
+          fi
+        done
         safe_path="$(/usr/bin/dirname "$NODE_BIN"):/usr/local/bin:/usr/bin:/bin"
         candidate_probe() {
           sudo --non-interactive /usr/bin/env -i \
-            HOME=/nonexistent \
+            HOME="$CANDIDATE_HOME_PATH" \
             LANG=C \
             LC_ALL=C \
             PATH="$safe_path" \
@@ -377,7 +402,7 @@ runs:
             --clear-groups \
             --no-new-privs \
             -- \
-            "$@"
+            /usr/bin/env --chdir="$CANDIDATE_HOME_PATH" -- "$@"
         }
         if ! candidate_probe "$NODE_BIN" --version >/dev/null; then
           echo "Candidate cannot execute protected path: $NODE_BIN" >&2
@@ -399,14 +424,6 @@ runs:
           materialize-source
         sudo --non-interactive /bin/chown \
           -R --no-dereference "$build_uid:$build_gid" "$CANDIDATE_SOURCE_PATH"
-        sudo --non-interactive /usr/bin/install \
-          -d -o "$build_uid" -g "$build_gid" -m 0700 \
-          "$CANDIDATE_HOME_PATH" \
-          "$CANDIDATE_HOME_PATH/cache" \
-          "$CANDIDATE_HOME_PATH/config" \
-          "$CANDIDATE_HOME_PATH/data" \
-          "$CANDIDATE_HOME_PATH/pnpm-store" \
-          "$CANDIDATE_HOME_PATH/tmp"
         printf '{"commitSha":"%s"}\n' "$DEPLOY_SHA" > "$PROVENANCE_PATH"
         /bin/chmod 0600 "$PROVENANCE_PATH"
         echo "build_uid=$build_uid" >> "$GITHUB_OUTPUT"
@@ -465,6 +482,7 @@ runs:
           --clear-groups \
           --no-new-privs \
           -- \
+          /usr/bin/env --chdir="$CANDIDATE_HOME_PATH" -- \
           "$PNPM_BIN" --dir "$CANDIDATE_SOURCE_PATH" install \
           --frozen-lockfile \
           --ignore-scripts \

--- a/scripts/vercel-production-shadow-workflow.test.mjs
+++ b/scripts/vercel-production-shadow-workflow.test.mjs
@@ -629,6 +629,82 @@ test("candidate execution seals command files and rejects hosted tool paths", ()
   );
 });
 
+test("candidate pnpm commands enter an authenticated readable cwd after privilege drop", () => {
+  const isolation = candidateAction.runs.steps.find(
+    (step) => step.name === "Prepare isolated exact-SHA candidate source",
+  );
+  const install = candidateAction.runs.steps.find(
+    (step) => step.name === "Install frozen dependencies as candidate",
+  );
+  assert.ok(isolation);
+  assert.ok(install);
+
+  const homeCreationIndex = isolation.run.indexOf(
+    "sudo --non-interactive /usr/bin/install",
+  );
+  const probeDefinitionIndex = isolation.run.indexOf("candidate_probe() {");
+  assert.ok(
+    homeCreationIndex >= 0 && homeCreationIndex < probeDefinitionIndex,
+    "candidate home must exist before protected runtime probes",
+  );
+  assert.match(isolation.run, /for candidate_home_entry in/);
+  assert.match(
+    isolation.run,
+    /sudo --non-interactive \/usr\/bin\/test -d "\$candidate_home_entry"/,
+  );
+  assert.match(
+    isolation.run,
+    /stat -c %u "\$candidate_home_entry"\)" != "\$build_uid"/,
+  );
+  assert.match(
+    isolation.run,
+    /stat -c %g "\$candidate_home_entry"\)" != "\$build_gid"/,
+  );
+  assert.match(isolation.run, /stat -c %a "\$candidate_home_entry"\)" != 700/);
+
+  const firstProbeIndex = isolation.run.indexOf(
+    'if ! candidate_probe "$NODE_BIN"',
+    probeDefinitionIndex,
+  );
+  assert.ok(
+    firstProbeIndex > probeDefinitionIndex,
+    "candidate Node probe must remain behind the cwd-pinning wrapper",
+  );
+  assert.match(isolation.run, /candidate_probe "\$PNPM_BIN" --version/);
+  const probeSource = isolation.run.slice(
+    probeDefinitionIndex,
+    firstProbeIndex,
+  );
+  const probeSetprivIndex = probeSource.indexOf("/usr/bin/setpriv");
+  const probeChdirIndex = probeSource.indexOf(
+    '/usr/bin/env --chdir="$CANDIDATE_HOME_PATH" -- "$@"',
+  );
+  assert.match(probeSource, /HOME="\$CANDIDATE_HOME_PATH"/);
+  assert.doesNotMatch(probeSource, /HOME=\/nonexistent/);
+  assert.ok(
+    probeSetprivIndex >= 0 && probeSetprivIndex < probeChdirIndex,
+    "candidate probe must change cwd after dropping privileges",
+  );
+
+  const installSetprivIndex = install.run.indexOf("/usr/bin/setpriv");
+  const installChdirIndex = install.run.indexOf(
+    '/usr/bin/env --chdir="$CANDIDATE_HOME_PATH" --',
+  );
+  const installPnpmIndex = install.run.indexOf(
+    '"$PNPM_BIN" --dir "$CANDIDATE_SOURCE_PATH" install',
+  );
+  assert.ok(
+    installSetprivIndex >= 0 &&
+      installSetprivIndex < installChdirIndex &&
+      installChdirIndex < installPnpmIndex,
+    "candidate install must enter its readable home after dropping privileges",
+  );
+  assert.doesNotMatch(
+    isolation.run,
+    /(?:chmod|chown|setfacl)[^\n]*(?:GITHUB_WORKSPACE|CONTROLLER_PATH|SOURCE_PATH)/,
+  );
+});
+
 test("fresh smoke jobs never reuse candidate dependencies or command files", () => {
   for (const target of ["governance", "reserve", "ui"]) {
     const job = workflow.jobs[`smoke-${target}`];


### PR DESCRIPTION
## The Problem

The first exact-main production-shadow run failed safely before any build or deployment. After the workflow dropped to the isolated candidate UID, pnpm inherited the protected controller working directory and failed with `EACCES` before it could process either `--version` or `--dir`. The run did not change protected aliases, create GitHub Deployments, or upload success artifacts.

Failed run: https://github.com/mento-protocol/frontend-monorepo/actions/runs/30017507653

## The Solution

Create and authenticate the candidate-owned `0700` home before runtime probes, then change into that readable directory after dropping privileges for both pnpm probes and dependency installation. The controller and source permissions remain unchanged.

Regression coverage fixes the required ordering and proves the workflow still routes pnpm through the privilege-drop wrapper without broadening protected-path permissions.

Refs #521.

## Validation

- `pnpm vercel:production-shadow:test` — 93/93 passed
- `pnpm vercel:workflow:test` — 93/93 passed
- `pnpm quality:budgets:test` — 30/30 passed
- `pnpm exec prettier --check .github/actions/vercel-candidate-build/action.yml scripts/vercel-production-shadow-workflow.test.mjs`
- `trunk check .github/actions/vercel-candidate-build/action.yml scripts/vercel-production-shadow-workflow.test.mjs`
- `git diff --check`
- `pnpm adr:check`
- Independent semantic review: no blocker, confidence 0.95

## Risk and follow-up

The implementation relies on GNU `env --chdir`, which is available on the pinned Ubuntu runner family. The required final proof is a post-merge hosted production-shadow rerun against the exact new `main` SHA; protected-domain comparison remains read-only and fail-closed.