### PR TITLE
fix(ci): validate Vercel generated aliases

### DIFF
--- a/.github/workflows/vercel-production-shadow.yml
+++ b/.github/workflows/vercel-production-shadow.yml
@@ -1,8 +1,11 @@
 name: Vercel Production Shadow
 
-# Manual, non-activating production pilot. Ordinary projects upload unaliased
-# production artifacts; app custom v3 is build-only because the pinned CLI has
-# no documented no-alias custom-environment deploy.
+# Manual, non-promoting production pilot. Ordinary uploads avoid protected and
+# custom production domains, but implicitly move the target's reviewed generated
+# project/team alias. The workflow issues no explicit alias assignment,
+# promotion, environment-configuration, ownership, or protected-domain
+# mutation. App custom v3 is build-only because the pinned CLI has no documented
+# non-activating custom-environment deploy.
 #checkov:skip=CKV_GHA_7:Immutable SHA and reviewed alias inputs are mandatory for this manual pilot.
 on:
   workflow_dispatch:
@@ -452,7 +455,7 @@ jobs:
           path: trusted-after-build
           persist-credentials: false
           ref: ${{ needs.preflight.outputs.deploy_sha }}
-      - name: Upload unchanged governance output without domains
+      - name: Upload unchanged governance output without custom production domains
         id: deploy
         env:
           DEPLOY_SHA: ${{ needs.preflight.outputs.deploy_sha }}
@@ -490,7 +493,7 @@ jobs:
           "${{ steps.runtime.outputs.node-bin }}" "$TRUSTED_POST_BUILD_PATH/scripts/vercel-production-shadow.mjs" create-spec --output "$RUNNER_TEMP/protected-spec.json"
           "${{ steps.runtime.outputs.node-bin }}" "$TRUSTED_POST_BUILD_PATH/scripts/vercel-deployment-state.mjs" snapshot --spec "$RUNNER_TEMP/protected-spec.json" --output "$RUNNER_TEMP/current.json"
           "${{ steps.runtime.outputs.node-bin }}" "$TRUSTED_POST_BUILD_PATH/scripts/vercel-deployment-state.mjs" compare --before "$RUNNER_TEMP/governance-compare-baseline.json" --after "$RUNNER_TEMP/current.json"
-      - name: Verify governance deployment provenance and readiness
+      - name: Verify governance deployment provenance, readiness, and generated aliases
         env:
           VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN_PRODUCTION }}
@@ -502,7 +505,7 @@ jobs:
             sleep 5
           done
           "$verified"
-          "${{ steps.runtime.outputs.node-bin }}" "$TRUSTED_POST_BUILD_PATH/scripts/vercel-production-shadow.mjs" assert-unaliased --input "$RUNNER_TEMP/governance-state.json"
+          "${{ steps.runtime.outputs.node-bin }}" "$TRUSTED_POST_BUILD_PATH/scripts/vercel-production-shadow.mjs" assert-generated-aliases --target governance --input "$RUNNER_TEMP/governance-state.json"
       - name: Scan governance canonical evidence
         run: |
           set -o noclobber
@@ -665,7 +668,7 @@ jobs:
           path: trusted-after-build
           persist-credentials: false
           ref: ${{ needs.preflight.outputs.deploy_sha }}
-      - name: Upload unchanged reserve output without domains
+      - name: Upload unchanged reserve output without custom production domains
         id: deploy
         env:
           DEPLOY_SHA: ${{ needs.preflight.outputs.deploy_sha }}
@@ -703,7 +706,7 @@ jobs:
           "${{ steps.runtime.outputs.node-bin }}" "$TRUSTED_POST_BUILD_PATH/scripts/vercel-production-shadow.mjs" create-spec --output "$RUNNER_TEMP/protected-spec.json"
           "${{ steps.runtime.outputs.node-bin }}" "$TRUSTED_POST_BUILD_PATH/scripts/vercel-deployment-state.mjs" snapshot --spec "$RUNNER_TEMP/protected-spec.json" --output "$RUNNER_TEMP/current.json"
           "${{ steps.runtime.outputs.node-bin }}" "$TRUSTED_POST_BUILD_PATH/scripts/vercel-deployment-state.mjs" compare --before "$RUNNER_TEMP/reserve-compare-baseline.json" --after "$RUNNER_TEMP/current.json"
-      - name: Verify reserve deployment provenance and readiness
+      - name: Verify reserve deployment provenance, readiness, and generated aliases
         env:
           VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN_PRODUCTION }}
@@ -715,7 +718,7 @@ jobs:
             sleep 5
           done
           "$verified"
