### PR TITLE
fix(ci): verify Vercel creator-scoped shadow aliases

### DIFF
--- a/.github/workflows/vercel-production-shadow.yml
+++ b/.github/workflows/vercel-production-shadow.yml
@@ -493,7 +493,7 @@ jobs:
           "${{ steps.runtime.outputs.node-bin }}" "$TRUSTED_POST_BUILD_PATH/scripts/vercel-production-shadow.mjs" create-spec --output "$RUNNER_TEMP/protected-spec.json"
           "${{ steps.runtime.outputs.node-bin }}" "$TRUSTED_POST_BUILD_PATH/scripts/vercel-deployment-state.mjs" snapshot --spec "$RUNNER_TEMP/protected-spec.json" --output "$RUNNER_TEMP/current.json"
           "${{ steps.runtime.outputs.node-bin }}" "$TRUSTED_POST_BUILD_PATH/scripts/vercel-deployment-state.mjs" compare --before "$RUNNER_TEMP/governance-compare-baseline.json" --after "$RUNNER_TEMP/current.json"
-      - name: Verify governance deployment provenance, readiness, immutable URL and generated alias
+      - name: Verify governance deployment provenance, readiness, immutable URL and generated aliases
         env:
           VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN_PRODUCTION }}
@@ -706,7 +706,7 @@ jobs:
           "${{ steps.runtime.outputs.node-bin }}" "$TRUSTED_POST_BUILD_PATH/scripts/vercel-production-shadow.mjs" create-spec --output "$RUNNER_TEMP/protected-spec.json"
           "${{ steps.runtime.outputs.node-bin }}" "$TRUSTED_POST_BUILD_PATH/scripts/vercel-deployment-state.mjs" snapshot --spec "$RUNNER_TEMP/protected-spec.json" --output "$RUNNER_TEMP/current.json"
           "${{ steps.runtime.outputs.node-bin }}" "$TRUSTED_POST_BUILD_PATH/scripts/vercel-deployment-state.mjs" compare --before "$RUNNER_TEMP/reserve-compare-baseline.json" --after "$RUNNER_TEMP/current.json"
-      - name: Verify reserve deployment provenance, readiness, immutable URL and generated alias
+      - name: Verify reserve deployment provenance, readiness, immutable URL and generated aliases
         env:
           VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN_PRODUCTION }}
@@ -918,7 +918,7 @@ jobs:
           "${{ steps.runtime.outputs.node-bin }}" "$TRUSTED_POST_BUILD_PATH/scripts/vercel-production-shadow.mjs" create-spec --output "$RUNNER_TEMP/protected-spec.json"
           "${{ steps.runtime.outputs.node-bin }}" "$TRUSTED_POST_BUILD_PATH/scripts/vercel-deployment-state.mjs" snapshot --spec "$RUNNER_TEMP/protected-spec.json" --output "$RUNNER_TEMP/current.json"
           "${{ steps.runtime.outputs.node-bin }}" "$TRUSTED_POST_BUILD_PATH/scripts/vercel-deployment-state.mjs" compare --before "$RUNNER_TEMP/ui-compare-baseline.json" --after "$RUNNER_TEMP/current.json"
-      - name: Verify UI deployment provenance, readiness, immutable URL and generated alias
+      - name: Verify UI deployment provenance, readiness, immutable URL and generated aliases
         env:
           VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN_PRODUCTION }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,7 +57,8 @@ this privileged `workflow_run` workflow.
 
 `.github/workflows/vercel-production-shadow.yml` is manual-only and
 non-promoting. Ordinary uploads implicitly move the target's reviewed generated
-project/team alias, but the workflow issues no explicit alias assignment, promotion,
+base project/team alias and may also move Vercel's exact creator-scoped alias,
+but the workflow issues no explicit alias assignment, promotion,
 environment-configuration, ownership, or protected-domain mutation. Candidate
 dependency installation and builds must run under its dedicated UID boundary
 with exact protected tools, private-umask runner-owned pull staging, raw
@@ -72,8 +73,10 @@ reauthenticate and remove the exact runtime in a final `if: always()` step.
 Preserve App custom `v3` as build-only and preserve the App `v2` alias.
 Governance, Reserve, and UI uploads must avoid custom production domains and
 must expose the immutable deployment hostname through the deployment URL/state
-identity while the provider alias list contains exactly the target's reviewed
-literal Vercel-generated project/team alias.
+identity. The provider alias list must contain the target's reviewed literal
+base project/team alias and may contain at most one author alias derived exactly
+from the canonical Vercel deployment `creator.username`; reject every other
+alias.
 Every candidate Vercel build must use `--standalone`; reject invalid, oversized,
 or non-empty-`filePathMap` `.vc-config.json` files before handoff and again on
 the runner-owned upload tree.

--- a/README.md
+++ b/README.md
@@ -501,9 +501,10 @@ The repository is set up with GitHub Actions for CI:
   without deploying it and upload Governance, Reserve, and UI production
   artifacts without custom production domains. Each staged ordinary
   deployment exposes its immutable hostname through the deployment URL/state
