### PR TITLE
fix(ci): separate Vercel deployment URL from aliases

### DIFF
--- a/.github/workflows/vercel-production-shadow.yml
+++ b/.github/workflows/vercel-production-shadow.yml
@@ -493,7 +493,7 @@ jobs:
           "${{ steps.runtime.outputs.node-bin }}" "$TRUSTED_POST_BUILD_PATH/scripts/vercel-production-shadow.mjs" create-spec --output "$RUNNER_TEMP/protected-spec.json"
           "${{ steps.runtime.outputs.node-bin }}" "$TRUSTED_POST_BUILD_PATH/scripts/vercel-deployment-state.mjs" snapshot --spec "$RUNNER_TEMP/protected-spec.json" --output "$RUNNER_TEMP/current.json"
           "${{ steps.runtime.outputs.node-bin }}" "$TRUSTED_POST_BUILD_PATH/scripts/vercel-deployment-state.mjs" compare --before "$RUNNER_TEMP/governance-compare-baseline.json" --after "$RUNNER_TEMP/current.json"
-      - name: Verify governance deployment provenance, readiness, and generated aliases
+      - name: Verify governance deployment provenance, readiness, immutable URL and generated alias
         env:
           VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN_PRODUCTION }}
@@ -706,7 +706,7 @@ jobs:
           "${{ steps.runtime.outputs.node-bin }}" "$TRUSTED_POST_BUILD_PATH/scripts/vercel-production-shadow.mjs" create-spec --output "$RUNNER_TEMP/protected-spec.json"
           "${{ steps.runtime.outputs.node-bin }}" "$TRUSTED_POST_BUILD_PATH/scripts/vercel-deployment-state.mjs" snapshot --spec "$RUNNER_TEMP/protected-spec.json" --output "$RUNNER_TEMP/current.json"
           "${{ steps.runtime.outputs.node-bin }}" "$TRUSTED_POST_BUILD_PATH/scripts/vercel-deployment-state.mjs" compare --before "$RUNNER_TEMP/reserve-compare-baseline.json" --after "$RUNNER_TEMP/current.json"
-      - name: Verify reserve deployment provenance, readiness, and generated aliases
+      - name: Verify reserve deployment provenance, readiness, immutable URL and generated alias
         env:
           VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN_PRODUCTION }}
@@ -918,7 +918,7 @@ jobs:
           "${{ steps.runtime.outputs.node-bin }}" "$TRUSTED_POST_BUILD_PATH/scripts/vercel-production-shadow.mjs" create-spec --output "$RUNNER_TEMP/protected-spec.json"
           "${{ steps.runtime.outputs.node-bin }}" "$TRUSTED_POST_BUILD_PATH/scripts/vercel-deployment-state.mjs" snapshot --spec "$RUNNER_TEMP/protected-spec.json" --output "$RUNNER_TEMP/current.json"
           "${{ steps.runtime.outputs.node-bin }}" "$TRUSTED_POST_BUILD_PATH/scripts/vercel-deployment-state.mjs" compare --before "$RUNNER_TEMP/ui-compare-baseline.json" --after "$RUNNER_TEMP/current.json"
-      - name: Verify UI deployment provenance, readiness, and generated aliases
+      - name: Verify UI deployment provenance, readiness, immutable URL and generated alias
         env:
           VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN_PRODUCTION }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,7 +71,8 @@ all build-boundary state below the target-scoped, authenticated
 reauthenticate and remove the exact runtime in a final `if: always()` step.
 Preserve App custom `v3` as build-only and preserve the App `v2` alias.
 Governance, Reserve, and UI uploads must avoid custom production domains and
-contain exactly the immutable deployment hostname plus the target's reviewed
+must expose the immutable deployment hostname through the deployment URL/state
+identity while the provider alias list contains exactly the target's reviewed
 literal Vercel-generated project/team alias.
 Every candidate Vercel build must use `--standalone`; reject invalid, oversized,
 or non-empty-`filePathMap` `.vc-config.json` files before handoff and again on

--- a/README.md
+++ b/README.md
@@ -499,13 +499,15 @@ The repository is set up with GitHub Actions for CI:
 
   The manual `Vercel Production Shadow` workflow can build App custom `v3`
   without deploying it and upload Governance, Reserve, and UI production