-          "${{ steps.runtime.outputs.node-bin }}" "$TRUSTED_POST_BUILD_PATH/scripts/vercel-production-shadow.mjs" assert-unaliased --input "$RUNNER_TEMP/reserve-state.json"
+          "${{ steps.runtime.outputs.node-bin }}" "$TRUSTED_POST_BUILD_PATH/scripts/vercel-production-shadow.mjs" assert-generated-aliases --target reserve --input "$RUNNER_TEMP/reserve-state.json"
       - name: Scan reserve canonical evidence
         run: |
           set -o noclobber
@@ -877,7 +880,7 @@ jobs:
           path: trusted-after-build
           persist-credentials: false
           ref: ${{ needs.preflight.outputs.deploy_sha }}
-      - name: Upload unchanged UI output without domains
+      - name: Upload unchanged UI output without custom production domains
         id: deploy
         env:
           DEPLOY_SHA: ${{ needs.preflight.outputs.deploy_sha }}
@@ -915,7 +918,7 @@ jobs:
           "${{ steps.runtime.outputs.node-bin }}" "$TRUSTED_POST_BUILD_PATH/scripts/vercel-production-shadow.mjs" create-spec --output "$RUNNER_TEMP/protected-spec.json"
           "${{ steps.runtime.outputs.node-bin }}" "$TRUSTED_POST_BUILD_PATH/scripts/vercel-deployment-state.mjs" snapshot --spec "$RUNNER_TEMP/protected-spec.json" --output "$RUNNER_TEMP/current.json"
           "${{ steps.runtime.outputs.node-bin }}" "$TRUSTED_POST_BUILD_PATH/scripts/vercel-deployment-state.mjs" compare --before "$RUNNER_TEMP/ui-compare-baseline.json" --after "$RUNNER_TEMP/current.json"
-      - name: Verify UI deployment provenance and readiness
+      - name: Verify UI deployment provenance, readiness, and generated aliases
         env:
           VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN_PRODUCTION }}
@@ -927,7 +930,7 @@ jobs:
             sleep 5
           done
           "$verified"
-          "${{ steps.runtime.outputs.node-bin }}" "$TRUSTED_POST_BUILD_PATH/scripts/vercel-production-shadow.mjs" assert-unaliased --input "$RUNNER_TEMP/ui-state.json"
+          "${{ steps.runtime.outputs.node-bin }}" "$TRUSTED_POST_BUILD_PATH/scripts/vercel-production-shadow.mjs" assert-generated-aliases --target ui --input "$RUNNER_TEMP/ui-state.json"
       - name: Scan UI canonical evidence
         run: |
           set -o noclobber

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,18 +56,23 @@ the structural test in the same PR. Never execute a triggering head SHA from
 this privileged `workflow_run` workflow.
 
 `.github/workflows/vercel-production-shadow.yml` is manual-only and
-non-activating. Candidate dependency installation and builds must run under its
-dedicated UID boundary with exact protected tools, private-umask runner-owned
-pull staging, raw Git-object materialization of the exact commit (never
-archive/checkout filters), and a runner-owned verified output handoff. Browser
-smoke must use a fresh trusted checkout and dependencies, never candidate
-`node_modules`; tear down every candidate boundary before upload or later
-production-token checks. Keep all build-boundary state below the target-scoped,
-authenticated `/var/lib/mento-vercel-runtime-<run>-<attempt>-<target>/work`
-root, seal `RUNNER_TEMP` to runner-owned mode `0700` before candidate execution,
-and reauthenticate and remove the exact runtime in a final `if: always()` step.
-Preserve App custom `v3` as build-only, preserve the App `v2` alias, and keep
-Governance, Reserve, and UI deployments unaliased.
+non-promoting. Ordinary uploads implicitly move the target's reviewed generated
+project/team alias, but the workflow issues no explicit alias assignment, promotion,
+environment-configuration, ownership, or protected-domain mutation. Candidate
+dependency installation and builds must run under its dedicated UID boundary
+with exact protected tools, private-umask runner-owned pull staging, raw
+Git-object materialization of the exact commit (never archive/checkout filters),
+and a runner-owned verified output handoff. Browser smoke must use a fresh
+trusted checkout and dependencies, never candidate `node_modules`; tear down
+every candidate boundary before upload or later production-token checks. Keep
+all build-boundary state below the target-scoped, authenticated
+`/var/lib/mento-vercel-runtime-<run>-<attempt>-<target>/work` root, seal
+`RUNNER_TEMP` to runner-owned mode `0700` before candidate execution, and
+reauthenticate and remove the exact runtime in a final `if: always()` step.
+Preserve App custom `v3` as build-only and preserve the App `v2` alias.
+Governance, Reserve, and UI uploads must avoid custom production domains and
+contain exactly the immutable deployment hostname plus the target's reviewed
+literal Vercel-generated project/team alias.
 Every candidate Vercel build must use `--standalone`; reject invalid, oversized,
 or non-empty-`filePathMap` `.vc-config.json` files before handoff and again on
 the runner-owned upload tree.