-  identity, while Vercel's provider alias list contains only the reviewed
-  generated project/team alias. The upload implicitly moves that generated system
-  alias, while the workflow performs no explicit alias, promote,
+  identity. Vercel's provider alias list must contain the reviewed base
+  project/team alias and may also contain one exact creator-scoped alias derived
+  from the canonical deployment `creator.username`. The upload implicitly moves
+  those generated system aliases, while the workflow performs no explicit alias, promote,
   environment-configuration, ownership, or protected/custom production-domain
   mutation. Its exact-SHA contract, read-only protected-domain drift checks,
   guarded manual operator recovery, and direct smoke are documented in the same

--- a/docs/adr/0001-github-actions-vercel-deployment-orchestration.md
+++ b/docs/adr/0001-github-actions-vercel-deployment-orchestration.md
@@ -180,11 +180,16 @@ Governance, reserve, and UI are built as staged production deployments without
 custom production domains, inspected, and runtime/browser verified before any
 protected or custom production domain moves. In the reviewed CI topology, each
 staged deployment exposes its immutable hostname through the deployment
-URL/state identity, while Vercel's provider alias list contains one literal
-project/team alias confirmed from the read-only observed public topology. The
-controller requires that exact identity and target-bound alias, rejects any
-protected or extra alias, and fails safely if Vercel changes that topology.
-The ordinary upload implicitly moves that generated system alias, so the
+URL/state identity. Vercel's provider alias list always contains the pinned
+target-bound base project/team alias and can contain one author-scoped alias.
+The controller accepts the author alias only when it is derived exactly from
+the canonical deployment `creator.username` plus the target's pinned project
+and scope slugs. It rejects protected, branch, global, wrong-target, second
+author, or other extra aliases and fails safely if Vercel changes that
+topology. A `git-*` creator can use the base-only form, but cannot authorize the
+ambiguous author/branch hostname; the same rule reserves `env-*` against
+custom-environment aliases. The ordinary upload implicitly moves those generated
+system aliases, so the
 controller treats staging as a limited public-routing mutation: it rechecks
 current `main`, journals the intended upload, verifies the resulting immutable
 deployment and generated-alias topology, and retains the transaction evidence

--- a/docs/vercel-deployments.md
+++ b/docs/vercel-deployments.md
@@ -29,7 +29,8 @@ copy a second ownership table into executable code.
 
 The guarded manual production-shadow pilot does not promote or mutate a
 protected/custom production domain or deployment ownership. Each ordinary
-upload implicitly moves the target's reviewed generated project/team alias.
+upload implicitly moves the target's reviewed base generated project/team alias
+and may also move Vercel's exact creator-scoped generated alias.
 Until the later production cutover issues ship, the Vercel Git integration
 remains the protected/custom production deployment owner.
 