-  artifacts without custom production domains. Each staged ordinary deployment
-  has only its immutable hostname and reviewed Vercel-generated project/team
-  alias. The upload implicitly moves that generated system alias, while the
-  workflow performs no explicit alias, promote, environment-configuration,
-  ownership, or protected/custom production-domain mutation. Its exact-SHA
-  contract, read-only protected-domain drift checks, guarded manual operator
-  recovery, and direct smoke are documented in the same runbook.
+  artifacts without custom production domains. Each staged ordinary
+  deployment exposes its immutable hostname through the deployment URL/state
+  identity, while Vercel's provider alias list contains only the reviewed
+  generated project/team alias. The upload implicitly moves that generated system
+  alias, while the workflow performs no explicit alias, promote,
+  environment-configuration, ownership, or protected/custom production-domain
+  mutation. Its exact-SHA contract, read-only protected-domain drift checks,
+  guarded manual operator recovery, and direct smoke are documented in the same
+  runbook.
 
 Dependency-installing jobs use `.github/actions/pnpm-install`, which pins the
 Node/pnpm bootstrap, relies on `actions/setup-node` as the single pnpm-store

--- a/docs/adr/0001-github-actions-vercel-deployment-orchestration.md
+++ b/docs/adr/0001-github-actions-vercel-deployment-orchestration.md
@@ -3,7 +3,7 @@ title: GitHub Actions owns Vercel build and deployment orchestration; Vercel rem
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-07-22
+last_verified: 2026-07-23
 scope: ci/deployment
 date: 2026-07
 ---
@@ -179,10 +179,11 @@ before the transaction and immediately before and after every public mutation.
 Governance, reserve, and UI are built as staged production deployments without
 custom production domains, inspected, and runtime/browser verified before any
 protected or custom production domain moves. In the reviewed CI topology, each
-staged deployment has its immutable hostname and one literal project/team alias
-confirmed from the read-only observed public topology. The controller requires
-exactly those two target-bound aliases, rejects any protected or extra alias,
-and fails safely if Vercel changes that topology.
+staged deployment exposes its immutable hostname through the deployment
+URL/state identity, while Vercel's provider alias list contains one literal
+project/team alias confirmed from the read-only observed public topology. The
+controller requires that exact identity and target-bound alias, rejects any
+protected or extra alias, and fails safely if Vercel changes that topology.
 The ordinary upload implicitly moves that generated system alias, so the
 controller treats staging as a limited public-routing mutation: it rechecks
 current `main`, journals the intended upload, verifies the resulting immutable

--- a/docs/vercel-deployments.md
+++ b/docs/vercel-deployments.md
@@ -526,19 +526,20 @@ runner:    vercel deploy --prebuilt --prod --skip-domain --archive=tgz --format=
 
 `--skip-domain` suppresses custom production-domain assignment. In this reviewed
 team/project topology, confirmed by read-only checks of the observed public
-routes, the Vercel CLI still assigns the deployment's immutable hostname and an
-unavoidable generated project/team alias; it offers no supported
-zero-generated-alias mode. The controller binds that generated alias to each
-literal target:
+routes, Vercel exposes the immutable deployment hostname as deployment
+identity, while the provider alias list still contains an unavoidable generated
+project/team alias; the CLI offers no supported zero-generated-alias mode. The
+controller binds that generated alias to each literal target:
 
 - Governance: `governancementoorg-mentolabs.vercel.app`
 - Reserve: `reservementoorg-mentolabs.vercel.app`
 - UI: `uimentoorg-mentolabs.vercel.app`
 
-Any missing immutable or generated alias, protected/custom domain, branch or
-global alias, wrong-target alias, or malformed canonical hostname evidence fails
-closed. The read-only state inspector normalizes and deduplicates raw provider
-aliases; persisted canonical evidence must remain deduplicated and sorted.
+Any immutable deployment identity mismatch, missing generated alias,
+protected/custom domain, branch or global alias, wrong-target alias, or
+malformed canonical hostname evidence fails closed. The read-only state
+inspector normalizes and deduplicates raw provider aliases; persisted canonical
+evidence must remain deduplicated and sorted.
 Protected-domain before/after equality remains the decisive proof that the
 upload did not activate protected/custom production traffic. A future
 provider-generated alias topology must fail first and receive a reviewed