--- a/README.md
+++ b/README.md
@@ -498,11 +498,14 @@ The repository is set up with GitHub Actions for CI:
   procedures.
 
   The manual `Vercel Production Shadow` workflow can build App custom `v3`
-  without deploying it and upload unaliased Governance, Reserve, and UI
-  production artifacts for verification; it never activates a domain or changes
-  ownership. Its exact-SHA contract, read-only protected-domain drift checks,
-  guarded manual operator recovery, and direct smoke are documented in the same
-  runbook.
+  without deploying it and upload Governance, Reserve, and UI production
+  artifacts without custom production domains. Each staged ordinary deployment
+  has only its immutable hostname and reviewed Vercel-generated project/team
+  alias. The upload implicitly moves that generated system alias, while the
+  workflow performs no explicit alias, promote, environment-configuration,
+  ownership, or protected/custom production-domain mutation. Its exact-SHA
+  contract, read-only protected-domain drift checks, guarded manual operator
+  recovery, and direct smoke are documented in the same runbook.
 
 Dependency-installing jobs use `.github/actions/pnpm-install`, which pins the
 Node/pnpm bootstrap, relies on `actions/setup-node` as the single pnpm-store

--- a/docs/adr/0001-github-actions-vercel-deployment-orchestration.md
+++ b/docs/adr/0001-github-actions-vercel-deployment-orchestration.md
@@ -176,15 +176,25 @@ definition after the exact `CI/CD` run and exact `Build and Test` job succeed
 for the deployment SHA. It rechecks that the candidate is still current `main`
 before the transaction and immediately before and after every public mutation.
 
-Governance, reserve, and UI are built as unaliased staged production
-deployments, inspected, and runtime/browser verified before any domain moves.
-They are then promoted sequentially by exact immutable deployment ID. The app
-`v3` prebuilt candidate is built and verified under custom-environment semantics
-before mutation, but `vercel deploy --prebuilt --target=v3` runs last because
-that upload is itself the activation mutation when attached `v3` domains move.
-The controller then verifies every reviewed alias and assigns only those that do
-not already point to the exact deployment as intended. `--prod` and
-`vercel promote` are forbidden for the app `main -> v3` path.
+Governance, reserve, and UI are built as staged production deployments without
+custom production domains, inspected, and runtime/browser verified before any
+protected or custom production domain moves. In the reviewed CI topology, each
+staged deployment has its immutable hostname and one literal project/team alias
+confirmed from the read-only observed public topology. The controller requires
+exactly those two target-bound aliases, rejects any protected or extra alias,
+and fails safely if Vercel changes that topology.
+The ordinary upload implicitly moves that generated system alias, so the
+controller treats staging as a limited public-routing mutation: it rechecks
+current `main`, journals the intended upload, verifies the resulting immutable
+deployment and generated-alias topology, and retains the transaction evidence
+before continuing. The deployments are then promoted sequentially by exact
+immutable deployment ID. The app `v3` prebuilt candidate is built and verified
+under custom-environment semantics before its app-v3 activation mutation, but
+`vercel deploy --prebuilt --target=v3` runs last because that upload is itself
+the activation mutation when attached `v3` domains move. The controller then
+verifies every reviewed alias and assigns only those that do not already point
+to the exact deployment as intended. `--prod` and `vercel promote` are
+forbidden for the app `main -> v3` path.
 
 Before mutation, the controller records the exact prior deployment and every
 protected alias for every selected target. It journals intent before each
@@ -219,8 +229,8 @@ with explicit compensation.
 
 Vercel Git remains authoritative until each Actions path has shadow or pilot
 evidence. Preview paths cut over before `main`; the three ordinary production
-targets prove no-domain staging, and app `v3` proves its activation semantics,
-before the final reviewed ownership change.
+targets prove staging without protected/custom-domain promotion, and app `v3`
+proves its activation semantics, before the final reviewed ownership change.
 
 The current version-controlled preview map assigns App, Governance, Reserve,
 and UI to GitHub Actions. App's configuration change was accepted after its
@@ -304,7 +314,8 @@ chosen first-plus-latest controller removes only superseded intermediate work.
 Rejected. Allowing Vercel Git and Actions to deploy the same target would create
 duplicate cost, competing GitHub Deployments, and races over aliases/domains.
 Dual execution is allowed only during a bounded non-authoritative pilot or