@@ -524,22 +525,39 @@ runner:    validate -> immutable handoff -> destroy candidate boundary
 runner:    vercel deploy --prebuilt --prod --skip-domain --archive=tgz --format=json
 ```
 
-`--skip-domain` suppresses custom production-domain assignment. In this reviewed
-team/project topology, confirmed by read-only checks of the observed public
-routes, Vercel exposes the immutable deployment hostname as deployment
-identity, while the provider alias list still contains an unavoidable generated
-project/team alias; the CLI offers no supported zero-generated-alias mode. The
-controller binds that generated alias to each literal target:
+`--skip-domain` suppresses custom production-domain assignment. Vercel's
+[generated-URL contract](https://vercel.com/docs/deployments/generated-urls)
+documents a CLI project/scope URL and, for Team deployments, an optional
+project/author/scope URL. The immutable deployment hostname remains separate
+deployment identity. Read-only evidence matched both documented provider alias
+forms: run `30034411210` exposed only the base alias, while run `30037927329`
+exposed the base alias plus the creator-scoped alias. The CLI offers no
+supported zero-generated-alias mode.
+
+The controller pins the project and scope slugs for each literal target and
+requires its base alias:
 
 - Governance: `governancementoorg-mentolabs.vercel.app`
 - Reserve: `reservementoorg-mentolabs.vercel.app`
 - UI: `uimentoorg-mentolabs.vercel.app`
 
-Any immutable deployment identity mismatch, missing generated alias,
-protected/custom domain, branch or global alias, wrong-target alias, or
-malformed canonical hostname evidence fails closed. The read-only state
-inspector normalizes and deduplicates raw provider aliases; persisted canonical
-evidence must remain deduplicated and sorted.
+It permits at most one additional alias: the exact
+`<project-slug>-<creator-username>-<scope-slug>.vercel.app` value derived from
+the same deployment response's canonical `creator.username`. The canonical
+state retains only that sanitized username; creator IDs, email, avatar, display
+name, Git author metadata, and `GITHUB_ACTOR` cannot authorize an alias. A
+creator username beginning with the reserved `git-` or `env-` generated-alias
+namespace can still produce the required base-only topology, but cannot
+authorize an author alias because that hostname is indistinguishable from
+Vercel's documented Git branch or custom-environment form. A
+creator whose full project/author/scope label exceeds DNS's 63-character limit
+can also use only the base topology; the provider's documented truncation is
+not stable enough to authorize without a reviewed contract update. A
+missing base alias, creator-less or wrong-author alias, protected/custom domain,
+branch or global alias, wrong-target alias, second author alias, immutable
+hostname in the alias list, or malformed canonical evidence fails closed. The
+read-only state inspector normalizes and deduplicates raw provider aliases;
+persisted canonical evidence must remain deduplicated and sorted.
 Protected-domain before/after equality remains the decisive proof that the
 upload did not activate protected/custom production traffic. A future
 provider-generated alias topology must fail first and receive a reviewed
@@ -568,7 +586,8 @@ never transferred as a GitHub artifact.
 Each staged state must prove the literal project, `production` target, `READY`
 state, exact repository/ref/SHA metadata, and an `alias` equal to the immutable
 hostname in `deploymentUrl`. Its provider-reported alias set must contain
-exactly the target's reviewed generated project/team alias before smoke begins.
+the target's reviewed base generated project/team alias and at most the exact
+creator-scoped alias described above before smoke begins.
 Smoke and browser verification use only the immutable deployment URL; the
 generated alias is state evidence, never the runtime test endpoint. The browser
 then proves critical security headers, a stable page marker, and a
@@ -665,7 +684,8 @@ alias list are confirmed present. The workflow itself performs no Vercel Git
 setting, explicit alias, promotion, environment-configuration, ownership,
 protected/custom production-domain, or serving-deployment cleanup command. Each
 ordinary deploy still performs the bounded implicit movement of its reviewed
-generated system alias.
+generated system aliases: the required project/scope alias and, when Vercel
+emits it, the exact creator-scoped project/creator/scope alias.
 
 Each candidate build must emit exactly one canonical Turbo
 `Cached: X cached, Y total` line. Missing, duplicate, malformed, or impossible
@@ -706,9 +726,11 @@ alias mutation, environment-configuration mutation, or Git-ownership change. The
 manual production-shadow workflow described above does use read-only Vercel API
 checks and stages ordinary-project deployments without promoting
 protected/custom production domains. Each upload implicitly moves the target's
-reviewed generated system alias; the workflow performs no explicit alias
-assignment, promotion, environment-configuration, ownership, or
-protected/custom production-domain mutation.
+reviewed generated system aliases: the required project/scope alias and, when
+Vercel emits it, the exact creator-scoped project/creator/scope alias. The
+workflow performs no explicit alias assignment, promotion,
+environment-configuration, ownership, or protected/custom production-domain
+mutation.
 
 ## Cost validation preparation
 

--- a/scripts/fixtures/vercel-deployment-state/sensitive-response.json
+++ b/scripts/fixtures/vercel-deployment-state/sensitive-response.json
@@ -4,6 +4,11 @@
     "protectionBypass": "test-value-not-printed",
     "env": [{ "key": "SECRET", "value": "test-value-not-printed" }],
     "buildEnv": ["test-value-not-printed"],
-    "creator": { "email": "test-value-not-printed@example.org" }
+    "creator": {
+      "uid": "test-value-not-printed-user-id",
+      "username": "fixture-author",
+      "email": "test-value-not-printed@example.org",
+      "avatar": "https://test-value-not-printed.example/avatar.png"
+    }
   }
 }

--- a/scripts/fixtures/vercel-deployment-state/valid-production.json
+++ b/scripts/fixtures/vercel-deployment-state/valid-production.json
@@ -11,6 +11,10 @@
     "name": "governance.mento.org",
     "readyState": "READY",
     "target": "production",
+    "creator": {
+      "uid": "user_fixture123",
+      "username": "chapati"
+    },
     "meta": {
       "githubCommitOrg": "mento-protocol",
       "githubCommitRepo": "frontend-monorepo",

--- a/scripts/fixtures/vercel-production-shadow/run-30034411210-governance-topology.json
+++ b/scripts/fixtures/vercel-production-shadow/run-30034411210-governance-topology.json
@@ -3,5 +3,6 @@
   "target": "governance",
   "sourceSha": "fd995b2413d983188de86e829f6ef21813ecbc23",
   "deploymentUrl": "https://governancemento-ktabi5bgi-mentolabs.vercel.app",
+  "creatorUsername": "chapati",
   "generatedAliases": ["governancementoorg-mentolabs.vercel.app"]
 }

--- a/scripts/fixtures/vercel-production-shadow/run-30037927329-governance-topology.json
+++ b/scripts/fixtures/vercel-production-shadow/run-30037927329-governance-topology.json
@@ -1,0 +1,11 @@
+{
+  "runId": 30037927329,
+  "target": "governance",
+  "sourceSha": "c92add2084ad3f1c0658ac126e2bbfa4ee86fee4",
+  "deploymentUrl": "https://governancemento-9npv94ib0-mentolabs.vercel.app",
+  "creatorUsername": "chapati",
+  "generatedAliases": [
+    "governancementoorg-chapati-mentolabs.vercel.app",
+    "governancementoorg-mentolabs.vercel.app"
+  ]
+}

--- a/scripts/fixtures/vercel-production-shadow/unexpected-alias.json
+++ b/scripts/fixtures/vercel-production-shadow/unexpected-alias.json
@@ -2,6 +2,7 @@
   "alias": "governance-immutable.vercel.app",
   "deploymentId": "dpl_governance123",
   "deploymentUrl": "https://governance-immutable.vercel.app",
+  "creatorUsername": null,
   "projectId": "prj_governance123",
   "projectName": "governance.mento.org",
   "readyState": "READY",

--- a/scripts/vercel-deployment-state.mjs
+++ b/scripts/vercel-deployment-state.mjs
@@ -25,6 +25,7 @@ export const CANONICAL_STATE_KEYS = Object.freeze([
   "alias",
   "deploymentId",
   "deploymentUrl",
+  "creatorUsername",
   "projectId",
   "projectName",
   "readyState",
@@ -35,6 +36,8 @@ export const CANONICAL_STATE_KEYS = Object.freeze([
 ]);
 
 const CANONICAL_GIT_KEYS = ["org", "repo", "ref", "sha"];
+const CREATOR_USERNAME_PATTERN =
+  /^(?=.{1,63}$)[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/;
 const CLI_OPTIONS = Object.freeze({
   compare: Object.freeze(["before", "after"]),
   deployment: Object.freeze(["expected", "output"]),
@@ -111,6 +114,23 @@ function consistentString(label, candidates, { pattern } = {}) {
     throw new Error(`Deployment ${label} is malformed`);
   }
   return distinct[0];
+}
+
+function canonicalizeCreatorUsername(deploymentResponse) {
+  const creator = deploymentResponse.creator;
+  if (creator === undefined || creator === null) return null;
+  if (typeof creator !== "object" || Array.isArray(creator)) {
+    throw new Error("Deployment creator is malformed");
+  }
+  if (creator.username === undefined || creator.username === null) return null;
+  if (typeof creator.username !== "string" || creator.username.length === 0) {
+    throw new Error("Deployment creator username is malformed");
+  }
+  const username = creator.username.toLowerCase();
+  if (!CREATOR_USERNAME_PATTERN.test(username)) {
+    throw new Error("Deployment creator username is malformed");
+  }
+  return username;
 }
 
 function canonicalizeAliasLookup(alias, response) {
@@ -225,6 +245,7 @@ export function canonicalizeDeploymentState({
     aliasResponse?.deployment?.id,
   ]);
   const deploymentUrl = canonicalizeDeploymentUrl(deploymentResponse.url);
+  const creatorUsername = canonicalizeCreatorUsername(deploymentResponse);
   const projectId = consistentString("project ID", [
     deploymentResponse.projectId,
     deploymentResponse.project?.id,
@@ -299,6 +320,7 @@ export function canonicalizeDeploymentState({
     alias: canonicalAlias,
     deploymentId,
     deploymentUrl,
+    creatorUsername,
     projectId,
     projectName,
     readyState,
@@ -335,6 +357,16 @@ export function assertCanonicalOutput(value) {
       canonicalizeDeploymentUrl(state.deploymentUrl) !== state.deploymentUrl
     ) {
       throw new Error("Canonical deployment URL is malformed");
+    }
+    if (
+      canonicalizeCreatorUsername({
+        creator:
+          state.creatorUsername === null
+            ? null
+            : { username: state.creatorUsername },
+      }) !== state.creatorUsername
+    ) {
+      throw new Error("Canonical deployment creator username is malformed");
     }
     requireIdentifier(state.projectId, "Canonical project ID");
     requireIdentifier(state.projectName, "Canonical project name");

--- a/scripts/vercel-deployment-state.test.mjs
+++ b/scripts/vercel-deployment-state.test.mjs
@@ -64,6 +64,7 @@ test("ordinary production fixture emits only canonical allowlisted state", () =>
     alias: "governance.mento.org",
     deploymentId: "dpl_governance123",
     deploymentUrl: "https://governance-immutable.vercel.app",
+    creatorUsername: "chapati",
     projectId: "prj_governance123",
     projectName: "governance.mento.org",
     readyState: "READY",
@@ -327,8 +328,79 @@ test("sensitive API fields cannot reach canonical JSON", () => {
     },
   });
   const output = JSON.stringify(state);
+  assert.equal(state.creatorUsername, "fixture-author");
   assert.doesNotMatch(output, /test-value-not-printed/);
-  assert.doesNotMatch(output, /protectionBypass|buildEnv|creator|env/);
+  assert.doesNotMatch(
+    output,
+    /protectionBypass|buildEnv|email|avatar|test-value-not-printed-user-id|env/,
+  );
+});
+
+test("creator username canonicalization is narrow and fail-closed", () => {
+  const production = fixture("valid-production.json");
+  assert.equal(
+    canonicalizeDeploymentState({
+      ...production,
+      deploymentResponse: {
+        ...production.deploymentResponse,
+        creator: { uid: "user_fixture123", username: "Chapati" },
+      },
+    }).creatorUsername,
+    "chapati",
+  );
+  assert.equal(
+    canonicalizeDeploymentState({
+      ...production,
+      deploymentResponse: {
+        ...production.deploymentResponse,
+        creator: { uid: "user_fixture123" },
+      },
+    }).creatorUsername,
+    null,
+  );
+  for (const creator of [
+    "chapati",
+    [],
+    { username: "" },
+    { username: "chapati.example" },
+    { username: "chapati_user" },
+    { username: "a".repeat(64) },
+  ]) {
+    assert.throws(
+      () =>
+        canonicalizeDeploymentState({
+          ...production,
+          deploymentResponse: {
+            ...production.deploymentResponse,
+            creator,
+          },
+        }),
+      /creator/,
+    );
+  }
+});
+
+test("creator display names and Git author metadata cannot authorize aliases", () => {
+  const production = fixture("valid-production.json");
+  const state = canonicalizeDeploymentState({
+    ...production,
+    deploymentResponse: {
+      ...production.deploymentResponse,
+      creator: {
+        uid: "user_fixture123",
+        username: "actual-creator",
+        name: "chapati",
+      },
+      meta: {
+        ...production.deploymentResponse.meta,
+        githubCommitAuthorLogin: "chapati23",
+        githubCommitAuthorName: "chapati",
+      },
+    },
+  });
+  assert.equal(state.creatorUsername, "actual-creator");
+  const output = JSON.stringify(state);
+  assert.doesNotMatch(output, /chapati23|githubCommitAuthor|"name"/);
 });
 
 test("canonical output boundary rejects every non-allowlisted field", () => {
@@ -361,6 +433,14 @@ test("canonical output boundary rejects every non-allowlisted field", () => {
         aliases: [...state.aliases].reverse(),
       }),
     /aliases are malformed/,
+  );
+  assert.throws(
+    () =>
+      assertCanonicalOutput({
+        ...state,
+        creatorUsername: "Chapati",
+      }),
+    /creator username is malformed/,
   );
 });
 

--- a/scripts/vercel-production-shadow-workflow.test.mjs
+++ b/scripts/vercel-production-shadow-workflow.test.mjs
@@ -1394,7 +1394,7 @@ test("every deploy is immediately checked for drift without automatic repair", (
       (step) =>
         step.name?.startsWith("Verify ") &&
         step.name.endsWith(
-          " deployment provenance, readiness, immutable URL and generated alias",
+          " deployment provenance, readiness, immutable URL and generated aliases",
         ),
     );
     assert.ok(deployIndex < deployIndex + 1);

--- a/scripts/vercel-production-shadow.mjs
+++ b/scripts/vercel-production-shadow.mjs
@@ -76,6 +76,10 @@ const MAX_SOURCE_TREE_BYTES = 16 * 1_024 * 1_024;
 const MAX_SOURCE_TOTAL_BYTES = 128 * 1_024 * 1_024;
 const MAX_PULLED_ENVIRONMENT_BYTES = 16 * 1_024 * 1_024;
 const MAX_MATERIALIZED_ENVIRONMENT_BYTES = 1_024 * 1_024;
+const RESERVED_GENERATED_ALIAS_CREATOR_PREFIXES = Object.freeze([
+  "env-",
+  "git-",
+]);
 const VERCEL_CLI_ENVIRONMENT_NAMES = Object.freeze([
   "CI",
   "HTTP_PROXY",
@@ -97,6 +101,8 @@ export const PRODUCTION_SHADOW_TARGETS = {
     buildArguments: ["build", "--yes", "--standalone", "--target", "v3"],
     deployArguments: null,
     generatedProjectAlias: null,
+    generatedProjectSlug: null,
+    generatedScopeSlug: null,
   },
   governance: {
     projectName: "governance.mento.org",
@@ -104,6 +110,8 @@ export const PRODUCTION_SHADOW_TARGETS = {
     pullEnvironment: "production",
     buildArguments: ["build", "--yes", "--standalone", "--prod"],
     generatedProjectAlias: "governancementoorg-mentolabs.vercel.app",
+    generatedProjectSlug: "governancementoorg",
+    generatedScopeSlug: "mentolabs",
     deployArguments: [
       "deploy",
       "--prebuilt",
@@ -120,6 +128,8 @@ export const PRODUCTION_SHADOW_TARGETS = {
     pullEnvironment: "production",
     buildArguments: ["build", "--yes", "--standalone", "--prod"],
     generatedProjectAlias: "reservementoorg-mentolabs.vercel.app",
+    generatedProjectSlug: "reservementoorg",
+    generatedScopeSlug: "mentolabs",
     deployArguments: [
       "deploy",
       "--prebuilt",
@@ -136,6 +146,8 @@ export const PRODUCTION_SHADOW_TARGETS = {
     pullEnvironment: "production",
     buildArguments: ["build", "--yes", "--standalone", "--prod"],
     generatedProjectAlias: "uimentoorg-mentolabs.vercel.app",
+    generatedProjectSlug: "uimentoorg",
+    generatedScopeSlug: "mentolabs",
     deployArguments: [
       "deploy",
       "--prebuilt",
@@ -169,6 +181,12 @@ function targetContract(logicalTarget) {
     );
   }
   return PRODUCTION_SHADOW_TARGETS[logicalTarget];
+}
+
+function creatorUsesReservedGeneratedAliasNamespace(creatorUsername) {
+  return RESERVED_GENERATED_ALIAS_CREATOR_PREFIXES.some((prefix) =>
+    creatorUsername.startsWith(prefix),
+  );
 }
 
 function numericIdentity(value, label) {
@@ -2207,12 +2225,22 @@ export function assertOnlyExpectedVercelGeneratedAliases(state, logicalTarget) {
   }
   const contract = targetContract(logicalTarget);
   const generatedProjectAlias = contract.generatedProjectAlias;
-  if (generatedProjectAlias === null) {
+  const generatedProjectSlug = contract.generatedProjectSlug;
+  const generatedScopeSlug = contract.generatedScopeSlug;
+  if (
+    generatedProjectAlias === null ||
+    generatedProjectSlug === null ||
+    generatedScopeSlug === null
+  ) {
     throw new Error(
       "Target does not support production generated-alias verification",
     );
   }
-  if (canonicalizeHostname(generatedProjectAlias) !== generatedProjectAlias) {
+  if (
+    canonicalizeHostname(generatedProjectAlias) !== generatedProjectAlias ||
+    generatedProjectAlias !==
+      `${generatedProjectSlug}-${generatedScopeSlug}.vercel.app`
+  ) {
     throw new Error("Reviewed generated project alias is malformed");
   }
   if (state.projectName !== contract.projectName) {
@@ -2229,10 +2257,34 @@ export function assertOnlyExpectedVercelGeneratedAliases(state, logicalTarget) {
       `Staged ${logicalTarget} production immutable hostname mismatch: expected ${immutableHostname} from deploymentUrl; actual ${state.alias}`,
     );
   }
-  const expectedAliases = [generatedProjectAlias];
-  if (JSON.stringify(state.aliases) !== JSON.stringify(expectedAliases)) {
+  if (state.aliases.includes(immutableHostname)) {
     throw new Error(
-      `Staged ${logicalTarget} production generated-alias topology mismatch: expected ${JSON.stringify(expectedAliases)}; actual ${JSON.stringify(state.aliases)}`,
+      `Staged ${logicalTarget} production immutable hostname must remain separate from the provider alias list`,
+    );
+  }
+  const allowedTopologies = [[generatedProjectAlias]];
+  if (
+    state.creatorUsername !== null &&
+    !creatorUsesReservedGeneratedAliasNamespace(state.creatorUsername)
+  ) {
+    const authorLabel = `${generatedProjectSlug}-${state.creatorUsername}-${generatedScopeSlug}`;
+    if (authorLabel.length <= 63) {
+      const generatedAuthorAlias = canonicalizeHostname(
+        `${authorLabel}.vercel.app`,
+      );
+      allowedTopologies.push(
+        [generatedProjectAlias, generatedAuthorAlias].sort(),
+      );
+    }
+  }
+  if (
+    !allowedTopologies.some(
+      (expectedAliases) =>
+        JSON.stringify(state.aliases) === JSON.stringify(expectedAliases),
+    )
+  ) {
+    throw new Error(
+      `Staged ${logicalTarget} production generated-alias topology mismatch: expected one of ${JSON.stringify(allowedTopologies)}; actual ${JSON.stringify(state.aliases)}`,
     );
   }
   return state;

--- a/scripts/vercel-production-shadow.test.mjs
+++ b/scripts/vercel-production-shadow.test.mjs
@@ -559,8 +559,12 @@ test("deployment expectation fixes production provenance and exact SHA", () => {
   );
 });
 
-test("run 30034411210 keeps immutable identity separate from the provider alias list", () => {
-  const unexpected = JSON.parse(
+test("observed runs allow only the base alias plus one exact optional creator alias", () => {
+  assert.doesNotMatch(
+    readFileSync(productionShadowScript, "utf8"),
+    /GITHUB_ACTOR|githubCommitAuthor|creator\.name/,
+  );
+  const template = JSON.parse(
     readFileSync(
       new URL(
         "./fixtures/vercel-production-shadow/unexpected-alias.json",
@@ -569,47 +573,77 @@ test("run 30034411210 keeps immutable identity separate from the provider alias 
       "utf8",
     ),
   );
-  const observedTopology = JSON.parse(
-    readFileSync(
-      new URL(
-        "./fixtures/vercel-production-shadow/run-30034411210-governance-topology.json",
-        import.meta.url,
+  const topologies = [
+    "run-30034411210-governance-topology.json",
+    "run-30037927329-governance-topology.json",
+  ].map((name) =>
+    JSON.parse(
+      readFileSync(
+        new URL(`./fixtures/vercel-production-shadow/${name}`, import.meta.url),
+        "utf8",
       ),
-      "utf8",
     ),
   );
-  assert.equal(observedTopology.runId, 30034411210);
-  assert.equal(observedTopology.target, "governance");
-  const immutableHostname = new URL(observedTopology.deploymentUrl).hostname;
   const generatedProjectAlias =
     PRODUCTION_SHADOW_TARGETS.governance.generatedProjectAlias;
-  assert.deepEqual(observedTopology.generatedAliases, [generatedProjectAlias]);
-  const expected = {
-    ...unexpected,
-    alias: immutableHostname,
-    deploymentUrl: observedTopology.deploymentUrl,
-    git: {
-      ...unexpected.git,
-      sha: observedTopology.sourceSha,
-    },
-    aliases: observedTopology.generatedAliases,
-  };
-  assert.equal(
-    assertOnlyExpectedVercelGeneratedAliases(expected, "governance"),
-    expected,
+  const generatedAuthorAlias =
+    "governancementoorg-chapati-mentolabs.vercel.app";
+  assert.deepEqual(
+    topologies.map((topology) => topology.runId),
+    [30034411210, 30037927329],
   );
+  assert.deepEqual(
+    topologies.map((topology) => topology.creatorUsername),
+    ["chapati", "chapati"],
+  );
+  assert.deepEqual(topologies[0].generatedAliases, [generatedProjectAlias]);
+  assert.deepEqual(topologies[1].generatedAliases, [
+    generatedAuthorAlias,
+    generatedProjectAlias,
+  ]);
+  const states = topologies.map((topology) => ({
+    ...template,
+    alias: new URL(topology.deploymentUrl).hostname,
+    deploymentUrl: topology.deploymentUrl,
+    creatorUsername: topology.creatorUsername,
+    git: {
+      ...template.git,
+      sha: topology.sourceSha,
+    },
+    aliases: topology.generatedAliases,
+  }));
+  for (const state of states) {
+    assert.equal(
+      assertOnlyExpectedVercelGeneratedAliases(state, "governance"),
+      state,
+    );
+  }
 
+  const expected = states[1];
+  const immutableHostname = new URL(expected.deploymentUrl).hostname;
   const unexpectedAliasSets = [
-    unexpected.aliases,
-    [immutableHostname],
+    template.aliases,
+    [generatedAuthorAlias],
     [],
-    ...[
-      "governance.mento.org",
+    [
+      generatedProjectAlias,
+      "governancementoorg-chapati23-mentolabs.vercel.app",
+    ].sort(),
+    [
+      generatedProjectAlias,
       "governancementoorg-git-main-mentolabs.vercel.app",
-      "governancementoorg.vercel.app",
-    ].map((extraAlias) => [generatedProjectAlias, extraAlias].sort()),
-    [immutableHostname, generatedProjectAlias].sort(),
-    [PRODUCTION_SHADOW_TARGETS.reserve.generatedProjectAlias],
+    ].sort(),
+    [generatedProjectAlias, "governancementoorg.vercel.app"].sort(),
+    [generatedProjectAlias, "governance.mento.org"].sort(),
+    [
+      generatedProjectAlias,
+      PRODUCTION_SHADOW_TARGETS.reserve.generatedProjectAlias,
+    ].sort(),
+    [
+      generatedAuthorAlias,
+      generatedProjectAlias,
+      "governancementoorg-other-mentolabs.vercel.app",
+    ].sort(),
   ];
   for (const aliases of unexpectedAliasSets) {
     assert.throws(
@@ -621,19 +655,16 @@ test("run 30034411210 keeps immutable identity separate from the provider alias 
           },
           "governance",
         ),
-      (error) => {
-        assert.equal(
-          error.message,
-          `Staged governance production generated-alias topology mismatch: expected ${JSON.stringify([generatedProjectAlias])}; actual ${JSON.stringify(aliases)}`,
-        );
-        return true;
-      },
+      /generated-alias topology mismatch/,
     );
   }
 
   for (const aliases of [
     [generatedProjectAlias, generatedProjectAlias],
+    [generatedAuthorAlias, generatedAuthorAlias, generatedProjectAlias].sort(),
     [generatedProjectAlias.toUpperCase()],
+    [...expected.aliases].reverse(),
+    [generatedProjectAlias, "not a hostname"].sort(),
   ]) {
     assert.throws(
       () =>
@@ -644,9 +675,144 @@ test("run 30034411210 keeps immutable identity separate from the provider alias 
           },
           "governance",
         ),
-      /aliases are malformed/,
+      /aliases are malformed|Alias hostname is malformed/,
     );
   }
+
+  assert.throws(
+    () =>
+      assertOnlyExpectedVercelGeneratedAliases(
+        {
+          ...expected,
+          aliases: [immutableHostname, generatedProjectAlias].sort(),
+        },
+        "governance",
+      ),
+    /immutable hostname must remain separate/,
+  );
+  assert.throws(
+    () =>
+      assertOnlyExpectedVercelGeneratedAliases(
+        {
+          ...expected,
+          alias: generatedProjectAlias,
+          deploymentUrl: `https://${generatedProjectAlias}`,
+          aliases: [generatedProjectAlias],
+        },
+        "governance",
+      ),
+    /immutable hostname must remain separate/,
+  );
+
+  assert.throws(
+    () =>
+      assertOnlyExpectedVercelGeneratedAliases(
+        {
+          ...expected,
+          creatorUsername: null,
+        },
+        "governance",
+      ),
+    /generated-alias topology mismatch/,
+  );
+  for (const creatorUsername of [
+    "chapati.example",
+    "chapati/name",
+    "chapati_name",
+    "a".repeat(64),
+  ]) {
+    assert.throws(
+      () =>
+        assertOnlyExpectedVercelGeneratedAliases(
+          {
+            ...expected,
+            creatorUsername,
+            aliases: [generatedProjectAlias],
+          },
+          "governance",
+        ),
+      /creator username is malformed/,
+    );
+  }
+  assert.throws(
+    () =>
+      assertOnlyExpectedVercelGeneratedAliases(
+        {
+          ...expected,
+          creatorUsername: "git-main",
+          aliases: [
+            generatedProjectAlias,
+            "governancementoorg-git-main-mentolabs.vercel.app",
+          ].sort(),
+        },
+        "governance",
+      ),
+    /generated-alias topology mismatch/,
+  );
+  const branchLikeCreatorBaseOnly = {
+    ...expected,
+    creatorUsername: "git-main",
+    aliases: [generatedProjectAlias],
+  };
+  assert.equal(
+    assertOnlyExpectedVercelGeneratedAliases(
+      branchLikeCreatorBaseOnly,
+      "governance",
+    ),
+    branchLikeCreatorBaseOnly,
+  );
+  assert.throws(
+    () =>
+      assertOnlyExpectedVercelGeneratedAliases(
+        {
+          ...expected,
+          creatorUsername: "env-staging",
+          aliases: [
+            generatedProjectAlias,
+            "governancementoorg-env-staging-mentolabs.vercel.app",
+          ].sort(),
+        },
+        "governance",
+      ),
+    /generated-alias topology mismatch/,
+  );
+  const environmentLikeCreatorBaseOnly = {
+    ...expected,
+    creatorUsername: "env-staging",
+    aliases: [generatedProjectAlias],
+  };
+  assert.equal(
+    assertOnlyExpectedVercelGeneratedAliases(
+      environmentLikeCreatorBaseOnly,
+      "governance",
+    ),
+    environmentLikeCreatorBaseOnly,
+  );
+  const truncationRequiredCreator = "a".repeat(40);
+  const truncationRequiredBaseOnly = {
+    ...expected,
+    creatorUsername: truncationRequiredCreator,
+    aliases: [generatedProjectAlias],
+  };
+  assert.equal(
+    assertOnlyExpectedVercelGeneratedAliases(
+      truncationRequiredBaseOnly,
+      "governance",
+    ),
+    truncationRequiredBaseOnly,
+  );
+  const truncatedAuthorAlias = `${`governancementoorg-${truncationRequiredCreator}-mentolabs`.slice(0, 63)}.vercel.app`;
+  assert.throws(
+    () =>
+      assertOnlyExpectedVercelGeneratedAliases(
+        {
+          ...truncationRequiredBaseOnly,
+          aliases: [generatedProjectAlias, truncatedAuthorAlias].sort(),
+        },
+        "governance",
+      ),
+    /generated-alias topology mismatch/,
+  );
 
   assert.throws(
     () =>
@@ -720,7 +886,28 @@ test("ordinary production targets pin reviewed generated project aliases", () =>
       ui: "uimentoorg-mentolabs.vercel.app",
     },
   );