@@ -564,13 +565,14 @@ project state and prebuilt output must exist below the matching
 The uploaded `apps/<target>/.vercel/output` is the exact output whose custom
 Next deployment ID was asserted and copied into the runner-owned handoff. It is
 never transferred as a GitHub artifact.
-Each immutable URL must prove the literal project, `production` target, `READY`
-state, exact repository/ref/SHA metadata, and an alias set containing exactly
-its immutable deployment hostname plus the target's reviewed generated
-project/team alias before smoke begins. Smoke and browser verification use only
-the immutable deployment URL; the generated alias is state evidence, never the
-runtime test endpoint. The browser then proves critical security headers, a
-stable page marker, and a target-specific non-transaction interaction.
+Each staged state must prove the literal project, `production` target, `READY`
+state, exact repository/ref/SHA metadata, and an `alias` equal to the immutable
+hostname in `deploymentUrl`. Its provider-reported alias set must contain
+exactly the target's reviewed generated project/team alias before smoke begins.
+Smoke and browser verification use only the immutable deployment URL; the
+generated alias is state evidence, never the runtime test endpoint. The browser
+then proves critical security headers, a stable page marker, and a
+target-specific non-transaction interaction.
 Protected alias mappings are compared after each upload and once again at the
 end. Once the candidate build boundary and fresh trusted-controller checkout
 both succeed, an always-run read-only check executes immediately after every

--- a/scripts/fixtures/vercel-deployment-state/duplicate-aliases.json
+++ b/scripts/fixtures/vercel-deployment-state/duplicate-aliases.json
@@ -2,6 +2,6 @@
   "aliases": [
     { "alias": "GOVERNANCE.MENTO.ORG" },
     { "alias": "governance.mento.org" },
-    { "alias": "governance-immutable.vercel.app" }
+    { "alias": "governancementoorg-mentolabs.vercel.app" }
   ]
 }

--- a/scripts/fixtures/vercel-deployment-state/valid-production.json
+++ b/scripts/fixtures/vercel-deployment-state/valid-production.json
@@ -21,7 +21,7 @@
   "aliasesResponse": {
     "aliases": [
       { "alias": "governance.mento.org" },
-      { "alias": "governance-immutable.vercel.app" }
+      { "alias": "governancementoorg-mentolabs.vercel.app" }
     ]
   },
   "expected": {

--- a/scripts/fixtures/vercel-production-shadow/run-30034411210-governance-topology.json
+++ b/scripts/fixtures/vercel-production-shadow/run-30034411210-governance-topology.json
@@ -1,0 +1,7 @@
+{
+  "runId": 30034411210,
+  "target": "governance",
+  "sourceSha": "fd995b2413d983188de86e829f6ef21813ecbc23",
+  "deploymentUrl": "https://governancemento-ktabi5bgi-mentolabs.vercel.app",
+  "generatedAliases": ["governancementoorg-mentolabs.vercel.app"]
+}

--- a/scripts/fixtures/vercel-production-shadow/unexpected-alias.json
+++ b/scripts/fixtures/vercel-production-shadow/unexpected-alias.json
@@ -13,5 +13,5 @@
     "ref": "main",
     "sha": "0123456789abcdef0123456789abcdef01234567"
   },
-  "aliases": ["governance-immutable.vercel.app", "governance.mento.org"]
+  "aliases": ["governance.mento.org", "governancementoorg-mentolabs.vercel.app"]
 }

--- a/scripts/vercel-deployment-state.test.mjs
+++ b/scripts/vercel-deployment-state.test.mjs
@@ -75,7 +75,10 @@ test("ordinary production fixture emits only canonical allowlisted state", () =>
       ref: "main",
       sha: "0123456789abcdef0123456789abcdef01234567",
     },
-    aliases: ["governance-immutable.vercel.app", "governance.mento.org"],
+    aliases: [
+      "governance.mento.org",
+      "governancementoorg-mentolabs.vercel.app",
+    ],
   });
 });
 