-shadow proof where exactly one path can serve public traffic.
+shadow proof where exactly one path owns protected and custom production
+traffic.
 
 ### GitHub-hosted prebuilt uploads
 

--- a/docs/vercel-deployments.md
+++ b/docs/vercel-deployments.md
@@ -27,9 +27,11 @@ per-target `shadow` or `github` mode live together in
 guards, and ownership tests import or structurally verify that source; do not
 copy a second ownership table into executable code.
 
-The guarded manual production-shadow pilot does not activate a domain or change
-deployment ownership. Until the later production cutover issues ship, the
-Vercel Git integration remains the production deployment owner.
+The guarded manual production-shadow pilot does not promote or mutate a
+protected/custom production domain or deployment ownership. Each ordinary
+upload implicitly moves the target's reviewed generated project/team alias.
+Until the later production cutover issues ship, the Vercel Git integration
+remains the protected/custom production deployment owner.
 
 ## Pinned prerequisites
 
@@ -361,7 +363,9 @@ them, and a Vercel Sensitive value must never be assumed to appear in
 ## Manual production-shadow pilot
 
 `.github/workflows/vercel-production-shadow.yml` is a manual-only,
-non-activating pilot. Dispatch it from `main` with:
+non-promoting pilot. Its ordinary uploads implicitly move the reviewed generated
+system aliases but do not move protected/custom production domains. Dispatch it
+from `main` with:
 
 - `deploy_sha`: a full 40-character commit SHA that exactly equals the fetched
   `refs/remotes/origin/main` tip;
