### PR TITLE
fix(ci): verify UI shadow identity after hydration

### DIFF
--- a/apps/app.mento.org/e2e/production-shadow/deployment-identity.mjs
+++ b/apps/app.mento.org/e2e/production-shadow/deployment-identity.mjs
@@ -1,0 +1,47 @@
+import { assertBrowserDeploymentIdentity } from "../../../ui.mento.org/e2e/vercel-preview-browser-smoke.mjs";
+import { assertHtmlDocumentDeploymentIdentity } from "../../../../scripts/vercel-html-deployment-identity.mjs";
+
+const TARGETS = new Set(["governance", "reserve", "ui"]);
+
+function requireTarget(target) {
+  if (!TARGETS.has(target)) {
+    throw new Error("Unknown production-shadow browser target");
+  }
+}
+
+export function assertProductionShadowServerIdentity(
+  html,
+  expectedDeploymentId,
+) {
+  assertHtmlDocumentDeploymentIdentity(
+    html,
+    expectedDeploymentId,
+    "Production-shadow server HTML does not carry only the expected build deployment ID",
+  );
+}
+
+export function assertProductionShadowHydratedIdentity({
+  target,
+  expectedDeploymentId,
+  renderedDeploymentId,
+  assetReferences,
+  expectedOrigin,
+}) {
+  requireTarget(target);
+  if (target === "ui") {
+    assertBrowserDeploymentIdentity(
+      {
+        htmlDeploymentId: renderedDeploymentId,
+        assetReferences,
+      },
+      expectedDeploymentId,
+      expectedOrigin,
+    );
+    return;
+  }
+  if (renderedDeploymentId !== expectedDeploymentId) {
+    throw new Error(
+      `Hydrated ${target} production-shadow page does not carry the expected build deployment ID`,
+    );
+  }
+}

--- a/apps/app.mento.org/e2e/production-shadow/smoke.spec.ts
+++ b/apps/app.mento.org/e2e/production-shadow/smoke.spec.ts
@@ -6,6 +6,14 @@ import {
   assertProductionShadowOrigin,
   fulfillProductionShadowRequest,
 } from "./request-policy.mjs";
+import {
+  assertProductionShadowHydratedIdentity,
+  assertProductionShadowServerIdentity,
+} from "./deployment-identity.mjs";
+import {
+  createBrowserDeploymentIdentityMonitor,
+  readSettledBrowserDeploymentIdentity,
+} from "../../../ui.mento.org/e2e/vercel-preview-browser-smoke.mjs";
 
 const TARGETS = ["governance", "reserve", "ui"] as const;
 type Target = (typeof TARGETS)[number];
@@ -157,10 +165,55 @@ async function verifyTarget(page: Page, target: Target, origin: string) {
   expect(() => assertProductionShadowOrigin(page.url(), origin)).not.toThrow();
 }
 