@@ -268,8 +271,8 @@ test("wrong or malformed deployment environments fail closed", () => {
 
 test("aliases are canonicalized, deduplicated, sorted, and validated", () => {
   assert.deepEqual(canonicalizeAliases(fixture("duplicate-aliases.json")), [
-    "governance-immutable.vercel.app",
     "governance.mento.org",
+    "governancementoorg-mentolabs.vercel.app",
   ]);
   assert.throws(
     () => canonicalizeAliases(fixture("malformed-aliases.json")),

--- a/scripts/vercel-production-shadow-workflow.test.mjs
+++ b/scripts/vercel-production-shadow-workflow.test.mjs
@@ -1394,7 +1394,7 @@ test("every deploy is immediately checked for drift without automatic repair", (
       (step) =>
         step.name?.startsWith("Verify ") &&
         step.name.endsWith(
-          " deployment provenance, readiness, and generated aliases",
+          " deployment provenance, readiness, immutable URL and generated alias",
         ),
     );
     assert.ok(deployIndex < deployIndex + 1);

--- a/scripts/vercel-production-shadow.mjs
+++ b/scripts/vercel-production-shadow.mjs
@@ -2224,13 +2224,15 @@ export function assertOnlyExpectedVercelGeneratedAliases(state, logicalTarget) {
     );
   }
   const immutableHostname = new URL(state.deploymentUrl).hostname;
-  const expectedAliases = [immutableHostname, generatedProjectAlias].sort();
-  if (
-    state.alias !== immutableHostname ||
-    JSON.stringify(state.aliases) !== JSON.stringify(expectedAliases)
-  ) {
+  if (state.alias !== immutableHostname) {
     throw new Error(
-      "Staged production deployment does not have only expected Vercel-generated aliases",
+      `Staged ${logicalTarget} production immutable hostname mismatch: expected ${immutableHostname} from deploymentUrl; actual ${state.alias}`,
+    );
+  }
+  const expectedAliases = [generatedProjectAlias];
+  if (JSON.stringify(state.aliases) !== JSON.stringify(expectedAliases)) {
+    throw new Error(
+      `Staged ${logicalTarget} production generated-alias topology mismatch: expected ${JSON.stringify(expectedAliases)}; actual ${JSON.stringify(state.aliases)}`,
     );
   }
   return state;
@@ -2809,7 +2811,7 @@ if (isCliEntrypoint()) {
       options.target,
     );
     process.stdout.write(
-      "Staged production deployment has only expected Vercel-generated aliases\n",
+      "Staged production deployment identity and generated-alias topology verified\n",
     );
   } else if (command === "evidence") {
     assertEvidenceFiles(readJson(options.files, "Evidence file list"));

--- a/scripts/vercel-production-shadow.test.mjs
+++ b/scripts/vercel-production-shadow.test.mjs
@@ -559,7 +559,7 @@ test("deployment expectation fixes production provenance and exact SHA", () => {
   );
 });
 
-test("staged production state permits only its immutable and literal generated aliases", () => {
+test("run 30034411210 keeps immutable identity separate from the provider alias list", () => {
   const unexpected = JSON.parse(
     readFileSync(
       new URL(
@@ -569,13 +569,30 @@ test("staged production state permits only its immutable and literal generated a
       "utf8",
     ),
   );
-  const immutableHostname = new URL(unexpected.deploymentUrl).hostname;
+  const observedTopology = JSON.parse(
+    readFileSync(
+      new URL(
+        "./fixtures/vercel-production-shadow/run-30034411210-governance-topology.json",
+        import.meta.url,
+      ),
+      "utf8",
+    ),
+  );
+  assert.equal(observedTopology.runId, 30034411210);
+  assert.equal(observedTopology.target, "governance");
+  const immutableHostname = new URL(observedTopology.deploymentUrl).hostname;
   const generatedProjectAlias =
     PRODUCTION_SHADOW_TARGETS.governance.generatedProjectAlias;
-  const expectedAliases = [immutableHostname, generatedProjectAlias].sort();
+  assert.deepEqual(observedTopology.generatedAliases, [generatedProjectAlias]);
   const expected = {
     ...unexpected,
-    aliases: expectedAliases,
+    alias: immutableHostname,
+    deploymentUrl: observedTopology.deploymentUrl,
+    git: {
+      ...unexpected.git,
+      sha: observedTopology.sourceSha,
+    },
+    aliases: observedTopology.generatedAliases,
   };
   assert.equal(
     assertOnlyExpectedVercelGeneratedAliases(expected, "governance"),
@@ -585,19 +602,14 @@ test("staged production state permits only its immutable and literal generated a
   const unexpectedAliasSets = [
     unexpected.aliases,
     [immutableHostname],
-    [generatedProjectAlias],
     [],
     ...[
       "governance.mento.org",
       "governancementoorg-git-main-mentolabs.vercel.app",
       "governancementoorg.vercel.app",
-    ].map((extraAlias) =>
-      [immutableHostname, generatedProjectAlias, extraAlias].sort(),
-    ),
-    [
-      immutableHostname,
-      PRODUCTION_SHADOW_TARGETS.reserve.generatedProjectAlias,
-    ].sort(),
+    ].map((extraAlias) => [generatedProjectAlias, extraAlias].sort()),
+    [immutableHostname, generatedProjectAlias].sort(),
+    [PRODUCTION_SHADOW_TARGETS.reserve.generatedProjectAlias],
   ];
   for (const aliases of unexpectedAliasSets) {
     assert.throws(
@@ -609,14 +621,19 @@ test("staged production state permits only its immutable and literal generated a
           },
           "governance",
         ),
-      /only expected Vercel-generated aliases/,
+      (error) => {
+        assert.equal(
+          error.message,
+          `Staged governance production generated-alias topology mismatch: expected ${JSON.stringify([generatedProjectAlias])}; actual ${JSON.stringify(aliases)}`,
+        );
+        return true;
+      },
     );
   }
 
   for (const aliases of [
-    [immutableHostname, immutableHostname, generatedProjectAlias],
-    [...expectedAliases].reverse(),
-    [immutableHostname, generatedProjectAlias.toUpperCase()].sort(),
+    [generatedProjectAlias, generatedProjectAlias],
+    [generatedProjectAlias.toUpperCase()],
   ]) {
     assert.throws(
       () =>
@@ -640,7 +657,9 @@ test("staged production state permits only its immutable and literal generated a
         },
         "governance",
       ),
-    /only expected Vercel-generated aliases/,
+    {
+      message: `Staged governance production immutable hostname mismatch: expected ${immutableHostname} from deploymentUrl; actual governance.mento.org`,
+    },
   );
   assert.throws(
     () =>


### PR DESCRIPTION
## The Problem

Exact-main production-shadow run [30034411210](https://github.com/mento-protocol/frontend-monorepo/actions/runs/30034411210) built App custom `v3` and staged Governance safely, then failed because the alias guard treated the immutable deployment hostname as an entry returned by Vercel's deployment-aliases API.

Vercel exposes that immutable hostname through the deployment URL/state identity. For the reviewed `--prod --skip-domain` topology, the assigned-alias array contains only the generated project/team alias. The incorrect two-entry expectation blocked Reserve, UI, and all staged browser smokes.

## The Solution

- verify `state.alias` against the hostname from `deploymentUrl` as a separate immutable-identity check;
- require `aliases` to equal only the target's reviewed generated project/team alias;
- keep missing, extra, immutable-as-alias, custom, protected, branch, bare-project, malformed, duplicate, and wrong-target aliases fail-closed;
- add a minimal public regression fixture from run `30034411210`;
- align lower-level state fixtures, workflow step labels, ADR 0001, the runbook, README, and agent guidance with the actual Vercel API model.

The failure diagnostics include only canonical public hostnames. No credential, raw API response, deployment command, promotion, or protected-domain mutation path changes.

## Validation

- `pnpm vercel:production-shadow:test` — 100/100 passed
- `pnpm quality:budgets:test` — 30/30 passed
- `pnpm adr:check:test` — 9/9 passed
- `pnpm adr:check` — clean
- `pnpm ci:action-pins` — all 26 workflow/composite files pinned
- `pnpm ci:action-pins:test` — 59/59 passed
- Prettier — clean
- Trunk — clean
- pre-push full Trunk/typecheck/Knip gate — passed
- two independent semantic/security reviews — no actionable findings

## Risk

The change is limited to the staged-production identity assertion, fixtures, step labels, and documentation. It deliberately remains fail-closed if Vercel changes the generated-alias topology. A complete exact-current-main shadow rerun is still required after merge before #521 can close or #522 can begin.

Refs #521
