### PR TITLE
fix(governance): resolve Apollo local proposal fields

### DIFF
--- a/apps/governance.mento.org/app/graphql/apollo.client.test.ts
+++ b/apps/governance.mento.org/app/graphql/apollo.client.test.ts
@@ -1,5 +1,10 @@
-import { gql } from "@apollo/client";
+import { gql, type ObservableQuery } from "@apollo/client";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  GetProposalsDocument,
+  type GetProposalsQuery,
+  type GetProposalsQueryVariables,
+} from "@/graphql/subgraph/generated/subgraph";
 
 vi.mock("@/env.mjs", () => ({
   env: {
@@ -144,8 +149,131 @@ describe("makeClient", () => {
 
     expect(result.error).toBeUndefined();
     expect(result.data?.proposals[0]?.metadata).toEqual({
+      __typename: "ProposalMetadata",
       title: "Test title",
       description: "Test description",
+    });
+  });
+
+  it("resolves nested local proposal fields in watched queries", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            data: {
+              proposals: [
+                {
+                  __typename: "Proposal",
+                  proposalId: "1",
+                  description: JSON.stringify({
+                    title: "Test title",
+                    description: "Test description",
+                  }),
+                  proposer: {
+                    __typename: "Account",
+                    id: "0x0000000000000000000000000000000000000002",
+                  },
+                  proposalCreated: [],
+                  proposalQueued: [],
+                  proposalExecuted: [],
+                  proposalCanceled: [],
+                  votecast: [
+                    {
+                      __typename: "VoteCast",
+                      id: "vote-1",
+                      support: {
+                        __typename: "ProposalSupport",
+                        weight: "10",
+                      },
+                      receipt: {
+                        __typename: "VoteReceipt",
+                        id: "receipt-1",
+                        voter: {
+                          __typename: "Account",
+                          id: "0x0000000000000000000000000000000000000001",
+                        },
+                        weight: "10",
+                        support: {
+                          __typename: "ProposalSupport",
+                          id: "support-1",
+                          support: 1,
+                        },
+                      },
+                    },
+                  ],
+                  startBlock: "1",
+                  endBlock: "2",
+                  queued: false,
+                  canceled: false,
+                  executed: false,
+                },
+              ],
+            },
+          }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        ),
+      ),
+    );
+
+    const observable = makeClient().watchQuery<
+      GetProposalsQuery,
+      GetProposalsQueryVariables
+    >({
+      query: GetProposalsDocument,
+      fetchPolicy: "network-only",
+      errorPolicy: "all",
+      context: { apiName: "subgraph" },
+    });
+    const result = await new Promise<ObservableQuery.Result<GetProposalsQuery>>(
+      (resolve, reject) => {
+        const subscription = observable.subscribe({
+          next: (nextResult) => {
+            if (!nextResult.loading) {
+              subscription.unsubscribe();
+              resolve(nextResult);
+            }
+          },
+          error: reject,
+        });
+      },
+    );
+
+    expect(result.error).toBeUndefined();
+    expect(result.data?.proposals?.[0]).toMatchObject({
+      metadata: {
+        __typename: "ProposalMetadata",
+        title: "Test title",
+        description: "Test description",
+      },
+      votes: {
+        __typename: "ProposalVotes",
+        for: {
+          __typename: "VoteType",
+          participants: [
+            {
+              __typename: "Participant",
+              address: "0x0000000000000000000000000000000000000001",
+              weight: 10n,
+            },
+          ],
+          total: 10n,
+        },
+        against: {
+          __typename: "VoteType",
+          participants: [],
+          total: 0n,
+        },
+        abstain: {
+          __typename: "VoteType",
+          participants: [],
+          total: 0n,
+        },
+        total: 10n,
+      },
     });
   });
 });