+async function assertHydratedDeploymentIdentity({
+  page,
+  target,
+  expectedDeploymentId,
+  expectedOrigin,
+  uiIdentityMonitor,
+}: {
+  page: Page;
+  target: Target;
+  expectedDeploymentId: string;
+  expectedOrigin: string;
+  uiIdentityMonitor?: ReturnType<typeof createBrowserDeploymentIdentityMonitor>;
+}) {
+  let renderedDeploymentId: string | null;
+  let assetReferences: string[] = [];
+  if (target === "ui") {
+    if (!uiIdentityMonitor) {
+      throw new Error("UI deployment identity monitor is required");
+    }
+    const identity = await readSettledBrowserDeploymentIdentity({
+      page,
+      monitor: uiIdentityMonitor,
+      expectedDeploymentId,
+      timeoutMs: 30_000,
+    });
+    renderedDeploymentId = identity.htmlDeploymentId;
+    assetReferences = identity.assetReferences;
+  } else {
+    renderedDeploymentId = await page
+      .locator("html")
+      .getAttribute("data-dpl-id");
+  }
+  assertProductionShadowHydratedIdentity({
+    target,
+    expectedDeploymentId,
+    renderedDeploymentId,
+    assetReferences,
+    expectedOrigin,
+  });
+}
+
 test("staged production artifact is healthy, secure, and interactive", async ({
   page,
 }) => {
   const { target, url, expectedDeploymentId, expectedSha } = requiredInputs();
+  const uiIdentityMonitor =
+    target === "ui"
+      ? createBrowserDeploymentIdentityMonitor(page, url.origin)
+      : undefined;
   await page.route("**/*", async (route) => {
     await fulfillProductionShadowRequest({ route });
   });
@@ -177,18 +230,32 @@ test("staged production artifact is healthy, secure, and interactive", async ({
   ).not.toThrow();
   assertSecurityHeaders(response as Response);
   expect(response?.headers()["x-mento-deployment-sha"]).toBe(expectedSha);
-  await expect(page.locator("html")).toHaveAttribute(
-    "data-dpl-id",
+  assertProductionShadowServerIdentity(
+    await (response as Response).text(),
     expectedDeploymentId,
   );
 
   // Target controls are server rendered. Wait for deferred client scripts so
   // the first interaction cannot race React hydration.
   await page.waitForLoadState("load");
+  await assertHydratedDeploymentIdentity({
+    page,
+    target,
+    expectedDeploymentId,
+    expectedOrigin: url.origin,
+    uiIdentityMonitor,
+  });
   await verifyTarget(page, target, url.origin);
   await page.waitForLoadState("networkidle", { timeout: 30_000 }).catch(() => {
     // Live data polling may keep the network active. The tracked document,
     // script, stylesheet, page, and console failures remain authoritative.
+  });
+  await assertHydratedDeploymentIdentity({
+    page,
+    target,
+    expectedDeploymentId,
+    expectedOrigin: url.origin,
+    uiIdentityMonitor,
   });
 
   expect(errors.origins, "cross-origin main-frame navigations").toEqual([]);

--- a/apps/ui.mento.org/e2e/vercel-preview-browser-smoke.mjs
+++ b/apps/ui.mento.org/e2e/vercel-preview-browser-smoke.mjs
@@ -216,11 +216,51 @@ export function assertBrowserDeploymentIdentity(
   }
 }
 
-function createBrowserDeploymentIdentityMonitor(page, expectedOrigin) {
-  const assetReferences = [];
+function assertTypedBrowserDeploymentIdentity(
+  assetRequests,
+  htmlDeploymentId,
+  expectedDeploymentId,
+  expectedOrigin,
+) {
+  const assetReferences = assetRequests.map((request) => request.reference);
+  assertBrowserDeploymentIdentity(
+    { htmlDeploymentId, assetReferences },
+    expectedDeploymentId,
+    expectedOrigin,
+  );
+
+  let javaScriptAsset = false;
+  let styleAsset = false;
+  for (const request of assetRequests) {
+    if (
+      !request ||
+      typeof request !== "object" ||
+      typeof request.resourceType !== "string"
+    ) {
+      throw new Error(
+        "Browser-loaded Next.js asset request types are missing or invalid",
+      );
+    }
+    const url = new URL(request.reference);
+    javaScriptAsset ||=
+      request.resourceType === "script" && url.pathname.endsWith(".js");
+    styleAsset ||=
+      request.resourceType === "stylesheet" && url.pathname.endsWith(".css");
+  }
+  if (!javaScriptAsset || !styleAsset) {
+    throw new Error(
+      "Browser-loaded Next.js asset request types are missing or invalid",
+    );
+  }
+  return assetReferences;
+}
+
+export function createBrowserDeploymentIdentityMonitor(page, expectedOrigin) {
+  const assetRequests = [];
   const activeRequests = new Set();
   const activityWaiters = new Set();
   let overflow = false;
+  let redirectViolation = false;
 
   function signalActivity() {
     for (const resolve of activityWaiters) {
@@ -246,26 +286,75 @@ function createBrowserDeploymentIdentityMonitor(page, expectedOrigin) {
     });
   }
 
+  function redirectedFromNextStatic(request) {
+    const seen = new Set();
+    let ancestor;
+    try {
+      ancestor = request.redirectedFrom?.() ?? null;
+    } catch {
+      redirectViolation = true;
+      return false;
+    }
+    while (ancestor) {
+      if (seen.has(ancestor) || seen.size >= 20) {
+        redirectViolation = true;
+        return false;
+      }
+      seen.add(ancestor);
+      try {
+        const url = new URL(ancestor.url());
+        if (
+          url.origin === expectedOrigin &&
+          url.pathname.startsWith("/_next/static/")
+        ) {
+          return true;
+        }
+        ancestor = ancestor.redirectedFrom?.() ?? null;
+      } catch {
+        redirectViolation = true;
+        return false;
+      }
+    }
+    return false;
+  }
+
   page.on("request", (request) => {
     let url;
     try {
       url = new URL(request.url());
     } catch {
+      if (redirectedFromNextStatic(request)) {
+        redirectViolation = true;
+        activeRequests.add(request);
+        signalActivity();
+      }
       return;
     }
-    if (
-      url.origin !== expectedOrigin ||
-      !url.pathname.startsWith("/_next/static/")
-    ) {
+    const isNextStatic =
+      url.origin === expectedOrigin &&
+      url.pathname.startsWith("/_next/static/");
+    const redirectedFromStatic = redirectedFromNextStatic(request);
+    if (!isNextStatic && !redirectedFromStatic) {
       return;
     }
-    if (assetReferences.length >= MAX_NEXT_STATIC_ASSET_REQUESTS) {
+    activeRequests.add(request);
+    if (!isNextStatic) {
+      redirectViolation = true;
+      signalActivity();
+      return;
+    }
+    if (assetRequests.length >= MAX_NEXT_STATIC_ASSET_REQUESTS) {
       overflow = true;
       signalActivity();
       return;
     }
-    assetReferences.push(url.toString());
-    activeRequests.add(request);
+    let resourceType = null;
+    try {
+      resourceType = request.resourceType();
+    } catch {
+      // The evidence assertion below rejects missing request types.
+    }
+    assetRequests.push({ reference: url.toString(), resourceType });
     signalActivity();
   });
 
@@ -276,6 +365,34 @@ function createBrowserDeploymentIdentityMonitor(page, expectedOrigin) {
   };
   page.on("requestfinished", finishRequest);
   page.on("requestfailed", finishRequest);
+
+  function evidence(expectedDeploymentId, htmlDeploymentId) {
+    if (overflow) {
+      throw new Error(
+        "Browser-loaded Next.js asset identity evidence exceeded its limit",
+      );
+    }
+    if (activeRequests.size > 0) {
+      throw new Error(
+        "Browser-loaded Next.js asset identity evidence is not settled",
+      );
+    }
+    if (redirectViolation) {
+      throw new Error(
+        "Browser-loaded Next.js asset redirected outside its immutable identity",
+      );
+    }
+    const assetReferences = assertTypedBrowserDeploymentIdentity(
+      assetRequests,
+      htmlDeploymentId,
+      expectedDeploymentId,
+      expectedOrigin,
+    );
+    return {
+      htmlDeploymentId,
+      assetReferences: [...assetReferences],
+    };
+  }
 
   return {
     async waitForIdle(timeoutMs) {
@@ -315,18 +432,24 @@ function createBrowserDeploymentIdentityMonitor(page, expectedOrigin) {
       }
     },
     assertExpected(expectedDeploymentId, htmlDeploymentId) {
-      if (overflow) {
-        throw new Error(
-          "Browser-loaded Next.js asset identity evidence exceeded its limit",
-        );
-      }
-      assertBrowserDeploymentIdentity(
-        { htmlDeploymentId, assetReferences },
-        expectedDeploymentId,
-        expectedOrigin,
-      );
+      evidence(expectedDeploymentId, htmlDeploymentId);
     },
+    evidence,
   };
+}
+
+export async function readSettledBrowserDeploymentIdentity({
+  page,
+  monitor,
+  expectedDeploymentId,
+  timeoutMs,
+}) {
+  await monitor.waitForIdle(timeoutMs);
+  const htmlDeploymentId = await page
+    .locator("html")
+    .getAttribute("data-dpl-id");
+  await monitor.waitForIdle(timeoutMs);
+  return monitor.evidence(expectedDeploymentId, htmlDeploymentId);
 }
 
 export async function runBrowserSmoke({
@@ -374,14 +497,12 @@ export async function runBrowserSmoke({
       .getByRole("heading", { name: "Basic Components", exact: true })
       .waitFor({ state: "visible" });
     await page.waitForLoadState("load");
-    await deploymentIdentityMonitor.waitForIdle(timeoutMs);
-    const renderedDeploymentId = await page
-      .locator("html")
-      .getAttribute("data-dpl-id");
-    deploymentIdentityMonitor.assertExpected(
-      validated.nextDeploymentId,
-      renderedDeploymentId,
-    );
+    await readSettledBrowserDeploymentIdentity({
+      page,
+      monitor: deploymentIdentityMonitor,
+      expectedDeploymentId: validated.nextDeploymentId,
+      timeoutMs,
+    });
 
     await page
       .getByPlaceholder("Search components...", { exact: true })
@@ -410,14 +531,12 @@ export async function runBrowserSmoke({
         "Browser smoke interaction did not remain updated after hydration",
       );
     }
-    const finalRenderedDeploymentId = await page
-      .locator("html")
-      .getAttribute("data-dpl-id");
-    await deploymentIdentityMonitor.waitForIdle(timeoutMs);
-    deploymentIdentityMonitor.assertExpected(
-      validated.nextDeploymentId,
-      finalRenderedDeploymentId,
-    );
+    await readSettledBrowserDeploymentIdentity({
+      page,
+      monitor: deploymentIdentityMonitor,
+      expectedDeploymentId: validated.nextDeploymentId,
+      timeoutMs,
+    });
     monitor.assertClean();
     return {
       deploymentUrl: validated.deploymentUrl,

--- a/apps/ui.mento.org/e2e/vercel-preview-browser-smoke.test.mjs
+++ b/apps/ui.mento.org/e2e/vercel-preview-browser-smoke.test.mjs
@@ -4,8 +4,10 @@ import { test } from "node:test";
 
 import {
   assertBrowserDeploymentIdentity,
+  createBrowserDeploymentIdentityMonitor,
   createBrowserFailureMonitor,
   loadTrustedChromium,
+  readSettledBrowserDeploymentIdentity,
   runBrowserSmoke,
   validateBrowserSmokeInput,
 } from "./vercel-preview-browser-smoke.mjs";
@@ -70,15 +72,27 @@ class FakePage extends EventEmitter {
     return this.currentUrl;
   }
 
-  emitAssetRequest(reference) {
-    const request = this.startAssetRequest(reference);
+  emitAssetRequest(reference, options) {
+    const request = this.startAssetRequest(reference, options);
     this.emit("requestfinished", request);
   }
 
-  startAssetRequest(reference) {
+  startAssetRequest(
+    reference,
+    {
+      redirectedFrom = null,
+      resourceType = reference.endsWith(".css")
+        ? "stylesheet"
+        : reference.includes(".css?")
+          ? "stylesheet"
+          : "script",
+    } = {},
+  ) {
     const request = {
       failure: () => ({ errorText: "net::ERR_FAILED" }),
       method: () => "GET",
+      redirectedFrom: () => redirectedFrom,
+      resourceType: () => resourceType,
       url: () => reference,
     };
     this.emit("request", request);
@@ -292,6 +306,156 @@ test("browser identity rejects missing, mixed, duplicate, or cross-origin eviden
       ),
     );
   }
+});
+
+test("browser identity monitor exposes settled defensive evidence", async () => {
+  const page = new EventEmitter();
+  const monitor = createBrowserDeploymentIdentityMonitor(
+    page,
+    new URL(INPUT.deploymentUrl).origin,
+  );
+  const references = [
+    [
+      `${INPUT.deploymentUrl}/_next/static/app.js?dpl=${NEXT_DEPLOYMENT_ID}`,
+      "script",
+    ],
+    [
+      `${INPUT.deploymentUrl}/_next/static/app.css?dpl=${NEXT_DEPLOYMENT_ID}`,
+      "stylesheet",
+    ],
+  ];
+  for (const [reference, resourceType] of references) {
+    const request = {
+      redirectedFrom: () => null,
+      resourceType: () => resourceType,
+      url: () => reference,
+    };
+    page.emit("request", request);
+    page.emit("requestfinished", request);
+  }
+  await monitor.waitForIdle(1_000);
+
+  const evidence = monitor.evidence(NEXT_DEPLOYMENT_ID, null);
+  assert.deepEqual(evidence, {
+    htmlDeploymentId: null,
+    assetReferences: references.map(([reference]) => reference),
+  });
+  evidence.assetReferences.push("https://attacker.example/chunk.js");
+  assert.deepEqual(
+    monitor.evidence(NEXT_DEPLOYMENT_ID, null).assetReferences,
+    references.map(([reference]) => reference),
+  );
+});
+
+test("browser identity monitor rejects fetch and image suffix spoofs", async () => {
+  const page = new EventEmitter();
+  const monitor = createBrowserDeploymentIdentityMonitor(
+    page,
+    new URL(INPUT.deploymentUrl).origin,
+  );
+  for (const [suffix, resourceType] of [
+    ["fake.js", "fetch"],
+    ["fake.css", "image"],
+  ]) {
+    const request = {
+      redirectedFrom: () => null,
+      resourceType: () => resourceType,
+      url: () =>
+        `${INPUT.deploymentUrl}/_next/static/${suffix}?dpl=${NEXT_DEPLOYMENT_ID}`,
+    };
+    page.emit("request", request);
+    page.emit("requestfinished", request);
+  }
+  await monitor.waitForIdle(1_000);
+
+  assert.throws(
+    () => monitor.evidence(NEXT_DEPLOYMENT_ID, null),
+    /request types are missing or invalid/,
+  );
+  assert.throws(
+    () => monitor.assertExpected(NEXT_DEPLOYMENT_ID, null),
+    /request types are missing or invalid/,
+  );
+});
+
+test("browser identity monitor rejects a cross-origin static redirect", async () => {
+  const page = new EventEmitter();
+  const monitor = createBrowserDeploymentIdentityMonitor(
+    page,
+    new URL(INPUT.deploymentUrl).origin,
+  );
+  const original = {
+    redirectedFrom: () => null,
+    resourceType: () => "script",
+    url: () =>
+      `${INPUT.deploymentUrl}/_next/static/app.js?dpl=${NEXT_DEPLOYMENT_ID}`,
+  };
+  const redirected = {
+    redirectedFrom: () => original,
+    resourceType: () => "script",
+    url: () => "https://assets.example.invalid/app.js",
+  };
+  page.emit("request", original);
+  page.emit("requestfinished", original);
+  page.emit("request", redirected);
+  page.emit("requestfinished", redirected);
+  await monitor.waitForIdle(1_000);
+
+  assert.throws(
+    () => monitor.evidence(NEXT_DEPLOYMENT_ID, null),
+    /redirected outside its immutable identity/,
+  );
+});
+
+test("settled browser identity waits for a request started during the DOM read", async () => {
+  const page = new EventEmitter();
+  const monitor = createBrowserDeploymentIdentityMonitor(
+    page,
+    new URL(INPUT.deploymentUrl).origin,
+  );
+  let requestFinished = false;
+  for (const [suffix, resourceType] of [
+    ["app.js", "script"],
+    ["app.css", "stylesheet"],
+  ]) {
+    const request = {
+      redirectedFrom: () => null,
+      resourceType: () => resourceType,
+      url: () =>
+        `${INPUT.deploymentUrl}/_next/static/${suffix}?dpl=${NEXT_DEPLOYMENT_ID}`,
+    };
+    page.emit("request", request);
+    page.emit("requestfinished", request);
+  }
+  page.locator = (selector) => {
+    assert.equal(selector, "html");
+    return {
+      getAttribute: async (attribute) => {
+        assert.equal(attribute, "data-dpl-id");
+        const request = {
+          redirectedFrom: () => null,
+          resourceType: () => "script",
+          url: () =>
+            `${INPUT.deploymentUrl}/_next/static/late.js?dpl=${NEXT_DEPLOYMENT_ID}`,
+        };
+        page.emit("request", request);
+        setTimeout(() => {
+          requestFinished = true;
+          page.emit("requestfinished", request);
+        }, 10);
+        return null;
+      },
+    };
+  };
+
+  const evidence = await readSettledBrowserDeploymentIdentity({
+    page,
+    monitor,
+    expectedDeploymentId: NEXT_DEPLOYMENT_ID,
+    timeoutMs: 1_000,
+  });
+  assert.equal(requestFinished, true);
+  assert.equal(evidence.assetReferences.length, 3);
 });
 
 test("trusted checkout resolves its own pinned Playwright package", async () => {

--- a/docs/vercel-deployments.md
+++ b/docs/vercel-deployments.md
@@ -668,15 +668,25 @@ bounded HTTP readiness, document status, stable target content, one
 safe interaction, critical security headers, uncaught page errors, console
 errors, failed document/script/style requests from any origin, critical HTTP
 responses with status 400 or higher from any origin, the exact custom Next
-build ID rendered as the document's `data-dpl-id`, and the exact deployed SHA
-from the build-bound `X-Mento-Deployment-Sha` response header. No deployment-protection header is
-supplied. The request policy rejects any ambient protection header, handles each
-redirect as a new browser request, and origin-checks main-frame navigation
-throughout the smoke and after every target interaction. HTTP readiness also
-uses manual redirects and rejects a cross-origin redirect. The fresh smoke job
-never links or executes candidate `node_modules`. Failure uploads only
-screenshots/video for seven days; tracing stays disabled to keep diagnostic
-artifacts bounded.
+build ID, and the exact deployed SHA from the build-bound
+`X-Mento-Deployment-Sha` response header. The raw server response's leading
+`<html>` start tag must contain exactly one quoted, case-insensitive
+`data-dpl-id` attribute with the expected value. Governance and Reserve must
+retain that exact marker in the hydrated DOM. For UI, the smoke accepts React
+removing the server-injected marker during hydration only when every observed
+same-origin `/_next/static/` request carries exactly one matching `?dpl=` value
+and Playwright classified representative requests as a JavaScript script and a
+CSS stylesheet. A static-asset redirect must retain the same immutable origin
+and identity. The UI identity monitor waits for all observed static requests to
+finish and for a quiet window both before and after reading the DOM marker, then
+checks before and after the interaction so late chunks cannot introduce a mixed
+build. No deployment-protection header is supplied. The request policy
+rejects any ambient protection header, handles each redirect as a new browser
+request, and origin-checks main-frame navigation throughout the smoke and after
+every target interaction. HTTP readiness also uses manual redirects and rejects
+a cross-origin redirect. The fresh smoke job never links or executes candidate
+`node_modules`. Failure uploads only screenshots/video for seven days; tracing
+stays disabled to keep diagnostic artifacts bounded.
 
 Do not run the manual pilot until the required GitHub Environment, repository
 variables, production token, mirrored build-variable names, and reviewed app-v3
@@ -1735,14 +1745,16 @@ pinned Playwright container and keeps the common bounded
 HTTP/header/static-asset checks before the trusted UI deployment-identity
 browser flow renders the showcase, searches and navigates to a second route,
 changes a form control, and fails on page/console errors or failed same-origin
-requests and responses. The HTTP phase verifies the server-rendered
-`data-dpl-id`; after hydration, the browser phase requires every loaded
-same-origin `/_next/static/` asset to carry exactly the expected `?dpl=` value
-and rejects any conflicting retained HTML deployment marker. Request monitoring
-remains active through the second-route interaction, so dynamically loaded
-chunks cannot escape the same identity check. The controller waits for all
-observed static requests to finish and for a quiet window before its final
-assertion. This preserves fail-closed deployment-identity proof when
+requests and responses. The HTTP phase verifies the server-rendered marker on
+the leading `<html>` start tag; after hydration, the browser phase requires
+every loaded same-origin `/_next/static/` asset to carry exactly the expected
+`?dpl=` value, requires actual script and stylesheet request types, rejects a
+static asset redirected outside that immutable identity, and rejects any
+conflicting retained HTML deployment marker. Request monitoring remains active
+through the second-route interaction, so dynamically loaded chunks cannot
+escape the same identity check. The controller waits for all observed static
+requests to finish and for a quiet window after each DOM marker read before its
+identity assertion. This preserves fail-closed deployment-identity proof when
 React reconciles the server-injected HTML attribute out of the live DOM. Chrome
 also waits for the initial page load before changing controlled inputs, then
 rechecks the changed form control after the hydration/interaction settle. Its

--- a/docs/wallet-testing.md
+++ b/docs/wallet-testing.md
@@ -268,12 +268,18 @@ pnpm --filter app.mento.org test:production-shadow
 
 This target-aware suite checks production headers, stable content, and one safe
 interaction, fails critical document/script/style responses from any origin,
-keeps the main frame on the exact immutable origin throughout, and binds the
-rendered `data-dpl-id` and `X-Mento-Deployment-Sha` response header to the exact
-prebuilt output and commit. No deployment-protection
-bypass is supplied; the request policy rejects any ambient protection header
-and handles every redirect as a new browser request. The real two-origin
-Chromium regression is
+keeps the main frame on the exact immutable origin throughout, requires the raw
+server response's leading `<html>` start tag to contain exactly one quoted
+expected `data-dpl-id`, and binds the `X-Mento-Deployment-Sha` response header
+to the exact commit. Governance and Reserve must retain the expected marker
+after hydration. For UI, the smoke accepts the server-injected marker being
+absent after hydration only when every observed same-origin Next.js static
+request carries exactly one expected `?dpl=` value, Playwright observed actual
+script and stylesheet request types, and no static asset redirected outside the
+same immutable identity.
+No deployment-protection bypass is supplied; the request policy rejects any
+ambient protection header and handles every redirect as a new browser request.
+The real two-origin Chromium regression is
 `pnpm --filter app.mento.org test:production-shadow:routing`. It does not enable
 the mock wallet and is not a replacement for the team-preview smoke above. See
 `docs/vercel-deployments.md` for the protected alias and deployment-provenance

--- a/scripts/vercel-html-deployment-identity.mjs
+++ b/scripts/vercel-html-deployment-identity.mjs
@@ -1,0 +1,105 @@
+const HTML_WHITESPACE = new Set(["\t", "\n", "\f", "\r", " "]);
+
+function skipWhitespace(html, start) {
+  let cursor = start;
+  while (cursor < html.length && HTML_WHITESPACE.has(html[cursor])) cursor += 1;
+  return cursor;
+}
+
+function startsWithIgnoreCase(html, cursor, value) {
+  return (
+    html.slice(cursor, cursor + value.length).toLowerCase() ===
+    value.toLowerCase()
+  );
+}
+
+function leadingHtmlAttributes(html) {
+  let cursor = html.charCodeAt(0) === 0xfeff ? 1 : 0;
+  cursor = skipWhitespace(html, cursor);
+
+  const doctype = /^<!doctype[\t\n\f\r ]+html[\t\n\f\r ]*>/i.exec(
+    html.slice(cursor),
+  );
+  if (doctype) {
+    cursor = skipWhitespace(html, cursor + doctype[0].length);
+  }
+
+  if (!startsWithIgnoreCase(html, cursor, "<html")) return null;
+  const boundary = html[cursor + 5];
+  if (boundary !== ">" && !HTML_WHITESPACE.has(boundary)) return null;
+  const attributes = [];
+  cursor += 5;
+  while (cursor < html.length) {
+    cursor = skipWhitespace(html, cursor);
+    if (html[cursor] === ">") return attributes;
+    if (cursor >= html.length) return null;
+
+    const nameStart = cursor;
+    while (
+      cursor < html.length &&
+      !HTML_WHITESPACE.has(html[cursor]) &&
+      !["=", '"', "'", "/", ">", "<", "`"].includes(html[cursor])
+    ) {
+      cursor += 1;
+    }
+    if (cursor === nameStart) return null;
+    const name = html.slice(nameStart, cursor).toLowerCase();
+    cursor = skipWhitespace(html, cursor);
+
+    let quoted = false;
+    let value = null;
+    if (html[cursor] === "=") {
+      cursor = skipWhitespace(html, cursor + 1);
+      const quote = html[cursor];
+      if (quote === '"' || quote === "'") {
+        quoted = true;
+        const valueStart = cursor + 1;
+        const valueEnd = html.indexOf(quote, valueStart);
+        if (valueEnd === -1) return null;
+        value = html.slice(valueStart, valueEnd);
+        cursor = valueEnd + 1;
+        if (html[cursor] !== ">" && !HTML_WHITESPACE.has(html[cursor] ?? "")) {
+          return null;
+        }
+      } else {
+        const valueStart = cursor;
+        while (
+          cursor < html.length &&
+          !HTML_WHITESPACE.has(html[cursor]) &&
+          html[cursor] !== ">"
+        ) {
+          if (['"', "'", "<", "=", "`"].includes(html[cursor])) return null;
+          cursor += 1;
+        }
+        if (cursor === valueStart) return null;
+        value = html.slice(valueStart, cursor);
+      }
+    }
+
+    if (name === "data-dpl-id") attributes.push({ quoted, value });
+  }
+  return null;
+}
+
+export function assertHtmlDocumentDeploymentIdentity(
+  html,
+  expectedDeploymentId,
+  failureMessage,
+) {
+  if (
+    typeof html !== "string" ||
+    typeof expectedDeploymentId !== "string" ||
+    expectedDeploymentId.length === 0
+  ) {
+    throw new Error(failureMessage);
+  }
+  const attributes = leadingHtmlAttributes(html);
+  if (
+    !attributes ||
+    attributes.length !== 1 ||
+    !attributes[0].quoted ||
+    attributes[0].value !== expectedDeploymentId
+  ) {
+    throw new Error(failureMessage);
+  }
+}

--- a/scripts/vercel-preview-smoke.mjs
+++ b/scripts/vercel-preview-smoke.mjs
@@ -8,6 +8,8 @@ import { resolve } from "node:path";
 import process from "node:process";
 import { fileURLToPath } from "node:url";
 
+import { assertHtmlDocumentDeploymentIdentity } from "./vercel-html-deployment-identity.mjs";
+
 export const PREVIEW_SMOKE_TARGETS = ["app", "governance", "reserve", "ui"];
 
 const REPOSITORY = "mento-protocol/frontend-monorepo";
@@ -602,11 +604,9 @@ function representativeAssets(html, baseUrl) {
 }
 
 function requireUiHtmlDeploymentIdentity(html, expectedDeploymentId) {
-  const deploymentIds = [
-    ...html.matchAll(/\bdata-dpl-id=(["'])([^"']+)\1/g),
-  ].map((match) => match[2]);
-  invariant(
-    deploymentIds.length === 1 && deploymentIds[0] === expectedDeploymentId,
+  assertHtmlDocumentDeploymentIdentity(
+    html,
+    expectedDeploymentId,
     "UI preview HTML does not carry only the expected build deployment ID",
   );
 }

--- a/scripts/vercel-preview-smoke.test.mjs
+++ b/scripts/vercel-preview-smoke.test.mjs
@@ -381,10 +381,12 @@ test("common HTTP smoke still requires representative JavaScript and CSS assets"
 
 test("common HTTP smoke fails closed on missing headers and mixed deployment assets", async () => {
   const values = controllerTuple("ui");
-  const html = `<main data-dpl-id="${values.nextDeploymentId}"><h1>Basic Components</h1></main>
-    <script src="/_next/static/app.js?dpl=${values.nextDeploymentId}"></script>
-    <link rel="stylesheet" href="/_next/static/app.css?dpl=wrong">
-    <link rel="preload" href="/_next/static/font.woff2?dpl=${values.nextDeploymentId}">`;
+  const html = `<html data-dpl-id="${values.nextDeploymentId}"><body>
+      <main><h1>Basic Components</h1></main>
+      <script src="/_next/static/app.js?dpl=${values.nextDeploymentId}"></script>
+      <link rel="stylesheet" href="/_next/static/app.css?dpl=wrong">
+      <link rel="preload" href="/_next/static/font.woff2?dpl=${values.nextDeploymentId}">
+    </body></html>`;
   const response = (headers) => async (url) =>
     new URL(url).pathname.startsWith("/_next/static/")
       ? fakeResponse(url, "asset")
@@ -415,9 +417,11 @@ test("UI common HTTP smoke requires the exact server-rendered deployment identit
       return fakeResponse(parsed, "asset");
     return fakeResponse(
       parsed,
-      `<main ${deploymentMarker}><h1>Basic Components</h1></main>
-        <script src="/_next/static/app.js?dpl=${values.nextDeploymentId}"></script>
-        <link rel="stylesheet" href="/_next/static/app.css?dpl=${values.nextDeploymentId}">`,
+      `<html ${deploymentMarker}><body>
+          <main><h1>Basic Components</h1></main>
+          <script src="/_next/static/app.js?dpl=${values.nextDeploymentId}"></script>
+          <link rel="stylesheet" href="/_next/static/app.css?dpl=${values.nextDeploymentId}">
+        </body></html>`,
       {
         headers: {
           "content-security-policy": "frame-ancestors 'none'",
@@ -438,6 +442,23 @@ test("UI common HTTP smoke requires the exact server-rendered deployment identit
       fetchImplementation: response('data-dpl-id="m-ui-wrongwrongwrong12"'),
     }),
     /HTML does not carry only the expected build deployment ID/,
+  );
+  await assert.rejects(
+    smokePreviewHttp({
+      values,
+      fetchImplementation: response(
+        `x-data-dpl-id="${values.nextDeploymentId}"`,
+      ),
+    }),
+    /HTML does not carry only the expected build deployment ID/,
+  );
+  await assert.doesNotReject(
+    smokePreviewHttp({
+      values,
+      fetchImplementation: response(
+        `DATA-DPL-ID = '${values.nextDeploymentId}'`,
+      ),
+    }),
   );
 });
 

--- a/scripts/vercel-production-shadow-workflow.test.mjs
+++ b/scripts/vercel-production-shadow-workflow.test.mjs
@@ -1484,10 +1484,17 @@ test("fresh smoke jobs resolve the Playwright config from the filtered workspace
   }
 });
 
-test("production-shadow smoke waits for hydration before target interaction", () => {
+test("production-shadow smoke settles deployment identity around hydration and interaction", () => {
   const spec = readFileSync(
     new URL(
       "../apps/app.mento.org/e2e/production-shadow/smoke.spec.ts",
+      import.meta.url,
+    ),
+    "utf8",
+  );
+  const browserIdentitySource = readFileSync(
+    new URL(
+      "../apps/ui.mento.org/e2e/vercel-preview-browser-smoke.mjs",
       import.meta.url,
     ),
     "utf8",
@@ -1498,10 +1505,58 @@ test("production-shadow smoke waits for hydration before target interaction", ()
   const targetInteractionIndex = spec.indexOf(
     "await verifyTarget(page, target, url.origin);",
   );
+  const serverIdentityIndex = spec.indexOf(
+    "assertProductionShadowServerIdentity(",
+  );
+  const firstHydratedIdentityIndex = spec.indexOf(
+    "await assertHydratedDeploymentIdentity({",
+    hydrationWaitIndex,
+  );
+  const finalHydratedIdentityIndex = spec.lastIndexOf(
+    "await assertHydratedDeploymentIdentity({",
+  );
 
   assert.notEqual(hydrationWaitIndex, -1);
   assert.notEqual(targetInteractionIndex, -1);
+  assert.notEqual(serverIdentityIndex, -1);
+  assert.notEqual(firstHydratedIdentityIndex, -1);
+  assert.notEqual(finalHydratedIdentityIndex, -1);
+  assert.ok(serverIdentityIndex < hydrationWaitIndex);
   assert.ok(hydrationWaitIndex < targetInteractionIndex);
+  assert.ok(hydrationWaitIndex < firstHydratedIdentityIndex);
+  assert.ok(firstHydratedIdentityIndex < targetInteractionIndex);
+  assert.ok(targetInteractionIndex < finalHydratedIdentityIndex);
+  assert.match(spec, /await \(response as Response\)\.text\(\)/);
+  assert.match(spec, /assertProductionShadowHydratedIdentity/);
+  assert.match(spec, /target === "ui"/);
+  assert.match(spec, /createBrowserDeploymentIdentityMonitor/);
+  assert.match(spec, /readSettledBrowserDeploymentIdentity/);
+  assert.match(spec, /monitor: uiIdentityMonitor/);
+
+  const helperStart = browserIdentitySource.indexOf(
+    "export async function readSettledBrowserDeploymentIdentity",
+  );
+  const preReadWait = browserIdentitySource.indexOf(
+    "await monitor.waitForIdle(timeoutMs);",
+    helperStart,
+  );
+  const domRead = browserIdentitySource.indexOf(
+    '.getAttribute("data-dpl-id");',
+    preReadWait,
+  );
+  const postReadWait = browserIdentitySource.indexOf(
+    "await monitor.waitForIdle(timeoutMs);",
+    domRead,
+  );
+  const evidence = browserIdentitySource.indexOf(
+    "return monitor.evidence(expectedDeploymentId, htmlDeploymentId);",
+    postReadWait,
+  );
+  assert.ok(helperStart >= 0);
+  assert.ok(helperStart < preReadWait);
+  assert.ok(preReadWait < domRead);
+  assert.ok(domRead < postReadWait);
+  assert.ok(postReadWait < evidence);
 });
 
 test("all external action references remain immutable full SHA pins", () => {

--- a/scripts/vercel-production-shadow.test.mjs
+++ b/scripts/vercel-production-shadow.test.mjs
@@ -73,6 +73,10 @@ import {
   assertProductionShadowOrigin,
   productionShadowRequestHeaders,
 } from "../apps/app.mento.org/e2e/production-shadow/request-policy.mjs";
+import {
+  assertProductionShadowHydratedIdentity,
+  assertProductionShadowServerIdentity,
+} from "../apps/app.mento.org/e2e/production-shadow/deployment-identity.mjs";
 
 const SHA = "0123456789abcdef0123456789abcdef01234567";
 const productionShadowScript = fileURLToPath(
@@ -2901,6 +2905,103 @@ test("browser request policy rejects protection headers", () => {
       "https://governance-immutable.vercel.app",
     ),
   );
+});
+
+test("production-shadow identity keeps server HTML strict across hydration", () => {
+  const expectedDeploymentId = "m-ui-0123456789abcdef012";
+  const expectedOrigin = "https://ui-immutable.vercel.app";
+  const exactAssets = [
+    `${expectedOrigin}/_next/static/app.js?dpl=${expectedDeploymentId}`,
+    `${expectedOrigin}/_next/static/app.css?dpl=${expectedDeploymentId}`,
+  ];
+
+  assert.doesNotThrow(() =>
+    assertProductionShadowServerIdentity(
+      `<!DOCTYPE html>
+        <HTML lang=en DATA-DPL-ID = '${expectedDeploymentId}'>
+          <body data-dpl-id="ignored">
+            <script>const marker = 'data-dpl-id="ignored"'</script>
+          </body>
+        </HTML>`,
+      expectedDeploymentId,
+    ),
+  );
+  for (const html of [
+    "<html></html>",
+    '<html data-dpl-id="m-ui-fffffffffffffffffff"></html>',
+    `<html data-dpl-id=${expectedDeploymentId}></html>`,
+    `<html x-data-dpl-id="${expectedDeploymentId}"></html>`,
+    `<script>"<html data-dpl-id='${expectedDeploymentId}'>"</script><html data-dpl-id="${expectedDeploymentId}"></html>`,
+    `<html><body><script>const fake = 'data-dpl-id="${expectedDeploymentId}"'</script></body></html>`,
+    `<html data-dpl-id="${expectedDeploymentId}" DATA-DPL-ID="${expectedDeploymentId}"></html>`,
+    `<html data-dpl-id="${expectedDeploymentId}" data-dpl-id="m-ui-fffffffffffffffffff"></html>`,
+    `<!DOCTYPE html "><html data-dpl-id="m-ui-fffffffffffffffffff">"><html data-dpl-id="${expectedDeploymentId}"><body>x</body></html>`,
+    `<!-- opener --!><html data-dpl-id="m-ui-fffffffffffffffffff"><!-- --><html data-dpl-id="${expectedDeploymentId}"><body>x</body></html>`,
+    `<!DOCTYPE html><html foo=bar">junk" data-dpl-id="${expectedDeploymentId}"><body>x</body></html>`,
+  ]) {
+    assert.throws(
+      () => assertProductionShadowServerIdentity(html, expectedDeploymentId),
+      /server HTML does not carry only the expected build deployment ID/,
+    );
+  }
+
+  assert.doesNotThrow(() =>
+    assertProductionShadowHydratedIdentity({
+      target: "ui",
+      expectedDeploymentId,
+      renderedDeploymentId: null,
+      assetReferences: exactAssets,
+      expectedOrigin,
+    }),
+  );
+  assert.throws(
+    () =>
+      assertProductionShadowHydratedIdentity({
+        target: "ui",
+        expectedDeploymentId,
+        renderedDeploymentId: null,
+        assetReferences: [exactAssets[0]],
+        expectedOrigin,
+      }),
+    /asset identity evidence is missing or invalid/,
+  );
+  assert.throws(
+    () =>
+      assertProductionShadowHydratedIdentity({
+        target: "ui",
+        expectedDeploymentId,
+        renderedDeploymentId: null,
+        assetReferences: [
+          exactAssets[0],
+          `${expectedOrigin}/_next/static/app.css?dpl=m-ui-fffffffffffffffffff`,
+        ],
+        expectedOrigin,
+      }),
+    /do not carry only the expected deployment ID/,
+  );
+
+  for (const target of ["governance", "reserve"]) {
+    assert.doesNotThrow(() =>
+      assertProductionShadowHydratedIdentity({
+        target,
+        expectedDeploymentId,
+        renderedDeploymentId: expectedDeploymentId,
+        assetReferences: [],
+        expectedOrigin,
+      }),
+    );
+    assert.throws(
+      () =>
+        assertProductionShadowHydratedIdentity({
+          target,
+          expectedDeploymentId,
+          renderedDeploymentId: null,
+          assetReferences: exactAssets,
+          expectedOrigin,
+        }),
+      new RegExp(`Hydrated ${target} production-shadow page`),
+    );
+  }
 });
 
 test("stable final gate fails skipped, cancelled, or failed dependencies", () => {


### PR DESCRIPTION
## The Problem

Production Shadow run [30045396420](https://github.com/mento-protocol/frontend-monorepo/actions/runs/30045396420) built and staged a healthy UI candidate, but its browser smoke failed after React hydration removed Next.js's server-injected `data-dpl-id` from the live `<html>` element. The raw HTML and every loaded Next.js asset still carried the exact expected deployment ID.

The initial correction also exposed four fail-closed gaps in the shared browser identity proof: raw HTML text could resemble an attribute, URL suffixes could resemble loaded JavaScript or CSS, a request could start during the DOM read, and a same-origin asset could redirect outside the immutable origin.

## The Solution

- Validate exactly one quoted deployment ID on the actual leading `<html>` tag in the raw server response.
- Share that strict parser with preview and production-shadow HTTP checks.
- Reuse one settled browser identity path for preview and production shadow.
- Require actual Playwright `script` and `stylesheet` request types with exact `?dpl=` values.
- Wait again after the asynchronous DOM read and reject cross-origin static-asset redirect chains.
- Keep Governance and Reserve's hydrated DOM marker requirement unchanged.
- Document the UI-specific post-hydration identity contract.

This fixes the false failure without weakening build identity. It also keeps the production-shadow workflow non-promoting and leaves every protected mapping unchanged.

Refs #521

## Validation

- `pnpm vercel:production-shadow:test` — 104/104 passed
- `pnpm vercel:workflow:test` — 97/97 passed
- `pnpm vercel:preview:test` — 254/254 passed
- `pnpm quality:budgets:test` — 30/30 passed
- `pnpm check-types` — 8/8 tasks passed
- `pnpm --filter app.mento.org test:production-shadow:routing` — 2/2 passed
- Full `trunk check` — 1,145 files, no issues
- `pnpm adr:check` — passed
- Hardened browser smoke against the exact failed-run UI deployment — 1/1 passed
- Independent parser review — 13/13 Chromium differential cases and all 11 generated Next.js HTML outputs passed
- Fresh-context review — 22 Chromium differential cases, redirect probe, and final review passed with no findings

## Material Risk

The shared preview browser monitor is stricter. It will now fail on an untyped asset lookalike, an unsettled request, or a Next.js static asset that redirects outside the immutable deployment origin. Those failures indicate missing deployment-identity proof.

## Ship Checklist

- [x] PR title follows the conventions
- [x] Performed a self-review of my own changes
- [x] Relevant automated checks and smoke tests pass
- [x] Architecture decision: Not applicable — this corrects and hardens the existing preview and production-shadow verification contract without changing deployment architecture.
