### PR TITLE
fix(ci): enable Vercel monorepo builds in production shadow

### DIFF
--- a/.github/actions/vercel-candidate-build/action.yml
+++ b/.github/actions/vercel-candidate-build/action.yml
@@ -552,6 +552,7 @@ runs:
         NODE_BIN: ${{ inputs.node-bin }}
         PNPM_BIN: ${{ inputs.pnpm-bin }}
         TRUSTED_VERCEL_CLI_PATH: ${{ inputs.vercel-cli }}
+        VERCEL_BUILD_MONOREPO_SUPPORT: "1"
         VERCEL_ORG_ID: ${{ inputs.vercel-org-id }}
         VERCEL_PROJECT_ID: ${{ inputs.vercel-project-id }}
       run: |
@@ -620,6 +621,7 @@ runs:
           TURBO_TEAM="${TURBO_TEAM:-}" \
           TURBO_TOKEN="${TURBO_TOKEN:-}" \
           VERCEL="${VERCEL:-1}" \
+          VERCEL_BUILD_MONOREPO_SUPPORT="$VERCEL_BUILD_MONOREPO_SUPPORT" \
           VERCEL_ENV="${VERCEL_ENV:-}" \
           VERCEL_GIT_COMMIT_REF="${VERCEL_GIT_COMMIT_REF:-main}" \
           VERCEL_GIT_COMMIT_SHA="$DEPLOY_SHA" \

--- a/scripts/vercel-production-shadow-workflow.test.mjs
+++ b/scripts/vercel-production-shadow-workflow.test.mjs
@@ -840,6 +840,52 @@ test("sanitized Vercel build child receives the exact Git identity tuple", () =>
   }
 });
 
+test("candidate build forces trusted Vercel monorepo support", () => {
+  const build = candidateAction.runs.steps.find(
+    (step) => step.name === "Build prebuilt output as candidate",
+  );
+  assert.ok(build, "missing candidate Vercel build step");
+  assert.equal(build.env.VERCEL_BUILD_MONOREPO_SUPPORT, "1");
+  assert.equal(
+    Object.hasOwn(candidateAction.inputs, "vercel-build-monorepo-support"),
+    false,
+    "candidate callers must not override the trusted constant",
+  );
+
+  const cliInvocation =
+    '"$NODE_BIN" "$TRUSTED_VERCEL_CLI_PATH" "${build_arguments[@]}"';
+  const invocationIndex = build.run.indexOf(cliInvocation);
+  assert.notEqual(invocationIndex, -1, "missing pinned Vercel CLI invocation");
+  const environmentIndex = build.run.lastIndexOf(
+    "sudo --non-interactive /usr/bin/env -i",
+    invocationIndex,
+  );
+  assert.notEqual(
+    environmentIndex,
+    -1,
+    "missing sanitized Vercel CLI environment",
+  );
+  const child = build.run.slice(
+    environmentIndex,
+    invocationIndex + cliInvocation.length,
+  );
+  assert.equal(
+    child
+      .split("\n")
+      .filter(
+        (line) =>
+          line.trim() ===
+          'VERCEL_BUILD_MONOREPO_SUPPORT="$VERCEL_BUILD_MONOREPO_SUPPORT" \\',
+      ).length,
+    1,
+  );
+  assert.doesNotMatch(
+    child,
+    /VERCEL_BUILD_MONOREPO_SUPPORT="\$\{VERCEL_BUILD_MONOREPO_SUPPORT[:-]/,
+    "candidate environment must not supply a fallback or override",
+  );
+});
+
 test("every repo-linked pull validates local and remote project identity before build", () => {
   for (const target of ["app", "governance", "reserve", "ui"]) {
     const targetLabel = target === "ui" ? "UI" : target;


### PR DESCRIPTION
## The Problem

Production-shadow run [30020476089](https://github.com/mento-protocol/frontend-monorepo/actions/runs/30020476089) failed safely before upload because App and Governance ran direct `pnpm run build` commands without first building their internal workspace dependencies. The production candidate action omitted `VERCEL_BUILD_MONOREPO_SUPPORT=1`, so pinned Vercel CLI 56.2.0 did not activate its Turborepo monorepo defaults. Both builds then failed to resolve `@mento-protocol/ui` and `@repo/web3` outputs.

The final protected-domain comparison passed. No deployment upload, artifact, GitHub Deployment, or protected-alias change occurred.

## The Solution

Set `VERCEL_BUILD_MONOREPO_SUPPORT` to the trusted literal `1` at the single composite candidate-build step and forward it exactly once through the sanitized `env -i` child before the pinned Vercel CLI invocation. The action exposes no caller override or fallback.

Structural coverage proves the literal value, absence of an action input override, and exact forwarding boundary. This restores the same reviewed behavior already used by successful preview builds and documented in the runbook.

Refs #521.

## Validation

- `pnpm vercel:production-shadow:test` — 94/94 passed
- `pnpm vercel:workflow:test` — 93/93 passed
- `pnpm quality:budgets:test` — 30/30 passed
- `pnpm exec prettier --check .github/actions/vercel-candidate-build/action.yml scripts/vercel-production-shadow-workflow.test.mjs`
- `trunk check .github/actions/vercel-candidate-build/action.yml scripts/vercel-production-shadow-workflow.test.mjs`
- `pnpm adr:check`
- `git diff --check`
- Fresh-context semantic autoreview — clean, confidence 0.97

## Risk and follow-up

This is deliberately coupled to pinned Vercel CLI 56.2.0, whose monorepo defaults are gated by this exact variable. The runbook already requires re-auditing the flag when the CLI changes. The final cross-UID proof remains a new exact-main hosted production-shadow run after merge.