### PR TITLE
fix(ci): wait for production-shadow hydration

### DIFF
--- a/apps/app.mento.org/e2e/production-shadow/smoke.spec.ts
+++ b/apps/app.mento.org/e2e/production-shadow/smoke.spec.ts
@@ -182,6 +182,9 @@ test("staged production artifact is healthy, secure, and interactive", async ({
     expectedDeploymentId,
   );
 
+  // Target controls are server rendered. Wait for deferred client scripts so
+  // the first interaction cannot race React hydration.
+  await page.waitForLoadState("load");
   await verifyTarget(page, target, url.origin);
   await page.waitForLoadState("networkidle", { timeout: 30_000 }).catch(() => {
     // Live data polling may keep the network active. The tracked document,

--- a/scripts/vercel-production-shadow-workflow.test.mjs
+++ b/scripts/vercel-production-shadow-workflow.test.mjs
@@ -1484,6 +1484,26 @@ test("fresh smoke jobs resolve the Playwright config from the filtered workspace
   }
 });
 
+test("production-shadow smoke waits for hydration before target interaction", () => {
+  const spec = readFileSync(
+    new URL(
+      "../apps/app.mento.org/e2e/production-shadow/smoke.spec.ts",
+      import.meta.url,
+    ),
+    "utf8",
+  );
+  const hydrationWaitIndex = spec.indexOf(
+    'await page.waitForLoadState("load");',
+  );
+  const targetInteractionIndex = spec.indexOf(
+    "await verifyTarget(page, target, url.origin);",
+  );
+
+  assert.notEqual(hydrationWaitIndex, -1);
+  assert.notEqual(targetInteractionIndex, -1);
+  assert.ok(hydrationWaitIndex < targetInteractionIndex);
+});
+
 test("all external action references remain immutable full SHA pins", () => {
   for (const value of allStrings(workflow)) {
     if (!value.includes("@") || value.startsWith("./")) continue;


### PR DESCRIPTION
## The Problem

Exact-main Production Shadow run 30042378568 staged a healthy Reserve deployment, but its browser smoke clicked the server-rendered `Supply` tab immediately after `DOMContentLoaded`. The click raced React hydration, so the tab stayed inactive and the workflow correctly skipped UI. The final protected-domain comparison passed; no production mapping changed.

## The Solution

Wait for the page `load` event before any target-specific interaction, matching the hydration barrier already used by the established preview smoke. Add a zero-network regression that requires this wait to exist before `verifyTarget`.

Refs #521.

## Validation

- `pnpm vercel:production-shadow:test` — 103/103 passed
- `pnpm vercel:preview:test` — 254/254 passed
- `pnpm quality:budgets:test` — 30/30 passed
- `pnpm check-types` — 8/8 tasks passed
- `pnpm adr:check`
- `trunk check apps/app.mento.org/e2e/production-shadow/smoke.spec.ts scripts/vercel-production-shadow-workflow.test.mjs`
- pre-push Trunk check — 1,143 files, no issues
- pre-push Knip — passed
- Browser: the failed run's immutable Reserve deployment selected `Supply`, persisted `?tab=stablecoins`, and emitted no console errors after `load`

## Risk

This changes only smoke timing and its structural regression. It does not change application behavior, Vercel credentials, deployment state, aliases, or protected domains. After merge, #521 still requires a completely green fresh exact-main Production Shadow run.

## Ship Checklist

- [x] ship skill used
- [x] independent and structured local review run
- [x] local validation run