+  assert.deepEqual(
+    Object.fromEntries(
+      ["governance", "reserve", "ui"].map((target) => [
+        target,
+        {
+          projectSlug: PRODUCTION_SHADOW_TARGETS[target].generatedProjectSlug,
+          scopeSlug: PRODUCTION_SHADOW_TARGETS[target].generatedScopeSlug,
+        },
+      ]),
+    ),
+    {
+      governance: {
+        projectSlug: "governancementoorg",
+        scopeSlug: "mentolabs",
+      },
+      reserve: { projectSlug: "reservementoorg", scopeSlug: "mentolabs" },
+      ui: { projectSlug: "uimentoorg", scopeSlug: "mentolabs" },
+    },
+  );
   assert.equal(PRODUCTION_SHADOW_TARGETS.app.generatedProjectAlias, null);
+  assert.equal(PRODUCTION_SHADOW_TARGETS.app.generatedProjectSlug, null);
+  assert.equal(PRODUCTION_SHADOW_TARGETS.app.generatedScopeSlug, null);
 });
 
 test("custom-v3 pull selects the custom target without a preview-only branch override", () => {


### PR DESCRIPTION
## The Problem

Production Shadow run [30037927329](https://github.com/mento-protocol/frontend-monorepo/actions/runs/30037927329) failed safely after Vercel returned its documented creator-scoped generated alias alongside the required project/team alias. The verifier required exactly one alias, so it rejected a legitimate Staged candidate even though all protected production mappings remained unchanged.

## The Solution

- Record only Vercel's sanitized public `creator.username` in canonical deployment state.
- Require the project/team alias and allow at most the exact project/creator/team alias documented for Vercel CLI deployments.
- Continue to reject branch, custom-environment, custom-domain, protected-domain, immutable, malformed, duplicated, truncated, wrong-target, and arbitrary extra aliases.
- Reserve `git-*` and `env-*` creator namespaces so ambiguous generated aliases fail closed.
- Add fixtures from both observed Governance shadow topologies and update workflow labels, the runbook, README, AGENTS, and ADR language.

## Validation

- `pnpm vercel:production-shadow:test` — 102/102 passed
- `pnpm vercel:deployment-state:test` — 28/28 passed
- `pnpm quality:budgets:test` — 30/30 passed
- `pnpm adr:check:test` — 9/9 passed
- `pnpm adr:check` — passed
- `pnpm ci:action-pins:test` — 59/59 passed
- `pnpm ci:action-pins` — all 26 workflow and composite-action manifests pinned
- `trunk check <15 changed files>` — no issues
- `git diff --check` — clean
- Independent security, acceptance, and fresh-context autoreviews — no findings
- Browser inspection of the failed candidate confirmed `Created by chapati`, Ready/Staged state, both generated aliases, skipped custom-domain assignment, a working Governance page, and no console errors.

The verifier remains fail-closed if Vercel changes its generated-alias format. This PR does not promote a candidate or mutate any custom or protected production domain.

Refs #521.

## Ship Checklist

- [x] PR title follows the [conventions](https://www.notion.so/Git-Branching-and-Commit-Message-Conventions-18f66f7d06444cfcbac5725ffbc7c04a?pvs=4#9355048863c549ef92fe210a8a1298aa)
- [x] Performed a self-review of my own changes
- [x] Relevant automated checks and smoke tests pass
- [x] Architecture decision: updates [ADR 0001](docs/adr/0001-github-actions-vercel-deployment-orchestration.md) to match the accepted generated-alias topology.
