### PR TITLE
fix(ci): verify hydrated custom deployment identity

### DIFF
--- a/apps/app.mento.org/e2e/production-shadow/deployment-identity.mjs
+++ b/apps/app.mento.org/e2e/production-shadow/deployment-identity.mjs
@@ -28,20 +28,12 @@ export function assertProductionShadowHydratedIdentity({
   expectedOrigin,
 }) {
   requireTarget(target);
-  if (target === "ui") {
-    assertBrowserDeploymentIdentity(
-      {
-        htmlDeploymentId: renderedDeploymentId,
-        assetReferences,
-      },
-      expectedDeploymentId,
-      expectedOrigin,
-    );
-    return;
-  }
-  if (renderedDeploymentId !== expectedDeploymentId) {
-    throw new Error(
-      `Hydrated ${target} production-shadow page does not carry the expected build deployment ID`,
-    );
-  }
+  assertBrowserDeploymentIdentity(
+    {
+      htmlDeploymentId: renderedDeploymentId,
+      assetReferences,
+    },
+    expectedDeploymentId,
+    expectedOrigin,
+  );
 }

--- a/apps/app.mento.org/e2e/production-shadow/smoke.spec.ts
+++ b/apps/app.mento.org/e2e/production-shadow/smoke.spec.ts
@@ -170,33 +170,26 @@ async function assertHydratedDeploymentIdentity({
   target,
   expectedDeploymentId,
   expectedOrigin,
-  uiIdentityMonitor,
+  deploymentIdentityMonitor,
 }: {
   page: Page;
   target: Target;
   expectedDeploymentId: string;
   expectedOrigin: string;
-  uiIdentityMonitor?: ReturnType<typeof createBrowserDeploymentIdentityMonitor>;
+  deploymentIdentityMonitor: ReturnType<
+    typeof createBrowserDeploymentIdentityMonitor
+  >;
 }) {
-  let renderedDeploymentId: string | null;
-  let assetReferences: string[] = [];
-  if (target === "ui") {
-    if (!uiIdentityMonitor) {
-      throw new Error("UI deployment identity monitor is required");
-    }
-    const identity = await readSettledBrowserDeploymentIdentity({
+  if (!deploymentIdentityMonitor) {
+    throw new Error(`${target} deployment identity monitor is required`);
+  }
+  const { htmlDeploymentId: renderedDeploymentId, assetReferences } =
+    await readSettledBrowserDeploymentIdentity({
       page,
-      monitor: uiIdentityMonitor,
+      monitor: deploymentIdentityMonitor,
       expectedDeploymentId,
       timeoutMs: 30_000,
     });
-    renderedDeploymentId = identity.htmlDeploymentId;
-    assetReferences = identity.assetReferences;
-  } else {
-    renderedDeploymentId = await page
-      .locator("html")
-      .getAttribute("data-dpl-id");
-  }
   assertProductionShadowHydratedIdentity({
     target,
     expectedDeploymentId,
@@ -210,10 +203,10 @@ test("staged production artifact is healthy, secure, and interactive", async ({
   page,
 }) => {
   const { target, url, expectedDeploymentId, expectedSha } = requiredInputs();
-  const uiIdentityMonitor =
-    target === "ui"
-      ? createBrowserDeploymentIdentityMonitor(page, url.origin)
-      : undefined;
+  const deploymentIdentityMonitor = createBrowserDeploymentIdentityMonitor(
+    page,
+    url.origin,
+  );
   await page.route("**/*", async (route) => {
     await fulfillProductionShadowRequest({ route });
   });
@@ -243,7 +236,7 @@ test("staged production artifact is healthy, secure, and interactive", async ({
     target,
     expectedDeploymentId,
     expectedOrigin: url.origin,
-    uiIdentityMonitor,
+    deploymentIdentityMonitor,
   });
   await verifyTarget(page, target, url.origin);
   await page.waitForLoadState("networkidle", { timeout: 30_000 }).catch(() => {
@@ -255,7 +248,7 @@ test("staged production artifact is healthy, secure, and interactive", async ({
     target,
     expectedDeploymentId,
     expectedOrigin: url.origin,
-    uiIdentityMonitor,
+    deploymentIdentityMonitor,
   });
 
   expect(errors.origins, "cross-origin main-frame navigations").toEqual([]);

--- a/docs/vercel-deployments.md
+++ b/docs/vercel-deployments.md
@@ -671,13 +671,13 @@ responses with status 400 or higher from any origin, the exact custom Next
 build ID, and the exact deployed SHA from the build-bound
 `X-Mento-Deployment-Sha` response header. The raw server response's leading
 `<html>` start tag must contain exactly one quoted, case-insensitive
-`data-dpl-id` attribute with the expected value. Governance and Reserve must
-retain that exact marker in the hydrated DOM. For UI, the smoke accepts React
-removing the server-injected marker during hydration only when every observed
-same-origin `/_next/static/` request carries exactly one matching `?dpl=` value
-and Playwright classified representative requests as a JavaScript script and a
-CSS stylesheet. A static-asset redirect must retain the same immutable origin
-and identity. The UI identity monitor waits for all observed static requests to
+`data-dpl-id` attribute with the expected value. For Governance, Reserve, and
+UI, the smoke accepts React removing the server-injected marker during
+hydration only when every observed same-origin `/_next/static/` request carries
+exactly one matching `?dpl=` value and Playwright classified representative
+requests as a JavaScript script and a CSS stylesheet. Any retained conflicting
+marker fails. A static-asset redirect must retain the same immutable origin and
+identity. The shared identity monitor waits for all observed static requests to
 finish and for a quiet window both before and after reading the DOM marker, then
 checks before and after the interaction so late chunks cannot introduce a mixed
 build. No deployment-protection header is supplied. The request policy
@@ -1232,6 +1232,16 @@ console/page errors, and same-origin failures, then runs the target interaction:
 - Reserve: Overview data plus Supply tab and URL/state transition;
 - UI: exact build/asset identity, navigation, and hydrated control interaction.
 
+For controller-built Governance and Reserve previews, the HTTP phase requires
+the raw response's leading `<html>` start tag to carry exactly one quoted
+expected `data-dpl-id`. Their browser phase then uses the same settled,
+typed-resource proof as UI: a missing hydrated marker is accepted only when
+every observed same-origin Next.js static request carries exactly one expected
+`?dpl=`, representative requests are actual scripts and stylesheets, and no
+static asset redirects outside the immutable origin. Any retained conflicting
+marker fails. Native rollback previews do not claim a custom deployment ID and
+keep their existing identity-free adapter contract.
+
 The transitional `.github/workflows/preview-smoke.yml` native adapter classifies
 only exact successful `Preview – app.mento.org` and
 `Preview – governance.mento.org` events created by Vercel's fixed bot identity
@@ -1742,25 +1752,27 @@ pass the complete controller-bound tuple to
 `.github/workflows/_vercel-preview-smoke.yml`; the old embedded UI-only HTTP and
 parallel browser paths no longer exist. The reusable workflow runs in the
 pinned Playwright container and keeps the common bounded
-HTTP/header/static-asset checks before the trusted UI deployment-identity
-browser flow renders the showcase, searches and navigates to a second route,
-changes a form control, and fails on page/console errors or failed same-origin
-requests and responses. The HTTP phase verifies the server-rendered marker on
-the leading `<html>` start tag; after hydration, the browser phase requires
-every loaded same-origin `/_next/static/` asset to carry exactly the expected
-`?dpl=` value, requires actual script and stylesheet request types, rejects a
-static asset redirected outside that immutable identity, and rejects any
+HTTP/header/static-asset checks before the target browser flow. Governance and
+Reserve use their existing interaction smoke plus the shared deployment
+identity monitor; UI renders the showcase, searches and navigates to a second
+route, and changes a form control. The HTTP phase verifies the server-rendered
+marker on the leading `<html>` start tag for controller-built Governance,
+Reserve, and UI previews. After hydration, those three paths require every
+loaded same-origin `/_next/static/` asset to carry exactly the expected
+`?dpl=` value, require actual script and stylesheet request types, reject a
+static asset redirected outside that immutable identity, and reject any
 conflicting retained HTML deployment marker. Request monitoring remains active
-through the second-route interaction, so dynamically loaded chunks cannot
-escape the same identity check. The controller waits for all observed static
-requests to finish and for a quiet window after each DOM marker read before its
-identity assertion. This preserves fail-closed deployment-identity proof when
-React reconciles the server-injected HTML attribute out of the live DOM. Chrome
-also waits for the initial page load before changing controlled inputs, then
-rechecks the changed form control after the hydration/interaction settle. Its
-dependency graph comes from the trusted workflow checkout, candidate lifecycle
-scripts stay disabled, and no Vercel or Turbo credential is present in the
-smoke job. The worker appends a durable non-terminal upload evidence entry;
+through each target interaction, so dynamically loaded chunks cannot escape
+the same identity check. The controller waits for all observed static requests
+to finish and for a quiet window after each DOM marker read before its identity
+assertion. This preserves fail-closed deployment-identity proof when React
+reconciles the server-injected HTML attribute out of the live DOM. Native
+rollback previews carry no custom deployment ID and keep their existing smoke
+contract. Chrome also waits for the initial page load before changing
+controlled inputs, then rechecks the interaction after the hydration settle.
+Its dependency graph comes from the trusted workflow checkout, candidate
+lifecycle scripts stay disabled, and no Vercel or Turbo credential is present
+in the smoke job. The worker appends a durable non-terminal upload evidence entry;
 the completed-run recovery re-queries the run, Deployment, and statuses before
 appending the terminal result entry. Cancellation before Deployment creation
 creates/reuses the canonical Deployment and immediately closes it as `error`.

--- a/docs/wallet-testing.md
+++ b/docs/wallet-testing.md
@@ -271,12 +271,12 @@ interaction, fails critical document/script/style responses from any origin,
 keeps the main frame on the exact immutable origin throughout, requires the raw
 server response's leading `<html>` start tag to contain exactly one quoted
 expected `data-dpl-id`, and binds the `X-Mento-Deployment-Sha` response header
-to the exact commit. Governance and Reserve must retain the expected marker
-after hydration. For UI, the smoke accepts the server-injected marker being
-absent after hydration only when every observed same-origin Next.js static
-request carries exactly one expected `?dpl=` value, Playwright observed actual
-script and stylesheet request types, and no static asset redirected outside the
-same immutable identity.
+to the exact commit. For Governance, Reserve, and UI, the smoke accepts the
+server-injected marker being absent after hydration only when every observed
+same-origin Next.js static request carries exactly one expected `?dpl=` value,
+Playwright observed actual script and stylesheet request types, no static asset
+redirected outside the same immutable identity, and no conflicting marker
+remained in the live DOM.
 No deployment-protection bypass is supplied; the request policy rejects any
 ambient protection header and handles every redirect as a new browser request.
 The real two-origin Chromium regression is

--- a/scripts/vercel-preview-browser-smoke.mjs
+++ b/scripts/vercel-preview-browser-smoke.mjs
@@ -5,6 +5,10 @@ import { join, resolve } from "node:path";
 import process from "node:process";
 import { fileURLToPath } from "node:url";
 
+import {
+  createBrowserDeploymentIdentityMonitor,
+  readSettledBrowserDeploymentIdentity,
+} from "../apps/ui.mento.org/e2e/vercel-preview-browser-smoke.mjs";
 import { validatePreviewSmokeTuple } from "./vercel-preview-smoke.mjs";
 
 const MAXIMUM_FAILURES = 100;
@@ -192,6 +196,12 @@ export async function runBrowserSmoke({
     page.setDefaultTimeout(timeoutMs);
     page.setDefaultNavigationTimeout(timeoutMs);
     const monitor = createBrowserFailureMonitor(page, baseUrl.origin);
+    const deploymentIdentityMonitor =
+      (tuple.logicalTarget === "governance" ||
+        tuple.logicalTarget === "reserve") &&
+      tuple.nextDeploymentId
+        ? createBrowserDeploymentIdentityMonitor(page, baseUrl.origin)
+        : undefined;
     const response = await page.goto(baseUrl.toString(), {
       waitUntil: "domcontentloaded",
     });
@@ -207,6 +217,14 @@ export async function runBrowserSmoke({
     // The tab shell is server rendered. Wait for all deferred client scripts
     // before clicking so the first interaction cannot race React hydration.
     await page.waitForLoadState("load");
+    if (deploymentIdentityMonitor) {
+      await readSettledBrowserDeploymentIdentity({
+        page,
+        monitor: deploymentIdentityMonitor,
+        expectedDeploymentId: tuple.nextDeploymentId,
+        timeoutMs,
+      });
+    }
     const interaction = await runTargetInteraction(
       page,
       tuple.logicalTarget,
@@ -228,6 +246,14 @@ export async function runBrowserSmoke({
       throw new Error(
         "Reserve Supply tab state did not persist after interaction settle",
       );
+    }
+    if (deploymentIdentityMonitor) {
+      await readSettledBrowserDeploymentIdentity({
+        page,
+        monitor: deploymentIdentityMonitor,
+        expectedDeploymentId: tuple.nextDeploymentId,
+        timeoutMs,
+      });
     }
     monitor.assertClean();
     return {

--- a/scripts/vercel-preview-browser-smoke.test.mjs
+++ b/scripts/vercel-preview-browser-smoke.test.mjs
@@ -11,9 +11,15 @@ import {
 
 const repoRoot = new URL("../", import.meta.url).pathname;
 const SHA = "0123456789abcdef0123456789abcdef01234567";
+const CUSTOM_ID_GENERIC_TARGETS = ["governance", "reserve"];
 
 function controllerTuple(target) {
-  const deploymentUrl = `https://${target === "reserve" ? "reservemento" : "appmento"}-abc123-mentolabs.vercel.app/`;
+  const hostname = {
+    app: "appmento",
+    governance: "governancemento",
+    reserve: "reservemento",
+  }[target];
+  const deploymentUrl = `https://${hostname}-abc123-mentolabs.vercel.app/`;
   return {
     logicalTarget: target,
     deploymentUrl,
@@ -40,11 +46,24 @@ function controllerTuple(target) {
 }
 
 class FakePage extends EventEmitter {
-  constructor(values, { afterInteraction, competingNavigation = false } = {}) {
+  constructor(
+    values,
+    {
+      afterInteraction,
+      assetRequests,
+      competingNavigation = false,
+      htmlDeploymentId = values.nextDeploymentId,
+      onHtmlDeploymentIdRead,
+    } = {},
+  ) {
     super();
     this.values = values;
     this.afterInteraction = afterInteraction;
+    this.assetRequests = assetRequests;
     this.competingNavigation = competingNavigation;
+    this.htmlDeploymentId = htmlDeploymentId;
+    this.onHtmlDeploymentIdRead = onHtmlDeploymentIdRead;
+    this.htmlDeploymentIdReads = 0;
     this.currentUrl = values.deploymentUrl;
     this.loadComplete = false;
     this.supplySelected = false;
@@ -61,15 +80,22 @@ class FakePage extends EventEmitter {
 
   async goto(url, options) {
     this.calls.push(["goto", url, options]);
-    for (const path of [
-      "/_next/static/app.js",
-      "/_next/static/app.css",
-      "/_next/static/font.woff2",
-    ]) {
-      this.emit("response", {
-        url: () => new URL(path, url).toString(),
-        status: () => 200,
-      });
+    const assetRequests = this.assetRequests ?? [
+      {
+        path: `/_next/static/app.js?dpl=${this.values.nextDeploymentId}`,
+        resourceType: "script",
+      },
+      {
+        path: `/_next/static/app.css?dpl=${this.values.nextDeploymentId}`,
+        resourceType: "stylesheet",
+      },
+      {
+        path: `/_next/static/font.woff2?dpl=${this.values.nextDeploymentId}`,
+        resourceType: "font",
+      },
+    ];
+    for (const request of assetRequests) {
+      this.emitAssetRequest(new URL(request.path, url).toString(), request);
     }
     return {
       ok: () => true,
@@ -82,11 +108,57 @@ class FakePage extends EventEmitter {
     };
   }
 
+  emitAssetRequest(
+    reference,
+    { redirectedFrom = null, resourceType = "script" } = {},
+  ) {
+    const request = this.startAssetRequest(reference, {
+      redirectedFrom,
+      resourceType,
+    });
+    this.finishAssetRequest(request);
+    return request;
+  }
+
+  startAssetRequest(
+    reference,
+    { redirectedFrom = null, resourceType = "script" } = {},
+  ) {
+    const request = {
+      failure: () => ({ errorText: "net::ERR_FAILED" }),
+      method: () => "GET",
+      redirectedFrom: () => redirectedFrom,
+      resourceType: () => resourceType,
+      url: () => reference,
+    };
+    this.emit("request", request);
+    this.emit("response", {
+      request: () => request,
+      url: () => reference,
+      status: () => 200,
+    });
+    return request;
+  }
+
+  finishAssetRequest(request) {
+    this.emit("requestfinished", request);
+  }
+
   url() {
     return this.currentUrl;
   }
 
   locator(selector) {
+    if (selector === "html") {
+      return {
+        getAttribute: async (attribute) => {
+          assert.equal(attribute, "data-dpl-id");
+          this.htmlDeploymentIdReads += 1;
+          this.onHtmlDeploymentIdRead?.(this, this.htmlDeploymentIdReads);
+          return this.htmlDeploymentId;
+        },
+      };
+    }
     assert.equal(selector, "body");
     return {
       waitFor: async (options) => {
@@ -308,6 +380,159 @@ test("App browser smoke uses system Chrome when explicitly requested", async () 
     "wallet-flow-runs-in-the-target-specific-suite",
   );
   assert.ok(page.calls.some(([name]) => name === "body"));
+});
+
+test("custom-ID Governance and Reserve accept exact typed assets after hydration removes the marker", async () => {
+  for (const target of CUSTOM_ID_GENERIC_TARGETS) {
+    const values = controllerTuple(target);
+    const page = new FakePage(values, { htmlDeploymentId: null });
+    const fake = fakeChromium(page);
+
+    const result = await runBrowserSmoke({
+      chromium: fake.chromium,
+      values,
+    });
+
+    assert.equal(result.logicalTarget, target);
+    assert.equal(fake.state.closed, true);
+  }
+});
+
+test("custom-ID Governance and Reserve reject conflicting hydrated markers", async () => {
+  for (const target of CUSTOM_ID_GENERIC_TARGETS) {
+    const values = controllerTuple(target);
+    const fake = fakeChromium(
+      new FakePage(values, {
+        htmlDeploymentId: `m-${target}-${"f".repeat(19)}`,
+      }),
+    );
+
+    await assert.rejects(
+      runBrowserSmoke({ chromium: fake.chromium, values }),
+      /conflicting deployment ID/,
+    );
+    assert.equal(fake.state.closed, true);
+  }
+});
+
+test("custom-ID Governance and Reserve reject wrong, missing, or duplicate asset deployment IDs", async () => {
+  for (const target of CUSTOM_ID_GENERIC_TARGETS) {
+    const values = controllerTuple(target);
+    const invalidJavaScriptPaths = [
+      `/_next/static/app.js?dpl=m-${target}-${"f".repeat(19)}`,
+      "/_next/static/app.js",
+      `/_next/static/app.js?dpl=${values.nextDeploymentId}&dpl=${values.nextDeploymentId}`,
+    ];
+    for (const path of invalidJavaScriptPaths) {
+      const fake = fakeChromium(
+        new FakePage(values, {
+          htmlDeploymentId: null,
+          assetRequests: [
+            { path, resourceType: "script" },
+            {
+              path: `/_next/static/app.css?dpl=${values.nextDeploymentId}`,
+              resourceType: "stylesheet",
+            },
+          ],
+        }),
+      );
+
+      await assert.rejects(
+        runBrowserSmoke({ chromium: fake.chromium, values }),
+        /do not carry only the expected deployment ID/,
+      );
+      assert.equal(fake.state.closed, true);
+    }
+  }
+});
+
+test("custom-ID Governance and Reserve reject resource-type suffix spoofs", async () => {
+  for (const target of CUSTOM_ID_GENERIC_TARGETS) {
+    const values = controllerTuple(target);
+    const fake = fakeChromium(
+      new FakePage(values, {
+        htmlDeploymentId: null,
+        assetRequests: [
+          {
+            path: `/_next/static/app.js?dpl=${values.nextDeploymentId}`,
+            resourceType: "fetch",
+          },
+          {
+            path: `/_next/static/app.css?dpl=${values.nextDeploymentId}`,
+            resourceType: "image",
+          },
+        ],
+      }),
+    );
+
+    await assert.rejects(
+      runBrowserSmoke({ chromium: fake.chromium, values }),
+      /request types are missing or invalid/,
+    );
+    assert.equal(fake.state.closed, true);
+  }
+});
+
+test("custom-ID Governance and Reserve reject late static asset redirects outside the immutable origin", async () => {
+  for (const target of CUSTOM_ID_GENERIC_TARGETS) {
+    const values = controllerTuple(target);
+    const page = new FakePage(values, {
+      htmlDeploymentId: null,
+      afterInteraction(currentPage) {
+        const original = currentPage.emitAssetRequest(
+          new URL(
+            `/_next/static/late.js?dpl=${values.nextDeploymentId}`,
+            values.deploymentUrl,
+          ).toString(),
+        );
+        currentPage.emitAssetRequest("https://assets.example.invalid/late.js", {
+          redirectedFrom: original,
+        });
+      },
+    });
+    const fake = fakeChromium(page);
+
+    await assert.rejects(
+      runBrowserSmoke({ chromium: fake.chromium, values }),
+      /redirected outside its immutable identity/,
+    );
+    assert.equal(fake.state.closed, true);
+  }
+});
+
+test("custom-ID Governance and Reserve settle requests started during the hydrated marker read", async () => {
+  for (const target of CUSTOM_ID_GENERIC_TARGETS) {
+    const values = controllerTuple(target);
+    const page = new FakePage(values, {
+      htmlDeploymentId: null,
+      onHtmlDeploymentIdRead(currentPage, readCount) {
+        if (readCount !== 1) return;
+        const request = currentPage.startAssetRequest(
+          new URL(
+            `/_next/static/late.js?dpl=${values.nextDeploymentId}`,
+            values.deploymentUrl,
+          ).toString(),
+        );
+        setTimeout(() => {
+          currentPage.calls.push(["race-asset-finished"]);
+          currentPage.finishAssetRequest(request);
+        }, 10);
+      },
+    });
+    const fake = fakeChromium(page);
+
+    await runBrowserSmoke({ chromium: fake.chromium, values });
+
+    const requestFinishedIndex = page.calls.findIndex(
+      ([name]) => name === "race-asset-finished",
+    );
+    const interactionIndex = page.calls.findIndex(([name]) =>
+      target === "reserve" ? name === "supply-click" : name === "body",
+    );
+    assert.ok(requestFinishedIndex >= 0);
+    assert.ok(interactionIndex > requestFinishedIndex);
+    assert.equal(fake.state.closed, true);
+  }
 });
 
 test("browser failure monitor fails on console, page, and same-origin asset errors", () => {

--- a/scripts/vercel-preview-smoke.mjs
+++ b/scripts/vercel-preview-smoke.mjs
@@ -603,11 +603,15 @@ function representativeAssets(html, baseUrl) {
   return [script, style, ...optionalAssets];
 }
 
-function requireUiHtmlDeploymentIdentity(html, expectedDeploymentId) {
+function requireCustomHtmlDeploymentIdentity(
+  target,
+  html,
+  expectedDeploymentId,
+) {
   assertHtmlDocumentDeploymentIdentity(
     html,
     expectedDeploymentId,
-    "UI preview HTML does not carry only the expected build deployment ID",
+    `${target} preview HTML does not carry only the expected build deployment ID`,
   );
 }
 
@@ -637,8 +641,15 @@ export async function smokePreviewHttp({
     ),
     "Preview did not render a target-specific document marker",
   );
-  if (tuple.logicalTarget === "ui") {
-    requireUiHtmlDeploymentIdentity(html, tuple.nextDeploymentId);
+  if (
+    tuple.nextDeploymentId &&
+    ["governance", "reserve", "ui"].includes(tuple.logicalTarget)
+  ) {
+    requireCustomHtmlDeploymentIdentity(
+      tuple.logicalTarget,
+      html,
+      tuple.nextDeploymentId,
+    );
   }
   const assets = representativeAssets(html, baseUrl);
   for (const asset of assets) {

--- a/scripts/vercel-preview-smoke.test.mjs
+++ b/scripts/vercel-preview-smoke.test.mjs
@@ -291,11 +291,13 @@ function fakeResponse(url, body, { status = 200, headers = {} } = {}) {
 test("common HTTP smoke checks target marker, headers, assets, and controller build identity", async () => {
   const values = controllerTuple("reserve");
   const requested = [];
-  const html = `<title>Mento Reserve</title>
+  const html = `<html data-dpl-id="${values.nextDeploymentId}"><body>
+    <title>Mento Reserve</title>
     <script src="/_next/static/app.js?dpl=${values.nextDeploymentId}"></script>
     <link rel="stylesheet" href="/_next/static/app.css?dpl=${values.nextDeploymentId}">
     <link rel="preload" href="/_next/static/font.woff2?dpl=${values.nextDeploymentId}">
-    <img src="/_next/static/media/graph.webp?dpl=${values.nextDeploymentId}">`;
+    <img src="/_next/static/media/graph.webp?dpl=${values.nextDeploymentId}">
+  </body></html>`;
   const fetchImplementation = async (url) => {
     const parsed = new URL(url);
     requested.push(parsed.toString());
@@ -363,7 +365,7 @@ test("common HTTP smoke still requires representative JavaScript and CSS assets"
     smokePreviewHttp({
       values,
       fetchImplementation: response(
-        `<title>Mento Reserve</title><link rel="stylesheet" href="/_next/static/app.css?dpl=${values.nextDeploymentId}">`,
+        `<html data-dpl-id="${values.nextDeploymentId}"><body><title>Mento Reserve</title><link rel="stylesheet" href="/_next/static/app.css?dpl=${values.nextDeploymentId}"></body></html>`,
       ),
     }),
     /representative \.js asset/,
@@ -372,7 +374,7 @@ test("common HTTP smoke still requires representative JavaScript and CSS assets"
     smokePreviewHttp({
       values,
       fetchImplementation: response(
-        `<title>Mento Reserve</title><script src="/_next/static/app.js?dpl=${values.nextDeploymentId}"></script>`,
+        `<html data-dpl-id="${values.nextDeploymentId}"><body><title>Mento Reserve</title><script src="/_next/static/app.js?dpl=${values.nextDeploymentId}"></script></body></html>`,
       ),
     }),
     /representative \.css asset/,
@@ -409,57 +411,68 @@ test("common HTTP smoke fails closed on missing headers and mixed deployment ass
   );
 });
 
-test("UI common HTTP smoke requires the exact server-rendered deployment identity", async () => {
-  const values = controllerTuple("ui");
-  const response = (deploymentMarker) => async (url) => {
-    const parsed = new URL(url);
-    if (parsed.pathname.startsWith("/_next/static/"))
-      return fakeResponse(parsed, "asset");
-    return fakeResponse(
-      parsed,
-      `<html ${deploymentMarker}><body>
-          <main><h1>Basic Components</h1></main>
+test("custom-ID Governance, Reserve, and UI HTTP smoke require exact server-rendered identity", async () => {
+  for (const target of ["governance", "reserve", "ui"]) {
+    const values = controllerTuple(target);
+    const documentMarker = {
+      governance: "Mento Governance",
+      reserve: "Mento Reserve",
+      ui: "Basic Components",
+    }[target];
+    const response = (deploymentMarker) => async (url) => {
+      const parsed = new URL(url);
+      if (parsed.pathname.startsWith("/_next/static/"))
+        return fakeResponse(parsed, "asset");
+      return fakeResponse(
+        parsed,
+        `<html ${deploymentMarker}><body>
+          <main><h1>${documentMarker}</h1></main>
           <script src="/_next/static/app.js?dpl=${values.nextDeploymentId}"></script>
           <link rel="stylesheet" href="/_next/static/app.css?dpl=${values.nextDeploymentId}">
         </body></html>`,
-      {
-        headers: {
-          "content-security-policy": "frame-ancestors 'none'",
-          "x-frame-options": "DENY",
-          "x-content-type-options": "nosniff",
+        {
+          headers: {
+            "content-security-policy": "frame-ancestors 'none'",
+            "x-frame-options": "DENY",
+            "x-content-type-options": "nosniff",
+          },
         },
-      },
-    );
-  };
+      );
+    };
 
-  await assert.rejects(
-    smokePreviewHttp({ values, fetchImplementation: response("") }),
-    /HTML does not carry only the expected build deployment ID/,
-  );
-  await assert.rejects(
-    smokePreviewHttp({
-      values,
-      fetchImplementation: response('data-dpl-id="m-ui-wrongwrongwrong12"'),
-    }),
-    /HTML does not carry only the expected build deployment ID/,
-  );
-  await assert.rejects(
-    smokePreviewHttp({
-      values,
-      fetchImplementation: response(
-        `x-data-dpl-id="${values.nextDeploymentId}"`,
+    await assert.rejects(
+      smokePreviewHttp({ values, fetchImplementation: response("") }),
+      new RegExp(
+        `${target} preview HTML does not carry only the expected build deployment ID`,
       ),
-    }),
-    /HTML does not carry only the expected build deployment ID/,
-  );
-  await assert.doesNotReject(
-    smokePreviewHttp({
-      values,
-      fetchImplementation: response(
-        `DATA-DPL-ID = '${values.nextDeploymentId}'`,
-      ),
-    }),
-  );
+    );
+    await assert.rejects(
+      smokePreviewHttp({
+        values,
+        fetchImplementation: response(
+          `data-dpl-id="m-${target}-fffffffffffffffffff"`,
+        ),
+      }),
+      /HTML does not carry only the expected build deployment ID/,
+    );
+    await assert.rejects(
+      smokePreviewHttp({
+        values,
+        fetchImplementation: response(
+          `x-data-dpl-id="${values.nextDeploymentId}"`,
+        ),
+      }),
+      /HTML does not carry only the expected build deployment ID/,
+    );
+    await assert.doesNotReject(
+      smokePreviewHttp({
+        values,
+        fetchImplementation: response(
+          `DATA-DPL-ID = '${values.nextDeploymentId}'`,
+        ),
+      }),
+    );
+  }
 });
 
 test("common HTTP smoke rejects representative assets redirected off the immutable origin", async () => {

--- a/scripts/vercel-production-shadow-workflow.test.mjs
+++ b/scripts/vercel-production-shadow-workflow.test.mjs
@@ -1528,10 +1528,9 @@ test("production-shadow smoke settles deployment identity around hydration and i
   assert.ok(targetInteractionIndex < finalHydratedIdentityIndex);
   assert.match(spec, /await \(response as Response\)\.text\(\)/);
   assert.match(spec, /assertProductionShadowHydratedIdentity/);
-  assert.match(spec, /target === "ui"/);
   assert.match(spec, /createBrowserDeploymentIdentityMonitor/);
   assert.match(spec, /readSettledBrowserDeploymentIdentity/);
-  assert.match(spec, /monitor: uiIdentityMonitor/);
+  assert.match(spec, /monitor: deploymentIdentityMonitor/);
 
   const helperStart = browserIdentitySource.indexOf(
     "export async function readSettledBrowserDeploymentIdentity",
@@ -1623,7 +1622,7 @@ test("shadow smoke strips protection headers and disables traces", () => {
   assert.match(spec, /PRODUCTION_SHADOW_EXPECTED_SHA|expectedSha/);
   assert.match(workflowSource, /PRODUCTION_SHADOW_EXPECTED_SHA/);
   assert.match(spec, /x-mento-deployment-sha/);
-  assert.match(spec, /data-dpl-id/);
+  assert.match(spec, /assertProductionShadowServerIdentity/);
   assert.match(spec, /My Voting Power/);
   assert.match(spec, /Supply/);
   assert.match(spec, /Search components/);

--- a/scripts/vercel-production-shadow.test.mjs
+++ b/scripts/vercel-production-shadow.test.mjs
@@ -2907,7 +2907,7 @@ test("browser request policy rejects protection headers", () => {
   );
 });
 
-test("production-shadow identity keeps server HTML strict across hydration", () => {
+test("production-shadow identity keeps server HTML strict and uses settled asset proof after hydration", () => {
   const expectedDeploymentId = "m-ui-0123456789abcdef012";
   const expectedOrigin = "https://ui-immutable.vercel.app";
   const exactAssets = [
@@ -2945,48 +2945,13 @@ test("production-shadow identity keeps server HTML strict across hydration", () 
     );
   }
 
-  assert.doesNotThrow(() =>
-    assertProductionShadowHydratedIdentity({
-      target: "ui",
-      expectedDeploymentId,
-      renderedDeploymentId: null,
-      assetReferences: exactAssets,
-      expectedOrigin,
-    }),
-  );
-  assert.throws(
-    () =>
-      assertProductionShadowHydratedIdentity({
-        target: "ui",
-        expectedDeploymentId,
-        renderedDeploymentId: null,
-        assetReferences: [exactAssets[0]],
-        expectedOrigin,
-      }),
-    /asset identity evidence is missing or invalid/,
-  );
-  assert.throws(
-    () =>
-      assertProductionShadowHydratedIdentity({
-        target: "ui",
-        expectedDeploymentId,
-        renderedDeploymentId: null,
-        assetReferences: [
-          exactAssets[0],
-          `${expectedOrigin}/_next/static/app.css?dpl=m-ui-fffffffffffffffffff`,
-        ],
-        expectedOrigin,
-      }),
-    /do not carry only the expected deployment ID/,
-  );
-
-  for (const target of ["governance", "reserve"]) {
+  for (const target of ["governance", "reserve", "ui"]) {
     assert.doesNotThrow(() =>
       assertProductionShadowHydratedIdentity({
         target,
         expectedDeploymentId,
-        renderedDeploymentId: expectedDeploymentId,
-        assetReferences: [],
+        renderedDeploymentId: null,
+        assetReferences: exactAssets,
         expectedOrigin,
       }),
     );
@@ -2995,11 +2960,46 @@ test("production-shadow identity keeps server HTML strict across hydration", () 
         assertProductionShadowHydratedIdentity({
           target,
           expectedDeploymentId,
-          renderedDeploymentId: null,
+          renderedDeploymentId: "m-ui-fffffffffffffffffff",
           assetReferences: exactAssets,
           expectedOrigin,
         }),
-      new RegExp(`Hydrated ${target} production-shadow page`),
+      /conflicting deployment ID/,
+    );
+    for (const assetReferences of [
+      [exactAssets[0]],
+      [exactAssets[0], `${expectedOrigin}/_next/static/app.css`],
+      [
+        exactAssets[0],
+        `${expectedOrigin}/_next/static/app.css?dpl=m-ui-fffffffffffffffffff`,
+      ],
+      [
+        exactAssets[0],
+        `${expectedOrigin}/_next/static/app.css?dpl=${expectedDeploymentId}&dpl=${expectedDeploymentId}`,
+      ],
+      [
+        exactAssets[0],
+        `https://assets.example.invalid/_next/static/app.css?dpl=${expectedDeploymentId}`,
+      ],
+    ]) {
+      assert.throws(() =>
+        assertProductionShadowHydratedIdentity({
+          target,
+          expectedDeploymentId,
+          renderedDeploymentId: null,
+          assetReferences,
+          expectedOrigin,
+        }),
+      );
+    }
+    assert.doesNotThrow(() =>
+      assertProductionShadowHydratedIdentity({
+        target,
+        expectedDeploymentId,
+        renderedDeploymentId: expectedDeploymentId,
+        assetReferences: exactAssets,
+        expectedOrigin,
+      }),
     );
   }
 });


### PR DESCRIPTION
## The Problem

The exact-main Production Shadow run [30050599804](https://github.com/mento-protocol/frontend-monorepo/actions/runs/30050599804) staged a healthy Governance candidate, then failed its fresh browser smoke because React removed the root `data-dpl-id` after hydration.

The raw document, response SHA, deployment provenance, protected-domain comparisons, and every loaded typed Next.js asset were correct. The same post-hydration behavior also occurs on the prior Reserve candidate. Reserve had only passed an earlier run because its smoke read the DOM marker before hydration settled.

## The Solution

- Keep the strict raw root-HTML deployment-ID proof for controller-built Governance, Reserve, and UI candidates.
- Verify hydrated identity for all three targets with the existing settled browser monitor:
  - reject a conflicting non-null DOM marker;
  - require actual Playwright `script` and `stylesheet` resources;
  - require every same-origin Next static resource to carry exactly one expected `dpl`;
  - reject resource-type spoofing and cross-origin redirects;
  - settle before and after the DOM read and repeat the proof after interaction.
- Apply the same custom-ID proof to GitHub-driven Governance and Reserve previews.
- Leave App and native no-ID rollback preview behavior unchanged.
- Update the deployment and wallet-testing docs to describe the target-agnostic identity contract.

Closes the false-negative blocker discovered while completing #521. It does not close #521; that issue still requires one fully green exact-main Production Shadow run after merge.

## Validation

- `pnpm vercel:production-shadow:test` — 104/104
- `pnpm vercel:preview:test` — 260/260
- `pnpm vercel:workflow:test` — 97/97
- focused identity suites — 106/106
- `pnpm quality:budgets:test` — 30/30
- `pnpm check-types` — 8/8 workspaces
- full Trunk check — 1,145 files, no issues
- `pnpm adr:check` — passed
- two independent reviews — approved
- live patched Governance smoke:
  - immutable candidate `governancemento-a1frxyxtm-mentolabs.vercel.app`
  - `/voting-power` interaction passed
  - 47 Next static resources carried the exact deployment ID
  - no console, page, critical-request, or HTTP errors
- live patched Reserve smoke:
  - immutable candidate `reservemento-n0xdg22wj-mentolabs.vercel.app`
  - Supply tab persisted at `?tab=stablecoins`
  - 17 Next static resources carried the exact deployment ID
  - no console, page, network, or HTTP errors

## Risk

The change affects only preview/production-shadow verification. It does not alter deployment, promotion, alias, rollback, Vercel Git, credential, or protected-domain logic.

A first Governance verification saw one transient generic upstream HTTP 429. The identical rerun and isolated/instrumented Chromium verification were clean; the identity assertions were unaffected.

## Checklist

- [x] Regression coverage includes Governance and Reserve post-hydration marker removal.
- [x] Conflicting markers, missing/wrong/duplicate IDs, resource-type spoofing, redirect escape, and settling races fail closed.
- [x] App and native no-ID preview paths remain unchanged.
- [x] Docs match the updated verification contract.
- [x] Browser verification completed against the exact immutable candidates.