@@ -520,6 +524,26 @@ runner:    validate -> immutable handoff -> destroy candidate boundary
 runner:    vercel deploy --prebuilt --prod --skip-domain --archive=tgz --format=json
 ```
 
+`--skip-domain` suppresses custom production-domain assignment. In this reviewed
+team/project topology, confirmed by read-only checks of the observed public
+routes, the Vercel CLI still assigns the deployment's immutable hostname and an
+unavoidable generated project/team alias; it offers no supported
+zero-generated-alias mode. The controller binds that generated alias to each
+literal target:
+
+- Governance: `governancementoorg-mentolabs.vercel.app`
+- Reserve: `reservementoorg-mentolabs.vercel.app`
+- UI: `uimentoorg-mentolabs.vercel.app`
+
+Any missing immutable or generated alias, protected/custom domain, branch or
+global alias, wrong-target alias, or malformed canonical hostname evidence fails
+closed. The read-only state inspector normalizes and deduplicates raw provider
+aliases; persisted canonical evidence must remain deduplicated and sorted.
+Protected-domain before/after equality remains the decisive proof that the
+upload did not activate protected/custom production traffic. A future
+provider-generated alias topology must fail first and receive a reviewed
+contract update rather than being accepted implicitly.
+
 Each command is launched at the monorepo root with an explicit literal
 `--project` argument. The controller removes `VERCEL_ORG_ID` and
 `VERCEL_PROJECT_ID` only from the CLI child environment after validating them
@@ -541,21 +565,23 @@ The uploaded `apps/<target>/.vercel/output` is the exact output whose custom
 Next deployment ID was asserted and copied into the runner-owned handoff. It is
 never transferred as a GitHub artifact.
 Each immutable URL must prove the literal project, `production` target, `READY`
-state, exact repository/ref/SHA metadata, and an alias set containing only its
-immutable deployment hostname before smoke begins. The browser then proves
-critical security headers, a stable page marker, and a target-specific
-non-transaction interaction. Protected alias
-mappings are compared after each upload and once again at the end. Once the
-candidate build boundary and fresh trusted-controller checkout both succeed, an
-always-run read-only check executes immediately after every deploy attempt,
-including failed deploy attempts, before state polling, Chromium installation,
-or smoke checks. Candidate-boundary or trusted-checkout failure never exposes
-the production token to this check. Any drift fails the run without executing
-an alias, deploy, promotion, or rollback command. The failure contains only
-canonical alias plus before/current deployment IDs and immutable URLs, followed
-by manual operator instructions. The final all-target comparison has its own
-fresh trusted checkout and likewise cannot receive the production token when
-that checkout fails.
+state, exact repository/ref/SHA metadata, and an alias set containing exactly
+its immutable deployment hostname plus the target's reviewed generated
+project/team alias before smoke begins. Smoke and browser verification use only
+the immutable deployment URL; the generated alias is state evidence, never the
+runtime test endpoint. The browser then proves critical security headers, a
+stable page marker, and a target-specific non-transaction interaction.
+Protected alias mappings are compared after each upload and once again at the
+end. Once the candidate build boundary and fresh trusted-controller checkout
+both succeed, an always-run read-only check executes immediately after every
+deploy attempt, including failed deploy attempts, before state polling,
+Chromium installation, or smoke checks. Candidate-boundary or trusted-checkout
+failure never exposes the production token to this check. Any drift fails the
+run without executing an alias, deploy, promotion, or rollback command. The
+failure contains only canonical alias plus before/current deployment IDs and
+immutable URLs, followed by manual operator instructions. The final all-target
+comparison has its own fresh trusted checkout and likewise cannot receive the
+production token when that checkout fails.
 
 On drift, stop all forward work. Confirm the change is not an intentional or
 concurrent activation, re-resolve every affected alias, and require it still to
@@ -634,8 +660,10 @@ artifacts bounded.
 Do not run the manual pilot until the required GitHub Environment, repository
 variables, production token, mirrored build-variable names, and reviewed app-v3
 alias list are confirmed present. The workflow itself performs no Vercel Git
-setting change, domain activation, promotion, or cleanup of a serving
-deployment.
+setting, explicit alias, promotion, environment-configuration, ownership,
+protected/custom production-domain, or serving-deployment cleanup command. Each
+ordinary deploy still performs the bounded implicit movement of its reviewed
+generated system alias.
 
 Each candidate build must emit exactly one canonical Turbo
 `Cached: X cached, Y total` line. Missing, duplicate, malformed, or impossible
@@ -672,10 +700,13 @@ loopback origins and the Playwright-pinned Chromium to prove a cross-origin
 redirect cannot inherit a protection header.
 
 The test commands above perform no Vercel API call, build upload, deployment,
-alias mutation, environment mutation, or Git-ownership change. The manual
-production-shadow workflow described above does use read-only Vercel API checks
-and stages non-activating ordinary-project deployments; it still performs no
-alias mutation, environment mutation, or Git-ownership change.
+alias mutation, environment-configuration mutation, or Git-ownership change. The
+manual production-shadow workflow described above does use read-only Vercel API
+checks and stages ordinary-project deployments without promoting
+protected/custom production domains. Each upload implicitly moves the target's
+reviewed generated system alias; the workflow performs no explicit alias
+assignment, promotion, environment-configuration, ownership, or
+protected/custom production-domain mutation.
 
 ## Cost validation preparation
 

--- a/scripts/vercel-production-shadow-workflow.test.mjs
+++ b/scripts/vercel-production-shadow-workflow.test.mjs
@@ -8,6 +8,7 @@ import {
   buildProductionShadowBuildArguments,
   buildProductionShadowDeployArguments,
   buildProductionShadowPullArguments,
+  PRODUCTION_SHADOW_TARGETS,
 } from "./vercel-production-shadow.mjs";
 
 const SHA = "0123456789abcdef0123456789abcdef01234567";
@@ -963,7 +964,12 @@ test("ordinary targets use isolated builds, runner-owned handoff, and fresh smok
     );
     assert.match(source, /vercel-deployment-state\.mjs"? deployment/);
     assert.match(source, /vercel-deployment-state\.mjs"? compare/);
-    assert.match(source, /vercel-production-shadow\.mjs"? assert-unaliased/);
+    assert.match(
+      source,
+      new RegExp(
+        `vercel-production-shadow\\.mjs"? assert-generated-aliases --target ${target}`,
+      ),
+    );
     assert.match(source, /check-versions --repo-root "\$SOURCE_PATH"/);
     assert.doesNotMatch(source, /playwright (?:install|test)/);
 