--- a/apps/governance.mento.org/app/graphql/subgraph/policies/Proposal.ts
+++ b/apps/governance.mento.org/app/graphql/subgraph/policies/Proposal.ts
@@ -3,6 +3,7 @@ import { makeVar, type TypePolicy } from "@apollo/client/cache";
 import {
   ProposalState,
   ProposalSupport,
+  ProposalMetadata,
   ProposalVotes,
   Scalars,
   VoteCast,
@@ -23,7 +24,7 @@ export const ProposalPolicy: TypePolicy = {
       },
     },
     metadata: {
-      read(_, { readField }): { title: string; description: string } {
+      read(_, { readField }): ProposalMetadata {
         const rawMetadata = readField<string>("description") || "";
         let metadata;
         try {
@@ -36,6 +37,7 @@ export const ProposalPolicy: TypePolicy = {
         }
 
         return {
+          __typename: "ProposalMetadata",
           title: metadata.title || "Missing title",
           description: metadata.description || "Missing description",
         };
@@ -67,17 +69,29 @@ export const ProposalPolicy: TypePolicy = {
             switch (support) {
               case 0: // AGAINST
                 acc.against.total += weight;
-                acc.against.participants.push({ address, weight });
+                acc.against.participants.push({
+                  __typename: "Participant",
+                  address,
+                  weight,
+                });
                 break;
 
               case 1: // FOR
                 acc.for.total += weight;
-                acc.for.participants.push({ address, weight });
+                acc.for.participants.push({
+                  __typename: "Participant",
+                  address,
+                  weight,
+                });
                 break;
 
               case 2: // ABSTAIN
                 acc.abstain.total += weight;
-                acc.abstain.participants.push({ address, weight });
+                acc.abstain.participants.push({
+                  __typename: "Participant",
+                  address,
+                  weight,
+                });
                 break;
 
               default:
@@ -88,9 +102,22 @@ export const ProposalPolicy: TypePolicy = {
             return acc;
           },
           {
-            for: { participants: [], total: 0n },
-            against: { participants: [], total: 0n },
-            abstain: { participants: [], total: 0n },
+            __typename: "ProposalVotes",
+            for: {
+              __typename: "VoteType",
+              participants: [],
+              total: 0n,
+            },
+            against: {
+              __typename: "VoteType",
+              participants: [],
+              total: 0n,
+            },
+            abstain: {
+              __typename: "VoteType",
+              participants: [],
+              total: 0n,
+            },
             total: 0n,
           },
         );


### PR DESCRIPTION
## The Problem

Apollo Client 4 requires client-resolved objects with child selections to
include `__typename`. The governance `Proposal.metadata` and `Proposal.votes`
type policies returned anonymous nested objects, so watched `GetProposals`
queries dropped those fields and reported handled Apollo invariant errors to
Sentry.

This caused the duplicate incident family tracked by
`GOVERNANCE-MENTO-ORG-55`, `GOVERNANCE-MENTO-ORG-5D`, and
mento-protocol/monitoring-monorepo#1509.

## The Solution

- Return the generated GraphQL typename for proposal metadata, vote summaries,
  vote buckets, and participants.
- Add a regression test that runs the generated `GetProposalsDocument` through
  `watchQuery` and asserts the complete nested local result.
- Keep vote aggregation and server query behavior unchanged.

## Validation

- `pnpm --filter governance.mento.org exec vitest run app/graphql/apollo.client.test.ts --reporter=verbose`
  — 7 tests passed.
- `pnpm exec turbo run test --filter governance.mento.org`
  — 17 files and 105 tests passed.
- `pnpm exec turbo run check-types --filter governance.mento.org`
  — 3 tasks passed.
- `pnpm quality:budgets:test`
  — 30 tests passed.
- `pnpm quality:coverage`
  — all four budgeted workspaces passed their coverage floors.
- `pnpm exec turbo run build --filter governance.mento.org`
  — the Turbopack production build and sharp runtime trace check passed.
- `trunk check apps/governance.mento.org/app/graphql/apollo.client.test.ts apps/governance.mento.org/app/graphql/subgraph/policies/Proposal.ts`
  — no issues.
- Chrome loaded the production build against the exact successful production
  `GetProposals` response: 23 proposals rendered, the canceled-proposals toggle
  changed to `aria-checked="true"`, and the console had zero errors.
- Fresh-context autoreview and the nine-lens specialist review plus independent
  Codex baseline found no actionable issues.
- The pre-push hook passed repo-wide Trunk, type checks, and Knip.

## Risk

Low. The patch adds schema-defined discriminators to existing client-only
objects and does not change GraphQL requests, vote math, or persistence.

Architecture decision: Not applicable — this is a compatibility fix inside the
existing Apollo type-policy boundary.

## Ship Checklist

- [x] PR title follows the conventions
- [x] Performed a self-review of my own changes
- [x] Relevant automated checks and smoke tests pass
- [x] Ship skill used
- [x] Local review run
- [x] Validation run