@@ -973,6 +979,21 @@ test("ordinary targets use isolated builds, runner-owned handoff, and fresh smok
     assert.match(smokeSource, /PRODUCTION_SHADOW_EXPECTED_DEPLOYMENT_ID/);
     assert.match(smokeSource, /PRODUCTION_SHADOW_EXPECTED_SHA/);
     assert.equal(workflow.jobs[`smoke-${target}`].needs.includes(target), true);
+    const directSmoke = stepNamed(
+      `smoke-${target}`,
+      `Run direct ${target === "ui" ? "UI" : target} production-shadow smoke`,
+    );
+    assert.equal(
+      directSmoke.env.PRODUCTION_SHADOW_URL,
+      `\${{ needs.${target}.outputs.deployment_url }}`,
+    );
+    assert.equal(
+      smokeSource.includes(
+        PRODUCTION_SHADOW_TARGETS[target].generatedProjectAlias,
+      ),
+      false,
+      `${target} smoke must use only the immutable deployment URL`,
+    );
 
     const projectId = `prj_${target}123`;
     assert.deepEqual(
@@ -1027,7 +1048,7 @@ test("ordinary uploads stop forward mutation after any prior drift failure", () 
     const targetLabel = target === "ui" ? "UI" : target;
     const upload = stepNamed(
       target,
-      `Upload unchanged ${targetLabel} output without domains`,
+      `Upload unchanged ${targetLabel} output without custom production domains`,
     );
     const drift = stepNamed(
       target,
@@ -1372,7 +1393,9 @@ test("every deploy is immediately checked for drift without automatic repair", (
     const stateIndex = steps.findIndex(
       (step) =>
         step.name?.startsWith("Verify ") &&
-        step.name.endsWith(" deployment provenance and readiness"),
+        step.name.endsWith(
+          " deployment provenance, readiness, and generated aliases",
+        ),
     );
     assert.ok(deployIndex < deployIndex + 1);
     assert.ok(deployIndex + 1 < compareIndex);

--- a/scripts/vercel-production-shadow.mjs
+++ b/scripts/vercel-production-shadow.mjs
@@ -96,12 +96,14 @@ export const PRODUCTION_SHADOW_TARGETS = {
     pullEnvironment: "v3",
     buildArguments: ["build", "--yes", "--standalone", "--target", "v3"],
     deployArguments: null,
+    generatedProjectAlias: null,
   },
   governance: {
     projectName: "governance.mento.org",
     rootDirectory: "apps/governance.mento.org",
     pullEnvironment: "production",
     buildArguments: ["build", "--yes", "--standalone", "--prod"],
+    generatedProjectAlias: "governancementoorg-mentolabs.vercel.app",
     deployArguments: [
       "deploy",
       "--prebuilt",
@@ -117,6 +119,7 @@ export const PRODUCTION_SHADOW_TARGETS = {
     rootDirectory: "apps/reserve.mento.org",
     pullEnvironment: "production",
     buildArguments: ["build", "--yes", "--standalone", "--prod"],
+    generatedProjectAlias: "reservementoorg-mentolabs.vercel.app",
     deployArguments: [
       "deploy",
       "--prebuilt",
@@ -132,6 +135,7 @@ export const PRODUCTION_SHADOW_TARGETS = {
     rootDirectory: "apps/ui.mento.org",
     pullEnvironment: "production",
     buildArguments: ["build", "--yes", "--standalone", "--prod"],
+    generatedProjectAlias: "uimentoorg-mentolabs.vercel.app",
     deployArguments: [
       "deploy",
       "--prebuilt",
@@ -2194,20 +2198,39 @@ export function createDeploymentExpectation({
   };
 }
 
-export function assertUnaliasedProductionShadowDeployment(state) {
+export function assertOnlyExpectedVercelGeneratedAliases(state, logicalTarget) {
   assertCanonicalOutput(state);
   if (Array.isArray(state)) {
     throw new Error(
       "Staged deployment state must describe exactly one deployment",
     );
   }
+  const contract = targetContract(logicalTarget);
+  const generatedProjectAlias = contract.generatedProjectAlias;
+  if (generatedProjectAlias === null) {
+    throw new Error(
+      "Target does not support production generated-alias verification",
+    );
+  }
+  if (canonicalizeHostname(generatedProjectAlias) !== generatedProjectAlias) {
+    throw new Error("Reviewed generated project alias is malformed");
+  }
+  if (state.projectName !== contract.projectName) {
+    throw new Error("Staged deployment project does not match literal target");
+  }
+  if (state.target !== "production" || state.customEnvironmentSlug !== null) {
+    throw new Error(
+      "Staged deployment is not an ordinary production deployment",
+    );
+  }
   const immutableHostname = new URL(state.deploymentUrl).hostname;
+  const expectedAliases = [immutableHostname, generatedProjectAlias].sort();
   if (
     state.alias !== immutableHostname ||
-    JSON.stringify(state.aliases) !== JSON.stringify([immutableHostname])
+    JSON.stringify(state.aliases) !== JSON.stringify(expectedAliases)
   ) {
     throw new Error(
-      "Staged production deployment received an unexpected alias",
+      "Staged production deployment does not have only expected Vercel-generated aliases",
     );
   }
   return state;
@@ -2780,11 +2803,14 @@ if (isCliEntrypoint()) {
       }),
     );
     process.stdout.write("App v3 build-only Outcome B verified\n");
-  } else if (command === "assert-unaliased") {
-    assertUnaliasedProductionShadowDeployment(
+  } else if (command === "assert-generated-aliases") {
+    assertOnlyExpectedVercelGeneratedAliases(
       readJson(options.input, "Staged deployment state"),
+      options.target,
     );
-    process.stdout.write("Staged production deployment is unaliased\n");
+    process.stdout.write(
+      "Staged production deployment has only expected Vercel-generated aliases\n",
+    );
   } else if (command === "evidence") {
     assertEvidenceFiles(readJson(options.files, "Evidence file list"));
     process.stdout.write("Canonical evidence scan passed\n");
@@ -2870,7 +2896,7 @@ if (isCliEntrypoint()) {
     process.stdout.write("Protected host health checks passed\n");
   } else {
     throw new Error(
-      "Usage: vercel-production-shadow.mjs validate-context|validate-source|create-spec|prepare-link|prepare-pull-staging|pull|materialize-source|validate-pull-staging|stage-pull|validate-candidate-pull|validate-pull|check-build-inputs|build|create-handoff|assert-output|deploy|app-proof|assert-unaliased|evidence|check-aliases|final|emit-output|cache-summary|summary|health",
+      "Usage: vercel-production-shadow.mjs validate-context|validate-source|create-spec|prepare-link|prepare-pull-staging|pull|materialize-source|validate-pull-staging|stage-pull|validate-candidate-pull|validate-pull|check-build-inputs|build|create-handoff|assert-output|deploy|app-proof|assert-generated-aliases|evidence|check-aliases|final|emit-output|cache-summary|summary|health",
     );
   }
 }

--- a/scripts/vercel-production-shadow.test.mjs
+++ b/scripts/vercel-production-shadow.test.mjs
@@ -33,10 +33,10 @@ import {
   assertProductionShadowOutput,
   assertProductionShadowPullStaging,
   assertProductionShadowReadyForUpload,
+  assertOnlyExpectedVercelGeneratedAliases,
   assertProtectedAliasesUnchanged,
   assertPulledProductionShadowProject,
   assertRequiredVariableNames,
-  assertUnaliasedProductionShadowDeployment,
   assignProductionShadowMaterializationOwnership,
   buildProductionShadowArtifact,
   buildProductionShadowBuildArguments,
@@ -559,7 +559,7 @@ test("deployment expectation fixes production provenance and exact SHA", () => {
   );
 });
 
-test("staged production state permits only its immutable deployment hostname", () => {
+test("staged production state permits only its immutable and literal generated aliases", () => {
   const unexpected = JSON.parse(
     readFileSync(
       new URL(
@@ -569,33 +569,139 @@ test("staged production state permits only its immutable deployment hostname", (
       "utf8",
     ),
   );
-  assert.throws(
-    () => assertUnaliasedProductionShadowDeployment(unexpected),
-    /unexpected alias/,
+  const immutableHostname = new URL(unexpected.deploymentUrl).hostname;
+  const generatedProjectAlias =
+    PRODUCTION_SHADOW_TARGETS.governance.generatedProjectAlias;
+  const expectedAliases = [immutableHostname, generatedProjectAlias].sort();
+  const expected = {
+    ...unexpected,
+    aliases: expectedAliases,
+  };
+  assert.equal(
+    assertOnlyExpectedVercelGeneratedAliases(expected, "governance"),
+    expected,
   );
 
-  const immutableHostname = new URL(unexpected.deploymentUrl).hostname;
-  const unaliased = {
-    ...unexpected,
-    aliases: [immutableHostname],
-  };
-  assert.equal(assertUnaliasedProductionShadowDeployment(unaliased), unaliased);
+  const unexpectedAliasSets = [
+    unexpected.aliases,
+    [immutableHostname],
+    [generatedProjectAlias],
+    [],
+    ...[
+      "governance.mento.org",
+      "governancementoorg-git-main-mentolabs.vercel.app",
+      "governancementoorg.vercel.app",
+    ].map((extraAlias) =>
+      [immutableHostname, generatedProjectAlias, extraAlias].sort(),
+    ),
+    [
+      immutableHostname,
+      PRODUCTION_SHADOW_TARGETS.reserve.generatedProjectAlias,
+    ].sort(),
+  ];
+  for (const aliases of unexpectedAliasSets) {
+    assert.throws(
+      () =>
+        assertOnlyExpectedVercelGeneratedAliases(
+          {
+            ...expected,
+            aliases,
+          },
+          "governance",
+        ),
+      /only expected Vercel-generated aliases/,
+    );
+  }
+
+  for (const aliases of [
+    [immutableHostname, immutableHostname, generatedProjectAlias],
+    [...expectedAliases].reverse(),
+    [immutableHostname, generatedProjectAlias.toUpperCase()].sort(),
+  ]) {
+    assert.throws(
+      () =>
+        assertOnlyExpectedVercelGeneratedAliases(
+          {
+            ...expected,
+            aliases,
+          },
+          "governance",
+        ),
+      /aliases are malformed/,
+    );
+  }
+
   assert.throws(
     () =>
-      assertUnaliasedProductionShadowDeployment({
-        ...unaliased,
-        aliases: [],
-      }),
-    /unexpected alias/,
+      assertOnlyExpectedVercelGeneratedAliases(
+        {
+          ...expected,
+          alias: "governance.mento.org",
+        },
+        "governance",
+      ),
+    /only expected Vercel-generated aliases/,
   );
   assert.throws(
     () =>
-      assertUnaliasedProductionShadowDeployment({
-        ...unaliased,
-        alias: "governance.mento.org",
-      }),
-    /unexpected alias/,
+      assertOnlyExpectedVercelGeneratedAliases(
+        {
+          ...expected,
+          projectName: "reserve.mento.org",
+        },
+        "governance",
+      ),
+    /project does not match literal target/,
   );
+  assert.throws(
+    () =>
+      assertOnlyExpectedVercelGeneratedAliases(
+        {
+          ...expected,
+          target: null,
+          customEnvironmentSlug: "v3",
+        },
+        "governance",
+      ),
+    /not an ordinary production deployment/,
+  );
+  assert.throws(
+    () => assertOnlyExpectedVercelGeneratedAliases(expected, "app"),
+    /does not support production generated-alias verification/,
+  );
+  assert.throws(
+    () => assertOnlyExpectedVercelGeneratedAliases(expected, "unknown"),
+    /Unknown production-shadow target/,
+  );
+  assert.throws(
+    () =>
+      assertOnlyExpectedVercelGeneratedAliases(
+        [
+          {
+            ...expected,
+          },
+        ],
+        "governance",
+      ),
+    /exactly one deployment/,
+  );
+});
+
+test("ordinary production targets pin reviewed generated project aliases", () => {
+  assert.deepEqual(
+    Object.fromEntries(
+      ["governance", "reserve", "ui"].map((target) => [
+        target,
+        PRODUCTION_SHADOW_TARGETS[target].generatedProjectAlias,
+      ]),
+    ),
+    {
+      governance: "governancementoorg-mentolabs.vercel.app",
+      reserve: "reservementoorg-mentolabs.vercel.app",
+      ui: "uimentoorg-mentolabs.vercel.app",
+    },
+  );
+  assert.equal(PRODUCTION_SHADOW_TARGETS.app.generatedProjectAlias, null);
 });
 
 test("custom-v3 pull selects the custom target without a preview-only branch override", () => {


### PR DESCRIPTION
## The Problem

Vercel Production Shadow run [30027087419](https://github.com/mento-protocol/frontend-monorepo/actions/runs/30027087419) built App v3 and Governance successfully, preserved every protected domain, then failed because the verifier treated Vercel's generated project/team alias as an unexpected custom domain.

Pinned Vercel CLI `56.2.0` implements `--skip-domain` by suppressing custom production-domain assignment. Vercel still assigns its generated `<project>-<scope>.vercel.app` route, and the platform provides no supported zero-generated-alias production mode.

## The Solution

- Require each ordinary staged deployment to expose exactly its immutable hostname and one reviewed, literal target-specific Vercel-generated project/team alias.
- Keep the project, production target, custom-environment, immutable primary URL, provenance, and protected-domain checks fail-closed.
- Reject protected, custom, branch, global, wrong-target, missing, malformed, or extra aliases.
- Smoke only the immutable deployment URL.
- Rename the old zero-alias command without retaining a legacy path.
- Update the workflow, ADR, runbook, README, agent guidance, and issue #521 to describe the limited generated-alias routing mutation accurately.

Closes no issue; this unblocks the remaining live pilot evidence for #521.

## Validation

- `pnpm vercel:production-shadow:test` — 100/100 passed
- `pnpm vercel:workflow:test` — 93/93 passed
- `pnpm quality:budgets:test` — 30/30 passed
- `pnpm adr:check:test` — 9/9 passed
- `pnpm adr:check` — passed
- Prettier and `git diff --check` — passed
- Two independent read-only reviews — implementation all clear; all prose findings incorporated
- Browser verification: not applicable to this CI/docs-only correction; the exact-main hosted production-shadow run owns runtime/browser proof

## Ship Checklist

- [x] PR title follows the conventions
- [x] Performed a self-review of my own changes
- [x] Relevant automated checks and smoke tests pass
- [x] Architecture decision: updates [ADR 0001](https://github.com/mento-protocol/frontend-monorepo/blob/main/docs/adr/0001-github-actions-vercel-deployment-orchestration.md)
