### PR TITLE
feat(ci): add automatic Vercel main deployment shadow

### DIFF
--- a/.github/workflows/ci-failure-notifier.yml
+++ b/.github/workflows/ci-failure-notifier.yml
@@ -11,6 +11,7 @@ on:
       - Quality Budgets
       - Scorecard supply-chain security
       - Supply Chain
+      - Vercel Main Deployment
       - Vercel Production Shadow
       - Visual Regression
     types: [completed]
@@ -22,7 +23,7 @@ jobs:
   reconcile-issue:
     name: reconcile failure issue
     if: >-
-      contains(fromJSON('["push", "schedule", "workflow_dispatch"]'), github.event.workflow_run.event) &&
+      contains(fromJSON('["push", "schedule", "workflow_dispatch", "workflow_run"]'), github.event.workflow_run.event) &&
       contains(fromJSON('["success", "action_required", "failure", "startup_failure", "timed_out"]'), github.event.workflow_run.conclusion) &&
       (
         github.event.workflow_run.event == 'schedule' ||
@@ -36,6 +37,12 @@ jobs:
         (
           github.event.workflow_run.event == 'workflow_dispatch' &&
           github.event.workflow_run.head_branch == github.event.repository.default_branch
+        ) ||
+        (
+          github.event.workflow_run.event == 'workflow_run' &&
+          github.event.workflow_run.name == 'Vercel Main Deployment' &&
+          github.event.workflow_run.head_branch == github.event.repository.default_branch &&
+          github.event.workflow_run.head_repository.full_name == github.repository
         )
       )
     concurrency:

--- a/.github/workflows/vercel-main-deployment.yml
+++ b/.github/workflows/vercel-main-deployment.yml
@@ -1312,28 +1312,18 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - name: Fail when the trusted gate or planner did not succeed
-        if: >-
-          needs.wait-for-ci.result != 'success' ||
-          needs.plan-main-deployments.result != 'success'
-        run: |
-          echo "The exact upstream CI gate or main planner did not succeed" >&2
-          exit 1
-
       - name: Check out trusted final controller
-        if: >-
-          needs.wait-for-ci.result == 'success' &&
-          needs.plan-main-deployments.result == 'success'
+        if: ${{ always() }}
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 1
           persist-credentials: false
-          ref: ${{ needs.wait-for-ci.outputs.deploy_sha }}
+          ref: ${{ github.workflow_sha }}
 
       - name: Enforce one safe final result
-        if: >-
-          needs.wait-for-ci.result == 'success' &&
-          needs.plan-main-deployments.result == 'success'
+        id: final-verdict
+        if: ${{ always() }}
+        continue-on-error: true
         env:
           PLAN_JSON: ${{ needs.plan-main-deployments.outputs.plan }}
           WAIT_FOR_CI_RESULT: ${{ needs.wait-for-ci.result }}
@@ -1348,6 +1338,8 @@ jobs:
         run: node scripts/vercel-main-deployment.mjs final
 
       - name: Write canonical redacted PR-A evidence
+        id: success-evidence
+        if: ${{ always() && steps.final-verdict.outcome == 'success' }}
         env:
           PLAN_JSON: ${{ needs.plan-main-deployments.outputs.plan }}
           EVIDENCE_GOVERNANCE_RESULT: ${{ needs.stage-governance.result }}
@@ -1389,10 +1381,36 @@ jobs:
           node scripts/vercel-main-deployment.mjs evidence
           --output "$RUNNER_TEMP/vercel-main-evidence.json"
 
+      - name: Write canonical redacted PR-A failure evidence
+        id: failure-evidence
+        if: ${{ always() && steps.final-verdict.outcome != 'success' }}
+        env:
+          EVENT_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          DEPLOY_SHA: ${{ needs.wait-for-ci.outputs.deploy_sha }}
+          PLAN_JSON: ${{ needs.plan-main-deployments.outputs.plan }}
+          GITHUB_WORKFLOW_SHA: ${{ github.workflow_sha }}
+          WAIT_FOR_CI_RESULT: ${{ needs.wait-for-ci.result }}
+          PLAN_RESULT: ${{ needs.plan-main-deployments.result }}
+          STAGE_GOVERNANCE_RESULT: ${{ needs.stage-governance.result }}
+          STAGE_RESERVE_RESULT: ${{ needs.stage-reserve.result }}
+          STAGE_UI_RESULT: ${{ needs.stage-ui.result }}
+          COORDINATOR_RESULT: ${{ needs.activate-and-verify.result }}
+          RECOVERY_RESULT: ${{ needs.recover-main-deployment.result }}
+        run: >-
+          node scripts/vercel-main-deployment.mjs failure-evidence
+          --output "$RUNNER_TEMP/vercel-main-evidence.json"
+
       - name: Upload canonical redacted PR-A evidence
+        if: ${{ always() }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: vercel-main-evidence-${{ github.run_id }}-${{ github.run_attempt }}
           path: ${{ runner.temp }}/vercel-main-evidence.json
           if-no-files-found: error
           retention-days: 14
+
+      - name: Fail after publishing an unsafe final result
+        if: ${{ always() && steps.final-verdict.outcome != 'success' }}
+        run: |
+          echo "The Vercel main deployment graph did not reach a safe final result" >&2
+          exit 1

--- a/.github/workflows/vercel-main-deployment.yml
+++ b/.github/workflows/vercel-main-deployment.yml
@@ -1,0 +1,1398 @@
+name: Vercel Main Deployment
+
+# PR A runs the complete main-deployment control plane in literal shadow mode.
+# Ordinary targets may upload immutable candidates with `--prod --skip-domain`,
+# which advances only their generated Vercel project aliases. The workflow does
+# not promote App v3, assign a public alias, or invoke any rollback adapter.
+on:
+  workflow_run:
+    workflows: [CI/CD]
+    types: [completed]
+    branches: [main]
+
+permissions:
+  contents: read
+  actions: read
+
+env:
+  VERCEL_MAIN_MODE: shadow
+  SOURCE_PATH: source
+  TRUSTED_POST_BUILD_PATH: trusted-after-build
+
+concurrency:
+  group: vercel-main-deployment
+  cancel-in-progress: false
+  queue: single # trunk-ignore(actionlint/syntax-check): Pinned actionlint has not learned GitHub's queue key.
+
+jobs:
+  wait-for-ci:
+    name: Verify exact successful CI attempt
+    if: >-
+      github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.head_branch == 'main' &&
+      github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      deploy_sha: ${{ steps.ci.outputs.deploy_sha }}
+      upstream_run_id: ${{ steps.ci.outputs.upstream_run_id }}
+      upstream_run_attempt: ${{ steps.ci.outputs.upstream_run_attempt }}
+      upstream_run_url: ${{ steps.ci.outputs.upstream_run_url }}
+      build_and_test_job_url: ${{ steps.ci.outputs.build_and_test_job_url }}
+    env:
+      DEPLOY_SHA: ${{ github.event.workflow_run.head_sha }}
+    steps:
+      - name: Check out trusted workflow controller
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+          ref: ${{ github.workflow_sha }}
+
+      - name: Validate immutable workflow controller
+        run: node scripts/vercel-main-deployment.mjs validate-context
+
+      - name: Verify exact successful upstream attempt
+        id: ci
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: node scripts/vercel-main-ci-attempt.mjs verify
+
+      - name: Check out exact deployment source
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+          path: source
+          persist-credentials: false
+          ref: ${{ github.event.workflow_run.head_sha }}
+
+      - name: Prove exact checked-out source
+        run: |
+          git -C "$SOURCE_PATH" fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
+          node scripts/vercel-main-deployment.mjs validate-source
+
+  plan-main-deployments:
+    name: Plan from currently served SHAs
+    needs: [wait-for-ci]
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment:
+      name: vercel-cli-production
+      deployment: false # trunk-ignore(actionlint/syntax-check): Pinned actionlint has not learned GitHub's deployment key.
+    outputs:
+      plan: ${{ steps.plan.outputs.plan }}
+      targets: ${{ steps.plan.outputs.targets }}
+    env:
+      DEPLOY_SHA: ${{ needs.wait-for-ci.outputs.deploy_sha }}
+      UPSTREAM_RUN_ID: ${{ needs.wait-for-ci.outputs.upstream_run_id }}
+      UPSTREAM_RUN_ATTEMPT: ${{ needs.wait-for-ci.outputs.upstream_run_attempt }}
+      UPSTREAM_RUN_URL: ${{ needs.wait-for-ci.outputs.upstream_run_url }}
+      BUILD_AND_TEST_JOB_URL: ${{ needs.wait-for-ci.outputs.build_and_test_job_url }}
+      VERCEL_PROJECT_ID_APP: ${{ vars.VERCEL_PROJECT_ID_APP }}
+      VERCEL_PROJECT_ID_GOVERNANCE: ${{ vars.VERCEL_PROJECT_ID_GOVERNANCE }}
+      VERCEL_PROJECT_ID_RESERVE: ${{ vars.VERCEL_PROJECT_ID_RESERVE }}
+      VERCEL_PROJECT_ID_UI: ${{ vars.VERCEL_PROJECT_ID_UI }}
+    steps:
+      - name: Check out trusted workflow controller
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+          ref: ${{ needs.wait-for-ci.outputs.deploy_sha }}
+
+      - name: Check out exact deployment source
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+          path: source
+          persist-credentials: false
+          ref: ${{ needs.wait-for-ci.outputs.deploy_sha }}
+
+      - name: Prove exact checked-out source
+        env:
+          GITHUB_WORKFLOW_SHA: ${{ needs.wait-for-ci.outputs.deploy_sha }}
+        run: |
+          git -C "$SOURCE_PATH" fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
+          node scripts/vercel-main-deployment.mjs validate-source
+
+      - name: Materialize reviewed main and legacy specifications
+        run: |
+          node scripts/vercel-main-deployment.mjs create-spec --scope main --output "$RUNNER_TEMP/main-spec.json"
+          node scripts/vercel-main-deployment.mjs create-spec --scope legacy --output "$RUNNER_TEMP/legacy-spec.json"
+
+      - name: Capture tolerant main planning state
+        env:
+          VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN_PRODUCTION }}
+        run: >-
+          node scripts/vercel-deployment-state.mjs planning-snapshot
+          --spec "$RUNNER_TEMP/main-spec.json"
+          --output "$RUNNER_TEMP/main-planning.json"
+
+      - name: Capture strict legacy rollback state
+        env:
+          VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN_PRODUCTION }}
+        run: >-
+          node scripts/vercel-deployment-state.mjs snapshot
+          --spec "$RUNNER_TEMP/legacy-spec.json"
+          --output "$RUNNER_TEMP/legacy-snapshot.json"
+
+      - name: Verify reviewed public aliases are healthy
+        run: |
+          node scripts/vercel-production-shadow.mjs health --spec "$RUNNER_TEMP/main-spec.json"
+          node scripts/vercel-production-shadow.mjs health --spec "$RUNNER_TEMP/legacy-spec.json"
+
+      - name: Select exact main targets from served SHAs
+        id: plan
+        run: >-
+          node scripts/vercel-main-deployment.mjs plan
+          --planning-snapshot "$RUNNER_TEMP/main-planning.json"
+          --legacy-snapshot "$RUNNER_TEMP/legacy-snapshot.json"
+          --output "$RUNNER_TEMP/main-plan.json"
+
+  stage-governance:
+    name: Stage and verify governance candidate
+    needs: [wait-for-ci, plan-main-deployments]
+    if: contains(fromJSON(needs.plan-main-deployments.outputs.targets), 'governance')
+    runs-on: ubuntu-latest
+    timeout-minutes: 50
+    environment:
+      name: vercel-cli-production
+      deployment: false # trunk-ignore(actionlint/syntax-check): Pinned actionlint has not learned GitHub's deployment key.
+    outputs:
+      handoff: ${{ steps.handoff.outputs.result }}
+      deployment_id: ${{ steps.deploy.outputs.vercel_deployment_id }}
+      deployment_url: ${{ steps.deploy.outputs.vercel_deployment_url }}
+      next_deployment_id: ${{ steps.identity.outputs.next_deployment_id }}
+      build_duration_ms: ${{ steps.build.outputs.build_duration_ms }}
+      deploy_duration_ms: ${{ steps.deploy.outputs.deploy_duration_ms }}
+      turbo_cache_hits: ${{ steps.build.outputs.turbo_cache_hits }}
+      turbo_cache_misses: ${{ steps.build.outputs.turbo_cache_misses }}
+      total_duration_ms: ${{ steps.total.outputs.total_duration_ms }}
+    env:
+      DEPLOY_SHA: ${{ needs.wait-for-ci.outputs.deploy_sha }}
+      PLAN_JSON: ${{ needs.plan-main-deployments.outputs.plan }}
+      LOGICAL_TARGET: governance
+      VERCEL_PROJECT_ID: ${{ vars.VERCEL_PROJECT_ID_GOVERNANCE }}
+      VERCEL_PROJECT_ID_APP: ${{ vars.VERCEL_PROJECT_ID_APP }}
+      VERCEL_PROJECT_ID_GOVERNANCE: ${{ vars.VERCEL_PROJECT_ID_GOVERNANCE }}
+      VERCEL_PROJECT_ID_RESERVE: ${{ vars.VERCEL_PROJECT_ID_RESERVE }}
+      VERCEL_PROJECT_ID_UI: ${{ vars.VERCEL_PROJECT_ID_UI }}
+    steps:
+      - name: Start governance runner timing
+        id: timing
+        run: echo "started_at_ms=$(date +%s%3N)" >> "$GITHUB_OUTPUT"
+
+      - name: Check out trusted governance controller
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+          ref: ${{ needs.wait-for-ci.outputs.deploy_sha }}
+
+      - name: Check out exact governance source
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+          path: source
+          persist-credentials: false
+          ref: ${{ needs.wait-for-ci.outputs.deploy_sha }}
+
+      - name: Prove exact governance source
+        env:
+          GITHUB_WORKFLOW_SHA: ${{ needs.wait-for-ci.outputs.deploy_sha }}
+        run: |
+          git -C "$SOURCE_PATH" fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
+          node scripts/vercel-main-deployment.mjs validate-source
+
+      - name: Prepare protected governance runtime
+        id: runtime
+        uses: ./.github/actions/vercel-protected-runtime
+        with:
+          operation: prepare
+          logical-target: governance
+          controller-path: ${{ github.workspace }}
+          source-path: ${{ github.workspace }}/source
+
+      - name: Verify pinned governance prerequisites
+        run: ${{ steps.runtime.outputs.node-bin }} scripts/vercel-prebuilt.mjs check-versions --repo-root "$SOURCE_PATH"
+
+      - name: Prepare runner-owned governance pull staging
+        env:
+          PULL_STAGING_PATH: ${{ steps.runtime.outputs.pull-staging-path }}
+          SOURCE_PATH: ${{ steps.runtime.outputs.pull-staging-path }}
+          VERCEL_ISOLATION_ROOT: ${{ steps.runtime.outputs.isolation-root }}
+          VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
+        run: ${{ steps.runtime.outputs.node-bin }} scripts/vercel-production-shadow.mjs prepare-pull-staging
+
+      - name: Pull governance production configuration
+        env:
+          SOURCE_PATH: ${{ steps.runtime.outputs.pull-staging-path }}
+          TRUSTED_NODE_PATH: ${{ steps.runtime.outputs.node-bin }}
+          TRUSTED_VERCEL_CLI_PATH: ${{ steps.runtime.outputs.vercel-cli }}
+          VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN_PRODUCTION }}
+        run: ${{ steps.runtime.outputs.node-bin }} scripts/vercel-production-shadow.mjs pull
+
+      - name: Validate governance project and Root Directory
+        env:
+          PULL_STAGING_PATH: ${{ steps.runtime.outputs.pull-staging-path }}
+          SOURCE_PATH: ${{ steps.runtime.outputs.pull-staging-path }}
+          VERCEL_ISOLATION_ROOT: ${{ steps.runtime.outputs.isolation-root }}
+          VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN_PRODUCTION }}
+        run: |
+          "${{ steps.runtime.outputs.node-bin }}" scripts/vercel-production-shadow.mjs validate-pull-staging
+          "${{ steps.runtime.outputs.node-bin }}" scripts/vercel-deployment-state.mjs project --project-id "$VERCEL_PROJECT_ID" --project-name governance.mento.org --root-directory apps/governance.mento.org
+
+      - name: Generate exact governance deployment identity
+        id: identity
+        run: |
+          next_deployment_id="$("${{ steps.runtime.outputs.node-bin }}" scripts/vercel-prebuilt.mjs deployment-id --target governance --sha "$DEPLOY_SHA" --run-id "$GITHUB_RUN_ID" --run-attempt "$GITHUB_RUN_ATTEMPT")"
+          echo "next_deployment_id=$next_deployment_id" >> "$GITHUB_OUTPUT"
+
+      - name: Build exact governance production candidate
+        id: build
+        env:
+          CI: 1
+          ETHERSCAN_API_KEY: ${{ secrets.ETHERSCAN_API_KEY }}
+          MENTO_NEXT_DEPLOYMENT_ID: ${{ steps.identity.outputs.next_deployment_id }}
+          NEXT_PUBLIC_VERCEL_ENV: production
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          TURBO_REMOTE_CACHE_SIGNATURE_KEY: ${{ secrets.TURBO_REMOTE_CACHE_SIGNATURE_KEY }}
+          TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+          TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+          VERCEL: 1
+          VERCEL_ENV: production
+          VERCEL_GIT_COMMIT_REF: main
+          VERCEL_GIT_COMMIT_SHA: ${{ needs.wait-for-ci.outputs.deploy_sha }}
+          VERCEL_GIT_PROVIDER: github
+          VERCEL_GIT_REPO_OWNER: mento-protocol
+          VERCEL_GIT_REPO_SLUG: frontend-monorepo
+          VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
+          VERCEL_TARGET_ENV: production
+        uses: ./.github/actions/vercel-candidate-build
+        with:
+          controller-path: ${{ github.workspace }}
+          source-path: ${{ github.workspace }}/source
+          runtime-root: ${{ steps.runtime.outputs.runtime-root }}
+          isolation-root: ${{ steps.runtime.outputs.isolation-root }}
+          runtime-marker: ${{ steps.runtime.outputs.runtime-marker }}
+          tools-path: ${{ steps.runtime.outputs.tools-path }}
+          build-environment-path: ${{ steps.runtime.outputs.build-environment-path }}
+          candidate-source-path: ${{ steps.runtime.outputs.candidate-source-path }}
+          candidate-home-path: ${{ steps.runtime.outputs.candidate-home-path }}
+          pull-staging-path: ${{ steps.runtime.outputs.pull-staging-path }}
+          candidate-identity-marker: ${{ steps.runtime.outputs.candidate-identity-marker }}
+          build-log-path: ${{ steps.runtime.outputs.build-log-path }}
+          provenance-path: ${{ steps.runtime.outputs.provenance-path }}
+          upload-source-path: ${{ steps.runtime.outputs.upload-source-path }}
+          node-bin: ${{ steps.runtime.outputs.node-bin }}
+          pnpm-bin: ${{ steps.runtime.outputs.pnpm-bin }}
+          vercel-cli: ${{ steps.runtime.outputs.vercel-cli }}
+          deploy-sha: ${{ needs.wait-for-ci.outputs.deploy_sha }}
+          next-deployment-id: ${{ steps.identity.outputs.next_deployment_id }}
+          logical-target: governance
+          expected-root-directory: apps/governance.mento.org
+          vercel-org-id: ${{ vars.VERCEL_ORG_ID }}
+          vercel-project-id: ${{ vars.VERCEL_PROJECT_ID_GOVERNANCE }}
+
+      - name: Restore trusted governance controller after build
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 1
+          path: trusted-after-build
+          persist-credentials: false
+          ref: ${{ needs.wait-for-ci.outputs.deploy_sha }}
+
+      - name: Upload governance candidate without public custom domains
+        id: deploy
+        env:
+          SOURCE_PATH: ${{ steps.runtime.outputs.upload-source-path }}
+          TRUSTED_NODE_PATH: ${{ steps.runtime.outputs.node-bin }}
+          TRUSTED_VERCEL_CLI_PATH: ${{ steps.runtime.outputs.vercel-cli }}
+          VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN_PRODUCTION }}
+        run: >-
+          ${{ steps.runtime.outputs.node-bin }}
+          "$TRUSTED_POST_BUILD_PATH/scripts/vercel-production-shadow.mjs"
+          deploy --expected "$RUNNER_TEMP/governance-expected.json"
+
+      - name: Verify governance candidate identity and generated aliases
+        env:
+          VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN_PRODUCTION }}
+        run: |
+          verified=false
+          for attempt in {1..12}; do
+            echo "Verifying governance candidate (attempt $attempt/12)"
+            if "${{ steps.runtime.outputs.node-bin }}" "$TRUSTED_POST_BUILD_PATH/scripts/vercel-deployment-state.mjs" deployment --expected "$RUNNER_TEMP/governance-expected.json" --output "$RUNNER_TEMP/governance-state.json"; then verified=true; break; fi
+            sleep 5
+          done
+          "$verified"
+          "${{ steps.runtime.outputs.node-bin }}" "$TRUSTED_POST_BUILD_PATH/scripts/vercel-production-shadow.mjs" assert-generated-aliases --target governance --input "$RUNNER_TEMP/governance-state.json"
+
+      - name: Revalidate protected mappings and rollback state
+        env:
+          VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN_PRODUCTION }}
+        run: |
+          "${{ steps.runtime.outputs.node-bin }}" "$TRUSTED_POST_BUILD_PATH/scripts/vercel-main-deployment.mjs" create-spec --scope main --output "$RUNNER_TEMP/current-main-spec.json"
+          "${{ steps.runtime.outputs.node-bin }}" "$TRUSTED_POST_BUILD_PATH/scripts/vercel-main-deployment.mjs" create-spec --scope legacy --output "$RUNNER_TEMP/current-legacy-spec.json"
+          "${{ steps.runtime.outputs.node-bin }}" "$TRUSTED_POST_BUILD_PATH/scripts/vercel-deployment-state.mjs" planning-snapshot --spec "$RUNNER_TEMP/current-main-spec.json" --output "$RUNNER_TEMP/current-main.json"
+          "${{ steps.runtime.outputs.node-bin }}" "$TRUSTED_POST_BUILD_PATH/scripts/vercel-deployment-state.mjs" snapshot --spec "$RUNNER_TEMP/current-legacy-spec.json" --output "$RUNNER_TEMP/current-legacy.json"
+          "${{ steps.runtime.outputs.node-bin }}" "$TRUSTED_POST_BUILD_PATH/scripts/vercel-main-deployment.mjs" revalidate-prior --planning-snapshot "$RUNNER_TEMP/current-main.json" --legacy-snapshot "$RUNNER_TEMP/current-legacy.json"
+
+      - name: Install trusted governance smoke dependencies
+        uses: ./.github/actions/pnpm-install
+        with:
+          working-directory: trusted-after-build
+
+      - name: Install governance smoke Chromium
+        working-directory: trusted-after-build
+        run: >-
+          env -u GITHUB_ENV -u GITHUB_OUTPUT -u GITHUB_PATH -u GITHUB_STATE
+          -u GITHUB_STEP_SUMMARY pnpm --filter app.mento.org exec playwright
+          install --with-deps chromium
+
+      - name: Smoke exact immutable governance candidate
+        env:
+          PRODUCTION_SHADOW_EXPECTED_DEPLOYMENT_ID: ${{ steps.identity.outputs.next_deployment_id }}
+          PRODUCTION_SHADOW_EXPECTED_SHA: ${{ needs.wait-for-ci.outputs.deploy_sha }}
+          PRODUCTION_SHADOW_OUTPUT_DIR: ${{ github.workspace }}/trusted-after-build/apps/app.mento.org/test-results
+          PRODUCTION_SHADOW_TARGET: governance
+          PRODUCTION_SHADOW_URL: ${{ steps.deploy.outputs.vercel_deployment_url }}
+        working-directory: trusted-after-build
+        run: |
+          node scripts/vercel-production-shadow.mjs health --url "$PRODUCTION_SHADOW_URL"
+          env -u GITHUB_ENV -u GITHUB_OUTPUT -u GITHUB_PATH -u GITHUB_STATE -u GITHUB_STEP_SUMMARY pnpm --filter app.mento.org exec playwright test -c playwright.production-shadow.config.ts
+
+      - name: Re-inspect every protected mapping after governance smoke
+        env:
+          VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN_PRODUCTION }}
+        run: |
+          "${{ steps.runtime.outputs.node-bin }}" "$TRUSTED_POST_BUILD_PATH/scripts/vercel-main-deployment.mjs" create-spec --scope main --output "$RUNNER_TEMP/final-main-spec.json"
+          "${{ steps.runtime.outputs.node-bin }}" "$TRUSTED_POST_BUILD_PATH/scripts/vercel-main-deployment.mjs" create-spec --scope legacy --output "$RUNNER_TEMP/final-legacy-spec.json"
+          "${{ steps.runtime.outputs.node-bin }}" "$TRUSTED_POST_BUILD_PATH/scripts/vercel-deployment-state.mjs" planning-snapshot --spec "$RUNNER_TEMP/final-main-spec.json" --output "$RUNNER_TEMP/final-main.json"
+          "${{ steps.runtime.outputs.node-bin }}" "$TRUSTED_POST_BUILD_PATH/scripts/vercel-deployment-state.mjs" snapshot --spec "$RUNNER_TEMP/final-legacy-spec.json" --output "$RUNNER_TEMP/final-legacy.json"
+          "${{ steps.runtime.outputs.node-bin }}" "$TRUSTED_POST_BUILD_PATH/scripts/vercel-main-deployment.mjs" revalidate-prior --planning-snapshot "$RUNNER_TEMP/final-main.json" --legacy-snapshot "$RUNNER_TEMP/final-legacy.json"
+
+      - name: Measure governance runner duration
+        id: total
+        env:
+          STARTED_AT_MS: ${{ steps.timing.outputs.started_at_ms }}
+        run: echo "total_duration_ms=$(($(date +%s%3N) - STARTED_AT_MS))" >> "$GITHUB_OUTPUT"
+
+      - name: Emit governance stage handoff
+        id: handoff
+        env:
+          IMMUTABLE_SMOKE_PASSED: "true"
+          PROTECTED_MAPPINGS_UNCHANGED: "true"
+        run: >-
+          node scripts/vercel-main-deployment.mjs stage-result
+          --state "$RUNNER_TEMP/governance-state.json"
+          --output "$RUNNER_TEMP/governance-stage.json"
+
+      - name: Upload governance browser diagnostics on failure
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: vercel-main-governance-${{ github.run_id }}-${{ github.run_attempt }}
+          path: trusted-after-build/apps/app.mento.org/test-results/
+          if-no-files-found: ignore
+          retention-days: 7
+
+      - name: Remove authenticated governance runtime
+        if: ${{ always() }}
+        uses: ./.github/actions/vercel-protected-runtime
+        with:
+          operation: cleanup
+          logical-target: governance
+
+  stage-reserve:
+    name: Stage and verify reserve candidate
+    needs: [wait-for-ci, plan-main-deployments]
+    if: contains(fromJSON(needs.plan-main-deployments.outputs.targets), 'reserve')
+    runs-on: ubuntu-latest
+    timeout-minutes: 50
+    environment:
+      name: vercel-cli-production
+      deployment: false # trunk-ignore(actionlint/syntax-check): Pinned actionlint has not learned GitHub's deployment key.
+    outputs:
+      handoff: ${{ steps.handoff.outputs.result }}
+      deployment_id: ${{ steps.deploy.outputs.vercel_deployment_id }}
+      deployment_url: ${{ steps.deploy.outputs.vercel_deployment_url }}
+      next_deployment_id: ${{ steps.identity.outputs.next_deployment_id }}
+      build_duration_ms: ${{ steps.build.outputs.build_duration_ms }}
+      deploy_duration_ms: ${{ steps.deploy.outputs.deploy_duration_ms }}
+      turbo_cache_hits: ${{ steps.build.outputs.turbo_cache_hits }}
+      turbo_cache_misses: ${{ steps.build.outputs.turbo_cache_misses }}
+      total_duration_ms: ${{ steps.total.outputs.total_duration_ms }}
+    env:
+      DEPLOY_SHA: ${{ needs.wait-for-ci.outputs.deploy_sha }}
+      PLAN_JSON: ${{ needs.plan-main-deployments.outputs.plan }}
+      LOGICAL_TARGET: reserve
+      VERCEL_PROJECT_ID: ${{ vars.VERCEL_PROJECT_ID_RESERVE }}
+      VERCEL_PROJECT_ID_APP: ${{ vars.VERCEL_PROJECT_ID_APP }}
+      VERCEL_PROJECT_ID_GOVERNANCE: ${{ vars.VERCEL_PROJECT_ID_GOVERNANCE }}
+      VERCEL_PROJECT_ID_RESERVE: ${{ vars.VERCEL_PROJECT_ID_RESERVE }}
+      VERCEL_PROJECT_ID_UI: ${{ vars.VERCEL_PROJECT_ID_UI }}
+    steps:
+      - name: Start reserve runner timing
+        id: timing
+        run: echo "started_at_ms=$(date +%s%3N)" >> "$GITHUB_OUTPUT"
+
+      - name: Check out trusted reserve controller
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+          ref: ${{ needs.wait-for-ci.outputs.deploy_sha }}
+
+      - name: Check out exact reserve source
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+          path: source
+          persist-credentials: false
+          ref: ${{ needs.wait-for-ci.outputs.deploy_sha }}
+
+      - name: Prove exact reserve source
+        env:
+          GITHUB_WORKFLOW_SHA: ${{ needs.wait-for-ci.outputs.deploy_sha }}
+        run: |
+          git -C "$SOURCE_PATH" fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
+          node scripts/vercel-main-deployment.mjs validate-source
+
+      - name: Prepare protected reserve runtime
+        id: runtime
+        uses: ./.github/actions/vercel-protected-runtime
+        with:
+          operation: prepare
+          logical-target: reserve
+          controller-path: ${{ github.workspace }}
+          source-path: ${{ github.workspace }}/source
+
+      - name: Verify pinned reserve prerequisites
+        run: ${{ steps.runtime.outputs.node-bin }} scripts/vercel-prebuilt.mjs check-versions --repo-root "$SOURCE_PATH"
+
+      - name: Prepare runner-owned reserve pull staging
+        env:
+          PULL_STAGING_PATH: ${{ steps.runtime.outputs.pull-staging-path }}
+          SOURCE_PATH: ${{ steps.runtime.outputs.pull-staging-path }}
+          VERCEL_ISOLATION_ROOT: ${{ steps.runtime.outputs.isolation-root }}
+          VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
+        run: ${{ steps.runtime.outputs.node-bin }} scripts/vercel-production-shadow.mjs prepare-pull-staging
+
+      - name: Pull reserve production configuration
+        env:
+          SOURCE_PATH: ${{ steps.runtime.outputs.pull-staging-path }}
+          TRUSTED_NODE_PATH: ${{ steps.runtime.outputs.node-bin }}
+          TRUSTED_VERCEL_CLI_PATH: ${{ steps.runtime.outputs.vercel-cli }}
+          VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN_PRODUCTION }}
+        run: ${{ steps.runtime.outputs.node-bin }} scripts/vercel-production-shadow.mjs pull
+
+      - name: Validate reserve project and Root Directory
+        env:
+          PULL_STAGING_PATH: ${{ steps.runtime.outputs.pull-staging-path }}
+          SOURCE_PATH: ${{ steps.runtime.outputs.pull-staging-path }}
+          VERCEL_ISOLATION_ROOT: ${{ steps.runtime.outputs.isolation-root }}
+          VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN_PRODUCTION }}
+        run: |
+          "${{ steps.runtime.outputs.node-bin }}" scripts/vercel-production-shadow.mjs validate-pull-staging
+          "${{ steps.runtime.outputs.node-bin }}" scripts/vercel-deployment-state.mjs project --project-id "$VERCEL_PROJECT_ID" --project-name reserve.mento.org --root-directory apps/reserve.mento.org
+
+      - name: Generate exact reserve deployment identity
+        id: identity
+        run: |
+          next_deployment_id="$("${{ steps.runtime.outputs.node-bin }}" scripts/vercel-prebuilt.mjs deployment-id --target reserve --sha "$DEPLOY_SHA" --run-id "$GITHUB_RUN_ID" --run-attempt "$GITHUB_RUN_ATTEMPT")"
+          echo "next_deployment_id=$next_deployment_id" >> "$GITHUB_OUTPUT"
+
+      - name: Build exact reserve production candidate
+        id: build
+        env:
+          CI: 1
+          MENTO_NEXT_DEPLOYMENT_ID: ${{ steps.identity.outputs.next_deployment_id }}
+          NEXT_PUBLIC_VERCEL_ENV: production
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          TURBO_REMOTE_CACHE_SIGNATURE_KEY: ${{ secrets.TURBO_REMOTE_CACHE_SIGNATURE_KEY }}
+          TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+          TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+          VERCEL: 1
+          VERCEL_ENV: production
+          VERCEL_GIT_COMMIT_REF: main
+          VERCEL_GIT_COMMIT_SHA: ${{ needs.wait-for-ci.outputs.deploy_sha }}
+          VERCEL_GIT_PROVIDER: github
+          VERCEL_GIT_REPO_OWNER: mento-protocol
+          VERCEL_GIT_REPO_SLUG: frontend-monorepo
+          VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
+          VERCEL_TARGET_ENV: production
+        uses: ./.github/actions/vercel-candidate-build
+        with:
+          controller-path: ${{ github.workspace }}
+          source-path: ${{ github.workspace }}/source
+          runtime-root: ${{ steps.runtime.outputs.runtime-root }}
+          isolation-root: ${{ steps.runtime.outputs.isolation-root }}
+          runtime-marker: ${{ steps.runtime.outputs.runtime-marker }}
+          tools-path: ${{ steps.runtime.outputs.tools-path }}
+          build-environment-path: ${{ steps.runtime.outputs.build-environment-path }}
+          candidate-source-path: ${{ steps.runtime.outputs.candidate-source-path }}
+          candidate-home-path: ${{ steps.runtime.outputs.candidate-home-path }}
+          pull-staging-path: ${{ steps.runtime.outputs.pull-staging-path }}
+          candidate-identity-marker: ${{ steps.runtime.outputs.candidate-identity-marker }}
+          build-log-path: ${{ steps.runtime.outputs.build-log-path }}
+          provenance-path: ${{ steps.runtime.outputs.provenance-path }}
+          upload-source-path: ${{ steps.runtime.outputs.upload-source-path }}
+          node-bin: ${{ steps.runtime.outputs.node-bin }}
+          pnpm-bin: ${{ steps.runtime.outputs.pnpm-bin }}
+          vercel-cli: ${{ steps.runtime.outputs.vercel-cli }}
+          deploy-sha: ${{ needs.wait-for-ci.outputs.deploy_sha }}
+          next-deployment-id: ${{ steps.identity.outputs.next_deployment_id }}
+          logical-target: reserve
+          expected-root-directory: apps/reserve.mento.org
+          vercel-org-id: ${{ vars.VERCEL_ORG_ID }}
+          vercel-project-id: ${{ vars.VERCEL_PROJECT_ID_RESERVE }}
+
+      - name: Restore trusted reserve controller after build
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 1
+          path: trusted-after-build
+          persist-credentials: false
+          ref: ${{ needs.wait-for-ci.outputs.deploy_sha }}
+
+      - name: Upload reserve candidate without public custom domains
+        id: deploy
+        env:
+          SOURCE_PATH: ${{ steps.runtime.outputs.upload-source-path }}
+          TRUSTED_NODE_PATH: ${{ steps.runtime.outputs.node-bin }}
+          TRUSTED_VERCEL_CLI_PATH: ${{ steps.runtime.outputs.vercel-cli }}
+          VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN_PRODUCTION }}
+        run: >-
+          ${{ steps.runtime.outputs.node-bin }}
+          "$TRUSTED_POST_BUILD_PATH/scripts/vercel-production-shadow.mjs"
+          deploy --expected "$RUNNER_TEMP/reserve-expected.json"
+
+      - name: Verify reserve candidate identity and generated aliases
+        env:
+          VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN_PRODUCTION }}
+        run: |
+          verified=false
+          for attempt in {1..12}; do
+            echo "Verifying reserve candidate (attempt $attempt/12)"
+            if "${{ steps.runtime.outputs.node-bin }}" "$TRUSTED_POST_BUILD_PATH/scripts/vercel-deployment-state.mjs" deployment --expected "$RUNNER_TEMP/reserve-expected.json" --output "$RUNNER_TEMP/reserve-state.json"; then verified=true; break; fi
+            sleep 5
+          done
+          "$verified"
+          "${{ steps.runtime.outputs.node-bin }}" "$TRUSTED_POST_BUILD_PATH/scripts/vercel-production-shadow.mjs" assert-generated-aliases --target reserve --input "$RUNNER_TEMP/reserve-state.json"
+
+      - name: Revalidate protected mappings and rollback state
+        env:
+          VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN_PRODUCTION }}
+        run: |
+          "${{ steps.runtime.outputs.node-bin }}" "$TRUSTED_POST_BUILD_PATH/scripts/vercel-main-deployment.mjs" create-spec --scope main --output "$RUNNER_TEMP/current-main-spec.json"
+          "${{ steps.runtime.outputs.node-bin }}" "$TRUSTED_POST_BUILD_PATH/scripts/vercel-main-deployment.mjs" create-spec --scope legacy --output "$RUNNER_TEMP/current-legacy-spec.json"
+          "${{ steps.runtime.outputs.node-bin }}" "$TRUSTED_POST_BUILD_PATH/scripts/vercel-deployment-state.mjs" planning-snapshot --spec "$RUNNER_TEMP/current-main-spec.json" --output "$RUNNER_TEMP/current-main.json"
+          "${{ steps.runtime.outputs.node-bin }}" "$TRUSTED_POST_BUILD_PATH/scripts/vercel-deployment-state.mjs" snapshot --spec "$RUNNER_TEMP/current-legacy-spec.json" --output "$RUNNER_TEMP/current-legacy.json"
+          "${{ steps.runtime.outputs.node-bin }}" "$TRUSTED_POST_BUILD_PATH/scripts/vercel-main-deployment.mjs" revalidate-prior --planning-snapshot "$RUNNER_TEMP/current-main.json" --legacy-snapshot "$RUNNER_TEMP/current-legacy.json"
+
+      - name: Install trusted reserve smoke dependencies
+        uses: ./.github/actions/pnpm-install
+        with:
+          working-directory: trusted-after-build
+
+      - name: Install reserve smoke Chromium
+        working-directory: trusted-after-build
+        run: >-
+          env -u GITHUB_ENV -u GITHUB_OUTPUT -u GITHUB_PATH -u GITHUB_STATE
+          -u GITHUB_STEP_SUMMARY pnpm --filter app.mento.org exec playwright
+          install --with-deps chromium
+
+      - name: Smoke exact immutable reserve candidate
+        env:
+          PRODUCTION_SHADOW_EXPECTED_DEPLOYMENT_ID: ${{ steps.identity.outputs.next_deployment_id }}
+          PRODUCTION_SHADOW_EXPECTED_SHA: ${{ needs.wait-for-ci.outputs.deploy_sha }}
+          PRODUCTION_SHADOW_OUTPUT_DIR: ${{ github.workspace }}/trusted-after-build/apps/app.mento.org/test-results
+          PRODUCTION_SHADOW_TARGET: reserve
+          PRODUCTION_SHADOW_URL: ${{ steps.deploy.outputs.vercel_deployment_url }}
+        working-directory: trusted-after-build
+        run: |
+          node scripts/vercel-production-shadow.mjs health --url "$PRODUCTION_SHADOW_URL"
+          env -u GITHUB_ENV -u GITHUB_OUTPUT -u GITHUB_PATH -u GITHUB_STATE -u GITHUB_STEP_SUMMARY pnpm --filter app.mento.org exec playwright test -c playwright.production-shadow.config.ts
+
+      - name: Re-inspect every protected mapping after reserve smoke
+        env:
+          VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN_PRODUCTION }}
+        run: |
+          "${{ steps.runtime.outputs.node-bin }}" "$TRUSTED_POST_BUILD_PATH/scripts/vercel-main-deployment.mjs" create-spec --scope main --output "$RUNNER_TEMP/final-main-spec.json"
+          "${{ steps.runtime.outputs.node-bin }}" "$TRUSTED_POST_BUILD_PATH/scripts/vercel-main-deployment.mjs" create-spec --scope legacy --output "$RUNNER_TEMP/final-legacy-spec.json"
+          "${{ steps.runtime.outputs.node-bin }}" "$TRUSTED_POST_BUILD_PATH/scripts/vercel-deployment-state.mjs" planning-snapshot --spec "$RUNNER_TEMP/final-main-spec.json" --output "$RUNNER_TEMP/final-main.json"
+          "${{ steps.runtime.outputs.node-bin }}" "$TRUSTED_POST_BUILD_PATH/scripts/vercel-deployment-state.mjs" snapshot --spec "$RUNNER_TEMP/final-legacy-spec.json" --output "$RUNNER_TEMP/final-legacy.json"
+          "${{ steps.runtime.outputs.node-bin }}" "$TRUSTED_POST_BUILD_PATH/scripts/vercel-main-deployment.mjs" revalidate-prior --planning-snapshot "$RUNNER_TEMP/final-main.json" --legacy-snapshot "$RUNNER_TEMP/final-legacy.json"
+
+      - name: Measure reserve runner duration
+        id: total
+        env:
+          STARTED_AT_MS: ${{ steps.timing.outputs.started_at_ms }}
+        run: echo "total_duration_ms=$(($(date +%s%3N) - STARTED_AT_MS))" >> "$GITHUB_OUTPUT"
+
+      - name: Emit reserve stage handoff
+        id: handoff
+        env:
+          IMMUTABLE_SMOKE_PASSED: "true"
+          PROTECTED_MAPPINGS_UNCHANGED: "true"
+        run: >-
+          node scripts/vercel-main-deployment.mjs stage-result
+          --state "$RUNNER_TEMP/reserve-state.json"
+          --output "$RUNNER_TEMP/reserve-stage.json"
+
+      - name: Upload reserve browser diagnostics on failure
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: vercel-main-reserve-${{ github.run_id }}-${{ github.run_attempt }}
+          path: trusted-after-build/apps/app.mento.org/test-results/
+          if-no-files-found: ignore
+          retention-days: 7
+
+      - name: Remove authenticated reserve runtime
+        if: ${{ always() }}
+        uses: ./.github/actions/vercel-protected-runtime
+        with:
+          operation: cleanup
+          logical-target: reserve
+
+  stage-ui:
+    name: Stage and verify UI candidate
+    needs: [wait-for-ci, plan-main-deployments]
+    if: contains(fromJSON(needs.plan-main-deployments.outputs.targets), 'ui')
+    runs-on: ubuntu-latest
+    timeout-minutes: 50
+    environment:
+      name: vercel-cli-production
+      deployment: false # trunk-ignore(actionlint/syntax-check): Pinned actionlint has not learned GitHub's deployment key.
+    outputs:
+      handoff: ${{ steps.handoff.outputs.result }}
+      deployment_id: ${{ steps.deploy.outputs.vercel_deployment_id }}
+      deployment_url: ${{ steps.deploy.outputs.vercel_deployment_url }}
+      next_deployment_id: ${{ steps.identity.outputs.next_deployment_id }}
+      build_duration_ms: ${{ steps.build.outputs.build_duration_ms }}
+      deploy_duration_ms: ${{ steps.deploy.outputs.deploy_duration_ms }}
+      turbo_cache_hits: ${{ steps.build.outputs.turbo_cache_hits }}
+      turbo_cache_misses: ${{ steps.build.outputs.turbo_cache_misses }}
+      total_duration_ms: ${{ steps.total.outputs.total_duration_ms }}
+    env:
+      DEPLOY_SHA: ${{ needs.wait-for-ci.outputs.deploy_sha }}
+      PLAN_JSON: ${{ needs.plan-main-deployments.outputs.plan }}
+      LOGICAL_TARGET: ui
+      VERCEL_PROJECT_ID: ${{ vars.VERCEL_PROJECT_ID_UI }}
+      VERCEL_PROJECT_ID_APP: ${{ vars.VERCEL_PROJECT_ID_APP }}
+      VERCEL_PROJECT_ID_GOVERNANCE: ${{ vars.VERCEL_PROJECT_ID_GOVERNANCE }}
+      VERCEL_PROJECT_ID_RESERVE: ${{ vars.VERCEL_PROJECT_ID_RESERVE }}
+      VERCEL_PROJECT_ID_UI: ${{ vars.VERCEL_PROJECT_ID_UI }}
+    steps:
+      - name: Start UI runner timing
+        id: timing
+        run: echo "started_at_ms=$(date +%s%3N)" >> "$GITHUB_OUTPUT"
+
+      - name: Check out trusted UI controller
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+          ref: ${{ needs.wait-for-ci.outputs.deploy_sha }}
+
+      - name: Check out exact UI source
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+          path: source
+          persist-credentials: false
+          ref: ${{ needs.wait-for-ci.outputs.deploy_sha }}
+
+      - name: Prove exact UI source
+        env:
+          GITHUB_WORKFLOW_SHA: ${{ needs.wait-for-ci.outputs.deploy_sha }}
+        run: |
+          git -C "$SOURCE_PATH" fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
+          node scripts/vercel-main-deployment.mjs validate-source
+
+      - name: Prepare protected UI runtime
+        id: runtime
+        uses: ./.github/actions/vercel-protected-runtime
+        with:
+          operation: prepare
+          logical-target: ui
+          controller-path: ${{ github.workspace }}
+          source-path: ${{ github.workspace }}/source
+
+      - name: Verify pinned UI prerequisites
+        run: ${{ steps.runtime.outputs.node-bin }} scripts/vercel-prebuilt.mjs check-versions --repo-root "$SOURCE_PATH"
+
+      - name: Prepare runner-owned UI pull staging
+        env:
+          PULL_STAGING_PATH: ${{ steps.runtime.outputs.pull-staging-path }}
+          SOURCE_PATH: ${{ steps.runtime.outputs.pull-staging-path }}
+          VERCEL_ISOLATION_ROOT: ${{ steps.runtime.outputs.isolation-root }}
+          VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
+        run: ${{ steps.runtime.outputs.node-bin }} scripts/vercel-production-shadow.mjs prepare-pull-staging
+
+      - name: Pull UI production configuration
+        env:
+          SOURCE_PATH: ${{ steps.runtime.outputs.pull-staging-path }}
+          TRUSTED_NODE_PATH: ${{ steps.runtime.outputs.node-bin }}
+          TRUSTED_VERCEL_CLI_PATH: ${{ steps.runtime.outputs.vercel-cli }}
+          VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN_PRODUCTION }}
+        run: ${{ steps.runtime.outputs.node-bin }} scripts/vercel-production-shadow.mjs pull
+
+      - name: Validate UI project and Root Directory
+        env:
+          PULL_STAGING_PATH: ${{ steps.runtime.outputs.pull-staging-path }}
+          SOURCE_PATH: ${{ steps.runtime.outputs.pull-staging-path }}
+          VERCEL_ISOLATION_ROOT: ${{ steps.runtime.outputs.isolation-root }}
+          VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN_PRODUCTION }}
+        run: |
+          "${{ steps.runtime.outputs.node-bin }}" scripts/vercel-production-shadow.mjs validate-pull-staging
+          "${{ steps.runtime.outputs.node-bin }}" scripts/vercel-deployment-state.mjs project --project-id "$VERCEL_PROJECT_ID" --project-name ui.mento.org --root-directory apps/ui.mento.org
+
+      - name: Generate exact UI deployment identity
+        id: identity
+        run: |
+          next_deployment_id="$("${{ steps.runtime.outputs.node-bin }}" scripts/vercel-prebuilt.mjs deployment-id --target ui --sha "$DEPLOY_SHA" --run-id "$GITHUB_RUN_ID" --run-attempt "$GITHUB_RUN_ATTEMPT")"
+          echo "next_deployment_id=$next_deployment_id" >> "$GITHUB_OUTPUT"
+
+      - name: Build exact UI production candidate
+        id: build
+        env:
+          CI: 1
+          MENTO_NEXT_DEPLOYMENT_ID: ${{ steps.identity.outputs.next_deployment_id }}
+          NEXT_PUBLIC_VERCEL_ENV: production
+          TURBO_REMOTE_CACHE_SIGNATURE_KEY: ${{ secrets.TURBO_REMOTE_CACHE_SIGNATURE_KEY }}
+          TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+          TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+          VERCEL: 1
+          VERCEL_ENV: production
+          VERCEL_GIT_COMMIT_REF: main
+          VERCEL_GIT_COMMIT_SHA: ${{ needs.wait-for-ci.outputs.deploy_sha }}
+          VERCEL_GIT_PROVIDER: github
+          VERCEL_GIT_REPO_OWNER: mento-protocol
+          VERCEL_GIT_REPO_SLUG: frontend-monorepo
+          VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
+          VERCEL_TARGET_ENV: production
+        uses: ./.github/actions/vercel-candidate-build
+        with:
+          controller-path: ${{ github.workspace }}
+          source-path: ${{ github.workspace }}/source
+          runtime-root: ${{ steps.runtime.outputs.runtime-root }}
+          isolation-root: ${{ steps.runtime.outputs.isolation-root }}
+          runtime-marker: ${{ steps.runtime.outputs.runtime-marker }}
+          tools-path: ${{ steps.runtime.outputs.tools-path }}
+          build-environment-path: ${{ steps.runtime.outputs.build-environment-path }}
+          candidate-source-path: ${{ steps.runtime.outputs.candidate-source-path }}
+          candidate-home-path: ${{ steps.runtime.outputs.candidate-home-path }}
+          pull-staging-path: ${{ steps.runtime.outputs.pull-staging-path }}
+          candidate-identity-marker: ${{ steps.runtime.outputs.candidate-identity-marker }}
+          build-log-path: ${{ steps.runtime.outputs.build-log-path }}
+          provenance-path: ${{ steps.runtime.outputs.provenance-path }}
+          upload-source-path: ${{ steps.runtime.outputs.upload-source-path }}
+          node-bin: ${{ steps.runtime.outputs.node-bin }}
+          pnpm-bin: ${{ steps.runtime.outputs.pnpm-bin }}
+          vercel-cli: ${{ steps.runtime.outputs.vercel-cli }}
+          deploy-sha: ${{ needs.wait-for-ci.outputs.deploy_sha }}
+          next-deployment-id: ${{ steps.identity.outputs.next_deployment_id }}
+          logical-target: ui
+          expected-root-directory: apps/ui.mento.org
+          vercel-org-id: ${{ vars.VERCEL_ORG_ID }}
+          vercel-project-id: ${{ vars.VERCEL_PROJECT_ID_UI }}
+
+      - name: Restore trusted UI controller after build
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 1
+          path: trusted-after-build
+          persist-credentials: false
+          ref: ${{ needs.wait-for-ci.outputs.deploy_sha }}
+
+      - name: Upload UI candidate without public custom domains
+        id: deploy
+        env:
+          SOURCE_PATH: ${{ steps.runtime.outputs.upload-source-path }}
+          TRUSTED_NODE_PATH: ${{ steps.runtime.outputs.node-bin }}
+          TRUSTED_VERCEL_CLI_PATH: ${{ steps.runtime.outputs.vercel-cli }}
+          VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN_PRODUCTION }}
+        run: >-
+          ${{ steps.runtime.outputs.node-bin }}
+          "$TRUSTED_POST_BUILD_PATH/scripts/vercel-production-shadow.mjs"
+          deploy --expected "$RUNNER_TEMP/ui-expected.json"
+
+      - name: Verify UI candidate identity and generated aliases
+        env:
+          VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN_PRODUCTION }}
+        run: |
+          verified=false
+          for attempt in {1..12}; do
+            echo "Verifying UI candidate (attempt $attempt/12)"
+            if "${{ steps.runtime.outputs.node-bin }}" "$TRUSTED_POST_BUILD_PATH/scripts/vercel-deployment-state.mjs" deployment --expected "$RUNNER_TEMP/ui-expected.json" --output "$RUNNER_TEMP/ui-state.json"; then verified=true; break; fi
+            sleep 5
+          done
+          "$verified"
+          "${{ steps.runtime.outputs.node-bin }}" "$TRUSTED_POST_BUILD_PATH/scripts/vercel-production-shadow.mjs" assert-generated-aliases --target ui --input "$RUNNER_TEMP/ui-state.json"
+
+      - name: Revalidate protected mappings and rollback state
+        env:
+          VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN_PRODUCTION }}
+        run: |
+          "${{ steps.runtime.outputs.node-bin }}" "$TRUSTED_POST_BUILD_PATH/scripts/vercel-main-deployment.mjs" create-spec --scope main --output "$RUNNER_TEMP/current-main-spec.json"
+          "${{ steps.runtime.outputs.node-bin }}" "$TRUSTED_POST_BUILD_PATH/scripts/vercel-main-deployment.mjs" create-spec --scope legacy --output "$RUNNER_TEMP/current-legacy-spec.json"
+          "${{ steps.runtime.outputs.node-bin }}" "$TRUSTED_POST_BUILD_PATH/scripts/vercel-deployment-state.mjs" planning-snapshot --spec "$RUNNER_TEMP/current-main-spec.json" --output "$RUNNER_TEMP/current-main.json"
+          "${{ steps.runtime.outputs.node-bin }}" "$TRUSTED_POST_BUILD_PATH/scripts/vercel-deployment-state.mjs" snapshot --spec "$RUNNER_TEMP/current-legacy-spec.json" --output "$RUNNER_TEMP/current-legacy.json"
+          "${{ steps.runtime.outputs.node-bin }}" "$TRUSTED_POST_BUILD_PATH/scripts/vercel-main-deployment.mjs" revalidate-prior --planning-snapshot "$RUNNER_TEMP/current-main.json" --legacy-snapshot "$RUNNER_TEMP/current-legacy.json"
+
+      - name: Install trusted UI smoke dependencies
+        uses: ./.github/actions/pnpm-install
+        with:
+          working-directory: trusted-after-build
+
+      - name: Install UI smoke Chromium
+        working-directory: trusted-after-build
+        run: >-
+          env -u GITHUB_ENV -u GITHUB_OUTPUT -u GITHUB_PATH -u GITHUB_STATE
+          -u GITHUB_STEP_SUMMARY pnpm --filter app.mento.org exec playwright
+          install --with-deps chromium
+
+      - name: Smoke exact immutable UI candidate
+        env:
+          PRODUCTION_SHADOW_EXPECTED_DEPLOYMENT_ID: ${{ steps.identity.outputs.next_deployment_id }}
+          PRODUCTION_SHADOW_EXPECTED_SHA: ${{ needs.wait-for-ci.outputs.deploy_sha }}
+          PRODUCTION_SHADOW_OUTPUT_DIR: ${{ github.workspace }}/trusted-after-build/apps/app.mento.org/test-results
+          PRODUCTION_SHADOW_TARGET: ui
+          PRODUCTION_SHADOW_URL: ${{ steps.deploy.outputs.vercel_deployment_url }}
+        working-directory: trusted-after-build
+        run: |
+          node scripts/vercel-production-shadow.mjs health --url "$PRODUCTION_SHADOW_URL"
+          env -u GITHUB_ENV -u GITHUB_OUTPUT -u GITHUB_PATH -u GITHUB_STATE -u GITHUB_STEP_SUMMARY pnpm --filter app.mento.org exec playwright test -c playwright.production-shadow.config.ts
+
+      - name: Re-inspect every protected mapping after UI smoke
+        env:
+          VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN_PRODUCTION }}
+        run: |
+          "${{ steps.runtime.outputs.node-bin }}" "$TRUSTED_POST_BUILD_PATH/scripts/vercel-main-deployment.mjs" create-spec --scope main --output "$RUNNER_TEMP/final-main-spec.json"
+          "${{ steps.runtime.outputs.node-bin }}" "$TRUSTED_POST_BUILD_PATH/scripts/vercel-main-deployment.mjs" create-spec --scope legacy --output "$RUNNER_TEMP/final-legacy-spec.json"
+          "${{ steps.runtime.outputs.node-bin }}" "$TRUSTED_POST_BUILD_PATH/scripts/vercel-deployment-state.mjs" planning-snapshot --spec "$RUNNER_TEMP/final-main-spec.json" --output "$RUNNER_TEMP/final-main.json"
+          "${{ steps.runtime.outputs.node-bin }}" "$TRUSTED_POST_BUILD_PATH/scripts/vercel-deployment-state.mjs" snapshot --spec "$RUNNER_TEMP/final-legacy-spec.json" --output "$RUNNER_TEMP/final-legacy.json"
+          "${{ steps.runtime.outputs.node-bin }}" "$TRUSTED_POST_BUILD_PATH/scripts/vercel-main-deployment.mjs" revalidate-prior --planning-snapshot "$RUNNER_TEMP/final-main.json" --legacy-snapshot "$RUNNER_TEMP/final-legacy.json"
+
+      - name: Measure UI runner duration
+        id: total
+        env:
+          STARTED_AT_MS: ${{ steps.timing.outputs.started_at_ms }}
+        run: echo "total_duration_ms=$(($(date +%s%3N) - STARTED_AT_MS))" >> "$GITHUB_OUTPUT"
+
+      - name: Emit UI stage handoff
+        id: handoff
+        env:
+          IMMUTABLE_SMOKE_PASSED: "true"
+          PROTECTED_MAPPINGS_UNCHANGED: "true"
+        run: >-
+          node scripts/vercel-main-deployment.mjs stage-result
+          --state "$RUNNER_TEMP/ui-state.json"
+          --output "$RUNNER_TEMP/ui-stage.json"
+
+      - name: Upload UI browser diagnostics on failure
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: vercel-main-ui-${{ github.run_id }}-${{ github.run_attempt }}
+          path: trusted-after-build/apps/app.mento.org/test-results/
+          if-no-files-found: ignore
+          retention-days: 7
+
+      - name: Remove authenticated UI runtime
+        if: ${{ always() }}
+        uses: ./.github/actions/vercel-protected-runtime
+        with:
+          operation: cleanup
+          logical-target: ui
+
+  activate-and-verify:
+    name: Prepare shadow transaction
+    if: ${{ always() }}
+    needs:
+      - wait-for-ci
+      - plan-main-deployments
+      - stage-governance
+      - stage-reserve
+      - stage-ui
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    environment:
+      name: vercel-cli-production
+      deployment: false # trunk-ignore(actionlint/syntax-check): Pinned actionlint has not learned GitHub's deployment key.
+    outputs:
+      outcome: ${{ steps.outcome.outputs.outcome }}
+      artifact_name: ${{ steps.journal.outputs.artifact_name }}
+      artifact_id: ${{ steps.journal-upload.outputs.artifact-id }}
+      transaction_id: ${{ steps.journal.outputs.transaction_id }}
+      app_next_deployment_id: ${{ steps.app-identity.outputs.next_deployment_id }}
+      app_build_duration_ms: ${{ steps.app-build.outputs.build_duration_ms }}
+      app_turbo_cache_hits: ${{ steps.app-build.outputs.turbo_cache_hits }}
+      app_turbo_cache_misses: ${{ steps.app-build.outputs.turbo_cache_misses }}
+      app_total_duration_ms: ${{ steps.app-total.outputs.total_duration_ms }}
+      total_duration_ms: ${{ steps.total.outputs.total_duration_ms }}
+    env:
+      DEPLOY_SHA: ${{ needs.wait-for-ci.outputs.deploy_sha }}
+      PLAN_JSON: ${{ needs.plan-main-deployments.outputs.plan }}
+      STAGE_GOVERNANCE_RESULT: ${{ needs.stage-governance.result }}
+      STAGE_GOVERNANCE_HANDOFF: ${{ needs.stage-governance.outputs.handoff }}
+      STAGE_RESERVE_RESULT: ${{ needs.stage-reserve.result }}
+      STAGE_RESERVE_HANDOFF: ${{ needs.stage-reserve.outputs.handoff }}
+      STAGE_UI_RESULT: ${{ needs.stage-ui.result }}
+      STAGE_UI_HANDOFF: ${{ needs.stage-ui.outputs.handoff }}
+      VERCEL_PROJECT_ID_APP: ${{ vars.VERCEL_PROJECT_ID_APP }}
+      VERCEL_PROJECT_ID_GOVERNANCE: ${{ vars.VERCEL_PROJECT_ID_GOVERNANCE }}
+      VERCEL_PROJECT_ID_RESERVE: ${{ vars.VERCEL_PROJECT_ID_RESERVE }}
+      VERCEL_PROJECT_ID_UI: ${{ vars.VERCEL_PROJECT_ID_UI }}
+    steps:
+      - name: Start coordinator runner timing
+        id: timing
+        run: echo "started_at_ms=$(date +%s%3N)" >> "$GITHUB_OUTPUT"
+
+      - name: Check out trusted coordinator
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+          ref: ${{ needs.wait-for-ci.outputs.deploy_sha }}
+
+      - name: Bind every selected stage to this exact attempt
+        id: stages
+        run: node scripts/vercel-main-deployment.mjs validate-stages
+
+      - name: Check freshness before any App work
+        if: steps.stages.outputs.outcome == 'eligible'
+        id: freshness
+        run: node scripts/vercel-main-deployment.mjs freshness
+
+      - name: Check out exact coordinator source
+        if: steps.freshness.outputs.status == 'fresh'
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+          path: source
+          persist-credentials: false
+          ref: ${{ needs.wait-for-ci.outputs.deploy_sha }}
+
+      - name: Prove exact coordinator source
+        if: steps.freshness.outputs.status == 'fresh'
+        env:
+          GITHUB_WORKFLOW_SHA: ${{ needs.wait-for-ci.outputs.deploy_sha }}
+        run: |
+          git -C "$SOURCE_PATH" fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
+          node scripts/vercel-main-deployment.mjs validate-source
+
+      - name: Re-inspect every protected mapping before App preparation
+        if: steps.freshness.outputs.status == 'fresh'
+        env:
+          VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN_PRODUCTION }}
+        run: |
+          node scripts/vercel-main-deployment.mjs create-spec --scope main --output "$RUNNER_TEMP/coordinator-main-spec.json"
+          node scripts/vercel-main-deployment.mjs create-spec --scope legacy --output "$RUNNER_TEMP/coordinator-legacy-spec.json"
+          node scripts/vercel-deployment-state.mjs planning-snapshot --spec "$RUNNER_TEMP/coordinator-main-spec.json" --output "$RUNNER_TEMP/coordinator-main.json"
+          node scripts/vercel-deployment-state.mjs snapshot --spec "$RUNNER_TEMP/coordinator-legacy-spec.json" --output "$RUNNER_TEMP/coordinator-legacy.json"
+          node scripts/vercel-main-deployment.mjs revalidate-prior --planning-snapshot "$RUNNER_TEMP/coordinator-main.json" --legacy-snapshot "$RUNNER_TEMP/coordinator-legacy.json"
+
+      - name: Start App runner timing
+        if: >-
+          steps.freshness.outputs.status == 'fresh' &&
+          contains(fromJSON(needs.plan-main-deployments.outputs.targets), 'app')
+        id: app-timing
+        run: echo "started_at_ms=$(date +%s%3N)" >> "$GITHUB_OUTPUT"
+
+      - name: Prepare protected App build runtime
+        if: >-
+          steps.freshness.outputs.status == 'fresh' &&
+          contains(fromJSON(needs.plan-main-deployments.outputs.targets), 'app')
+        id: app-runtime
+        uses: ./.github/actions/vercel-protected-runtime
+        with:
+          operation: prepare
+          logical-target: app
+          controller-path: ${{ github.workspace }}
+          source-path: ${{ github.workspace }}/source
+
+      - name: Verify pinned App prerequisites
+        if: steps.app-runtime.outcome == 'success'
+        run: ${{ steps.app-runtime.outputs.node-bin }} scripts/vercel-prebuilt.mjs check-versions --repo-root "$SOURCE_PATH"
+
+      - name: Prepare runner-owned App pull staging
+        if: steps.app-runtime.outcome == 'success'
+        env:
+          LOGICAL_TARGET: app
+          PULL_STAGING_PATH: ${{ steps.app-runtime.outputs.pull-staging-path }}
+          SOURCE_PATH: ${{ steps.app-runtime.outputs.pull-staging-path }}
+          VERCEL_ISOLATION_ROOT: ${{ steps.app-runtime.outputs.isolation-root }}
+          VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ vars.VERCEL_PROJECT_ID_APP }}
+        run: ${{ steps.app-runtime.outputs.node-bin }} scripts/vercel-production-shadow.mjs prepare-pull-staging
+
+      - name: Pull App custom-v3 configuration
+        if: steps.app-runtime.outcome == 'success'
+        env:
+          LOGICAL_TARGET: app
+          SOURCE_PATH: ${{ steps.app-runtime.outputs.pull-staging-path }}
+          TRUSTED_NODE_PATH: ${{ steps.app-runtime.outputs.node-bin }}
+          TRUSTED_VERCEL_CLI_PATH: ${{ steps.app-runtime.outputs.vercel-cli }}
+          VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ vars.VERCEL_PROJECT_ID_APP }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN_PRODUCTION }}
+        run: ${{ steps.app-runtime.outputs.node-bin }} scripts/vercel-production-shadow.mjs pull
+
+      - name: Validate App custom-v3 project and Root Directory
+        if: steps.app-runtime.outcome == 'success'
+        env:
+          LOGICAL_TARGET: app
+          PULL_STAGING_PATH: ${{ steps.app-runtime.outputs.pull-staging-path }}
+          SOURCE_PATH: ${{ steps.app-runtime.outputs.pull-staging-path }}
+          VERCEL_ISOLATION_ROOT: ${{ steps.app-runtime.outputs.isolation-root }}
+          VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ vars.VERCEL_PROJECT_ID_APP }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN_PRODUCTION }}
+        run: |
+          "${{ steps.app-runtime.outputs.node-bin }}" scripts/vercel-production-shadow.mjs validate-pull-staging
+          "${{ steps.app-runtime.outputs.node-bin }}" scripts/vercel-deployment-state.mjs project --project-id "$VERCEL_PROJECT_ID" --project-name app.mento.org --root-directory apps/app.mento.org
+
+      - name: Generate exact App custom deployment identity
+        if: steps.app-runtime.outcome == 'success'
+        id: app-identity
+        run: |
+          next_deployment_id="$("${{ steps.app-runtime.outputs.node-bin }}" scripts/vercel-prebuilt.mjs deployment-id --target app --sha "$DEPLOY_SHA" --run-id "$GITHUB_RUN_ID" --run-attempt "$GITHUB_RUN_ATTEMPT")"
+          echo "next_deployment_id=$next_deployment_id" >> "$GITHUB_OUTPUT"
+
+      - name: Build App custom-v3 candidate without deployment
+        if: steps.app-runtime.outcome == 'success'
+        id: app-build
+        env:
+          CI: 1
+          LOGICAL_TARGET: app
+          MENTO_NEXT_DEPLOYMENT_ID: ${{ steps.app-identity.outputs.next_deployment_id }}
+          NEXT_PUBLIC_VERCEL_ENV: preview
+          SENTRY_AUTH_TOKEN: ""
+          TURBO_REMOTE_CACHE_SIGNATURE_KEY: ${{ secrets.TURBO_REMOTE_CACHE_SIGNATURE_KEY }}
+          TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+          TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+          VERCEL: 1
+          VERCEL_ENV: preview
+          VERCEL_GIT_COMMIT_REF: main
+          VERCEL_GIT_COMMIT_SHA: ${{ needs.wait-for-ci.outputs.deploy_sha }}
+          VERCEL_GIT_PROVIDER: github
+          VERCEL_GIT_REPO_OWNER: mento-protocol
+          VERCEL_GIT_REPO_SLUG: frontend-monorepo
+          VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ vars.VERCEL_PROJECT_ID_APP }}
+          VERCEL_TARGET_ENV: v3
+        uses: ./.github/actions/vercel-candidate-build
+        with:
+          controller-path: ${{ github.workspace }}
+          source-path: ${{ github.workspace }}/source
+          runtime-root: ${{ steps.app-runtime.outputs.runtime-root }}
+          isolation-root: ${{ steps.app-runtime.outputs.isolation-root }}
+          runtime-marker: ${{ steps.app-runtime.outputs.runtime-marker }}
+          tools-path: ${{ steps.app-runtime.outputs.tools-path }}
+          build-environment-path: ${{ steps.app-runtime.outputs.build-environment-path }}
+          candidate-source-path: ${{ steps.app-runtime.outputs.candidate-source-path }}
+          candidate-home-path: ${{ steps.app-runtime.outputs.candidate-home-path }}
+          pull-staging-path: ${{ steps.app-runtime.outputs.pull-staging-path }}
+          candidate-identity-marker: ${{ steps.app-runtime.outputs.candidate-identity-marker }}
+          build-log-path: ${{ steps.app-runtime.outputs.build-log-path }}
+          provenance-path: ${{ steps.app-runtime.outputs.provenance-path }}
+          upload-source-path: ${{ steps.app-runtime.outputs.upload-source-path }}
+          node-bin: ${{ steps.app-runtime.outputs.node-bin }}
+          pnpm-bin: ${{ steps.app-runtime.outputs.pnpm-bin }}
+          vercel-cli: ${{ steps.app-runtime.outputs.vercel-cli }}
+          deploy-sha: ${{ needs.wait-for-ci.outputs.deploy_sha }}
+          next-deployment-id: ${{ steps.app-identity.outputs.next_deployment_id }}
+          logical-target: app
+          expected-root-directory: apps/app.mento.org
+          vercel-org-id: ${{ vars.VERCEL_ORG_ID }}
+          vercel-project-id: ${{ vars.VERCEL_PROJECT_ID_APP }}
+
+      - name: Restore fresh trusted transaction controller
+        if: steps.freshness.outputs.status == 'fresh'
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 1
+          path: trusted-coordinator
+          persist-credentials: false
+          ref: ${{ needs.wait-for-ci.outputs.deploy_sha }}
+
+      - name: Record exact App build-only proof
+        if: steps.app-build.outcome == 'success'
+        id: app-proof
+        env:
+          MENTO_NEXT_DEPLOYMENT_ID: ${{ steps.app-identity.outputs.next_deployment_id }}
+        run: >-
+          node trusted-coordinator/scripts/vercel-main-deployment.mjs
+          app-build-proof --output "$RUNNER_TEMP/app-build-proof.json"
+
+      - name: Measure App runner duration
+        if: steps.app-proof.outcome == 'success'
+        id: app-total
+        env:
+          STARTED_AT_MS: ${{ steps.app-timing.outputs.started_at_ms }}
+        run: echo "total_duration_ms=$(($(date +%s%3N) - STARTED_AT_MS))" >> "$GITHUB_OUTPUT"
+
+      - name: Prepare exact immutable transaction journal
+        if: steps.freshness.outputs.status == 'fresh'
+        id: journal
+        env:
+          APP_BUILD_PROOF: ${{ steps.app-proof.outputs.proof }}
+        run: >-
+          node trusted-coordinator/scripts/vercel-main-deployment.mjs
+          prepare-journal --output "$RUNNER_TEMP/main-journal.json"
+
+      - name: Upload prepared transaction journal
+        if: steps.journal.outcome == 'success'
+        id: journal-upload
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ${{ steps.journal.outputs.artifact_name }}
+          path: ${{ runner.temp }}/main-journal.json
+          if-no-files-found: error
+          retention-days: 7
+
+      - name: Exercise shadow transaction and second freshness gate
+        if: steps.journal-upload.outcome == 'success'
+        id: shadow
+        env:
+          APP_BUILD_PROOF: ${{ steps.app-proof.outputs.proof }}
+          JOURNAL_ARTIFACT_ID: ${{ steps.journal-upload.outputs.artifact-id }}
+          JOURNAL_ARTIFACT_NAME: ${{ steps.journal.outputs.artifact_name }}
+        run: >-
+          node trusted-coordinator/scripts/vercel-main-deployment.mjs
+          run-shadow --journal "$RUNNER_TEMP/main-journal.json"
+
+      - name: Measure coordinator runner duration
+        if: ${{ always() }}
+        id: total
+        env:
+          STARTED_AT_MS: ${{ steps.timing.outputs.started_at_ms }}
+        run: echo "total_duration_ms=$(($(date +%s%3N) - STARTED_AT_MS))" >> "$GITHUB_OUTPUT"
+
+      - name: Publish one canonical coordinator outcome
+        if: ${{ always() }}
+        id: outcome
+        env:
+          PLANNING_OUTCOME: ${{ steps.stages.outputs.outcome }}
+          FRESHNESS_STATUS: ${{ steps.freshness.outputs.status }}
+          SHADOW_OUTCOME: ${{ steps.shadow.outputs.outcome }}
+        run: |
+          if [ "$PLANNING_OUTCOME" = "no-target" ]; then
+            echo "outcome=no-target" >> "$GITHUB_OUTPUT"
+          elif [ "$FRESHNESS_STATUS" = "superseded" ]; then
+            echo "outcome=superseded-before-journal" >> "$GITHUB_OUTPUT"
+          elif [ -n "$SHADOW_OUTCOME" ]; then
+            echo "outcome=$SHADOW_OUTCOME" >> "$GITHUB_OUTPUT"
+          else
+            echo "Coordinator did not produce a safe shadow outcome" >&2
+            exit 1
+          fi
+
+      - name: Remove authenticated App runtime
+        if: ${{ always() }}
+        uses: ./.github/actions/vercel-protected-runtime
+        with:
+          operation: cleanup
+          logical-target: app
+
+  recover-main-deployment:
+    name: Verify durable shadow recovery
+    if: ${{ always() }}
+    needs:
+      - wait-for-ci
+      - plan-main-deployments
+      - stage-governance
+      - stage-reserve
+      - stage-ui
+      - activate-and-verify
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment:
+      name: vercel-cli-production
+      deployment: false # trunk-ignore(actionlint/syntax-check): Pinned actionlint has not learned GitHub's deployment key.
+    outputs:
+      outcome: ${{ steps.outcome.outputs.outcome }}
+    env:
+      DEPLOY_SHA: ${{ needs.wait-for-ci.outputs.deploy_sha }}
+      PLAN_JSON: ${{ needs.plan-main-deployments.outputs.plan }}
+    steps:
+      - name: Check out trusted recovery controller
+        if: >-
+          needs.wait-for-ci.result == 'success' &&
+          needs.plan-main-deployments.result == 'success'
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+          ref: ${{ needs.wait-for-ci.outputs.deploy_sha }}
+
+      - name: Derive exact journal name without coordinator outputs
+        if: >-
+          needs.wait-for-ci.result == 'success' &&
+          needs.plan-main-deployments.result == 'success' &&
+          needs.activate-and-verify.outputs.outcome != 'no-target' &&
+          needs.activate-and-verify.outputs.outcome != 'superseded-before-journal'
+        id: journal-name
+        run: node scripts/vercel-main-deployment.mjs journal-name
+
+      - name: Download this attempt's exact prepared journal
+        if: steps.journal-name.outcome == 'success'
+        id: journal-download
+        continue-on-error: true
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: ${{ steps.journal-name.outputs.artifact_name }}
+          path: ${{ runner.temp }}/main-recovery
+
+      - name: Verify shadow recovery from durable journal
+        if: steps.journal-download.outcome == 'success'
+        id: recover
+        run: >-
+          node scripts/vercel-main-deployment.mjs recover-shadow
+          --journal "$RUNNER_TEMP/main-recovery/main-journal.json"
+
+      - name: Publish one canonical recovery outcome
+        if: ${{ always() }}
+        id: outcome
+        env:
+          COORDINATOR_OUTCOME: ${{ needs.activate-and-verify.outputs.outcome }}
+          COORDINATOR_RESULT: ${{ needs.activate-and-verify.result }}
+          DOWNLOAD_OUTCOME: ${{ steps.journal-download.outcome }}
+          RECOVERY_OUTCOME: ${{ steps.recover.outputs.outcome }}
+        run: |
+          if [ "$COORDINATOR_OUTCOME" = "no-target" ] ||
+            [ "$COORDINATOR_OUTCOME" = "superseded-before-journal" ]; then
+            echo "outcome=not-required" >> "$GITHUB_OUTPUT"
+          elif [ "$DOWNLOAD_OUTCOME" = "success" ] &&
+            [ "$RECOVERY_OUTCOME" = "verified-no-mutation" ]; then
+            echo "outcome=verified-no-mutation" >> "$GITHUB_OUTPUT"
+          elif [ "$COORDINATOR_RESULT" != "success" ] &&
+            [ "$DOWNLOAD_OUTCOME" != "success" ]; then
+            echo "outcome=not-found-after-runner-failure" >> "$GITHUB_OUTPUT"
+          else
+            echo "Durable shadow journal was not recovery-verified" >&2
+            exit 1
+          fi
+
+  result:
+    name: Vercel Main Deployment
+    if: ${{ always() }}
+    needs:
+      - wait-for-ci
+      - plan-main-deployments
+      - stage-governance
+      - stage-reserve
+      - stage-ui
+      - activate-and-verify
+      - recover-main-deployment
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Fail when the trusted gate or planner did not succeed
+        if: >-
+          needs.wait-for-ci.result != 'success' ||
+          needs.plan-main-deployments.result != 'success'
+        run: |
+          echo "The exact upstream CI gate or main planner did not succeed" >&2
+          exit 1
+
+      - name: Check out trusted final controller
+        if: >-
+          needs.wait-for-ci.result == 'success' &&
+          needs.plan-main-deployments.result == 'success'
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+          ref: ${{ needs.wait-for-ci.outputs.deploy_sha }}
+
+      - name: Enforce one safe final result
+        if: >-
+          needs.wait-for-ci.result == 'success' &&
+          needs.plan-main-deployments.result == 'success'
+        env:
+          PLAN_JSON: ${{ needs.plan-main-deployments.outputs.plan }}
+          WAIT_FOR_CI_RESULT: ${{ needs.wait-for-ci.result }}
+          PLAN_RESULT: ${{ needs.plan-main-deployments.result }}
+          STAGE_GOVERNANCE_RESULT: ${{ needs.stage-governance.result }}
+          STAGE_RESERVE_RESULT: ${{ needs.stage-reserve.result }}
+          STAGE_UI_RESULT: ${{ needs.stage-ui.result }}
+          COORDINATOR_RESULT: ${{ needs.activate-and-verify.result }}
+          COORDINATOR_OUTCOME: ${{ needs.activate-and-verify.outputs.outcome }}
+          RECOVERY_RESULT: ${{ needs.recover-main-deployment.result }}
+          RECOVERY_OUTCOME: ${{ needs.recover-main-deployment.outputs.outcome }}
+        run: node scripts/vercel-main-deployment.mjs final
+
+      - name: Write canonical redacted PR-A evidence
+        env:
+          PLAN_JSON: ${{ needs.plan-main-deployments.outputs.plan }}
+          EVIDENCE_GOVERNANCE_RESULT: ${{ needs.stage-governance.result }}
+          EVIDENCE_GOVERNANCE_HANDOFF: ${{ needs.stage-governance.outputs.handoff }}
+          EVIDENCE_GOVERNANCE_NEXT_DEPLOYMENT_ID: ${{ needs.stage-governance.outputs.next_deployment_id }}
+          EVIDENCE_GOVERNANCE_BUILD_DURATION_MS: ${{ needs.stage-governance.outputs.build_duration_ms }}
+          EVIDENCE_GOVERNANCE_DEPLOY_DURATION_MS: ${{ needs.stage-governance.outputs.deploy_duration_ms }}
+          EVIDENCE_GOVERNANCE_TOTAL_DURATION_MS: ${{ needs.stage-governance.outputs.total_duration_ms }}
+          EVIDENCE_GOVERNANCE_TURBO_CACHE_HITS: ${{ needs.stage-governance.outputs.turbo_cache_hits }}
+          EVIDENCE_GOVERNANCE_TURBO_CACHE_MISSES: ${{ needs.stage-governance.outputs.turbo_cache_misses }}
+          EVIDENCE_RESERVE_RESULT: ${{ needs.stage-reserve.result }}
+          EVIDENCE_RESERVE_HANDOFF: ${{ needs.stage-reserve.outputs.handoff }}
+          EVIDENCE_RESERVE_NEXT_DEPLOYMENT_ID: ${{ needs.stage-reserve.outputs.next_deployment_id }}
+          EVIDENCE_RESERVE_BUILD_DURATION_MS: ${{ needs.stage-reserve.outputs.build_duration_ms }}
+          EVIDENCE_RESERVE_DEPLOY_DURATION_MS: ${{ needs.stage-reserve.outputs.deploy_duration_ms }}
+          EVIDENCE_RESERVE_TOTAL_DURATION_MS: ${{ needs.stage-reserve.outputs.total_duration_ms }}
+          EVIDENCE_RESERVE_TURBO_CACHE_HITS: ${{ needs.stage-reserve.outputs.turbo_cache_hits }}
+          EVIDENCE_RESERVE_TURBO_CACHE_MISSES: ${{ needs.stage-reserve.outputs.turbo_cache_misses }}
+          EVIDENCE_UI_RESULT: ${{ needs.stage-ui.result }}
+          EVIDENCE_UI_HANDOFF: ${{ needs.stage-ui.outputs.handoff }}
+          EVIDENCE_UI_NEXT_DEPLOYMENT_ID: ${{ needs.stage-ui.outputs.next_deployment_id }}
+          EVIDENCE_UI_BUILD_DURATION_MS: ${{ needs.stage-ui.outputs.build_duration_ms }}
+          EVIDENCE_UI_DEPLOY_DURATION_MS: ${{ needs.stage-ui.outputs.deploy_duration_ms }}
+          EVIDENCE_UI_TOTAL_DURATION_MS: ${{ needs.stage-ui.outputs.total_duration_ms }}
+          EVIDENCE_UI_TURBO_CACHE_HITS: ${{ needs.stage-ui.outputs.turbo_cache_hits }}
+          EVIDENCE_UI_TURBO_CACHE_MISSES: ${{ needs.stage-ui.outputs.turbo_cache_misses }}
+          EVIDENCE_APP_NEXT_DEPLOYMENT_ID: ${{ needs.activate-and-verify.outputs.app_next_deployment_id }}
+          EVIDENCE_APP_BUILD_DURATION_MS: ${{ needs.activate-and-verify.outputs.app_build_duration_ms }}
+          EVIDENCE_APP_TOTAL_DURATION_MS: ${{ needs.activate-and-verify.outputs.app_total_duration_ms }}
+          EVIDENCE_APP_TURBO_CACHE_HITS: ${{ needs.activate-and-verify.outputs.app_turbo_cache_hits }}
+          EVIDENCE_APP_TURBO_CACHE_MISSES: ${{ needs.activate-and-verify.outputs.app_turbo_cache_misses }}
+          COORDINATOR_OUTCOME: ${{ needs.activate-and-verify.outputs.outcome }}
+          COORDINATOR_TOTAL_DURATION_MS: ${{ needs.activate-and-verify.outputs.total_duration_ms }}
+          TRANSACTION_ID: ${{ needs.activate-and-verify.outputs.transaction_id }}
+          JOURNAL_ARTIFACT_NAME: ${{ needs.activate-and-verify.outputs.artifact_name }}
+          JOURNAL_ARTIFACT_ID: ${{ needs.activate-and-verify.outputs.artifact_id }}
+          RECOVERY_OUTCOME: ${{ needs.recover-main-deployment.outputs.outcome }}
+        run: >-
+          node scripts/vercel-main-deployment.mjs evidence
+          --output "$RUNNER_TEMP/vercel-main-evidence.json"
+
+      - name: Upload canonical redacted PR-A evidence
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: vercel-main-evidence-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/vercel-main-evidence.json
+          if-no-files-found: error
+          retention-days: 14

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,27 @@ When adding or renaming an operational workflow, update its static allowlist and
 the structural test in the same PR. Never execute a triggering head SHA from
 this privileged `workflow_run` workflow.
 
+`.github/workflows/vercel-main-deployment.yml` automatically consumes only the
+exact successful `CI/CD` `main` attempt and runs in literal `shadow` mode until
+the separately reviewed production cutover. Its token-free gate must bind the
+event run/attempt, literal `Build and Test` job, workflow definition, checked-out
+source, and `DEPLOY_SHA` before any job can use `vercel-cli-production`.
+Planning starts from each target's actual served SHA. Ambiguous path planning
+selects a target; ambiguous protected state aborts the whole run. Governance,
+Reserve, and UI may stage only with `--prod --skip-domain`; App custom `v3`
+remains build-only. For each ordinary target, the public custom domain is the
+only protected runtime and rollback alias; generated project/team and
+creator-scoped aliases may move during staging and are candidate evidence only.
+Shadow mode must never reach promote, alias, rollback, App deployment,
+ownership-change, or compensating-mutation callbacks. Its only terminal
+coordinator outcomes are `no-target`, `superseded-before-journal`,
+`superseded-after-journal`, and `shadow-prepared`; only the latter two require
+`verified-no-mutation` recovery. The final job writes one canonical redacted
+summary and `vercel-main-evidence-${run_id}-${run_attempt}` artifact. Keep App
+`v2` native and independently verify its exact captured mapping. The PR-A
+canary, PR-B cutover, public runtime proof, journal, recovery, and native-owner
+restoration contract lives in `docs/vercel-deployments.md`.
+
 `.github/workflows/vercel-production-shadow.yml` is manual-only and
 non-promoting. Ordinary uploads implicitly move the target's reviewed generated
 base project/team alias and may also move Vercel's exact creator-scoped alias,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,7 +59,7 @@ pnpm fork:seed:monad                 # Monad sibling of fork:seed (Reserve colla
 pnpm pr:description:test             # Test the required PR-description format validator
 pnpm vercel:deployment-state:test    # Test canonical read-only Vercel state and alias-drift evidence
 pnpm vercel:primitives:test          # Test affected planning, custom deployment IDs, and build-env contracts
-pnpm vercel:workflow:test            # Test the manual prebuilt pilot, REST lifecycle, CLI args, and HTTP/browser smoke
+pnpm vercel:workflow:test            # Test manual and automatic Vercel workflows, exact-main gating, transactions, and smoke
 pnpm vercel:preview:test             # Test preview state plus reusable smoke trust, native-adapter, and Git-ownership boundaries
 pnpm vercel:production-shadow:test   # Test state allowlisting, shadow helpers, and workflow invariants
 pnpm --filter app.mento.org test:production-shadow:routing  # Prove bypass headers do not cross Chromium redirects
@@ -149,6 +149,18 @@ canary, cutover, and rollback contract is in `docs/vercel-deployments.md`.
 Manual staged production URLs use the separate target-aware
 `test:production-shadow` command documented in `docs/vercel-deployments.md`; it
 never enables the mock wallet.
+
+The automatic `.github/workflows/vercel-main-deployment.yml` path runs only
+from the exact successful `CI/CD` attempt for `main`. PR A is literal `shadow`
+mode: Governance, Reserve, and UI may stage and smoke immutable production
+candidates, while App custom `v3` is build-only. Promote, alias, rollback, App
+deployment, recovery mutation, and Vercel Git ownership changes must remain
+unreachable until the separately reviewed PR-B cutover. Planning uses the SHA
+each public target actually serves, and every credential-bearing job uses only
+`vercel-cli-production` with `deployment: false`. The exact-attempt gate,
+journal, canonical redacted evidence artifact, public runtime smoke, App
+real-wallet check, rollback, and native-owner restoration procedures are in
+`docs/vercel-deployments.md`.
 
 ## Coding Conventions
 

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ pnpm vercel:primitives:test
 # Test canonical read-only Vercel state and guarded alias-drift evidence
 pnpm vercel:deployment-state:test
 
-# Test the manual UI prebuilt workflow, GitHub Deployment lifecycle, and smoke controller
+# Test manual and automatic Vercel workflows, exact-main gating, transactions, and smoke
 pnpm vercel:workflow:test
 
 # Test preview state, reusable smoke trust, native-adapter, and Git ownership
@@ -468,14 +468,20 @@ The repository is set up with GitHub Actions for CI:
   post-merge canary gates in [PR #609](https://github.com/mento-protocol/frontend-monorepo/pull/609)
   and [PR #610](https://github.com/mento-protocol/frontend-monorepo/pull/610),
   respectively. Ordinary pull requests therefore have no native Vercel branch
-  preview path. Until the production cutover in
+  preview path. The automatic `Vercel Main Deployment` workflow now runs in
+  literal `shadow` mode to prove exact-attempt gating, served-SHA planning,
+  ordinary-target staging, App custom-`v3` build output, and the transaction
+  recovery handoff.
+  It cannot move a protected domain or change deployment ownership. Vercel Git
+  therefore still owns every public `main` deployment during PR A of
   [issue #522](https://github.com/mento-protocol/frontend-monorepo/issues/522),
-  Vercel Git still owns every `main`/production deployment, including App's
-  `main -> v3` path, and the legacy App `v2 -> production` path remains native;
-  App's custom `v3` deployment semantics are unchanged.
-  The version-controlled controller mode is `active`; per-target ownership and
-  exact expected Vercel configurations are executable invariants. The trusted
-  controller reads every selected target's bounded exact-head Vercel
+  including App's `main -> v3` path. The legacy App
+  `v2 -> production` path remains native. PR B enables activation and disables
+  only the replaced native `main` paths in one separately reviewed change.
+  The version-controlled preview-controller mode is `active`; per-target
+  preview ownership and exact expected Vercel configurations are executable
+  invariants. The trusted preview controller reads every selected target's
+  bounded exact-head Vercel
   configuration and rechecks it before dispatch. An exact native configuration
   suppresses GitHub dispatch only for a target whose canonical ownership mode
   is `github`; unknown or contradictory configuration fails closed.
@@ -509,6 +515,22 @@ The repository is set up with GitHub Actions for CI:
   mutation. Its exact-SHA contract, read-only protected-domain drift checks,
   guarded manual operator recovery, and direct smoke are documented in the same
   runbook.
+
+  `Vercel Main Deployment` starts only after the exact successful `CI/CD`
+  `main` attempt and literal `Build and Test` job. It plans from each target's
+  currently served SHA, so coalesced pushes cannot omit an affected change.
+  Governance, Reserve, and UI stage immutable production candidates with
+  `--prod --skip-domain` and run direct browser smoke. App custom `v3` remains
+  build-only because its upload is activation. The three public custom domains
+  are the ordinary targets' only protected runtime and rollback aliases;
+  generated Vercel aliases are candidate evidence only. A durable redacted
+  journal proves the handoff and recovery decision; PR-A shadow mode
+  structurally forbids promotion, alias assignment, rollback, App deployment,
+  and recovery mutation. The final job writes one canonical redacted step
+  summary and 14-day evidence artifact. See the main-shadow and PR-B sections of
+  [`docs/vercel-deployments.md`](docs/vercel-deployments.md) for the exact
+  operator evidence, public runtime proof, and rollback/native-owner restoration
+  order.
 
 Dependency-installing jobs use `.github/actions/pnpm-install`, which pins the
 Node/pnpm bootstrap, relies on `actions/setup-node` as the single pnpm-store

--- a/apps/app.mento.org/next.config.ts
+++ b/apps/app.mento.org/next.config.ts
@@ -13,6 +13,12 @@ const sentryAuthToken = env.SENTRY_AUTH_TOKEN;
 // Declared in this app's turbo.json so deployment attempts do not invalidate shared-package caches.
 // eslint-disable-next-line turbo/no-undeclared-env-vars
 const deploymentId = process.env.MENTO_NEXT_DEPLOYMENT_ID;
+// Vercel provides this in hosted builds; the main deployment workflow binds it to the exact main SHA.
+// eslint-disable-next-line turbo/no-undeclared-env-vars
+const deploymentSha = process.env.VERCEL_GIT_COMMIT_SHA;
+if (deploymentSha && !/^[a-f0-9]{40}$/i.test(deploymentSha)) {
+  throw new Error("VERCEL_GIT_COMMIT_SHA must be a full commit SHA");
+}
 
 if (uploadSentrySourceMaps && !sentryAuthToken) {
   throw new Error("SENTRY_AUTH_TOKEN is required for production builds");
@@ -91,7 +97,17 @@ const nextConfig: NextConfig = {
     return [
       {
         source: "/:path*",
-        headers: buildSecurityHeaders({ reportOnlyCsp }),
+        headers: [
+          ...buildSecurityHeaders({ reportOnlyCsp }),
+          ...(deploymentSha
+            ? [
+                {
+                  key: "X-Mento-Deployment-Sha",
+                  value: deploymentSha.toLowerCase(),
+                },
+              ]
+            : []),
+        ],
       },
     ];
   },

--- a/apps/app.mento.org/turbo.json
+++ b/apps/app.mento.org/turbo.json
@@ -3,7 +3,12 @@
   "extends": ["//"],
   "tasks": {
     "build": {
-      "env": ["$TURBO_EXTENDS$", "MENTO_NEXT_DEPLOYMENT_ID", "VERCEL_ENV"],
+      "env": [
+        "$TURBO_EXTENDS$",
+        "MENTO_NEXT_DEPLOYMENT_ID",
+        "VERCEL_ENV",
+        "VERCEL_GIT_COMMIT_SHA"
+      ],
       "inputs": ["$TURBO_EXTENDS$", "$TURBO_ROOT$/scripts/security-headers.mjs"]
     }
   }

--- a/docs/adr/0001-github-actions-vercel-deployment-orchestration.md
+++ b/docs/adr/0001-github-actions-vercel-deployment-orchestration.md
@@ -3,14 +3,15 @@ title: GitHub Actions owns Vercel build and deployment orchestration; Vercel rem
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-07-23
+last_verified: 2026-07-24
 scope: ci/deployment
 date: 2026-07
 ---
 
 # ADR 0001 — GitHub Actions owns Vercel build and deployment orchestration; Vercel remains hosting and runtime
 
-**Status:** Accepted (Jul 2026); phased rollout in progress.
+**Status:** Accepted (Jul 2026); previews cut over, automatic main shadow
+rollout in progress, and main activation pending.
 **Scope:** ci/deployment
 
 ## Context
@@ -189,22 +190,24 @@ author, or other extra aliases and fails safely if Vercel changes that
 topology. A `git-*` creator can use the base-only form, but cannot authorize the
 ambiguous author/branch hostname; the same rule reserves `env-*` against
 custom-environment aliases. The ordinary upload implicitly moves those generated
-system aliases, so the
-controller treats staging as a limited public-routing mutation: it rechecks
-current `main`, journals the intended upload, verifies the resulting immutable
-deployment and generated-alias topology, and retains the transaction evidence
-before continuing. The deployments are then promoted sequentially by exact
-immutable deployment ID. The app `v3` prebuilt candidate is built and verified
-under custom-environment semantics before its app-v3 activation mutation, but
-`vercel deploy --prebuilt --target=v3` runs last because that upload is itself
-the activation mutation when attached `v3` domains move. The controller then
-verifies every reviewed alias and assigns only those that do not already point
-to the exact deployment as intended. `--prod` and `vercel promote` are
+system aliases, so the controller treats staging as a limited public-routing
+mutation: it rechecks current `main`, journals the intended upload, verifies the
+resulting immutable deployment and generated-alias topology, and retains the
+transaction evidence before continuing. The deployments are then promoted
+sequentially by exact immutable deployment ID. The app `v3` prebuilt candidate
+is built and verified under custom-environment semantics before its app-v3
+activation mutation, but `vercel deploy --prebuilt --target=v3` runs last
+because that upload is itself the activation mutation when attached `v3`
+domains move. The controller then verifies every reviewed alias and assigns only
+those that do not already point to the exact deployment as intended. The three
+ordinary public custom domains are the only protected runtime and rollback
+aliases; generated project/team and creator-scoped aliases are
+candidate-verification evidence only. `--prod` and `vercel promote` are
 forbidden for the app `main -> v3` path.
 
 Before mutation, the controller records the exact prior deployment and every
-protected alias for every selected target. It journals intent before each
-command and verifies the observed mapping afterward. Stale-main detection,
+protected public alias for every selected target. It journals intent before
+each command and verifies the observed mapping afterward. Stale-main detection,
 failure, cancellation, timeout, or unknown command outcome initiates
 reverse-order compensation to that captured set. Unexpected operator-owned
 mappings stop for manual review rather than being overwritten. The design does
@@ -242,9 +245,27 @@ The current version-controlled preview map assigns App, Governance, Reserve,
 and UI to GitHub Actions. App's configuration change was accepted after its
 exact-head PR #609 and fresh post-merge PR #610 canaries passed, following the
 earlier Governance post-merge canary. Ordinary native branch previews are now
-disabled for every target. Until #522, Vercel Git still owns App's `main -> v3`
-and legacy `v2 -> production` paths as well as every other main/production
-deployment; custom-`v3` semantics do not change in this preview step.
+disabled for every target.
+
+PR A of #522 adds a separate automatic `Vercel Main Deployment` workflow in
+literal `shadow` mode. It authenticates the exact successful upstream CI
+attempt, plans from each target's actual served SHA, stages and browser-smokes
+selected ordinary production candidates, builds selected App custom-`v3`
+output without uploading it, and verifies the durable transaction/recovery
+handoff. Shadow mode structurally cannot promote, deploy App `v3`, assign an
+alias, roll back, run a recovery mutation, or change Vercel Git ownership.
+Vercel Git remains the only public `main` activation owner during this proof.
+The coordinator reports exactly `no-target`, `superseded-before-journal`,
+`superseded-after-journal`, or `shadow-prepared`. A durable journal exists only
+for the latter two outcomes, which require `verified-no-mutation`; the other two
+require `not-required`. After the final sentinel accepts that matrix, the
+workflow writes a canonical redacted job summary and uploads
+`vercel-main-evidence-${run_id}-${run_attempt}` for 14 days.
+
+PR B is the separate reviewed cutover. It enables active mutation and disables
+the replaced native `main` paths in the same commit. App always retains
+`v2: true`; legacy `v2 -> production` remains Vercel-Git-owned and is verified
+independently before and after activation or recovery.
 
 `git.deploymentEnabled` branch rules disable only replaced native paths. The app
 configuration always retains `v2: true`. Outside a bounded shadow canary or
@@ -371,18 +392,18 @@ failure of the hosting/runtime platform.
 
 ### Tracked rollout
 
-Status at decision adoption on 2026-07-15:
+Rollout status reverified on 2026-07-24:
 
 | Issue                                                                  | Responsibility                                                 | Adoption status                                            |
 | ---------------------------------------------------------------------- | -------------------------------------------------------------- | ---------------------------------------------------------- |
 | [#515](https://github.com/mento-protocol/frontend-monorepo/issues/515) | Epic and non-negotiable behavior                               | Open; rollout owner                                        |
 | [#516](https://github.com/mento-protocol/frontend-monorepo/issues/516) | Planner, deployment ID, environment primitives                 | Complete                                                   |
-| [#517](https://github.com/mento-protocol/frontend-monorepo/issues/517) | Maintainer-provisioned credentials and mapping                 | Open                                                       |
-| [#518](https://github.com/mento-protocol/frontend-monorepo/issues/518) | Manual no-cutover UI pilot and cost go/no-go                   | Open; pilot implementation merged, live acceptance pending |
-| [#519](https://github.com/mento-protocol/frontend-monorepo/issues/519) | Automatic UI previews and durable batching                     | Open                                                       |
-| [#520](https://github.com/mento-protocol/frontend-monorepo/issues/520) | App, governance, and reserve preview cutover                   | Open                                                       |
-| [#521](https://github.com/mento-protocol/frontend-monorepo/issues/521) | Main shadow proof and app `v3` semantics                       | Open                                                       |
-| [#522](https://github.com/mento-protocol/frontend-monorepo/issues/522) | Main transaction, cutover, rollback, and app `v2` preservation | Open                                                       |
+| [#517](https://github.com/mento-protocol/frontend-monorepo/issues/517) | Maintainer-provisioned credentials and mapping                 | Complete                                                   |
+| [#518](https://github.com/mento-protocol/frontend-monorepo/issues/518) | Manual no-cutover UI pilot and cost go/no-go                   | Complete                                                   |
+| [#519](https://github.com/mento-protocol/frontend-monorepo/issues/519) | Automatic UI previews and durable batching                     | Complete                                                   |
+| [#520](https://github.com/mento-protocol/frontend-monorepo/issues/520) | App, governance, and reserve preview cutover                   | Complete                                                   |
+| [#521](https://github.com/mento-protocol/frontend-monorepo/issues/521) | Main shadow proof and app `v3` semantics                       | Complete                                                   |
+| [#522](https://github.com/mento-protocol/frontend-monorepo/issues/522) | Main transaction, cutover, rollback, and app `v2` preservation | Open; automatic PR-A shadow proof, then PR-B cutover       |
 | [#523](https://github.com/mento-protocol/frontend-monorepo/issues/523) | Observation, savings proof, and migration cleanup              | Open; analyzer preparation merged, observation not started |
 
 Merged implementation evidence:
@@ -398,6 +419,14 @@ Merged implementation evidence:
 - [PR #528](https://github.com/mento-protocol/frontend-monorepo/pull/528) —
   public-safe cost-analysis tooling in preparation for #523; it does not start
   the observation window.
+- [PR #604](https://github.com/mento-protocol/frontend-monorepo/pull/604) and
+  [PR #609](https://github.com/mento-protocol/frontend-monorepo/pull/609) —
+  final Governance and App preview-ownership cutovers; all four ordinary
+  previews are now GitHub-owned.
+- [PR #616](https://github.com/mento-protocol/frontend-monorepo/pull/616) and
+  [PR #620](https://github.com/mento-protocol/frontend-monorepo/pull/620) —
+  repo-linked Vercel settings validation and isolated production-shadow
+  runtime, completing #521's protected main prerequisites.
 
 Canonical repository evidence:
 
@@ -410,6 +439,10 @@ Canonical repository evidence:
 - `.github/workflows/vercel-prebuilt-pilot.yml` and
   `.github/workflows/_vercel-prebuilt.yml` — merged manual pilot path, not an
   automatic cutover.
+- `.github/workflows/vercel-main-deployment.yml`,
+  `scripts/vercel-main-deployment.mjs`, and the exact-attempt, served-SHA,
+  transaction, and runtime helpers — automatic PR-A main shadow proof and the
+  tested PR-B activation/recovery contract.
 - [`docs/vercel-cost-validation.md`](../vercel-cost-validation.md) — private
   evidence boundary and public aggregate acceptance calculations.
 

--- a/docs/adr/0001-github-actions-vercel-deployment-orchestration.md
+++ b/docs/adr/0001-github-actions-vercel-deployment-orchestration.md
@@ -258,9 +258,11 @@ Vercel Git remains the only public `main` activation owner during this proof.
 The coordinator reports exactly `no-target`, `superseded-before-journal`,
 `superseded-after-journal`, or `shadow-prepared`. A durable journal exists only
 for the latter two outcomes, which require `verified-no-mutation`; the other two
-require `not-required`. After the final sentinel accepts that matrix, the
-workflow writes a canonical redacted job summary and uploads
-`vercel-main-evidence-${run_id}-${run_attempt}` for 14 days.
+require `not-required`. The final job validates that matrix without ending the
+job, writes either the full success evidence or a minimal redacted failure
+graph, uploads
+`vercel-main-evidence-${run_id}-${run_attempt}` for 14 days, and only then
+returns the terminal result.
 
 PR B is the separate reviewed cutover. It enables active mutation and disables
 the replaced native `main` paths in the same commit. App always retains

--- a/docs/dependency-overrides.md
+++ b/docs/dependency-overrides.md
@@ -16,8 +16,9 @@ below).
 
 ## Standalone Vercel CLI override mirror
 
-The protected production-shadow jobs install Vercel from the standalone
-`scripts/vercel-cli-runtime` package instead of the root workspace. Its
+The protected production-shadow and automatic main-deployment jobs install
+Vercel from the standalone `scripts/vercel-cli-runtime` package instead of the
+root workspace. Its
 `pnpm.overrides` object must remain deeply equal to the root
 `package.json` object so the protected CLI receives the same security
 resolutions. Its only dependency must remain the same exact Vercel version as
@@ -29,7 +30,7 @@ runtime in the same PR:
 1. Mirror the root Vercel pin and complete override object into the standalone
    manifest. If the Vercel version changed, also update
    `PINNED_VERCEL_CLI_VERSION` in
-   `scripts/vercel-cli-runtime-contract.mjs`; the production-shadow structural
+   `scripts/vercel-cli-runtime-contract.mjs`; the Vercel workflow structural
    tests identify every remaining reviewed version assertion that must change:
 
    ```bash
@@ -67,6 +68,7 @@ runtime in the same PR:
    ```bash
    pnpm vercel:versions:check
    pnpm vercel:production-shadow:test
+   pnpm vercel:workflow:test
    pnpm supply-chain:lockfile-lint
    ```
 

--- a/docs/vercel-cost-validation.md
+++ b/docs/vercel-cost-validation.md
@@ -6,12 +6,13 @@ not start the observation window, query Vercel or GitHub, change a deployment,
 or remove migration scaffolding. The observation window starts only after the
 four-target preview and PR-B main ownership cutover in issue #522 is complete.
 Automatic PR-A `Vercel Main Deployment` shadow runs are canary evidence, not
-post-cutover observations.
-After its final sentinel succeeds, each shadow run writes a canonical redacted
-job summary and uploads
-`vercel-main-evidence-${run_id}-${run_attempt}` for 14 days. Its build, deploy,
-runner, and Turbo-cache measurements help diagnose the canary, but they remain
-log-duration evidence rather than invoice-grade Build CPU allocation.
+post-cutover observations. Each shadow run writes a canonical redacted job
+summary and uploads
+`vercel-main-evidence-${run_id}-${run_attempt}` for 14 days before returning its
+terminal result. Successful runs contain build, deploy, runner, and Turbo-cache
+measurements; failed runs contain only the redacted failure graph. Successful
+shadow measurements help diagnose the canary, but they remain log-duration
+evidence rather than invoice-grade Build CPU allocation.
 
 The repository provides a deterministic, network-free analyzer:
 

--- a/docs/vercel-cost-validation.md
+++ b/docs/vercel-cost-validation.md
@@ -4,7 +4,14 @@ This runbook prepares the measurement and closeout work tracked in [issue
 #523](https://github.com/mento-protocol/frontend-monorepo/issues/523). It does
 not start the observation window, query Vercel or GitHub, change a deployment,
 or remove migration scaffolding. The observation window starts only after the
-four-target preview and main cutover in issue #522 is complete.
+four-target preview and PR-B main ownership cutover in issue #522 is complete.
+Automatic PR-A `Vercel Main Deployment` shadow runs are canary evidence, not
+post-cutover observations.
+After its final sentinel succeeds, each shadow run writes a canonical redacted
+job summary and uploads
+`vercel-main-evidence-${run_id}-${run_attempt}` for 14 days. Its build, deploy,
+runner, and Turbo-cache measurements help diagnose the canary, but they remain
+log-duration evidence rather than invoice-grade Build CPU allocation.
 
 The repository provides a deterministic, network-free analyzer:
 
@@ -174,12 +181,14 @@ cannot reuse the same provider evidence for its baseline and post-cutover split.
 5. Classify app deployments as migrated PR preview, migrated `main -> v3`,
    preserved native `v2 -> production`, or manual/unknown. Keep v2 visible and
    apply the invoice-grade attribution limitation above.
-6. Build a GitHub Actions census from the final preview and main workflows:
-   standard-runner minutes, larger-runner minutes, artifact and cache GB-hours,
-   queue/build/deploy durations, failures, reruns, and Turbo cache hits/misses.
-   Record whether the repository stayed public for the entire interval. Use the
-   final workflow inventory from #519 and #522 rather than names proposed before
-   those changes merge.
+6. Build a GitHub Actions census from the final preview workflow inventory
+   (`Vercel Preview Intake`, `Vercel Preview Controller`,
+   `Vercel Preview Worker`, and their reusable build/smoke workflows) plus
+   `Vercel Main Deployment`: standard-runner minutes, larger-runner minutes,
+   artifact and cache GB-hours, queue/build/deploy durations, failures, reruns,
+   and Turbo cache hits/misses. Record whether the repository stayed public for
+   the entire interval. Use the final workflow inventory from #519 and #522
+   rather than names proposed before those changes merge.
    Re-check the current [GitHub Actions billing documentation](https://docs.github.com/en/billing/concepts/product-billing/github-actions)
    when closing #523. The analyzer requires a public repository for the whole
    interval and zero larger-runner minutes; it never assumes artifact or cache

--- a/docs/vercel-deployments.md
+++ b/docs/vercel-deployments.md
@@ -211,9 +211,19 @@ that is the canary PR A must prove.
 
 ### PR-A canary and copy-safe diagnostics
 
-After the final sentinel succeeds, the `result` job runs `evidence`, appends one
-canonical redacted report to `$GITHUB_STEP_SUMMARY`, and uploads the exact JSON
-as artifact
+The `result` job evaluates the complete graph without ending the job, then
+writes and uploads one canonical redacted report before it returns the terminal
+result. A safe graph uses schema `vercel-main-evidence:v1`; any failed gate,
+planner, stage, coordinator, recovery, or final validation uses the separate
+`vercel-main-failure-evidence:v1` schema. Failure evidence records only trusted
+run identity, valid SHA values when available, whether planner output existed,
+the literal job-result graph, and the shadow invariant of zero public-serving
+mutation commands. It never parses or embeds an unavailable or malformed plan.
+The job fails only after the failure report is uploaded, so the diagnostic
+artifact survives without weakening the sentinel.
+
+Both paths append their canonical redacted report to `$GITHUB_STEP_SUMMARY` and
+upload the exact JSON as artifact
 `vercel-main-evidence-${run_id}-${run_attempt}` with 14-day retention. Link the
 first merged PR-A run and artifact on issue #522 or its PR; do not embed observed
 IDs in this canonical runbook. The evidence contains only:

--- a/docs/vercel-deployments.md
+++ b/docs/vercel-deployments.md
@@ -185,13 +185,15 @@ The only successful coordinator/recovery pairs are:
 
 For a durable outcome, `recover-main-deployment` derives the exact artifact
 identity with `journal-name` rather than trusting coordinator outputs, downloads
-that attempt's journal, validates its canonical bytes and positive artifact ID,
-and returns `verified-no-mutation`. In PR A, the job cannot execute Vercel
-mutation commands. A coordinator runner failure with no downloadable artifact
-can produce the diagnostic `not-found-after-runner-failure`, but the final
-sentinel never accepts that as successful recovery. `Vercel Main Deployment`
-inspects the literal full graph and fails if a selected build, journal, shadow
-proof, recovery decision, or required skip has an unexpected outcome.
+that attempt's journal, validates its canonical identity and bytes, and returns
+`verified-no-mutation`. The coordinator already required a positive artifact ID
+before it could publish either durable outcome. In PR A, the recovery job cannot
+execute Vercel mutation commands. A coordinator runner failure with no
+downloadable artifact can produce the diagnostic
+`not-found-after-runner-failure`, but the final sentinel never accepts that as
+successful recovery. `Vercel Main Deployment` inspects the literal full graph
+and fails if a selected build, journal, shadow proof, recovery decision, or
+required skip has an unexpected outcome.
 
 These PR-A mutation prohibitions are version-controlled structural invariants:
 

--- a/docs/vercel-deployments.md
+++ b/docs/vercel-deployments.md
@@ -5,18 +5,24 @@ four-target preview controller used by the GitHub Actions deployment migration t
 [issue #515](https://github.com/mento-protocol/frontend-monorepo/issues/515).
 The ownership boundary and its trade-offs are recorded in
 [ADR 0001](adr/0001-github-actions-vercel-deployment-orchestration.md).
-The v2 controller builds App, Governance, Reserve, and UI independently from one
-target-ordered plan. All four ordinary branch-preview paths are GitHub-only;
-App completed the last exact-head and fresh post-merge canary gates in PRs
+The preview v2 controller builds App, Governance, Reserve, and UI independently
+from one target-ordered plan. All four ordinary branch-preview paths are
+GitHub-only. App completed the last exact-head and fresh post-merge canary gates
+in PRs
 [#609](https://github.com/mento-protocol/frontend-monorepo/pull/609) and
 [#610](https://github.com/mento-protocol/frontend-monorepo/pull/610).
-Until the production cutover in
-[#522](https://github.com/mento-protocol/frontend-monorepo/issues/522), Vercel
-Git continues to own every main and production deployment, including App's
-`main -> v3` path, plus the legacy App `v2 -> production` path. App's custom
-`v3` deployment semantics are unchanged.
+The separate automatic `Vercel Main Deployment` workflow now runs its PR-A
+proof in literal `shadow` mode after successful `main` CI. It plans from the
+SHA each public target actually serves, stages and verifies selected ordinary
+targets, builds selected App `v3` output without deploying it, and proves the
+transaction handoff without moving protected domains. Vercel Git therefore
+continues to own every public `main` deployment during PR A, including App's
+`main -> v3` path, while the legacy App `v2 -> production` path remains native.
+PR B of
+[#522](https://github.com/mento-protocol/frontend-monorepo/issues/522) is the
+separate reviewed ownership cutover.
 
-The automatic controller's version-controlled
+The automatic preview controller's version-controlled
 `VERCEL_PREVIEW_CONTROLLER_MODE` is `active` in this ownership state. The only
 other accepted value is `observe-only`, which records receipts, recovers or
 retires already-persisted dispatch ownership, and publishes a truthful
@@ -27,21 +33,344 @@ per-target `shadow` or `github` mode live together in
 guards, and ownership tests import or structurally verify that source; do not
 copy a second ownership table into executable code.
 
-The guarded manual production-shadow pilot does not promote or mutate a
-protected/custom production domain or deployment ownership. Each ordinary
-upload implicitly moves the target's reviewed base generated project/team alias
-and may also move Vercel's exact creator-scoped generated alias.
-Until the later production cutover issues ship, the Vercel Git integration
-remains the protected/custom production deployment owner.
+The guarded manual production-shadow pilot remains an operator tool. Like the
+automatic PR-A shadow path, it does not promote or mutate a protected/custom
+production domain or deployment ownership. Each ordinary upload implicitly
+moves the target's reviewed base generated project/team alias and may also move
+Vercel's exact creator-scoped generated alias.
+
+## Automatic main shadow proof
+
+`.github/workflows/vercel-main-deployment.yml`, named
+`Vercel Main Deployment`, is the automatic PR-A proof for
+[#522](https://github.com/mento-protocol/frontend-monorepo/issues/522). A
+completed successful `CI/CD` push run on `main` starts it through
+`workflow_run`. Its concurrency group keeps an in-progress run and at most one
+pending run; ordering is never trusted for correctness.
+
+The workflow has these literal jobs:
+
+1. `wait-for-ci`;
+2. `plan-main-deployments`;
+3. `stage-governance`;
+4. `stage-reserve`;
+5. `stage-ui`;
+6. `activate-and-verify`;
+7. `recover-main-deployment`;
+8. job ID `result`, whose literal check name is `Vercel Main Deployment`.
+
+The Node controller is `scripts/vercel-main-deployment.mjs`. Its reviewed
+subcommands are `validate-context`, `validate-source`, `create-spec`, `plan`,
+`freshness`, `revalidate-prior`, `app-build-proof`,
+`app-candidate-expectation`, `stage-result`, `validate-stages`,
+`prepare-journal`, `journal-name`, `run-shadow`, `recover-shadow`, `final`, and
+`evidence`. Keep orchestration in YAML and validation, canonicalization,
+journal construction, and outcome decisions in tested Node code.
+`app-candidate-expectation` is reserved for the later active cutover and
+recovery path; the PR-A shadow YAML does not invoke it.
+
+### Exact upstream attempt and source gate
+
+`wait-for-ci` is token-free with respect to Vercel. It sets `DEPLOY_SHA` only
+from `github.event.workflow_run.head_sha` and validates the event plus GitHub
+API record with `scripts/vercel-main-ci-attempt.mjs`. The accepted run must:
+
+- belong to `mento-protocol/frontend-monorepo`;
+- be the completed successful `CI/CD` push workflow at
+  `.github/workflows/ci.yml` on branch `main`;
+- identify the exact event run ID, run attempt, and lowercase 40-character
+  `DEPLOY_SHA`;
+- return exactly one literal `Build and Test` job from the
+  attempt-specific, fully paginated jobs endpoint, and that job must have
+  concluded `success`.
+
+The job then requires `github.workflow_ref` to identify
+`.github/workflows/vercel-main-deployment.yml` on `refs/heads/main`,
+`github.workflow_sha == DEPLOY_SHA`, checked-out `HEAD == DEPLOY_SHA`, and
+`DEPLOY_SHA` reachable from freshly fetched `refs/heads/main`. A mismatched
+workflow definition or superseded definition exits before any Vercel
+environment or credential is available. The gate records only the upstream run
+URL and attempt, exact `Build and Test` job URL, and `DEPLOY_SHA`.
+
+### Served-SHA planning and prior-state handoff
+
+`plan-main-deployments` reads canonical protected state for App, Governance,
+Reserve, UI, and legacy App v2. It requires each reviewed alias set to resolve
+consistently to one expected project, ready deployment, environment, and
+healthy public surface. It also records the exact prior deployment ID, immutable
+URL, aliases, and served Git SHA in one redacted handoff.
+
+For Governance, Reserve, and UI, that protected runtime and rollback mapping
+contains only the literal public custom domain. Generated project/team and
+creator-scoped aliases are not protected aliases or rollback inputs. They are
+candidate-verification evidence because `--prod --skip-domain` necessarily
+moves them.
+
+Planning compares each target's served SHA with `DEPLOY_SHA`; it does not use
+the triggering push's `before` field. Outside the PR-A native-shadow fallback,
+an exact served-SHA match skips that target. Otherwise the repository planner
+evaluates the complete `served SHA..DEPLOY_SHA` range, which accumulates changes
+hidden by coalesced workflow runs. Proven non-runtime changes skip. Missing,
+malformed, non-ancestral, wrong-source, or otherwise ambiguous planning metadata
+selects the affected target so uncertainty cannot suppress a deployment.
+Ambiguous alias ownership, project, environment, prior deployment, health, or
+rollback state aborts the whole transaction because selecting more targets
+cannot make compensation safe.
+
+In shadow mode, native Vercel may already serve `DEPLOY_SHA` before this
+workflow reaches planning. The planner then uses the first parent as the
+comparison base so PR A can still exercise the affected-target path. If it
+cannot resolve that parent safely, it selects the target.
+
+### Credential and build boundary
+
+Every job that can receive `VERCEL_TOKEN_PRODUCTION`, a mirrored build secret,
+or an automation-bypass value declares:
+
+```yaml
+environment:
+  name: vercel-cli-production
+  deployment: false
+```
+
+Never reference the generic `Production` environment. Map the production token
+only as a step-scoped `VERCEL_TOKEN`; never put it in a command argument. Expose
+each mirrored build secret only to the literal target build step that consumes
+it. App `v3` explicitly receives an empty `SENTRY_AUTH_TOKEN`. Missing
+configuration fails by variable name. Automation must never inspect 1Password
+or another credential store.
+
+The three ordinary stage jobs use production build semantics and
+`vercel deploy --prebuilt --prod --skip-domain`. They reuse the protected #521
+candidate UID/runtime boundary, inspect exact deployment state, recheck drift,
+and run the credential-free production-shadow browser smoke against the
+immutable staged URL in the same job. These uploads may move only the reviewed
+generated Vercel system aliases described below. Those aliases are evidence of
+the candidate upload, never runtime-smoke endpoints or rollback mappings. The
+uploads cannot move protected or custom production domains.
+
+App has no stage job because its custom `v3` upload is activation. If App is
+selected, `activate-and-verify` performs `vercel pull` plus the protected
+custom-`v3` build and output validation in place, but stops before
+`vercel deploy --prebuilt --target=v3`. App therefore has no PR-A candidate URL
+or staged runtime smoke.
+
+### Shadow transaction and recovery proof
+
+`activate-and-verify` uses `if: always()` and validates that every selected
+ordinary stage succeeded and every unselected stage skipped. Before App
+preparation or transaction handoff, it performs a bounded remote-`main` check
+and revalidates the captured prior mappings. If `main` advanced before the
+journal, the terminal coordinator outcome is `superseded-before-journal`. No
+journal exists, recovery returns `not-required`, and the retained newer workflow
+run owns convergence.
+
+For a current SHA, the coordinator creates the exact prepared journal bytes and
+canonical artifact name, uploads that single redacted journal with seven-day
+retention, and requires a positive artifact ID before proceeding.
+`run-shadow` then performs a second bounded freshness check. If `main` advanced
+after the upload, it returns `superseded-after-journal`, with recovery-decision
+reason `superseded-before-mutation`. Otherwise it returns `shadow-prepared`
+after verify-only callbacks. It cannot call promotion, public App `v3`
+deployment, alias assignment, rollback, or recovery mutation code.
+
+The only successful coordinator/recovery pairs are:
+
+| Coordinator outcome         | Durable journal | Recovery outcome       |
+| --------------------------- | --------------- | ---------------------- |
+| `no-target`                 | no              | `not-required`         |
+| `superseded-before-journal` | no              | `not-required`         |
+| `superseded-after-journal`  | yes             | `verified-no-mutation` |
+| `shadow-prepared`           | yes             | `verified-no-mutation` |
+
+For a durable outcome, `recover-main-deployment` derives the exact artifact
+identity with `journal-name` rather than trusting coordinator outputs, downloads
+that attempt's journal, validates its canonical bytes and positive artifact ID,
+and returns `verified-no-mutation`. In PR A, the job cannot execute Vercel
+mutation commands. A coordinator runner failure with no downloadable artifact
+can produce the diagnostic `not-found-after-runner-failure`, but the final
+sentinel never accepts that as successful recovery. `Vercel Main Deployment`
+inspects the literal full graph and fails if a selected build, journal, shadow
+proof, recovery decision, or required skip has an unexpected outcome.
+
+These PR-A mutation prohibitions are version-controlled structural invariants:
+
+- no `vercel promote`;
+- no `vercel alias set`;
+- no `vercel rollback`;
+- no `vercel deploy --prebuilt --target=v3`;
+- no protected/custom production-domain movement;
+- no Vercel Git ownership change;
+- no active-mode transaction or compensating-recovery callback.
+
+Ordinary `--prod --skip-domain` staging remains intentionally reachable because
+that is the canary PR A must prove.
+
+### PR-A canary and copy-safe diagnostics
+
+After the final sentinel succeeds, the `result` job runs `evidence`, appends one
+canonical redacted report to `$GITHUB_STEP_SUMMARY`, and uploads the exact JSON
+as artifact
+`vercel-main-evidence-${run_id}-${run_attempt}` with 14-day retention. Link the
+first merged PR-A run and artifact on issue #522 or its PR; do not embed observed
+IDs in this canonical runbook. The evidence contains only:
+
+- downstream workflow run ID, attempt, URL, and exact workflow-definition SHA;
+- upstream run ID/attempt, `Build and Test` URL/conclusion, and `DEPLOY_SHA`;
+- each target's canonical prior deployment ID/URL, public aliases, served SHA,
+  planner range, reason, and selected/skipped outcome;
+- the independently verified legacy App v2 deployment, alias, ref, SHA, state,
+  and health;
+- each selected ordinary staged deployment ID/URL plus canonical state,
+  immutable browser/runtime/security, and protected-mapping results;
+- App build result and validated deterministic Next deployment ID, without a
+  Vercel deployment ID or URL;
+- coordinator outcome; journal name, ID, sequence, status, and transaction ID
+  when durable; and the recovery outcome;
+- both freshness decisions, per-target and coordinator durations, and Turbo
+  cache hits/misses;
+- an empty ordinary rollback-state target set;
+- a zero count for public-serving activation, alias, promotion, rollback, and
+  recovery commands.
+
+Use these copy-safe diagnostics:
+
+```bash
+gh run view <run-id> \
+  --repo mento-protocol/frontend-monorepo \
+  --attempt <run-attempt>
+
+gh run view <run-id> \
+  --repo mento-protocol/frontend-monorepo \
+  --job <failed-job-id> \
+  --log-failed
+```
+
+Copy only the allowlisted summary fields above. Never attach raw GitHub or
+Vercel API bodies, pulled `.env` files, `.vercel/output`, cookies, tokens,
+bypass values, environment dumps, or unreviewed workflow artifacts.
+
+### PR-B ownership cutover and runtime proof
+
+PR B is a separate reviewed change after PR A's automatic shadow canary is
+accepted. It changes the controller from literal `shadow` to `active` and
+changes Vercel Git ownership in the same commit:
+
+- Governance, Reserve, and UI:
+  `git.deploymentEnabled` becomes `{"**": false}`;
+- App: `git.deploymentEnabled` becomes
+  `{"**": false, "v2": true}`.
+
+Do not enable active mode before those exact ownership changes, and do not
+disable native `main` while the workflow remains shadow-only. App `v2` remains
+native in both configurations.
+
+Active mode reuses the prepared transaction and journal identity. It stages and
+verifies Governance, Reserve, and UI, builds App `v3`, then mutates targets
+sequentially from exact immutable IDs. Before every command it uploads a
+`started` journal; after the command it inspects exact public mapping and
+uploads the verified next sequence. Governance, Reserve, and UI use
+`vercel promote <exact-staged-id-or-url>`. App activates last with
+`vercel deploy --prebuilt --target=v3`, then verifies or restores each reviewed
+v3 alias independently. `--prod`, `--skip-domain`, and `vercel promote` remain
+forbidden for App.
+
+After active-mode activation, run the credential-free public smoke for every
+selected target with its literal URL:
+
+| `LOGICAL_TARGET` | `PUBLIC_URL`                    |
+| ---------------- | ------------------------------- |
+| `app`            | `https://app.mento.org/`        |
+| `governance`     | `https://governance.mento.org/` |
+| `reserve`        | `https://reserve.mento.org/`    |
+| `ui`             | `https://ui.mento.org/`         |
+
+```bash
+LOGICAL_TARGET=<app|governance|reserve|ui> \
+PUBLIC_URL=<matching-literal-url-above> \
+DEPLOY_SHA=<lowercase-40-character-sha> \
+node scripts/vercel-main-runtime.mjs
+```
+
+The checker binds `X-Mento-Deployment-Sha` and the required security headers,
+requires successful same-origin document/script/style/font resources, and
+rejects page and console errors, failed critical static resources from any
+origin, and failed same-origin fetch/XHR traffic outside its narrow optional
+telemetry exception. It exercises Governance voting-power navigation, Reserve
+Overview data and Supply state, and UI search, navigation, and checkbox state.
+App uses the real production wallet list: MetaMask and WalletConnect must be
+visible, the E2E Test Wallet must be absent, and no preview/mock-wallet
+local-storage flag may exist.
+
+Record PR-B observed deployment IDs, mappings, mutation sequences, public smoke
+results, native-duplicate proof, and legacy-v2 evidence on PR B or issue #522.
+Do not paste observed IDs into this runbook.
+
+### Exact rollback and native-owner restoration
+
+Recovery always starts from the highest valid journal for the exact repository,
+SHA, run ID, run attempt, and transaction ID. It inspects the current mapping
+before acting. Mapping already at the captured prior is a no-op; mapping at the
+candidate or partially moved is restored in reverse mutation order; an
+unexpected operator-owned mapping stops for manual review.
+
+For each ordinary target that moved, run the journal's exact command:
+
+```text
+vercel rollback <captured-prior-id-or-url>
+```
+
+Then bounded-wait for readiness, inspect every reviewed public custom domain,
+verify the exact captured prior ID, run the public browser smoke, and record
+that the project entered rollback state. Never substitute `latest`.
+
+For App `v3`, restore every reviewed intended alias independently:
+
+```text
+vercel alias set <captured-prior-v3-immutable-url> <reviewed-v3-alias>
+```
+
+Verify every alias, then independently prove that `v2-app.mento.org` still maps
+to its captured ready production deployment with repository
+`mento-protocol/frontend-monorepo`, ref `v2`, and the captured legacy SHA. The
+normal transaction never stages, deploys, promotes, or aliases legacy v2.
+Emergency legacy restoration may point only its reviewed alias to that exact
+captured legacy deployment.
+
+If GitHub activation must remain disabled after an incident, restore one owner
+in this order:
+
+1. In one reviewed recovery PR, set the controller back to literal `shadow` and
+   restore native `main` configuration together:
+   Governance/Reserve/UI use `{"**": false, "main": true}`; App uses
+   `{"**": false, "main": true, "v2": true}`.
+2. Keep the automatic workflow enabled only in shadow mode. Prove its exact CI
+   gate, planning, staging, and no-mutation result while native Vercel owns
+   public `main`.
+3. For an ordinary project in rollback state, capture the recovery PR's exact
+   unaliased native deployment and run
+   `vercel promote <exact-native-canary-id-or-url>` to exit rollback state.
+4. Verify that exact canary on the public domain with deployment state and
+   browser smoke.
+5. Push a second reviewed target-local canary and prove native Vercel Git moves
+   the domain automatically.
+6. Only then retire the GitHub path for that target or leave it explicitly in
+   shadow mode.
+7. Verify App `main -> v3` and `v2 -> production` independently. Never use App
+   production or `--prod` for `main`.
+
+Restoring only `vercel.json` is insufficient after `vercel rollback`; the exact
+promote/canary sequence proves native automatic ownership has resumed.
 
 ## Pinned prerequisites
 
 - Vercel CLI: exactly `56.2.0` in the root `devDependencies` and the standalone
   `scripts/vercel-cli-runtime/package.json` dependency. The root dependency
-  remains available for reviewed operator commands; protected production-shadow
-  jobs install only the standalone runtime. The project owner approved the
-  dependency as part of delivering the epic. The stable npm version was
-  re-queried on 2026-07-14 before it was pinned.
+  remains available for reviewed operator commands; protected
+  production-shadow and main-deployment jobs install only the standalone
+  runtime. The project owner approved the dependency as part of delivering the
+  epic. The stable npm version was re-queried on 2026-07-14 before it was
+  pinned.
 - Resolved Next.js: `16.2.11` in `pnpm-lock.yaml`.
 
 Both exceed Vercel's custom deployment-ID prerequisites: Next.js newer than
@@ -191,8 +520,8 @@ unverified artifact, or pass an invented deployment-ID option to
 
 Vercel system variables are injected on Vercel's builders, but a local
 `vercel build` used for a prebuilt deployment does not receive those platform
-values automatically. The future workflow must restore the following safe
-constants before validating and building:
+values automatically. GitHub-built preview, production-shadow, and main
+workflows restore the following safe constants before validating and building:
 
 | Deployment environment | `VERCEL_ENV` | `VERCEL_TARGET_ENV` | `NEXT_PUBLIC_VERCEL_ENV` |
 | ---------------------- | ------------ | ------------------- | ------------------------ |
@@ -325,13 +654,16 @@ prerequisite.
 
 The following Vercel build-value mirrors come from issue #517:
 
+- `vercel-cli-production` environment secret `VERCEL_TOKEN_PRODUCTION`: the
+  production-scoped Vercel credential used only as step-scoped
+  `VERCEL_TOKEN`. It is separately revocable from the preview credential.
 - Repository secret `ETHERSCAN_API_KEY`: governance trusted previews only.
 - `vercel-cli-production` environment secret `ETHERSCAN_API_KEY`: governance
   production build step only.
 - `vercel-cli-production` environment secret `SENTRY_AUTH_TOKEN`: expose only
-  to the governance or reserve production build step that consumes it. If app
-  production is ever migrated separately, scope it to that app step as well.
-- Standard previews and app `v3`: no `SENTRY_AUTH_TOKEN`.
+  to the governance or reserve production build step that consumes it.
+- Standard previews and App custom `v3`: no `SENTRY_AUTH_TOKEN`; the automatic
+  main App build sets it explicitly to the empty string.
 
 The automatic preview controller additionally requires repository Actions
 secret `GH_PREVIEW_WORKFLOW_DISPATCH_TOKEN`. Create a fine-grained GitHub
@@ -726,10 +1058,13 @@ all target/environment classifications, canonical alias mappings, guarded
 rollback evidence, exclusive private-file output, and redaction-safe
 missing-variable and API-error handling. The production-shadow command adds
 canonical Vercel state fixtures, read-only protected mapping failures, workflow
-structure, and direct runtime-smoke structure. Those commands are offline and
-do not contact or mutate Vercel. The separate routing regression starts two
-loopback origins and the Playwright-pinned Chromium to prove a cross-origin
-redirect cannot inherit a protection header.
+structure, and direct runtime-smoke structure. `vercel:workflow:test` also
+covers exact-attempt main CI, served-SHA planning, state discovery,
+transaction/recovery, public runtime, controller, and automatic-workflow
+structure. Those commands are offline and do not contact or mutate Vercel. The
+separate routing
+regression starts two loopback origins and the Playwright-pinned Chromium to
+prove a cross-origin redirect cannot inherit a protection header.
 
 The test commands above perform no Vercel API call, build upload, deployment,
 alias mutation, environment-configuration mutation, or Git-ownership change. The
@@ -2030,8 +2365,9 @@ did not edit a Vercel project configuration. In the initial ownership map,
 GitHub Actions was the sole automatic branch-preview owner for `ui`; `app`,
 `governance`, and `reserve` remained in shadow mode so their native Vercel and
 GitHub-built previews ran together. All four ordinary preview paths are now
-GitHub-owned. Main and production deployments remain native for every target
-until #522, and App `v2` remains native throughout this epic.
+GitHub-owned. Public main deployments remain native during #522's automatic
+PR-A shadow proof; PR B replaces only those native `main` paths. App `v2`
+remains native throughout this epic.
 
 After the v2 bootstrap, the rollout exercised one runtime-affecting PR per
 target before a single PR that affects multiple targets. For every canary, it

--- a/docs/vercel-deployments.md
+++ b/docs/vercel-deployments.md
@@ -185,11 +185,12 @@ The only successful coordinator/recovery pairs are:
 
 For a durable outcome, `recover-main-deployment` derives the exact artifact
 identity with `journal-name` rather than trusting coordinator outputs, downloads
-that attempt's journal, validates its canonical identity and bytes, and returns
-`verified-no-mutation`. The coordinator already required a positive artifact ID
-before it could publish either durable outcome. In PR A, the recovery job cannot
-execute Vercel mutation commands. A coordinator runner failure with no
-downloadable artifact can produce the diagnostic
+that attempt's journal, validates its canonical schema, identity, and history,
+and returns `verified-no-mutation`. The coordinator already validated the exact
+uploaded bytes and required a positive artifact ID before it could publish
+either durable outcome. In PR A, the recovery job cannot execute Vercel mutation
+commands. A coordinator runner failure with no downloadable artifact can
+produce the diagnostic
 `not-found-after-runner-failure`, but the final sentinel never accepts that as
 successful recovery. `Vercel Main Deployment` inspects the literal full graph
 and fails if a selected build, journal, shadow proof, recovery decision, or

--- a/docs/wallet-testing.md
+++ b/docs/wallet-testing.md
@@ -286,6 +286,40 @@ the mock wallet and is not a replacement for the team-preview smoke above. See
 gates around it, including the independent Vercel state check that proves the
 exact repository, ref, and SHA before browser smoke starts.
 
+After the separately reviewed main activation, public-domain verification uses
+the credential-free main runtime smoke:
+
+```bash
+LOGICAL_TARGET=app \
+PUBLIC_URL=https://app.mento.org/ \
+DEPLOY_SHA=<lowercase-40-character-sha> \
+node scripts/vercel-main-runtime.mjs
+```
+
+Use the corresponding literal reviewed URL for `governance`, `reserve`, or
+`ui`; arbitrary URLs are rejected. The smoke binds the public response's exact
+`X-Mento-Deployment-Sha` and required security headers, observes successful
+same-origin document/script/style/font loads, rejects browser and console
+errors, failed critical static resources from any origin, and failed
+same-origin fetch/XHR traffic outside its narrow optional telemetry exception.
+It also performs one target-specific safe interaction.
+
+For Governance, Reserve, and UI, these literal public custom domains are the
+only protected runtime and rollback aliases. Generated Vercel aliases are
+candidate-verification evidence, not public-smoke or rollback endpoints.
+
+The App path is deliberately different from preview smoke. It first proves
+that `mento_e2e_wallet`, `mento_e2e_eager_connect`, and `mento_use_fork` are
+absent from local storage, then opens the real production wallet list. MetaMask
+and WalletConnect must be visible and the E2E Test Wallet must be absent. Never
+set a mock-wallet or fork flag to make a public production smoke pass.
+
+PR-A main shadow mode does not call this public smoke because Vercel Git still
+owns the public domains; it uses immutable production-shadow smoke for staged
+Governance, Reserve, and UI candidates and keeps App `v3` build-only. PR B runs
+the public smoke after each exact activation. The full transaction and recovery
+order is in `docs/vercel-deployments.md`.
+
 ## Activation flags
 
 Two equivalent activation paths. Env vars are read at build/dev-server start;

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "vercel:primitives:test": "node --test scripts/plan-vercel-deployments.test.mjs scripts/vercel-build-environment.test.mjs scripts/vercel-prebuilt.test.mjs",
     "vercel:production-shadow:test": "node --test scripts/vercel-deployment-state.test.mjs scripts/vercel-production-shadow.test.mjs scripts/vercel-production-shadow-workflow.test.mjs",
     "vercel:versions:check": "node scripts/vercel-prebuilt.mjs check-versions",
-    "vercel:workflow:test": "node --test scripts/github-deployment.test.mjs scripts/vercel-prebuilt-workflow.test.mjs scripts/vercel-prebuilt-workflows.test.mjs apps/ui.mento.org/e2e/vercel-preview-browser-smoke.test.mjs"
+    "vercel:workflow:test": "node --test scripts/github-deployment.test.mjs scripts/vercel-prebuilt-workflow.test.mjs scripts/vercel-prebuilt-workflows.test.mjs scripts/vercel-main-ci-attempt.test.mjs scripts/vercel-main-plan.test.mjs scripts/vercel-main-transaction.test.mjs scripts/vercel-main-runtime.test.mjs scripts/vercel-main-deployment.test.mjs scripts/vercel-main-deployment-workflow.test.mjs apps/ui.mento.org/e2e/vercel-preview-browser-smoke.test.mjs"
   },
   "devDependencies": {
     "@eslint/js": "catalog:",

--- a/scripts/ci-failure-issue.mjs
+++ b/scripts/ci-failure-issue.mjs
@@ -1,4 +1,9 @@
-const TRACKED_EVENTS = new Set(["push", "schedule", "workflow_dispatch"]);
+const TRACKED_EVENTS = new Set([
+  "push",
+  "schedule",
+  "workflow_dispatch",
+  "workflow_run",
+]);
 const FAILURE_CONCLUSIONS = new Set([
   "action_required",
   "failure",
@@ -7,6 +12,7 @@ const FAILURE_CONCLUSIONS = new Set([
 ]);
 const NOTIFIER_WORKFLOW_NAME = "CI Failure Notifier";
 const TAG_PUSH_WORKFLOW_NAMES = new Set(["Publish UI Package"]);
+const OPERATIONAL_WORKFLOW_RUN_NAMES = new Set(["Vercel Main Deployment"]);
 
 function runPosition(run) {
   return [run.run_number ?? 0, run.run_attempt ?? 1];
@@ -80,7 +86,7 @@ function recoveryBody(existingBody, run, targetRef) {
   ].join("\n");
 }
 
-function isRelevantRun(run, defaultBranch) {
+function isRelevantRun(run, defaultBranch, repositoryFullName) {
   const isOperationalPush =
     run.event === "push" &&
     (run.head_branch === defaultBranch ||
@@ -88,7 +94,11 @@ function isRelevantRun(run, defaultBranch) {
   const isOperationalRun =
     run.event === "schedule" ||
     isOperationalPush ||
-    (run.event === "workflow_dispatch" && run.head_branch === defaultBranch);
+    (run.event === "workflow_dispatch" && run.head_branch === defaultBranch) ||
+    (run.event === "workflow_run" &&
+      OPERATIONAL_WORKFLOW_RUN_NAMES.has(run.name) &&
+      run.head_branch === defaultBranch &&
+      run.head_repository?.full_name === repositoryFullName);
 
   return (
     TRACKED_EVENTS.has(run.event) &&
@@ -148,13 +158,18 @@ async function listCompletedWorkflowRuns(
   return runs;
 }
 
-function findLatestDecisiveRun(runs, defaultBranch, partition) {
+function findLatestDecisiveRun(
+  runs,
+  defaultBranch,
+  repositoryFullName,
+  partition,
+) {
   const seen = new Set();
 
   return runs
     .filter(
       (candidate) =>
-        isRelevantRun(candidate, defaultBranch) &&
+        isRelevantRun(candidate, defaultBranch, repositoryFullName) &&
         isDecisiveRun(candidate) &&
         partitionIdentity(candidate, defaultBranch) === partition,
     )
@@ -171,8 +186,13 @@ export async function reconcileCiFailureIssue({ github, context, core }) {
   const run = context.payload.workflow_run;
   const defaultBranch = context.payload.repository.default_branch;
   const repo = context.repo;
+  const repositoryFullName = `${repo.owner}/${repo.repo}`;
 
-  if (!run || !defaultBranch || !isRelevantRun(run, defaultBranch)) {
+  if (
+    !run ||
+    !defaultBranch ||
+    !isRelevantRun(run, defaultBranch, repositoryFullName)
+  ) {
     core?.info(
       "Ignoring a non-default-branch or non-operational workflow run.",
     );
@@ -194,6 +214,7 @@ export async function reconcileCiFailureIssue({ github, context, core }) {
   const effectiveRun = findLatestDecisiveRun(
     [run, ...completedRuns],
     defaultBranch,
+    repositoryFullName,
     partition,
   );
   if (!effectiveRun) {

--- a/scripts/ci-failure-issue.test.mjs
+++ b/scripts/ci-failure-issue.test.mjs
@@ -18,11 +18,22 @@ function workflowRun(overrides = {}) {
     html_url:
       "https://github.com/mento-protocol/frontend-monorepo/actions/runs/1234",
     head_branch: "main",
+    head_repository: {
+      full_name: "mento-protocol/frontend-monorepo",
+    },
     event: "push",
     status: "completed",
     conclusion: "failure",
     ...overrides,
   };
+}
+
+function mainDeploymentRun(overrides = {}) {
+  return workflowRun({
+    name: "Vercel Main Deployment",
+    event: "workflow_run",
+    ...overrides,
+  });
 }
 
 function managedIssue(overrides = {}) {
@@ -306,6 +317,87 @@ test("exposes the manual trigger in the incident title", async () => {
     calls.create[0].title,
     "CI: Quality Budgets is failing (main; workflow_dispatch)",
   );
+});
+
+test("opens and updates the managed main-deployment workflow_run issue", async () => {
+  const firstFailure = mainDeploymentRun({ run_number: 30 });
+  const openedHarness = harness({ run: firstFailure });
+  const opened = await reconcileCiFailureIssue(openedHarness);
+  assert.deepEqual(opened, { action: "opened", issueNumber: 91 });
+  assert.equal(
+    openedHarness.calls.create[0].title,
+    "CI: Vercel Main Deployment is failing (main; workflow_run)",
+  );
+  assert.match(
+    openedHarness.calls.create[0].body,
+    /managed-ci-failure:77:workflow_run:main/,
+  );
+
+  const repeatedFailure = mainDeploymentRun({ run_number: 31 });
+  const existing = managedIssue({
+    body: `failure\n\n${managedMarker("workflow_run")}`,
+  });
+  const updatedHarness = harness({
+    run: repeatedFailure,
+    issues: [existing],
+  });
+  const updated = await reconcileCiFailureIssue(updatedHarness);
+  assert.deepEqual(updated, { action: "updated", issueNumber: 42 });
+  assert.equal(updatedHarness.calls.update[0].state, "open");
+  assert.match(updatedHarness.calls.update[0].body, /run #31/);
+});
+
+test("a later main-deployment workflow_run success closes only its partition", async () => {
+  const success = mainDeploymentRun({
+    conclusion: "success",
+    run_number: 32,
+  });
+  const existing = managedIssue({
+    body: `failure\n\n${managedMarker("workflow_run")}`,
+  });
+  const { github, context, calls } = harness({
+    run: success,
+    issues: [existing],
+  });
+  const result = await reconcileCiFailureIssue({ github, context });
+  assert.deepEqual(result, { action: "closed", issueNumber: 42 });
+  assert.equal(calls.update[0].state, "closed");
+  assert.match(calls.update[0].body, /run #32/);
+});
+
+test("workflow_run monitoring rejects unrelated workflows, wrong branches, and forks", async () => {
+  for (const run of [
+    workflowRun({ event: "workflow_run", name: "Quality Budgets" }),
+    mainDeploymentRun({ head_branch: "feature/example" }),
+    mainDeploymentRun({
+      head_repository: { full_name: "contributor/frontend-monorepo" },
+    }),
+  ]) {
+    const { github, context, calls } = harness({ run });
+    const result = await reconcileCiFailureIssue({ github, context });
+    assert.deepEqual(result, { action: "ignored", reason: "untracked-run" });
+    assert.equal(calls.listRuns, 0);
+    assert.equal(calls.listIssues, 0);
+  }
+});
+
+test("a cross-event success cannot close a workflow_run failure", async () => {
+  const pushSuccess = workflowRun({
+    name: "Vercel Main Deployment",
+    event: "push",
+    conclusion: "success",
+    run_number: 33,
+  });
+  const existing = managedIssue({
+    body: `failure\n\n${managedMarker("workflow_run")}`,
+  });
+  const { github, context, calls } = harness({
+    run: pushSuccess,
+    issues: [existing],
+  });
+  const result = await reconcileCiFailureIssue({ github, context });
+  assert.deepEqual(result, { action: "ignored", reason: "nothing-to-close" });
+  assert.equal(calls.update.length, 0);
 });
 
 test("a manual success does not close a scheduled failure issue", async () => {

--- a/scripts/fixtures/vercel-main-ci-attempt/negative-scenarios.json
+++ b/scripts/fixtures/vercel-main-ci-attempt/negative-scenarios.json
@@ -1,0 +1,54 @@
+{
+  "duplicate-sentinel": {
+    "target": "jobs",
+    "property": "name",
+    "value": "Build and Test"
+  },
+  "missing-sentinel": {
+    "target": "sentinel",
+    "property": "name",
+    "value": "Release sentinel"
+  },
+  "wrong-workflow-path": {
+    "target": "event-and-run",
+    "property": "path",
+    "value": ".github/workflows/not-ci.yml"
+  },
+  "wrong-repository": {
+    "target": "event-and-run-repositories",
+    "property": "full_name",
+    "value": "attacker/frontend-monorepo"
+  },
+  "wrong-sha": {
+    "target": "event-and-run",
+    "property": "head_sha",
+    "value": "ffffffffffffffffffffffffffffffffffffffff"
+  },
+  "wrong-branch": {
+    "target": "event-and-run-and-jobs",
+    "property": "head_branch",
+    "value": "feature"
+  },
+  "wrong-event": {
+    "target": "event-and-run",
+    "property": "event",
+    "value": "pull_request"
+  },
+  "wrong-conclusion": {
+    "target": "event-and-run",
+    "property": "conclusion",
+    "value": "cancelled"
+  },
+  "api-failure": {
+    "fault": "http-500"
+  },
+  "timeout": {
+    "fault": "timeout"
+  },
+  "cancellation": {
+    "fault": "abort"
+  },
+  "malformed-response": {
+    "fault": "invalid-json"
+  }
+}

--- a/scripts/fixtures/vercel-main-ci-attempt/pagination.json
+++ b/scripts/fixtures/vercel-main-ci-attempt/pagination.json
@@ -1,0 +1,13 @@
+{
+  "base": "success-first-attempt.json",
+  "job_pages": [
+    {
+      "job_indexes": [0],
+      "total_count": 2
+    },
+    {
+      "job_indexes": [1],
+      "total_count": 2
+    }
+  ]
+}

--- a/scripts/fixtures/vercel-main-ci-attempt/prior-attempt-confusion.json
+++ b/scripts/fixtures/vercel-main-ci-attempt/prior-attempt-confusion.json
@@ -1,0 +1,9 @@
+{
+  "base": "success-rerun-attempt.json",
+  "job_overrides": {
+    "run_attempt": 1,
+    "id": 90000000004,
+    "url": "https://api.github.com/repos/mento-protocol/frontend-monorepo/actions/jobs/90000000004",
+    "html_url": "https://github.com/mento-protocol/frontend-monorepo/actions/runs/40000000002/job/90000000004"
+  }
+}

--- a/scripts/fixtures/vercel-main-ci-attempt/success-first-attempt.json
+++ b/scripts/fixtures/vercel-main-ci-attempt/success-first-attempt.json
@@ -1,0 +1,81 @@
+{
+  "event": {
+    "action": "completed",
+    "repository": {
+      "full_name": "mento-protocol/frontend-monorepo"
+    },
+    "workflow_run": {
+      "id": 40000000001,
+      "run_attempt": 1,
+      "name": "CI/CD",
+      "path": ".github/workflows/ci.yml",
+      "event": "push",
+      "head_branch": "main",
+      "head_sha": "0123456789abcdef0123456789abcdef01234567",
+      "status": "completed",
+      "conclusion": "success",
+      "repository": {
+        "full_name": "mento-protocol/frontend-monorepo"
+      },
+      "head_repository": {
+        "full_name": "mento-protocol/frontend-monorepo"
+      },
+      "url": "https://api.github.com/repos/mento-protocol/frontend-monorepo/actions/runs/40000000001",
+      "html_url": "https://github.com/mento-protocol/frontend-monorepo/actions/runs/40000000001"
+    }
+  },
+  "run": {
+    "id": 40000000001,
+    "run_attempt": 1,
+    "name": "CI/CD",
+    "path": ".github/workflows/ci.yml",
+    "event": "push",
+    "head_branch": "main",
+    "head_sha": "0123456789abcdef0123456789abcdef01234567",
+    "status": "completed",
+    "conclusion": "success",
+    "repository": {
+      "full_name": "mento-protocol/frontend-monorepo"
+    },
+    "head_repository": {
+      "full_name": "mento-protocol/frontend-monorepo"
+    },
+    "url": "https://api.github.com/repos/mento-protocol/frontend-monorepo/actions/runs/40000000001",
+    "html_url": "https://github.com/mento-protocol/frontend-monorepo/actions/runs/40000000001"
+  },
+  "job_pages": [
+    {
+      "total_count": 2,
+      "jobs": [
+        {
+          "id": 90000000001,
+          "run_id": 40000000001,
+          "run_attempt": 1,
+          "workflow_name": "CI/CD",
+          "head_branch": "main",
+          "head_sha": "0123456789abcdef0123456789abcdef01234567",
+          "name": "Build",
+          "run_url": "https://api.github.com/repos/mento-protocol/frontend-monorepo/actions/runs/40000000001",
+          "url": "https://api.github.com/repos/mento-protocol/frontend-monorepo/actions/jobs/90000000001",
+          "html_url": "https://github.com/mento-protocol/frontend-monorepo/actions/runs/40000000001/job/90000000001",
+          "status": "completed",
+          "conclusion": "success"
+        },
+        {
+          "id": 90000000002,
+          "run_id": 40000000001,
+          "run_attempt": 1,
+          "workflow_name": "CI/CD",
+          "head_branch": "main",
+          "head_sha": "0123456789abcdef0123456789abcdef01234567",
+          "name": "Build and Test",
+          "run_url": "https://api.github.com/repos/mento-protocol/frontend-monorepo/actions/runs/40000000001",
+          "url": "https://api.github.com/repos/mento-protocol/frontend-monorepo/actions/jobs/90000000002",
+          "html_url": "https://github.com/mento-protocol/frontend-monorepo/actions/runs/40000000001/job/90000000002",
+          "status": "completed",
+          "conclusion": "success"
+        }
+      ]
+    }
+  ]
+}

--- a/scripts/fixtures/vercel-main-ci-attempt/success-rerun-attempt.json
+++ b/scripts/fixtures/vercel-main-ci-attempt/success-rerun-attempt.json
@@ -1,0 +1,67 @@
+{
+  "event": {
+    "action": "completed",
+    "repository": {
+      "full_name": "mento-protocol/frontend-monorepo"
+    },
+    "workflow_run": {
+      "id": 40000000002,
+      "run_attempt": 2,
+      "name": "CI/CD",
+      "path": ".github/workflows/ci.yml",
+      "event": "push",
+      "head_branch": "main",
+      "head_sha": "123456789abcdef0123456789abcdef012345678",
+      "status": "completed",
+      "conclusion": "success",
+      "repository": {
+        "full_name": "mento-protocol/frontend-monorepo"
+      },
+      "head_repository": {
+        "full_name": "mento-protocol/frontend-monorepo"
+      },
+      "url": "https://api.github.com/repos/mento-protocol/frontend-monorepo/actions/runs/40000000002",
+      "html_url": "https://github.com/mento-protocol/frontend-monorepo/actions/runs/40000000002"
+    }
+  },
+  "run": {
+    "id": 40000000002,
+    "run_attempt": 2,
+    "name": "CI/CD",
+    "path": ".github/workflows/ci.yml",
+    "event": "push",
+    "head_branch": "main",
+    "head_sha": "123456789abcdef0123456789abcdef012345678",
+    "status": "completed",
+    "conclusion": "success",
+    "repository": {
+      "full_name": "mento-protocol/frontend-monorepo"
+    },
+    "head_repository": {
+      "full_name": "mento-protocol/frontend-monorepo"
+    },
+    "url": "https://api.github.com/repos/mento-protocol/frontend-monorepo/actions/runs/40000000002",
+    "html_url": "https://github.com/mento-protocol/frontend-monorepo/actions/runs/40000000002"
+  },
+  "job_pages": [
+    {
+      "total_count": 1,
+      "jobs": [
+        {
+          "id": 90000000003,
+          "run_id": 40000000002,
+          "run_attempt": 2,
+          "workflow_name": "CI/CD",
+          "head_branch": "main",
+          "head_sha": "123456789abcdef0123456789abcdef012345678",
+          "name": "Build and Test",
+          "run_url": "https://api.github.com/repos/mento-protocol/frontend-monorepo/actions/runs/40000000002",
+          "url": "https://api.github.com/repos/mento-protocol/frontend-monorepo/actions/jobs/90000000003",
+          "html_url": "https://github.com/mento-protocol/frontend-monorepo/actions/runs/40000000002/job/90000000003",
+          "status": "completed",
+          "conclusion": "success"
+        }
+      ]
+    }
+  ]
+}

--- a/scripts/fixtures/vercel-main-plan/valid-priors.json
+++ b/scripts/fixtures/vercel-main-plan/valid-priors.json
@@ -79,27 +79,6 @@
             "governance.mento.org",
             "governancementoorg-mentolabs.vercel.app"
           ]
-        },
-        {
-          "alias": "governancementoorg-mentolabs.vercel.app",
-          "deploymentId": "dpl_governanceB123",
-          "deploymentUrl": "https://governance-main-b.vercel.app",
-          "creatorUsername": "fixture-author",
-          "projectId": "prj_governance123",
-          "projectName": "governance.mento.org",
-          "readyState": "READY",
-          "target": "production",
-          "customEnvironmentSlug": null,
-          "git": {
-            "org": "mento-protocol",
-            "repo": "frontend-monorepo",
-            "ref": "main",
-            "sha": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
-          },
-          "aliases": [
-            "governance.mento.org",
-            "governancementoorg-mentolabs.vercel.app"
-          ]
         }
       ]
     },
@@ -126,27 +105,6 @@
             "reserve.mento.org",
             "reservementoorg-mentolabs.vercel.app"
           ]
-        },
-        {
-          "alias": "reservementoorg-mentolabs.vercel.app",
-          "deploymentId": "dpl_reserveB123",
-          "deploymentUrl": "https://reserve-main-b.vercel.app",
-          "creatorUsername": "fixture-author",
-          "projectId": "prj_reserve123",
-          "projectName": "reserve.mento.org",
-          "readyState": "READY",
-          "target": "production",
-          "customEnvironmentSlug": null,
-          "git": {
-            "org": "mento-protocol",
-            "repo": "frontend-monorepo",
-            "ref": "main",
-            "sha": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
-          },
-          "aliases": [
-            "reserve.mento.org",
-            "reservementoorg-mentolabs.vercel.app"
-          ]
         }
       ]
     },
@@ -155,24 +113,6 @@
       "states": [
         {
           "alias": "ui.mento.org",
-          "deploymentId": "dpl_uiC123",
-          "deploymentUrl": "https://ui-main-c.vercel.app",
-          "creatorUsername": "fixture-author",
-          "projectId": "prj_ui123",
-          "projectName": "ui.mento.org",
-          "readyState": "READY",
-          "target": "production",
-          "customEnvironmentSlug": null,
-          "git": {
-            "org": "mento-protocol",
-            "repo": "frontend-monorepo",
-            "ref": "main",
-            "sha": "cccccccccccccccccccccccccccccccccccccccc"
-          },
-          "aliases": ["ui.mento.org", "uimentoorg-mentolabs.vercel.app"]
-        },
-        {
-          "alias": "uimentoorg-mentolabs.vercel.app",
           "deploymentId": "dpl_uiC123",
           "deploymentUrl": "https://ui-main-c.vercel.app",
           "creatorUsername": "fixture-author",

--- a/scripts/fixtures/vercel-main-plan/valid-priors.json
+++ b/scripts/fixtures/vercel-main-plan/valid-priors.json
@@ -1,0 +1,195 @@
+{
+  "mode": "shadow",
+  "deploySha": "dddddddddddddddddddddddddddddddddddddddd",
+  "firstParent": "cccccccccccccccccccccccccccccccccccccccc",
+  "projectIds": {
+    "app": "prj_app123",
+    "governance": "prj_governance123",
+    "reserve": "prj_reserve123",
+    "ui": "prj_ui123"
+  },
+  "priorStates": {
+    "app": {
+      "health": "passed",
+      "states": [
+        {
+          "alias": "app.mento.org",
+          "deploymentId": "dpl_appA123",
+          "deploymentUrl": "https://app-main-a.vercel.app",
+          "creatorUsername": "fixture-author",
+          "projectId": "prj_app123",
+          "projectName": "app.mento.org",
+          "readyState": "READY",
+          "target": null,
+          "customEnvironmentSlug": "v3",
+          "git": {
+            "org": "mento-protocol",
+            "repo": "frontend-monorepo",
+            "ref": "main",
+            "sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+          },
+          "aliases": [
+            "app.mento.org",
+            "appmentoorg-env-v3-mentolabs.vercel.app"
+          ]
+        },
+        {
+          "alias": "appmentoorg-env-v3-mentolabs.vercel.app",
+          "deploymentId": "dpl_appA123",
+          "deploymentUrl": "https://app-main-a.vercel.app",
+          "creatorUsername": "fixture-author",
+          "projectId": "prj_app123",
+          "projectName": "app.mento.org",
+          "readyState": "READY",
+          "target": null,
+          "customEnvironmentSlug": "v3",
+          "git": {
+            "org": "mento-protocol",
+            "repo": "frontend-monorepo",
+            "ref": "main",
+            "sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+          },
+          "aliases": [
+            "app.mento.org",
+            "appmentoorg-env-v3-mentolabs.vercel.app"
+          ]
+        }
+      ]
+    },
+    "governance": {
+      "health": "passed",
+      "states": [
+        {
+          "alias": "governance.mento.org",
+          "deploymentId": "dpl_governanceB123",
+          "deploymentUrl": "https://governance-main-b.vercel.app",
+          "creatorUsername": "fixture-author",
+          "projectId": "prj_governance123",
+          "projectName": "governance.mento.org",
+          "readyState": "READY",
+          "target": "production",
+          "customEnvironmentSlug": null,
+          "git": {
+            "org": "mento-protocol",
+            "repo": "frontend-monorepo",
+            "ref": "main",
+            "sha": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+          },
+          "aliases": [
+            "governance.mento.org",
+            "governancementoorg-mentolabs.vercel.app"
+          ]
+        },
+        {
+          "alias": "governancementoorg-mentolabs.vercel.app",
+          "deploymentId": "dpl_governanceB123",
+          "deploymentUrl": "https://governance-main-b.vercel.app",
+          "creatorUsername": "fixture-author",
+          "projectId": "prj_governance123",
+          "projectName": "governance.mento.org",
+          "readyState": "READY",
+          "target": "production",
+          "customEnvironmentSlug": null,
+          "git": {
+            "org": "mento-protocol",
+            "repo": "frontend-monorepo",
+            "ref": "main",
+            "sha": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+          },
+          "aliases": [
+            "governance.mento.org",
+            "governancementoorg-mentolabs.vercel.app"
+          ]
+        }
+      ]
+    },
+    "reserve": {
+      "health": "passed",
+      "states": [
+        {
+          "alias": "reserve.mento.org",
+          "deploymentId": "dpl_reserveB123",
+          "deploymentUrl": "https://reserve-main-b.vercel.app",
+          "creatorUsername": "fixture-author",
+          "projectId": "prj_reserve123",
+          "projectName": "reserve.mento.org",
+          "readyState": "READY",
+          "target": "production",
+          "customEnvironmentSlug": null,
+          "git": {
+            "org": "mento-protocol",
+            "repo": "frontend-monorepo",
+            "ref": "main",
+            "sha": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+          },
+          "aliases": [
+            "reserve.mento.org",
+            "reservementoorg-mentolabs.vercel.app"
+          ]
+        },
+        {
+          "alias": "reservementoorg-mentolabs.vercel.app",
+          "deploymentId": "dpl_reserveB123",
+          "deploymentUrl": "https://reserve-main-b.vercel.app",
+          "creatorUsername": "fixture-author",
+          "projectId": "prj_reserve123",
+          "projectName": "reserve.mento.org",
+          "readyState": "READY",
+          "target": "production",
+          "customEnvironmentSlug": null,
+          "git": {
+            "org": "mento-protocol",
+            "repo": "frontend-monorepo",
+            "ref": "main",
+            "sha": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+          },
+          "aliases": [
+            "reserve.mento.org",
+            "reservementoorg-mentolabs.vercel.app"
+          ]
+        }
+      ]
+    },
+    "ui": {
+      "health": "passed",
+      "states": [
+        {
+          "alias": "ui.mento.org",
+          "deploymentId": "dpl_uiC123",
+          "deploymentUrl": "https://ui-main-c.vercel.app",
+          "creatorUsername": "fixture-author",
+          "projectId": "prj_ui123",
+          "projectName": "ui.mento.org",
+          "readyState": "READY",
+          "target": "production",
+          "customEnvironmentSlug": null,
+          "git": {
+            "org": "mento-protocol",
+            "repo": "frontend-monorepo",
+            "ref": "main",
+            "sha": "cccccccccccccccccccccccccccccccccccccccc"
+          },
+          "aliases": ["ui.mento.org", "uimentoorg-mentolabs.vercel.app"]
+        },
+        {
+          "alias": "uimentoorg-mentolabs.vercel.app",
+          "deploymentId": "dpl_uiC123",
+          "deploymentUrl": "https://ui-main-c.vercel.app",
+          "creatorUsername": "fixture-author",
+          "projectId": "prj_ui123",
+          "projectName": "ui.mento.org",
+          "readyState": "READY",
+          "target": "production",
+          "customEnvironmentSlug": null,
+          "git": {
+            "org": "mento-protocol",
+            "repo": "frontend-monorepo",
+            "ref": "main",
+            "sha": "cccccccccccccccccccccccccccccccccccccccc"
+          },
+          "aliases": ["ui.mento.org", "uimentoorg-mentolabs.vercel.app"]
+        }
+      ]
+    }
+  }
+}

--- a/scripts/fixtures/vercel-main-transaction/prepared-shadow.json
+++ b/scripts/fixtures/vercel-main-transaction/prepared-shadow.json
@@ -1,0 +1,79 @@
+{
+  "schema": 1,
+  "repository": "mento-protocol/frontend-monorepo",
+  "deploySha": "0123456789abcdef0123456789abcdef01234567",
+  "runId": "987654321",
+  "runAttempt": "2",
+  "transactionId": "main-6cddb358375c408df694966a3b498246",
+  "mode": "shadow",
+  "sequence": 0,
+  "status": "prepared",
+  "prior": {
+    "app": {
+      "deploymentId": "dpl_appPrior123",
+      "deploymentUrl": "https://app-prior.vercel.app",
+      "aliases": ["app.mento.org", "appmentoorg-env-v3-mentolabs.vercel.app"]
+    },
+    "governance": {
+      "deploymentId": "dpl_governancePrior123",
+      "deploymentUrl": "https://governance-prior.vercel.app",
+      "aliases": [
+        "governance.mento.org",
+        "governancementoorg-mentolabs.vercel.app"
+      ]
+    },
+    "reserve": {
+      "deploymentId": "dpl_reservePrior123",
+      "deploymentUrl": "https://reserve-prior.vercel.app",
+      "aliases": ["reserve.mento.org", "reservementoorg-mentolabs.vercel.app"]
+    },
+    "ui": {
+      "deploymentId": "dpl_uiPrior123",
+      "deploymentUrl": "https://ui-prior.vercel.app",
+      "aliases": ["ui.mento.org", "uimentoorg-mentolabs.vercel.app"]
+    },
+    "legacy-app": {
+      "deploymentId": "dpl_legacyPrior123",
+      "deploymentUrl": "https://legacy-prior.vercel.app",
+      "aliases": ["v2-app.mento.org"]
+    }
+  },
+  "candidates": {
+    "app": {
+      "deploymentId": null,
+      "deploymentUrl": null,
+      "aliases": ["app.mento.org", "appmentoorg-env-v3-mentolabs.vercel.app"],
+      "discovery": {
+        "projectId": "prj_app123",
+        "projectName": "app.mento.org",
+        "deploySha": "0123456789abcdef0123456789abcdef01234567",
+        "runId": "987654321",
+        "runAttempt": "2",
+        "transactionId": "main-6cddb358375c408df694966a3b498246",
+        "customEnvironmentSlug": "v3"
+      }
+    },
+    "governance": {
+      "deploymentId": "dpl_governanceCandidate123",
+      "deploymentUrl": "https://governance-candidate.vercel.app",
+      "aliases": [
+        "governance.mento.org",
+        "governancementoorg-mentolabs.vercel.app"
+      ],
+      "discovery": null
+    },
+    "reserve": {
+      "deploymentId": "dpl_reserveCandidate123",
+      "deploymentUrl": "https://reserve-candidate.vercel.app",
+      "aliases": ["reserve.mento.org", "reservementoorg-mentolabs.vercel.app"],
+      "discovery": null
+    },
+    "ui": {
+      "deploymentId": "dpl_uiCandidate123",
+      "deploymentUrl": "https://ui-candidate.vercel.app",
+      "aliases": ["ui.mento.org", "uimentoorg-mentolabs.vercel.app"],
+      "discovery": null
+    }
+  },
+  "operations": []
+}

--- a/scripts/fixtures/vercel-main-transaction/prepared-shadow.json
+++ b/scripts/fixtures/vercel-main-transaction/prepared-shadow.json
@@ -17,20 +17,17 @@
     "governance": {
       "deploymentId": "dpl_governancePrior123",
       "deploymentUrl": "https://governance-prior.vercel.app",
-      "aliases": [
-        "governance.mento.org",
-        "governancementoorg-mentolabs.vercel.app"
-      ]
+      "aliases": ["governance.mento.org"]
     },
     "reserve": {
       "deploymentId": "dpl_reservePrior123",
       "deploymentUrl": "https://reserve-prior.vercel.app",
-      "aliases": ["reserve.mento.org", "reservementoorg-mentolabs.vercel.app"]
+      "aliases": ["reserve.mento.org"]
     },
     "ui": {
       "deploymentId": "dpl_uiPrior123",
       "deploymentUrl": "https://ui-prior.vercel.app",
-      "aliases": ["ui.mento.org", "uimentoorg-mentolabs.vercel.app"]
+      "aliases": ["ui.mento.org"]
     },
     "legacy-app": {
       "deploymentId": "dpl_legacyPrior123",
@@ -56,22 +53,19 @@
     "governance": {
       "deploymentId": "dpl_governanceCandidate123",
       "deploymentUrl": "https://governance-candidate.vercel.app",
-      "aliases": [
-        "governance.mento.org",
-        "governancementoorg-mentolabs.vercel.app"
-      ],
+      "aliases": ["governance.mento.org"],
       "discovery": null
     },
     "reserve": {
       "deploymentId": "dpl_reserveCandidate123",
       "deploymentUrl": "https://reserve-candidate.vercel.app",
-      "aliases": ["reserve.mento.org", "reservementoorg-mentolabs.vercel.app"],
+      "aliases": ["reserve.mento.org"],
       "discovery": null
     },
     "ui": {
       "deploymentId": "dpl_uiCandidate123",
       "deploymentUrl": "https://ui-candidate.vercel.app",
-      "aliases": ["ui.mento.org", "uimentoorg-mentolabs.vercel.app"],
+      "aliases": ["ui.mento.org"],
       "discovery": null
     }
   },

--- a/scripts/quality-workflows.test.mjs
+++ b/scripts/quality-workflows.test.mjs
@@ -159,6 +159,7 @@ test("the notifier is loop-safe, secretless, and least privilege", () => {
     ".github/workflows/quality-budgets.yml",
     ".github/workflows/scorecard.yml",
     ".github/workflows/supply-chain.yml",
+    ".github/workflows/vercel-main-deployment.yml",
     ".github/workflows/vercel-production-shadow.yml",
     ".github/workflows/visual.yml",
   ].map((path) => /^name: (.+)$/m.exec(read(path))?.[1]);
@@ -167,6 +168,7 @@ test("the notifier is loop-safe, secretless, and least privilege", () => {
   assert.match(workflow, /^ {2}workflow_run:$/m);
   assert.match(workflow, /^ {6}- Quality Budgets$/m);
   assert.match(workflow, /^ {6}- Supply Chain$/m);
+  assert.match(workflow, /^ {6}- Vercel Main Deployment$/m);
   assert.match(workflow, /^ {6}- Vercel Production Shadow$/m);
   assert.ok(
     monitoredNames.every(Boolean),
@@ -190,6 +192,16 @@ test("the notifier is loop-safe, secretless, and least privilege", () => {
     workflow,
     /^ {4}concurrency:\n {6}group: ci-failure-\$\{\{ github\.event\.workflow_run\.workflow_id \}\}\n {6}cancel-in-progress: false$/m,
   );
+  const handledEvents =
+    /contains\(fromJSON\('(\[[^']+\])'\), github\.event\.workflow_run\.event\)/.exec(
+      workflow,
+    )?.[1];
+  assert.deepEqual(JSON.parse(handledEvents ?? "[]"), [
+    "push",
+    "schedule",
+    "workflow_dispatch",
+    "workflow_run",
+  ]);
   const handledConclusions =
     /contains\(fromJSON\('(\[[^']+\])'\), github\.event\.workflow_run\.conclusion\)/.exec(
       workflow,
@@ -204,6 +216,10 @@ test("the notifier is loop-safe, secretless, and least privilege", () => {
   assert.match(workflow, /^ {6}actions: read$/m);
   assert.match(workflow, /^ {6}issues: write$/m);
   assert.match(workflow, /workflow_run\.name == 'Publish UI Package'/);
+  assert.match(
+    workflow,
+    /workflow_run\.event == 'workflow_run' &&\n {10}github\.event\.workflow_run\.name == 'Vercel Main Deployment' &&\n {10}github\.event\.workflow_run\.head_branch == github\.event\.repository\.default_branch &&\n {10}github\.event\.workflow_run\.head_repository\.full_name == github\.repository/,
+  );
   assert.match(
     workflow,
     /workflow_run\.event == 'schedule' \|\|\n {8}\(\n {10}github\.event\.workflow_run\.event == 'push'/,

--- a/scripts/vercel-deployment-state.mjs
+++ b/scripts/vercel-deployment-state.mjs
@@ -70,6 +70,17 @@ const CLI_OPTIONS = Object.freeze({
   project: Object.freeze(["project-id", "project-name", "root-directory"]),
   snapshot: Object.freeze(["spec", "output"]),
 });
+const APP_CANDIDATE_PENDING_STATES = new Set([
+  "BUILDING",
+  "INITIALIZING",
+  "QUEUED",
+]);
+
+function sleep(milliseconds) {
+  return new Promise((resolvePromise) => {
+    setTimeout(resolvePromise, milliseconds);
+  });
+}
 
 class CanonicalDriftError extends Error {}
 
@@ -976,27 +987,64 @@ export class VercelStateClient {
     throw new Error("App candidate pagination exceeded its bounded limit");
   }
 
-  async discoverAppTransactionCandidate(expected) {
+  async discoverAppTransactionCandidate(
+    expected,
+    {
+      maximumAttempts = 6,
+      sleepImplementation = sleep,
+      stabilizationDelayMs = 2_000,
+    } = {},
+  ) {
     const expectation = canonicalAppTransactionExpectation(expected);
-    const ids = await this.listAppTransactionDeploymentIds(expectation);
-    const matches = [];
-    for (const id of ids) {
-      const deploymentResponse = await this.requestWithRetry(
-        `/v13/deployments/${encodeURIComponent(id)}?withGitRepoInfo=true`,
-      );
-      matches.push(
+    if (
+      !Number.isSafeInteger(maximumAttempts) ||
+      maximumAttempts < 1 ||
+      maximumAttempts > 10 ||
+      typeof sleepImplementation !== "function" ||
+      !Number.isSafeInteger(stabilizationDelayMs) ||
+      stabilizationDelayMs < 0 ||
+      stabilizationDelayMs > 10_000
+    ) {
+      throw new Error("App candidate stabilization limits are malformed");
+    }
+    for (let attempt = 1; attempt <= maximumAttempts; attempt += 1) {
+      const ids = await this.listAppTransactionDeploymentIds(expectation);
+      if (ids.length > 1) {
+        throw new Error(
+          `App transaction candidate discovery requires exactly one match; received ${ids.length}`,
+        );
+      }
+      if (ids.length === 1) {
+        const deploymentResponse = await this.requestWithRetry(
+          `/v13/deployments/${encodeURIComponent(ids[0])}?withGitRepoInfo=true`,
+        );
+        const readyState = consistentString("readiness", [
+          deploymentResponse?.readyState,
+        ]);
+        if (readyState === "READY") {
+          return canonicalizeAppTransactionCandidate({
+            deploymentResponse,
+            expected: expectation,
+          });
+        }
+        if (!APP_CANDIDATE_PENDING_STATES.has(readyState)) {
+          throw new Error("App transaction candidate did not become READY");
+        }
         canonicalizeAppTransactionCandidate({
-          deploymentResponse,
+          deploymentResponse: {
+            ...deploymentResponse,
+            readyState: "READY",
+          },
           expected: expectation,
-        }),
-      );
+        });
+      }
+      if (attempt < maximumAttempts) {
+        await sleepImplementation(stabilizationDelayMs);
+      }
     }
-    if (matches.length !== 1) {
-      throw new Error(
-        `App transaction candidate discovery requires exactly one match; received ${matches.length}`,
-      );
-    }
-    return matches[0];
+    throw new Error(
+      "App transaction candidate did not stabilize within the bounded window",
+    );
   }
 
   async canonicalAliasState(spec) {

--- a/scripts/vercel-deployment-state.mjs
+++ b/scripts/vercel-deployment-state.mjs
@@ -35,12 +35,38 @@ export const CANONICAL_STATE_KEYS = Object.freeze([
   "aliases",
 ]);
 
+export const MAIN_PLANNING_SNAPSHOT_SCHEMA = "vercel-main-planning-snapshot:v1";
+export const MAIN_PLANNING_SNAPSHOT_KEYS = Object.freeze(["schema", "states"]);
+
 const CANONICAL_GIT_KEYS = ["org", "repo", "ref", "sha"];
+const APP_TRANSACTION_CANDIDATE_KEYS = Object.freeze([
+  "deploymentId",
+  "deploymentUrl",
+  "projectId",
+  "projectName",
+  "deploySha",
+  "runId",
+  "runAttempt",
+  "transactionId",
+  "customEnvironmentSlug",
+]);
+const APP_TRANSACTION_EXPECTATION_KEYS = Object.freeze([
+  "projectId",
+  "projectName",
+  "deploySha",
+  "runId",
+  "runAttempt",
+  "transactionId",
+  "customEnvironmentSlug",
+  "nextDeploymentId",
+]);
 const CREATOR_USERNAME_PATTERN =
   /^(?=.{1,63}$)[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/;
 const CLI_OPTIONS = Object.freeze({
+  "app-candidate": Object.freeze(["expected", "output"]),
   compare: Object.freeze(["before", "after"]),
   deployment: Object.freeze(["expected", "output"]),
+  "planning-snapshot": Object.freeze(["spec", "output"]),
   project: Object.freeze(["project-id", "project-name", "root-directory"]),
   snapshot: Object.freeze(["spec", "output"]),
 });
@@ -184,6 +210,65 @@ function canonicalizeGit(raw) {
   };
 }
 
+function planningGitCandidates(raw) {
+  const meta = raw.meta ?? {};
+  const gitSource = raw.gitSource ?? {};
+  const gitRepo = raw.gitRepo ?? raw.gitRepository ?? {};
+  return {
+    org: [
+      meta.githubCommitOrg,
+      gitSource.org,
+      gitSource.owner,
+      gitRepo.org,
+      gitRepo.owner,
+      gitRepo.namespace,
+    ],
+    repo: [
+      meta.githubCommitRepo,
+      gitSource.repo,
+      gitSource.repoSlug,
+      gitRepo.repo,
+      gitRepo.name,
+    ],
+    ref: [meta.githubCommitRef, gitSource.ref, gitRepo.ref],
+    sha: [meta.githubCommitSha, gitSource.sha, gitRepo.sha],
+  };
+}
+
+function canonicalizeMainPlanningGit(raw) {
+  const candidates = planningGitCandidates(raw);
+  const supplied = Object.values(candidates).flatMap((values) =>
+    values.filter((value) => value !== undefined && value !== null),
+  );
+  if (supplied.length === 0) return null;
+  const canonical = {};
+  for (const key of CANONICAL_GIT_KEYS) {
+    const values = candidates[key].filter(
+      (value) => value !== undefined && value !== null,
+    );
+    if (
+      values.length === 0 ||
+      values.some((value) => typeof value !== "string" || value.length === 0)
+    ) {
+      return {};
+    }
+    const distinct = [...new Set(values)];
+    if (distinct.length !== 1) return {};
+    canonical[key] = distinct[0];
+  }
+  if (!SHA_PATTERN.test(canonical.sha)) return {};
+  if (
+    !/^[A-Za-z0-9._-]+$/.test(canonical.org) ||
+    !/^[A-Za-z0-9._-]+$/.test(canonical.repo) ||
+    !/^[A-Za-z0-9._/-]+$/.test(canonical.ref) ||
+    canonical.ref.includes("..")
+  ) {
+    return {};
+  }
+  canonical.sha = canonical.sha.toLowerCase();
+  return canonical;
+}
+
 function assertExpected(actual, expected, label) {
   if (expected !== undefined && actual !== expected) {
     throw new Error(`Unexpected deployment ${label}`);
@@ -195,6 +280,147 @@ function canonicalizeRunTransaction(value) {
     /^[1-9][0-9]*-[1-9][0-9]*-(?:governance|reserve|ui)$/.test(value)
     ? value
     : null;
+}
+
+function canonicalAppTransactionExpectation(value) {
+  assertExactKeys(
+    value,
+    APP_TRANSACTION_EXPECTATION_KEYS,
+    "App transaction candidate expectation",
+  );
+  const canonical = {
+    projectId: requireIdentifier(value.projectId, "App project ID"),
+    projectName: requireIdentifier(value.projectName, "App project name"),
+    deploySha: requireIdentifier(
+      value.deploySha,
+      "App deploy SHA",
+    ).toLowerCase(),
+    runId: requireIdentifier(String(value.runId), "App run ID"),
+    runAttempt: requireIdentifier(String(value.runAttempt), "App run attempt"),
+    transactionId: requireIdentifier(value.transactionId, "App transaction ID"),
+    customEnvironmentSlug: value.customEnvironmentSlug,
+    nextDeploymentId: requireIdentifier(
+      value.nextDeploymentId,
+      "App custom Next deployment ID",
+    ),
+  };
+  if (
+    canonical.projectName !== "app.mento.org" ||
+    !SHA_PATTERN.test(canonical.deploySha) ||
+    !/^[1-9][0-9]*$/.test(canonical.runId) ||
+    !/^[1-9][0-9]*$/.test(canonical.runAttempt) ||
+    !/^main-[a-f0-9]{32}$/.test(canonical.transactionId) ||
+    canonical.customEnvironmentSlug !== "v3" ||
+    canonical.nextDeploymentId.length > 32 ||
+    canonical.nextDeploymentId.startsWith("dpl_") ||
+    !/^[A-Za-z0-9_-]+$/.test(canonical.nextDeploymentId)
+  ) {
+    throw new Error("App transaction candidate expectation is malformed");
+  }
+  return canonical;
+}
+
+export function canonicalizeAppTransactionCandidate({
+  deploymentResponse,
+  expected,
+}) {
+  if (
+    !deploymentResponse ||
+    typeof deploymentResponse !== "object" ||
+    Array.isArray(deploymentResponse)
+  ) {
+    throw new Error("App transaction candidate response is malformed");
+  }
+  const expectation = canonicalAppTransactionExpectation(expected);
+  const deploymentId = requireIdentifier(
+    deploymentResponse.id,
+    "App candidate deployment ID",
+  );
+  if (!deploymentId.startsWith("dpl_")) {
+    throw new Error("App candidate deployment ID is malformed");
+  }
+  const deploymentUrl = canonicalizeDeploymentUrl(deploymentResponse.url);
+  const projectId = consistentString("project ID", [
+    deploymentResponse.projectId,
+    deploymentResponse.project?.id,
+  ]);
+  const projectName = consistentString("project name", [
+    deploymentResponse.name,
+    deploymentResponse.project?.name,
+  ]);
+  const readyState = consistentString("readiness", [
+    deploymentResponse.readyState,
+  ]);
+  const git = canonicalizeGit(deploymentResponse);
+  const target = deploymentResponse.target ?? null;
+  const customEnvironmentSlug =
+    deploymentResponse.customEnvironment?.slug ?? null;
+  const meta = deploymentResponse.meta;
+  if (!meta || typeof meta !== "object" || Array.isArray(meta)) {
+    throw new Error("App transaction candidate metadata is malformed");
+  }
+  const runId = meta.mentoRunId;
+  const runAttempt = meta.mentoRunAttempt;
+  const transactionId = meta.mentoTransactionId;
+  const nextDeploymentId = meta.mentoNextDeploymentId;
+  if (
+    projectId !== expectation.projectId ||
+    projectName !== expectation.projectName ||
+    readyState !== "READY" ||
+    target !== null ||
+    customEnvironmentSlug !== expectation.customEnvironmentSlug ||
+    git.org !== "mento-protocol" ||
+    git.repo !== "frontend-monorepo" ||
+    git.ref !== "main" ||
+    git.sha !== expectation.deploySha ||
+    runId !== expectation.runId ||
+    runAttempt !== expectation.runAttempt ||
+    transactionId !== expectation.transactionId ||
+    nextDeploymentId !== expectation.nextDeploymentId
+  ) {
+    throw new Error("App transaction candidate identity does not match");
+  }
+  const result = {
+    deploymentId,
+    deploymentUrl,
+    projectId,
+    projectName,
+    deploySha: git.sha,
+    runId,
+    runAttempt,
+    transactionId,
+    customEnvironmentSlug,
+  };
+  return assertAppTransactionCandidateOutput(result);
+}
+
+export function assertAppTransactionCandidateOutput(value) {
+  assertExactKeys(
+    value,
+    APP_TRANSACTION_CANDIDATE_KEYS,
+    "App transaction candidate",
+  );
+  if (
+    typeof value.deploymentId !== "string" ||
+    !/^dpl_[A-Za-z0-9]+$/.test(value.deploymentId) ||
+    canonicalizeDeploymentUrl(value.deploymentUrl) !== value.deploymentUrl ||
+    typeof value.projectId !== "string" ||
+    !/^[A-Za-z0-9._-]+$/.test(value.projectId) ||
+    value.projectName !== "app.mento.org" ||
+    typeof value.deploySha !== "string" ||
+    !SHA_PATTERN.test(value.deploySha) ||
+    value.deploySha !== value.deploySha.toLowerCase() ||
+    typeof value.runId !== "string" ||
+    !/^[1-9][0-9]*$/.test(value.runId) ||
+    typeof value.runAttempt !== "string" ||
+    !/^[1-9][0-9]*$/.test(value.runAttempt) ||
+    typeof value.transactionId !== "string" ||
+    !/^main-[a-f0-9]{32}$/.test(value.transactionId) ||
+    value.customEnvironmentSlug !== "v3"
+  ) {
+    throw new Error("App transaction candidate output is malformed");
+  }
+  return value;
 }
 
 export function canonicalizeAliasMapping({
@@ -331,6 +557,107 @@ export function canonicalizeDeploymentState({
   };
 }
 
+export function canonicalizeMainPlanningDeploymentState({
+  alias,
+  aliasResponse,
+  deploymentResponse,
+  aliasesResponse,
+  expected = {},
+}) {
+  if (
+    !deploymentResponse ||
+    typeof deploymentResponse !== "object" ||
+    Array.isArray(deploymentResponse)
+  ) {
+    throw new Error("Deployment response is malformed");
+  }
+  const canonicalAlias = canonicalizeHostname(
+    alias ?? aliasResponse?.alias ?? deploymentResponse.url,
+  );
+  const deploymentId = consistentString("ID", [
+    deploymentResponse.id,
+    aliasResponse?.deploymentId,
+    aliasResponse?.deployment?.id,
+  ]);
+  const deploymentUrl = canonicalizeDeploymentUrl(deploymentResponse.url);
+  const creatorUsername = canonicalizeCreatorUsername(deploymentResponse);
+  const projectId = consistentString("project ID", [
+    deploymentResponse.projectId,
+    deploymentResponse.project?.id,
+    aliasResponse?.projectId,
+  ]);
+  const projectName = consistentString("project name", [
+    deploymentResponse.name,
+    deploymentResponse.project?.name,
+  ]);
+  const readyState = consistentString("readiness", [
+    deploymentResponse.readyState,
+  ]);
+  const git = canonicalizeMainPlanningGit(deploymentResponse);
+  const target = deploymentResponse.target ?? null;
+  if (target !== null && (typeof target !== "string" || target.length === 0)) {
+    throw new Error("Deployment target is malformed");
+  }
+  let customEnvironmentSlug = null;
+  if (
+    deploymentResponse.customEnvironment !== undefined &&
+    deploymentResponse.customEnvironment !== null
+  ) {
+    if (
+      typeof deploymentResponse.customEnvironment !== "object" ||
+      Array.isArray(deploymentResponse.customEnvironment) ||
+      typeof deploymentResponse.customEnvironment.slug !== "string" ||
+      deploymentResponse.customEnvironment.slug.length === 0
+    ) {
+      throw new Error("Deployment custom environment is malformed");
+    }
+    customEnvironmentSlug = deploymentResponse.customEnvironment.slug;
+  }
+
+  assertExpected(projectId, expected.projectId, "project ID");
+  assertExpected(deploymentId, expected.deployment, "ID");
+  assertExpected(
+    deploymentUrl,
+    expected.deploymentUrl === undefined
+      ? undefined
+      : canonicalizeDeploymentUrl(expected.deploymentUrl),
+    "URL",
+  );
+  assertExpected(projectName, expected.projectName, "project name");
+  assertExpected(readyState, expected.readyState ?? "READY", "readiness");
+  assertExpected(target, expected.target, "target");
+  assertExpected(
+    customEnvironmentSlug,
+    expected.customEnvironmentSlug,
+    "custom environment",
+  );
+
+  const aliases = canonicalizeAliases(aliasesResponse);
+  if (
+    aliasResponse &&
+    canonicalizeHostname(aliasResponse.alias) !== canonicalAlias
+  ) {
+    throw new Error("Alias lookup returned a different hostname");
+  }
+  if (aliasResponse && !aliases.includes(canonicalAlias)) {
+    throw new Error("Resolved alias is absent from the deployment alias list");
+  }
+
+  return {
+    alias: canonicalAlias,
+    deploymentId,
+    deploymentUrl,
+    creatorUsername,
+    projectId,
+    projectName,
+    readyState,
+    target,
+    customEnvironmentSlug,
+    git,
+    aliases,
+  };
+}
+
 function assertExactKeys(value, keys, label) {
   if (!value || typeof value !== "object" || Array.isArray(value)) {
     throw new Error(`${label} is malformed`);
@@ -403,6 +730,73 @@ export function assertCanonicalOutput(value) {
   return value;
 }
 
+export function assertMainPlanningSnapshot(value) {
+  assertExactKeys(value, MAIN_PLANNING_SNAPSHOT_KEYS, "Main planning snapshot");
+  if (
+    value.schema !== MAIN_PLANNING_SNAPSHOT_SCHEMA ||
+    !Array.isArray(value.states) ||
+    value.states.length === 0
+  ) {
+    throw new Error("Main planning snapshot schema is malformed");
+  }
+  const aliases = new Set();
+  for (const state of value.states) {
+    assertExactKeys(
+      state,
+      CANONICAL_STATE_KEYS,
+      "Main planning deployment state",
+    );
+    assertCanonicalOutput({
+      ...state,
+      git: {
+        org: "mento-protocol",
+        repo: "frontend-monorepo",
+        ref: "main",
+        sha: "0000000000000000000000000000000000000000",
+      },
+    });
+    const git = state.git;
+    const isMissing = git === null;
+    const isMalformed =
+      git !== null &&
+      typeof git === "object" &&
+      !Array.isArray(git) &&
+      Object.keys(git).length === 0;
+    const isExact =
+      git !== null &&
+      typeof git === "object" &&
+      !Array.isArray(git) &&
+      Object.keys(git).length === CANONICAL_GIT_KEYS.length &&
+      CANONICAL_GIT_KEYS.every((key) =>
+        Object.prototype.hasOwnProperty.call(git, key),
+      ) &&
+      typeof git.org === "string" &&
+      /^[A-Za-z0-9._-]+$/.test(git.org) &&
+      typeof git.repo === "string" &&
+      /^[A-Za-z0-9._-]+$/.test(git.repo) &&
+      typeof git.ref === "string" &&
+      /^[A-Za-z0-9._/-]+$/.test(git.ref) &&
+      !git.ref.includes("..") &&
+      typeof git.sha === "string" &&
+      SHA_PATTERN.test(git.sha) &&
+      git.sha === git.sha.toLowerCase();
+    if (!isMissing && !isMalformed && !isExact) {
+      throw new Error("Main planning Git evidence is malformed");
+    }
+    if (aliases.has(state.alias)) {
+      throw new Error("Main planning snapshot contains duplicate aliases");
+    }
+    aliases.add(state.alias);
+  }
+  const ordered = value.states.toSorted((left, right) =>
+    left.alias.localeCompare(right.alias),
+  );
+  if (JSON.stringify(ordered) !== JSON.stringify(value.states)) {
+    throw new Error("Main planning snapshot aliases are not canonical");
+  }
+  return value;
+}
+
 function requireIdentifier(value, label) {
   if (
     typeof value !== "string" ||
@@ -469,6 +863,21 @@ export class VercelStateClient {
     }
   }
 
+  async requestWithRetry(path, { attempts = 3 } = {}) {
+    if (!Number.isSafeInteger(attempts) || attempts < 1 || attempts > 3) {
+      throw new Error("Vercel read retry limit is malformed");
+    }
+    let lastError;
+    for (let attempt = 1; attempt <= attempts; attempt += 1) {
+      try {
+        return await this.request(path);
+      } catch (error) {
+        lastError = error;
+      }
+    }
+    throw lastError;
+  }
+
   async resolveAlias(alias) {
     const hostname = canonicalizeHostname(alias);
     return this.request(`/v4/aliases/${encodeURIComponent(hostname)}`);
@@ -497,6 +906,99 @@ export class VercelStateClient {
     return this.request(`/v9/projects/${encodeURIComponent(id)}`);
   }
 
+  async listAppTransactionDeploymentIds(expected, { maximumPages = 5 } = {}) {
+    const expectation = canonicalAppTransactionExpectation(expected);
+    if (
+      !Number.isSafeInteger(maximumPages) ||
+      maximumPages < 1 ||
+      maximumPages > 5
+    ) {
+      throw new Error("App candidate pagination limit is malformed");
+    }
+    const ids = [];
+    const seenIds = new Set();
+    const seenCursors = new Set();
+    let cursor = null;
+    for (let page = 1; page <= maximumPages; page += 1) {
+      const url = new URL("/v6/deployments", API_ORIGIN);
+      url.searchParams.set("projectId", expectation.projectId);
+      url.searchParams.set("target", "v3");
+      url.searchParams.set("limit", "100");
+      url.searchParams.set(
+        "meta-mentoTransactionId",
+        expectation.transactionId,
+      );
+      if (cursor !== null) url.searchParams.set("until", cursor);
+      const response = await this.requestWithRetry(
+        `${url.pathname}${url.search}`,
+      );
+      if (
+        !response ||
+        typeof response !== "object" ||
+        Array.isArray(response) ||
+        !Array.isArray(response.deployments) ||
+        !response.pagination ||
+        typeof response.pagination !== "object" ||
+        Array.isArray(response.pagination)
+      ) {
+        throw new Error("App candidate deployment list is malformed");
+      }
+      for (const summary of response.deployments) {
+        if (!summary || typeof summary !== "object" || Array.isArray(summary)) {
+          throw new Error("App candidate deployment summary is malformed");
+        }
+        const id = requireIdentifier(
+          consistentString("ID", [summary.uid, summary.id]),
+          "App candidate deployment ID",
+        );
+        if (!id.startsWith("dpl_") || seenIds.has(id)) {
+          throw new Error("App candidate deployment list is ambiguous");
+        }
+        seenIds.add(id);
+        ids.push(id);
+      }
+      const next = response.pagination.next ?? null;
+      if (next === null) return ids;
+      const nextCursor =
+        typeof next === "number" && Number.isSafeInteger(next)
+          ? String(next)
+          : next;
+      if (
+        typeof nextCursor !== "string" ||
+        !/^[1-9][0-9]*$/.test(nextCursor) ||
+        seenCursors.has(nextCursor)
+      ) {
+        throw new Error("App candidate pagination cursor is malformed");
+      }
+      seenCursors.add(nextCursor);
+      cursor = nextCursor;
+    }
+    throw new Error("App candidate pagination exceeded its bounded limit");
+  }
+
+  async discoverAppTransactionCandidate(expected) {
+    const expectation = canonicalAppTransactionExpectation(expected);
+    const ids = await this.listAppTransactionDeploymentIds(expectation);
+    const matches = [];
+    for (const id of ids) {
+      const deploymentResponse = await this.requestWithRetry(
+        `/v13/deployments/${encodeURIComponent(id)}?withGitRepoInfo=true`,
+      );
+      matches.push(
+        canonicalizeAppTransactionCandidate({
+          deploymentResponse,
+          expected: expectation,
+        }),
+      );
+    }
+    if (matches.length !== 1) {
+      throw new Error(
+        `App transaction candidate discovery requires exactly one match; received ${matches.length}`,
+      );
+    }
+    return matches[0];
+  }
+
   async canonicalAliasState(spec) {
     assertStateExpectation(spec);
     const aliasResponse = await this.resolveAlias(spec.alias);
@@ -519,6 +1021,36 @@ export class VercelStateClient {
       throw new Error("Alias mapping changed during inspection");
     }
     return canonicalizeDeploymentState({
+      alias: spec.alias,
+      aliasResponse: confirmedAliasResponse,
+      deploymentResponse,
+      aliasesResponse,
+      expected: spec,
+    });
+  }
+
+  async mainPlanningAliasState(spec) {
+    assertStateExpectation(spec);
+    const aliasResponse = await this.resolveAlias(spec.alias);
+    const lookup = canonicalizeAliasLookup(spec.alias, aliasResponse);
+    const deploymentResponse = await this.inspectDeployment(
+      lookup.deploymentId,
+    );
+    const aliasesResponse = await this.listDeploymentAliases(
+      lookup.deploymentId,
+    );
+    const confirmedAliasResponse = await this.resolveAlias(spec.alias);
+    const confirmedLookup = canonicalizeAliasLookup(
+      spec.alias,
+      confirmedAliasResponse,
+    );
+    if (
+      confirmedLookup.deploymentId !== lookup.deploymentId ||
+      confirmedLookup.projectId !== lookup.projectId
+    ) {
+      throw new Error("Alias mapping changed during inspection");
+    }
+    return canonicalizeMainPlanningDeploymentState({
       alias: spec.alias,
       aliasResponse: confirmedAliasResponse,
       deploymentResponse,
@@ -671,6 +1203,82 @@ export function assertSnapshotSpec(spec) {
     assertStateExpectation(entry);
   }
   return spec;
+}
+
+export async function captureMainPlanningSnapshot(client, spec) {
+  assertSnapshotSpec(spec);
+  if (spec.some((entry) => entry.git.ref !== "main")) {
+    throw new Error("Main planning snapshot may only inspect main aliases");
+  }
+  if (!client || typeof client.mainPlanningAliasState !== "function") {
+    throw new Error("Main planning state client is malformed");
+  }
+  const states = [];
+  for (const entry of spec) {
+    states.push(await client.mainPlanningAliasState(entry));
+  }
+  const ordered = states.sort((left, right) =>
+    left.alias.localeCompare(right.alias),
+  );
+  const groups = new Map();
+  for (const entry of spec) {
+    const key = JSON.stringify([
+      entry.projectId,
+      entry.projectName,
+      entry.target,
+      entry.customEnvironmentSlug,
+    ]);
+    const group = groups.get(key) ?? [];
+    group.push(canonicalizeHostname(entry.alias));
+    groups.set(key, group);
+  }
+  for (const [key, reviewedAliases] of groups) {
+    const [projectId, projectName, target, customEnvironmentSlug] =
+      JSON.parse(key);
+    const groupStates = ordered.filter(
+      (state) =>
+        state.projectId === projectId &&
+        state.projectName === projectName &&
+        state.target === target &&
+        state.customEnvironmentSlug === customEnvironmentSlug,
+    );
+    if (groupStates.length !== reviewedAliases.length) {
+      throw new Error("Main planning alias group is incomplete");
+    }
+    if (
+      new Set(groupStates.map((state) => state.deploymentId)).size !== 1 ||
+      new Set(groupStates.map((state) => state.deploymentUrl)).size !== 1
+    ) {
+      throw new Error(
+        "Main planning aliases do not share one rollback deployment",
+      );
+    }
+    const aliasSets = new Set(
+      groupStates.map((state) => JSON.stringify(state.aliases)),
+    );
+    if (aliasSets.size !== 1) {
+      throw new Error("Main planning deployment alias sets conflict");
+    }
+    const deploymentAliases = groupStates[0].aliases;
+    if (reviewedAliases.some((alias) => !deploymentAliases.includes(alias))) {
+      throw new Error(
+        "Main planning deployment omits a reviewed protected alias",
+      );
+    }
+    if (
+      customEnvironmentSlug === "v3" &&
+      JSON.stringify(deploymentAliases) !==
+        JSON.stringify(reviewedAliases.toSorted())
+    ) {
+      throw new Error(
+        "Main planning app-v3 aliases do not exactly match the reviewed set",
+      );
+    }
+  }
+  return assertMainPlanningSnapshot({
+    schema: MAIN_PLANNING_SNAPSHOT_SCHEMA,
+    states: ordered,
+  });
 }
 
 export async function captureProtectedSnapshot(client, spec) {
@@ -844,12 +1452,13 @@ function sameInode(left, right) {
   return left.dev === right.dev && left.ino === right.ino;
 }
 
-export function writeCanonicalJson(
+function writeValidatedPrivateJson(
   path,
   value,
+  validate,
   { runnerTemp = process.env.RUNNER_TEMP } = {},
 ) {
-  assertCanonicalOutput(value);
+  validate(value);
   const directory = privateDirectory(runnerTemp);
   if (typeof path !== "string" || !isAbsolute(path)) {
     throw new Error("Private output path is missing or unsafe");
@@ -917,6 +1526,28 @@ export function writeCanonicalJson(
   }
 }
 
+export function writeCanonicalJson(path, value, options = {}) {
+  return writeValidatedPrivateJson(path, value, assertCanonicalOutput, options);
+}
+
+export function writeMainPlanningSnapshot(path, value, options = {}) {
+  return writeValidatedPrivateJson(
+    path,
+    value,
+    assertMainPlanningSnapshot,
+    options,
+  );
+}
+
+export function writeAppTransactionCandidate(path, value, options = {}) {
+  return writeValidatedPrivateJson(
+    path,
+    value,
+    assertAppTransactionCandidateOutput,
+    options,
+  );
+}
+
 function createClient(env, clientFactory) {
   return clientFactory({
     token: env.VERCEL_TOKEN,
@@ -951,6 +1582,23 @@ export async function runCli({
       runnerTemp: env.RUNNER_TEMP,
     });
     stdout.write("Canonical protected-domain snapshot written\n");
+  } else if (command === "planning-snapshot") {
+    const result = await captureMainPlanningSnapshot(
+      client,
+      readJson(options.spec, "Main planning alias specification"),
+    );
+    writeMainPlanningSnapshot(options.output, result, {
+      runnerTemp: env.RUNNER_TEMP,
+    });
+    stdout.write("Canonical main planning snapshot written\n");
+  } else if (command === "app-candidate") {
+    const result = await client.discoverAppTransactionCandidate(
+      readJson(options.expected, "App candidate expectation"),
+    );
+    writeAppTransactionCandidate(options.output, result, {
+      runnerTemp: env.RUNNER_TEMP,
+    });
+    stdout.write("Canonical App transaction candidate written\n");
   } else if (command === "deployment") {
     const expected = readJson(options.expected, "Deployment expectation");
     const result = await client.canonicalDeploymentState(expected);

--- a/scripts/vercel-deployment-state.test.mjs
+++ b/scripts/vercel-deployment-state.test.mjs
@@ -17,20 +17,28 @@ import { fileURLToPath } from "node:url";
 
 import {
   CANONICAL_STATE_KEYS,
+  MAIN_PLANNING_SNAPSHOT_SCHEMA,
   VercelStateClient,
+  assertAppTransactionCandidateOutput,
   assertCanonicalOutput,
+  assertMainPlanningSnapshot,
   assertSnapshotSpec,
   canonicalizeAliasMapping,
+  canonicalizeAppTransactionCandidate,
   canonicalizeAliases,
   canonicalizeDeploymentState,
+  canonicalizeMainPlanningDeploymentState,
   canonicalizeDeploymentUrl,
   canonicalizeHostname,
+  captureMainPlanningSnapshot,
   captureProtectedSnapshot,
   compareProtectedSnapshots,
   parseArguments,
   renderCliFailure,
   runCli,
+  writeAppTransactionCandidate,
   writeCanonicalJson,
+  writeMainPlanningSnapshot,
 } from "./vercel-deployment-state.mjs";
 
 const fixtureDirectory = new URL(
@@ -44,6 +52,15 @@ function fixture(name) {
 
 function canonicalizeFixture(value) {
   return canonicalizeDeploymentState({
+    aliasResponse: value.aliasResponse,
+    deploymentResponse: value.deploymentResponse,
+    aliasesResponse: value.aliasesResponse,
+    expected: value.expected,
+  });
+}
+
+function canonicalizePlanningFixture(value) {
+  return canonicalizeMainPlanningDeploymentState({
     aliasResponse: value.aliasResponse,
     deploymentResponse: value.deploymentResponse,
     aliasesResponse: value.aliasesResponse,
@@ -90,6 +107,272 @@ test("custom v3 fixture proves slug independently from target", () => {
   assert.equal(state.alias, "app.mento.org");
 });
 
+test("main planning capture sanitizes Git ambiguity without weakening rollback identity", () => {
+  const production = fixture("valid-production.json");
+  const valid = canonicalizePlanningFixture(production);
+  assert.deepEqual(valid.git, {
+    org: "mento-protocol",
+    repo: "frontend-monorepo",
+    ref: "main",
+    sha: "0123456789abcdef0123456789abcdef01234567",
+  });
+
+  const missing = canonicalizePlanningFixture({
+    ...production,
+    deploymentResponse: {
+      ...production.deploymentResponse,
+      meta: {
+        protectionBypass: "test-sensitive-value-never-output",
+      },
+    },
+  });
+  assert.equal(missing.git, null);
+  assert.doesNotMatch(
+    JSON.stringify(missing),
+    /protectionBypass|test-sensitive-value-never-output/,
+  );
+
+  for (const meta of [
+    {
+      githubCommitOrg: "mento-protocol",
+      githubCommitRepo: "frontend-monorepo",
+      githubCommitRef: "main",
+    },
+    {
+      githubCommitOrg: "mento-protocol",
+      githubCommitRepo: "frontend-monorepo",
+      githubCommitRef: "main",
+      githubCommitSha: "not-a-sha",
+    },
+    {
+      githubCommitOrg: "unsafe value",
+      githubCommitRepo: "frontend-monorepo",
+      githubCommitRef: "main",
+      githubCommitSha: "0123456789abcdef0123456789abcdef01234567",
+    },
+  ]) {
+    const malformed = canonicalizePlanningFixture({
+      ...production,
+      deploymentResponse: {
+        ...production.deploymentResponse,
+        meta,
+      },
+    });
+    assert.deepEqual(malformed.git, {});
+  }
+
+  const conflictingRawSources = canonicalizePlanningFixture({
+    ...production,
+    deploymentResponse: {
+      ...production.deploymentResponse,
+      gitSource: {
+        org: "different-org",
+        repo: "frontend-monorepo",
+        ref: "main",
+        sha: "0123456789abcdef0123456789abcdef01234567",
+      },
+    },
+  });
+  assert.deepEqual(conflictingRawSources.git, {});
+
+  const wrongSource = canonicalizePlanningFixture({
+    ...production,
+    deploymentResponse: {
+      ...production.deploymentResponse,
+      meta: {
+        ...production.deploymentResponse.meta,
+        githubCommitOrg: "other-org",
+      },
+    },
+  });
+  assert.deepEqual(wrongSource.git, {
+    org: "other-org",
+    repo: "frontend-monorepo",
+    ref: "main",
+    sha: "0123456789abcdef0123456789abcdef01234567",
+  });
+});
+
+test("main planning capture keeps every non-Git activation-state check strict", () => {
+  const production = fixture("valid-production.json");
+  const scenarios = [
+    {
+      label: "deployment ID",
+      mutate(value) {
+        value.deploymentResponse.id = "dpl_other123";
+      },
+    },
+    {
+      label: "URL",
+      mutate(value) {
+        value.deploymentResponse.url = "https://example.com";
+      },
+    },
+    {
+      label: "project",
+      mutate(value) {
+        value.deploymentResponse.projectId = "prj_other123";
+      },
+    },
+    {
+      label: "name",
+      mutate(value) {
+        value.deploymentResponse.name = "reserve.mento.org";
+      },
+    },
+    {
+      label: "readiness",
+      mutate(value) {
+        value.deploymentResponse.readyState = "BUILDING";
+      },
+    },
+    {
+      label: "target",
+      mutate(value) {
+        value.deploymentResponse.target = "preview";
+      },
+    },
+    {
+      label: "creator",
+      mutate(value) {
+        value.deploymentResponse.creator.username = "unsafe user";
+      },
+    },
+    {
+      label: "aliases",
+      mutate(value) {
+        value.aliasesResponse.aliases = [{ alias: "other.mento.org" }];
+      },
+    },
+  ];
+  for (const scenario of scenarios) {
+    const input = structuredClone(production);
+    scenario.mutate(input);
+    assert.throws(
+      () => canonicalizePlanningFixture(input),
+      undefined,
+      scenario.label,
+    );
+  }
+});
+
+test("main planning snapshot preserves cross-alias valid Git conflicts for planner classification", async () => {
+  const base = canonicalizePlanningFixture(fixture("valid-production.json"));
+  const aliases = [
+    "governance.mento.org",
+    "governancementoorg-mentolabs.vercel.app",
+  ];
+  const states = await captureMainPlanningSnapshot(
+    {
+      mainPlanningAliasState: async (entry) => ({
+        ...base,
+        alias: entry.alias,
+        git:
+          entry.alias === aliases[0]
+            ? base.git
+            : {
+                ...base.git,
+                sha: "abcdef0123456789abcdef0123456789abcdef01",
+              },
+      }),
+    },
+    aliases.map((alias) => ({
+      alias,
+      ...fixture("valid-production.json").expected,
+    })),
+  );
+  assert.equal(states.schema, MAIN_PLANNING_SNAPSHOT_SCHEMA);
+  assert.equal(states.states.length, 2);
+  assert.notDeepEqual(states.states[0].git, states.states[1].git);
+  assert.deepEqual(assertMainPlanningSnapshot(states), states);
+});
+
+test("main planning snapshot rejects rollback, alias-set, and mapping-race ambiguity", async () => {
+  const production = fixture("valid-production.json");
+  const base = canonicalizePlanningFixture(production);
+  const aliases = [
+    "governance.mento.org",
+    "governancementoorg-mentolabs.vercel.app",
+  ];
+  const spec = aliases.map((alias) => ({
+    alias,
+    ...production.expected,
+  }));
+  await assert.rejects(
+    () =>
+      captureMainPlanningSnapshot(
+        {
+          mainPlanningAliasState: async (entry) => ({
+            ...base,
+            alias: entry.alias,
+            deploymentId:
+              entry.alias === aliases[0] ? base.deploymentId : "dpl_other123",
+          }),
+        },
+        spec,
+      ),
+    /do not share one rollback deployment/,
+  );
+  await assert.rejects(
+    () =>
+      captureMainPlanningSnapshot(
+        {
+          mainPlanningAliasState: async (entry) => ({
+            ...base,
+            alias: entry.alias,
+            aliases:
+              entry.alias === aliases[0]
+                ? base.aliases
+                : ["governancementoorg-mentolabs.vercel.app"],
+          }),
+        },
+        spec,
+      ),
+    /alias sets conflict/,
+  );
+
+  const client = new VercelStateClient({
+    token: "fixture-token",
+    teamId: "team_fixture123",
+    fetchImplementation: async () => {
+      throw new Error("unused");
+    },
+  });
+  let lookups = 0;
+  client.resolveAlias = async (alias) => ({
+    ...production.aliasResponse,
+    alias,
+    deploymentId: ++lookups === 1 ? "dpl_governance123" : "dpl_concurrent123",
+  });
+  client.inspectDeployment = async () => production.deploymentResponse;
+  client.listDeploymentAliases = async () => production.aliasesResponse;
+  await assert.rejects(
+    () => client.mainPlanningAliasState(spec[0]),
+    /changed during inspection/,
+  );
+
+  const appFixture = fixture("valid-custom-v3.json");
+  const appBase = canonicalizePlanningFixture(appFixture);
+  const appAliases = [
+    "app.mento.org",
+    "appmentoorg-env-v3-mentolabs.vercel.app",
+  ];
+  await assert.rejects(
+    () =>
+      captureMainPlanningSnapshot(
+        {
+          mainPlanningAliasState: async (entry) => ({
+            ...appBase,
+            alias: entry.alias,
+            aliases: [...appBase.aliases, "unexpected-v3.mento.org"].sort(),
+          }),
+        },
+        appAliases.map((alias) => ({ alias, ...appFixture.expected })),
+      ),
+    /do not exactly match the reviewed set/,
+  );
+});
+
 test("minimal alias mapping exposes only read-only drift fields", () => {
   const production = fixture("valid-production.json");
   const mapping = canonicalizeAliasMapping({
@@ -113,6 +396,177 @@ test("minimal alias mapping exposes only read-only drift fields", () => {
   assert.doesNotMatch(
     JSON.stringify(mapping),
     /test-value-not-printed|buildEnv/,
+  );
+});
+
+function appCandidateFixture(overrides = {}) {
+  const app = fixture("valid-custom-v3.json");
+  const expected = {
+    projectId: "prj_app123",
+    projectName: "app.mento.org",
+    deploySha: "abcdef0123456789abcdef0123456789abcdef01",
+    runId: "800",
+    runAttempt: "3",
+    transactionId: "main-0123456789abcdef0123456789abcdef",
+    customEnvironmentSlug: "v3",
+    nextDeploymentId: "m-app-0123456789abcdef012",
+  };
+  return {
+    expected: { ...expected, ...(overrides.expected ?? {}) },
+    deploymentResponse: {
+      ...app.deploymentResponse,
+      meta: {
+        ...app.deploymentResponse.meta,
+        mentoTransactionId: expected.transactionId,
+        mentoRunId: expected.runId,
+        mentoRunAttempt: expected.runAttempt,
+        mentoNextDeploymentId: expected.nextDeploymentId,
+        protectionBypass: "test-sensitive-value-never-output",
+        ...(overrides.meta ?? {}),
+      },
+      ...(overrides.deploymentResponse ?? {}),
+    },
+  };
+}
+
+test("App transaction candidate is exact, canonical, and redacted", () => {
+  const input = appCandidateFixture();
+  const result = canonicalizeAppTransactionCandidate(input);
+  assert.deepEqual(result, {
+    deploymentId: "dpl_appv3abc",
+    deploymentUrl: "https://app-v3-immutable.vercel.app",
+    projectId: "prj_app123",
+    projectName: "app.mento.org",
+    deploySha: "abcdef0123456789abcdef0123456789abcdef01",
+    runId: "800",
+    runAttempt: "3",
+    transactionId: "main-0123456789abcdef0123456789abcdef",
+    customEnvironmentSlug: "v3",
+  });
+  assert.deepEqual(assertAppTransactionCandidateOutput(result), result);
+  assert.doesNotMatch(
+    JSON.stringify(result),
+    /nextDeploymentId|protectionBypass|test-sensitive-value-never-output/,
+  );
+});
+
+test("App transaction candidate rejects same SHA and transaction with wrong run or attempt", () => {
+  for (const meta of [
+    { mentoRunId: "801" },
+    { mentoRunAttempt: "4" },
+    { mentoNextDeploymentId: "m-app-different123" },
+  ]) {
+    assert.throws(
+      () => canonicalizeAppTransactionCandidate(appCandidateFixture({ meta })),
+      /identity does not match/,
+    );
+  }
+});
+
+test("App transaction candidate discovery uses filtered bounded pagination and exact inspection", async () => {
+  const input = appCandidateFixture();
+  const requests = [];
+  const client = new VercelStateClient({
+    token: "fixture-token",
+    teamId: "team_fixture123",
+    fetchImplementation: async () => {
+      throw new Error("unused");
+    },
+  });
+  client.requestWithRetry = async (path) => {
+    requests.push(path);
+    if (path.startsWith("/v6/deployments")) {
+      const url = new URL(path, "https://api.vercel.com");
+      assert.equal(url.searchParams.get("projectId"), "prj_app123");
+      assert.equal(url.searchParams.get("target"), "v3");
+      assert.equal(
+        url.searchParams.get("meta-mentoTransactionId"),
+        input.expected.transactionId,
+      );
+      if (url.searchParams.get("until") === null) {
+        return {
+          deployments: [{ uid: "dpl_appv3abc" }],
+          pagination: { next: 12345 },
+        };
+      }
+      assert.equal(url.searchParams.get("until"), "12345");
+      return { deployments: [], pagination: { next: null } };
+    }
+    assert.equal(path, "/v13/deployments/dpl_appv3abc?withGitRepoInfo=true");
+    return input.deploymentResponse;
+  };
+  const result = await client.discoverAppTransactionCandidate(input.expected);
+  assert.equal(result.deploymentId, "dpl_appv3abc");
+  assert.equal(requests.length, 3);
+
+  let attempts = 0;
+  const retryClient = new VercelStateClient({
+    token: "fixture-token",
+    teamId: "team_fixture123",
+    fetchImplementation: async () => {
+      throw new Error("unused");
+    },
+  });
+  retryClient.request = async () => {
+    attempts += 1;
+    if (attempts < 3) throw new Error("transient");
+    return { ok: true };
+  };
+  assert.deepEqual(
+    await retryClient.requestWithRetry("/read-only", { attempts: 3 }),
+    { ok: true },
+  );
+  assert.equal(attempts, 3);
+});
+
+test("App transaction candidate discovery fails closed on zero, multiple, and unbounded pages", async () => {
+  const input = appCandidateFixture();
+  const client = new VercelStateClient({
+    token: "fixture-token",
+    teamId: "team_fixture123",
+    fetchImplementation: async () => {
+      throw new Error("unused");
+    },
+  });
+  client.listAppTransactionDeploymentIds = async () => [];
+  await assert.rejects(
+    () => client.discoverAppTransactionCandidate(input.expected),
+    /exactly one match; received 0/,
+  );
+
+  client.listAppTransactionDeploymentIds = async () => [
+    "dpl_appv3abc",
+    "dpl_appv3def",
+  ];
+  client.requestWithRetry = async (path) => ({
+    ...input.deploymentResponse,
+    id: path.includes("dpl_appv3def") ? "dpl_appv3def" : "dpl_appv3abc",
+    url: path.includes("dpl_appv3def")
+      ? "app-v3-other.vercel.app"
+      : "app-v3-immutable.vercel.app",
+  });
+  await assert.rejects(
+    () => client.discoverAppTransactionCandidate(input.expected),
+    /exactly one match; received 2/,
+  );
+
+  const paginatedClient = new VercelStateClient({
+    token: "fixture-token",
+    teamId: "team_fixture123",
+    fetchImplementation: async () => {
+      throw new Error("unused");
+    },
+  });
+  paginatedClient.requestWithRetry = async () => ({
+    deployments: [],
+    pagination: { next: 12345 },
+  });
+  await assert.rejects(
+    () =>
+      paginatedClient.listAppTransactionDeploymentIds(input.expected, {
+        maximumPages: 2,
+      }),
+    /cursor is malformed|bounded limit/,
   );
 });
 
@@ -529,7 +983,15 @@ test("protected snapshot comparison detects every mapping change", () => {
 
 test("CLI parser accepts only each command's exact option set", () => {
   const cases = [
+    [
+      "app-candidate",
+      "--expected",
+      "expected.json",
+      "--output",
+      "candidate.json",
+    ],
     ["compare", "--before", "before.json", "--after", "after.json"],
+    ["planning-snapshot", "--spec", "spec.json", "--output", "snapshot.json"],
     ["snapshot", "--spec", "spec.json", "--output", "snapshot.json"],
     [
       "deployment",
@@ -700,6 +1162,52 @@ test("private canonical output is exclusive, mode 0600, and symlink-safe", (t) =
   assert.throws(
     () => writeCanonicalJson("relative.json", state, { runnerTemp: directory }),
     /path is missing or unsafe/,
+  );
+});
+
+test("planning snapshots and App candidates use distinct validated private writers", (t) => {
+  const directory = privateTestDirectory(t);
+  const planningState = canonicalizePlanningFixture(
+    fixture("valid-production.json"),
+  );
+  const planning = {
+    schema: MAIN_PLANNING_SNAPSHOT_SCHEMA,
+    states: [planningState],
+  };
+  const candidate = canonicalizeAppTransactionCandidate(appCandidateFixture());
+  const planningPath = join(directory, "planning.json");
+  const candidatePath = join(directory, "candidate.json");
+  writeMainPlanningSnapshot(planningPath, planning, {
+    runnerTemp: directory,
+  });
+  writeAppTransactionCandidate(candidatePath, candidate, {
+    runnerTemp: directory,
+  });
+  assert.equal(
+    readFileSync(planningPath, "utf8"),
+    `${JSON.stringify(planning)}\n`,
+  );
+  assert.equal(
+    readFileSync(candidatePath, "utf8"),
+    `${JSON.stringify(candidate)}\n`,
+  );
+  assert.throws(
+    () =>
+      writeMainPlanningSnapshot(
+        join(directory, "bad-planning.json"),
+        { schema: MAIN_PLANNING_SNAPSHOT_SCHEMA, states: [candidate] },
+        { runnerTemp: directory },
+      ),
+    /planning deployment state/,
+  );
+  assert.throws(
+    () =>
+      writeAppTransactionCandidate(
+        join(directory, "bad-candidate.json"),
+        planning,
+        { runnerTemp: directory },
+      ),
+    /App transaction candidate/,
   );
 });
 

--- a/scripts/vercel-deployment-state.test.mjs
+++ b/scripts/vercel-deployment-state.test.mjs
@@ -519,6 +519,62 @@ test("App transaction candidate discovery uses filtered bounded pagination and e
   assert.equal(attempts, 3);
 });
 
+test("App discovery stabilizes zero and exact pending candidates within a bounded window", async () => {
+  const input = appCandidateFixture();
+  const client = new VercelStateClient({
+    token: "fixture-token",
+    teamId: "team_fixture123",
+    fetchImplementation: async () => {
+      throw new Error("unused");
+    },
+  });
+  let lists = 0;
+  let inspections = 0;
+  const sleeps = [];
+  client.listAppTransactionDeploymentIds = async () => {
+    lists += 1;
+    return lists === 1 ? [] : ["dpl_appv3abc"];
+  };
+  client.requestWithRetry = async () => {
+    inspections += 1;
+    return {
+      ...input.deploymentResponse,
+      readyState: inspections === 1 ? "BUILDING" : "READY",
+    };
+  };
+  const result = await client.discoverAppTransactionCandidate(input.expected, {
+    maximumAttempts: 4,
+    stabilizationDelayMs: 5,
+    sleepImplementation: async (milliseconds) => sleeps.push(milliseconds),
+  });
+  assert.equal(result.deploymentId, "dpl_appv3abc");
+  assert.equal(lists, 3);
+  assert.equal(inspections, 2);
+  assert.deepEqual(sleeps, [5, 5]);
+
+  inspections = 0;
+  client.listAppTransactionDeploymentIds = async () => ["dpl_appv3abc"];
+  client.requestWithRetry = async () => ({
+    ...input.deploymentResponse,
+    readyState: "BUILDING",
+    meta: {
+      ...input.deploymentResponse.meta,
+      mentoRunAttempt: "wrong",
+    },
+  });
+  await assert.rejects(
+    () =>
+      client.discoverAppTransactionCandidate(input.expected, {
+        maximumAttempts: 4,
+        stabilizationDelayMs: 0,
+        sleepImplementation: async () => {
+          assert.fail("identity mismatch must not retry");
+        },
+      }),
+    /identity does not match/,
+  );
+});
+
 test("App transaction candidate discovery fails closed on zero, multiple, and unbounded pages", async () => {
   const input = appCandidateFixture();
   const client = new VercelStateClient({
@@ -530,8 +586,13 @@ test("App transaction candidate discovery fails closed on zero, multiple, and un
   });
   client.listAppTransactionDeploymentIds = async () => [];
   await assert.rejects(
-    () => client.discoverAppTransactionCandidate(input.expected),
-    /exactly one match; received 0/,
+    () =>
+      client.discoverAppTransactionCandidate(input.expected, {
+        maximumAttempts: 1,
+        sleepImplementation: async () => {},
+        stabilizationDelayMs: 0,
+      }),
+    /did not stabilize/,
   );
 
   client.listAppTransactionDeploymentIds = async () => [

--- a/scripts/vercel-main-ci-attempt.mjs
+++ b/scripts/vercel-main-ci-attempt.mjs
@@ -7,10 +7,9 @@ import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 export const MAIN_DEPLOYMENT_REPOSITORY = "mento-protocol/frontend-monorepo";
-export const MAIN_DEPLOYMENT_UPSTREAM_WORKFLOW = "CI/CD";
-export const MAIN_DEPLOYMENT_UPSTREAM_WORKFLOW_PATH =
-  ".github/workflows/ci.yml";
-export const MAIN_DEPLOYMENT_SENTINEL_JOB = "Build and Test";
+const MAIN_DEPLOYMENT_UPSTREAM_WORKFLOW = "CI/CD";
+const MAIN_DEPLOYMENT_UPSTREAM_WORKFLOW_PATH = ".github/workflows/ci.yml";
+const MAIN_DEPLOYMENT_SENTINEL_JOB = "Build and Test";
 
 const GITHUB_API_ORIGIN = "https://api.github.com";
 const GITHUB_WEB_ORIGIN = "https://github.com";

--- a/scripts/vercel-main-ci-attempt.mjs
+++ b/scripts/vercel-main-ci-attempt.mjs
@@ -1,0 +1,654 @@
+#!/usr/bin/env node
+
+import { Buffer } from "node:buffer";
+import { appendFileSync, readFileSync } from "node:fs";
+import process from "node:process";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export const MAIN_DEPLOYMENT_REPOSITORY = "mento-protocol/frontend-monorepo";
+export const MAIN_DEPLOYMENT_UPSTREAM_WORKFLOW = "CI/CD";
+export const MAIN_DEPLOYMENT_UPSTREAM_WORKFLOW_PATH =
+  ".github/workflows/ci.yml";
+export const MAIN_DEPLOYMENT_SENTINEL_JOB = "Build and Test";
+
+const GITHUB_API_ORIGIN = "https://api.github.com";
+const GITHUB_WEB_ORIGIN = "https://github.com";
+const GITHUB_API_VERSION = "2022-11-28";
+const SHA_PATTERN = /^[0-9a-f]{40}$/;
+const MAX_EVENT_BYTES = 1024 * 1024;
+const MAX_API_RESPONSE_BYTES = 4 * 1024 * 1024;
+const JOBS_PER_PAGE = 100;
+const MAX_JOB_PAGES = 10;
+const MAX_JOBS = JOBS_PER_PAGE * MAX_JOB_PAGES;
+const DEFAULT_REQUEST_ATTEMPTS = 3;
+const DEFAULT_REQUEST_TIMEOUT_MS = 10_000;
+const DEFAULT_RETRY_DELAY_MS = 250;
+const RETRYABLE_HTTP_STATUSES = new Set([408, 429]);
+
+function invariant(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+function plainObject(value, label) {
+  invariant(
+    value !== null &&
+      typeof value === "object" &&
+      !Array.isArray(value) &&
+      Object.getPrototypeOf(value) === Object.prototype,
+    `${label} must be a plain object`,
+  );
+  return value;
+}
+
+function exactString(value, expected, label) {
+  invariant(
+    typeof value === "string" && value === expected,
+    `${label} mismatch`,
+  );
+  return value;
+}
+
+function boundedString(value, label, maximum = 255) {
+  invariant(
+    typeof value === "string" &&
+      value.length > 0 &&
+      value.length <= maximum &&
+      ![...value].some((character) => {
+        const codePoint = character.codePointAt(0);
+        return codePoint <= 31 || codePoint === 127;
+      }),
+    `${label} is missing or invalid`,
+  );
+  return value;
+}
+
+function positiveInteger(value, label) {
+  invariant(
+    Number.isSafeInteger(value) && value > 0,
+    `${label} must be a positive safe integer`,
+  );
+  return value;
+}
+
+function nonNegativeInteger(value, label) {
+  invariant(
+    Number.isSafeInteger(value) && value >= 0,
+    `${label} must be a non-negative safe integer`,
+  );
+  return value;
+}
+
+function exactSha(value, label = "DEPLOY_SHA") {
+  invariant(
+    typeof value === "string" && SHA_PATTERN.test(value),
+    `${label} must be an immutable lowercase 40-character SHA`,
+  );
+  return value;
+}
+
+function repositoryObject(value, label) {
+  const repository = plainObject(value, label);
+  exactString(
+    repository.full_name,
+    MAIN_DEPLOYMENT_REPOSITORY,
+    `${label} full name`,
+  );
+  return repository;
+}
+
+function canonicalRunApiUrl(runId) {
+  return `${GITHUB_API_ORIGIN}/repos/${MAIN_DEPLOYMENT_REPOSITORY}/actions/runs/${runId}`;
+}
+
+function canonicalRunWebUrl(runId) {
+  return `${GITHUB_WEB_ORIGIN}/${MAIN_DEPLOYMENT_REPOSITORY}/actions/runs/${runId}`;
+}
+
+function canonicalAttemptWebUrl(runId, runAttempt) {
+  return `${canonicalRunWebUrl(runId)}/attempts/${runAttempt}`;
+}
+
+function canonicalJobApiUrl(jobId) {
+  return `${GITHUB_API_ORIGIN}/repos/${MAIN_DEPLOYMENT_REPOSITORY}/actions/jobs/${jobId}`;
+}
+
+function canonicalJobWebUrl(runId, jobId) {
+  return `${canonicalRunWebUrl(runId)}/job/${jobId}`;
+}
+
+function validateRunIdentity(run, { deploySha, runId, runAttempt, label }) {
+  positiveInteger(run.id, `${label} ID`);
+  invariant(run.id === runId, `${label} ID mismatch`);
+  positiveInteger(run.run_attempt, `${label} attempt`);
+  invariant(run.run_attempt === runAttempt, `${label} attempt mismatch`);
+  exactString(run.name, MAIN_DEPLOYMENT_UPSTREAM_WORKFLOW, `${label} name`);
+  exactString(
+    run.path,
+    MAIN_DEPLOYMENT_UPSTREAM_WORKFLOW_PATH,
+    `${label} path`,
+  );
+  exactString(run.event, "push", `${label} event`);
+  exactString(run.head_branch, "main", `${label} head branch`);
+  invariant(
+    exactSha(run.head_sha, `${label} head SHA`) === deploySha,
+    `${label} head SHA mismatch`,
+  );
+  exactString(run.status, "completed", `${label} status`);
+  exactString(run.conclusion, "success", `${label} conclusion`);
+  repositoryObject(run.repository, `${label} repository`);
+  repositoryObject(run.head_repository, `${label} head repository`);
+  exactString(run.url, canonicalRunApiUrl(runId), `${label} API URL`);
+  exactString(run.html_url, canonicalRunWebUrl(runId), `${label} web URL`);
+}
+
+/**
+ * Authenticate the workflow_run event before making any API request.
+ *
+ * @param {{ eventPayload: unknown, deploySha: string }} options
+ */
+export function validateMainCiWorkflowRunEvent({ eventPayload, deploySha }) {
+  const expectedSha = exactSha(deploySha);
+  const payload = plainObject(eventPayload, "GitHub event payload");
+  exactString(payload.action, "completed", "GitHub event action");
+  repositoryObject(payload.repository, "GitHub event repository");
+
+  const run = plainObject(payload.workflow_run, "GitHub event workflow run");
+  const runId = positiveInteger(run.id, "GitHub event workflow run ID");
+  const runAttempt = positiveInteger(
+    run.run_attempt,
+    "GitHub event workflow run attempt",
+  );
+  validateRunIdentity(run, {
+    deploySha: expectedSha,
+    runId,
+    runAttempt,
+    label: "GitHub event workflow run",
+  });
+
+  return {
+    deploySha: expectedSha,
+    runAttempt,
+    runId,
+  };
+}
+
+function validateMainCiRunRecord(rawRun, expected) {
+  const run = plainObject(rawRun, "GitHub API workflow run");
+  validateRunIdentity(run, {
+    ...expected,
+    label: "GitHub API workflow run",
+  });
+  return run;
+}
+
+function validateMainCiJob(rawJob, expected) {
+  const job = plainObject(rawJob, "GitHub API workflow job");
+  const jobId = positiveInteger(job.id, "GitHub API workflow job ID");
+  invariant(
+    positiveInteger(job.run_id, "GitHub API workflow job run ID") ===
+      expected.runId,
+    "GitHub API workflow job run ID mismatch",
+  );
+  invariant(
+    positiveInteger(job.run_attempt, "GitHub API workflow job run attempt") ===
+      expected.runAttempt,
+    "GitHub API workflow job run attempt mismatch",
+  );
+  exactString(
+    job.workflow_name,
+    MAIN_DEPLOYMENT_UPSTREAM_WORKFLOW,
+    "GitHub API workflow job workflow name",
+  );
+  exactString(job.head_branch, "main", "GitHub API workflow job head branch");
+  invariant(
+    exactSha(job.head_sha, "GitHub API workflow job head SHA") ===
+      expected.deploySha,
+    "GitHub API workflow job head SHA mismatch",
+  );
+  const name = boundedString(job.name, "GitHub API workflow job name");
+  exactString(
+    job.run_url,
+    canonicalRunApiUrl(expected.runId),
+    "GitHub API workflow job run URL",
+  );
+  exactString(
+    job.url,
+    canonicalJobApiUrl(jobId),
+    "GitHub API workflow job API URL",
+  );
+  exactString(
+    job.html_url,
+    canonicalJobWebUrl(expected.runId, jobId),
+    "GitHub API workflow job web URL",
+  );
+  boundedString(job.status, "GitHub API workflow job status", 32);
+  invariant(
+    job.conclusion === null ||
+      (typeof job.conclusion === "string" && job.conclusion.length <= 32),
+    "GitHub API workflow job conclusion is invalid",
+  );
+  return {
+    conclusion: job.conclusion,
+    id: jobId,
+    name,
+    status: job.status,
+  };
+}
+
+function validateApiBase(apiUrl) {
+  let parsed;
+  try {
+    parsed = new URL(apiUrl);
+  } catch {
+    throw new Error("GITHUB_API_URL is invalid");
+  }
+  invariant(
+    parsed.origin === GITHUB_API_ORIGIN &&
+      (parsed.pathname === "" || parsed.pathname === "/") &&
+      parsed.search === "" &&
+      parsed.hash === "" &&
+      parsed.username === "" &&
+      parsed.password === "",
+    "GITHUB_API_URL must be the canonical public GitHub API origin",
+  );
+  return GITHUB_API_ORIGIN;
+}
+
+function validateToken(token) {
+  invariant(
+    typeof token === "string" &&
+      token.length > 0 &&
+      token.length <= 2_048 &&
+      !/\s/.test(token),
+    "GITHUB_TOKEN is missing or invalid",
+  );
+  return token;
+}
+
+function boundedPolicyInteger(value, label, minimum, maximum) {
+  invariant(
+    Number.isSafeInteger(value) && value >= minimum && value <= maximum,
+    `${label} is outside its bounded policy`,
+  );
+  return value;
+}
+
+function retryableStatus(status) {
+  return RETRYABLE_HTTP_STATUSES.has(status) || status >= 500;
+}
+
+function requestHeaders(token) {
+  return {
+    Accept: "application/vnd.github+json",
+    Authorization: `Bearer ${token}`,
+    "User-Agent": "mento-vercel-main-ci-attempt",
+    "X-GitHub-Api-Version": GITHUB_API_VERSION,
+  };
+}
+
+class RetryableGitHubApiError extends Error {
+  constructor(reason) {
+    super(reason);
+    this.name = "RetryableGitHubApiError";
+    this.reason = reason;
+  }
+}
+
+async function pause(milliseconds, sleepImplementation) {
+  await sleepImplementation(milliseconds);
+}
+
+function defaultSleep(milliseconds) {
+  return new Promise((resolveDelay) => setTimeout(resolveDelay, milliseconds));
+}
+
+async function requestJson(
+  path,
+  {
+    apiUrl,
+    fetchImplementation,
+    token,
+    signal,
+    requestAttempts,
+    requestTimeoutMs,
+    retryDelayMs,
+    sleepImplementation,
+  },
+) {
+  const url = new URL(path, `${apiUrl}/`);
+  let finalReason = "network failure";
+
+  for (let attempt = 1; attempt <= requestAttempts; attempt += 1) {
+    if (signal?.aborted) {
+      throw new Error("GitHub API verification was cancelled");
+    }
+
+    const controller = new AbortController();
+    let timedOut = false;
+    const timeout = setTimeout(() => {
+      timedOut = true;
+      controller.abort();
+    }, requestTimeoutMs);
+    const cancel = () => controller.abort(signal.reason);
+    signal?.addEventListener("abort", cancel, { once: true });
+
+    try {
+      const response = await fetchImplementation(url, {
+        method: "GET",
+        redirect: "error",
+        headers: requestHeaders(token),
+        signal: controller.signal,
+      });
+
+      if (!response?.ok) {
+        const status = Number(response?.status);
+        if (!Number.isInteger(status) || status < 100 || status > 599) {
+          throw new Error("GitHub API returned an invalid HTTP response");
+        }
+        finalReason = `HTTP ${status}`;
+        if (!retryableStatus(status)) {
+          throw new Error(
+            `GitHub API request failed: GET ${url.pathname} (${finalReason})`,
+          );
+        }
+        throw new RetryableGitHubApiError(finalReason);
+      }
+
+      const contentType = response.headers?.get?.("content-type");
+      invariant(
+        typeof contentType === "string" &&
+          /^(?:application\/json|application\/vnd\.github\+json)(?:;|$)/i.test(
+            contentType,
+          ),
+        `GitHub API returned a non-JSON response for ${url.pathname}`,
+      );
+      const declaredLength = response.headers?.get?.("content-length");
+      if (declaredLength !== null && declaredLength !== undefined) {
+        invariant(
+          /^[0-9]+$/.test(declaredLength) &&
+            Number(declaredLength) <= MAX_API_RESPONSE_BYTES,
+          `GitHub API response exceeded its size limit for ${url.pathname}`,
+        );
+      }
+      const text = await response.text();
+      invariant(
+        Buffer.byteLength(text) <= MAX_API_RESPONSE_BYTES,
+        `GitHub API response exceeded its size limit for ${url.pathname}`,
+      );
+      try {
+        return JSON.parse(text);
+      } catch {
+        throw new Error(`GitHub API returned invalid JSON for ${url.pathname}`);
+      }
+    } catch (error) {
+      if (signal?.aborted) {
+        throw new Error("GitHub API verification was cancelled");
+      }
+      if (error instanceof RetryableGitHubApiError) {
+        finalReason = error.reason;
+      } else if (
+        error instanceof Error &&
+        /GitHub API (?:request failed|returned|response exceeded)/.test(
+          error.message,
+        )
+      ) {
+        throw error;
+      } else {
+        finalReason = timedOut ? "request timeout" : "network failure";
+      }
+      if (attempt === requestAttempts) {
+        break;
+      }
+    } finally {
+      clearTimeout(timeout);
+      signal?.removeEventListener("abort", cancel);
+    }
+
+    await pause(retryDelayMs, sleepImplementation);
+  }
+
+  throw new Error(
+    `GitHub API request failed after ${requestAttempts} bounded attempts: GET ${url.pathname} (${finalReason})`,
+  );
+}
+
+async function listMainCiAttemptJobs(expected, requestOptions) {
+  const jobs = [];
+  const seenJobIds = new Set();
+  let expectedTotal = null;
+
+  for (let page = 1; page <= MAX_JOB_PAGES; page += 1) {
+    const payload = plainObject(
+      await requestJson(
+        `/repos/${MAIN_DEPLOYMENT_REPOSITORY}/actions/runs/${expected.runId}/attempts/${expected.runAttempt}/jobs?per_page=${JOBS_PER_PAGE}&page=${page}`,
+        requestOptions,
+      ),
+      `GitHub API workflow jobs page ${page}`,
+    );
+    const totalCount = nonNegativeInteger(
+      payload.total_count,
+      `GitHub API workflow jobs page ${page} total count`,
+    );
+    invariant(
+      totalCount <= MAX_JOBS,
+      `GitHub API workflow jobs exceeded the ${MAX_JOBS}-job bound`,
+    );
+    if (expectedTotal === null) expectedTotal = totalCount;
+    invariant(
+      totalCount === expectedTotal,
+      "GitHub API workflow jobs total changed during pagination",
+    );
+    invariant(
+      Array.isArray(payload.jobs) && payload.jobs.length <= JOBS_PER_PAGE,
+      `GitHub API workflow jobs page ${page} is malformed`,
+    );
+    invariant(
+      payload.jobs.length > 0 || jobs.length === expectedTotal,
+      "GitHub API workflow jobs pagination ended before total_count",
+    );
+
+    for (const rawJob of payload.jobs) {
+      const job = validateMainCiJob(rawJob, expected);
+      invariant(
+        !seenJobIds.has(job.id),
+        "GitHub API workflow jobs contained a duplicate job ID",
+      );
+      seenJobIds.add(job.id);
+      jobs.push(job);
+      invariant(
+        jobs.length <= expectedTotal,
+        "GitHub API workflow jobs exceeded total_count",
+      );
+    }
+    if (jobs.length === expectedTotal) return jobs;
+  }
+
+  throw new Error(
+    `GitHub API workflow jobs pagination exceeded the ${MAX_JOB_PAGES}-page bound`,
+  );
+}
+
+/**
+ * Verify the exact successful CI/CD attempt that triggered a main deployment.
+ * Only canonical identifiers, URLs, the attempt number, and DEPLOY_SHA leave
+ * this trust boundary.
+ *
+ * @param {{
+ *   eventPayload: unknown,
+ *   deploySha: string,
+ *   token: string,
+ *   apiUrl?: string,
+ *   fetchImplementation?: typeof fetch,
+ *   sleepImplementation?: (milliseconds: number) => Promise<void>,
+ *   signal?: AbortSignal,
+ *   requestAttempts?: number,
+ *   requestTimeoutMs?: number,
+ *   retryDelayMs?: number,
+ * }} options
+ */
+export async function verifyMainCiAttempt({
+  eventPayload,
+  deploySha,
+  token,
+  apiUrl = GITHUB_API_ORIGIN,
+  fetchImplementation = fetch,
+  sleepImplementation = defaultSleep,
+  signal,
+  requestAttempts = DEFAULT_REQUEST_ATTEMPTS,
+  requestTimeoutMs = DEFAULT_REQUEST_TIMEOUT_MS,
+  retryDelayMs = DEFAULT_RETRY_DELAY_MS,
+}) {
+  invariant(
+    typeof fetchImplementation === "function",
+    "fetchImplementation must be a function",
+  );
+  invariant(
+    typeof sleepImplementation === "function",
+    "sleepImplementation must be a function",
+  );
+  const expected = validateMainCiWorkflowRunEvent({
+    eventPayload,
+    deploySha,
+  });
+  const requestOptions = {
+    apiUrl: validateApiBase(apiUrl),
+    fetchImplementation,
+    token: validateToken(token),
+    signal,
+    requestAttempts: boundedPolicyInteger(
+      requestAttempts,
+      "GitHub API request attempts",
+      1,
+      4,
+    ),
+    requestTimeoutMs: boundedPolicyInteger(
+      requestTimeoutMs,
+      "GitHub API request timeout",
+      1,
+      30_000,
+    ),
+    retryDelayMs: boundedPolicyInteger(
+      retryDelayMs,
+      "GitHub API retry delay",
+      0,
+      5_000,
+    ),
+    sleepImplementation,
+  };
+
+  const run = await requestJson(
+    `/repos/${MAIN_DEPLOYMENT_REPOSITORY}/actions/runs/${expected.runId}`,
+    requestOptions,
+  );
+  validateMainCiRunRecord(run, expected);
+
+  const jobs = await listMainCiAttemptJobs(expected, requestOptions);
+  const sentinels = jobs.filter(
+    (job) => job.name === MAIN_DEPLOYMENT_SENTINEL_JOB,
+  );
+  invariant(
+    sentinels.length === 1,
+    `Expected exactly one literal ${MAIN_DEPLOYMENT_SENTINEL_JOB} job in the exact upstream attempt`,
+  );
+  const [sentinel] = sentinels;
+  invariant(
+    sentinel.status === "completed" && sentinel.conclusion === "success",
+    `${MAIN_DEPLOYMENT_SENTINEL_JOB} did not complete successfully in the exact upstream attempt`,
+  );
+
+  return Object.freeze({
+    build_and_test_job_id: sentinel.id,
+    build_and_test_job_url: canonicalJobWebUrl(expected.runId, sentinel.id),
+    deploy_sha: expected.deploySha,
+    upstream_run_attempt: expected.runAttempt,
+    upstream_run_id: expected.runId,
+    upstream_run_url: canonicalAttemptWebUrl(
+      expected.runId,
+      expected.runAttempt,
+    ),
+  });
+}
+
+export function formatMainCiAttemptSummary(result) {
+  return [
+    "### Verified upstream CI attempt",
+    "",
+    `- Upstream run ID: \`${result.upstream_run_id}\``,
+    `- Upstream run attempt: \`${result.upstream_run_attempt}\``,
+    `- Upstream run URL: ${result.upstream_run_url}`,
+    `- Build and Test job ID: \`${result.build_and_test_job_id}\``,
+    `- Build and Test job URL: ${result.build_and_test_job_url}`,
+    `- DEPLOY_SHA: \`${result.deploy_sha}\``,
+    "",
+  ].join("\n");
+}
+
+function appendOutputs(path, result) {
+  for (const [name, value] of Object.entries(result)) {
+    appendFileSync(path, `${name}=${value}\n`);
+  }
+}
+
+function readEventPayload(path) {
+  const raw = readFileSync(path);
+  invariant(
+    raw.byteLength <= MAX_EVENT_BYTES,
+    "GITHUB_EVENT_PATH exceeded its size limit",
+  );
+  try {
+    return JSON.parse(raw.toString("utf8"));
+  } catch {
+    throw new Error("GITHUB_EVENT_PATH contained invalid JSON");
+  }
+}
+
+export async function verifyMainCiAttemptFromEnvironment({
+  values = process.env,
+  fetchImplementation = fetch,
+  sleepImplementation = defaultSleep,
+  signal,
+} = {}) {
+  const eventPath = boundedString(
+    values.GITHUB_EVENT_PATH,
+    "GITHUB_EVENT_PATH",
+    4_096,
+  );
+  const result = await verifyMainCiAttempt({
+    eventPayload: readEventPayload(eventPath),
+    deploySha: values.DEPLOY_SHA,
+    token: values.GITHUB_TOKEN,
+    apiUrl: values.GITHUB_API_URL ?? GITHUB_API_ORIGIN,
+    fetchImplementation,
+    sleepImplementation,
+    signal,
+  });
+  const outputPath = boundedString(
+    values.GITHUB_OUTPUT,
+    "GITHUB_OUTPUT",
+    4_096,
+  );
+  appendOutputs(outputPath, result);
+  if (values.GITHUB_STEP_SUMMARY) {
+    appendFileSync(
+      boundedString(values.GITHUB_STEP_SUMMARY, "GITHUB_STEP_SUMMARY", 4_096),
+      formatMainCiAttemptSummary(result),
+    );
+  }
+  return result;
+}
+
+function isCliEntrypoint() {
+  return (
+    process.argv[1] !== undefined &&
+    fileURLToPath(import.meta.url) === resolve(process.argv[1])
+  );
+}
+
+if (isCliEntrypoint()) {
+  if (process.argv[2] !== "verify" || process.argv.length !== 3) {
+    throw new Error("Usage: vercel-main-ci-attempt.mjs verify");
+  }
+  await verifyMainCiAttemptFromEnvironment();
+  process.stdout.write("Verified exact upstream CI attempt\n");
+}

--- a/scripts/vercel-main-ci-attempt.mjs
+++ b/scripts/vercel-main-ci-attempt.mjs
@@ -573,10 +573,8 @@ export function formatMainCiAttemptSummary(result) {
   return [
     "### Verified upstream CI attempt",
     "",
-    `- Upstream run ID: \`${result.upstream_run_id}\``,
     `- Upstream run attempt: \`${result.upstream_run_attempt}\``,
     `- Upstream run URL: ${result.upstream_run_url}`,
-    `- Build and Test job ID: \`${result.build_and_test_job_id}\``,
     `- Build and Test job URL: ${result.build_and_test_job_url}`,
     `- DEPLOY_SHA: \`${result.deploy_sha}\``,
     "",

--- a/scripts/vercel-main-ci-attempt.test.mjs
+++ b/scripts/vercel-main-ci-attempt.test.mjs
@@ -1,0 +1,681 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+
+import {
+  formatMainCiAttemptSummary,
+  MAIN_DEPLOYMENT_REPOSITORY,
+  validateMainCiWorkflowRunEvent,
+  verifyMainCiAttempt,
+  verifyMainCiAttemptFromEnvironment,
+} from "./vercel-main-ci-attempt.mjs";
+
+const TOKEN = "github-token-fixture";
+const fixtureDirectory = new URL(
+  "./fixtures/vercel-main-ci-attempt/",
+  import.meta.url,
+);
+
+function loadFixture(name) {
+  return JSON.parse(readFileSync(new URL(name, fixtureDirectory), "utf8"));
+}
+
+function successFixture() {
+  return loadFixture("success-first-attempt.json");
+}
+
+function rerunFixture() {
+  return loadFixture("success-rerun-attempt.json");
+}
+
+function priorAttemptFixture() {
+  const description = loadFixture("prior-attempt-confusion.json");
+  const fixture = rerunFixture();
+  Object.assign(fixture.job_pages[0].jobs[0], description.job_overrides);
+  return fixture;
+}
+
+function paginationFixture() {
+  const description = loadFixture("pagination.json");
+  const fixture = successFixture();
+  const jobs = fixture.job_pages[0].jobs;
+  fixture.job_pages = description.job_pages.map((page) => ({
+    total_count: page.total_count,
+    jobs: page.job_indexes.map((index) => jobs[index]),
+  }));
+  return fixture;
+}
+
+function jsonResponse(value, status = 200) {
+  return new Response(JSON.stringify(value), {
+    status,
+    headers: { "content-type": "application/json; charset=utf-8" },
+  });
+}
+
+function textResponse(value, contentType = "application/json") {
+  return new Response(value, {
+    status: 200,
+    headers: { "content-type": contentType },
+  });
+}
+
+function fakeGitHubApi(fixture, { intercept } = {}) {
+  const calls = [];
+  const runId = fixture.event.workflow_run.id;
+  const runAttempt = fixture.event.workflow_run.run_attempt;
+  const runPath = `/repos/${MAIN_DEPLOYMENT_REPOSITORY}/actions/runs/${runId}`;
+  const jobsPath = `${runPath}/attempts/${runAttempt}/jobs`;
+
+  const fetchImplementation = async (input, options) => {
+    const url = new URL(input);
+    calls.push({ options, url });
+    const intercepted = await intercept?.({
+      call: calls.length,
+      options,
+      url,
+    });
+    if (intercepted !== undefined) return intercepted;
+    if (url.pathname === runPath && url.search === "") {
+      return jsonResponse(fixture.run);
+    }
+    if (url.pathname === jobsPath) {
+      assert.equal(url.searchParams.get("per_page"), "100");
+      const page = Number(url.searchParams.get("page"));
+      return fixture.job_pages[page - 1]
+        ? jsonResponse(fixture.job_pages[page - 1])
+        : jsonResponse({ message: "Not Found" }, 404);
+    }
+    return jsonResponse({ message: "Not Found" }, 404);
+  };
+
+  return { calls, fetchImplementation, jobsPath, runPath };
+}
+
+function verificationOptions(fixture, fetchImplementation, additional = {}) {
+  return {
+    eventPayload: fixture.event,
+    deploySha: fixture.event.workflow_run.head_sha,
+    token: TOKEN,
+    fetchImplementation,
+    sleepImplementation: async () => {},
+    ...additional,
+  };
+}
+
+test("verifies a first-attempt CI run and emits only canonical evidence", async () => {
+  const fixture = successFixture();
+  const api = fakeGitHubApi(fixture);
+  const result = await verifyMainCiAttempt(
+    verificationOptions(fixture, api.fetchImplementation),
+  );
+
+  assert.deepEqual(result, {
+    build_and_test_job_id: 90000000002,
+    build_and_test_job_url:
+      "https://github.com/mento-protocol/frontend-monorepo/actions/runs/40000000001/job/90000000002",
+    deploy_sha: "0123456789abcdef0123456789abcdef01234567",
+    upstream_run_attempt: 1,
+    upstream_run_id: 40000000001,
+    upstream_run_url:
+      "https://github.com/mento-protocol/frontend-monorepo/actions/runs/40000000001/attempts/1",
+  });
+  assert.equal(Object.isFrozen(result), true);
+  assert.equal(api.calls.length, 2);
+  for (const { options, url } of api.calls) {
+    assert.equal(url.origin, "https://api.github.com");
+    assert.equal(options.method, "GET");
+    assert.equal(options.redirect, "error");
+    assert.equal(options.headers.Authorization, `Bearer ${TOKEN}`);
+  }
+});
+
+test("verifies a rerun only through the attempt-specific jobs endpoint", async () => {
+  const fixture = rerunFixture();
+  const api = fakeGitHubApi(fixture);
+  const result = await verifyMainCiAttempt(
+    verificationOptions(fixture, api.fetchImplementation),
+  );
+
+  assert.equal(result.upstream_run_attempt, 2);
+  assert.equal(
+    result.upstream_run_url,
+    "https://github.com/mento-protocol/frontend-monorepo/actions/runs/40000000002/attempts/2",
+  );
+  const jobCalls = api.calls.filter(({ url }) =>
+    url.pathname.endsWith("/jobs"),
+  );
+  assert.equal(jobCalls.length, 1);
+  assert.equal(
+    jobCalls[0].url.pathname,
+    "/repos/mento-protocol/frontend-monorepo/actions/runs/40000000002/attempts/2/jobs",
+  );
+  assert.equal(
+    api.calls.some(({ url }) =>
+      url.pathname.endsWith("/actions/runs/40000000002/jobs"),
+    ),
+    false,
+  );
+});
+
+test("rejects a prior-attempt sentinel returned for a rerun", async () => {
+  const fixture = priorAttemptFixture();
+  const api = fakeGitHubApi(fixture);
+  await assert.rejects(
+    verifyMainCiAttempt(verificationOptions(fixture, api.fetchImplementation)),
+    /job run attempt mismatch/,
+  );
+});
+
+test("authenticates the completed event before making API requests", async () => {
+  const scenarios = loadFixture("negative-scenarios.json");
+  const mutations = {
+    "wrong-workflow-path": (fixture, scenario) => {
+      fixture.event.workflow_run[scenario.property] = scenario.value;
+    },
+    "wrong-repository": (fixture, scenario) => {
+      fixture.event.repository[scenario.property] = scenario.value;
+    },
+    "wrong-sha": (fixture, scenario) => {
+      fixture.event.workflow_run[scenario.property] = scenario.value;
+    },
+    "wrong-branch": (fixture, scenario) => {
+      fixture.event.workflow_run[scenario.property] = scenario.value;
+    },
+    "wrong-event": (fixture, scenario) => {
+      fixture.event.workflow_run[scenario.property] = scenario.value;
+    },
+    "wrong-conclusion": (fixture, scenario) => {
+      fixture.event.workflow_run[scenario.property] = scenario.value;
+    },
+  };
+
+  for (const [name, mutate] of Object.entries(mutations)) {
+    const fixture = successFixture();
+    mutate(fixture, scenarios[name]);
+    let calls = 0;
+    await assert.rejects(
+      verifyMainCiAttempt({
+        ...verificationOptions(fixture, async () => {
+          calls += 1;
+          throw new Error("unexpected fetch");
+        }),
+        deploySha: successFixture().event.workflow_run.head_sha,
+      }),
+      /mismatch/,
+      name,
+    );
+    assert.equal(calls, 0, name);
+  }
+
+  const malformedSha = successFixture();
+  assert.throws(
+    () =>
+      validateMainCiWorkflowRunEvent({
+        eventPayload: malformedSha.event,
+        deploySha: "ABCDEF",
+      }),
+    /immutable lowercase 40-character SHA/,
+  );
+});
+
+test("rejects every API run-record identity mismatch", async () => {
+  const cases = [
+    ["name", "Other workflow"],
+    ["path", ".github/workflows/other.yml"],
+    ["event", "workflow_dispatch"],
+    ["head_branch", "feature"],
+    ["head_sha", "f".repeat(40)],
+    ["status", "in_progress"],
+    ["conclusion", "cancelled"],
+    ["run_attempt", 2],
+    ["id", 40000000009],
+    [
+      "url",
+      "https://api.github.com/repos/mento-protocol/frontend-monorepo/actions/runs/40000000009",
+    ],
+    [
+      "html_url",
+      "https://github.com/mento-protocol/frontend-monorepo/actions/runs/40000000009",
+    ],
+  ];
+
+  for (const [property, value] of cases) {
+    const fixture = successFixture();
+    fixture.run[property] = value;
+    const api = fakeGitHubApi(fixture);
+    await assert.rejects(
+      verifyMainCiAttempt(
+        verificationOptions(fixture, api.fetchImplementation),
+      ),
+      /mismatch/,
+      property,
+    );
+    assert.equal(api.calls.length, 1, property);
+  }
+
+  for (const repositoryProperty of ["repository", "head_repository"]) {
+    const fixture = successFixture();
+    fixture.run[repositoryProperty].full_name = "attacker/frontend-monorepo";
+    const api = fakeGitHubApi(fixture);
+    await assert.rejects(
+      verifyMainCiAttempt(
+        verificationOptions(fixture, api.fetchImplementation),
+      ),
+      /full name mismatch/,
+      repositoryProperty,
+    );
+  }
+});
+
+test("requires exactly one literal successful Build and Test sentinel", async () => {
+  const scenarios = loadFixture("negative-scenarios.json");
+
+  const duplicate = successFixture();
+  duplicate.job_pages[0].jobs[0].name = scenarios["duplicate-sentinel"].value;
+  await assert.rejects(
+    verifyMainCiAttempt(
+      verificationOptions(
+        duplicate,
+        fakeGitHubApi(duplicate).fetchImplementation,
+      ),
+    ),
+    /exactly one literal Build and Test/,
+  );
+
+  const missing = successFixture();
+  missing.job_pages[0].jobs[1].name = scenarios["missing-sentinel"].value;
+  await assert.rejects(
+    verifyMainCiAttempt(
+      verificationOptions(missing, fakeGitHubApi(missing).fetchImplementation),
+    ),
+    /exactly one literal Build and Test/,
+  );
+
+  for (const [status, conclusion] of [
+    ["completed", "failure"],
+    ["completed", "cancelled"],
+    ["in_progress", null],
+  ]) {
+    const fixture = successFixture();
+    Object.assign(fixture.job_pages[0].jobs[1], {
+      status,
+      conclusion,
+    });
+    await assert.rejects(
+      verifyMainCiAttempt(
+        verificationOptions(
+          fixture,
+          fakeGitHubApi(fixture).fetchImplementation,
+        ),
+      ),
+      /did not complete successfully/,
+      `${status}/${conclusion}`,
+    );
+  }
+});
+
+test("validates every job as part of the exact attempt response", async () => {
+  const cases = [
+    ["run_id", 40000000009],
+    ["run_attempt", 2],
+    ["workflow_name", "Other workflow"],
+    ["head_branch", "feature"],
+    ["head_sha", "f".repeat(40)],
+    [
+      "run_url",
+      "https://api.github.com/repos/mento-protocol/frontend-monorepo/actions/runs/40000000009",
+    ],
+    [
+      "url",
+      "https://api.github.com/repos/mento-protocol/frontend-monorepo/actions/jobs/90000000009",
+    ],
+    [
+      "html_url",
+      "https://github.com/mento-protocol/frontend-monorepo/actions/runs/40000000001/job/90000000009",
+    ],
+  ];
+  for (const [property, value] of cases) {
+    const fixture = successFixture();
+    fixture.job_pages[0].jobs[0][property] = value;
+    const api = fakeGitHubApi(fixture);
+    await assert.rejects(
+      verifyMainCiAttempt(
+        verificationOptions(fixture, api.fetchImplementation),
+      ),
+      /mismatch/,
+      property,
+    );
+  }
+});
+
+test("paginates the complete attempt-specific job list", async () => {
+  const fixture = paginationFixture();
+  const api = fakeGitHubApi(fixture);
+  const result = await verifyMainCiAttempt(
+    verificationOptions(fixture, api.fetchImplementation),
+  );
+
+  assert.equal(result.build_and_test_job_id, 90000000002);
+  assert.deepEqual(
+    api.calls
+      .filter(({ url }) => url.pathname.endsWith("/jobs"))
+      .map(({ url }) => url.searchParams.get("page")),
+    ["1", "2"],
+  );
+});
+
+test("fails closed on incomplete, inconsistent, duplicate, or unbounded pagination", async () => {
+  const malformedPages = [
+    {
+      name: "early empty page",
+      mutate(fixture) {
+        fixture.job_pages = [
+          { total_count: 2, jobs: [fixture.job_pages[0].jobs[0]] },
+          { total_count: 2, jobs: [] },
+        ];
+      },
+      pattern: /ended before total_count/,
+    },
+    {
+      name: "changing total",
+      mutate(fixture) {
+        fixture.job_pages = [
+          { total_count: 2, jobs: [fixture.job_pages[0].jobs[0]] },
+          { total_count: 3, jobs: [fixture.job_pages[0].jobs[1]] },
+        ];
+      },
+      pattern: /total changed/,
+    },
+    {
+      name: "duplicate job ID",
+      mutate(fixture) {
+        fixture.job_pages = [
+          { total_count: 2, jobs: [fixture.job_pages[0].jobs[0]] },
+          { total_count: 2, jobs: [fixture.job_pages[0].jobs[0]] },
+        ];
+      },
+      pattern: /duplicate job ID/,
+    },
+    {
+      name: "unbounded total",
+      mutate(fixture) {
+        fixture.job_pages[0].total_count = 1_001;
+      },
+      pattern: /1000-job bound/,
+    },
+    {
+      name: "malformed total",
+      mutate(fixture) {
+        fixture.job_pages[0].total_count = "2";
+      },
+      pattern: /non-negative safe integer/,
+    },
+  ];
+
+  for (const scenario of malformedPages) {
+    const fixture = successFixture();
+    scenario.mutate(fixture);
+    const api = fakeGitHubApi(fixture);
+    await assert.rejects(
+      verifyMainCiAttempt(
+        verificationOptions(fixture, api.fetchImplementation),
+      ),
+      scenario.pattern,
+      scenario.name,
+    );
+  }
+});
+
+test("retries transient API failures with a bounded delay", async () => {
+  const fixture = successFixture();
+  const sleeps = [];
+  let runRequests = 0;
+  const api = fakeGitHubApi(fixture, {
+    intercept: ({ url }) => {
+      if (url.pathname === api.runPath) {
+        runRequests += 1;
+        if (runRequests === 1) {
+          return jsonResponse({ message: "server error" }, 500);
+        }
+      }
+      return undefined;
+    },
+  });
+  await verifyMainCiAttempt({
+    ...verificationOptions(fixture, api.fetchImplementation),
+    retryDelayMs: 17,
+    sleepImplementation: async (milliseconds) => sleeps.push(milliseconds),
+  });
+  assert.equal(runRequests, 2);
+  assert.deepEqual(sleeps, [17]);
+});
+
+test("stops after bounded retries on an API failure", async () => {
+  const fixture = successFixture();
+  const scenarios = loadFixture("negative-scenarios.json");
+  assert.equal(scenarios["api-failure"].fault, "http-500");
+  const sleeps = [];
+  const api = fakeGitHubApi(fixture, {
+    intercept: () => jsonResponse({ message: "server error" }, 500),
+  });
+  await assert.rejects(
+    verifyMainCiAttempt({
+      ...verificationOptions(fixture, api.fetchImplementation),
+      requestAttempts: 3,
+      retryDelayMs: 7,
+      sleepImplementation: async (milliseconds) => sleeps.push(milliseconds),
+    }),
+    /after 3 bounded attempts.*HTTP 500/,
+  );
+  assert.equal(api.calls.length, 3);
+  assert.deepEqual(sleeps, [7, 7]);
+
+  const forbidden = fakeGitHubApi(fixture, {
+    intercept: () => jsonResponse({ message: "forbidden" }, 403),
+  });
+  await assert.rejects(
+    verifyMainCiAttempt(
+      verificationOptions(fixture, forbidden.fetchImplementation),
+    ),
+    /HTTP 403/,
+  );
+  assert.equal(forbidden.calls.length, 1);
+});
+
+test("bounds request timeouts and retries without hanging", async () => {
+  const fixture = successFixture();
+  const scenarios = loadFixture("negative-scenarios.json");
+  assert.equal(scenarios.timeout.fault, "timeout");
+  let calls = 0;
+  const fetchImplementation = (_input, { signal }) => {
+    calls += 1;
+    return new Promise((_resolve, reject) => {
+      signal.addEventListener(
+        "abort",
+        () => reject(new DOMException("aborted", "AbortError")),
+        { once: true },
+      );
+    });
+  };
+  await assert.rejects(
+    verifyMainCiAttempt({
+      ...verificationOptions(fixture, fetchImplementation),
+      requestAttempts: 2,
+      requestTimeoutMs: 2,
+    }),
+    /after 2 bounded attempts.*request timeout/,
+  );
+  assert.equal(calls, 2);
+});
+
+test("external cancellation stops immediately without retry", async () => {
+  const fixture = successFixture();
+  const scenarios = loadFixture("negative-scenarios.json");
+  assert.equal(scenarios.cancellation.fault, "abort");
+
+  const alreadyCancelled = new AbortController();
+  alreadyCancelled.abort();
+  let calls = 0;
+  await assert.rejects(
+    verifyMainCiAttempt({
+      ...verificationOptions(fixture, async () => {
+        calls += 1;
+        throw new Error("unexpected fetch");
+      }),
+      signal: alreadyCancelled.signal,
+    }),
+    /cancelled/,
+  );
+  assert.equal(calls, 0);
+
+  const duringRequest = new AbortController();
+  const fetchImplementation = async () => {
+    calls += 1;
+    duringRequest.abort();
+    throw new DOMException("aborted", "AbortError");
+  };
+  await assert.rejects(
+    verifyMainCiAttempt({
+      ...verificationOptions(fixture, fetchImplementation),
+      signal: duringRequest.signal,
+    }),
+    /cancelled/,
+  );
+  assert.equal(calls, 1);
+});
+
+test("rejects malformed API response envelopes without exposing bodies", async () => {
+  const fixture = successFixture();
+  const scenarios = loadFixture("negative-scenarios.json");
+  assert.equal(scenarios["malformed-response"].fault, "invalid-json");
+
+  const responses = [
+    {
+      name: "invalid JSON",
+      response: textResponse("{"),
+      pattern: /invalid JSON/,
+    },
+    {
+      name: "wrong content type",
+      response: textResponse("{}", "text/html"),
+      pattern: /non-JSON/,
+    },
+    {
+      name: "non-object run",
+      response: jsonResponse([]),
+      pattern: /plain object/,
+    },
+    {
+      name: "oversized declared body",
+      response: new Response("{}", {
+        status: 200,
+        headers: {
+          "content-type": "application/json",
+          "content-length": String(4 * 1024 * 1024 + 1),
+        },
+      }),
+      pattern: /size limit/,
+    },
+  ];
+
+  for (const scenario of responses) {
+    const api = fakeGitHubApi(fixture, {
+      intercept: ({ url }) =>
+        url.pathname ===
+        `/repos/${MAIN_DEPLOYMENT_REPOSITORY}/actions/runs/40000000001`
+          ? scenario.response
+          : undefined,
+    });
+    await assert.rejects(
+      verifyMainCiAttempt(
+        verificationOptions(fixture, api.fetchImplementation),
+      ),
+      scenario.pattern,
+      scenario.name,
+    );
+  }
+
+  const malformedJobs = successFixture();
+  malformedJobs.job_pages[0] = {
+    total_count: 1,
+    jobs: "not-an-array",
+  };
+  await assert.rejects(
+    verifyMainCiAttempt(
+      verificationOptions(
+        malformedJobs,
+        fakeGitHubApi(malformedJobs).fetchImplementation,
+      ),
+    ),
+    /jobs page 1 is malformed/,
+  );
+});
+
+test("rejects unsafe API configuration before fetching", async () => {
+  const fixture = successFixture();
+  let calls = 0;
+  const fetchImplementation = async () => {
+    calls += 1;
+    throw new Error("unexpected fetch");
+  };
+  for (const options of [
+    { token: "" },
+    { token: "bad token" },
+    { apiUrl: "https://example.com" },
+    { apiUrl: "https://api.github.com/repos" },
+    { requestAttempts: 0 },
+    { requestAttempts: 5 },
+    { requestTimeoutMs: 0 },
+    { retryDelayMs: 5_001 },
+  ]) {
+    await assert.rejects(
+      verifyMainCiAttempt({
+        ...verificationOptions(fixture, fetchImplementation),
+        ...options,
+      }),
+      /GITHUB_TOKEN|GITHUB_API_URL|bounded policy/,
+    );
+  }
+  assert.equal(calls, 0);
+});
+
+test("environment CLI API writes only canonical outputs and summary evidence", async () => {
+  const fixture = successFixture();
+  const api = fakeGitHubApi(fixture);
+  const directory = mkdtempSync(join(tmpdir(), "main-ci-attempt-"));
+  const eventPath = join(directory, "event.json");
+  const outputPath = join(directory, "output");
+  const summaryPath = join(directory, "summary");
+  try {
+    writeFileSync(eventPath, JSON.stringify(fixture.event));
+    writeFileSync(outputPath, "");
+    writeFileSync(summaryPath, "");
+    const result = await verifyMainCiAttemptFromEnvironment({
+      values: {
+        DEPLOY_SHA: fixture.event.workflow_run.head_sha,
+        GITHUB_API_URL: "https://api.github.com",
+        GITHUB_EVENT_PATH: eventPath,
+        GITHUB_OUTPUT: outputPath,
+        GITHUB_STEP_SUMMARY: summaryPath,
+        GITHUB_TOKEN: TOKEN,
+      },
+      fetchImplementation: api.fetchImplementation,
+      sleepImplementation: async () => {},
+    });
+
+    const outputs = readFileSync(outputPath, "utf8");
+    const summary = readFileSync(summaryPath, "utf8");
+    for (const [name, value] of Object.entries(result)) {
+      assert.match(outputs, new RegExp(`^${name}=${value}$`, "m"));
+    }
+    assert.equal(outputs.includes(TOKEN), false);
+    assert.equal(summary, formatMainCiAttemptSummary(result));
+    assert.equal(summary.includes(TOKEN), false);
+    assert.match(summary, /Verified upstream CI attempt/);
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});

--- a/scripts/vercel-main-ci-attempt.test.mjs
+++ b/scripts/vercel-main-ci-attempt.test.mjs
@@ -673,8 +673,20 @@ test("environment CLI API writes only canonical outputs and summary evidence", a
     }
     assert.equal(outputs.includes(TOKEN), false);
     assert.equal(summary, formatMainCiAttemptSummary(result));
+    assert.equal(
+      summary,
+      [
+        "### Verified upstream CI attempt",
+        "",
+        `- Upstream run attempt: \`${result.upstream_run_attempt}\``,
+        `- Upstream run URL: ${result.upstream_run_url}`,
+        `- Build and Test job URL: ${result.build_and_test_job_url}`,
+        `- DEPLOY_SHA: \`${result.deploy_sha}\``,
+        "",
+      ].join("\n"),
+    );
+    assert.doesNotMatch(summary, /Upstream run ID|Build and Test job ID/);
     assert.equal(summary.includes(TOKEN), false);
-    assert.match(summary, /Verified upstream CI attempt/);
   } finally {
     rmSync(directory, { recursive: true, force: true });
   }

--- a/scripts/vercel-main-deployment-workflow.test.mjs
+++ b/scripts/vercel-main-deployment-workflow.test.mjs
@@ -1,0 +1,653 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { test } from "node:test";
+import { parse } from "yaml";
+
+const workflowPath = ".github/workflows/vercel-main-deployment.yml";
+const workflowSource = readFileSync(
+  new URL(`../${workflowPath}`, import.meta.url),
+  "utf8",
+);
+const workflow = parse(workflowSource);
+
+const CHECKOUT = "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0";
+const UPLOAD =
+  "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a";
+const DOWNLOAD =
+  "actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093";
+const ORDINARY = Object.freeze({
+  governance: Object.freeze({
+    project: "${{ vars.VERCEL_PROJECT_ID_GOVERNANCE }}",
+    root: "apps/governance.mento.org",
+    sentry: true,
+    etherscan: true,
+  }),
+  reserve: Object.freeze({
+    project: "${{ vars.VERCEL_PROJECT_ID_RESERVE }}",
+    root: "apps/reserve.mento.org",
+    sentry: true,
+    etherscan: false,
+  }),
+  ui: Object.freeze({
+    project: "${{ vars.VERCEL_PROJECT_ID_UI }}",
+    root: "apps/ui.mento.org",
+    sentry: false,
+    etherscan: false,
+  }),
+});
+
+function stepNamed(jobName, name) {
+  const step = workflow.jobs[jobName].steps.find((item) => item.name === name);
+  assert.ok(step, `missing ${jobName} step: ${name}`);
+  return step;
+}
+
+function stepIncluding(jobName, text) {
+  const step = workflow.jobs[jobName].steps.find((item) =>
+    item.run?.includes(text),
+  );
+  assert.ok(step, `missing ${jobName} command: ${text}`);
+  return step;
+}
+
+function allStrings(value, output = []) {
+  if (typeof value === "string") output.push(value);
+  if (Array.isArray(value)) value.forEach((item) => allStrings(item, output));
+  if (value && typeof value === "object") {
+    Object.values(value).forEach((item) => allStrings(item, output));
+  }
+  return output;
+}
+
+test("workflow_run gate, permissions, mode, queue, and DAG are literal", () => {
+  assert.equal(workflow.name, "Vercel Main Deployment");
+  assert.deepEqual(workflow.on, {
+    workflow_run: {
+      workflows: ["CI/CD"],
+      types: ["completed"],
+      branches: ["main"],
+    },
+  });
+  assert.deepEqual(workflow.permissions, {
+    contents: "read",
+    actions: "read",
+  });
+  assert.deepEqual(workflow.concurrency, {
+    group: "vercel-main-deployment",
+    "cancel-in-progress": false,
+    queue: "single",
+  });
+  assert.equal(workflow.env.VERCEL_MAIN_MODE, "shadow");
+  assert.deepEqual(Object.keys(workflow.jobs), [
+    "wait-for-ci",
+    "plan-main-deployments",
+    "stage-governance",
+    "stage-reserve",
+    "stage-ui",
+    "activate-and-verify",
+    "recover-main-deployment",
+    "result",
+  ]);
+  assert.equal(workflow.jobs.result.name, "Vercel Main Deployment");
+  assert.equal(workflow.jobs.result.environment, undefined);
+  for (const [jobName, job] of Object.entries(workflow.jobs)) {
+    if (job.environment === undefined) continue;
+    assert.deepEqual(
+      job.environment,
+      {
+        name: "vercel-cli-production",
+        deployment: false,
+      },
+      `${jobName} environment`,
+    );
+  }
+  assert.doesNotMatch(workflowSource, /name:\s*Production\b/);
+  assert.doesNotMatch(workflowSource, /deployments:\s*write/);
+  assert.doesNotMatch(workflowSource, /\bgithub\.sha\b/);
+});
+
+test("upstream receipt binds the exact successful attempt before credentials", () => {
+  const job = workflow.jobs["wait-for-ci"];
+  assert.equal(
+    job.if,
+    "github.event.workflow_run.event == 'push' && github.event.workflow_run.head_branch == 'main' && github.event.workflow_run.conclusion == 'success'",
+  );
+  assert.equal(job.env.DEPLOY_SHA, "${{ github.event.workflow_run.head_sha }}");
+  assert.equal(job.environment, undefined);
+  const checkouts = job.steps.filter((step) => step.uses === CHECKOUT);
+  assert.equal(checkouts.length, 2);
+  assert.deepEqual(checkouts[0].with, {
+    "fetch-depth": 1,
+    "persist-credentials": false,
+    ref: "${{ github.workflow_sha }}",
+  });
+  assert.deepEqual(checkouts[1].with, {
+    "fetch-depth": 0,
+    path: "source",
+    "persist-credentials": false,
+    ref: "${{ github.event.workflow_run.head_sha }}",
+  });
+  const context = stepIncluding("wait-for-ci", "validate-context");
+  const receipt = stepIncluding(
+    "wait-for-ci",
+    "vercel-main-ci-attempt.mjs verify",
+  );
+  const source = stepIncluding("wait-for-ci", "validate-source");
+  assert.ok(job.steps.indexOf(context) < job.steps.indexOf(receipt));
+  assert.ok(job.steps.indexOf(receipt) < job.steps.indexOf(checkouts[1]));
+  assert.ok(job.steps.indexOf(checkouts[1]) < job.steps.indexOf(source));
+  assert.equal(receipt.env.GITHUB_TOKEN, "${{ github.token }}");
+  assert.match(source.run, /fetch --no-tags origin \+refs\/heads\/main/);
+});
+
+test("planner captures tolerant main evidence and strict legacy rollback state", () => {
+  const job = workflow.jobs["plan-main-deployments"];
+  assert.deepEqual(job.needs, ["wait-for-ci"]);
+  assert.deepEqual(job.environment, {
+    name: "vercel-cli-production",
+    deployment: false,
+  });
+  assert.equal(
+    job.env.DEPLOY_SHA,
+    "${{ needs.wait-for-ci.outputs.deploy_sha }}",
+  );
+  assert.equal(
+    job.env.UPSTREAM_RUN_ATTEMPT,
+    "${{ needs.wait-for-ci.outputs.upstream_run_attempt }}",
+  );
+  assert.equal(job.outputs.plan, "${{ steps.plan.outputs.plan }}");
+  assert.equal(job.outputs.targets, "${{ steps.plan.outputs.targets }}");
+  const planning = stepIncluding("plan-main-deployments", "planning-snapshot");
+  const legacy = stepIncluding("plan-main-deployments", "snapshot --spec");
+  const select = stepIncluding(
+    "plan-main-deployments",
+    "vercel-main-deployment.mjs plan",
+  );
+  const health = stepNamed(
+    "plan-main-deployments",
+    "Verify reviewed public aliases are healthy",
+  );
+  assert.equal(
+    planning.env.VERCEL_TOKEN,
+    "${{ secrets.VERCEL_TOKEN_PRODUCTION }}",
+  );
+  assert.equal(
+    legacy.env.VERCEL_TOKEN,
+    "${{ secrets.VERCEL_TOKEN_PRODUCTION }}",
+  );
+  assert.match(select.run, /--planning-snapshot/);
+  assert.match(select.run, /--legacy-snapshot/);
+  assert.match(health.run, /health --spec "\$RUNNER_TEMP\/main-spec\.json"/);
+  assert.match(health.run, /health --spec "\$RUNNER_TEMP\/legacy-spec\.json"/);
+  assert.ok(job.steps.indexOf(health) < job.steps.indexOf(select));
+  assert.match(
+    stepIncluding("plan-main-deployments", "validate-source").run,
+    /fetch --no-tags origin/,
+  );
+});
+
+test("each ordinary lane visibly binds one literal project, build, deploy, smoke, and handoff contract", () => {
+  for (const [target, contract] of Object.entries(ORDINARY)) {
+    const name = `stage-${target}`;
+    const job = workflow.jobs[name];
+    assert.deepEqual(job.needs, ["wait-for-ci", "plan-main-deployments"]);
+    assert.equal(
+      job.if,
+      `contains(fromJSON(needs.plan-main-deployments.outputs.targets), '${target}')`,
+    );
+    assert.deepEqual(job.environment, {
+      name: "vercel-cli-production",
+      deployment: false,
+    });
+    assert.equal(job.env.LOGICAL_TARGET, target);
+    assert.equal(job.env.VERCEL_PROJECT_ID, contract.project);
+    assert.equal(job.outputs.handoff, "${{ steps.handoff.outputs.result }}");
+
+    const checkouts = job.steps.filter((step) => step.uses === CHECKOUT);
+    assert.equal(checkouts.length, 3);
+    assert.deepEqual(checkouts[0].with, {
+      "fetch-depth": 1,
+      "persist-credentials": false,
+      ref: "${{ needs.wait-for-ci.outputs.deploy_sha }}",
+    });
+    assert.equal(checkouts[1].with.path, "source");
+    assert.equal(checkouts[1].with["fetch-depth"], 0);
+    assert.equal(checkouts[2].with.path, "trusted-after-build");
+    assert.equal(checkouts[2].with["fetch-depth"], 1);
+
+    const pull = stepIncluding(name, "vercel-production-shadow.mjs pull");
+    assert.equal(
+      pull.env.VERCEL_TOKEN,
+      "${{ secrets.VERCEL_TOKEN_PRODUCTION }}",
+    );
+    assert.equal(pull.env.VERCEL_PROJECT_ID, undefined);
+    const project = stepIncluding(name, "vercel-deployment-state.mjs project");
+    assert.match(
+      project.run,
+      new RegExp(`--project-name ${target}\\.mento\\.org`),
+    );
+    assert.match(project.run, new RegExp(`--root-directory ${contract.root}`));
+
+    const build = job.steps.find(
+      (step) => step.uses === "./.github/actions/vercel-candidate-build",
+    );
+    assert.ok(build);
+    assert.equal(build.with["logical-target"], target);
+    assert.equal(build.with["expected-root-directory"], contract.root);
+    assert.equal(build.with["vercel-project-id"], contract.project);
+    assert.equal(build.env.VERCEL_ENV, "production");
+    assert.equal(build.env.VERCEL_TARGET_ENV, "production");
+    assert.equal(build.env.NEXT_PUBLIC_VERCEL_ENV, "production");
+    assert.equal(build.env.TURBO_TOKEN, "${{ secrets.TURBO_TOKEN }}");
+    assert.equal(
+      build.env.TURBO_REMOTE_CACHE_SIGNATURE_KEY,
+      "${{ secrets.TURBO_REMOTE_CACHE_SIGNATURE_KEY }}",
+    );
+    assert.equal(
+      Object.hasOwn(build.env, "SENTRY_AUTH_TOKEN"),
+      contract.sentry,
+    );
+    assert.equal(
+      Object.hasOwn(build.env, "ETHERSCAN_API_KEY"),
+      contract.etherscan,
+    );
+
+    const deploy = stepIncluding(name, "deploy --expected");
+    assert.equal(
+      deploy.env.VERCEL_TOKEN,
+      "${{ secrets.VERCEL_TOKEN_PRODUCTION }}",
+    );
+    assert.equal(
+      deploy.env.SOURCE_PATH,
+      "${{ steps.runtime.outputs.upload-source-path }}",
+    );
+    assert.match(deploy.run, /TRUSTED_POST_BUILD_PATH/);
+    const state = stepIncluding(name, "deployment --expected");
+    assert.match(
+      state.run,
+      new RegExp(`assert-generated-aliases --target ${target}`),
+    );
+
+    const smoke = stepIncluding(name, "playwright.production-shadow.config.ts");
+    assert.equal(smoke["working-directory"], "trusted-after-build");
+    assert.equal(smoke.env.PRODUCTION_SHADOW_TARGET, target);
+    assert.equal(
+      smoke.env.PRODUCTION_SHADOW_URL,
+      "${{ steps.deploy.outputs.vercel_deployment_url }}",
+    );
+    const finalInspection = stepNamed(
+      name,
+      `Re-inspect every protected mapping after ${
+        target === "ui" ? "UI" : target
+      } smoke`,
+    );
+    const handoff = stepIncluding(name, "stage-result");
+    assert.ok(job.steps.indexOf(smoke) < job.steps.indexOf(finalInspection));
+    assert.ok(job.steps.indexOf(finalInspection) < job.steps.indexOf(handoff));
+    assert.equal(handoff.id, "handoff");
+    assert.equal(handoff.env.IMMUTABLE_SMOKE_PASSED, "true");
+    assert.equal(handoff.env.PROTECTED_MAPPINGS_UNCHANGED, "true");
+    assert.match(
+      handoff.run,
+      new RegExp(`--state "\\$RUNNER_TEMP/${target}-state\\.json"`),
+    );
+
+    const cleanup = job.steps.at(-1);
+    assert.equal(cleanup.if, "${{ always() }}");
+    assert.equal(cleanup.with.operation, "cleanup");
+    assert.equal(cleanup.with["logical-target"], target);
+  }
+});
+
+test("coordinator revalidates, builds App only, durably journals, and stays mutation-free", () => {
+  const name = "activate-and-verify";
+  const job = workflow.jobs[name];
+  assert.equal(job.if, "${{ always() }}");
+  assert.deepEqual(job.needs, [
+    "wait-for-ci",
+    "plan-main-deployments",
+    "stage-governance",
+    "stage-reserve",
+    "stage-ui",
+  ]);
+  assert.deepEqual(job.environment, {
+    name: "vercel-cli-production",
+    deployment: false,
+  });
+  const validate = stepIncluding(name, "validate-stages");
+  const freshness = stepIncluding(name, " freshness");
+  const revalidate = stepNamed(
+    name,
+    "Re-inspect every protected mapping before App preparation",
+  );
+  const appRuntime = stepNamed(name, "Prepare protected App build runtime");
+  assert.ok(job.steps.indexOf(validate) < job.steps.indexOf(freshness));
+  assert.ok(job.steps.indexOf(freshness) < job.steps.indexOf(revalidate));
+  assert.ok(job.steps.indexOf(revalidate) < job.steps.indexOf(appRuntime));
+  assert.match(appRuntime.if, /contains\(fromJSON/);
+
+  const appBuild = job.steps.find(
+    (step) => step.name === "Build App custom-v3 candidate without deployment",
+  );
+  assert.equal(appBuild.uses, "./.github/actions/vercel-candidate-build");
+  assert.equal(appBuild.with["logical-target"], "app");
+  assert.equal(
+    appBuild.with["vercel-project-id"],
+    "${{ vars.VERCEL_PROJECT_ID_APP }}",
+  );
+  assert.equal(appBuild.env.VERCEL_ENV, "preview");
+  assert.equal(appBuild.env.VERCEL_TARGET_ENV, "v3");
+  assert.equal(appBuild.env.SENTRY_AUTH_TOKEN, "");
+  const restore = stepNamed(
+    name,
+    "Restore fresh trusted transaction controller",
+  );
+  const proof = stepIncluding(name, "app-build-proof");
+  const journal = stepIncluding(name, "prepare-journal");
+  const upload = job.steps.find((step) => step.id === "journal-upload");
+  const shadow = stepIncluding(name, "run-shadow");
+  assert.ok(job.steps.indexOf(appBuild) < job.steps.indexOf(restore));
+  assert.ok(job.steps.indexOf(restore) < job.steps.indexOf(proof));
+  assert.ok(job.steps.indexOf(proof) < job.steps.indexOf(journal));
+  assert.ok(job.steps.indexOf(journal) < job.steps.indexOf(upload));
+  assert.ok(job.steps.indexOf(upload) < job.steps.indexOf(shadow));
+  assert.equal(upload.uses, UPLOAD);
+  assert.equal(upload.with.name, "${{ steps.journal.outputs.artifact_name }}");
+  assert.equal(upload.with["retention-days"], 7);
+  assert.equal(upload.with["if-no-files-found"], "error");
+  assert.equal(
+    shadow.env.JOURNAL_ARTIFACT_ID,
+    "${{ steps.journal-upload.outputs.artifact-id }}",
+  );
+  assert.equal(
+    shadow.env.JOURNAL_ARTIFACT_NAME,
+    "${{ steps.journal.outputs.artifact_name }}",
+  );
+  const cleanup = job.steps.at(-1);
+  assert.equal(cleanup.if, "${{ always() }}");
+  assert.equal(cleanup.with["logical-target"], "app");
+});
+
+test("runner-failure recovery derives the exact artifact and final result is fail-closed", () => {
+  const recovery = workflow.jobs["recover-main-deployment"];
+  assert.equal(recovery.if, "${{ always() }}");
+  assert.deepEqual(recovery.environment, {
+    name: "vercel-cli-production",
+    deployment: false,
+  });
+  const derived = stepIncluding("recover-main-deployment", "journal-name");
+  const download = recovery.steps.find(
+    (step) => step.id === "journal-download",
+  );
+  const recover = stepIncluding("recover-main-deployment", "recover-shadow");
+  assert.ok(recovery.steps.indexOf(derived) < recovery.steps.indexOf(download));
+  assert.ok(recovery.steps.indexOf(download) < recovery.steps.indexOf(recover));
+  assert.equal(download.uses, DOWNLOAD);
+  assert.equal(download["continue-on-error"], true);
+  assert.equal(
+    download.with.name,
+    "${{ steps.journal-name.outputs.artifact_name }}",
+  );
+  assert.doesNotMatch(download.with.name, /activate-and-verify/);
+
+  const finalJob = workflow.jobs.result;
+  assert.equal(finalJob.if, "${{ always() }}");
+  assert.deepEqual(finalJob.needs, [
+    "wait-for-ci",
+    "plan-main-deployments",
+    "stage-governance",
+    "stage-reserve",
+    "stage-ui",
+    "activate-and-verify",
+    "recover-main-deployment",
+  ]);
+  const sentinel = stepIncluding("result", "vercel-main-deployment.mjs final");
+  assert.equal(
+    sentinel.env.COORDINATOR_RESULT,
+    "${{ needs.activate-and-verify.result }}",
+  );
+  assert.equal(
+    sentinel.env.RECOVERY_RESULT,
+    "${{ needs.recover-main-deployment.result }}",
+  );
+  const evidence = stepIncluding(
+    "result",
+    "vercel-main-deployment.mjs evidence",
+  );
+  assert.ok(
+    finalJob.steps.indexOf(sentinel) < finalJob.steps.indexOf(evidence),
+  );
+  for (const target of ["GOVERNANCE", "RESERVE", "UI"]) {
+    assert.match(evidence.env[`EVIDENCE_${target}_HANDOFF`], /needs\.stage-/);
+    assert.match(
+      evidence.env[`EVIDENCE_${target}_BUILD_DURATION_MS`],
+      /outputs\.build_duration_ms/,
+    );
+    assert.match(
+      evidence.env[`EVIDENCE_${target}_DEPLOY_DURATION_MS`],
+      /outputs\.deploy_duration_ms/,
+    );
+    assert.match(
+      evidence.env[`EVIDENCE_${target}_TOTAL_DURATION_MS`],
+      /outputs\.total_duration_ms/,
+    );
+    assert.match(
+      evidence.env[`EVIDENCE_${target}_TURBO_CACHE_HITS`],
+      /outputs\.turbo_cache_hits/,
+    );
+    assert.match(
+      evidence.env[`EVIDENCE_${target}_TURBO_CACHE_MISSES`],
+      /outputs\.turbo_cache_misses/,
+    );
+  }
+  assert.equal(
+    evidence.env.COORDINATOR_OUTCOME,
+    "${{ needs.activate-and-verify.outputs.outcome }}",
+  );
+  assert.equal(
+    evidence.env.JOURNAL_ARTIFACT_ID,
+    "${{ needs.activate-and-verify.outputs.artifact_id }}",
+  );
+  assert.equal(
+    evidence.env.RECOVERY_OUTCOME,
+    "${{ needs.recover-main-deployment.outputs.outcome }}",
+  );
+  const artifact = finalJob.steps.find(
+    (step) => step.name === "Upload canonical redacted PR-A evidence",
+  );
+  assert.ok(
+    finalJob.steps.indexOf(evidence) < finalJob.steps.indexOf(artifact),
+  );
+  assert.equal(artifact.uses, UPLOAD);
+  assert.equal(artifact.with["if-no-files-found"], "error");
+  assert.equal(artifact.with["retention-days"], 14);
+  assert.equal(
+    artifact.with.path,
+    "${{ runner.temp }}/vercel-main-evidence.json",
+  );
+});
+
+test("existing workflow test command owns every main-deployment regression", () => {
+  const rootPackage = JSON.parse(
+    readFileSync(new URL("../package.json", import.meta.url), "utf8"),
+  );
+  const command = rootPackage.scripts["vercel:workflow:test"];
+  for (const file of [
+    "scripts/vercel-main-ci-attempt.test.mjs",
+    "scripts/vercel-main-plan.test.mjs",
+    "scripts/vercel-main-transaction.test.mjs",
+    "scripts/vercel-main-runtime.test.mjs",
+    "scripts/vercel-main-deployment.test.mjs",
+    "scripts/vercel-main-deployment-workflow.test.mjs",
+  ]) {
+    assert.match(command, new RegExp(file.replaceAll(".", "\\.")));
+  }
+  assert.equal(rootPackage.scripts["vercel:main:test"], undefined);
+});
+
+test("shadow workflow contains no reachable public mutation or sensitive artifact path", () => {
+  const strings = allStrings(workflow).join("\n");
+  assert.doesNotMatch(strings, /\bvercel\s+promote\b/i);
+  assert.doesNotMatch(strings, /\bvercel\s+rollback\b/i);
+  assert.doesNotMatch(strings, /\bvercel\s+alias\s+set\b/i);
+  assert.doesNotMatch(strings, /\bvercel\s+deploy\b[^\n]*--target[ =]v3\b/i);
+  assert.doesNotMatch(strings, /--token\b/);
+  assert.doesNotMatch(strings, /\.vercel\/output/);
+  assert.doesNotMatch(workflowSource, /secrets:\s*inherit/);
+  assert.doesNotMatch(workflowSource, /secrets\[[^\]]+\]/);
+  assert.doesNotMatch(workflowSource, /\$\{\{\s*inputs\.(?:target|project)/);
+  for (const [jobName, job] of Object.entries(workflow.jobs)) {
+    for (const step of job.steps) {
+      if (step.uses?.startsWith("actions/checkout@")) {
+        assert.equal(step.uses, CHECKOUT, `${jobName} checkout pin`);
+      }
+      if (step.uses?.startsWith("actions/upload-artifact@")) {
+        assert.equal(step.uses, UPLOAD, `${jobName} upload pin`);
+      }
+      if (step.uses?.startsWith("actions/download-artifact@")) {
+        assert.equal(step.uses, DOWNLOAD, `${jobName} download pin`);
+      }
+    }
+  }
+});
+
+test("production and build secrets stay in their exact literal step allowlist", () => {
+  const references = [];
+  const walk = (value, path = []) => {
+    if (typeof value === "string") {
+      if (value.includes("secrets.")) references.push({ path, value });
+      return;
+    }
+    if (Array.isArray(value)) {
+      value.forEach((item, index) => walk(item, [...path, index]));
+      return;
+    }
+    if (value && typeof value === "object") {
+      for (const [key, item] of Object.entries(value)) {
+        walk(item, [...path, key]);
+      }
+    }
+  };
+  walk(workflow);
+  const actual = [];
+  for (const { path, value } of references) {
+    assert.equal(path.length, 6, `forbidden secret path ${path.join(".")}`);
+    assert.equal(path[0], "jobs", `forbidden secret path ${path.join(".")}`);
+    const jobName = path[1];
+    assert.equal(path[2], "steps", `forbidden secret path ${path.join(".")}`);
+    const stepIndex = path[3];
+    assert.equal(
+      Number.isSafeInteger(stepIndex),
+      true,
+      `forbidden secret path ${path.join(".")}`,
+    );
+    assert.equal(path[4], "env", `forbidden secret path ${path.join(".")}`);
+    const envKey = path[5];
+    const match = value.match(/^\$\{\{ secrets\.([A-Z0-9_]+) \}\}$/);
+    assert.ok(match, `forbidden secret expression ${path.join(".")}`);
+    const step = workflow.jobs[jobName].steps[stepIndex];
+    actual.push({
+      job: jobName,
+      step: step.name,
+      envKey,
+      secretName: match[1],
+    });
+  }
+  const expected = new Map([
+    [
+      "VERCEL_TOKEN_PRODUCTION",
+      [
+        "plan-main-deployments/Capture tolerant main planning state",
+        "plan-main-deployments/Capture strict legacy rollback state",
+        "stage-governance/Pull governance production configuration",
+        "stage-governance/Validate governance project and Root Directory",
+        "stage-governance/Upload governance candidate without public custom domains",
+        "stage-governance/Verify governance candidate identity and generated aliases",
+        "stage-governance/Revalidate protected mappings and rollback state",
+        "stage-governance/Re-inspect every protected mapping after governance smoke",
+        "stage-reserve/Pull reserve production configuration",
+        "stage-reserve/Validate reserve project and Root Directory",
+        "stage-reserve/Upload reserve candidate without public custom domains",
+        "stage-reserve/Verify reserve candidate identity and generated aliases",
+        "stage-reserve/Revalidate protected mappings and rollback state",
+        "stage-reserve/Re-inspect every protected mapping after reserve smoke",
+        "stage-ui/Pull UI production configuration",
+        "stage-ui/Validate UI project and Root Directory",
+        "stage-ui/Upload UI candidate without public custom domains",
+        "stage-ui/Verify UI candidate identity and generated aliases",
+        "stage-ui/Revalidate protected mappings and rollback state",
+        "stage-ui/Re-inspect every protected mapping after UI smoke",
+        "activate-and-verify/Re-inspect every protected mapping before App preparation",
+        "activate-and-verify/Pull App custom-v3 configuration",
+        "activate-and-verify/Validate App custom-v3 project and Root Directory",
+      ],
+    ],
+    [
+      "ETHERSCAN_API_KEY",
+      ["stage-governance/Build exact governance production candidate"],
+    ],
+    [
+      "SENTRY_AUTH_TOKEN",
+      [
+        "stage-governance/Build exact governance production candidate",
+        "stage-reserve/Build exact reserve production candidate",
+      ],
+    ],
+    [
+      "TURBO_REMOTE_CACHE_SIGNATURE_KEY",
+      [
+        "stage-governance/Build exact governance production candidate",
+        "stage-reserve/Build exact reserve production candidate",
+        "stage-ui/Build exact UI production candidate",
+        "activate-and-verify/Build App custom-v3 candidate without deployment",
+      ],
+    ],
+    [
+      "TURBO_TOKEN",
+      [
+        "stage-governance/Build exact governance production candidate",
+        "stage-reserve/Build exact reserve production candidate",
+        "stage-ui/Build exact UI production candidate",
+        "activate-and-verify/Build App custom-v3 candidate without deployment",
+      ],
+    ],
+  ]);
+  const expectedEntries = [...expected].flatMap(([secretName, sites]) =>
+    sites.map((site) => {
+      const [job, step] = site.split("/");
+      return {
+        job,
+        step,
+        envKey:
+          secretName === "VERCEL_TOKEN_PRODUCTION"
+            ? "VERCEL_TOKEN"
+            : secretName,
+        secretName,
+      };
+    }),
+  );
+  const bySite = (left, right) =>
+    `${left.job}/${left.step}/${left.envKey}/${left.secretName}`.localeCompare(
+      `${right.job}/${right.step}/${right.envKey}/${right.secretName}`,
+    );
+  assert.deepEqual(actual.toSorted(bySite), expectedEntries.toSorted(bySite));
+  for (const [jobName, job] of Object.entries(workflow.jobs)) {
+    if (
+      !job.steps.some((step) =>
+        Object.values(step.env ?? {}).some((value) =>
+          String(value).includes("secrets."),
+        ),
+      )
+    ) {
+      continue;
+    }
+    assert.deepEqual(
+      job.environment,
+      {
+        name: "vercel-cli-production",
+        deployment: false,
+      },
+      `${jobName} secret-bearing environment`,
+    );
+  }
+});

--- a/scripts/vercel-main-deployment-workflow.test.mjs
+++ b/scripts/vercel-main-deployment-workflow.test.mjs
@@ -401,7 +401,15 @@ test("runner-failure recovery derives the exact artifact and final result is fai
     "activate-and-verify",
     "recover-main-deployment",
   ]);
+  const checkout = finalJob.steps.find(
+    (step) => step.name === "Check out trusted final controller",
+  );
+  assert.equal(checkout.if, "${{ always() }}");
+  assert.equal(checkout.with.ref, "${{ github.workflow_sha }}");
   const sentinel = stepIncluding("result", "vercel-main-deployment.mjs final");
+  assert.equal(sentinel.id, "final-verdict");
+  assert.equal(sentinel.if, "${{ always() }}");
+  assert.equal(sentinel["continue-on-error"], true);
   assert.equal(
     sentinel.env.COORDINATOR_RESULT,
     "${{ needs.activate-and-verify.result }}",
@@ -413,6 +421,11 @@ test("runner-failure recovery derives the exact artifact and final result is fai
   const evidence = stepIncluding(
     "result",
     "vercel-main-deployment.mjs evidence",
+  );
+  assert.equal(evidence.id, "success-evidence");
+  assert.equal(
+    evidence.if,
+    "${{ always() && steps.final-verdict.outcome == 'success' }}",
   );
   assert.ok(
     finalJob.steps.indexOf(sentinel) < finalJob.steps.indexOf(evidence),
@@ -452,18 +465,65 @@ test("runner-failure recovery derives the exact artifact and final result is fai
     evidence.env.RECOVERY_OUTCOME,
     "${{ needs.recover-main-deployment.outputs.outcome }}",
   );
+  const failureEvidence = stepIncluding(
+    "result",
+    "vercel-main-deployment.mjs failure-evidence",
+  );
+  assert.equal(failureEvidence.id, "failure-evidence");
+  assert.equal(
+    failureEvidence.if,
+    "${{ always() && steps.final-verdict.outcome != 'success' }}",
+  );
+  assert.equal(
+    failureEvidence.env.EVENT_HEAD_SHA,
+    "${{ github.event.workflow_run.head_sha }}",
+  );
+  assert.equal(
+    failureEvidence.env.GITHUB_WORKFLOW_SHA,
+    "${{ github.workflow_sha }}",
+  );
+  assert.equal(
+    failureEvidence.env.WAIT_FOR_CI_RESULT,
+    "${{ needs.wait-for-ci.result }}",
+  );
+  assert.equal(
+    failureEvidence.env.RECOVERY_RESULT,
+    "${{ needs.recover-main-deployment.result }}",
+  );
   const artifact = finalJob.steps.find(
     (step) => step.name === "Upload canonical redacted PR-A evidence",
   );
   assert.ok(
     finalJob.steps.indexOf(evidence) < finalJob.steps.indexOf(artifact),
   );
+  assert.ok(
+    finalJob.steps.indexOf(failureEvidence) < finalJob.steps.indexOf(artifact),
+  );
+  assert.equal(artifact.if, "${{ always() }}");
   assert.equal(artifact.uses, UPLOAD);
   assert.equal(artifact.with["if-no-files-found"], "error");
   assert.equal(artifact.with["retention-days"], 14);
   assert.equal(
     artifact.with.path,
     "${{ runner.temp }}/vercel-main-evidence.json",
+  );
+  const terminalFailure = finalJob.steps.find(
+    (step) => step.name === "Fail after publishing an unsafe final result",
+  );
+  assert.ok(
+    finalJob.steps.indexOf(artifact) < finalJob.steps.indexOf(terminalFailure),
+  );
+  assert.equal(
+    terminalFailure.if,
+    "${{ always() && steps.final-verdict.outcome != 'success' }}",
+  );
+  assert.match(terminalFailure.run, /exit 1/);
+  assert.equal(
+    finalJob.steps.some(
+      (step) =>
+        step.name === "Fail when the trusted gate or planner did not succeed",
+    ),
+    false,
   );
 });
 

--- a/scripts/vercel-main-deployment.mjs
+++ b/scripts/vercel-main-deployment.mjs
@@ -1,0 +1,1994 @@
+#!/usr/bin/env node
+
+import { Buffer } from "node:buffer";
+import { spawnSync } from "node:child_process";
+import { appendFileSync, readFileSync, writeFileSync } from "node:fs";
+import process from "node:process";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  MAIN_DEPLOYMENT_MODES,
+  MAIN_DEPLOYMENT_TARGETS,
+  MAIN_TARGET_CONTRACTS,
+  assertMainDeploymentPlan,
+  planMainDeployments,
+} from "./vercel-main-plan.mjs";
+import {
+  MAIN_TRANSACTION_MODE,
+  MAIN_TRANSACTION_REPOSITORY,
+  MainTransactionError,
+  assertMainTransactionJournal,
+  createMainTransactionId,
+  createPreparedMainTransactionJournal,
+  decideMainTransactionRecovery,
+  mainTransactionJournalArtifactName,
+  runMainTransaction,
+} from "./vercel-main-transaction.mjs";
+import {
+  assertCanonicalOutput,
+  assertMainPlanningSnapshot,
+  assertSnapshotSpec,
+  canonicalizeDeploymentUrl,
+  canonicalizeHostname,
+} from "./vercel-deployment-state.mjs";
+import {
+  assertOnlyExpectedVercelGeneratedAliases,
+  validateImmutableMainSource,
+} from "./vercel-production-shadow.mjs";
+import { generateVercelDeploymentId } from "./vercel-prebuilt.mjs";
+
+export const MAIN_DEPLOYMENT_SCHEMA = "vercel-main-deployment:v1";
+export const MAIN_STAGE_SCHEMA = "vercel-main-stage:v1";
+export const MAIN_EVIDENCE_SCHEMA = "vercel-main-evidence:v1";
+export const MAIN_DEPLOYMENT_MODE = MAIN_TRANSACTION_MODE;
+export const MAIN_DEPLOYMENT_WORKFLOW =
+  ".github/workflows/vercel-main-deployment.yml";
+export const MAIN_DEPLOYMENT_ENVIRONMENT = "vercel-cli-production";
+export const MAIN_ORDINARY_TARGETS = Object.freeze([
+  "governance",
+  "reserve",
+  "ui",
+]);
+
+const SHA_PATTERN = /^[a-f0-9]{40}$/;
+const ID_PATTERN = /^[A-Za-z0-9._-]+$/;
+const DEPLOYMENT_ID_PATTERN = /^dpl_[A-Za-z0-9]+$/;
+const POSITIVE_ID_PATTERN = /^[1-9][0-9]*$/;
+const JOB_RESULTS = new Set(["success", "failure", "cancelled", "skipped"]);
+const PLAN_KEYS = Object.freeze([
+  "schema",
+  "mode",
+  "deploySha",
+  "upstream",
+  "projectIds",
+  "protectedSnapshot",
+  "legacySnapshot",
+  "planning",
+  "legacyPrior",
+]);
+const UPSTREAM_KEYS = Object.freeze([
+  "runId",
+  "runAttempt",
+  "runUrl",
+  "buildAndTestJobUrl",
+]);
+const PROJECT_KEYS = Object.freeze(["app", "governance", "reserve", "ui"]);
+const PRIOR_KEYS = Object.freeze(["deploymentId", "deploymentUrl", "aliases"]);
+const STAGE_KEYS = Object.freeze([
+  "schema",
+  "target",
+  "deploySha",
+  "transactionKey",
+  "prior",
+  "candidate",
+  "verification",
+]);
+const CANDIDATE_KEYS = Object.freeze([
+  "deploymentId",
+  "deploymentUrl",
+  "aliases",
+  "discovery",
+]);
+const VERIFICATION_KEYS = Object.freeze([
+  "canonicalState",
+  "immutableSmoke",
+  "protectedMappings",
+]);
+const LEGACY_ALIAS = "v2-app.mento.org";
+const MAX_JSON_BYTES = 256 * 1024;
+const APP_BUILD_PROOF_SCHEMA = "vercel-main-app-build:v1";
+const CLI_COMMAND_OPTIONS = Object.freeze({
+  "app-build-proof": Object.freeze(["output"]),
+  "app-candidate-expectation": Object.freeze(["journal", "output"]),
+  "create-spec": Object.freeze(["output", "scope"]),
+  evidence: Object.freeze(["output"]),
+  final: Object.freeze([]),
+  freshness: Object.freeze([]),
+  "journal-name": Object.freeze([]),
+  plan: Object.freeze(["legacy-snapshot", "output", "planning-snapshot"]),
+  "prepare-journal": Object.freeze(["output"]),
+  "recover-shadow": Object.freeze(["journal"]),
+  "revalidate-prior": Object.freeze(["legacy-snapshot", "planning-snapshot"]),
+  "run-shadow": Object.freeze(["journal"]),
+  "stage-result": Object.freeze(["output", "state"]),
+  "validate-context": Object.freeze([]),
+  "validate-source": Object.freeze([]),
+  "validate-stages": Object.freeze([]),
+});
+
+function isPlainObject(value) {
+  return (
+    value !== null &&
+    typeof value === "object" &&
+    !Array.isArray(value) &&
+    Object.getPrototypeOf(value) === Object.prototype
+  );
+}
+
+function assertExactKeys(value, keys, label) {
+  if (
+    !isPlainObject(value) ||
+    JSON.stringify(Object.keys(value).sort()) !==
+      JSON.stringify([...keys].sort())
+  ) {
+    throw new Error(`${label} contains forbidden or missing fields`);
+  }
+}
+
+function requireString(value, label, pattern = ID_PATTERN) {
+  if (typeof value !== "string" || !pattern.test(value)) {
+    throw new Error(`${label} is missing or malformed`);
+  }
+  return value;
+}
+
+function requireSha(value, label = "DEPLOY_SHA") {
+  return requireString(value, label, SHA_PATTERN);
+}
+
+function requirePositiveId(value, label) {
+  const normalized =
+    typeof value === "number" && Number.isSafeInteger(value)
+      ? String(value)
+      : value;
+  return requireString(normalized, label, POSITIVE_ID_PATTERN);
+}
+
+function requireNonNegativeCount(value, label) {
+  const normalized =
+    typeof value === "number" && Number.isSafeInteger(value)
+      ? String(value)
+      : value;
+  return requireString(normalized, label, /^[0-9]+$/);
+}
+
+function requireUrl(value, label, origin = "https://github.com") {
+  let url;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new Error(`${label} is malformed`);
+  }
+  if (
+    url.origin !== origin ||
+    url.username !== "" ||
+    url.password !== "" ||
+    url.hash !== ""
+  ) {
+    throw new Error(`${label} is malformed`);
+  }
+  return url.toString();
+}
+
+function parseJson(raw, label) {
+  if (
+    typeof raw !== "string" ||
+    Buffer.byteLength(raw, "utf8") > MAX_JSON_BYTES
+  ) {
+    throw new Error(`${label} is missing or exceeds its size limit`);
+  }
+  try {
+    return JSON.parse(raw);
+  } catch {
+    throw new Error(`${label} is not valid JSON`);
+  }
+}
+
+function readJson(path, label) {
+  const raw = readFileSync(path);
+  if (raw.byteLength > MAX_JSON_BYTES) {
+    throw new Error(`${label} exceeds its size limit`);
+  }
+  try {
+    return JSON.parse(raw.toString("utf8"));
+  } catch {
+    throw new Error(`${label} is not valid JSON`);
+  }
+}
+
+function writeCanonicalJson(path, value) {
+  writeFileSync(path, `${JSON.stringify(value)}\n`, {
+    encoding: "utf8",
+    mode: 0o600,
+    flag: "wx",
+  });
+}
+
+function appendOutput(path, name, value) {
+  if (!path) throw new Error("GITHUB_OUTPUT is required");
+  if (!/^[a-z][a-z0-9_]*$/.test(name)) {
+    throw new Error("GitHub output name is malformed");
+  }
+  if (String(value).includes("\n")) {
+    throw new Error(`GitHub output ${name} contains a newline`);
+  }
+  appendFileSync(path, `${name}=${value}\n`);
+}
+
+function canonicalProjectIds(projectIds) {
+  assertExactKeys(projectIds, PROJECT_KEYS, "Main project IDs");
+  return Object.fromEntries(
+    MAIN_DEPLOYMENT_TARGETS.map((target) => [
+      target,
+      requireString(projectIds[target], `${target} project ID`),
+    ]),
+  );
+}
+
+function expectedGit(ref) {
+  return {
+    org: "mento-protocol",
+    repo: "frontend-monorepo",
+    ref,
+  };
+}
+
+export function createMainProtectedAliasSpec({ projectIds }) {
+  const ids = canonicalProjectIds(projectIds);
+  const entries = [];
+  for (const target of MAIN_DEPLOYMENT_TARGETS) {
+    const contract = MAIN_TARGET_CONTRACTS[target];
+    for (const alias of contract.aliases) {
+      entries.push({
+        alias,
+        projectId: ids[target],
+        projectName: contract.projectName,
+        target: contract.target,
+        customEnvironmentSlug: contract.customEnvironmentSlug,
+        git: expectedGit("main"),
+      });
+    }
+  }
+  const spec = entries.sort((left, right) =>
+    left.alias.localeCompare(right.alias),
+  );
+  return assertSnapshotSpec(spec);
+}
+
+export function createMainLegacyAliasSpec({ projectIds }) {
+  const ids = canonicalProjectIds(projectIds);
+  return assertSnapshotSpec([
+    {
+      alias: LEGACY_ALIAS,
+      projectId: ids.app,
+      projectName: MAIN_TARGET_CONTRACTS.app.projectName,
+      target: "production",
+      customEnvironmentSlug: null,
+      git: expectedGit("v2"),
+    },
+  ]);
+}
+
+function canonicalPlanningSnapshotForSpec({ snapshot, projectIds }) {
+  const canonical = assertMainPlanningSnapshot(snapshot);
+  const spec = createMainProtectedAliasSpec({ projectIds });
+  if (canonical.states.length !== spec.length) {
+    throw new Error("Protected snapshot does not contain every reviewed alias");
+  }
+  const ordered = canonical.states.toSorted((left, right) =>
+    left.alias.localeCompare(right.alias),
+  );
+  for (const [index, state] of ordered.entries()) {
+    const expected = spec[index];
+    if (
+      state.alias !== expected.alias ||
+      state.projectId !== expected.projectId ||
+      state.projectName !== expected.projectName ||
+      state.target !== expected.target ||
+      state.customEnvironmentSlug !== expected.customEnvironmentSlug ||
+      state.readyState !== "READY" ||
+      !state.aliases.includes(expected.alias)
+    ) {
+      throw new Error(
+        `Protected snapshot state is ambiguous for ${expected.alias}`,
+      );
+    }
+    if (
+      expected.customEnvironmentSlug === "v3" &&
+      JSON.stringify(state.aliases) !==
+        JSON.stringify([...MAIN_TARGET_CONTRACTS.app.aliases])
+    ) {
+      throw new Error("Protected App alias set is ambiguous");
+    }
+  }
+  return { schema: canonical.schema, states: ordered };
+}
+
+function canonicalLegacySnapshotForSpec({ snapshot, projectIds }) {
+  assertCanonicalOutput(snapshot);
+  const spec = createMainLegacyAliasSpec({ projectIds });
+  if (!Array.isArray(snapshot) || snapshot.length !== 1) {
+    throw new Error("Legacy snapshot must contain exactly v2-app.mento.org");
+  }
+  const state = snapshot[0];
+  const expected = spec[0];
+  if (
+    state.alias !== expected.alias ||
+    state.projectId !== expected.projectId ||
+    state.projectName !== expected.projectName ||
+    state.target !== expected.target ||
+    state.customEnvironmentSlug !== expected.customEnvironmentSlug ||
+    state.git.org !== expected.git.org ||
+    state.git.repo !== expected.git.repo ||
+    state.git.ref !== expected.git.ref ||
+    state.readyState !== "READY"
+  ) {
+    throw new Error("Legacy app rollback state is ambiguous");
+  }
+  return [state];
+}
+
+function groupSnapshot(snapshot, target) {
+  const aliases = MAIN_TARGET_CONTRACTS[target].aliases;
+  const states = snapshot.filter((state) => aliases.includes(state.alias));
+  if (states.length !== aliases.length) {
+    throw new Error(`Protected snapshot is incomplete for ${target}`);
+  }
+  return { health: "passed", states };
+}
+
+function canonicalPrior(value, label) {
+  assertExactKeys(value, PRIOR_KEYS, label);
+  const aliases = value.aliases.map(canonicalizeHostname).sort();
+  if (
+    aliases.length === 0 ||
+    new Set(aliases).size !== aliases.length ||
+    JSON.stringify(aliases) !== JSON.stringify(value.aliases)
+  ) {
+    throw new Error(`${label} aliases are malformed`);
+  }
+  return {
+    deploymentId: requireString(
+      value.deploymentId,
+      `${label} deployment ID`,
+      DEPLOYMENT_ID_PATTERN,
+    ),
+    deploymentUrl: canonicalizeDeploymentUrl(value.deploymentUrl),
+    aliases,
+  };
+}
+
+function legacyPriorFromSnapshot(snapshot, projectId) {
+  const states = snapshot.filter((state) => state.alias === LEGACY_ALIAS);
+  if (states.length !== 1) {
+    throw new Error("Legacy app rollback state is ambiguous");
+  }
+  const state = states[0];
+  if (
+    state.projectId !== projectId ||
+    state.projectName !== "app.mento.org" ||
+    state.target !== "production" ||
+    state.customEnvironmentSlug !== null ||
+    state.git.org !== "mento-protocol" ||
+    state.git.repo !== "frontend-monorepo" ||
+    state.git.ref !== "v2" ||
+    state.readyState !== "READY" ||
+    JSON.stringify(state.aliases) !== JSON.stringify([LEGACY_ALIAS])
+  ) {
+    throw new Error("Legacy app rollback state is ambiguous");
+  }
+  return canonicalPrior(
+    {
+      deploymentId: state.deploymentId,
+      deploymentUrl: state.deploymentUrl,
+      aliases: [LEGACY_ALIAS],
+    },
+    "Legacy app prior",
+  );
+}
+
+function canonicalUpstream(upstream) {
+  assertExactKeys(upstream, UPSTREAM_KEYS, "Upstream CI receipt");
+  return {
+    runId: requirePositiveId(upstream.runId, "Upstream run ID"),
+    runAttempt: requirePositiveId(upstream.runAttempt, "Upstream run attempt"),
+    runUrl: requireUrl(upstream.runUrl, "Upstream run URL"),
+    buildAndTestJobUrl: requireUrl(
+      upstream.buildAndTestJobUrl,
+      "Build and Test job URL",
+    ),
+  };
+}
+
+export function createMainDeploymentPlan({
+  mode,
+  deploySha,
+  projectIds,
+  planningSnapshot,
+  legacySnapshot,
+  upstream,
+  repoRoot = process.cwd(),
+  gitAdapter,
+  runPlanner,
+}) {
+  if (mode !== MAIN_DEPLOYMENT_MODES.SHADOW) {
+    throw new Error("PR A main deployment mode must be literal shadow");
+  }
+  const sha = requireSha(deploySha);
+  const ids = canonicalProjectIds(projectIds);
+  const protectedSnapshot = canonicalPlanningSnapshotForSpec({
+    snapshot: planningSnapshot,
+    projectIds: ids,
+  });
+  const strictLegacySnapshot = canonicalLegacySnapshotForSpec({
+    snapshot: legacySnapshot,
+    projectIds: ids,
+  });
+  const priorStates = Object.fromEntries(
+    MAIN_DEPLOYMENT_TARGETS.map((target) => [
+      target,
+      groupSnapshot(protectedSnapshot.states, target),
+    ]),
+  );
+  const planning = planMainDeployments({
+    mode,
+    deploySha: sha,
+    projectIds: ids,
+    priorStates,
+    repoRoot,
+    ...(gitAdapter ? { gitAdapter } : {}),
+    ...(runPlanner ? { runPlanner } : {}),
+  });
+  const result = {
+    schema: MAIN_DEPLOYMENT_SCHEMA,
+    mode,
+    deploySha: sha,
+    upstream: canonicalUpstream(upstream),
+    projectIds: ids,
+    protectedSnapshot,
+    legacySnapshot: strictLegacySnapshot,
+    planning,
+    legacyPrior: legacyPriorFromSnapshot(strictLegacySnapshot, ids.app),
+  };
+  return assertMainDeploymentHandoff(result);
+}
+
+export function assertMainDeploymentHandoff(value) {
+  assertExactKeys(value, PLAN_KEYS, "Main deployment handoff");
+  if (
+    value.schema !== MAIN_DEPLOYMENT_SCHEMA ||
+    value.mode !== MAIN_DEPLOYMENT_MODE
+  ) {
+    throw new Error("Main deployment handoff schema or mode is invalid");
+  }
+  const deploySha = requireSha(value.deploySha);
+  const projectIds = canonicalProjectIds(value.projectIds);
+  const upstream = canonicalUpstream(value.upstream);
+  const protectedSnapshot = canonicalPlanningSnapshotForSpec({
+    snapshot: value.protectedSnapshot,
+    projectIds,
+  });
+  const legacySnapshot = canonicalLegacySnapshotForSpec({
+    snapshot: value.legacySnapshot,
+    projectIds,
+  });
+  const planning = assertMainDeploymentPlan(value.planning);
+  if (planning.deploySha !== deploySha || planning.mode !== value.mode) {
+    throw new Error("Served-SHA plan does not match its workflow handoff");
+  }
+  const legacyPrior = legacyPriorFromSnapshot(legacySnapshot, projectIds.app);
+  if (JSON.stringify(legacyPrior) !== JSON.stringify(value.legacyPrior)) {
+    throw new Error("Legacy app prior changed inside the plan handoff");
+  }
+  return {
+    schema: value.schema,
+    mode: value.mode,
+    deploySha,
+    upstream,
+    projectIds,
+    protectedSnapshot,
+    legacySnapshot,
+    planning,
+    legacyPrior,
+  };
+}
+
+export function validateMainWorkflowContext({
+  repository,
+  eventName,
+  workflowRef,
+  workflowSha,
+  deploySha,
+}) {
+  const sha = requireSha(deploySha);
+  if (
+    repository !== MAIN_TRANSACTION_REPOSITORY ||
+    eventName !== "workflow_run"
+  ) {
+    throw new Error("Main deployment workflow context is untrusted");
+  }
+  const expectedRef = `${MAIN_TRANSACTION_REPOSITORY}/${MAIN_DEPLOYMENT_WORKFLOW}@refs/heads/main`;
+  if (workflowRef !== expectedRef || workflowSha !== sha) {
+    throw new Error(
+      "Main deployment workflow definition is not the exact DEPLOY_SHA on main",
+    );
+  }
+  return sha;
+}
+
+export function validateMainDeploymentSource({
+  repoRoot,
+  deploySha,
+  workflowSha,
+  execute,
+}) {
+  return validateImmutableMainSource({
+    sourcePath: repoRoot,
+    deploySha,
+    workflowSha,
+    ...(execute ? { execute } : {}),
+  });
+}
+
+export function createMainStageResult({
+  target,
+  plan,
+  state,
+  runId,
+  runAttempt,
+  smokePassed,
+  protectedMappingsUnchanged,
+}) {
+  if (!MAIN_ORDINARY_TARGETS.includes(target)) {
+    throw new Error("Stage result target is not an ordinary main target");
+  }
+  const handoff = assertMainDeploymentHandoff(plan);
+  if (!handoff.planning.plan.includes(target)) {
+    throw new Error(`Unselected target ${target} cannot return a stage result`);
+  }
+  assertCanonicalOutput(state);
+  if (Array.isArray(state)) {
+    throw new Error("Stage result must contain exactly one deployment");
+  }
+  assertOnlyExpectedVercelGeneratedAliases(state, target);
+  if (
+    state.projectId !== handoff.projectIds[target] ||
+    state.projectName !== MAIN_TARGET_CONTRACTS[target].projectName ||
+    state.readyState !== "READY" ||
+    state.target !== "production" ||
+    state.customEnvironmentSlug !== null ||
+    state.git.org !== "mento-protocol" ||
+    state.git.repo !== "frontend-monorepo" ||
+    state.git.ref !== "main" ||
+    state.git.sha !== handoff.deploySha
+  ) {
+    throw new Error(`Staged ${target} deployment identity is invalid`);
+  }
+  if (smokePassed !== true || protectedMappingsUnchanged !== true) {
+    throw new Error(`Staged ${target} verification is incomplete`);
+  }
+  const prior = handoff.planning.priors.find(
+    (entry) => entry.target === target,
+  );
+  const result = {
+    schema: MAIN_STAGE_SCHEMA,
+    target,
+    deploySha: handoff.deploySha,
+    transactionKey: `${requirePositiveId(runId, "Run ID")}-${requirePositiveId(
+      runAttempt,
+      "Run attempt",
+    )}-${target}`,
+    prior: {
+      deploymentId: prior.deploymentId,
+      deploymentUrl: prior.deploymentUrl,
+      aliases: [...prior.aliases].sort(),
+    },
+    candidate: {
+      deploymentId: state.deploymentId,
+      deploymentUrl: state.deploymentUrl,
+      aliases: [...prior.aliases].sort(),
+      discovery: null,
+    },
+    verification: {
+      canonicalState: "passed",
+      immutableSmoke: "passed",
+      protectedMappings: "unchanged",
+    },
+  };
+  return assertMainStageResult(result, {
+    plan: handoff,
+    expectedTarget: target,
+  });
+}
+
+export function assertMainStageResult(
+  value,
+  { plan, expectedTarget, expectedRunId, expectedRunAttempt } = {},
+) {
+  assertExactKeys(value, STAGE_KEYS, "Main stage result");
+  if (
+    value.schema !== MAIN_STAGE_SCHEMA ||
+    !MAIN_ORDINARY_TARGETS.includes(value.target) ||
+    (expectedTarget && value.target !== expectedTarget)
+  ) {
+    throw new Error("Main stage result target is invalid");
+  }
+  const deploySha = requireSha(value.deploySha, "Stage DEPLOY_SHA");
+  const prior = canonicalPrior(value.prior, "Stage prior");
+  assertExactKeys(value.candidate, CANDIDATE_KEYS, "Stage candidate");
+  if (value.candidate.discovery !== null) {
+    throw new Error("Ordinary stage candidate discovery must be null");
+  }
+  const candidate = {
+    deploymentId: requireString(
+      value.candidate.deploymentId,
+      "Stage candidate deployment ID",
+      DEPLOYMENT_ID_PATTERN,
+    ),
+    deploymentUrl: canonicalizeDeploymentUrl(value.candidate.deploymentUrl),
+    aliases: canonicalPrior(
+      {
+        deploymentId: value.candidate.deploymentId,
+        deploymentUrl: value.candidate.deploymentUrl,
+        aliases: value.candidate.aliases,
+      },
+      "Stage candidate",
+    ).aliases,
+    discovery: null,
+  };
+  if (JSON.stringify(candidate.aliases) !== JSON.stringify(prior.aliases)) {
+    throw new Error("Stage candidate protected alias intent changed");
+  }
+  assertExactKeys(value.verification, VERIFICATION_KEYS, "Stage verification");
+  if (
+    value.verification.canonicalState !== "passed" ||
+    value.verification.immutableSmoke !== "passed" ||
+    value.verification.protectedMappings !== "unchanged"
+  ) {
+    throw new Error("Stage verification is incomplete");
+  }
+  requireString(
+    value.transactionKey,
+    "Stage transaction key",
+    /^[1-9][0-9]*-[1-9][0-9]*-(?:governance|reserve|ui)$/,
+  );
+  if (expectedRunId !== undefined || expectedRunAttempt !== undefined) {
+    const expectedKey = `${requirePositiveId(
+      expectedRunId,
+      "Expected run ID",
+    )}-${requirePositiveId(
+      expectedRunAttempt,
+      "Expected run attempt",
+    )}-${value.target}`;
+    if (value.transactionKey !== expectedKey) {
+      throw new Error(
+        "Stage transaction key does not match the coordinator attempt",
+      );
+    }
+  }
+  if (plan) {
+    const handoff = assertMainDeploymentHandoff(plan);
+    if (
+      deploySha !== handoff.deploySha ||
+      !handoff.planning.plan.includes(value.target)
+    ) {
+      throw new Error("Stage result does not match its plan");
+    }
+    const expectedPrior = handoff.planning.priors.find(
+      (entry) => entry.target === value.target,
+    );
+    if (
+      JSON.stringify(prior) !==
+      JSON.stringify({
+        deploymentId: expectedPrior.deploymentId,
+        deploymentUrl: expectedPrior.deploymentUrl,
+        aliases: [...expectedPrior.aliases].sort(),
+      })
+    ) {
+      throw new Error("Stage result prior does not match the captured plan");
+    }
+  }
+  return {
+    schema: value.schema,
+    target: value.target,
+    deploySha,
+    transactionKey: value.transactionKey,
+    prior,
+    candidate,
+    verification: { ...value.verification },
+  };
+}
+
+export function validateMainStageJobs({ plan, jobs, runId, runAttempt }) {
+  const handoff = assertMainDeploymentHandoff(plan);
+  const expectedRunId = requirePositiveId(runId, "Expected run ID");
+  const expectedRunAttempt = requirePositiveId(
+    runAttempt,
+    "Expected run attempt",
+  );
+  assertExactKeys(jobs, MAIN_ORDINARY_TARGETS, "Main stage jobs");
+  const results = {};
+  for (const target of MAIN_ORDINARY_TARGETS) {
+    const job = jobs[target];
+    assertExactKeys(job, ["result", "handoff"], `${target} stage job`);
+    if (!JOB_RESULTS.has(job.result)) {
+      throw new Error(`${target} stage job result is invalid`);
+    }
+    const selected = handoff.planning.plan.includes(target);
+    if (selected) {
+      if (job.result !== "success" || !job.handoff) {
+        throw new Error(`Selected ${target} stage did not succeed`);
+      }
+      results[target] = assertMainStageResult(job.handoff, {
+        plan: handoff,
+        expectedTarget: target,
+        expectedRunId,
+        expectedRunAttempt,
+      });
+    } else {
+      if (job.result !== "skipped" || job.handoff !== null) {
+        throw new Error(`Unselected ${target} stage was not cleanly skipped`);
+      }
+      results[target] = null;
+    }
+  }
+  return {
+    outcome: handoff.planning.plan.length === 0 ? "no-target" : "eligible",
+    stages: results,
+  };
+}
+
+export function createMainAppTransactionMetadata({
+  deploySha,
+  runId,
+  runAttempt,
+  transactionId,
+  nextDeploymentId,
+}) {
+  return {
+    githubCommitOrg: "mento-protocol",
+    githubCommitRepo: "frontend-monorepo",
+    githubCommitRef: "main",
+    githubCommitSha: requireSha(deploySha),
+    mentoTransactionId: requireString(
+      transactionId,
+      "App transaction ID",
+      /^main-[a-f0-9]{32}$/,
+    ),
+    mentoRunId: requirePositiveId(runId, "App run ID"),
+    mentoRunAttempt: requirePositiveId(runAttempt, "App run attempt"),
+    mentoNextDeploymentId: requireString(
+      nextDeploymentId,
+      "App custom Next deployment ID",
+      /^(?!dpl_)[A-Za-z0-9_-]{1,32}$/,
+    ),
+  };
+}
+
+export function createMainAppBuildProof({
+  deploySha,
+  runId,
+  runAttempt,
+  projectId,
+  nextDeploymentId,
+}) {
+  const identity = {
+    repository: MAIN_TRANSACTION_REPOSITORY,
+    deploySha: requireSha(deploySha),
+    runId: requirePositiveId(runId, "App run ID"),
+    runAttempt: requirePositiveId(runAttempt, "App run attempt"),
+  };
+  const transactionId = createMainTransactionId(identity);
+  const expectedNextDeploymentId = generateVercelDeploymentId({
+    target: "app",
+    commitSha: identity.deploySha,
+    runId: identity.runId,
+    runAttempt: identity.runAttempt,
+  });
+  if (nextDeploymentId !== expectedNextDeploymentId) {
+    throw new Error(
+      "App custom Next deployment ID is not deterministic for this run",
+    );
+  }
+  return {
+    schema: APP_BUILD_PROOF_SCHEMA,
+    target: "app",
+    deploySha: identity.deploySha,
+    runId: identity.runId,
+    runAttempt: identity.runAttempt,
+    transactionId,
+    projectId: requireString(projectId, "App project ID"),
+    projectName: "app.mento.org",
+    customEnvironmentSlug: "v3",
+    vercelEnv: "preview",
+    vercelTargetEnv: "v3",
+    nextPublicVercelEnv: "preview",
+    sentryAuthToken: "",
+    nextDeploymentId: expectedNextDeploymentId,
+    deployReachable: false,
+    metadata: createMainAppTransactionMetadata({
+      ...identity,
+      transactionId,
+      nextDeploymentId,
+    }),
+  };
+}
+
+export function createMainAppCandidateExpectation({ journal, projectId }) {
+  const canonical = assertMainTransactionJournal(journal);
+  const app = canonical.candidates.app;
+  if (app === null || app.discovery === null) {
+    throw new Error("Journal does not contain App candidate discovery");
+  }
+  if (app.discovery.projectId !== projectId) {
+    throw new Error("App recovery project does not match the journal");
+  }
+  return {
+    projectId: requireString(projectId, "App project ID"),
+    projectName: "app.mento.org",
+    deploySha: canonical.deploySha,
+    runId: canonical.runId,
+    runAttempt: canonical.runAttempt,
+    transactionId: canonical.transactionId,
+    customEnvironmentSlug: "v3",
+    nextDeploymentId: generateVercelDeploymentId({
+      target: "app",
+      commitSha: canonical.deploySha,
+      runId: canonical.runId,
+      runAttempt: canonical.runAttempt,
+    }),
+  };
+}
+
+function assertAppBuildProof(
+  proof,
+  { deploySha, runId, runAttempt, projectId },
+) {
+  const expected = createMainAppBuildProof({
+    deploySha,
+    runId,
+    runAttempt,
+    projectId,
+    nextDeploymentId: proof?.nextDeploymentId,
+  });
+  if (JSON.stringify(expected) !== JSON.stringify(proof)) {
+    throw new Error("App v3 build proof is invalid");
+  }
+  return proof;
+}
+
+export function createMainTransactionInputs({
+  plan,
+  stageJobs,
+  appBuildProof = null,
+  runId,
+  runAttempt,
+}) {
+  const handoff = assertMainDeploymentHandoff(plan);
+  const identity = {
+    repository: MAIN_TRANSACTION_REPOSITORY,
+    deploySha: handoff.deploySha,
+    runId: requirePositiveId(runId, "Run ID"),
+    runAttempt: requirePositiveId(runAttempt, "Run attempt"),
+  };
+  const stages = validateMainStageJobs({
+    plan: handoff,
+    jobs: stageJobs,
+    runId: identity.runId,
+    runAttempt: identity.runAttempt,
+  }).stages;
+  const transactionId = createMainTransactionId(identity);
+  const priorByTarget = Object.fromEntries(
+    handoff.planning.priors.map((entry) => [
+      entry.target,
+      canonicalPrior(
+        {
+          deploymentId: entry.deploymentId,
+          deploymentUrl: entry.deploymentUrl,
+          aliases: [...entry.aliases].sort(),
+        },
+        `${entry.target} prior`,
+      ),
+    ]),
+  );
+  const prior = {
+    app: priorByTarget.app,
+    governance: priorByTarget.governance,
+    reserve: priorByTarget.reserve,
+    ui: priorByTarget.ui,
+    "legacy-app": canonicalPrior(handoff.legacyPrior, "Legacy app prior"),
+  };
+  let appCandidate = null;
+  if (handoff.planning.plan.includes("app")) {
+    assertAppBuildProof(appBuildProof, {
+      deploySha: handoff.deploySha,
+      runId: identity.runId,
+      runAttempt: identity.runAttempt,
+      projectId: handoff.projectIds.app,
+    });
+    appCandidate = {
+      deploymentId: null,
+      deploymentUrl: null,
+      aliases: [...prior.app.aliases],
+      discovery: {
+        projectId: handoff.projectIds.app,
+        projectName: MAIN_TARGET_CONTRACTS.app.projectName,
+        deploySha: handoff.deploySha,
+        runId: identity.runId,
+        runAttempt: identity.runAttempt,
+        transactionId,
+        customEnvironmentSlug: "v3",
+      },
+    };
+  } else if (appBuildProof !== null) {
+    throw new Error("Unselected app returned a build proof");
+  }
+  const candidates = {
+    app: appCandidate,
+    governance: stages.governance?.candidate ?? null,
+    reserve: stages.reserve?.candidate ?? null,
+    ui: stages.ui?.candidate ?? null,
+  };
+  return { identity, prior, candidates };
+}
+
+export function assertProtectedSnapshotMatchesPlan({
+  plan,
+  planningSnapshot,
+  legacySnapshot,
+}) {
+  const handoff = assertMainDeploymentHandoff(plan);
+  const currentPlanning = canonicalPlanningSnapshotForSpec({
+    snapshot: planningSnapshot,
+    projectIds: handoff.projectIds,
+  });
+  const currentLegacy = canonicalLegacySnapshotForSpec({
+    snapshot: legacySnapshot,
+    projectIds: handoff.projectIds,
+  });
+  const rollbackIdentity = (snapshot) =>
+    snapshot.states.map((state) => {
+      const identity = {
+        alias: state.alias,
+        deploymentId: state.deploymentId,
+        deploymentUrl: state.deploymentUrl,
+        projectId: state.projectId,
+        projectName: state.projectName,
+        readyState: state.readyState,
+        target: state.target,
+        customEnvironmentSlug: state.customEnvironmentSlug,
+      };
+      if (MAIN_TARGET_CONTRACTS.app.aliases.includes(state.alias)) {
+        return {
+          ...identity,
+          creatorUsername: state.creatorUsername,
+          aliases: state.aliases,
+        };
+      }
+      return identity;
+    });
+  if (
+    JSON.stringify(rollbackIdentity(currentPlanning)) !==
+      JSON.stringify(rollbackIdentity(handoff.protectedSnapshot)) ||
+    JSON.stringify(currentLegacy) !== JSON.stringify(handoff.legacySnapshot)
+  ) {
+    throw new Error(
+      "Protected mappings or rollback state drifted after planning",
+    );
+  }
+  return {
+    protectedSnapshot: currentPlanning,
+    legacySnapshot: currentLegacy,
+  };
+}
+
+export function readRemoteMainSha({
+  remote = "origin",
+  spawn = spawnSync,
+  attempts = 3,
+}) {
+  requireString(remote, "Git remote");
+  if (!Number.isSafeInteger(attempts) || attempts < 1 || attempts > 5) {
+    throw new Error("Remote-main retry limit is invalid");
+  }
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    const result = spawn(
+      "git",
+      ["ls-remote", "--exit-code", remote, "refs/heads/main"],
+      {
+        encoding: "utf8",
+        timeout: 15_000,
+        maxBuffer: 16 * 1024,
+      },
+    );
+    if (result.status !== 0) continue;
+    const lines = result.stdout.trim().split("\n");
+    if (lines.length !== 1) continue;
+    const match = lines[0].match(/^([a-f0-9]{40})\trefs\/heads\/main$/);
+    if (match) return match[1];
+  }
+  throw new Error("Remote main freshness could not be proven");
+}
+
+export function classifyRemoteMainFreshness({ deploySha, remoteSha }) {
+  const expected = requireSha(deploySha);
+  const current = requireSha(remoteSha, "Remote main SHA");
+  return {
+    status: current === expected ? "fresh" : "superseded",
+    sha: current,
+  };
+}
+
+export function createPreparedMainJournal(options) {
+  const inputs = createMainTransactionInputs(options);
+  return createPreparedMainTransactionJournal({
+    ...inputs.identity,
+    mode: MAIN_DEPLOYMENT_MODE,
+    prior: inputs.prior,
+    candidates: inputs.candidates,
+  });
+}
+
+export function createMainJournalArtifactIdentity({
+  deploySha,
+  runId,
+  runAttempt,
+}) {
+  const identity = {
+    repository: MAIN_TRANSACTION_REPOSITORY,
+    deploySha: requireSha(deploySha),
+    runId: requirePositiveId(runId, "Run ID"),
+    runAttempt: requirePositiveId(runAttempt, "Run attempt"),
+  };
+  const transactionId = createMainTransactionId(identity);
+  return {
+    transactionId,
+    artifactName: `vercel-main-journal-${transactionId}-000000`,
+  };
+}
+
+export function createMainWorkflowRunUrl({ serverUrl, repository, runId }) {
+  if (
+    serverUrl !== "https://github.com" ||
+    repository !== MAIN_TRANSACTION_REPOSITORY
+  ) {
+    throw new Error("Downstream workflow repository origin is invalid");
+  }
+  return `https://github.com/${MAIN_TRANSACTION_REPOSITORY}/actions/runs/${requirePositiveId(
+    runId,
+    "Evidence run ID",
+  )}`;
+}
+
+export function assertUploadedPreparedJournal({
+  journal,
+  journalBytes,
+  artifactName,
+  artifactId,
+}) {
+  const canonical = assertMainTransactionJournal(journal, {
+    mode: MAIN_DEPLOYMENT_MODE,
+    status: "prepared",
+    sequence: 0,
+  });
+  const expectedName = mainTransactionJournalArtifactName(canonical);
+  const expectedBytes = `${JSON.stringify(canonical)}\n`;
+  if (
+    artifactName !== expectedName ||
+    journalBytes !== expectedBytes ||
+    !POSITIVE_ID_PATTERN.test(String(artifactId))
+  ) {
+    throw new Error(
+      "Prepared journal artifact does not acknowledge these exact bytes",
+    );
+  }
+  return {
+    acknowledged: true,
+    artifactName: expectedName,
+    artifactId: String(artifactId),
+  };
+}
+
+export async function runMainShadowTransaction({
+  plan,
+  stageJobs,
+  appBuildProof,
+  runId,
+  runAttempt,
+  journalBytes,
+  artifactName,
+  artifactId,
+  readRemoteMain = () => readRemoteMainSha({}),
+}) {
+  const inputs = createMainTransactionInputs({
+    plan,
+    stageJobs,
+    appBuildProof,
+    runId,
+    runAttempt,
+  });
+  const regenerated = createPreparedMainTransactionJournal({
+    ...inputs.identity,
+    mode: MAIN_DEPLOYMENT_MODE,
+    prior: inputs.prior,
+    candidates: inputs.candidates,
+  });
+  assertUploadedPreparedJournal({
+    journal: regenerated,
+    journalBytes,
+    artifactName,
+    artifactId,
+  });
+  const forbidden = () => {
+    throw new Error("Mutation callback is unreachable in shadow mode");
+  };
+  try {
+    return await runMainTransaction({
+      mode: MAIN_DEPLOYMENT_MODE,
+      identity: inputs.identity,
+      prior: inputs.prior,
+      candidates: inputs.candidates,
+      assertFreshness: async () => ({ sha: readRemoteMain() }),
+      uploadJournal: async ({ artifactName: name, journal }) =>
+        assertUploadedPreparedJournal({
+          journal,
+          journalBytes,
+          artifactName: name,
+          artifactId,
+        }),
+      inspectRecoveryState: async ({ decision }) => {
+        if (decision !== "verify-only") {
+          throw new Error("Shadow recovery decision may only verify");
+        }
+      },
+      mutationAdapters: {
+        promote: forbidden,
+        deployAppV3: forbidden,
+        assignAlias: forbidden,
+        ordinaryRollback: forbidden,
+        restoreAppAlias: forbidden,
+        restoreLegacyAlias: forbidden,
+      },
+    });
+  } catch (error) {
+    if (
+      error instanceof MainTransactionError &&
+      error.code === "SUPERSEDED_BEFORE_MUTATION"
+    ) {
+      return {
+        mode: MAIN_DEPLOYMENT_MODE,
+        outcome: "superseded-after-journal",
+        journal: regenerated,
+        recoveryDecision: {
+          decision: "verify-only",
+          reason: "superseded-before-mutation",
+        },
+        mutationCallbacksCalled: 0,
+      };
+    }
+    throw error;
+  }
+}
+
+export function recoverMainShadowTransaction({ journal, expectedIdentity }) {
+  const canonical = assertMainTransactionJournal(journal, {
+    ...expectedIdentity,
+    mode: MAIN_DEPLOYMENT_MODE,
+  });
+  const decision = decideMainTransactionRecovery([canonical], {
+    ...expectedIdentity,
+    mode: MAIN_DEPLOYMENT_MODE,
+  });
+  if (decision.decision !== "verify-only") {
+    throw new Error("Shadow recovery must remain read-only");
+  }
+  return {
+    outcome: "verified-no-mutation",
+    decision: decision.decision,
+    reason: decision.reason,
+    transactionId: canonical.transactionId,
+  };
+}
+
+function canonicalEvidenceMetrics(value, label, { deploy = true } = {}) {
+  assertExactKeys(
+    value,
+    deploy
+      ? [
+          "buildDurationMs",
+          "deployDurationMs",
+          "totalDurationMs",
+          "turboCacheHits",
+          "turboCacheMisses",
+        ]
+      : [
+          "buildDurationMs",
+          "totalDurationMs",
+          "turboCacheHits",
+          "turboCacheMisses",
+        ],
+    `${label} metrics`,
+  );
+  return {
+    buildDurationMs: requireNonNegativeCount(
+      value.buildDurationMs,
+      `${label} build duration`,
+    ),
+    ...(deploy
+      ? {
+          deployDurationMs: requireNonNegativeCount(
+            value.deployDurationMs,
+            `${label} deploy duration`,
+          ),
+        }
+      : {}),
+    totalDurationMs: requireNonNegativeCount(
+      value.totalDurationMs,
+      `${label} total duration`,
+    ),
+    turboCacheHits: requireNonNegativeCount(
+      value.turboCacheHits,
+      `${label} Turbo cache hits`,
+    ),
+    turboCacheMisses: requireNonNegativeCount(
+      value.turboCacheMisses,
+      `${label} Turbo cache misses`,
+    ),
+  };
+}
+
+export function createMainDeploymentEvidence({
+  plan,
+  stages,
+  app,
+  coordinator,
+  recovery,
+  runId,
+  runAttempt,
+  workflowRunUrl,
+}) {
+  const handoff = assertMainDeploymentHandoff(plan);
+  const expectedRunId = requirePositiveId(runId, "Evidence run ID");
+  const expectedRunAttempt = requirePositiveId(
+    runAttempt,
+    "Evidence run attempt",
+  );
+  const expectedWorkflowRunUrl = createMainWorkflowRunUrl({
+    serverUrl: "https://github.com",
+    repository: MAIN_TRANSACTION_REPOSITORY,
+    runId: expectedRunId,
+  });
+  if (workflowRunUrl !== expectedWorkflowRunUrl) {
+    throw new Error("Downstream workflow run URL is invalid");
+  }
+  assertExactKeys(stages, MAIN_ORDINARY_TARGETS, "Evidence stage targets");
+  const canonicalStages = {};
+  for (const target of MAIN_ORDINARY_TARGETS) {
+    const selected = handoff.planning.plan.includes(target);
+    const value = stages[target];
+    if (!selected) {
+      if (value !== null) {
+        throw new Error(`Unselected ${target} has unexpected evidence`);
+      }
+      canonicalStages[target] = null;
+      continue;
+    }
+    assertExactKeys(
+      value,
+      ["handoff", "metrics", "nextDeploymentId"],
+      `${target} evidence`,
+    );
+    const stage = assertMainStageResult(value.handoff, {
+      plan: handoff,
+      expectedTarget: target,
+      expectedRunId,
+      expectedRunAttempt,
+    });
+    const expectedNextDeploymentId = generateVercelDeploymentId({
+      target,
+      commitSha: handoff.deploySha,
+      runId: expectedRunId,
+      runAttempt: expectedRunAttempt,
+    });
+    if (value.nextDeploymentId !== expectedNextDeploymentId) {
+      throw new Error(`${target} evidence has the wrong custom Next ID`);
+    }
+    canonicalStages[target] = {
+      candidate: {
+        deploymentId: stage.candidate.deploymentId,
+        deploymentUrl: stage.candidate.deploymentUrl,
+        nextDeploymentId: expectedNextDeploymentId,
+      },
+      verification: { ...stage.verification },
+      metrics: canonicalEvidenceMetrics(value.metrics, `${target} evidence`),
+    };
+  }
+  assertExactKeys(
+    coordinator,
+    [
+      "artifactName",
+      "artifactId",
+      "outcome",
+      "totalDurationMs",
+      "transactionId",
+    ],
+    "Coordinator evidence",
+  );
+  if (
+    ![
+      "shadow-prepared",
+      "superseded-before-journal",
+      "superseded-after-journal",
+      "no-target",
+    ].includes(coordinator.outcome)
+  ) {
+    throw new Error("Coordinator evidence outcome is invalid");
+  }
+  const durable = ["shadow-prepared", "superseded-after-journal"].includes(
+    coordinator.outcome,
+  );
+  const expectedIdentity = createMainJournalArtifactIdentity({
+    deploySha: handoff.deploySha,
+    runId: expectedRunId,
+    runAttempt: expectedRunAttempt,
+  });
+  if (
+    durable
+      ? coordinator.transactionId !== expectedIdentity.transactionId ||
+        coordinator.artifactName !== expectedIdentity.artifactName ||
+        !POSITIVE_ID_PATTERN.test(String(coordinator.artifactId))
+      : coordinator.transactionId !== null ||
+        coordinator.artifactName !== null ||
+        coordinator.artifactId !== null
+  ) {
+    throw new Error("Coordinator evidence journal identity is invalid");
+  }
+  const coordinatorEvidence = {
+    outcome: coordinator.outcome,
+    totalDurationMs: requireNonNegativeCount(
+      coordinator.totalDurationMs,
+      "Coordinator total duration",
+    ),
+  };
+  const journal = durable
+    ? {
+        transactionId: expectedIdentity.transactionId,
+        artifactName: expectedIdentity.artifactName,
+        journalArtifactId: String(coordinator.artifactId),
+        sequence: 0,
+        status: "prepared",
+      }
+    : null;
+  let canonicalApp = null;
+  const appSelected = handoff.planning.plan.includes("app");
+  if (app !== null) {
+    if (!appSelected || coordinator.outcome === "superseded-before-journal") {
+      throw new Error("App evidence exists without completed App work");
+    }
+    assertExactKeys(app, ["metrics", "nextDeploymentId"], "App evidence");
+    const expectedNextDeploymentId = generateVercelDeploymentId({
+      target: "app",
+      commitSha: handoff.deploySha,
+      runId: expectedRunId,
+      runAttempt: expectedRunAttempt,
+    });
+    if (app.nextDeploymentId !== expectedNextDeploymentId) {
+      throw new Error("App evidence has the wrong custom Next ID");
+    }
+    canonicalApp = {
+      outcome: "build-only",
+      nextDeploymentId: expectedNextDeploymentId,
+      metrics: canonicalEvidenceMetrics(app.metrics, "App evidence", {
+        deploy: false,
+      }),
+    };
+  } else if (
+    appSelected &&
+    !["superseded-before-journal"].includes(coordinator.outcome)
+  ) {
+    throw new Error("Selected App is missing build-only evidence");
+  }
+  assertExactKeys(recovery, ["outcome"], "Recovery evidence");
+  if (
+    durable
+      ? recovery.outcome !== "verified-no-mutation"
+      : recovery.outcome !== "not-required"
+  ) {
+    throw new Error("Recovery evidence does not match journal durability");
+  }
+  const legacyState = handoff.legacySnapshot[0];
+  const legacy = {
+    alias: LEGACY_ALIAS,
+    deploymentId: handoff.legacyPrior.deploymentId,
+    deploymentUrl: handoff.legacyPrior.deploymentUrl,
+    servedSha: legacyState.git.sha,
+    ref: legacyState.git.ref,
+    readyState: legacyState.readyState,
+    health: "passed",
+  };
+  const freshness = {
+    "no-target": {
+      beforeAppPreparation: "not-run",
+      beforeTransaction: "not-run",
+    },
+    "superseded-before-journal": {
+      beforeAppPreparation: "superseded",
+      beforeTransaction: "not-run",
+    },
+    "shadow-prepared": {
+      beforeAppPreparation: "fresh",
+      beforeTransaction: "fresh",
+    },
+    "superseded-after-journal": {
+      beforeAppPreparation: "fresh",
+      beforeTransaction: "superseded",
+    },
+  }[coordinator.outcome];
+  return {
+    schema: MAIN_EVIDENCE_SCHEMA,
+    mode: MAIN_DEPLOYMENT_MODE,
+    deploySha: handoff.deploySha,
+    workflowDefinitionSha: handoff.deploySha,
+    runId: expectedRunId,
+    runAttempt: expectedRunAttempt,
+    workflowRunUrl: expectedWorkflowRunUrl,
+    upstream: {
+      ...handoff.upstream,
+      buildAndTestConclusion: "success",
+    },
+    planning: handoff.planning,
+    legacy,
+    stages: canonicalStages,
+    app: canonicalApp,
+    coordinator: coordinatorEvidence,
+    journal,
+    recovery: { outcome: recovery.outcome },
+    freshness,
+    ordinaryRollbackStateTargets: [],
+  };
+}
+
+export function renderMainDeploymentEvidence(evidence) {
+  if (!isPlainObject(evidence) || evidence.schema !== MAIN_EVIDENCE_SCHEMA) {
+    throw new Error("Main deployment evidence is malformed");
+  }
+  const lines = [
+    "### Vercel main deployment shadow evidence",
+    "",
+    `- DEPLOY_SHA: \`${evidence.deploySha}\``,
+    `- Downstream workflow: [run ${evidence.runId}, attempt ${evidence.runAttempt}](${evidence.workflowRunUrl})`,
+    `- Final plan: ${
+      evidence.planning.plan.length === 0
+        ? "no targets"
+        : evidence.planning.plan.map((target) => `\`${target}\``).join(", ")
+    }`,
+    `- Upstream CI: [run ${evidence.upstream.runId}, attempt ${evidence.upstream.runAttempt}](${evidence.upstream.runUrl})`,
+    `- Workflow definition SHA: \`${evidence.workflowDefinitionSha}\``,
+    `- Upstream sentinel: [Build and Test](${evidence.upstream.buildAndTestJobUrl}) — \`${evidence.upstream.buildAndTestConclusion}\``,
+    "",
+    "#### Served deployment priors",
+    "",
+    "| Target | Deployment | Served SHA | Reviewed aliases |",
+    "|---|---|---|---|",
+    ...evidence.planning.priors.map(
+      (prior) =>
+        `| ${prior.target} | \`${prior.deploymentId}\` / ${prior.deploymentUrl} | ${
+          prior.servedSha ? `\`${prior.servedSha}\`` : "unknown"
+        } | ${prior.aliases.map((alias) => `\`${alias}\``).join(", ")} |`,
+    ),
+    `| legacy-app | \`${evidence.legacy.deploymentId}\` / ${evidence.legacy.deploymentUrl} | \`${evidence.legacy.servedSha}\` (\`${evidence.legacy.ref}\`, \`${evidence.legacy.readyState}\`, health \`${evidence.legacy.health}\`) | \`${evidence.legacy.alias}\` |`,
+    "",
+    "#### Served-SHA ranges and selection reasons",
+    "",
+    "| Kind | Base → head | Source targets | Selected packages | Reason |",
+    "|---|---|---|---|---|",
+    ...evidence.planning.ranges.map(
+      (range) =>
+        `| ${range.kind} | ${
+          range.base ? `\`${range.base}\`` : "unknown"
+        } → \`${range.head}\` | ${range.targets.join(", ")} | ${
+          range.deployments.join(", ") || "none"
+        } | \`${range.reason}\` |`,
+    ),
+    "",
+    ...evidence.planning.reasons.map(
+      (reason) =>
+        `- \`${reason.target}\`: \`${reason.reason}\`${
+          reason.base ? ` from \`${reason.base}\`` : ""
+        }`,
+    ),
+    "",
+    "#### Candidate evidence",
+    "",
+    "| Target | Candidate | Verification | Build / deploy / runner | Turbo cache |",
+    "|---|---|---|---|---|",
+    ...MAIN_ORDINARY_TARGETS.map((target) => {
+      const stage = evidence.stages[target];
+      return stage === null
+        ? `| ${target} | not selected | n/a | n/a | n/a |`
+        : `| ${target} | \`${stage.candidate.deploymentId}\` / ${stage.candidate.deploymentUrl} | canonical \`${stage.verification.canonicalState}\`; immutable browser/runtime/security \`${stage.verification.immutableSmoke}\`; mappings \`${stage.verification.protectedMappings}\` | ${stage.metrics.buildDurationMs} / ${stage.metrics.deployDurationMs} / ${stage.metrics.totalDurationMs} ms | ${stage.metrics.turboCacheHits} hit / ${stage.metrics.turboCacheMisses} miss |`;
+    }),
+    evidence.app === null
+      ? "| app | not built | n/a | n/a | n/a |"
+      : `| app | build-only Next ID \`${evidence.app.nextDeploymentId}\` | exact custom-v3 build proof; deploy unreachable | ${evidence.app.metrics.buildDurationMs} / n/a / ${evidence.app.metrics.totalDurationMs} ms | ${evidence.app.metrics.turboCacheHits} hit / ${evidence.app.metrics.turboCacheMisses} miss |`,
+    "",
+    `- Coordinator: \`${evidence.coordinator.outcome}\` in ${evidence.coordinator.totalDurationMs} ms`,
+    `- Journal: ${
+      evidence.journal
+        ? `\`${evidence.journal.artifactName}\` (artifact \`${evidence.journal.journalArtifactId}\`, sequence \`${evidence.journal.sequence}\`, status \`${evidence.journal.status}\`) for \`${evidence.journal.transactionId}\``
+        : "not created"
+    }`,
+    `- Recovery: \`${evidence.recovery.outcome}\``,
+    `- Freshness barriers: before App preparation \`${evidence.freshness.beforeAppPreparation}\`; before transaction \`${evidence.freshness.beforeTransaction}\``,
+    "- Ordinary rollback-state targets: none",
+    `- Unaliased ordinary staging uploads: ${
+      MAIN_ORDINARY_TARGETS.filter((target) => evidence.stages[target] !== null)
+        .map((target) => `\`${target}\``)
+        .join(", ") || "none"
+    }`,
+    "- Public-serving activation, alias, promotion, rollback, and recovery commands: `0`",
+    "",
+  ];
+  return lines.join("\n");
+}
+
+export function assertMainFinalResults({
+  plan,
+  jobs,
+  coordinatorOutcome,
+  recoveryOutcome,
+}) {
+  const handoff = assertMainDeploymentHandoff(plan);
+  const expectedJobKeys = [
+    "waitForCi",
+    "plan",
+    "stageGovernance",
+    "stageReserve",
+    "stageUi",
+    "coordinator",
+    "recovery",
+  ];
+  assertExactKeys(jobs, expectedJobKeys, "Main final job results");
+  for (const [name, result] of Object.entries(jobs)) {
+    if (!JOB_RESULTS.has(result)) {
+      throw new Error(`Main final job result is invalid for ${name}`);
+    }
+  }
+  if (
+    jobs.waitForCi !== "success" ||
+    jobs.plan !== "success" ||
+    jobs.coordinator !== "success" ||
+    jobs.recovery !== "success"
+  ) {
+    throw new Error("A required main deployment job did not succeed");
+  }
+  for (const target of MAIN_ORDINARY_TARGETS) {
+    const jobName =
+      target === "governance"
+        ? "stageGovernance"
+        : target === "reserve"
+          ? "stageReserve"
+          : "stageUi";
+    const expected = handoff.planning.plan.includes(target)
+      ? "success"
+      : "skipped";
+    if (jobs[jobName] !== expected) {
+      throw new Error(`Final stage result is invalid for ${target}`);
+    }
+  }
+  if (
+    ![
+      "shadow-prepared",
+      "superseded-before-journal",
+      "superseded-after-journal",
+      "no-target",
+    ].includes(coordinatorOutcome)
+  ) {
+    throw new Error("Coordinator outcome is not safe for PR A");
+  }
+  const durableJournalExists = [
+    "shadow-prepared",
+    "superseded-after-journal",
+  ].includes(coordinatorOutcome);
+  if (durableJournalExists && recoveryOutcome !== "verified-no-mutation") {
+    throw new Error("Prepared shadow transaction was not recovery-verified");
+  }
+  if (!durableJournalExists && recoveryOutcome !== "not-required") {
+    throw new Error("No-op coordinator outcome has unexpected recovery");
+  }
+  return { outcome: coordinatorOutcome };
+}
+
+export function parseMainDeploymentArguments(argv) {
+  if (!Array.isArray(argv) || !Object.hasOwn(CLI_COMMAND_OPTIONS, argv[0])) {
+    throw new Error("Main deployment command is missing or unsupported");
+  }
+  const command = argv[0];
+  const allowed = new Set(CLI_COMMAND_OPTIONS[command]);
+  const options = Object.create(null);
+  if ((argv.length - 1) % 2 !== 0) {
+    throw new Error("Main deployment CLI arguments are malformed");
+  }
+  for (let index = 1; index < argv.length; index += 2) {
+    const flag = argv[index];
+    const value = argv[index + 1];
+    if (
+      typeof flag !== "string" ||
+      !/^--[a-z][a-z-]*$/.test(flag) ||
+      typeof value !== "string" ||
+      value.length === 0 ||
+      value.startsWith("--")
+    ) {
+      throw new Error("Main deployment CLI arguments are malformed");
+    }
+    const name = flag.slice(2);
+    if (!allowed.has(name)) {
+      throw new Error("Main deployment CLI option is unsupported");
+    }
+    if (Object.hasOwn(options, name)) {
+      throw new Error("Main deployment CLI option is duplicated");
+    }
+    options[name] = value;
+  }
+  if (
+    Object.keys(options).length !== allowed.size ||
+    [...allowed].some((name) => !Object.hasOwn(options, name))
+  ) {
+    throw new Error("Main deployment CLI required option is missing");
+  }
+  return { command, options };
+}
+
+function projectIdsFromEnvironment(values) {
+  return {
+    app: values.VERCEL_PROJECT_ID_APP,
+    governance: values.VERCEL_PROJECT_ID_GOVERNANCE,
+    reserve: values.VERCEL_PROJECT_ID_RESERVE,
+    ui: values.VERCEL_PROJECT_ID_UI,
+  };
+}
+
+function stageJobsFromEnvironment(values) {
+  const parseOptional = (raw, label) => (raw ? parseJson(raw, label) : null);
+  return {
+    governance: {
+      result: values.STAGE_GOVERNANCE_RESULT,
+      handoff: parseOptional(
+        values.STAGE_GOVERNANCE_HANDOFF,
+        "Governance stage handoff",
+      ),
+    },
+    reserve: {
+      result: values.STAGE_RESERVE_RESULT,
+      handoff: parseOptional(
+        values.STAGE_RESERVE_HANDOFF,
+        "Reserve stage handoff",
+      ),
+    },
+    ui: {
+      result: values.STAGE_UI_RESULT,
+      handoff: parseOptional(values.STAGE_UI_HANDOFF, "UI stage handoff"),
+    },
+  };
+}
+
+function appProofFromEnvironment(values) {
+  return values.APP_BUILD_PROOF
+    ? parseJson(values.APP_BUILD_PROOF, "App build proof")
+    : null;
+}
+
+function evidenceStageFromEnvironment(values, target) {
+  const prefix = `EVIDENCE_${target.toUpperCase()}`;
+  const result = values[`${prefix}_RESULT`];
+  if (result === "skipped") return null;
+  if (result !== "success") {
+    throw new Error(`${target} evidence job did not succeed or skip`);
+  }
+  return {
+    handoff: parseJson(
+      values[`${prefix}_HANDOFF`],
+      `${target} evidence handoff`,
+    ),
+    nextDeploymentId: values[`${prefix}_NEXT_DEPLOYMENT_ID`],
+    metrics: {
+      buildDurationMs: values[`${prefix}_BUILD_DURATION_MS`],
+      deployDurationMs: values[`${prefix}_DEPLOY_DURATION_MS`],
+      totalDurationMs: values[`${prefix}_TOTAL_DURATION_MS`],
+      turboCacheHits: values[`${prefix}_TURBO_CACHE_HITS`],
+      turboCacheMisses: values[`${prefix}_TURBO_CACHE_MISSES`],
+    },
+  };
+}
+
+function evidenceAppFromEnvironment(values) {
+  if (!values.EVIDENCE_APP_NEXT_DEPLOYMENT_ID) return null;
+  return {
+    nextDeploymentId: values.EVIDENCE_APP_NEXT_DEPLOYMENT_ID,
+    metrics: {
+      buildDurationMs: values.EVIDENCE_APP_BUILD_DURATION_MS,
+      totalDurationMs: values.EVIDENCE_APP_TOTAL_DURATION_MS,
+      turboCacheHits: values.EVIDENCE_APP_TURBO_CACHE_HITS,
+      turboCacheMisses: values.EVIDENCE_APP_TURBO_CACHE_MISSES,
+    },
+  };
+}
+
+async function runCli({ argv = process.argv.slice(2), values = process.env }) {
+  const { command, options } = parseMainDeploymentArguments(argv);
+  if (command === "validate-context") {
+    validateMainWorkflowContext({
+      repository: values.GITHUB_REPOSITORY,
+      eventName: values.GITHUB_EVENT_NAME,
+      workflowRef: values.GITHUB_WORKFLOW_REF,
+      workflowSha: values.GITHUB_WORKFLOW_SHA,
+      deploySha: values.DEPLOY_SHA,
+    });
+    return;
+  }
+  if (command === "validate-source") {
+    validateMainDeploymentSource({
+      repoRoot: values.SOURCE_PATH,
+      deploySha: values.DEPLOY_SHA,
+      workflowSha: values.GITHUB_WORKFLOW_SHA,
+    });
+    return;
+  }
+  if (command === "create-spec") {
+    const scope = options.scope;
+    if (!["main", "legacy"].includes(scope)) {
+      throw new Error("create-spec requires scope main or legacy");
+    }
+    writeCanonicalJson(
+      options.output,
+      scope === "main"
+        ? createMainProtectedAliasSpec({
+            projectIds: projectIdsFromEnvironment(values),
+          })
+        : createMainLegacyAliasSpec({
+            projectIds: projectIdsFromEnvironment(values),
+          }),
+    );
+    return;
+  }
+  if (command === "evidence") {
+    const evidence = createMainDeploymentEvidence({
+      plan: parseJson(values.PLAN_JSON, "Main deployment plan"),
+      stages: Object.fromEntries(
+        MAIN_ORDINARY_TARGETS.map((target) => [
+          target,
+          evidenceStageFromEnvironment(values, target),
+        ]),
+      ),
+      app: evidenceAppFromEnvironment(values),
+      coordinator: {
+        outcome: values.COORDINATOR_OUTCOME,
+        transactionId: values.TRANSACTION_ID || null,
+        artifactName: values.JOURNAL_ARTIFACT_NAME || null,
+        artifactId: values.JOURNAL_ARTIFACT_ID || null,
+        totalDurationMs: values.COORDINATOR_TOTAL_DURATION_MS,
+      },
+      recovery: { outcome: values.RECOVERY_OUTCOME },
+      runId: values.GITHUB_RUN_ID,
+      runAttempt: values.GITHUB_RUN_ATTEMPT,
+      workflowRunUrl: createMainWorkflowRunUrl({
+        serverUrl: values.GITHUB_SERVER_URL,
+        repository: values.GITHUB_REPOSITORY,
+        runId: values.GITHUB_RUN_ID,
+      }),
+    });
+    writeCanonicalJson(options.output, evidence);
+    if (!values.GITHUB_STEP_SUMMARY) {
+      throw new Error("GITHUB_STEP_SUMMARY is required");
+    }
+    appendFileSync(
+      values.GITHUB_STEP_SUMMARY,
+      renderMainDeploymentEvidence(evidence),
+    );
+    return;
+  }
+  if (command === "plan") {
+    const result = createMainDeploymentPlan({
+      mode: values.VERCEL_MAIN_MODE,
+      deploySha: values.DEPLOY_SHA,
+      projectIds: projectIdsFromEnvironment(values),
+      planningSnapshot: readJson(
+        options["planning-snapshot"],
+        "Main planning snapshot",
+      ),
+      legacySnapshot: readJson(
+        options["legacy-snapshot"],
+        "Legacy app snapshot",
+      ),
+      upstream: {
+        runId: values.UPSTREAM_RUN_ID,
+        runAttempt: values.UPSTREAM_RUN_ATTEMPT,
+        runUrl: values.UPSTREAM_RUN_URL,
+        buildAndTestJobUrl: values.BUILD_AND_TEST_JOB_URL,
+      },
+      repoRoot: values.SOURCE_PATH,
+    });
+    writeCanonicalJson(options.output, result);
+    appendOutput(values.GITHUB_OUTPUT, "plan", JSON.stringify(result));
+    appendOutput(
+      values.GITHUB_OUTPUT,
+      "targets",
+      JSON.stringify(result.planning.plan),
+    );
+    return;
+  }
+  if (command === "freshness") {
+    const result = classifyRemoteMainFreshness({
+      deploySha: values.DEPLOY_SHA,
+      remoteSha: readRemoteMainSha({}),
+    });
+    appendOutput(values.GITHUB_OUTPUT, "status", result.status);
+    return;
+  }
+  if (command === "journal-name") {
+    const identity = createMainJournalArtifactIdentity({
+      deploySha: values.DEPLOY_SHA,
+      runId: values.GITHUB_RUN_ID,
+      runAttempt: values.GITHUB_RUN_ATTEMPT,
+    });
+    appendOutput(values.GITHUB_OUTPUT, "artifact_name", identity.artifactName);
+    appendOutput(
+      values.GITHUB_OUTPUT,
+      "transaction_id",
+      identity.transactionId,
+    );
+    return;
+  }
+  if (command === "revalidate-prior") {
+    assertProtectedSnapshotMatchesPlan({
+      plan: parseJson(values.PLAN_JSON, "Main deployment plan"),
+      planningSnapshot: readJson(
+        options["planning-snapshot"],
+        "Current main planning snapshot",
+      ),
+      legacySnapshot: readJson(
+        options["legacy-snapshot"],
+        "Current legacy snapshot",
+      ),
+    });
+    return;
+  }
+  if (command === "app-build-proof") {
+    const proof = createMainAppBuildProof({
+      deploySha: values.DEPLOY_SHA,
+      runId: values.GITHUB_RUN_ID,
+      runAttempt: values.GITHUB_RUN_ATTEMPT,
+      projectId: values.VERCEL_PROJECT_ID_APP,
+      nextDeploymentId: values.MENTO_NEXT_DEPLOYMENT_ID,
+    });
+    writeCanonicalJson(options.output, proof);
+    appendOutput(values.GITHUB_OUTPUT, "proof", JSON.stringify(proof));
+    return;
+  }
+  if (command === "app-candidate-expectation") {
+    writeCanonicalJson(
+      options.output,
+      createMainAppCandidateExpectation({
+        journal: readJson(options.journal, "Prepared transaction journal"),
+        projectId: values.VERCEL_PROJECT_ID_APP,
+      }),
+    );
+    return;
+  }
+  if (command === "stage-result") {
+    const result = createMainStageResult({
+      target: values.LOGICAL_TARGET,
+      plan: parseJson(values.PLAN_JSON, "Main deployment plan"),
+      state: readJson(options.state, "Staged deployment state"),
+      runId: values.GITHUB_RUN_ID,
+      runAttempt: values.GITHUB_RUN_ATTEMPT,
+      smokePassed: values.IMMUTABLE_SMOKE_PASSED === "true",
+      protectedMappingsUnchanged:
+        values.PROTECTED_MAPPINGS_UNCHANGED === "true",
+    });
+    writeCanonicalJson(options.output, result);
+    appendOutput(values.GITHUB_OUTPUT, "result", JSON.stringify(result));
+    return;
+  }
+  if (command === "validate-stages") {
+    const result = validateMainStageJobs({
+      plan: parseJson(values.PLAN_JSON, "Main deployment plan"),
+      jobs: stageJobsFromEnvironment(values),
+      runId: values.GITHUB_RUN_ID,
+      runAttempt: values.GITHUB_RUN_ATTEMPT,
+    });
+    appendOutput(values.GITHUB_OUTPUT, "outcome", result.outcome);
+    return;
+  }
+  if (command === "prepare-journal") {
+    const journal = createPreparedMainJournal({
+      plan: parseJson(values.PLAN_JSON, "Main deployment plan"),
+      stageJobs: stageJobsFromEnvironment(values),
+      appBuildProof: appProofFromEnvironment(values),
+      runId: values.GITHUB_RUN_ID,
+      runAttempt: values.GITHUB_RUN_ATTEMPT,
+    });
+    writeCanonicalJson(options.output, journal);
+    appendOutput(
+      values.GITHUB_OUTPUT,
+      "artifact_name",
+      mainTransactionJournalArtifactName(journal),
+    );
+    appendOutput(values.GITHUB_OUTPUT, "transaction_id", journal.transactionId);
+    return;
+  }
+  if (command === "run-shadow") {
+    const journalBytes = readFileSync(options.journal, "utf8");
+    const result = await runMainShadowTransaction({
+      plan: parseJson(values.PLAN_JSON, "Main deployment plan"),
+      stageJobs: stageJobsFromEnvironment(values),
+      appBuildProof: appProofFromEnvironment(values),
+      runId: values.GITHUB_RUN_ID,
+      runAttempt: values.GITHUB_RUN_ATTEMPT,
+      journalBytes,
+      artifactName: values.JOURNAL_ARTIFACT_NAME,
+      artifactId: values.JOURNAL_ARTIFACT_ID,
+    });
+    appendOutput(values.GITHUB_OUTPUT, "outcome", result.outcome);
+    return;
+  }
+  if (command === "recover-shadow") {
+    const plan = assertMainDeploymentHandoff(
+      parseJson(values.PLAN_JSON, "Main deployment plan"),
+    );
+    const result = recoverMainShadowTransaction({
+      journal: readJson(options.journal, "Prepared transaction journal"),
+      expectedIdentity: {
+        repository: MAIN_TRANSACTION_REPOSITORY,
+        deploySha: plan.deploySha,
+        runId: values.GITHUB_RUN_ID,
+        runAttempt: values.GITHUB_RUN_ATTEMPT,
+      },
+    });
+    appendOutput(values.GITHUB_OUTPUT, "outcome", result.outcome);
+    return;
+  }
+  if (command === "final") {
+    const result = assertMainFinalResults({
+      plan: parseJson(values.PLAN_JSON, "Main deployment plan"),
+      jobs: {
+        waitForCi: values.WAIT_FOR_CI_RESULT,
+        plan: values.PLAN_RESULT,
+        stageGovernance: values.STAGE_GOVERNANCE_RESULT,
+        stageReserve: values.STAGE_RESERVE_RESULT,
+        stageUi: values.STAGE_UI_RESULT,
+        coordinator: values.COORDINATOR_RESULT,
+        recovery: values.RECOVERY_RESULT,
+      },
+      coordinatorOutcome: values.COORDINATOR_OUTCOME,
+      recoveryOutcome: values.RECOVERY_OUTCOME,
+    });
+    process.stdout.write(
+      `Validated Vercel main deployment outcome: ${result.outcome}\n`,
+    );
+    return;
+  }
+  throw new Error("Main deployment command is missing or unsupported");
+}
+
+function isCliEntrypoint() {
+  return (
+    process.argv[1] !== undefined &&
+    fileURLToPath(import.meta.url) === resolve(process.argv[1])
+  );
+}
+
+if (isCliEntrypoint()) {
+  await runCli({});
+}

--- a/scripts/vercel-main-deployment.mjs
+++ b/scripts/vercel-main-deployment.mjs
@@ -41,6 +41,7 @@ import { generateVercelDeploymentId } from "./vercel-prebuilt.mjs";
 export const MAIN_DEPLOYMENT_SCHEMA = "vercel-main-deployment:v1";
 export const MAIN_STAGE_SCHEMA = "vercel-main-stage:v1";
 export const MAIN_EVIDENCE_SCHEMA = "vercel-main-evidence:v1";
+export const MAIN_FAILURE_EVIDENCE_SCHEMA = "vercel-main-failure-evidence:v1";
 export const MAIN_DEPLOYMENT_MODE = MAIN_TRANSACTION_MODE;
 export const MAIN_DEPLOYMENT_WORKFLOW =
   ".github/workflows/vercel-main-deployment.yml";
@@ -56,6 +57,15 @@ const ID_PATTERN = /^[A-Za-z0-9._-]+$/;
 const DEPLOYMENT_ID_PATTERN = /^dpl_[A-Za-z0-9]+$/;
 const POSITIVE_ID_PATTERN = /^[1-9][0-9]*$/;
 const JOB_RESULTS = new Set(["success", "failure", "cancelled", "skipped"]);
+const FINAL_JOB_KEYS = Object.freeze([
+  "waitForCi",
+  "plan",
+  "stageGovernance",
+  "stageReserve",
+  "stageUi",
+  "coordinator",
+  "recovery",
+]);
 const PLAN_KEYS = Object.freeze([
   "schema",
   "mode",
@@ -103,6 +113,7 @@ const CLI_COMMAND_OPTIONS = Object.freeze({
   "app-candidate-expectation": Object.freeze(["journal", "output"]),
   "create-spec": Object.freeze(["output", "scope"]),
   evidence: Object.freeze(["output"]),
+  "failure-evidence": Object.freeze(["output"]),
   final: Object.freeze([]),
   freshness: Object.freeze([]),
   "journal-name": Object.freeze([]),
@@ -1248,6 +1259,73 @@ function canonicalEvidenceMetrics(value, label, { deploy = true } = {}) {
   };
 }
 
+function canonicalFinalJobResults(jobs, label = "Main final job results") {
+  assertExactKeys(jobs, FINAL_JOB_KEYS, label);
+  return Object.fromEntries(
+    FINAL_JOB_KEYS.map((name) => {
+      const result = jobs[name];
+      if (!JOB_RESULTS.has(result)) {
+        throw new Error(`${label} is invalid for ${name}`);
+      }
+      return [name, result];
+    }),
+  );
+}
+
+function canonicalOptionalSha(value) {
+  return typeof value === "string" && SHA_PATTERN.test(value) ? value : null;
+}
+
+export function createMainDeploymentFailureEvidence({
+  eventHeadSha,
+  verifiedDeploySha,
+  planOutput,
+  jobs,
+  workflowDefinitionSha,
+  runId,
+  runAttempt,
+  workflowRunUrl,
+}) {
+  const expectedRunId = requirePositiveId(runId, "Failure evidence run ID");
+  const expectedRunAttempt = requirePositiveId(
+    runAttempt,
+    "Failure evidence run attempt",
+  );
+  const expectedWorkflowRunUrl = createMainWorkflowRunUrl({
+    serverUrl: "https://github.com",
+    repository: MAIN_TRANSACTION_REPOSITORY,
+    runId: expectedRunId,
+  });
+  if (workflowRunUrl !== expectedWorkflowRunUrl) {
+    throw new Error("Failure evidence workflow run URL is invalid");
+  }
+  const canonicalJobs = canonicalFinalJobResults(
+    jobs,
+    "Failure evidence job results",
+  );
+  return {
+    schema: MAIN_FAILURE_EVIDENCE_SCHEMA,
+    mode: MAIN_DEPLOYMENT_MODE,
+    repository: MAIN_TRANSACTION_REPOSITORY,
+    eventHeadSha: canonicalOptionalSha(eventHeadSha),
+    verifiedDeploySha:
+      canonicalJobs.waitForCi === "success"
+        ? canonicalOptionalSha(verifiedDeploySha)
+        : null,
+    workflowDefinitionSha: requireSha(
+      workflowDefinitionSha,
+      "Failure evidence workflow definition SHA",
+    ),
+    runId: expectedRunId,
+    runAttempt: expectedRunAttempt,
+    workflowRunUrl: expectedWorkflowRunUrl,
+    planOutputPresent: typeof planOutput === "string" && planOutput.length > 0,
+    jobs: canonicalJobs,
+    publicServingMutationCommands: 0,
+    outcome: "failed",
+  };
+}
+
 export function createMainDeploymentEvidence({
   plan,
   stages,
@@ -1543,6 +1621,90 @@ export function renderMainDeploymentEvidence(evidence) {
   return lines.join("\n");
 }
 
+export function renderMainDeploymentFailureEvidence(evidence) {
+  assertExactKeys(
+    evidence,
+    [
+      "eventHeadSha",
+      "jobs",
+      "mode",
+      "outcome",
+      "planOutputPresent",
+      "publicServingMutationCommands",
+      "repository",
+      "runAttempt",
+      "runId",
+      "schema",
+      "verifiedDeploySha",
+      "workflowDefinitionSha",
+      "workflowRunUrl",
+    ],
+    "Main deployment failure evidence",
+  );
+  if (
+    evidence.schema !== MAIN_FAILURE_EVIDENCE_SCHEMA ||
+    evidence.mode !== MAIN_DEPLOYMENT_MODE ||
+    evidence.repository !== MAIN_TRANSACTION_REPOSITORY ||
+    evidence.outcome !== "failed" ||
+    typeof evidence.planOutputPresent !== "boolean" ||
+    evidence.publicServingMutationCommands !== 0
+  ) {
+    throw new Error("Main deployment failure evidence is malformed");
+  }
+  const jobs = canonicalFinalJobResults(
+    evidence.jobs,
+    "Failure evidence job results",
+  );
+  const runUrl = createMainWorkflowRunUrl({
+    serverUrl: "https://github.com",
+    repository: evidence.repository,
+    runId: evidence.runId,
+  });
+  if (
+    evidence.workflowRunUrl !== runUrl ||
+    requirePositiveId(evidence.runAttempt, "Failure evidence run attempt") !==
+      evidence.runAttempt ||
+    requireSha(
+      evidence.workflowDefinitionSha,
+      "Failure evidence workflow definition SHA",
+    ) !== evidence.workflowDefinitionSha ||
+    (evidence.eventHeadSha !== null &&
+      canonicalOptionalSha(evidence.eventHeadSha) !== evidence.eventHeadSha) ||
+    (evidence.verifiedDeploySha !== null &&
+      canonicalOptionalSha(evidence.verifiedDeploySha) !==
+        evidence.verifiedDeploySha)
+  ) {
+    throw new Error("Main deployment failure evidence is malformed");
+  }
+  return [
+    "### Vercel main deployment failure evidence",
+    "",
+    `- Downstream workflow: [run ${evidence.runId}, attempt ${evidence.runAttempt}](${evidence.workflowRunUrl})`,
+    `- Workflow definition SHA: \`${evidence.workflowDefinitionSha}\``,
+    `- Event head SHA: ${
+      evidence.eventHeadSha ? `\`${evidence.eventHeadSha}\`` : "unavailable"
+    }`,
+    `- Verified deploy SHA: ${
+      evidence.verifiedDeploySha
+        ? `\`${evidence.verifiedDeploySha}\``
+        : "unavailable"
+    }`,
+    `- Planner output: ${
+      evidence.planOutputPresent ? "present but not embedded" : "unavailable"
+    }`,
+    "",
+    "#### Final job graph",
+    "",
+    "| Job | Result |",
+    "|---|---|",
+    ...FINAL_JOB_KEYS.map((name) => `| ${name} | \`${jobs[name]}\` |`),
+    "",
+    "- Public-serving activation, alias, promotion, rollback, and recovery commands: `0`",
+    "- Outcome: `failed`; this report does not authorize activation.",
+    "",
+  ].join("\n");
+}
+
 export function assertMainFinalResults({
   plan,
   jobs,
@@ -1550,26 +1712,12 @@ export function assertMainFinalResults({
   recoveryOutcome,
 }) {
   const handoff = assertMainDeploymentHandoff(plan);
-  const expectedJobKeys = [
-    "waitForCi",
-    "plan",
-    "stageGovernance",
-    "stageReserve",
-    "stageUi",
-    "coordinator",
-    "recovery",
-  ];
-  assertExactKeys(jobs, expectedJobKeys, "Main final job results");
-  for (const [name, result] of Object.entries(jobs)) {
-    if (!JOB_RESULTS.has(result)) {
-      throw new Error(`Main final job result is invalid for ${name}`);
-    }
-  }
+  const canonicalJobs = canonicalFinalJobResults(jobs);
   if (
-    jobs.waitForCi !== "success" ||
-    jobs.plan !== "success" ||
-    jobs.coordinator !== "success" ||
-    jobs.recovery !== "success"
+    canonicalJobs.waitForCi !== "success" ||
+    canonicalJobs.plan !== "success" ||
+    canonicalJobs.coordinator !== "success" ||
+    canonicalJobs.recovery !== "success"
   ) {
     throw new Error("A required main deployment job did not succeed");
   }
@@ -1583,7 +1731,7 @@ export function assertMainFinalResults({
     const expected = handoff.planning.plan.includes(target)
       ? "success"
       : "skipped";
-    if (jobs[jobName] !== expected) {
+    if (canonicalJobs[jobName] !== expected) {
       throw new Error(`Final stage result is invalid for ${target}`);
     }
   }
@@ -1680,6 +1828,18 @@ function stageJobsFromEnvironment(values) {
       result: values.STAGE_UI_RESULT,
       handoff: parseOptional(values.STAGE_UI_HANDOFF, "UI stage handoff"),
     },
+  };
+}
+
+function finalJobsFromEnvironment(values) {
+  return {
+    waitForCi: values.WAIT_FOR_CI_RESULT,
+    plan: values.PLAN_RESULT,
+    stageGovernance: values.STAGE_GOVERNANCE_RESULT,
+    stageReserve: values.STAGE_RESERVE_RESULT,
+    stageUi: values.STAGE_UI_RESULT,
+    coordinator: values.COORDINATOR_RESULT,
+    recovery: values.RECOVERY_RESULT,
   };
 }
 
@@ -1795,6 +1955,31 @@ async function runCli({ argv = process.argv.slice(2), values = process.env }) {
     appendFileSync(
       values.GITHUB_STEP_SUMMARY,
       renderMainDeploymentEvidence(evidence),
+    );
+    return;
+  }
+  if (command === "failure-evidence") {
+    const evidence = createMainDeploymentFailureEvidence({
+      eventHeadSha: values.EVENT_HEAD_SHA,
+      verifiedDeploySha: values.DEPLOY_SHA,
+      planOutput: values.PLAN_JSON,
+      jobs: finalJobsFromEnvironment(values),
+      workflowDefinitionSha: values.GITHUB_WORKFLOW_SHA,
+      runId: values.GITHUB_RUN_ID,
+      runAttempt: values.GITHUB_RUN_ATTEMPT,
+      workflowRunUrl: createMainWorkflowRunUrl({
+        serverUrl: values.GITHUB_SERVER_URL,
+        repository: values.GITHUB_REPOSITORY,
+        runId: values.GITHUB_RUN_ID,
+      }),
+    });
+    writeCanonicalJson(options.output, evidence);
+    if (!values.GITHUB_STEP_SUMMARY) {
+      throw new Error("GITHUB_STEP_SUMMARY is required");
+    }
+    appendFileSync(
+      values.GITHUB_STEP_SUMMARY,
+      renderMainDeploymentFailureEvidence(evidence),
     );
     return;
   }
@@ -1962,15 +2147,7 @@ async function runCli({ argv = process.argv.slice(2), values = process.env }) {
   if (command === "final") {
     const result = assertMainFinalResults({
       plan: parseJson(values.PLAN_JSON, "Main deployment plan"),
-      jobs: {
-        waitForCi: values.WAIT_FOR_CI_RESULT,
-        plan: values.PLAN_RESULT,
-        stageGovernance: values.STAGE_GOVERNANCE_RESULT,
-        stageReserve: values.STAGE_RESERVE_RESULT,
-        stageUi: values.STAGE_UI_RESULT,
-        coordinator: values.COORDINATOR_RESULT,
-        recovery: values.RECOVERY_RESULT,
-      },
+      jobs: finalJobsFromEnvironment(values),
       coordinatorOutcome: values.COORDINATOR_OUTCOME,
       recoveryOutcome: values.RECOVERY_OUTCOME,
     });

--- a/scripts/vercel-main-deployment.test.mjs
+++ b/scripts/vercel-main-deployment.test.mjs
@@ -10,6 +10,7 @@ import { fileURLToPath } from "node:url";
 import {
   MAIN_DEPLOYMENT_MODE,
   MAIN_DEPLOYMENT_SCHEMA,
+  MAIN_FAILURE_EVIDENCE_SCHEMA,
   MAIN_STAGE_SCHEMA,
   assertMainDeploymentHandoff,
   assertMainFinalResults,
@@ -22,6 +23,7 @@ import {
   createMainAppTransactionMetadata,
   createMainDeploymentPlan,
   createMainDeploymentEvidence,
+  createMainDeploymentFailureEvidence,
   createMainJournalArtifactIdentity,
   createMainWorkflowRunUrl,
   createMainLegacyAliasSpec,
@@ -33,6 +35,7 @@ import {
   readRemoteMainSha,
   recoverMainShadowTransaction,
   renderMainDeploymentEvidence,
+  renderMainDeploymentFailureEvidence,
   runMainShadowTransaction,
   validateMainDeploymentSource,
   validateMainStageJobs,
@@ -251,6 +254,7 @@ test("controller CLI accepts only each command's exact non-duplicated options", 
     ["validate-source"],
     ["create-spec", "--scope", "main", "--output", "/tmp/spec.json"],
     ["evidence", "--output", "/tmp/evidence.json"],
+    ["failure-evidence", "--output", "/tmp/failure-evidence.json"],
     [
       "plan",
       "--planning-snapshot",
@@ -504,6 +508,93 @@ test("canonical evidence records planning, candidates, timings, cache, journal, 
   );
 });
 
+test("failure evidence records the complete redacted job graph without parsing planner output", () => {
+  const jobs = {
+    waitForCi: "success",
+    plan: "success",
+    stageGovernance: "failure",
+    stageReserve: "cancelled",
+    stageUi: "skipped",
+    coordinator: "skipped",
+    recovery: "success",
+  };
+  const evidence = createMainDeploymentFailureEvidence({
+    eventHeadSha: SHA,
+    verifiedDeploySha: SHA,
+    planOutput: '{"token":"must-not-be-embedded"',
+    jobs,
+    workflowDefinitionSha: SHA,
+    runId: "800",
+    runAttempt: "3",
+    workflowRunUrl: WORKFLOW_RUN_URL,
+  });
+  assert.equal(evidence.schema, MAIN_FAILURE_EVIDENCE_SCHEMA);
+  assert.equal(evidence.outcome, "failed");
+  assert.equal(evidence.eventHeadSha, SHA);
+  assert.equal(evidence.verifiedDeploySha, SHA);
+  assert.equal(evidence.planOutputPresent, true);
+  assert.deepEqual(evidence.jobs, jobs);
+  assert.equal(evidence.publicServingMutationCommands, 0);
+  assert.doesNotMatch(JSON.stringify(evidence), /must-not-be-embedded|token/);
+  const summary = renderMainDeploymentFailureEvidence(evidence);
+  assert.match(summary, /Vercel main deployment failure evidence/);
+  assert.match(summary, /stageGovernance \| `failure`/);
+  assert.match(summary, /does not authorize activation/);
+  assert.match(
+    summary,
+    /Public-serving activation, alias, promotion, rollback, and recovery commands: `0`/,
+  );
+
+  const unavailable = createMainDeploymentFailureEvidence({
+    eventHeadSha: "malformed",
+    verifiedDeploySha: SHA,
+    planOutput: "",
+    jobs: {
+      waitForCi: "failure",
+      plan: "skipped",
+      stageGovernance: "skipped",
+      stageReserve: "skipped",
+      stageUi: "skipped",
+      coordinator: "skipped",
+      recovery: "success",
+    },
+    workflowDefinitionSha: SHA,
+    runId: "800",
+    runAttempt: "3",
+    workflowRunUrl: WORKFLOW_RUN_URL,
+  });
+  assert.equal(unavailable.eventHeadSha, null);
+  assert.equal(unavailable.verifiedDeploySha, null);
+  assert.equal(unavailable.planOutputPresent, false);
+  assert.match(
+    renderMainDeploymentFailureEvidence(unavailable),
+    /Verified deploy SHA: unavailable/,
+  );
+
+  assert.throws(
+    () =>
+      createMainDeploymentFailureEvidence({
+        eventHeadSha: SHA,
+        verifiedDeploySha: SHA,
+        planOutput: "",
+        jobs: { ...jobs, plan: "unknown" },
+        workflowDefinitionSha: SHA,
+        runId: "800",
+        runAttempt: "3",
+        workflowRunUrl: WORKFLOW_RUN_URL,
+      }),
+    /Failure evidence job results is invalid for plan/,
+  );
+  assert.throws(
+    () =>
+      renderMainDeploymentFailureEvidence({
+        ...evidence,
+        rawResponse: { token: "forbidden" },
+      }),
+    /forbidden or missing fields/,
+  );
+});
+
 test("canonical evidence accepts no-target and superseded-before-journal outcomes without invented artifacts", () => {
   for (const { deploymentPlan, outcome } of [
     { deploymentPlan: plan({ deployments: [] }), outcome: "no-target" },
@@ -646,6 +737,68 @@ test("evidence CLI entrypoint writes canonical run JSON and summary from the exa
       rendered,
       /Freshness barriers: before App preparation `fresh`; before transaction `fresh`/,
     );
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("failure-evidence CLI writes one canonical report when the planner output is unavailable", () => {
+  const directory = mkdtempSync(
+    join(tmpdir(), "vercel-main-failure-evidence-"),
+  );
+  try {
+    const output = join(directory, "evidence.json");
+    const summary = join(directory, "summary.md");
+    writeFileSync(summary, "", { encoding: "utf8", mode: 0o600 });
+    const result = spawnSync(
+      process.execPath,
+      [
+        fileURLToPath(new URL("./vercel-main-deployment.mjs", import.meta.url)),
+        "failure-evidence",
+        "--output",
+        output,
+      ],
+      {
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          EVENT_HEAD_SHA: SHA,
+          DEPLOY_SHA: "",
+          PLAN_JSON: "",
+          GITHUB_WORKFLOW_SHA: SHA,
+          GITHUB_RUN_ID: "800",
+          GITHUB_RUN_ATTEMPT: "3",
+          GITHUB_SERVER_URL: "https://github.com",
+          GITHUB_REPOSITORY: "mento-protocol/frontend-monorepo",
+          GITHUB_STEP_SUMMARY: summary,
+          WAIT_FOR_CI_RESULT: "failure",
+          PLAN_RESULT: "skipped",
+          STAGE_GOVERNANCE_RESULT: "skipped",
+          STAGE_RESERVE_RESULT: "skipped",
+          STAGE_UI_RESULT: "skipped",
+          COORDINATOR_RESULT: "skipped",
+          RECOVERY_RESULT: "success",
+        },
+      },
+    );
+    assert.equal(result.status, 0, result.stderr);
+    const evidence = JSON.parse(readFileSync(output, "utf8"));
+    assert.equal(evidence.schema, MAIN_FAILURE_EVIDENCE_SCHEMA);
+    assert.equal(evidence.eventHeadSha, SHA);
+    assert.equal(evidence.verifiedDeploySha, null);
+    assert.equal(evidence.planOutputPresent, false);
+    assert.deepEqual(evidence.jobs, {
+      waitForCi: "failure",
+      plan: "skipped",
+      stageGovernance: "skipped",
+      stageReserve: "skipped",
+      stageUi: "skipped",
+      coordinator: "skipped",
+      recovery: "success",
+    });
+    const rendered = readFileSync(summary, "utf8");
+    assert.match(rendered, /Planner output: unavailable/);
+    assert.match(rendered, /waitForCi \| `failure`/);
   } finally {
     rmSync(directory, { recursive: true, force: true });
   }

--- a/scripts/vercel-main-deployment.test.mjs
+++ b/scripts/vercel-main-deployment.test.mjs
@@ -1,0 +1,1350 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import process from "node:process";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+import {
+  MAIN_DEPLOYMENT_MODE,
+  MAIN_DEPLOYMENT_SCHEMA,
+  MAIN_STAGE_SCHEMA,
+  assertMainDeploymentHandoff,
+  assertMainFinalResults,
+  assertMainStageResult,
+  assertProtectedSnapshotMatchesPlan,
+  assertUploadedPreparedJournal,
+  classifyRemoteMainFreshness,
+  createMainAppBuildProof,
+  createMainAppCandidateExpectation,
+  createMainAppTransactionMetadata,
+  createMainDeploymentPlan,
+  createMainDeploymentEvidence,
+  createMainJournalArtifactIdentity,
+  createMainWorkflowRunUrl,
+  createMainLegacyAliasSpec,
+  createMainProtectedAliasSpec,
+  createMainStageResult,
+  createMainTransactionInputs,
+  createPreparedMainJournal,
+  parseMainDeploymentArguments,
+  readRemoteMainSha,
+  recoverMainShadowTransaction,
+  renderMainDeploymentEvidence,
+  runMainShadowTransaction,
+  validateMainDeploymentSource,
+  validateMainStageJobs,
+  validateMainWorkflowContext,
+} from "./vercel-main-deployment.mjs";
+import {
+  createMainTransactionId,
+  mainTransactionJournalArtifactName,
+} from "./vercel-main-transaction.mjs";
+import { generateVercelDeploymentId } from "./vercel-prebuilt.mjs";
+
+const SHA = "dddddddddddddddddddddddddddddddddddddddd";
+const OTHER_SHA = "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee";
+const PARENT = "cccccccccccccccccccccccccccccccccccccccc";
+const WORKFLOW_RUN_URL =
+  "https://github.com/mento-protocol/frontend-monorepo/actions/runs/800";
+const fixture = JSON.parse(
+  readFileSync(
+    new URL("./fixtures/vercel-main-plan/valid-priors.json", import.meta.url),
+    "utf8",
+  ),
+);
+const projectIds = fixture.projectIds;
+
+function allProtectedStates() {
+  const source = structuredClone(fixture);
+  const states = Object.values(source.priorStates).flatMap(
+    (group) => group.states,
+  );
+  states.push({
+    alias: "v2-app.mento.org",
+    deploymentId: "dpl_legacyV2123",
+    deploymentUrl: "https://app-v2-prior.vercel.app",
+    creatorUsername: "fixture-author",
+    projectId: projectIds.app,
+    projectName: "app.mento.org",
+    readyState: "READY",
+    target: "production",
+    customEnvironmentSlug: null,
+    git: {
+      org: "mento-protocol",
+      repo: "frontend-monorepo",
+      ref: "v2",
+      sha: "9999999999999999999999999999999999999999",
+    },
+    aliases: ["v2-app.mento.org"],
+  });
+  return states.sort((left, right) => left.alias.localeCompare(right.alias));
+}
+
+function planningSnapshot() {
+  return {
+    schema: "vercel-main-planning-snapshot:v1",
+    states: allProtectedStates().filter(
+      (state) => state.alias !== "v2-app.mento.org",
+    ),
+  };
+}
+
+function legacySnapshot() {
+  return allProtectedStates().filter(
+    (state) => state.alias === "v2-app.mento.org",
+  );
+}
+
+function gitAdapter() {
+  return {
+    resolveCommit(value) {
+      return value;
+    },
+    isAncestor() {
+      return true;
+    },
+    firstParent() {
+      return PARENT;
+    },
+  };
+}
+
+function upstream() {
+  return {
+    runId: "123456",
+    runAttempt: "2",
+    runUrl:
+      "https://github.com/mento-protocol/frontend-monorepo/actions/runs/123456",
+    buildAndTestJobUrl:
+      "https://github.com/mento-protocol/frontend-monorepo/actions/runs/123456/job/654321",
+  };
+}
+
+function plan({ deployments = ["app", "governance", "reserve", "ui"] } = {}) {
+  return createMainDeploymentPlan({
+    mode: MAIN_DEPLOYMENT_MODE,
+    deploySha: SHA,
+    projectIds,
+    planningSnapshot: planningSnapshot(),
+    legacySnapshot: legacySnapshot(),
+    upstream: upstream(),
+    gitAdapter: gitAdapter(),
+    runPlanner: ({ base, head }) => ({
+      base,
+      head,
+      deployments,
+      reason:
+        deployments.length === 0 ? "non-runtime-only" : "affected-packages",
+    }),
+  });
+}
+
+function stagedState(target) {
+  const generated = {
+    governance: "governancementoorg-mentolabs.vercel.app",
+    reserve: "reservementoorg-mentolabs.vercel.app",
+    ui: "uimentoorg-mentolabs.vercel.app",
+  };
+  const immutable = `${target}-candidate.vercel.app`;
+  return {
+    alias: immutable,
+    deploymentId: `dpl_${target}Candidate123`,
+    deploymentUrl: `https://${immutable}`,
+    creatorUsername: null,
+    projectId: projectIds[target],
+    projectName: `${target}.mento.org`,
+    readyState: "READY",
+    target: "production",
+    customEnvironmentSlug: null,
+    git: {
+      org: "mento-protocol",
+      repo: "frontend-monorepo",
+      ref: "main",
+      sha: SHA,
+    },
+    aliases: [generated[target]],
+  };
+}
+
+function stageResult(target, deploymentPlan = plan()) {
+  return createMainStageResult({
+    target,
+    plan: deploymentPlan,
+    state: stagedState(target),
+    runId: "800",
+    runAttempt: "3",
+    smokePassed: true,
+    protectedMappingsUnchanged: true,
+  });
+}
+
+function stageJobs(deploymentPlan = plan()) {
+  return Object.fromEntries(
+    ["governance", "reserve", "ui"].map((target) => {
+      const selected = deploymentPlan.planning.plan.includes(target);
+      return [
+        target,
+        {
+          result: selected ? "success" : "skipped",
+          handoff: selected ? stageResult(target, deploymentPlan) : null,
+        },
+      ];
+    }),
+  );
+}
+
+function appProof() {
+  return createMainAppBuildProof({
+    deploySha: SHA,
+    runId: "800",
+    runAttempt: "3",
+    projectId: projectIds.app,
+    nextDeploymentId: generateVercelDeploymentId({
+      target: "app",
+      commitSha: SHA,
+      runId: "800",
+      runAttempt: "3",
+    }),
+  });
+}
+
+test("protected spec binds every reviewed main alias and legacy v2", () => {
+  const spec = createMainProtectedAliasSpec({ projectIds });
+  const legacy = createMainLegacyAliasSpec({ projectIds });
+  assert.equal(spec.length, 5);
+  assert.deepEqual(
+    spec.map((entry) => entry.alias),
+    [
+      "app.mento.org",
+      "appmentoorg-env-v3-mentolabs.vercel.app",
+      "governance.mento.org",
+      "reserve.mento.org",
+      "ui.mento.org",
+    ],
+  );
+  assert.equal(
+    spec.filter((entry) => entry.projectName === "app.mento.org").length,
+    2,
+  );
+  assert.deepEqual(legacy, [
+    {
+      alias: "v2-app.mento.org",
+      projectId: projectIds.app,
+      projectName: "app.mento.org",
+      target: "production",
+      customEnvironmentSlug: null,
+      git: {
+        org: "mento-protocol",
+        repo: "frontend-monorepo",
+        ref: "v2",
+      },
+    },
+  ]);
+});
+
+test("controller CLI accepts only each command's exact non-duplicated options", () => {
+  const valid = [
+    ["validate-context"],
+    ["validate-source"],
+    ["create-spec", "--scope", "main", "--output", "/tmp/spec.json"],
+    ["evidence", "--output", "/tmp/evidence.json"],
+    [
+      "plan",
+      "--planning-snapshot",
+      "/tmp/main.json",
+      "--legacy-snapshot",
+      "/tmp/legacy.json",
+      "--output",
+      "/tmp/plan.json",
+    ],
+    ["freshness"],
+    ["journal-name"],
+    [
+      "revalidate-prior",
+      "--planning-snapshot",
+      "/tmp/main.json",
+      "--legacy-snapshot",
+      "/tmp/legacy.json",
+    ],
+    ["app-build-proof", "--output", "/tmp/app.json"],
+    [
+      "app-candidate-expectation",
+      "--journal",
+      "/tmp/journal.json",
+      "--output",
+      "/tmp/expected.json",
+    ],
+    [
+      "stage-result",
+      "--state",
+      "/tmp/state.json",
+      "--output",
+      "/tmp/result.json",
+    ],
+    ["validate-stages"],
+    ["prepare-journal", "--output", "/tmp/journal.json"],
+    ["run-shadow", "--journal", "/tmp/journal.json"],
+    ["recover-shadow", "--journal", "/tmp/journal.json"],
+    ["final"],
+  ];
+  for (const argv of valid) {
+    assert.equal(parseMainDeploymentArguments(argv).command, argv[0]);
+  }
+  for (const argv of [
+    [],
+    ["unknown"],
+    ["validate-context", "--extra", "x"],
+    ["plan", "--output", "/tmp/plan.json"],
+    [
+      "create-spec",
+      "--scope",
+      "main",
+      "--scope",
+      "legacy",
+      "--output",
+      "/tmp/spec.json",
+    ],
+    ["stage-result", "--state", "--output", "/tmp/result.json"],
+    ["freshness", "extra"],
+  ]) {
+    assert.throws(() => parseMainDeploymentArguments(argv));
+  }
+});
+
+test("journal artifact identity is recoverable without coordinator outputs", () => {
+  const journal = createPreparedMainJournal({
+    plan: plan(),
+    stageJobs: stageJobs(),
+    appBuildProof: appProof(),
+    runId: "800",
+    runAttempt: "3",
+  });
+  assert.deepEqual(
+    createMainJournalArtifactIdentity({
+      deploySha: SHA,
+      runId: "800",
+      runAttempt: "3",
+    }),
+    {
+      transactionId: journal.transactionId,
+      artifactName: mainTransactionJournalArtifactName(journal),
+    },
+  );
+  assert.throws(
+    () =>
+      createMainJournalArtifactIdentity({
+        deploySha: SHA,
+        runId: "800",
+        runAttempt: "0",
+      }),
+    /Run attempt/,
+  );
+});
+
+test("canonical evidence records planning, candidates, timings, cache, journal, and recovery without raw responses", () => {
+  const deploymentPlan = plan();
+  const jobs = stageJobs(deploymentPlan);
+  const identity = createMainJournalArtifactIdentity({
+    deploySha: SHA,
+    runId: "800",
+    runAttempt: "3",
+  });
+  const stages = Object.fromEntries(
+    ["governance", "reserve", "ui"].map((target, index) => [
+      target,
+      {
+        handoff: jobs[target].handoff,
+        nextDeploymentId: generateVercelDeploymentId({
+          target,
+          commitSha: SHA,
+          runId: "800",
+          runAttempt: "3",
+        }),
+        metrics: {
+          buildDurationMs: String(10_000 + index),
+          deployDurationMs: String(2_000 + index),
+          totalDurationMs: String(20_000 + index),
+          turboCacheHits: String(3 + index),
+          turboCacheMisses: String(1 + index),
+        },
+      },
+    ]),
+  );
+  const evidence = createMainDeploymentEvidence({
+    plan: deploymentPlan,
+    stages,
+    app: {
+      nextDeploymentId: appProof().nextDeploymentId,
+      metrics: {
+        buildDurationMs: "12000",
+        totalDurationMs: "18000",
+        turboCacheHits: "5",
+        turboCacheMisses: "2",
+      },
+    },
+    coordinator: {
+      outcome: "shadow-prepared",
+      transactionId: identity.transactionId,
+      artifactName: identity.artifactName,
+      artifactId: "98123",
+      totalDurationMs: "25000",
+    },
+    recovery: { outcome: "verified-no-mutation" },
+    runId: "800",
+    runAttempt: "3",
+    workflowRunUrl: WORKFLOW_RUN_URL,
+  });
+  assert.equal(evidence.schema, "vercel-main-evidence:v1");
+  assert.equal(evidence.workflowRunUrl, WORKFLOW_RUN_URL);
+  assert.deepEqual(evidence.planning.priors, deploymentPlan.planning.priors);
+  assert.deepEqual(evidence.planning.ranges, deploymentPlan.planning.ranges);
+  assert.deepEqual(evidence.planning.reasons, deploymentPlan.planning.reasons);
+  assert.deepEqual(evidence.planning.plan, deploymentPlan.planning.plan);
+  assert.equal(
+    evidence.stages.governance.candidate.deploymentId,
+    jobs.governance.handoff.candidate.deploymentId,
+  );
+  assert.equal(evidence.stages.reserve.metrics.deployDurationMs, "2001");
+  assert.equal(evidence.app.outcome, "build-only");
+  assert.equal(evidence.workflowDefinitionSha, SHA);
+  assert.equal(evidence.upstream.buildAndTestConclusion, "success");
+  assert.equal(evidence.journal.artifactName, identity.artifactName);
+  assert.equal(evidence.journal.journalArtifactId, "98123");
+  assert.equal(evidence.journal.sequence, 0);
+  assert.equal(evidence.journal.status, "prepared");
+  assert.equal(evidence.legacy.alias, "v2-app.mento.org");
+  assert.equal(evidence.legacy.ref, "v2");
+  assert.equal(evidence.legacy.readyState, "READY");
+  assert.equal(evidence.legacy.health, "passed");
+  assert.deepEqual(evidence.stages.governance.verification, {
+    canonicalState: "passed",
+    immutableSmoke: "passed",
+    protectedMappings: "unchanged",
+  });
+  assert.equal(evidence.recovery.outcome, "verified-no-mutation");
+  assert.deepEqual(evidence.freshness, {
+    beforeAppPreparation: "fresh",
+    beforeTransaction: "fresh",
+  });
+  assert.deepEqual(evidence.ordinaryRollbackStateTargets, []);
+  const summary = renderMainDeploymentEvidence(evidence);
+  assert.match(summary, /Served deployment priors/);
+  assert.match(summary, /Served-SHA ranges and selection reasons/);
+  assert.match(summary, /Candidate evidence/);
+  assert.match(
+    summary,
+    /Public-serving activation, alias, promotion, rollback, and recovery commands: `0`/,
+  );
+  assert.match(summary, /Unaliased ordinary staging uploads/);
+  assert.match(summary, /legacy-app/);
+  assert.doesNotMatch(
+    JSON.stringify(evidence),
+    /creatorUsername|VERCEL_TOKEN|SENTRY_AUTH_TOKEN|github_event|rawResponse/,
+  );
+
+  assert.throws(
+    () =>
+      createMainDeploymentEvidence({
+        plan: deploymentPlan,
+        stages,
+        app: {
+          nextDeploymentId: "wrong-next-id",
+          metrics: {
+            buildDurationMs: "12000",
+            totalDurationMs: "18000",
+            turboCacheHits: "5",
+            turboCacheMisses: "2",
+          },
+        },
+        coordinator: {
+          outcome: "shadow-prepared",
+          transactionId: identity.transactionId,
+          artifactName: identity.artifactName,
+          artifactId: "98123",
+          totalDurationMs: "25000",
+        },
+        recovery: { outcome: "verified-no-mutation" },
+        runId: "800",
+        runAttempt: "3",
+        workflowRunUrl: WORKFLOW_RUN_URL,
+      }),
+    /wrong custom Next ID/,
+  );
+  assert.throws(
+    () =>
+      createMainDeploymentEvidence({
+        plan: deploymentPlan,
+        stages,
+        app: {
+          nextDeploymentId: appProof().nextDeploymentId,
+          metrics: {
+            buildDurationMs: "12000",
+            totalDurationMs: "18000",
+            turboCacheHits: "5",
+            turboCacheMisses: "2",
+          },
+        },
+        coordinator: {
+          outcome: "shadow-prepared",
+          transactionId: identity.transactionId,
+          artifactName: identity.artifactName,
+          artifactId: "98123",
+          totalDurationMs: "25000",
+          rawResponse: { token: "forbidden" },
+        },
+        recovery: { outcome: "verified-no-mutation" },
+        runId: "800",
+        runAttempt: "3",
+        workflowRunUrl: WORKFLOW_RUN_URL,
+      }),
+    /forbidden or missing fields/,
+  );
+});
+
+test("canonical evidence accepts no-target and superseded-before-journal outcomes without invented artifacts", () => {
+  for (const { deploymentPlan, outcome } of [
+    { deploymentPlan: plan({ deployments: [] }), outcome: "no-target" },
+    {
+      deploymentPlan: plan({ deployments: ["app"] }),
+      outcome: "superseded-before-journal",
+    },
+  ]) {
+    const evidence = createMainDeploymentEvidence({
+      plan: deploymentPlan,
+      stages: {
+        governance: null,
+        reserve: null,
+        ui: null,
+      },
+      app: null,
+      coordinator: {
+        outcome,
+        transactionId: null,
+        artifactName: null,
+        artifactId: null,
+        totalDurationMs: "1500",
+      },
+      recovery: { outcome: "not-required" },
+      runId: "800",
+      runAttempt: "3",
+      workflowRunUrl: WORKFLOW_RUN_URL,
+    });
+    assert.equal(evidence.coordinator.outcome, outcome);
+    assert.equal(evidence.journal, null);
+    assert.equal(evidence.app, null);
+    assert.deepEqual(
+      evidence.freshness,
+      outcome === "no-target"
+        ? {
+            beforeAppPreparation: "not-run",
+            beforeTransaction: "not-run",
+          }
+        : {
+            beforeAppPreparation: "superseded",
+            beforeTransaction: "not-run",
+          },
+    );
+  }
+});
+
+test("downstream workflow URL is exact and repository-bound", () => {
+  assert.equal(
+    createMainWorkflowRunUrl({
+      serverUrl: "https://github.com",
+      repository: "mento-protocol/frontend-monorepo",
+      runId: "800",
+    }),
+    WORKFLOW_RUN_URL,
+  );
+  for (const override of [
+    { serverUrl: "https://github.example.com" },
+    { repository: "fork/frontend-monorepo" },
+    { runId: "0" },
+  ]) {
+    assert.throws(() =>
+      createMainWorkflowRunUrl({
+        serverUrl: "https://github.com",
+        repository: "mento-protocol/frontend-monorepo",
+        runId: "800",
+        ...override,
+      }),
+    );
+  }
+});
+
+test("evidence CLI entrypoint writes canonical run JSON and summary from the exact Actions environment", () => {
+  const directory = mkdtempSync(join(tmpdir(), "vercel-main-evidence-"));
+  try {
+    const output = join(directory, "evidence.json");
+    const summary = join(directory, "summary.md");
+    writeFileSync(summary, "", { encoding: "utf8", mode: 0o600 });
+    const deploymentPlan = plan();
+    const jobs = stageJobs(deploymentPlan);
+    const identity = createMainJournalArtifactIdentity({
+      deploySha: SHA,
+      runId: "800",
+      runAttempt: "3",
+    });
+    const values = {
+      ...process.env,
+      PLAN_JSON: JSON.stringify(deploymentPlan),
+      GITHUB_RUN_ID: "800",
+      GITHUB_RUN_ATTEMPT: "3",
+      GITHUB_SERVER_URL: "https://github.com",
+      GITHUB_REPOSITORY: "mento-protocol/frontend-monorepo",
+      GITHUB_STEP_SUMMARY: summary,
+      COORDINATOR_OUTCOME: "shadow-prepared",
+      COORDINATOR_TOTAL_DURATION_MS: "25000",
+      TRANSACTION_ID: identity.transactionId,
+      JOURNAL_ARTIFACT_NAME: identity.artifactName,
+      JOURNAL_ARTIFACT_ID: "98123",
+      RECOVERY_OUTCOME: "verified-no-mutation",
+      EVIDENCE_APP_NEXT_DEPLOYMENT_ID: appProof().nextDeploymentId,
+      EVIDENCE_APP_BUILD_DURATION_MS: "12000",
+      EVIDENCE_APP_TOTAL_DURATION_MS: "18000",
+      EVIDENCE_APP_TURBO_CACHE_HITS: "5",
+      EVIDENCE_APP_TURBO_CACHE_MISSES: "2",
+    };
+    for (const [index, target] of ["governance", "reserve", "ui"].entries()) {
+      const prefix = `EVIDENCE_${target.toUpperCase()}`;
+      values[`${prefix}_RESULT`] = "success";
+      values[`${prefix}_HANDOFF`] = JSON.stringify(jobs[target].handoff);
+      values[`${prefix}_NEXT_DEPLOYMENT_ID`] = generateVercelDeploymentId({
+        target,
+        commitSha: SHA,
+        runId: "800",
+        runAttempt: "3",
+      });
+      values[`${prefix}_BUILD_DURATION_MS`] = String(10_000 + index);
+      values[`${prefix}_DEPLOY_DURATION_MS`] = String(2_000 + index);
+      values[`${prefix}_TOTAL_DURATION_MS`] = String(20_000 + index);
+      values[`${prefix}_TURBO_CACHE_HITS`] = String(3 + index);
+      values[`${prefix}_TURBO_CACHE_MISSES`] = String(1 + index);
+    }
+    const result = spawnSync(
+      process.execPath,
+      [
+        fileURLToPath(new URL("./vercel-main-deployment.mjs", import.meta.url)),
+        "evidence",
+        "--output",
+        output,
+      ],
+      { encoding: "utf8", env: values },
+    );
+    assert.equal(result.status, 0, result.stderr);
+    const evidence = JSON.parse(readFileSync(output, "utf8"));
+    assert.equal(evidence.workflowRunUrl, WORKFLOW_RUN_URL);
+    assert.equal(evidence.workflowDefinitionSha, SHA);
+    assert.deepEqual(evidence.ordinaryRollbackStateTargets, []);
+    const rendered = readFileSync(summary, "utf8");
+    assert.match(rendered, new RegExp(WORKFLOW_RUN_URL.replaceAll("/", "\\/")));
+    assert.match(rendered, /Ordinary rollback-state targets: none/);
+    assert.match(
+      rendered,
+      /Freshness barriers: before App preparation `fresh`; before transaction `fresh`/,
+    );
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("plan handoff binds upstream receipt, protected state, served-SHA plan, and legacy prior", () => {
+  const result = plan();
+  assert.equal(result.schema, MAIN_DEPLOYMENT_SCHEMA);
+  assert.equal(result.mode, "shadow");
+  assert.equal(result.deploySha, SHA);
+  assert.deepEqual(result.planning.plan, [
+    "app",
+    "governance",
+    "reserve",
+    "ui",
+  ]);
+  assert.equal(result.protectedSnapshot.states.length, 5);
+  assert.equal(result.legacySnapshot.length, 1);
+  assert.deepEqual(result.legacyPrior, {
+    deploymentId: "dpl_legacyV2123",
+    deploymentUrl: "https://app-v2-prior.vercel.app",
+    aliases: ["v2-app.mento.org"],
+  });
+  assert.deepEqual(assertMainDeploymentHandoff(result), result);
+  assert.throws(
+    () =>
+      assertMainDeploymentHandoff({
+        ...result,
+        token: "forbidden",
+      }),
+    /forbidden or missing fields/,
+  );
+});
+
+for (const [name, mutate, reason] of [
+  [
+    "missing Git",
+    (snapshot) => {
+      for (const state of snapshot.states.filter((entry) =>
+        entry.alias.startsWith("app"),
+      )) {
+        state.git = null;
+      }
+    },
+    "served-git-metadata-missing",
+  ],
+  [
+    "malformed Git",
+    (snapshot) => {
+      for (const state of snapshot.states.filter((entry) =>
+        entry.alias.startsWith("app"),
+      )) {
+        state.git = {};
+      }
+    },
+    "served-git-metadata-malformed",
+  ],
+  [
+    "wrong repository",
+    (snapshot) => {
+      for (const state of snapshot.states.filter((entry) =>
+        entry.alias.startsWith("app"),
+      )) {
+        state.git.repo = "other-repository";
+      }
+    },
+    "served-git-metadata-wrong-source",
+  ],
+  [
+    "wrong ref",
+    (snapshot) => {
+      for (const state of snapshot.states.filter((entry) =>
+        entry.alias.startsWith("app"),
+      )) {
+        state.git.ref = "v2";
+      }
+    },
+    "served-git-metadata-wrong-source",
+  ],
+  [
+    "cross-alias conflict",
+    (snapshot) => {
+      snapshot.states.find(
+        (entry) => entry.alias === "appmentoorg-env-v3-mentolabs.vercel.app",
+      ).git.sha = "9".repeat(40);
+    },
+    "served-git-metadata-conflicting",
+  ],
+]) {
+  test(`controller passes sanitized ${name} through to target-local fail-closed planning`, () => {
+    const snapshot = planningSnapshot();
+    mutate(snapshot);
+    const result = createMainDeploymentPlan({
+      mode: MAIN_DEPLOYMENT_MODE,
+      deploySha: SHA,
+      projectIds,
+      planningSnapshot: snapshot,
+      legacySnapshot: legacySnapshot(),
+      upstream: upstream(),
+      gitAdapter: gitAdapter(),
+      runPlanner: ({ base, head }) => ({
+        base,
+        head,
+        deployments: [],
+        reason: "non-runtime-only",
+      }),
+    });
+    assert.deepEqual(result.planning.plan, ["app"]);
+    assert.equal(result.planning.reasons[0].reason, reason);
+  });
+}
+
+test("workflow context and source proof bind the default-branch definition to DEPLOY_SHA", () => {
+  assert.equal(
+    validateMainWorkflowContext({
+      repository: "mento-protocol/frontend-monorepo",
+      eventName: "workflow_run",
+      workflowRef:
+        "mento-protocol/frontend-monorepo/.github/workflows/vercel-main-deployment.yml@refs/heads/main",
+      workflowSha: SHA,
+      deploySha: SHA,
+    }),
+    SHA,
+  );
+  assert.throws(
+    () =>
+      validateMainWorkflowContext({
+        repository: "mento-protocol/frontend-monorepo",
+        eventName: "workflow_run",
+        workflowRef:
+          "mento-protocol/frontend-monorepo/.github/workflows/vercel-main-deployment.yml@refs/pull/522/merge",
+        workflowSha: SHA,
+        deploySha: SHA,
+      }),
+    /not the exact DEPLOY_SHA/,
+  );
+
+  const calls = [];
+  validateMainDeploymentSource({
+    repoRoot: "/trusted/source",
+    deploySha: SHA,
+    workflowSha: SHA,
+    execute(command, args) {
+      calls.push([command, args]);
+      const gitArgs = args.slice(2);
+      if (gitArgs[0] === "rev-parse") return `${SHA}\n`;
+      return "";
+    },
+  });
+  assert.ok(calls.some(([, args]) => args[2] === "merge-base"));
+  assert.throws(
+    () =>
+      validateMainDeploymentSource({
+        repoRoot: "/trusted/source",
+        deploySha: SHA,
+        workflowSha: OTHER_SHA,
+        execute: () => assert.fail("git must stay inert"),
+      }),
+    /GITHUB_WORKFLOW_SHA/,
+  );
+});
+
+test("stage handoffs contain only canonical candidate identity and completed verification", () => {
+  const result = stageResult("governance");
+  assert.equal(result.schema, MAIN_STAGE_SCHEMA);
+  assert.equal(result.target, "governance");
+  assert.equal(result.candidate.deploymentId, "dpl_governanceCandidate123");
+  assert.equal(result.candidate.discovery, null);
+  assert.equal(result.verification.immutableSmoke, "passed");
+  assert.deepEqual(
+    assertMainStageResult(result, {
+      plan: plan(),
+      expectedTarget: "governance",
+    }),
+    result,
+  );
+  assert.throws(
+    () =>
+      createMainStageResult({
+        target: "governance",
+        plan: plan(),
+        state: stagedState("governance"),
+        runId: "800",
+        runAttempt: "3",
+        smokePassed: false,
+        protectedMappingsUnchanged: true,
+      }),
+    /verification is incomplete/,
+  );
+});
+
+test("selected stages must succeed and unselected stages must be skipped", () => {
+  const selected = plan({ deployments: ["governance"] });
+  assert.equal(
+    validateMainStageJobs({
+      plan: selected,
+      jobs: stageJobs(selected),
+      runId: "800",
+      runAttempt: "3",
+    }).outcome,
+    "eligible",
+  );
+  assert.throws(
+    () =>
+      validateMainStageJobs({
+        plan: selected,
+        runId: "800",
+        runAttempt: "3",
+        jobs: {
+          ...stageJobs(selected),
+          governance: { result: "skipped", handoff: null },
+        },
+      }),
+    /did not succeed/,
+  );
+  assert.throws(
+    () =>
+      validateMainStageJobs({
+        plan: selected,
+        runId: "800",
+        runAttempt: "3",
+        jobs: {
+          ...stageJobs(selected),
+          reserve: {
+            result: "success",
+            handoff: stageResult("reserve", plan()),
+          },
+        },
+      }),
+    /was not cleanly skipped/,
+  );
+  const noTargets = plan({ deployments: [] });
+  assert.equal(
+    validateMainStageJobs({
+      plan: noTargets,
+      jobs: stageJobs(noTargets),
+      runId: "800",
+      runAttempt: "3",
+    }).outcome,
+    "no-target",
+  );
+});
+
+test("protected rollback identity remains stable while ordinary generated aliases move", () => {
+  const deploymentPlan = plan();
+  assert.deepEqual(
+    assertProtectedSnapshotMatchesPlan({
+      plan: deploymentPlan,
+      planningSnapshot: planningSnapshot(),
+      legacySnapshot: legacySnapshot(),
+    }),
+    {
+      protectedSnapshot: deploymentPlan.protectedSnapshot,
+      legacySnapshot: deploymentPlan.legacySnapshot,
+    },
+  );
+  const drifted = structuredClone(planningSnapshot());
+  drifted.states[0].deploymentId = "dpl_operatorMove123";
+  assert.throws(
+    () =>
+      assertProtectedSnapshotMatchesPlan({
+        plan: deploymentPlan,
+        planningSnapshot: drifted,
+        legacySnapshot: legacySnapshot(),
+      }),
+    /drifted/,
+  );
+  for (const mutate of [
+    (snapshot) => {
+      snapshot.states[0].deploymentUrl = "https://operator-move.vercel.app";
+    },
+    (snapshot) => {
+      snapshot.states[0].projectId = "prj_operator123";
+    },
+    (snapshot) => {
+      snapshot.states[0].customEnvironmentSlug = "other";
+    },
+    (snapshot) => {
+      snapshot.states[0].aliases = ["appmentoorg-env-v3-mentolabs.vercel.app"];
+    },
+  ]) {
+    const changed = structuredClone(planningSnapshot());
+    mutate(changed);
+    assert.throws(() =>
+      assertProtectedSnapshotMatchesPlan({
+        plan: deploymentPlan,
+        planningSnapshot: changed,
+        legacySnapshot: legacySnapshot(),
+      }),
+    );
+  }
+  const refreshedGitEvidence = structuredClone(planningSnapshot());
+  refreshedGitEvidence.states[0].git = null;
+  assert.doesNotThrow(() =>
+    assertProtectedSnapshotMatchesPlan({
+      plan: deploymentPlan,
+      planningSnapshot: refreshedGitEvidence,
+      legacySnapshot: legacySnapshot(),
+    }),
+  );
+  const ordinaryGeneratedAliasesMoved = structuredClone(planningSnapshot());
+  const governance = ordinaryGeneratedAliasesMoved.states.find(
+    (state) => state.alias === "governance.mento.org",
+  );
+  governance.aliases = ["governance.mento.org"];
+  governance.creatorUsername = null;
+  assert.doesNotThrow(() =>
+    assertProtectedSnapshotMatchesPlan({
+      plan: deploymentPlan,
+      planningSnapshot: ordinaryGeneratedAliasesMoved,
+      legacySnapshot: legacySnapshot(),
+    }),
+  );
+  const legacyAliasDrift = structuredClone(legacySnapshot());
+  legacyAliasDrift[0].aliases = [
+    "v2-app.mento.org",
+    "unexpected-legacy-alias.vercel.app",
+  ];
+  assert.throws(() =>
+    assertProtectedSnapshotMatchesPlan({
+      plan: deploymentPlan,
+      planningSnapshot: planningSnapshot(),
+      legacySnapshot: legacyAliasDrift,
+    }),
+  );
+  for (const mutate of [
+    (state) => {
+      state.deploymentId = "dpl_operatorMove123";
+    },
+    (state) => {
+      state.deploymentUrl = "https://operator-move.vercel.app";
+    },
+    (state) => {
+      state.projectId = "prj_operator123";
+    },
+    (state) => {
+      state.customEnvironmentSlug = "unexpected";
+    },
+    (state) => {
+      state.alias = "governance-other.mento.org";
+    },
+  ]) {
+    const changed = structuredClone(planningSnapshot());
+    const state = changed.states.find(
+      (entry) => entry.alias === "governance.mento.org",
+    );
+    mutate(state);
+    assert.throws(() =>
+      assertProtectedSnapshotMatchesPlan({
+        plan: deploymentPlan,
+        planningSnapshot: changed,
+        legacySnapshot: legacySnapshot(),
+      }),
+    );
+  }
+  for (const sanitizedGit of [null, {}]) {
+    const captured = planningSnapshot();
+    for (const state of captured.states.filter((entry) =>
+      entry.alias.startsWith("app"),
+    )) {
+      state.git = sanitizedGit;
+    }
+    const ambiguityPlan = createMainDeploymentPlan({
+      mode: MAIN_DEPLOYMENT_MODE,
+      deploySha: SHA,
+      projectIds,
+      planningSnapshot: captured,
+      legacySnapshot: legacySnapshot(),
+      upstream: upstream(),
+      gitAdapter: gitAdapter(),
+      runPlanner: ({ base, head }) => ({
+        base,
+        head,
+        deployments: [],
+        reason: "non-runtime-only",
+      }),
+    });
+    assert.doesNotThrow(() =>
+      assertProtectedSnapshotMatchesPlan({
+        plan: ambiguityPlan,
+        planningSnapshot: planningSnapshot(),
+        legacySnapshot: legacySnapshot(),
+      }),
+    );
+  }
+});
+
+test("remote-main freshness uses one bounded exact ls-remote ref", () => {
+  const calls = [];
+  assert.equal(
+    readRemoteMainSha({
+      spawn(command, args, options) {
+        calls.push({ command, args, options });
+        return {
+          status: 0,
+          stdout: `${SHA}\trefs/heads/main\n`,
+        };
+      },
+    }),
+    SHA,
+  );
+  assert.deepEqual(calls[0].args, [
+    "ls-remote",
+    "--exit-code",
+    "origin",
+    "refs/heads/main",
+  ]);
+  assert.deepEqual(
+    classifyRemoteMainFreshness({ deploySha: SHA, remoteSha: SHA }),
+    {
+      status: "fresh",
+      sha: SHA,
+    },
+  );
+  assert.equal(
+    classifyRemoteMainFreshness({ deploySha: SHA, remoteSha: OTHER_SHA })
+      .status,
+    "superseded",
+  );
+  assert.throws(
+    () =>
+      readRemoteMainSha({
+        attempts: 3,
+        spawn: () => ({ status: 1, stdout: "" }),
+      }),
+    /could not be proven/,
+  );
+});
+
+test("transaction inputs preserve ordered priors and make app build-only discovery explicit", () => {
+  const deploymentPlan = plan();
+  const inputs = createMainTransactionInputs({
+    plan: deploymentPlan,
+    stageJobs: stageJobs(deploymentPlan),
+    appBuildProof: appProof(),
+    runId: "800",
+    runAttempt: "3",
+  });
+  assert.deepEqual(Object.keys(inputs.prior), [
+    "app",
+    "governance",
+    "reserve",
+    "ui",
+    "legacy-app",
+  ]);
+  assert.deepEqual(Object.keys(inputs.candidates), [
+    "app",
+    "governance",
+    "reserve",
+    "ui",
+  ]);
+  assert.equal(inputs.candidates.app.deploymentId, null);
+  assert.equal(inputs.candidates.app.discovery.customEnvironmentSlug, "v3");
+  assert.equal(
+    inputs.candidates.app.discovery.transactionId,
+    createMainTransactionId(inputs.identity),
+  );
+  assert.deepEqual(
+    appProof().metadata,
+    createMainAppTransactionMetadata({
+      deploySha: SHA,
+      runId: "800",
+      runAttempt: "3",
+      transactionId: inputs.candidates.app.discovery.transactionId,
+      nextDeploymentId: appProof().nextDeploymentId,
+    }),
+  );
+  assert.equal(appProof().deployReachable, false);
+  assert.equal(appProof().sentryAuthToken, "");
+  assert.throws(
+    () =>
+      createMainTransactionInputs({
+        plan: deploymentPlan,
+        stageJobs: stageJobs(deploymentPlan),
+        appBuildProof: {
+          ...appProof(),
+          deployReachable: true,
+        },
+        runId: "800",
+        runAttempt: "3",
+      }),
+    /build proof is invalid/,
+  );
+  for (const transactionKey of ["999-3-governance", "800-4-governance"]) {
+    const staleJobs = structuredClone(stageJobs(deploymentPlan));
+    staleJobs.governance.handoff.transactionKey = transactionKey;
+    assert.throws(
+      () =>
+        createMainTransactionInputs({
+          plan: deploymentPlan,
+          stageJobs: staleJobs,
+          appBuildProof: appProof(),
+          runId: "800",
+          runAttempt: "3",
+        }),
+      /does not match the coordinator attempt/,
+    );
+  }
+});
+
+test("prepared artifact acknowledgment binds positive artifact ID, exact name, and exact bytes", () => {
+  const deploymentPlan = plan();
+  const journal = createPreparedMainJournal({
+    plan: deploymentPlan,
+    stageJobs: stageJobs(deploymentPlan),
+    appBuildProof: appProof(),
+    runId: "800",
+    runAttempt: "3",
+  });
+  const bytes = `${JSON.stringify(journal)}\n`;
+  const artifactName = mainTransactionJournalArtifactName(journal);
+  assert.deepEqual(
+    createMainAppCandidateExpectation({
+      journal,
+      projectId: projectIds.app,
+    }),
+    {
+      projectId: projectIds.app,
+      projectName: "app.mento.org",
+      deploySha: SHA,
+      runId: "800",
+      runAttempt: "3",
+      transactionId: journal.transactionId,
+      customEnvironmentSlug: "v3",
+      nextDeploymentId: appProof().nextDeploymentId,
+    },
+  );
+  assert.deepEqual(
+    assertUploadedPreparedJournal({
+      journal,
+      journalBytes: bytes,
+      artifactName,
+      artifactId: "98123",
+    }),
+    {
+      acknowledged: true,
+      artifactName,
+      artifactId: "98123",
+    },
+  );
+  for (const override of [
+    { journalBytes: `${JSON.stringify({ ...journal, status: "started" })}\n` },
+    { artifactName: `${artifactName}-other` },
+    { artifactId: "0" },
+  ]) {
+    assert.throws(
+      () =>
+        assertUploadedPreparedJournal({
+          journal,
+          journalBytes: bytes,
+          artifactName,
+          artifactId: "98123",
+          ...override,
+        }),
+      /does not acknowledge these exact bytes/,
+    );
+  }
+});
+
+test("shadow transaction exercises freshness, journal acknowledgment, and recovery decision without mutations", async () => {
+  const deploymentPlan = plan();
+  const journal = createPreparedMainJournal({
+    plan: deploymentPlan,
+    stageJobs: stageJobs(deploymentPlan),
+    appBuildProof: appProof(),
+    runId: "800",
+    runAttempt: "3",
+  });
+  const result = await runMainShadowTransaction({
+    plan: deploymentPlan,
+    stageJobs: stageJobs(deploymentPlan),
+    appBuildProof: appProof(),
+    runId: "800",
+    runAttempt: "3",
+    journalBytes: `${JSON.stringify(journal)}\n`,
+    artifactName: mainTransactionJournalArtifactName(journal),
+    artifactId: "91919",
+    readRemoteMain: () => SHA,
+  });
+  assert.equal(result.outcome, "shadow-prepared");
+  assert.equal(result.mutationCallbacksCalled, 0);
+  assert.equal(result.recoveryDecision.decision, "verify-only");
+
+  const stale = await runMainShadowTransaction({
+    plan: deploymentPlan,
+    stageJobs: stageJobs(deploymentPlan),
+    appBuildProof: appProof(),
+    runId: "800",
+    runAttempt: "3",
+    journalBytes: `${JSON.stringify(journal)}\n`,
+    artifactName: mainTransactionJournalArtifactName(journal),
+    artifactId: "91919",
+    readRemoteMain: () => OTHER_SHA,
+  });
+  assert.equal(stale.outcome, "superseded-after-journal");
+  assert.deepEqual(stale.journal, journal);
+  assert.equal(
+    recoverMainShadowTransaction({
+      journal: stale.journal,
+      expectedIdentity: {
+        repository: "mento-protocol/frontend-monorepo",
+        deploySha: SHA,
+        runId: "800",
+        runAttempt: "3",
+      },
+    }).outcome,
+    "verified-no-mutation",
+  );
+});
+
+test("shadow recovery remains verify-only and final sentinel accepts only safe PR A outcomes", () => {
+  const deploymentPlan = plan();
+  const journal = createPreparedMainJournal({
+    plan: deploymentPlan,
+    stageJobs: stageJobs(deploymentPlan),
+    appBuildProof: appProof(),
+    runId: "800",
+    runAttempt: "3",
+  });
+  const recovery = recoverMainShadowTransaction({
+    journal,
+    expectedIdentity: {
+      repository: "mento-protocol/frontend-monorepo",
+      deploySha: SHA,
+      runId: "800",
+      runAttempt: "3",
+    },
+  });
+  assert.equal(recovery.outcome, "verified-no-mutation");
+  assert.equal(recovery.decision, "verify-only");
+
+  assert.deepEqual(
+    assertMainFinalResults({
+      plan: deploymentPlan,
+      jobs: {
+        waitForCi: "success",
+        plan: "success",
+        stageGovernance: "success",
+        stageReserve: "success",
+        stageUi: "success",
+        coordinator: "success",
+        recovery: "success",
+      },
+      coordinatorOutcome: "shadow-prepared",
+      recoveryOutcome: "verified-no-mutation",
+    }),
+    { outcome: "shadow-prepared" },
+  );
+  assert.throws(
+    () =>
+      assertMainFinalResults({
+        plan: deploymentPlan,
+        jobs: {
+          waitForCi: "success",
+          plan: "success",
+          stageGovernance: "success",
+          stageReserve: "success",
+          stageUi: "failure",
+          coordinator: "success",
+          recovery: "success",
+        },
+        coordinatorOutcome: "shadow-prepared",
+        recoveryOutcome: "verified-no-mutation",
+      }),
+    /did not succeed|invalid for ui/,
+  );
+  assert.deepEqual(
+    assertMainFinalResults({
+      plan: deploymentPlan,
+      jobs: {
+        waitForCi: "success",
+        plan: "success",
+        stageGovernance: "success",
+        stageReserve: "success",
+        stageUi: "success",
+        coordinator: "success",
+        recovery: "success",
+      },
+      coordinatorOutcome: "superseded-after-journal",
+      recoveryOutcome: "verified-no-mutation",
+    }),
+    { outcome: "superseded-after-journal" },
+  );
+  assert.throws(
+    () =>
+      assertMainFinalResults({
+        plan: deploymentPlan,
+        jobs: {
+          waitForCi: "success",
+          plan: "success",
+          stageGovernance: "success",
+          stageReserve: "success",
+          stageUi: "success",
+          coordinator: "success",
+          recovery: "success",
+        },
+        coordinatorOutcome: "superseded-after-journal",
+        recoveryOutcome: "not-required",
+      }),
+    /not recovery-verified/,
+  );
+});

--- a/scripts/vercel-main-plan.mjs
+++ b/scripts/vercel-main-plan.mjs
@@ -78,25 +78,19 @@ export const MAIN_TARGET_CONTRACTS = Object.freeze({
     target: null,
   }),
   governance: Object.freeze({
-    aliases: Object.freeze([
-      "governance.mento.org",
-      "governancementoorg-mentolabs.vercel.app",
-    ]),
+    aliases: Object.freeze(["governance.mento.org"]),
     customEnvironmentSlug: null,
     projectName: "governance.mento.org",
     target: "production",
   }),
   reserve: Object.freeze({
-    aliases: Object.freeze([
-      "reserve.mento.org",
-      "reservementoorg-mentolabs.vercel.app",
-    ]),
+    aliases: Object.freeze(["reserve.mento.org"]),
     customEnvironmentSlug: null,
     projectName: "reserve.mento.org",
     target: "production",
   }),
   ui: Object.freeze({
-    aliases: Object.freeze(["ui.mento.org", "uimentoorg-mentolabs.vercel.app"]),
+    aliases: Object.freeze(["ui.mento.org"]),
     customEnvironmentSlug: null,
     projectName: "ui.mento.org",
     target: "production",

--- a/scripts/vercel-main-plan.mjs
+++ b/scripts/vercel-main-plan.mjs
@@ -1,0 +1,948 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+import process from "node:process";
+
+import { planVercelDeployments } from "./plan-vercel-deployments.mjs";
+import {
+  canonicalizeDeploymentUrl,
+  canonicalizeHostname,
+} from "./vercel-deployment-state.mjs";
+
+const SHA_PATTERN = /^[a-f0-9]{40}$/;
+const IDENTIFIER_PATTERN = /^[A-Za-z0-9._-]+$/;
+const PLANNER_OUTPUT_KEYS = Object.freeze([
+  "base",
+  "deployments",
+  "head",
+  "reason",
+]);
+const KNOWN_PLANNER_REASONS = new Set([
+  "affected-packages",
+  "diff-failed",
+  "empty-diff",
+  "global-build-input",
+  "invalid-commits",
+  "non-runtime-only",
+  "turbo-planning-failed",
+]);
+const FAIL_CLOSED_PLANNER_REASONS = new Set([
+  "diff-failed",
+  "empty-diff",
+  "invalid-commits",
+  "turbo-planning-failed",
+]);
+const RANGE_REASONS = new Set([
+  ...KNOWN_PLANNER_REASONS,
+  "planner-affected-set-unknown",
+  "planner-execution-failed",
+  "planner-output-malformed",
+  "served-sha-already-current",
+  "shadow-first-parent-unresolved",
+]);
+const SELECTION_REASONS = new Set([
+  ...KNOWN_PLANNER_REASONS,
+  "planner-affected-set-unknown",
+  "planner-execution-failed",
+  "planner-output-malformed",
+  "served-git-metadata-conflicting",
+  "served-git-metadata-malformed",
+  "served-git-metadata-missing",
+  "served-git-metadata-wrong-source",
+  "served-git-sha-not-ancestor",
+  "served-git-sha-unresolvable",
+  "shadow-first-parent-unresolved",
+  "shadow-native-already-current",
+]);
+
+export const MAIN_DEPLOYMENT_TARGETS = Object.freeze([
+  "app",
+  "governance",
+  "reserve",
+  "ui",
+]);
+
+export const MAIN_DEPLOYMENT_MODES = Object.freeze({
+  ACTIVE: "active",
+  SHADOW: "shadow",
+});
+
+export const MAIN_TARGET_CONTRACTS = Object.freeze({
+  app: Object.freeze({
+    aliases: Object.freeze([
+      "app.mento.org",
+      "appmentoorg-env-v3-mentolabs.vercel.app",
+    ]),
+    customEnvironmentSlug: "v3",
+    projectName: "app.mento.org",
+    target: null,
+  }),
+  governance: Object.freeze({
+    aliases: Object.freeze([
+      "governance.mento.org",
+      "governancementoorg-mentolabs.vercel.app",
+    ]),
+    customEnvironmentSlug: null,
+    projectName: "governance.mento.org",
+    target: "production",
+  }),
+  reserve: Object.freeze({
+    aliases: Object.freeze([
+      "reserve.mento.org",
+      "reservementoorg-mentolabs.vercel.app",
+    ]),
+    customEnvironmentSlug: null,
+    projectName: "reserve.mento.org",
+    target: "production",
+  }),
+  ui: Object.freeze({
+    aliases: Object.freeze(["ui.mento.org", "uimentoorg-mentolabs.vercel.app"]),
+    customEnvironmentSlug: null,
+    projectName: "ui.mento.org",
+    target: "production",
+  }),
+});
+
+const PRIOR_STATE_REQUIRED_KEYS = Object.freeze([
+  "alias",
+  "customEnvironmentSlug",
+  "deploymentId",
+  "deploymentUrl",
+  "projectId",
+  "projectName",
+  "readyState",
+  "target",
+]);
+const PRIOR_STATE_ALLOWED_KEYS = new Set([
+  ...PRIOR_STATE_REQUIRED_KEYS,
+  "aliases",
+  "creatorUsername",
+  "git",
+]);
+const PLANNING_GIT_KEYS = Object.freeze(["org", "ref", "repo", "sha"]);
+
+export class MainActivationStateError extends Error {
+  constructor(target, code) {
+    super(
+      target === null
+        ? `Main activation state is ambiguous (${code})`
+        : `Main activation state is ambiguous for ${target} (${code})`,
+    );
+    this.name = "MainActivationStateError";
+    this.target = target;
+    this.code = code;
+  }
+}
+
+function isPlainObject(value) {
+  return (
+    value !== null &&
+    typeof value === "object" &&
+    !Array.isArray(value) &&
+    Object.getPrototypeOf(value) === Object.prototype
+  );
+}
+
+function exactKeys(value, expected) {
+  if (!isPlainObject(value)) return false;
+  return (
+    JSON.stringify(Object.keys(value).toSorted()) ===
+    JSON.stringify([...expected].toSorted())
+  );
+}
+
+function containsOnlyKeys(value, allowed) {
+  return (
+    isPlainObject(value) && Object.keys(value).every((key) => allowed.has(key))
+  );
+}
+
+function requireSha(value, label) {
+  if (typeof value !== "string" || !SHA_PATTERN.test(value.toLowerCase())) {
+    throw new Error(`${label} must be an immutable 40-hex SHA`);
+  }
+  return value.toLowerCase();
+}
+
+function requireIdentifier(value, label) {
+  if (
+    typeof value !== "string" ||
+    value.length === 0 ||
+    !IDENTIFIER_PATTERN.test(value)
+  ) {
+    throw new Error(`${label} is missing or malformed`);
+  }
+  return value;
+}
+
+function requireMode(value) {
+  if (!Object.values(MAIN_DEPLOYMENT_MODES).includes(value)) {
+    throw new Error("Main deployment mode must be shadow or active");
+  }
+  return value;
+}
+
+function activationError(target, code) {
+  throw new MainActivationStateError(target, code);
+}
+
+function assertTargetObject(value, label) {
+  if (
+    !isPlainObject(value) ||
+    JSON.stringify(Object.keys(value).toSorted()) !==
+      JSON.stringify([...MAIN_DEPLOYMENT_TARGETS].toSorted())
+  ) {
+    throw new Error(`${label} must contain exactly the four main targets`);
+  }
+}
+
+function canonicalizeReviewedAliases(aliases, target) {
+  if (!Array.isArray(aliases)) {
+    activationError(target, "alias-set-ambiguous");
+  }
+  let normalized;
+  try {
+    normalized = aliases.map((alias) => canonicalizeHostname(alias));
+  } catch {
+    activationError(target, "alias-set-ambiguous");
+  }
+  if (
+    new Set(normalized).size !== normalized.length ||
+    JSON.stringify(normalized.toSorted()) !==
+      JSON.stringify([...MAIN_TARGET_CONTRACTS[target].aliases].toSorted())
+  ) {
+    activationError(target, "alias-set-ambiguous");
+  }
+  return normalized;
+}
+
+function canonicalizeOptionalDeploymentAliases(value, target) {
+  if (value === undefined) return null;
+  if (!Array.isArray(value)) {
+    activationError(target, "alias-set-ambiguous");
+  }
+  let aliases;
+  try {
+    aliases = value.map((alias) => canonicalizeHostname(alias));
+  } catch {
+    activationError(target, "alias-set-ambiguous");
+  }
+  const sorted = [...new Set(aliases)].toSorted();
+  if (
+    sorted.length !== aliases.length ||
+    JSON.stringify(sorted) !== JSON.stringify(aliases)
+  ) {
+    activationError(target, "alias-set-ambiguous");
+  }
+  for (const reviewedAlias of MAIN_TARGET_CONTRACTS[target].aliases) {
+    if (!sorted.includes(reviewedAlias)) {
+      activationError(target, "alias-set-ambiguous");
+    }
+  }
+  if (
+    target === "app" &&
+    JSON.stringify(sorted) !==
+      JSON.stringify([...MAIN_TARGET_CONTRACTS.app.aliases].toSorted())
+  ) {
+    activationError(target, "alias-set-ambiguous");
+  }
+  return sorted;
+}
+
+function syntacticServedSha(gitValues) {
+  const values = new Set();
+  for (const git of gitValues) {
+    if (
+      isPlainObject(git) &&
+      typeof git.sha === "string" &&
+      SHA_PATTERN.test(git.sha.toLowerCase())
+    ) {
+      values.add(git.sha.toLowerCase());
+    }
+  }
+  return values.size === 1 ? [...values][0] : null;
+}
+
+function classifyPlanningGit(gitValues) {
+  const servedSha = syntacticServedSha(gitValues);
+  if (
+    gitValues.some(
+      (git) => git === undefined || git === null || !isPlainObject(git),
+    )
+  ) {
+    return {
+      base: null,
+      reason: "served-git-metadata-missing",
+      servedSha,
+    };
+  }
+  if (
+    gitValues.some(
+      (git) =>
+        !exactKeys(git, PLANNING_GIT_KEYS) ||
+        Object.values(git).some(
+          (value) => typeof value !== "string" || value.length === 0,
+        ) ||
+        !SHA_PATTERN.test(git.sha.toLowerCase()),
+    )
+  ) {
+    return {
+      base: null,
+      reason: "served-git-metadata-malformed",
+      servedSha,
+    };
+  }
+  const normalized = gitValues.map((git) => ({
+    org: git.org,
+    ref: git.ref,
+    repo: git.repo,
+    sha: git.sha.toLowerCase(),
+  }));
+  if (new Set(normalized.map((git) => JSON.stringify(git))).size !== 1) {
+    return {
+      base: null,
+      reason: "served-git-metadata-conflicting",
+      servedSha,
+    };
+  }
+  const git = normalized[0];
+  if (
+    git.org !== "mento-protocol" ||
+    git.repo !== "frontend-monorepo" ||
+    git.ref !== "main"
+  ) {
+    return {
+      base: null,
+      reason: "served-git-metadata-wrong-source",
+      servedSha: git.sha,
+    };
+  }
+  return { base: git.sha, reason: null, servedSha: git.sha };
+}
+
+function canonicalizePriorGroup({ target, group, projectId }) {
+  const contract = MAIN_TARGET_CONTRACTS[target];
+  if (!exactKeys(group, ["health", "states"]) || group.health !== "passed") {
+    activationError(target, "prior-health-ambiguous");
+  }
+  if (!Array.isArray(group.states) || group.states.length === 0) {
+    activationError(target, "alias-set-ambiguous");
+  }
+
+  const statesByAlias = new Map();
+  const gitValues = [];
+  let optionalDeploymentAliases = null;
+  for (const state of group.states) {
+    if (
+      !containsOnlyKeys(state, PRIOR_STATE_ALLOWED_KEYS) ||
+      PRIOR_STATE_REQUIRED_KEYS.some(
+        (key) => !Object.prototype.hasOwnProperty.call(state, key),
+      )
+    ) {
+      activationError(target, "prior-state-forbidden-fields");
+    }
+    let alias;
+    try {
+      alias = canonicalizeHostname(state.alias);
+    } catch {
+      activationError(target, "alias-set-ambiguous");
+    }
+    if (alias !== state.alias || statesByAlias.has(alias)) {
+      activationError(target, "alias-set-ambiguous");
+    }
+    statesByAlias.set(alias, state);
+
+    if (
+      state.projectId !== projectId ||
+      state.projectName !== contract.projectName
+    ) {
+      activationError(target, "project-identity-ambiguous");
+    }
+    if (
+      state.target !== contract.target ||
+      state.customEnvironmentSlug !== contract.customEnvironmentSlug
+    ) {
+      activationError(target, "environment-identity-ambiguous");
+    }
+    if (state.readyState !== "READY") {
+      activationError(target, "prior-readiness-ambiguous");
+    }
+    if (
+      typeof state.deploymentId !== "string" ||
+      !/^dpl_[A-Za-z0-9]+$/.test(state.deploymentId)
+    ) {
+      activationError(target, "rollback-target-ambiguous");
+    }
+    let deploymentUrl;
+    try {
+      deploymentUrl = canonicalizeDeploymentUrl(state.deploymentUrl);
+    } catch {
+      activationError(target, "rollback-target-ambiguous");
+    }
+    if (deploymentUrl !== state.deploymentUrl) {
+      activationError(target, "rollback-target-ambiguous");
+    }
+
+    const aliases = canonicalizeOptionalDeploymentAliases(
+      state.aliases,
+      target,
+    );
+    if (aliases !== null) {
+      if (
+        optionalDeploymentAliases !== null &&
+        JSON.stringify(optionalDeploymentAliases) !== JSON.stringify(aliases)
+      ) {
+        activationError(target, "alias-set-ambiguous");
+      }
+      optionalDeploymentAliases = aliases;
+    }
+    gitValues.push(state.git);
+  }
+
+  canonicalizeReviewedAliases([...statesByAlias.keys()], target);
+  const orderedStates = contract.aliases.map((alias) =>
+    statesByAlias.get(alias),
+  );
+  if (orderedStates.some((state) => state === undefined)) {
+    activationError(target, "alias-set-ambiguous");
+  }
+  const deploymentIds = new Set(
+    orderedStates.map((state) => state.deploymentId),
+  );
+  const deploymentUrls = new Set(
+    orderedStates.map((state) => state.deploymentUrl),
+  );
+  if (deploymentIds.size !== 1 || deploymentUrls.size !== 1) {
+    activationError(target, "rollback-target-ambiguous");
+  }
+
+  const planningGit = classifyPlanningGit(gitValues);
+  return {
+    planningGit,
+    prior: {
+      target,
+      aliases: [...contract.aliases],
+      deploymentId: [...deploymentIds][0],
+      deploymentUrl: [...deploymentUrls][0],
+      servedSha: planningGit.servedSha,
+    },
+  };
+}
+
+function runGit(spawn, repoRoot, argumentsList) {
+  const result = spawn("git", argumentsList, {
+    cwd: repoRoot,
+    encoding: "utf8",
+    maxBuffer: 20 * 1024 * 1024,
+  });
+  if (result.error || result.status !== 0) {
+    throw new Error("Git proof failed");
+  }
+  return result.stdout.trim();
+}
+
+export function createMainPlanGitAdapter({
+  repoRoot = process.cwd(),
+  spawn = spawnSync,
+} = {}) {
+  return {
+    firstParent(head) {
+      return runGit(spawn, repoRoot, [
+        "rev-parse",
+        "--verify",
+        `${requireSha(head, "Head SHA")}^1^{commit}`,
+      ]);
+    },
+    isAncestor(base, head) {
+      const result = spawn(
+        "git",
+        [
+          "merge-base",
+          "--is-ancestor",
+          requireSha(base, "Base SHA"),
+          requireSha(head, "Head SHA"),
+        ],
+        {
+          cwd: repoRoot,
+          encoding: "utf8",
+          maxBuffer: 20 * 1024 * 1024,
+        },
+      );
+      if (result.error || ![0, 1].includes(result.status)) {
+        throw new Error("Git ancestry proof failed");
+      }
+      return result.status === 0;
+    },
+    resolveCommit(sha) {
+      return runGit(spawn, repoRoot, [
+        "rev-parse",
+        "--verify",
+        `${requireSha(sha, "Commit SHA")}^{commit}`,
+      ]);
+    },
+  };
+}
+
+function assertGitAdapter(gitAdapter) {
+  if (
+    !isPlainObject(gitAdapter) ||
+    ["firstParent", "isAncestor", "resolveCommit"].some(
+      (name) => typeof gitAdapter[name] !== "function",
+    )
+  ) {
+    throw new Error("Main plan Git adapter is malformed");
+  }
+}
+
+function stableTargets(values) {
+  const selected = new Set(values);
+  return MAIN_DEPLOYMENT_TARGETS.filter((target) => selected.has(target));
+}
+
+function malformedPlannerRange({ kind, base, head, targets, all = false }) {
+  return {
+    range: {
+      kind,
+      base,
+      head,
+      targets: [...targets],
+      deployments: all ? [...MAIN_DEPLOYMENT_TARGETS] : stableTargets(targets),
+      reason: all ? "planner-affected-set-unknown" : "planner-output-malformed",
+    },
+    selectionReason: all
+      ? "planner-affected-set-unknown"
+      : "planner-output-malformed",
+  };
+}
+
+function executePlannerRange({ kind, base, head, targets, runPlanner }) {
+  let output;
+  try {
+    output = runPlanner({ base, head });
+  } catch {
+    return {
+      range: {
+        kind,
+        base,
+        head,
+        targets: [...targets],
+        deployments: stableTargets(targets),
+        reason: "planner-execution-failed",
+      },
+      selectionReason: "planner-execution-failed",
+    };
+  }
+  if (
+    !isPlainObject(output) ||
+    !exactKeys(output, PLANNER_OUTPUT_KEYS) ||
+    !Array.isArray(output.deployments)
+  ) {
+    return malformedPlannerRange({
+      kind,
+      base,
+      head,
+      targets,
+      all: isPlainObject(output) && !Array.isArray(output.deployments),
+    });
+  }
+  if (
+    output.deployments.some(
+      (target) =>
+        typeof target !== "string" || !MAIN_DEPLOYMENT_TARGETS.includes(target),
+    )
+  ) {
+    return malformedPlannerRange({
+      kind,
+      base,
+      head,
+      targets,
+      all: true,
+    });
+  }
+  const stableDeployments = stableTargets(output.deployments);
+  if (
+    JSON.stringify(stableDeployments) !== JSON.stringify(output.deployments) ||
+    output.base !== base ||
+    output.head !== head ||
+    typeof output.reason !== "string" ||
+    !KNOWN_PLANNER_REASONS.has(output.reason)
+  ) {
+    return malformedPlannerRange({ kind, base, head, targets });
+  }
+
+  if (output.reason === "non-runtime-only") {
+    if (output.deployments.length !== 0) {
+      return malformedPlannerRange({ kind, base, head, targets });
+    }
+    return {
+      range: {
+        kind,
+        base,
+        head,
+        targets: [...targets],
+        deployments: [],
+        reason: output.reason,
+      },
+      selectionReason: null,
+    };
+  }
+  if (output.reason === "global-build-input") {
+    if (
+      JSON.stringify(output.deployments) !==
+      JSON.stringify(MAIN_DEPLOYMENT_TARGETS)
+    ) {
+      return malformedPlannerRange({ kind, base, head, targets });
+    }
+    return {
+      range: {
+        kind,
+        base,
+        head,
+        targets: [...targets],
+        deployments: [...MAIN_DEPLOYMENT_TARGETS],
+        reason: output.reason,
+      },
+      selectionReason: output.reason,
+    };
+  }
+  if (output.reason === "affected-packages") {
+    if (output.deployments.length === 0) {
+      return malformedPlannerRange({ kind, base, head, targets });
+    }
+    return {
+      range: {
+        kind,
+        base,
+        head,
+        targets: [...targets],
+        deployments: [...output.deployments],
+        reason: output.reason,
+      },
+      selectionReason: output.reason,
+    };
+  }
+  if (FAIL_CLOSED_PLANNER_REASONS.has(output.reason)) {
+    return {
+      range: {
+        kind,
+        base,
+        head,
+        targets: [...targets],
+        deployments: stableTargets(targets),
+        reason: output.reason,
+      },
+      selectionReason: output.reason,
+    };
+  }
+  return malformedPlannerRange({ kind, base, head, targets });
+}
+
+function proveServedBase({ base, deploySha, gitAdapter }) {
+  try {
+    const resolved = requireSha(
+      gitAdapter.resolveCommit(base),
+      "Resolved served SHA",
+    );
+    if (resolved !== base) {
+      return { base: null, reason: "served-git-sha-unresolvable" };
+    }
+    if (!gitAdapter.isAncestor(resolved, deploySha)) {
+      return { base: null, reason: "served-git-sha-not-ancestor" };
+    }
+    return { base: resolved, reason: null };
+  } catch {
+    return { base: null, reason: "served-git-sha-unresolvable" };
+  }
+}
+
+function proveFirstParent({ deploySha, gitAdapter }) {
+  const parent = requireSha(
+    gitAdapter.firstParent(deploySha),
+    "First-parent SHA",
+  );
+  const resolved = requireSha(
+    gitAdapter.resolveCommit(parent),
+    "Resolved first-parent SHA",
+  );
+  if (
+    resolved !== parent ||
+    resolved === deploySha ||
+    !gitAdapter.isAncestor(resolved, deploySha)
+  ) {
+    throw new Error("First-parent proof failed");
+  }
+  return resolved;
+}
+
+function exactOutputKeys(value, keys, label) {
+  if (!exactKeys(value, keys)) {
+    throw new Error(`${label} contains forbidden fields`);
+  }
+}
+
+export function assertMainDeploymentPlan(plan) {
+  exactOutputKeys(
+    plan,
+    ["deploySha", "mode", "plan", "priors", "ranges", "reasons", "schema"],
+    "Main deployment plan",
+  );
+  if (plan.schema !== "vercel-main-plan:v1") {
+    throw new Error("Main deployment plan schema is invalid");
+  }
+  requireMode(plan.mode);
+  requireSha(plan.deploySha, "Main deployment plan SHA");
+  if (
+    !Array.isArray(plan.plan) ||
+    JSON.stringify(stableTargets(plan.plan)) !== JSON.stringify(plan.plan)
+  ) {
+    throw new Error("Main deployment final plan is malformed");
+  }
+  if (
+    !Array.isArray(plan.priors) ||
+    plan.priors.length !== MAIN_DEPLOYMENT_TARGETS.length
+  ) {
+    throw new Error("Main deployment priors are malformed");
+  }
+  for (const [index, prior] of plan.priors.entries()) {
+    exactOutputKeys(
+      prior,
+      ["aliases", "deploymentId", "deploymentUrl", "servedSha", "target"],
+      "Main deployment prior",
+    );
+    if (
+      prior.target !== MAIN_DEPLOYMENT_TARGETS[index] ||
+      JSON.stringify(prior.aliases) !==
+        JSON.stringify(MAIN_TARGET_CONTRACTS[prior.target].aliases)
+    ) {
+      throw new Error("Main deployment prior target is malformed");
+    }
+    if (!/^dpl_[A-Za-z0-9]+$/.test(prior.deploymentId)) {
+      throw new Error("Main deployment prior ID is malformed");
+    }
+    if (
+      canonicalizeDeploymentUrl(prior.deploymentUrl) !== prior.deploymentUrl
+    ) {
+      throw new Error("Main deployment prior URL is malformed");
+    }
+    if (prior.servedSha !== null) {
+      requireSha(prior.servedSha, "Main deployment served SHA");
+    }
+  }
+  if (!Array.isArray(plan.ranges) || !Array.isArray(plan.reasons)) {
+    throw new Error("Main deployment range evidence is malformed");
+  }
+  for (const range of plan.ranges) {
+    exactOutputKeys(
+      range,
+      ["base", "deployments", "head", "kind", "reason", "targets"],
+      "Main deployment planner range",
+    );
+    if (!["served", "shadow-first-parent"].includes(range.kind)) {
+      throw new Error("Main deployment planner range kind is malformed");
+    }
+    if (range.base !== null) {
+      requireSha(range.base, "Main deployment planner base");
+    }
+    requireSha(range.head, "Main deployment planner head");
+    if (
+      JSON.stringify(stableTargets(range.targets)) !==
+        JSON.stringify(range.targets) ||
+      range.targets.length === 0 ||
+      JSON.stringify(stableTargets(range.deployments)) !==
+        JSON.stringify(range.deployments) ||
+      typeof range.reason !== "string" ||
+      !RANGE_REASONS.has(range.reason)
+    ) {
+      throw new Error("Main deployment planner range is malformed");
+    }
+  }
+  for (const reason of plan.reasons) {
+    exactOutputKeys(
+      reason,
+      ["base", "reason", "target"],
+      "Main deployment selection reason",
+    );
+    if (
+      !MAIN_DEPLOYMENT_TARGETS.includes(reason.target) ||
+      typeof reason.reason !== "string" ||
+      !SELECTION_REASONS.has(reason.reason) ||
+      !plan.plan.includes(reason.target)
+    ) {
+      throw new Error("Main deployment selection reason is malformed");
+    }
+    if (reason.base !== null) {
+      requireSha(reason.base, "Main deployment selection base");
+    }
+  }
+  return plan;
+}
+
+export function planMainDeployments({
+  mode,
+  deploySha,
+  projectIds,
+  priorStates,
+  repoRoot = process.cwd(),
+  gitAdapter = createMainPlanGitAdapter({ repoRoot }),
+  runPlanner = ({ base, head }) =>
+    planVercelDeployments({ repoRoot, base, head }),
+}) {
+  const canonicalMode = requireMode(mode);
+  const canonicalDeploySha = requireSha(deploySha, "DEPLOY_SHA");
+  assertTargetObject(projectIds, "Main project IDs");
+  assertTargetObject(priorStates, "Main prior states");
+  if (typeof runPlanner !== "function") {
+    throw new Error("Main deployment planner adapter is malformed");
+  }
+  assertGitAdapter(gitAdapter);
+  for (const target of MAIN_DEPLOYMENT_TARGETS) {
+    requireIdentifier(projectIds[target], `${target} project ID`);
+  }
+  let resolvedHead;
+  try {
+    resolvedHead = requireSha(
+      gitAdapter.resolveCommit(canonicalDeploySha),
+      "Resolved DEPLOY_SHA",
+    );
+  } catch {
+    throw new Error("DEPLOY_SHA cannot be resolved");
+  }
+  if (resolvedHead !== canonicalDeploySha) {
+    throw new Error("DEPLOY_SHA did not resolve exactly");
+  }
+
+  const normalized = MAIN_DEPLOYMENT_TARGETS.map((target) => ({
+    target,
+    ...canonicalizePriorGroup({
+      target,
+      group: priorStates[target],
+      projectId: projectIds[target],
+    }),
+  }));
+  const selected = new Set();
+  const reasons = [];
+  const ranges = [];
+  const groupedBases = new Map();
+
+  function addSelection(target, reason, base = null) {
+    selected.add(target);
+    if (
+      !reasons.some(
+        (entry) =>
+          entry.target === target &&
+          entry.reason === reason &&
+          entry.base === base,
+      )
+    ) {
+      reasons.push({ target, reason, base });
+    }
+  }
+
+  for (const entry of normalized) {
+    if (entry.planningGit.reason !== null) {
+      addSelection(
+        entry.target,
+        entry.planningGit.reason,
+        entry.planningGit.servedSha,
+      );
+      continue;
+    }
+    const proof = proveServedBase({
+      base: entry.planningGit.base,
+      deploySha: canonicalDeploySha,
+      gitAdapter,
+    });
+    if (proof.reason !== null) {
+      addSelection(entry.target, proof.reason, entry.planningGit.base);
+      continue;
+    }
+    const targets = groupedBases.get(proof.base) ?? [];
+    targets.push(entry.target);
+    groupedBases.set(proof.base, targets);
+  }
+
+  const alreadyCurrentTargets = [];
+  for (const [base, targets] of groupedBases) {
+    if (base === canonicalDeploySha) {
+      ranges.push({
+        kind: "served",
+        base,
+        head: canonicalDeploySha,
+        targets: [...targets],
+        deployments: [],
+        reason: "served-sha-already-current",
+      });
+      alreadyCurrentTargets.push(...targets);
+      continue;
+    }
+    const result = executePlannerRange({
+      kind: "served",
+      base,
+      head: canonicalDeploySha,
+      targets,
+      runPlanner,
+    });
+    ranges.push(result.range);
+    for (const target of result.range.deployments) {
+      addSelection(target, result.selectionReason, base);
+    }
+  }
+
+  if (
+    canonicalMode === MAIN_DEPLOYMENT_MODES.SHADOW &&
+    alreadyCurrentTargets.length > 0
+  ) {
+    let firstParent;
+    try {
+      firstParent = proveFirstParent({
+        deploySha: canonicalDeploySha,
+        gitAdapter,
+      });
+    } catch {
+      ranges.push({
+        kind: "shadow-first-parent",
+        base: null,
+        head: canonicalDeploySha,
+        targets: stableTargets(alreadyCurrentTargets),
+        deployments: [...MAIN_DEPLOYMENT_TARGETS],
+        reason: "shadow-first-parent-unresolved",
+      });
+      for (const target of MAIN_DEPLOYMENT_TARGETS) {
+        addSelection(target, "shadow-first-parent-unresolved");
+      }
+      firstParent = null;
+    }
+    if (firstParent !== null) {
+      const result = executePlannerRange({
+        kind: "shadow-first-parent",
+        base: firstParent,
+        head: canonicalDeploySha,
+        targets: stableTargets(alreadyCurrentTargets),
+        runPlanner,
+      });
+      ranges.push(result.range);
+      for (const target of result.range.deployments) {
+        addSelection(target, "shadow-native-already-current", firstParent);
+      }
+    }
+  }
+
+  const plan = {
+    schema: "vercel-main-plan:v1",
+    mode: canonicalMode,
+    deploySha: canonicalDeploySha,
+    priors: normalized.map((entry) => entry.prior),
+    ranges,
+    reasons: reasons.toSorted((left, right) => {
+      const targetOrder =
+        MAIN_DEPLOYMENT_TARGETS.indexOf(left.target) -
+        MAIN_DEPLOYMENT_TARGETS.indexOf(right.target);
+      if (targetOrder !== 0) return targetOrder;
+      const reasonOrder = left.reason.localeCompare(right.reason);
+      if (reasonOrder !== 0) return reasonOrder;
+      return (left.base ?? "").localeCompare(right.base ?? "");
+    }),
+    plan: stableTargets(selected),
+  };
+  return assertMainDeploymentPlan(plan);
+}

--- a/scripts/vercel-main-plan.test.mjs
+++ b/scripts/vercel-main-plan.test.mjs
@@ -315,10 +315,26 @@ for (const [name, mutate, expectedReason, expectedServedSha] of [
     null,
   ],
   [
+    "sanitized missing",
+    (input) => {
+      for (const state of input.priorStates.app.states) state.git = null;
+    },
+    "served-git-metadata-missing",
+    null,
+  ],
+  [
     "malformed",
     (input) => {
       input.priorStates.app.states[0].git.sha = "main";
       input.priorStates.app.states[1].git.sha = "main";
+    },
+    "served-git-metadata-malformed",
+    null,
+  ],
+  [
+    "sanitized malformed",
+    (input) => {
+      for (const state of input.priorStates.app.states) state.git = {};
     },
     "served-git-metadata-malformed",
     null,

--- a/scripts/vercel-main-plan.test.mjs
+++ b/scripts/vercel-main-plan.test.mjs
@@ -1,0 +1,898 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { test } from "node:test";
+
+import {
+  assertMainDeploymentPlan,
+  createMainPlanGitAdapter,
+  MAIN_DEPLOYMENT_TARGETS,
+  MainActivationStateError,
+  planMainDeployments,
+} from "./vercel-main-plan.mjs";
+
+const fixtureUrl = new URL(
+  "./fixtures/vercel-main-plan/valid-priors.json",
+  import.meta.url,
+);
+
+function fixture() {
+  return JSON.parse(readFileSync(fixtureUrl, "utf8"));
+}
+
+function setTargetSha(input, target, sha) {
+  for (const state of input.priorStates[target].states) {
+    state.git.sha = sha;
+  }
+}
+
+function setAllTargetShas(input, sha) {
+  for (const target of MAIN_DEPLOYMENT_TARGETS) {
+    setTargetSha(input, target, sha);
+  }
+}
+
+function plannerOutput(base, head, deployments, reason) {
+  return { base, head, deployments, reason };
+}
+
+function createGitFixture(
+  input,
+  {
+    firstParent = input.firstParent,
+    firstParentError = false,
+    nonAncestors = [],
+    unresolvable = [],
+  } = {},
+) {
+  const calls = [];
+  const nonAncestorSet = new Set(nonAncestors);
+  const unresolvableSet = new Set(unresolvable);
+  return {
+    calls,
+    adapter: {
+      firstParent(head) {
+        calls.push(["firstParent", head]);
+        if (firstParentError) throw new Error("fixture first-parent failure");
+        return firstParent;
+      },
+      isAncestor(base, head) {
+        calls.push(["isAncestor", base, head]);
+        return !nonAncestorSet.has(base);
+      },
+      resolveCommit(sha) {
+        calls.push(["resolveCommit", sha]);
+        if (unresolvableSet.has(sha)) {
+          throw new Error("fixture resolution failure");
+        }
+        return sha.toLowerCase();
+      },
+    },
+  };
+}
+
+function createPlannerFixture(responses = new Map()) {
+  const calls = [];
+  return {
+    calls,
+    runPlanner({ base, head }) {
+      calls.push({ base, head });
+      const response = responses.get(base);
+      if (response instanceof Error) throw response;
+      if (typeof response === "function") return response({ base, head });
+      if (response !== undefined) return structuredClone(response);
+      return plannerOutput(base, head, [], "non-runtime-only");
+    },
+  };
+}
+
+function runFixture(input, options = {}) {
+  const git = options.git ?? createGitFixture(input);
+  const planner = options.planner ?? createPlannerFixture();
+  return {
+    git,
+    planner,
+    plan: planMainDeployments({
+      mode: input.mode,
+      deploySha: input.deploySha,
+      projectIds: input.projectIds,
+      priorStates: input.priorStates,
+      gitAdapter: git.adapter,
+      runPlanner: planner.runPlanner,
+    }),
+  };
+}
+
+function assertActivationError(callback, target, code) {
+  assert.throws(callback, (error) => {
+    assert.ok(error instanceof MainActivationStateError);
+    assert.equal(error.target, target);
+    assert.equal(error.code, code);
+    return true;
+  });
+}
+
+test("groups distinct served bases, accumulates ranges, and unions targets in canonical order", () => {
+  const input = fixture();
+  const planner = createPlannerFixture(
+    new Map([
+      [
+        "a".repeat(40),
+        plannerOutput(
+          "a".repeat(40),
+          input.deploySha,
+          ["governance"],
+          "affected-packages",
+        ),
+      ],
+      [
+        "b".repeat(40),
+        plannerOutput(
+          "b".repeat(40),
+          input.deploySha,
+          ["app", "reserve"],
+          "affected-packages",
+        ),
+      ],
+      [
+        "c".repeat(40),
+        plannerOutput("c".repeat(40), input.deploySha, [], "non-runtime-only"),
+      ],
+    ]),
+  );
+  const { plan } = runFixture(input, { planner });
+
+  assert.deepEqual(planner.calls, [
+    { base: "a".repeat(40), head: input.deploySha },
+    { base: "b".repeat(40), head: input.deploySha },
+    { base: "c".repeat(40), head: input.deploySha },
+  ]);
+  assert.deepEqual(
+    plan.ranges.map(({ base, targets, deployments, reason }) => ({
+      base,
+      targets,
+      deployments,
+      reason,
+    })),
+    [
+      {
+        base: "a".repeat(40),
+        targets: ["app"],
+        deployments: ["governance"],
+        reason: "affected-packages",
+      },
+      {
+        base: "b".repeat(40),
+        targets: ["governance", "reserve"],
+        deployments: ["app", "reserve"],
+        reason: "affected-packages",
+      },
+      {
+        base: "c".repeat(40),
+        targets: ["ui"],
+        deployments: [],
+        reason: "non-runtime-only",
+      },
+    ],
+  );
+  assert.deepEqual(plan.plan, ["app", "governance", "reserve"]);
+  assert.deepEqual(
+    plan.priors.map(({ target, deploymentId, deploymentUrl, servedSha }) => ({
+      target,
+      deploymentId,
+      deploymentUrl,
+      servedSha,
+    })),
+    [
+      {
+        target: "app",
+        deploymentId: "dpl_appA123",
+        deploymentUrl: "https://app-main-a.vercel.app",
+        servedSha: "a".repeat(40),
+      },
+      {
+        target: "governance",
+        deploymentId: "dpl_governanceB123",
+        deploymentUrl: "https://governance-main-b.vercel.app",
+        servedSha: "b".repeat(40),
+      },
+      {
+        target: "reserve",
+        deploymentId: "dpl_reserveB123",
+        deploymentUrl: "https://reserve-main-b.vercel.app",
+        servedSha: "b".repeat(40),
+      },
+      {
+        target: "ui",
+        deploymentId: "dpl_uiC123",
+        deploymentUrl: "https://ui-main-c.vercel.app",
+        servedSha: "c".repeat(40),
+      },
+    ],
+  );
+  assert.doesNotMatch(
+    JSON.stringify(plan),
+    /creatorUsername|projectId|projectName|readyState|customEnvironmentSlug/,
+  );
+});
+
+test("a served base accumulates changes across skipped or superseded pushes", () => {
+  const input = fixture();
+  input.mode = "active";
+  setAllTargetShas(input, input.deploySha);
+  setTargetSha(input, "app", "a".repeat(40));
+  const planner = createPlannerFixture(
+    new Map([
+      [
+        "a".repeat(40),
+        plannerOutput(
+          "a".repeat(40),
+          input.deploySha,
+          ["app"],
+          "affected-packages",
+        ),
+      ],
+    ]),
+  );
+  const { plan } = runFixture(input, { planner });
+  assert.deepEqual(planner.calls, [
+    { base: "a".repeat(40), head: input.deploySha },
+  ]);
+  assert.deepEqual(plan.plan, ["app"]);
+  assert.equal(plan.ranges[0].base, "a".repeat(40));
+  assert.equal(plan.ranges[0].head, input.deploySha);
+});
+
+test("a valid non-runtime result for every served range is an explained no-op", () => {
+  const input = fixture();
+  input.mode = "active";
+  const { plan } = runFixture(input);
+  assert.deepEqual(plan.plan, []);
+  assert.deepEqual(plan.reasons, []);
+  assert.equal(plan.ranges.length, 3);
+  assert.ok(plan.ranges.every((range) => range.reason === "non-runtime-only"));
+});
+
+test("one valid global build-input range preserves the all-target planner result", () => {
+  const input = fixture();
+  input.mode = "active";
+  const planner = createPlannerFixture(
+    new Map([
+      [
+        "a".repeat(40),
+        plannerOutput(
+          "a".repeat(40),
+          input.deploySha,
+          [...MAIN_DEPLOYMENT_TARGETS],
+          "global-build-input",
+        ),
+      ],
+    ]),
+  );
+  const { plan } = runFixture(input, { planner });
+  assert.deepEqual(plan.plan, MAIN_DEPLOYMENT_TARGETS);
+  assert.equal(plan.reasons[0].reason, "global-build-input");
+});
+
+test("App always plans from its reviewed v3 aliases and never legacy v2", () => {
+  const input = fixture();
+  input.mode = "active";
+  const planner = createPlannerFixture();
+  const { plan } = runFixture(input, { planner });
+  assert.deepEqual(plan.priors[0].aliases, [
+    "app.mento.org",
+    "appmentoorg-env-v3-mentolabs.vercel.app",
+  ]);
+  assert.equal(planner.calls[0].base, "a".repeat(40));
+
+  const v2Environment = fixture();
+  for (const state of v2Environment.priorStates.app.states) {
+    state.target = "production";
+    state.customEnvironmentSlug = null;
+    state.git.ref = "v2";
+  }
+  assertActivationError(
+    () => runFixture(v2Environment),
+    "app",
+    "environment-identity-ambiguous",
+  );
+
+  const v2Alias = fixture();
+  v2Alias.priorStates.app.states[1].alias = "v2-app.mento.org";
+  assertActivationError(
+    () => runFixture(v2Alias),
+    "app",
+    "alias-set-ambiguous",
+  );
+});
+
+for (const [name, mutate, expectedReason, expectedServedSha] of [
+  [
+    "missing",
+    (input) => {
+      for (const state of input.priorStates.app.states) delete state.git;
+    },
+    "served-git-metadata-missing",
+    null,
+  ],
+  [
+    "malformed",
+    (input) => {
+      input.priorStates.app.states[0].git.sha = "main";
+      input.priorStates.app.states[1].git.sha = "main";
+    },
+    "served-git-metadata-malformed",
+    null,
+  ],
+  [
+    "conflicting",
+    (input) => {
+      input.priorStates.app.states[1].git.sha = "9".repeat(40);
+    },
+    "served-git-metadata-conflicting",
+    null,
+  ],
+  [
+    "wrong repository",
+    (input) => {
+      for (const state of input.priorStates.app.states) {
+        state.git.repo = "other-repository";
+      }
+    },
+    "served-git-metadata-wrong-source",
+    "a".repeat(40),
+  ],
+  [
+    "wrong ref",
+    (input) => {
+      for (const state of input.priorStates.app.states) state.git.ref = "v2";
+    },
+    "served-git-metadata-wrong-source",
+    "a".repeat(40),
+  ],
+]) {
+  test(`${name} planning metadata selects only its affected target`, () => {
+    const input = fixture();
+    input.mode = "active";
+    setTargetSha(input, "governance", input.deploySha);
+    setTargetSha(input, "reserve", input.deploySha);
+    setTargetSha(input, "ui", input.deploySha);
+    mutate(input);
+    const { plan, planner } = runFixture(input);
+    assert.deepEqual(plan.plan, ["app"]);
+    assert.deepEqual(plan.reasons, [
+      {
+        target: "app",
+        reason: expectedReason,
+        base: expectedServedSha,
+      },
+    ]);
+    assert.equal(plan.priors[0].servedSha, expectedServedSha);
+    assert.equal(planner.calls.length, 0);
+  });
+}
+
+for (const [name, gitOptions, reason] of [
+  [
+    "unresolvable",
+    { unresolvable: ["a".repeat(40)] },
+    "served-git-sha-unresolvable",
+  ],
+  [
+    "non-ancestor",
+    { nonAncestors: ["a".repeat(40)] },
+    "served-git-sha-not-ancestor",
+  ],
+]) {
+  test(`${name} served SHA proof selects the affected target`, () => {
+    const input = fixture();
+    input.mode = "active";
+    setTargetSha(input, "governance", input.deploySha);
+    setTargetSha(input, "reserve", input.deploySha);
+    setTargetSha(input, "ui", input.deploySha);
+    const git = createGitFixture(input, gitOptions);
+    const { plan } = runFixture(input, { git });
+    assert.deepEqual(plan.plan, ["app"]);
+    assert.deepEqual(plan.reasons, [
+      { target: "app", reason, base: "a".repeat(40) },
+    ]);
+  });
+}
+
+test("planner execution failure selects every target that uses that served base", () => {
+  const input = fixture();
+  input.mode = "active";
+  setTargetSha(input, "app", input.deploySha);
+  setTargetSha(input, "ui", input.deploySha);
+  const planner = createPlannerFixture(
+    new Map([["b".repeat(40), new Error("private fixture error")]]),
+  );
+  const { plan } = runFixture(input, { planner });
+  assert.deepEqual(plan.plan, ["governance", "reserve"]);
+  assert.deepEqual(plan.ranges[1], {
+    kind: "served",
+    base: "b".repeat(40),
+    head: input.deploySha,
+    targets: ["governance", "reserve"],
+    deployments: ["governance", "reserve"],
+    reason: "planner-execution-failed",
+  });
+  assert.doesNotMatch(JSON.stringify(plan), /private fixture error/);
+});
+
+test("known fail-closed planner output selects only targets sharing the failed range", () => {
+  const input = fixture();
+  input.mode = "active";
+  setTargetSha(input, "app", input.deploySha);
+  setTargetSha(input, "ui", input.deploySha);
+  const planner = createPlannerFixture(
+    new Map([
+      [
+        "b".repeat(40),
+        plannerOutput(
+          "b".repeat(40),
+          input.deploySha,
+          [...MAIN_DEPLOYMENT_TARGETS],
+          "turbo-planning-failed",
+        ),
+      ],
+    ]),
+  );
+  const { plan } = runFixture(input, { planner });
+  assert.deepEqual(plan.plan, ["governance", "reserve"]);
+  assert.equal(plan.ranges[1].reason, "turbo-planning-failed");
+});
+
+test("an unknowable affected set selects all four targets", () => {
+  const input = fixture();
+  input.mode = "active";
+  setTargetSha(input, "governance", input.deploySha);
+  setTargetSha(input, "reserve", input.deploySha);
+  setTargetSha(input, "ui", input.deploySha);
+  const planner = createPlannerFixture(
+    new Map([
+      [
+        "a".repeat(40),
+        {
+          base: "a".repeat(40),
+          head: input.deploySha,
+          deployments: ["unknown"],
+          reason: "affected-packages",
+        },
+      ],
+    ]),
+  );
+  const { plan } = runFixture(input, { planner });
+  assert.deepEqual(plan.plan, MAIN_DEPLOYMENT_TARGETS);
+  assert.equal(plan.ranges[0].reason, "planner-affected-set-unknown");
+});
+
+for (const [name, response] of [
+  [
+    "extra output fields",
+    ({ base, head }) => ({
+      ...plannerOutput(base, head, ["app"], "affected-packages"),
+      rawVercelResponse: "must-not-cross",
+    }),
+  ],
+  [
+    "duplicate target output",
+    ({ base, head }) =>
+      plannerOutput(base, head, ["app", "app"], "affected-packages"),
+  ],
+  [
+    "wrong range",
+    ({ head }) =>
+      plannerOutput("9".repeat(40), head, ["app"], "affected-packages"),
+  ],
+  [
+    "non-runtime with a target",
+    ({ base, head }) => plannerOutput(base, head, ["app"], "non-runtime-only"),
+  ],
+]) {
+  test(`${name} is treated as malformed planner output`, () => {
+    const input = fixture();
+    input.mode = "active";
+    setTargetSha(input, "governance", input.deploySha);
+    setTargetSha(input, "reserve", input.deploySha);
+    setTargetSha(input, "ui", input.deploySha);
+    const planner = createPlannerFixture(new Map([["a".repeat(40), response]]));
+    const { plan } = runFixture(input, { planner });
+    assert.deepEqual(plan.plan, ["app"]);
+    assert.equal(plan.ranges[0].reason, "planner-output-malformed");
+    assert.doesNotMatch(
+      JSON.stringify(plan),
+      /rawVercelResponse|must-not-cross/,
+    );
+  });
+}
+
+test("shadow mode uses the first-parent delta when native Vercel already serves DEPLOY_SHA", () => {
+  const input = fixture();
+  setTargetSha(input, "ui", input.deploySha);
+  const planner = createPlannerFixture(
+    new Map([
+      [
+        input.firstParent,
+        plannerOutput(
+          input.firstParent,
+          input.deploySha,
+          ["ui"],
+          "affected-packages",
+        ),
+      ],
+    ]),
+  );
+  const { plan, git } = runFixture(input, { planner });
+  assert.deepEqual(plan.plan, ["ui"]);
+  assert.deepEqual(plan.ranges.at(-1), {
+    kind: "shadow-first-parent",
+    base: input.firstParent,
+    head: input.deploySha,
+    targets: ["ui"],
+    deployments: ["ui"],
+    reason: "affected-packages",
+  });
+  assert.deepEqual(plan.reasons.at(-1), {
+    target: "ui",
+    reason: "shadow-native-already-current",
+    base: input.firstParent,
+  });
+  assert.ok(
+    git.calls.some(
+      (call) => call[0] === "firstParent" && call[1] === input.deploySha,
+    ),
+  );
+});
+
+test("the shadow head-delta can select a target whose own served base differs", () => {
+  const input = fixture();
+  setTargetSha(input, "ui", input.deploySha);
+  const planner = createPlannerFixture(
+    new Map([
+      [
+        input.firstParent,
+        plannerOutput(
+          input.firstParent,
+          input.deploySha,
+          ["governance"],
+          "affected-packages",
+        ),
+      ],
+    ]),
+  );
+  const { plan } = runFixture(input, { planner });
+  assert.deepEqual(plan.plan, ["governance"]);
+  assert.deepEqual(plan.reasons.at(-1), {
+    target: "governance",
+    reason: "shadow-native-already-current",
+    base: input.firstParent,
+  });
+});
+
+test("active mode has no first-parent fallback for an already-current target", () => {
+  const input = fixture();
+  input.mode = "active";
+  setAllTargetShas(input, input.deploySha);
+  const { plan, git, planner } = runFixture(input);
+  assert.deepEqual(plan.plan, []);
+  assert.equal(planner.calls.length, 0);
+  assert.equal(
+    git.calls.some((call) => call[0] === "firstParent"),
+    false,
+  );
+  assert.deepEqual(plan.ranges, [
+    {
+      kind: "served",
+      base: input.deploySha,
+      head: input.deploySha,
+      targets: [...MAIN_DEPLOYMENT_TARGETS],
+      deployments: [],
+      reason: "served-sha-already-current",
+    },
+  ]);
+});
+
+test("an unresolvable first parent selects all four only in shadow mode", () => {
+  const input = fixture();
+  setTargetSha(input, "app", input.deploySha);
+  const git = createGitFixture(input, { firstParentError: true });
+  const { plan } = runFixture(input, { git });
+  assert.deepEqual(plan.plan, MAIN_DEPLOYMENT_TARGETS);
+  assert.equal(plan.ranges.at(-1).reason, "shadow-first-parent-unresolved");
+  assert.deepEqual(
+    plan.reasons.slice(-4).map((reason) => reason.reason),
+    Array(4).fill("shadow-first-parent-unresolved"),
+  );
+});
+
+test("a malformed shadow fallback plan selects its current-base target and keeps the required label", () => {
+  const input = fixture();
+  setTargetSha(input, "ui", input.deploySha);
+  const planner = createPlannerFixture(
+    new Map([[input.firstParent, new Error("fixture planner failure")]]),
+  );
+  const { plan } = runFixture(input, { planner });
+  assert.deepEqual(plan.plan, ["ui"]);
+  assert.equal(plan.ranges.at(-1).reason, "planner-execution-failed");
+  assert.deepEqual(plan.reasons.at(-1), {
+    target: "ui",
+    reason: "shadow-native-already-current",
+    base: input.firstParent,
+  });
+});
+
+const activationAmbiguities = [
+  {
+    name: "missing protected alias",
+    target: "governance",
+    code: "alias-set-ambiguous",
+    mutate(input) {
+      input.priorStates.governance.states.pop();
+    },
+  },
+  {
+    name: "duplicated protected alias",
+    target: "reserve",
+    code: "alias-set-ambiguous",
+    mutate(input) {
+      input.priorStates.reserve.states[1].alias = "reserve.mento.org";
+    },
+  },
+  {
+    name: "unexpected protected alias",
+    target: "ui",
+    code: "alias-set-ambiguous",
+    mutate(input) {
+      input.priorStates.ui.states[1].alias = "unexpected.vercel.app";
+    },
+  },
+  {
+    name: "deployment alias disagreement",
+    target: "governance",
+    code: "alias-set-ambiguous",
+    mutate(input) {
+      input.priorStates.governance.states[1].aliases = [
+        "governance.mento.org",
+        "governancementoorg-mentolabs.vercel.app",
+        "unexpected.vercel.app",
+      ];
+    },
+  },
+  {
+    name: "wrong project ID",
+    target: "app",
+    code: "project-identity-ambiguous",
+    mutate(input) {
+      input.priorStates.app.states[0].projectId = "prj_wrong123";
+    },
+  },
+  {
+    name: "conflicting project name",
+    target: "reserve",
+    code: "project-identity-ambiguous",
+    mutate(input) {
+      input.priorStates.reserve.states[1].projectName = "other-project";
+    },
+  },
+  {
+    name: "wrong production environment",
+    target: "ui",
+    code: "environment-identity-ambiguous",
+    mutate(input) {
+      input.priorStates.ui.states[0].target = "preview";
+    },
+  },
+  {
+    name: "wrong app custom environment",
+    target: "app",
+    code: "environment-identity-ambiguous",
+    mutate(input) {
+      input.priorStates.app.states[1].customEnvironmentSlug = "preview";
+    },
+  },
+  {
+    name: "non-ready deployment",
+    target: "governance",
+    code: "prior-readiness-ambiguous",
+    mutate(input) {
+      input.priorStates.governance.states[0].readyState = "BUILDING";
+    },
+  },
+  {
+    name: "failed public health",
+    target: "reserve",
+    code: "prior-health-ambiguous",
+    mutate(input) {
+      input.priorStates.reserve.health = "failed";
+    },
+  },
+  {
+    name: "conflicting rollback deployment ID",
+    target: "ui",
+    code: "rollback-target-ambiguous",
+    mutate(input) {
+      input.priorStates.ui.states[1].deploymentId = "dpl_other123";
+    },
+  },
+  {
+    name: "conflicting rollback deployment URL",
+    target: "app",
+    code: "rollback-target-ambiguous",
+    mutate(input) {
+      input.priorStates.app.states[1].deploymentUrl =
+        "https://other-app.vercel.app";
+    },
+  },
+  {
+    name: "malformed rollback deployment ID",
+    target: "governance",
+    code: "rollback-target-ambiguous",
+    mutate(input) {
+      input.priorStates.governance.states[0].deploymentId = "latest";
+    },
+  },
+  {
+    name: "non-Vercel rollback URL",
+    target: "reserve",
+    code: "rollback-target-ambiguous",
+    mutate(input) {
+      input.priorStates.reserve.states[0].deploymentUrl =
+        "https://reserve.mento.org";
+    },
+  },
+  {
+    name: "raw Vercel field",
+    target: "ui",
+    code: "prior-state-forbidden-fields",
+    mutate(input) {
+      input.priorStates.ui.states[0].protectionBypass = "secret-must-not-cross";
+    },
+  },
+];
+
+for (const scenario of activationAmbiguities) {
+  test(`activation-state ambiguity aborts before planning: ${scenario.name}`, () => {
+    const input = fixture();
+    let gitCalled = false;
+    let plannerCalled = false;
+    const gitAdapter = {
+      firstParent() {
+        gitCalled = true;
+      },
+      isAncestor() {
+        gitCalled = true;
+      },
+      resolveCommit(value) {
+        gitCalled = true;
+        return value;
+      },
+    };
+    scenario.mutate(input);
+    assertActivationError(
+      () =>
+        planMainDeployments({
+          mode: input.mode,
+          deploySha: input.deploySha,
+          projectIds: input.projectIds,
+          priorStates: input.priorStates,
+          gitAdapter,
+          runPlanner: () => {
+            plannerCalled = true;
+          },
+        }),
+      scenario.target,
+      scenario.code,
+    );
+    assert.equal(plannerCalled, false);
+    assert.equal(
+      gitCalled,
+      true,
+      "only immutable DEPLOY_SHA resolution may precede state validation",
+    );
+  });
+}
+
+test("invalid global input fails before any served-range planning", () => {
+  const input = fixture();
+  for (const override of [
+    { mode: "preview" },
+    { deploySha: "main" },
+    {
+      projectIds: {
+        app: "prj_app123",
+        governance: "prj_governance123",
+        reserve: "prj_reserve123",
+      },
+    },
+  ]) {
+    assert.throws(() =>
+      planMainDeployments({
+        mode: input.mode,
+        deploySha: input.deploySha,
+        projectIds: input.projectIds,
+        priorStates: input.priorStates,
+        gitAdapter: createGitFixture(input).adapter,
+        runPlanner: () => assert.fail("planner must remain inert"),
+        ...override,
+      }),
+    );
+  }
+});
+
+test("DEPLOY_SHA resolution failure aborts globally", () => {
+  const input = fixture();
+  const git = createGitFixture(input, {
+    unresolvable: [input.deploySha],
+  });
+  assert.throws(
+    () => runFixture(input, { git }),
+    /DEPLOY_SHA cannot be resolved/,
+  );
+});
+
+test("the default Git adapter uses immutable rev-parse and ancestry commands", () => {
+  const calls = [];
+  const head = "d".repeat(40);
+  const parent = "c".repeat(40);
+  const adapter = createMainPlanGitAdapter({
+    repoRoot: "/trusted/repository",
+    spawn(command, argumentsList, options) {
+      calls.push({ command, argumentsList, options });
+      if (argumentsList[0] === "merge-base") {
+        return { status: 0, stdout: "" };
+      }
+      return {
+        status: 0,
+        stdout: `${argumentsList[2].includes("^1") ? parent : head}\n`,
+      };
+    },
+  });
+  assert.equal(adapter.resolveCommit(head), head);
+  assert.equal(adapter.isAncestor(parent, head), true);
+  assert.equal(adapter.firstParent(head), parent);
+  assert.deepEqual(
+    calls.map(({ command, argumentsList }) => [command, ...argumentsList]),
+    [
+      ["git", "rev-parse", "--verify", `${head}^{commit}`],
+      ["git", "merge-base", "--is-ancestor", parent, head],
+      ["git", "rev-parse", "--verify", `${head}^1^{commit}`],
+    ],
+  );
+  assert.ok(
+    calls.every(({ options }) => options.cwd === "/trusted/repository"),
+  );
+});
+
+test("canonical output validation rejects appended machine or provider fields", () => {
+  const input = fixture();
+  input.mode = "active";
+  const { plan } = runFixture(input);
+  assert.equal(assertMainDeploymentPlan(plan), plan);
+  assert.throws(
+    () =>
+      assertMainDeploymentPlan({
+        ...plan,
+        rawVercelResponse: { token: "must-not-cross" },
+      }),
+    /forbidden fields/,
+  );
+  assert.throws(
+    () =>
+      assertMainDeploymentPlan({
+        ...plan,
+        priors: [
+          { ...plan.priors[0], protectionBypass: "must-not-cross" },
+          ...plan.priors.slice(1),
+        ],
+      }),
+    /forbidden fields/,
+  );
+});
+
+test("the same canonical evidence produces byte-identical JSON", () => {
+  const input = fixture();
+  input.mode = "active";
+  const first = runFixture(structuredClone(input)).plan;
+  const second = runFixture(structuredClone(input)).plan;
+  assert.equal(JSON.stringify(first), JSON.stringify(second));
+});

--- a/scripts/vercel-main-plan.test.mjs
+++ b/scripts/vercel-main-plan.test.mjs
@@ -651,7 +651,9 @@ const activationAmbiguities = [
     target: "reserve",
     code: "alias-set-ambiguous",
     mutate(input) {
-      input.priorStates.reserve.states[1].alias = "reserve.mento.org";
+      input.priorStates.reserve.states.push(
+        structuredClone(input.priorStates.reserve.states[0]),
+      );
     },
   },
   {
@@ -659,18 +661,17 @@ const activationAmbiguities = [
     target: "ui",
     code: "alias-set-ambiguous",
     mutate(input) {
-      input.priorStates.ui.states[1].alias = "unexpected.vercel.app";
+      input.priorStates.ui.states[0].alias = "unexpected.vercel.app";
     },
   },
   {
-    name: "deployment alias disagreement",
+    name: "malformed deployment alias set",
     target: "governance",
     code: "alias-set-ambiguous",
     mutate(input) {
-      input.priorStates.governance.states[1].aliases = [
+      input.priorStates.governance.states[0].aliases = [
         "governance.mento.org",
-        "governancementoorg-mentolabs.vercel.app",
-        "unexpected.vercel.app",
+        "governance.mento.org",
       ];
     },
   },
@@ -687,7 +688,7 @@ const activationAmbiguities = [
     target: "reserve",
     code: "project-identity-ambiguous",
     mutate(input) {
-      input.priorStates.reserve.states[1].projectName = "other-project";
+      input.priorStates.reserve.states[0].projectName = "other-project";
     },
   },
   {
@@ -724,10 +725,10 @@ const activationAmbiguities = [
   },
   {
     name: "conflicting rollback deployment ID",
-    target: "ui",
+    target: "app",
     code: "rollback-target-ambiguous",
     mutate(input) {
-      input.priorStates.ui.states[1].deploymentId = "dpl_other123";
+      input.priorStates.app.states[1].deploymentId = "dpl_other123";
     },
   },
   {

--- a/scripts/vercel-main-runtime.mjs
+++ b/scripts/vercel-main-runtime.mjs
@@ -1,0 +1,536 @@
+#!/usr/bin/env node
+
+import { appendFileSync } from "node:fs";
+import process from "node:process";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { loadTrustedChromium } from "./vercel-preview-browser-smoke.mjs";
+
+const SHA_PATTERN = /^[0-9a-f]{40}$/;
+const MAXIMUM_FAILURES = 100;
+const CRITICAL_RESOURCE_TYPES = new Set([
+  "document",
+  "fetch",
+  "font",
+  "script",
+  "stylesheet",
+  "xhr",
+]);
+const REQUIRED_RESOURCE_TYPES = ["document", "font", "script", "stylesheet"];
+
+export const MAIN_RUNTIME_TARGETS = Object.freeze({
+  app: Object.freeze({
+    publicUrl: "https://app.mento.org/",
+    landingPath: "/",
+    finalPath: "/",
+    interaction: "real-production-wallet-list",
+  }),
+  governance: Object.freeze({
+    publicUrl: "https://governance.mento.org/",
+    landingPath: "/",
+    finalPath: "/voting-power",
+    interaction: "governance-voting-power-navigation",
+  }),
+  reserve: Object.freeze({
+    publicUrl: "https://reserve.mento.org/",
+    landingPath: "/",
+    finalPath: "/",
+    interaction: "reserve-overview-data-and-supply-tab",
+  }),
+  ui: Object.freeze({
+    publicUrl: "https://ui.mento.org/",
+    landingPath: "/basic-components",
+    finalPath: "/form-components",
+    interaction: "ui-search-navigation-and-checkbox",
+  }),
+});
+
+function invariant(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+function boundedText(value, label, maximum = 2_048) {
+  invariant(
+    typeof value === "string" &&
+      value.length > 0 &&
+      value.length <= maximum &&
+      ![...value].some((character) => {
+        const codePoint = character.codePointAt(0);
+        return codePoint <= 31 || codePoint === 127;
+      }),
+    `${label} is missing or invalid`,
+  );
+  return value;
+}
+
+function concise(value) {
+  return String(value).replaceAll(/\s+/g, " ").trim().slice(0, 500);
+}
+
+function sameOrigin(value, expectedOrigin) {
+  try {
+    return new URL(value).origin === expectedOrigin;
+  } catch {
+    return false;
+  }
+}
+
+function exactTarget(value) {
+  const target = boundedText(value, "Main runtime target", 32);
+  invariant(
+    Object.hasOwn(MAIN_RUNTIME_TARGETS, target),
+    "Main runtime target must be app, governance, reserve, or ui",
+  );
+  return target;
+}
+
+function exactPublicUrl(value, target) {
+  const expected = MAIN_RUNTIME_TARGETS[target].publicUrl;
+  invariant(value === expected, `${target} public URL mismatch`);
+  return expected;
+}
+
+function exactSha(value) {
+  invariant(
+    typeof value === "string" && SHA_PATTERN.test(value),
+    "Main runtime SHA must be an immutable lowercase 40-character SHA",
+  );
+  return value;
+}
+
+export function validateMainRuntimeInput(values) {
+  invariant(
+    values !== null && typeof values === "object" && !Array.isArray(values),
+    "Main runtime input must be an object",
+  );
+  const logicalTarget = exactTarget(values.logicalTarget);
+  return Object.freeze({
+    deploySha: exactSha(values.deploySha),
+    logicalTarget,
+    publicUrl: exactPublicUrl(values.publicUrl, logicalTarget),
+  });
+}
+
+export function assertMainRuntimeSecurityHeaders(headers, expectedSha) {
+  invariant(
+    headers !== null && typeof headers === "object" && !Array.isArray(headers),
+    "Main runtime response headers are malformed",
+  );
+  const required = {
+    "content-security-policy": "frame-ancestors 'none'",
+    "x-frame-options": "DENY",
+    "x-content-type-options": "nosniff",
+    "referrer-policy": "strict-origin-when-cross-origin",
+    "permissions-policy": "camera=(), microphone=(), geolocation=()",
+    "x-mento-deployment-sha": exactSha(expectedSha),
+  };
+  for (const [name, expected] of Object.entries(required)) {
+    invariant(headers[name] === expected, `Main runtime ${name} mismatch`);
+  }
+  invariant(
+    typeof headers["content-security-policy-report-only"] === "string" &&
+      headers["content-security-policy-report-only"].length > 0,
+    "Main runtime content-security-policy-report-only is missing",
+  );
+  return true;
+}
+
+function expectedNextNavigationAbort(request, expectedOrigin) {
+  try {
+    const url = new URL(request.url());
+    const resourceType = request.resourceType();
+    return (
+      url.origin === expectedOrigin &&
+      url.searchParams.has("_rsc") &&
+      request.failure()?.errorText === "net::ERR_ABORTED" &&
+      (resourceType === "fetch" || resourceType === "xhr")
+    );
+  } catch {
+    return false;
+  }
+}
+
+export function createMainRuntimeMonitor(page, expectedOrigin) {
+  const failures = [];
+  const successfulResources = {
+    document: 0,
+    fetch: 0,
+    font: 0,
+    script: 0,
+    stylesheet: 0,
+    xhr: 0,
+  };
+  const record = (message) => {
+    if (failures.length < MAXIMUM_FAILURES) failures.push(message);
+  };
+
+  page.on("pageerror", (error) => {
+    record(`page error: ${concise(error?.message ?? error)}`);
+  });
+  page.on("console", (message) => {
+    if (message.type() !== "error") return;
+    const location = message.location?.();
+    const suffix = location?.url ? ` (${concise(location.url)})` : "";
+    record(`console error: ${concise(message.text())}${suffix}`);
+  });
+  page.on("framenavigated", (frame) => {
+    if (frame !== page.mainFrame() || frame.url() === "about:blank") return;
+    if (!sameOrigin(frame.url(), expectedOrigin)) {
+      record(`main frame left expected origin: ${concise(frame.url())}`);
+    }
+  });
+  page.on("requestfailed", (request) => {
+    if (!sameOrigin(request.url(), expectedOrigin)) return;
+    const resourceType = request.resourceType();
+    if (!CRITICAL_RESOURCE_TYPES.has(resourceType)) return;
+    if (expectedNextNavigationAbort(request, expectedOrigin)) return;
+    record(
+      `same-origin ${resourceType} request failed: ${concise(
+        request.method(),
+      )} ${concise(request.url())} (${concise(
+        request.failure()?.errorText ?? "unknown error",
+      )})`,
+    );
+  });
+  page.on("response", (response) => {
+    if (!sameOrigin(response.url(), expectedOrigin)) return;
+    const resourceType = response.request().resourceType();
+    if (!CRITICAL_RESOURCE_TYPES.has(resourceType)) return;
+    if (response.status() >= 400) {
+      record(
+        `same-origin ${resourceType} response failed: HTTP ${response.status()} ${concise(
+          response.url(),
+        )}`,
+      );
+      return;
+    }
+    if (response.status() >= 200 && response.status() < 300) {
+      successfulResources[resourceType] += 1;
+    }
+  });
+
+  return {
+    failures,
+    successfulResources,
+    assertClean() {
+      if (failures.length > 0) {
+        throw new Error(
+          `Main runtime smoke observed failures:\n- ${failures.join("\n- ")}`,
+        );
+      }
+      for (const resourceType of REQUIRED_RESOURCE_TYPES) {
+        invariant(
+          successfulResources[resourceType] > 0,
+          `Main runtime smoke observed no successful same-origin ${resourceType}`,
+        );
+      }
+    },
+  };
+}
+
+export function productionWalletFlagsAreAbsent({
+  storage = window.localStorage,
+} = {}) {
+  return [
+    "mento_e2e_wallet",
+    "mento_e2e_eager_connect",
+    "mento_use_fork",
+  ].every((name) => storage.getItem(name) === null);
+}
+
+export function reserveSupplyStateMatches({
+  currentHref = window.location.href,
+  expectedOrigin,
+  selectedTabLabel = document
+    .querySelector('[role="tab"][aria-selected="true"]')
+    ?.textContent?.trim(),
+}) {
+  try {
+    const current = new URL(currentHref);
+    return (
+      current.origin === expectedOrigin &&
+      current.pathname === "/" &&
+      current.searchParams.size === 1 &&
+      current.searchParams.get("tab") === "stablecoins" &&
+      selectedTabLabel === "Supply"
+    );
+  } catch {
+    return false;
+  }
+}
+
+export function uiCheckboxStateMatches({
+  checkbox = document.querySelector("#checkbox-demo"),
+} = {}) {
+  return (
+    checkbox?.getAttribute("aria-checked") === "true" &&
+    checkbox?.getAttribute("data-state") === "checked"
+  );
+}
+
+function reserveSupplyState(expectedOrigin) {
+  return { expectedOrigin };
+}
+
+async function assertProductionWalletFlagsAbsent(page) {
+  invariant(
+    await page.evaluate(productionWalletFlagsAreAbsent),
+    "App public smoke detected preview or mock-wallet browser flags",
+  );
+}
+
+async function interactWithApp(page) {
+  await assertProductionWalletFlagsAbsent(page);
+  const connectButton = page
+    .getByRole("banner")
+    .getByRole("button", { name: "Connect" })
+    .filter({ visible: true });
+  await connectButton.waitFor({ state: "visible" });
+  await connectButton.click();
+  await page.getByText("MetaMask").waitFor({ state: "visible" });
+  await page.getByText("WalletConnect").waitFor({ state: "visible" });
+  invariant(
+    (await page.getByText("E2E Test Wallet").count()) === 0,
+    "App public smoke rendered the preview-only E2E Test Wallet",
+  );
+  await assertProductionWalletFlagsAbsent(page);
+}
+
+async function interactWithGovernance(page, origin) {
+  await page
+    .getByRole("heading", { name: "Mento Governance", exact: true })
+    .waitFor({ state: "visible" });
+  await page
+    .getByRole("link", { name: "My Voting Power", exact: true })
+    .click();
+  await page.waitForURL(new URL("/voting-power", origin).toString());
+  await page
+    .getByRole("heading", { name: "Your voting power", exact: true })
+    .waitFor({ state: "visible" });
+}
+
+async function interactWithReserve(page, origin) {
+  const overview = page.getByRole("tab", { name: "Overview", exact: true });
+  await overview.waitFor({ state: "visible" });
+  invariant(
+    (await overview.getAttribute("aria-selected")) === "true",
+    "Reserve Overview tab was not initially selected",
+  );
+  await page
+    .getByText("Supply Breakdown", { exact: true })
+    .waitFor({ state: "visible" });
+  const supply = page.getByRole("tab", { name: "Supply", exact: true });
+  await supply.click();
+  await page.waitForFunction(
+    reserveSupplyStateMatches,
+    reserveSupplyState(origin),
+  );
+  invariant(
+    reserveSupplyStateMatches({
+      currentHref: page.url(),
+      expectedOrigin: origin,
+      selectedTabLabel: await supply.textContent(),
+    }),
+    "Reserve Supply tab state did not persist",
+  );
+}
+
+async function interactWithUi(page, origin) {
+  await page
+    .getByRole("heading", { name: "Basic Components", exact: true })
+    .waitFor({ state: "visible" });
+  await page
+    .getByPlaceholder("Search components...", { exact: true })
+    .fill("Textarea");
+  await page.getByRole("link", { name: "Textarea", exact: true }).click();
+  await page.waitForURL(new URL("/form-components", origin).toString(), {
+    waitUntil: "domcontentloaded",
+  });
+  await page
+    .getByRole("heading", { name: "Form Components", exact: true })
+    .waitFor({ state: "visible" });
+  const checkbox = page.getByRole("checkbox", {
+    name: "Checkbox option",
+    exact: true,
+  });
+  await checkbox.waitFor({ state: "visible" });
+  await checkbox.click();
+  await page.waitForFunction(uiCheckboxStateMatches);
+  invariant(
+    await checkbox.isChecked(),
+    "UI public smoke checkbox interaction did not update",
+  );
+}
+
+async function runTargetInteraction(page, target, origin) {
+  if (target === "app") return interactWithApp(page);
+  if (target === "governance") return interactWithGovernance(page, origin);
+  if (target === "reserve") return interactWithReserve(page, origin);
+  return interactWithUi(page, origin);
+}
+
+function assertExactPageLocation(page, expectedUrl, label) {
+  const actual = new URL(page.url());
+  invariant(
+    actual.origin === expectedUrl.origin &&
+      actual.pathname === expectedUrl.pathname &&
+      actual.search === expectedUrl.search &&
+      actual.hash === "",
+    `${label} mismatch`,
+  );
+}
+
+export async function runMainRuntimeSmoke({
+  chromium,
+  values,
+  timeoutMs = 30_000,
+  browserChannel = "bundled",
+}) {
+  const input = validateMainRuntimeInput(values);
+  invariant(
+    browserChannel === "bundled" || browserChannel === "chrome",
+    "Main runtime browser channel must be bundled or chrome",
+  );
+  invariant(
+    Number.isSafeInteger(timeoutMs) &&
+      timeoutMs >= 1_000 &&
+      timeoutMs <= 120_000,
+    "Main runtime browser timeout is outside its bounded policy",
+  );
+  const config = MAIN_RUNTIME_TARGETS[input.logicalTarget];
+  const publicUrl = new URL(input.publicUrl);
+  const browser = await chromium.launch({
+    ...(browserChannel === "chrome" ? { channel: "chrome" } : {}),
+    headless: true,
+  });
+
+  try {
+    const context = await browser.newContext({ colorScheme: "dark" });
+    const page = await context.newPage();
+    page.setDefaultTimeout(timeoutMs);
+    page.setDefaultNavigationTimeout(timeoutMs);
+    const monitor = createMainRuntimeMonitor(page, publicUrl.origin);
+    const response = await page.goto(publicUrl.toString(), {
+      waitUntil: "domcontentloaded",
+    });
+    invariant(
+      response && response.ok(),
+      `Main runtime navigation failed with HTTP ${response?.status() ?? "unknown"}`,
+    );
+    assertExactPageLocation(
+      page,
+      new URL(config.landingPath, publicUrl),
+      `${input.logicalTarget} public landing URL`,
+    );
+    assertMainRuntimeSecurityHeaders(response.headers(), input.deploySha);
+
+    await page.waitForLoadState("load");
+    await runTargetInteraction(page, input.logicalTarget, publicUrl.origin);
+    await page.waitForTimeout(500);
+    const expectedFinalUrl = new URL(config.finalPath, publicUrl);
+    if (input.logicalTarget === "reserve") {
+      expectedFinalUrl.searchParams.set("tab", "stablecoins");
+    }
+    assertExactPageLocation(
+      page,
+      expectedFinalUrl,
+      `${input.logicalTarget} public interaction URL`,
+    );
+    if (input.logicalTarget === "reserve") {
+      invariant(
+        await page.evaluate(
+          reserveSupplyStateMatches,
+          reserveSupplyState(publicUrl.origin),
+        ),
+        "Reserve Supply tab state changed after interaction settle",
+      );
+    }
+    monitor.assertClean();
+
+    return Object.freeze({
+      deploy_sha: input.deploySha,
+      final_url: expectedFinalUrl.toString(),
+      interaction: config.interaction,
+      logical_target: input.logicalTarget,
+      public_url: input.publicUrl,
+      successful_documents: monitor.successfulResources.document,
+      successful_fonts: monitor.successfulResources.font,
+      successful_scripts: monitor.successfulResources.script,
+      successful_stylesheets: monitor.successfulResources.stylesheet,
+    });
+  } finally {
+    await browser.close();
+  }
+}
+
+function valuesFromEnvironment(environment) {
+  return {
+    deploySha: environment.DEPLOY_SHA,
+    logicalTarget: environment.LOGICAL_TARGET,
+    publicUrl: environment.PUBLIC_URL,
+  };
+}
+
+function appendOutputs(path, result) {
+  for (const [name, value] of Object.entries(result)) {
+    appendFileSync(path, `${name}=${value}\n`);
+  }
+}
+
+export function formatMainRuntimeSummary(result) {
+  return [
+    `### ${result.logical_target} public runtime verification`,
+    "",
+    `- Public URL: ${result.public_url}`,
+    `- Final URL: ${result.final_url}`,
+    `- DEPLOY_SHA: \`${result.deploy_sha}\``,
+    `- Interaction: \`${result.interaction}\``,
+    `- Successful same-origin resources: documents=${result.successful_documents}, scripts=${result.successful_scripts}, stylesheets=${result.successful_stylesheets}, fonts=${result.successful_fonts}`,
+    "",
+  ].join("\n");
+}
+
+export async function runMainRuntimeSmokeFromEnvironment({
+  environment = process.env,
+  controllerRoot = fileURLToPath(new URL("../", import.meta.url)),
+  chromium,
+} = {}) {
+  const result = await runMainRuntimeSmoke({
+    chromium: chromium ?? (await loadTrustedChromium(controllerRoot)),
+    values: valuesFromEnvironment(environment),
+    browserChannel: environment.PLAYWRIGHT_BROWSER_CHANNEL ?? "bundled",
+  });
+  if (environment.GITHUB_OUTPUT) {
+    appendOutputs(
+      boundedText(environment.GITHUB_OUTPUT, "GITHUB_OUTPUT", 4_096),
+      result,
+    );
+  }
+  if (environment.GITHUB_STEP_SUMMARY) {
+    appendFileSync(
+      boundedText(
+        environment.GITHUB_STEP_SUMMARY,
+        "GITHUB_STEP_SUMMARY",
+        4_096,
+      ),
+      formatMainRuntimeSummary(result),
+    );
+  }
+  return result;
+}
+
+function isCliEntrypoint() {
+  return (
+    process.argv[1] !== undefined &&
+    fileURLToPath(import.meta.url) === resolve(process.argv[1])
+  );
+}
+
+if (isCliEntrypoint()) {
+  if (process.argv.length !== 2) {
+    throw new Error("Usage: vercel-main-runtime.mjs");
+  }
+  const result = await runMainRuntimeSmokeFromEnvironment();
+  process.stdout.write(`${JSON.stringify(result)}\n`);
+}

--- a/scripts/vercel-main-runtime.mjs
+++ b/scripts/vercel-main-runtime.mjs
@@ -17,6 +17,7 @@ const CRITICAL_RESOURCE_TYPES = new Set([
   "stylesheet",
   "xhr",
 ]);
+const SAME_ORIGIN_ONLY_RESOURCE_TYPES = new Set(["fetch", "xhr"]);
 const REQUIRED_RESOURCE_TYPES = ["document", "font", "script", "stylesheet"];
 
 export const MAIN_RUNTIME_TARGETS = Object.freeze({
@@ -151,6 +152,38 @@ function expectedNextNavigationAbort(request, expectedOrigin) {
   }
 }
 
+function isOptionalTelemetryUrl(value, expectedOrigin) {
+  try {
+    const url = new URL(value);
+    return (
+      url.origin === expectedOrigin &&
+      url.pathname === "/monitoring" &&
+      url.hash === ""
+    );
+  } catch {
+    return false;
+  }
+}
+
+function expectedOptionalTelemetryFailure(request, expectedOrigin) {
+  const resourceType = request.resourceType();
+  return (
+    SAME_ORIGIN_ONLY_RESOURCE_TYPES.has(resourceType) &&
+    request.method() === "POST" &&
+    isOptionalTelemetryUrl(request.url(), expectedOrigin)
+  );
+}
+
+function expectedOptionalTelemetryConsoleError(message, expectedOrigin) {
+  const location = message.location?.();
+  return (
+    isOptionalTelemetryUrl(location?.url, expectedOrigin) &&
+    /^Failed to load resource: the server responded with a status of [45][0-9]{2} \(\)$/.test(
+      message.text(),
+    )
+  );
+}
+
 export function createMainRuntimeMonitor(page, expectedOrigin) {
   const failures = [];
   const successfulResources = {
@@ -170,6 +203,7 @@ export function createMainRuntimeMonitor(page, expectedOrigin) {
   });
   page.on("console", (message) => {
     if (message.type() !== "error") return;
+    if (expectedOptionalTelemetryConsoleError(message, expectedOrigin)) return;
     const location = message.location?.();
     const suffix = location?.url ? ` (${concise(location.url)})` : "";
     record(`console error: ${concise(message.text())}${suffix}`);
@@ -181,12 +215,19 @@ export function createMainRuntimeMonitor(page, expectedOrigin) {
     }
   });
   page.on("requestfailed", (request) => {
-    if (!sameOrigin(request.url(), expectedOrigin)) return;
     const resourceType = request.resourceType();
     if (!CRITICAL_RESOURCE_TYPES.has(resourceType)) return;
+    const requestIsSameOrigin = sameOrigin(request.url(), expectedOrigin);
+    if (
+      SAME_ORIGIN_ONLY_RESOURCE_TYPES.has(resourceType) &&
+      !requestIsSameOrigin
+    ) {
+      return;
+    }
+    if (expectedOptionalTelemetryFailure(request, expectedOrigin)) return;
     if (expectedNextNavigationAbort(request, expectedOrigin)) return;
     record(
-      `same-origin ${resourceType} request failed: ${concise(
+      `${requestIsSameOrigin ? "same-origin" : "cross-origin"} ${resourceType} request failed: ${concise(
         request.method(),
       )} ${concise(request.url())} (${concise(
         request.failure()?.errorText ?? "unknown error",
@@ -194,18 +235,30 @@ export function createMainRuntimeMonitor(page, expectedOrigin) {
     );
   });
   page.on("response", (response) => {
-    if (!sameOrigin(response.url(), expectedOrigin)) return;
-    const resourceType = response.request().resourceType();
+    const request = response.request();
+    const resourceType = request.resourceType();
     if (!CRITICAL_RESOURCE_TYPES.has(resourceType)) return;
+    const responseIsSameOrigin = sameOrigin(response.url(), expectedOrigin);
+    if (
+      SAME_ORIGIN_ONLY_RESOURCE_TYPES.has(resourceType) &&
+      !responseIsSameOrigin
+    ) {
+      return;
+    }
+    if (expectedOptionalTelemetryFailure(request, expectedOrigin)) return;
     if (response.status() >= 400) {
       record(
-        `same-origin ${resourceType} response failed: HTTP ${response.status()} ${concise(
+        `${responseIsSameOrigin ? "same-origin" : "cross-origin"} ${resourceType} response failed: HTTP ${response.status()} ${concise(
           response.url(),
         )}`,
       );
       return;
     }
-    if (response.status() >= 200 && response.status() < 300) {
+    if (
+      responseIsSameOrigin &&
+      response.status() >= 200 &&
+      response.status() < 300
+    ) {
       successfulResources[resourceType] += 1;
     }
   });

--- a/scripts/vercel-main-runtime.test.mjs
+++ b/scripts/vercel-main-runtime.test.mjs
@@ -451,11 +451,21 @@ function barePage(origin) {
   return { frame, page };
 }
 
-function emitResponse(page, origin, resourceType, status = 200) {
+function emitResponse(
+  page,
+  origin,
+  resourceType,
+  status = 200,
+  { method = "GET", path = `/asset-${resourceType}` } = {},
+) {
   page.emit("response", {
-    request: () => ({ resourceType: () => resourceType }),
+    request: () => ({
+      method: () => method,
+      resourceType: () => resourceType,
+      url: () => new URL(path, origin).toString(),
+    }),
     status: () => status,
-    url: () => `${origin}/asset-${resourceType}`,
+    url: () => new URL(path, origin).toString(),
   });
 }
 
@@ -497,7 +507,28 @@ test("monitor fails on page, console, origin, request, and response errors", () 
   );
 });
 
-test("monitor ignores only unrelated traffic and superseded same-origin RSC aborts", () => {
+test("monitor rejects failed critical static resources from any origin", () => {
+  const origin = "https://app.mento.org";
+  const { page } = barePage(origin);
+  const monitor = createMainRuntimeMonitor(page, origin);
+  primeRequiredResources(page, origin);
+  page.emit("requestfailed", {
+    failure: () => ({ errorText: "net::ERR_FAILED" }),
+    method: () => "GET",
+    resourceType: () => "script",
+    url: () => "https://cdn.example/app.js",
+  });
+  emitResponse(page, "https://fonts.example", "font", 503);
+
+  assert.throws(
+    () => monitor.assertClean(),
+    (error) =>
+      error.message.includes("cross-origin script request failed") &&
+      error.message.includes("cross-origin font response failed"),
+  );
+});
+
+test("monitor ignores only optional traffic and superseded same-origin RSC aborts", () => {
   const origin = "https://reserve.mento.org";
   const { page } = barePage(origin);
   const monitor = createMainRuntimeMonitor(page, origin);
@@ -517,9 +548,10 @@ test("monitor ignores only unrelated traffic and superseded same-origin RSC abor
   page.emit("requestfailed", {
     failure: () => ({ errorText: "net::ERR_FAILED" }),
     method: () => "GET",
-    resourceType: () => "script",
-    url: () => "https://third-party.example/script.js",
+    resourceType: () => "fetch",
+    url: () => "https://third-party.example/optional-data",
   });
+  emitResponse(page, "https://third-party.example", "xhr", 503);
   assert.doesNotThrow(() => monitor.assertClean());
 
   page.emit("requestfailed", {
@@ -529,6 +561,73 @@ test("monitor ignores only unrelated traffic and superseded same-origin RSC abor
     url: () => `${origin}/_next/static/app.js`,
   });
   assert.throws(() => monitor.assertClean(), /script request failed/);
+});
+
+test("monitor narrowly ignores the exact same-origin Sentry tunnel failure", () => {
+  const origin = "https://reserve.mento.org";
+  const { page } = barePage(origin);
+  const monitor = createMainRuntimeMonitor(page, origin);
+  primeRequiredResources(page, origin);
+  const monitoringUrl = `${origin}/monitoring?o=123&p=456&r=us`;
+  page.emit("requestfailed", {
+    failure: () => ({ errorText: "net::ERR_FAILED" }),
+    method: () => "POST",
+    resourceType: () => "fetch",
+    url: () => monitoringUrl,
+  });
+  emitResponse(page, origin, "xhr", 429, {
+    method: "POST",
+    path: "/monitoring?o=123&p=456&r=us",
+  });
+  page.emit("console", {
+    location: () => ({ url: monitoringUrl }),
+    text: () =>
+      "Failed to load resource: the server responded with a status of 429 ()",
+    type: () => "error",
+  });
+
+  assert.doesNotThrow(() => monitor.assertClean());
+});
+
+test("monitor rejects every near miss around the optional telemetry exception", () => {
+  const origin = "https://reserve.mento.org";
+  const { page } = barePage(origin);
+  const monitor = createMainRuntimeMonitor(page, origin);
+  primeRequiredResources(page, origin);
+  page.emit("requestfailed", {
+    failure: () => ({ errorText: "net::ERR_FAILED" }),
+    method: () => "GET",
+    resourceType: () => "fetch",
+    url: () => `${origin}/monitoring`,
+  });
+  page.emit("requestfailed", {
+    failure: () => ({ errorText: "net::ERR_FAILED" }),
+    method: () => "POST",
+    resourceType: () => "xhr",
+    url: () => `${origin}/monitoring/other`,
+  });
+  page.emit("console", {
+    location: () => ({ url: `${origin}/another-path` }),
+    text: () =>
+      "Failed to load resource: the server responded with a status of 429 ()",
+    type: () => "error",
+  });
+  page.emit("console", {
+    location: () => ({ url: `${origin}/monitoring` }),
+    text: () => "Sentry application error",
+    type: () => "error",
+  });
+
+  assert.throws(
+    () => monitor.assertClean(),
+    (error) =>
+      error.message.includes("GET https://reserve.mento.org/monitoring") &&
+      error.message.includes(
+        "POST https://reserve.mento.org/monitoring/other",
+      ) &&
+      error.message.includes("another-path") &&
+      error.message.includes("Sentry application error"),
+  );
 });
 
 test("monitor requires successful same-origin documents, scripts, styles, and fonts", async () => {

--- a/scripts/vercel-main-runtime.test.mjs
+++ b/scripts/vercel-main-runtime.test.mjs
@@ -1,0 +1,646 @@
+import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+
+import {
+  assertMainRuntimeSecurityHeaders,
+  createMainRuntimeMonitor,
+  formatMainRuntimeSummary,
+  MAIN_RUNTIME_TARGETS,
+  productionWalletFlagsAreAbsent,
+  reserveSupplyStateMatches,
+  runMainRuntimeSmoke,
+  runMainRuntimeSmokeFromEnvironment,
+  uiCheckboxStateMatches,
+  validateMainRuntimeInput,
+} from "./vercel-main-runtime.mjs";
+
+const SHA = "0123456789abcdef0123456789abcdef01234567";
+
+function securityHeaders(sha = SHA) {
+  return {
+    "content-security-policy": "frame-ancestors 'none'",
+    "content-security-policy-report-only": "default-src 'self'",
+    "permissions-policy": "camera=(), microphone=(), geolocation=()",
+    "referrer-policy": "strict-origin-when-cross-origin",
+    "x-content-type-options": "nosniff",
+    "x-frame-options": "DENY",
+    "x-mento-deployment-sha": sha,
+  };
+}
+
+function inputFor(target) {
+  return {
+    deploySha: SHA,
+    logicalTarget: target,
+    publicUrl: MAIN_RUNTIME_TARGETS[target].publicUrl,
+  };
+}
+
+class FakeLocator {
+  constructor(page, kind, name) {
+    this.page = page;
+    this.kind = kind;
+    this.name = name;
+  }
+
+  getByRole(role, options) {
+    assert.equal(this.kind, "banner");
+    return new FakeLocator(this.page, role, options.name);
+  }
+
+  filter(options) {
+    assert.deepEqual(options, { visible: true });
+    return this;
+  }
+
+  async waitFor(options) {
+    assert.deepEqual(options, { state: "visible" });
+    this.page.calls.push(["wait", this.kind, this.name]);
+    if (
+      (this.name === "MetaMask" || this.name === "WalletConnect") &&
+      !this.page.walletOpened
+    ) {
+      throw new Error(`${this.name} was not visible`);
+    }
+  }
+
+  async click() {
+    this.page.calls.push(["click", this.kind, this.name]);
+    if (this.kind === "button" && this.name === "Connect") {
+      this.page.walletOpened = true;
+      return;
+    }
+    if (this.kind === "link" && this.name === "My Voting Power") {
+      this.page.navigate("/voting-power");
+      return;
+    }
+    if (this.kind === "tab" && this.name === "Supply") {
+      this.page.supplySelected = true;
+      this.page.navigate("/?tab=stablecoins");
+      return;
+    }
+    if (this.kind === "link" && this.name === "Textarea") {
+      this.page.navigate("/form-components");
+      return;
+    }
+    if (this.kind === "checkbox" && this.name === "Checkbox option") {
+      this.page.checkboxChecked = true;
+      return;
+    }
+    throw new Error(`Unexpected click: ${this.kind}/${this.name}`);
+  }
+
+  async fill(value) {
+    assert.equal(this.kind, "placeholder");
+    assert.equal(this.name, "Search components...");
+    assert.equal(value, "Textarea");
+    this.page.searchValue = value;
+    this.page.calls.push(["fill", value]);
+  }
+
+  async getAttribute(attribute) {
+    assert.equal(attribute, "aria-selected");
+    if (this.name === "Overview") {
+      return this.page.supplySelected ? "false" : "true";
+    }
+    if (this.name === "Supply") {
+      return this.page.supplySelected ? "true" : "false";
+    }
+    throw new Error(`Unexpected attribute locator: ${this.name}`);
+  }
+
+  async textContent() {
+    return this.name;
+  }
+
+  async count() {
+    assert.equal(this.name, "E2E Test Wallet");
+    return this.page.mockWalletVisible ? 1 : 0;
+  }
+
+  async isChecked() {
+    assert.equal(this.name, "Checkbox option");
+    return this.page.checkboxChecked;
+  }
+}
+
+class FakePage extends EventEmitter {
+  constructor(
+    target,
+    {
+      afterInteraction,
+      headers = securityHeaders(),
+      mockWalletVisible = false,
+      omitResource,
+      walletFlagsAbsent = true,
+      wrongLanding,
+    } = {},
+  ) {
+    super();
+    this.target = target;
+    this.config = MAIN_RUNTIME_TARGETS[target];
+    this.afterInteraction = afterInteraction;
+    this.responseHeaders = headers;
+    this.mockWalletVisible = mockWalletVisible;
+    this.omitResource = omitResource;
+    this.walletFlagsAbsent = walletFlagsAbsent;
+    this.wrongLanding = wrongLanding;
+    this.currentUrl = this.config.publicUrl;
+    this.frame = { url: () => this.currentUrl };
+    this.calls = [];
+    this.walletOpened = false;
+    this.supplySelected = false;
+    this.checkboxChecked = false;
+  }
+
+  setDefaultTimeout(timeout) {
+    this.calls.push(["timeout", timeout]);
+  }
+
+  setDefaultNavigationTimeout(timeout) {
+    this.calls.push(["navigation-timeout", timeout]);
+  }
+
+  mainFrame() {
+    return this.frame;
+  }
+
+  response(path, resourceType, status = 200) {
+    const url = new URL(path, this.config.publicUrl).toString();
+    const request = {
+      failure: () => null,
+      method: () => "GET",
+      resourceType: () => resourceType,
+      url: () => url,
+    };
+    return {
+      headers: () => this.responseHeaders,
+      ok: () => status >= 200 && status < 400,
+      request: () => request,
+      status: () => status,
+      url: () => url,
+    };
+  }
+
+  navigate(path) {
+    this.currentUrl = new URL(path, this.config.publicUrl).toString();
+    this.emit("framenavigated", this.frame);
+    this.emit("response", this.response(`${path}?_rsc=fixture`, "fetch"));
+  }
+
+  async goto(url, options) {
+    assert.equal(url, this.config.publicUrl);
+    assert.deepEqual(options, { waitUntil: "domcontentloaded" });
+    const landingPath = this.wrongLanding ?? this.config.landingPath;
+    this.currentUrl = new URL(landingPath, url).toString();
+    this.emit("framenavigated", this.frame);
+    const documentResponse = this.response(landingPath, "document");
+    if (this.omitResource !== "document") {
+      this.emit("response", documentResponse);
+    }
+    const resources = {
+      font: "/_next/static/font.woff2",
+      script: "/_next/static/app.js",
+      stylesheet: "/_next/static/app.css",
+    };
+    for (const [type, path] of Object.entries(resources)) {
+      if (this.omitResource === type) continue;
+      this.emit("response", this.response(path, type));
+    }
+    return documentResponse;
+  }
+
+  url() {
+    return this.currentUrl;
+  }
+
+  async waitForLoadState(state) {
+    assert.equal(state, "load");
+    this.calls.push(["load"]);
+  }
+
+  async waitForTimeout(timeout) {
+    assert.equal(timeout, 500);
+    this.afterInteraction?.(this);
+    this.calls.push(["settle"]);
+  }
+
+  getByRole(role, options) {
+    if (role === "banner") return new FakeLocator(this, "banner", "");
+    return new FakeLocator(this, role, options.name);
+  }
+
+  getByText(name) {
+    return new FakeLocator(this, "text", name);
+  }
+
+  getByPlaceholder(name) {
+    return new FakeLocator(this, "placeholder", name);
+  }
+
+  async waitForURL(expected) {
+    const expectedUrl =
+      typeof expected === "string" ? expected : expected.toString();
+    assert.equal(this.currentUrl, expectedUrl);
+    this.calls.push(["wait-url", expectedUrl]);
+  }
+
+  async waitForFunction(predicate, argument) {
+    assert.equal(await this.evaluate(predicate, argument), true);
+    this.calls.push(["wait-function"]);
+  }
+
+  async evaluate(predicate, argument) {
+    if (predicate === productionWalletFlagsAreAbsent) {
+      return this.walletFlagsAbsent;
+    }
+    if (predicate === reserveSupplyStateMatches) {
+      return predicate({
+        ...argument,
+        currentHref: this.currentUrl,
+        selectedTabLabel: this.supplySelected ? "Supply" : "Overview",
+      });
+    }
+    if (predicate === uiCheckboxStateMatches) {
+      return this.checkboxChecked;
+    }
+    throw new Error("Unexpected page evaluator");
+  }
+}
+
+function fakeChromium(page) {
+  const state = {
+    closed: false,
+    contextOptions: null,
+    launchOptions: null,
+  };
+  return {
+    state,
+    chromium: {
+      async launch(options) {
+        state.launchOptions = options;
+        return {
+          async newContext(contextOptions) {
+            state.contextOptions = contextOptions;
+            return { newPage: async () => page };
+          },
+          async close() {
+            state.closed = true;
+          },
+        };
+      },
+    },
+  };
+}
+
+test("hard-binds each logical target to its literal public URL and SHA", () => {
+  for (const target of Object.keys(MAIN_RUNTIME_TARGETS)) {
+    assert.deepEqual(validateMainRuntimeInput(inputFor(target)), {
+      deploySha: SHA,
+      logicalTarget: target,
+      publicUrl: MAIN_RUNTIME_TARGETS[target].publicUrl,
+    });
+  }
+
+  for (const invalid of [
+    { ...inputFor("app"), logicalTarget: "unknown" },
+    { ...inputFor("app"), publicUrl: "https://example.com/" },
+    { ...inputFor("app"), publicUrl: "https://app.mento.org/path" },
+    { ...inputFor("app"), publicUrl: "http://app.mento.org/" },
+    { ...inputFor("app"), deploySha: "main" },
+    { ...inputFor("app"), deploySha: SHA.toUpperCase() },
+  ]) {
+    assert.throws(
+      () => validateMainRuntimeInput(invalid),
+      /target|public URL mismatch|immutable lowercase/,
+    );
+  }
+});
+
+test("requires the exact deployment SHA and complete security-header contract", () => {
+  assert.equal(assertMainRuntimeSecurityHeaders(securityHeaders(), SHA), true);
+
+  for (const name of Object.keys(securityHeaders())) {
+    const headers = securityHeaders();
+    headers[name] = name === "x-mento-deployment-sha" ? "f".repeat(40) : "";
+    assert.throws(
+      () => assertMainRuntimeSecurityHeaders(headers, SHA),
+      new RegExp(name),
+      name,
+    );
+  }
+  assert.throws(() => assertMainRuntimeSecurityHeaders(null, SHA), /malformed/);
+});
+
+test("runs the literal interaction contract for all four public targets", async () => {
+  for (const target of Object.keys(MAIN_RUNTIME_TARGETS)) {
+    const page = new FakePage(target);
+    const fake = fakeChromium(page);
+    const result = await runMainRuntimeSmoke({
+      chromium: fake.chromium,
+      values: inputFor(target),
+    });
+
+    assert.equal(result.logical_target, target);
+    assert.equal(result.interaction, MAIN_RUNTIME_TARGETS[target].interaction);
+    assert.equal(result.deploy_sha, SHA);
+    assert.equal(result.successful_documents, 1);
+    assert.equal(result.successful_scripts, 1);
+    assert.equal(result.successful_stylesheets, 1);
+    assert.equal(result.successful_fonts, 1);
+    assert.equal(Object.isFrozen(result), true);
+    assert.deepEqual(fake.state.launchOptions, { headless: true });
+    assert.deepEqual(fake.state.contextOptions, { colorScheme: "dark" });
+    assert.equal(fake.state.closed, true);
+  }
+});
+
+test("App proves real production wallets without enabling preview flags", async () => {
+  const page = new FakePage("app");
+  await runMainRuntimeSmoke({
+    chromium: fakeChromium(page).chromium,
+    values: inputFor("app"),
+  });
+  assert.equal(page.walletOpened, true);
+  assert.equal(
+    page.calls.filter((entry) => {
+      const [operation, , name] = entry;
+      return (
+        operation === "wait" &&
+        (name === "MetaMask" || name === "WalletConnect")
+      );
+    }).length,
+    2,
+  );
+
+  for (const options of [
+    { walletFlagsAbsent: false },
+    { mockWalletVisible: true },
+  ]) {
+    const failingPage = new FakePage("app", options);
+    const fake = fakeChromium(failingPage);
+    await assert.rejects(
+      runMainRuntimeSmoke({
+        chromium: fake.chromium,
+        values: inputFor("app"),
+      }),
+      /preview or mock-wallet browser flags|preview-only E2E Test Wallet/,
+    );
+    assert.equal(fake.state.closed, true);
+  }
+});
+
+test("production wallet flag predicate rejects each E2E activation key", () => {
+  const values = new Map();
+  const storage = { getItem: (name) => values.get(name) ?? null };
+  assert.equal(productionWalletFlagsAreAbsent({ storage }), true);
+  for (const name of [
+    "mento_e2e_wallet",
+    "mento_e2e_eager_connect",
+    "mento_use_fork",
+  ]) {
+    values.set(name, "true");
+    assert.equal(productionWalletFlagsAreAbsent({ storage }), false);
+    values.clear();
+  }
+});
+
+test("Reserve state predicate binds origin, route, query, and selected tab", () => {
+  const expectedOrigin = "https://reserve.mento.org";
+  const valid = {
+    currentHref: `${expectedOrigin}/?tab=stablecoins`,
+    expectedOrigin,
+    selectedTabLabel: "Supply",
+  };
+  assert.equal(reserveSupplyStateMatches(valid), true);
+  for (const invalid of [
+    { currentHref: "https://example.com/?tab=stablecoins" },
+    { currentHref: `${expectedOrigin}/path?tab=stablecoins` },
+    { currentHref: `${expectedOrigin}/?tab=stablecoins&extra=true` },
+    { currentHref: `${expectedOrigin}/?tab=collateral` },
+    { selectedTabLabel: "Overview" },
+    { selectedTabLabel: null },
+  ]) {
+    assert.equal(reserveSupplyStateMatches({ ...valid, ...invalid }), false);
+  }
+});
+
+test("UI checkbox predicate requires semantic and component checked state", () => {
+  const attributes = new Map([
+    ["aria-checked", "true"],
+    ["data-state", "checked"],
+  ]);
+  const checkbox = { getAttribute: (name) => attributes.get(name) ?? null };
+  assert.equal(uiCheckboxStateMatches({ checkbox }), true);
+  attributes.set("aria-checked", "false");
+  assert.equal(uiCheckboxStateMatches({ checkbox }), false);
+  attributes.set("aria-checked", "true");
+  attributes.set("data-state", "unchecked");
+  assert.equal(uiCheckboxStateMatches({ checkbox }), false);
+  assert.equal(uiCheckboxStateMatches({ checkbox: null }), false);
+});
+
+function barePage(origin) {
+  const page = new EventEmitter();
+  const frame = { url: () => `${origin}/` };
+  page.mainFrame = () => frame;
+  return { frame, page };
+}
+
+function emitResponse(page, origin, resourceType, status = 200) {
+  page.emit("response", {
+    request: () => ({ resourceType: () => resourceType }),
+    status: () => status,
+    url: () => `${origin}/asset-${resourceType}`,
+  });
+}
+
+function primeRequiredResources(page, origin) {
+  for (const resourceType of ["document", "font", "script", "stylesheet"]) {
+    emitResponse(page, origin, resourceType);
+  }
+}
+
+test("monitor fails on page, console, origin, request, and response errors", () => {
+  const origin = "https://app.mento.org";
+  const { frame, page } = barePage(origin);
+  const monitor = createMainRuntimeMonitor(page, origin);
+  primeRequiredResources(page, origin);
+  page.emit("pageerror", new Error("render exploded"));
+  page.emit("console", {
+    location: () => ({ url: `${origin}/_next/static/app.js` }),
+    text: () => "hydration failed",
+    type: () => "error",
+  });
+  frame.url = () => "https://example.com/";
+  page.emit("framenavigated", frame);
+  page.emit("requestfailed", {
+    failure: () => ({ errorText: "net::ERR_FAILED" }),
+    method: () => "GET",
+    resourceType: () => "script",
+    url: () => `${origin}/_next/static/fail.js`,
+  });
+  emitResponse(page, origin, "stylesheet", 503);
+
+  assert.throws(
+    () => monitor.assertClean(),
+    (error) =>
+      error.message.includes("render exploded") &&
+      error.message.includes("hydration failed") &&
+      error.message.includes("left expected origin") &&
+      error.message.includes("script request failed") &&
+      error.message.includes("stylesheet response failed"),
+  );
+});
+
+test("monitor ignores only unrelated traffic and superseded same-origin RSC aborts", () => {
+  const origin = "https://reserve.mento.org";
+  const { page } = barePage(origin);
+  const monitor = createMainRuntimeMonitor(page, origin);
+  primeRequiredResources(page, origin);
+  page.emit("requestfailed", {
+    failure: () => ({ errorText: "net::ERR_ABORTED" }),
+    method: () => "GET",
+    resourceType: () => "fetch",
+    url: () => `${origin}/?tab=stablecoins&_rsc=route`,
+  });
+  page.emit("requestfailed", {
+    failure: () => ({ errorText: "net::ERR_FAILED" }),
+    method: () => "GET",
+    resourceType: () => "image",
+    url: () => `${origin}/optional.png`,
+  });
+  page.emit("requestfailed", {
+    failure: () => ({ errorText: "net::ERR_FAILED" }),
+    method: () => "GET",
+    resourceType: () => "script",
+    url: () => "https://third-party.example/script.js",
+  });
+  assert.doesNotThrow(() => monitor.assertClean());
+
+  page.emit("requestfailed", {
+    failure: () => ({ errorText: "net::ERR_ABORTED" }),
+    method: () => "GET",
+    resourceType: () => "script",
+    url: () => `${origin}/_next/static/app.js`,
+  });
+  assert.throws(() => monitor.assertClean(), /script request failed/);
+});
+
+test("monitor requires successful same-origin documents, scripts, styles, and fonts", async () => {
+  for (const resourceType of ["document", "font", "script", "stylesheet"]) {
+    const page = new FakePage("app", { omitResource: resourceType });
+    const fake = fakeChromium(page);
+    await assert.rejects(
+      runMainRuntimeSmoke({
+        chromium: fake.chromium,
+        values: inputFor("app"),
+      }),
+      new RegExp(`no successful same-origin ${resourceType}`),
+    );
+    assert.equal(fake.state.closed, true);
+  }
+});
+
+test("rejects wrong landing, final location, SHA header, and browser policy", async () => {
+  const cases = [
+    {
+      page: new FakePage("ui", { wrongLanding: "/form-components" }),
+      target: "ui",
+      pattern: /public landing URL mismatch/,
+    },
+    {
+      page: new FakePage("governance", {
+        afterInteraction(currentPage) {
+          currentPage.navigate("/");
+        },
+      }),
+      target: "governance",
+      pattern: /public interaction URL mismatch/,
+    },
+    {
+      page: new FakePage("reserve", {
+        headers: securityHeaders("f".repeat(40)),
+      }),
+      target: "reserve",
+      pattern: /x-mento-deployment-sha mismatch/,
+    },
+  ];
+  for (const scenario of cases) {
+    const fake = fakeChromium(scenario.page);
+    await assert.rejects(
+      runMainRuntimeSmoke({
+        chromium: fake.chromium,
+        values: inputFor(scenario.target),
+      }),
+      scenario.pattern,
+    );
+    assert.equal(fake.state.closed, true);
+  }
+
+  await assert.rejects(
+    runMainRuntimeSmoke({
+      chromium: fakeChromium(new FakePage("app")).chromium,
+      values: inputFor("app"),
+      browserChannel: "unknown",
+    }),
+    /browser channel/,
+  );
+  await assert.rejects(
+    runMainRuntimeSmoke({
+      chromium: fakeChromium(new FakePage("app")).chromium,
+      values: inputFor("app"),
+      timeoutMs: 0,
+    }),
+    /bounded policy/,
+  );
+});
+
+test("uses system Chrome only when explicitly selected", async () => {
+  const page = new FakePage("app");
+  const fake = fakeChromium(page);
+  await runMainRuntimeSmoke({
+    browserChannel: "chrome",
+    chromium: fake.chromium,
+    values: inputFor("app"),
+  });
+  assert.deepEqual(fake.state.launchOptions, {
+    channel: "chrome",
+    headless: true,
+  });
+});
+
+test("environment entrypoint writes canonical outputs and summary", async () => {
+  const directory = mkdtempSync(join(tmpdir(), "main-runtime-"));
+  const output = join(directory, "output");
+  const summary = join(directory, "summary");
+  writeFileSync(output, "");
+  writeFileSync(summary, "");
+  try {
+    const page = new FakePage("governance");
+    const result = await runMainRuntimeSmokeFromEnvironment({
+      chromium: fakeChromium(page).chromium,
+      environment: {
+        DEPLOY_SHA: SHA,
+        GITHUB_OUTPUT: output,
+        GITHUB_STEP_SUMMARY: summary,
+        LOGICAL_TARGET: "governance",
+        PUBLIC_URL: MAIN_RUNTIME_TARGETS.governance.publicUrl,
+      },
+    });
+    const outputText = readFileSync(output, "utf8");
+    for (const [name, value] of Object.entries(result)) {
+      assert.match(outputText, new RegExp(`^${name}=${value}$`, "m"));
+    }
+    assert.equal(
+      readFileSync(summary, "utf8"),
+      formatMainRuntimeSummary(result),
+    );
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});

--- a/scripts/vercel-main-transaction.mjs
+++ b/scripts/vercel-main-transaction.mjs
@@ -7,7 +7,7 @@ import {
   canonicalizeHostname,
 } from "./vercel-deployment-state.mjs";
 
-export const MAIN_TRANSACTION_SCHEMA = 1;
+const MAIN_TRANSACTION_SCHEMA = 1;
 export const MAIN_TRANSACTION_REPOSITORY = "mento-protocol/frontend-monorepo";
 export const MAIN_TRANSACTION_MODE = "shadow";
 

--- a/scripts/vercel-main-transaction.mjs
+++ b/scripts/vercel-main-transaction.mjs
@@ -437,6 +437,9 @@ function canonicalOperation(operation, journal) {
     operation.target === "legacy-app"
       ? journal.candidates.app
       : journal.candidates[operation.target];
+  if (expectedCandidate === null) {
+    throw new Error("Operation target was not selected for this transaction");
+  }
   if (
     candidateDeploymentId !== null &&
     expectedCandidate?.deploymentId !== null &&
@@ -1151,6 +1154,7 @@ export function assertMainTransactionJournalHistory(
     const appendedEvents =
       journal.operations.length - previous.operations.length;
     const candidateChanged = !sameJson(previous.candidates, journal.candidates);
+    let expected;
     if (appendedEvents === 0) {
       const isCandidateAttachment =
         candidateChanged && journal.status === previous.status;
@@ -1160,31 +1164,69 @@ export function assertMainTransactionJournalHistory(
       if (!isCandidateAttachment && !isStatusOnlyTransition) {
         throw new Error("Journal snapshot did not append one legal event");
       }
-      continue;
-    }
-    if (appendedEvents !== 1) {
+      if (isCandidateAttachment) {
+        expected = attachDiscoveredAppCandidate(previous, {
+          deploymentId: journal.candidates.app.deploymentId,
+          deploymentUrl: journal.candidates.app.deploymentUrl,
+          ...journal.candidates.app.discovery,
+        });
+      } else if (journal.status === "committed") {
+        expected = markMainTransactionCommitted(previous);
+      } else {
+        if (
+          ["recovered", "manual_intervention"].includes(journal.status) &&
+          !canonical
+            .slice(0, index)
+            .some((snapshot) => snapshot.status === "recovering")
+        ) {
+          throw new Error(
+            "Terminal recovery status requires a recovering snapshot",
+          );
+        }
+        expected = appendStatus(previous, journal.status);
+      }
+    } else if (appendedEvents !== 1) {
       throw new Error("Journal snapshot batched operation events");
+    } else {
+      const appended = journal.operations.at(-1);
+      if (appended.state === "started") {
+        if (candidateChanged) {
+          throw new Error("Operation start cannot change staged candidates");
+        }
+        expected = startMainTransactionOperation(previous, {
+          type: appended.type,
+          target: appended.target,
+          alias: appended.alias,
+        });
+      } else if (appended.state === "command_returned") {
+        expected = recordMainTransactionCommandReturned(previous, {
+          operationId: appended.operationId,
+          outcome: appended.commandOutcome,
+          candidate: candidateChanged
+            ? {
+                deploymentId: journal.candidates.app.deploymentId,
+                deploymentUrl: journal.candidates.app.deploymentUrl,
+                ...journal.candidates.app.discovery,
+              }
+            : null,
+        });
+      } else if (appended.state === "verified") {
+        if (candidateChanged) {
+          throw new Error(
+            "Operation verification cannot change staged candidates",
+          );
+        }
+        expected = recordMainTransactionVerified(previous, {
+          operationId: appended.operationId,
+          mappingState: appended.mappingState,
+          rollbackState: appended.rollbackState,
+        });
+      } else {
+        throw new Error("Journal appended an unsupported operation event");
+      }
     }
-    const appended = journal.operations.at(-1);
-    if (journal.status !== appended.state) {
-      throw new Error("Journal status does not match its appended operation");
-    }
-    const expectedPreviousStatuses = {
-      started: new Set(["prepared", "verified", "recovering"]),
-      command_returned: new Set(["started"]),
-      verified: new Set(["command_returned"]),
-    };
-    if (!expectedPreviousStatuses[appended.state].has(previous.status)) {
-      throw new Error("Journal operation append is invalid for its status");
-    }
-    if (
-      candidateChanged &&
-      (appended.type !== "app_v3_deploy" ||
-        appended.state !== "command_returned")
-    ) {
-      throw new Error(
-        "App candidate attachment must accompany its command-return event",
-      );
+    if (!sameJson(expected, journal)) {
+      throw new Error("Journal snapshot differs from its legal helper append");
     }
   }
   return canonical;
@@ -2170,6 +2212,28 @@ export async function executeMainTransactionRecovery({
       requireFreshness: false,
     });
     lastDurableJournal = highest;
+  }
+  if (canonicalPlan.decision === "recover") {
+    for (const entry of canonicalPlan.actions) {
+      let inspected;
+      try {
+        inspected = await inspectMapping(clone(entry), {
+          phase: "recovery-final",
+          transactionId: highest.transactionId,
+        });
+      } catch {
+        inspected = null;
+      }
+      if (inspected?.mappingState !== "prior") {
+        throw new MainTransactionError(
+          "Recovered mapping no longer matches the captured prior",
+          {
+            code: "RECOVERY_VERIFICATION_FAILED",
+            journal: highest,
+          },
+        );
+      }
+    }
   }
   highest = appendStatus(
     highest,

--- a/scripts/vercel-main-transaction.mjs
+++ b/scripts/vercel-main-transaction.mjs
@@ -1,0 +1,1859 @@
+#!/usr/bin/env node
+
+import { createHash } from "node:crypto";
+
+import {
+  canonicalizeDeploymentUrl,
+  canonicalizeHostname,
+} from "./vercel-deployment-state.mjs";
+
+export const MAIN_TRANSACTION_SCHEMA = 1;
+export const MAIN_TRANSACTION_REPOSITORY = "mento-protocol/frontend-monorepo";
+export const MAIN_TRANSACTION_MODE = "shadow";
+
+const SHA_PATTERN = /^[a-f0-9]{40}$/;
+const NUMERIC_ID_PATTERN = /^[1-9][0-9]*$/;
+const IDENTIFIER_PATTERN = /^[A-Za-z0-9._-]+$/;
+const DEPLOYMENT_ID_PATTERN = /^dpl_[A-Za-z0-9]+$/;
+const TRANSACTION_ID_PATTERN = /^main-[a-f0-9]{32}$/;
+const ORDINARY_TARGETS = Object.freeze(["governance", "reserve", "ui"]);
+const PROTECTED_TARGETS = Object.freeze([
+  "app",
+  "governance",
+  "reserve",
+  "ui",
+  "legacy-app",
+]);
+const CANDIDATE_TARGETS = Object.freeze(["app", "governance", "reserve", "ui"]);
+const MODES = Object.freeze(["shadow", "active"]);
+const STATUSES = Object.freeze([
+  "prepared",
+  "started",
+  "command_returned",
+  "verified",
+  "committed",
+  "recovering",
+  "recovered",
+  "manual_intervention",
+]);
+const OPERATION_TYPES = Object.freeze([
+  "promote",
+  "app_v3_deploy",
+  "app_alias_set",
+  "ordinary_rollback",
+  "app_alias_restore",
+  "legacy_emergency_restore",
+]);
+const OPERATION_STATES = Object.freeze([
+  "started",
+  "command_returned",
+  "verified",
+  "recovering",
+  "recovered",
+  "manual_intervention",
+]);
+const COMMAND_OUTCOMES = Object.freeze([null, "success", "unknown"]);
+const MAPPING_STATES = Object.freeze([
+  null,
+  "prior",
+  "candidate",
+  "partial",
+  "unexpected",
+  "unknown",
+]);
+const ROLLBACK_STATES = Object.freeze([null, "entered"]);
+const JOURNAL_KEYS = Object.freeze([
+  "schema",
+  "repository",
+  "deploySha",
+  "runId",
+  "runAttempt",
+  "transactionId",
+  "mode",
+  "sequence",
+  "status",
+  "prior",
+  "candidates",
+  "operations",
+]);
+const PRIOR_KEYS = Object.freeze(["deploymentId", "deploymentUrl", "aliases"]);
+const CANDIDATE_KEYS = Object.freeze([
+  "deploymentId",
+  "deploymentUrl",
+  "aliases",
+  "discovery",
+]);
+const DISCOVERY_KEYS = Object.freeze([
+  "projectId",
+  "projectName",
+  "deploySha",
+  "runId",
+  "runAttempt",
+  "transactionId",
+  "customEnvironmentSlug",
+]);
+const OPERATION_KEYS = Object.freeze([
+  "operationId",
+  "target",
+  "type",
+  "alias",
+  "priorDeploymentId",
+  "priorDeploymentUrl",
+  "candidateDeploymentId",
+  "candidateDeploymentUrl",
+  "state",
+  "commandOutcome",
+  "mappingState",
+  "rollbackState",
+]);
+const CURRENT_MAPPING_KEYS = Object.freeze([
+  "alias",
+  "deploymentId",
+  "deploymentUrl",
+]);
+const APP_CANDIDATE_MATCH_KEYS = Object.freeze([
+  "deploymentId",
+  "deploymentUrl",
+  "projectId",
+  "projectName",
+  "deploySha",
+  "runId",
+  "runAttempt",
+  "transactionId",
+  "customEnvironmentSlug",
+]);
+
+export class MainTransactionError extends Error {
+  constructor(message, { code = "MAIN_TRANSACTION_FAILED", journal } = {}) {
+    super(message);
+    this.name = "MainTransactionError";
+    this.code = code;
+    this.journal = journal;
+  }
+}
+
+function assertExactKeys(value, expectedKeys, label) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${label} is malformed`);
+  }
+  const actual = Object.keys(value).sort();
+  const expected = [...expectedKeys].sort();
+  if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+    throw new Error(`${label} contains forbidden or missing fields`);
+  }
+}
+
+function assertOrderedExactKeys(value, expectedKeys, label) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${label} is malformed`);
+  }
+  if (JSON.stringify(Object.keys(value)) !== JSON.stringify(expectedKeys)) {
+    throw new Error(`${label} keys are missing, extra, or out of order`);
+  }
+}
+
+function requireString(value, label, pattern) {
+  if (typeof value !== "string" || !pattern.test(value)) {
+    throw new Error(`${label} is malformed`);
+  }
+  return value;
+}
+
+function requireNumericId(value, label) {
+  const normalized =
+    typeof value === "number" && Number.isSafeInteger(value)
+      ? String(value)
+      : value;
+  return requireString(normalized, label, NUMERIC_ID_PATTERN);
+}
+
+function requireDeploymentId(value, label) {
+  return requireString(value, label, DEPLOYMENT_ID_PATTERN);
+}
+
+function canonicalAliases(values, label) {
+  if (!Array.isArray(values) || values.length === 0) {
+    throw new Error(`${label} must be a non-empty array`);
+  }
+  const aliases = values.map((value) => canonicalizeHostname(value));
+  const canonical = [...new Set(aliases)].sort();
+  if (
+    canonical.length !== aliases.length ||
+    JSON.stringify(canonical) !== JSON.stringify(values)
+  ) {
+    throw new Error(`${label} must be unique and canonically sorted`);
+  }
+  return canonical;
+}
+
+function canonicalPriorRecord(record, label) {
+  assertExactKeys(record, PRIOR_KEYS, label);
+  return {
+    deploymentId: requireDeploymentId(
+      record.deploymentId,
+      `${label} deployment ID`,
+    ),
+    deploymentUrl: canonicalizeDeploymentUrl(record.deploymentUrl),
+    aliases: canonicalAliases(record.aliases, `${label} aliases`),
+  };
+}
+
+function canonicalDiscovery(discovery, identity, label) {
+  assertExactKeys(discovery, DISCOVERY_KEYS, label);
+  const canonical = {
+    projectId: requireString(
+      discovery.projectId,
+      `${label} project ID`,
+      IDENTIFIER_PATTERN,
+    ),
+    projectName: requireString(
+      discovery.projectName,
+      `${label} project name`,
+      IDENTIFIER_PATTERN,
+    ),
+    deploySha: requireString(
+      discovery.deploySha,
+      `${label} deploy SHA`,
+      SHA_PATTERN,
+    ),
+    runId: requireNumericId(discovery.runId, `${label} run ID`),
+    runAttempt: requireNumericId(discovery.runAttempt, `${label} run attempt`),
+    transactionId: requireString(
+      discovery.transactionId,
+      `${label} transaction ID`,
+      TRANSACTION_ID_PATTERN,
+    ),
+    customEnvironmentSlug: discovery.customEnvironmentSlug,
+  };
+  if (canonical.customEnvironmentSlug !== "v3") {
+    throw new Error(`${label} custom environment must be v3`);
+  }
+  if (
+    canonical.deploySha !== identity.deploySha ||
+    canonical.runId !== identity.runId ||
+    canonical.runAttempt !== identity.runAttempt ||
+    canonical.transactionId !== identity.transactionId
+  ) {
+    throw new Error(`${label} does not match the journal identity`);
+  }
+  return canonical;
+}
+
+function canonicalCandidateRecord(record, target, identity, prior) {
+  if (record === null) return null;
+  const label = `Candidate ${target}`;
+  assertExactKeys(record, CANDIDATE_KEYS, label);
+  const deploymentId =
+    record.deploymentId === null
+      ? null
+      : requireDeploymentId(record.deploymentId, `${label} deployment ID`);
+  const deploymentUrl =
+    record.deploymentUrl === null
+      ? null
+      : canonicalizeDeploymentUrl(record.deploymentUrl);
+  if ((deploymentId === null) !== (deploymentUrl === null)) {
+    throw new Error(`${label} ID and URL must both be known or both be null`);
+  }
+  if (target !== "app" && deploymentId === null) {
+    throw new Error(`${label} must identify the staged deployment`);
+  }
+  if (target === "app" && record.discovery === null) {
+    throw new Error("Candidate app discovery metadata is required");
+  }
+  if (target !== "app" && record.discovery !== null) {
+    throw new Error(`${label} must not contain app discovery metadata`);
+  }
+  const aliases = canonicalAliases(record.aliases, `${label} aliases`);
+  if (JSON.stringify(aliases) !== JSON.stringify(prior.aliases)) {
+    throw new Error(`${label} aliases differ from the captured prior aliases`);
+  }
+  return {
+    deploymentId,
+    deploymentUrl,
+    aliases,
+    discovery:
+      target === "app"
+        ? canonicalDiscovery(record.discovery, identity, `${label} discovery`)
+        : null,
+  };
+}
+
+function canonicalIdentity(value) {
+  if (value.repository !== MAIN_TRANSACTION_REPOSITORY) {
+    throw new Error("Journal repository is unexpected");
+  }
+  const identity = {
+    repository: value.repository,
+    deploySha: requireString(
+      value.deploySha,
+      "Journal deploy SHA",
+      SHA_PATTERN,
+    ),
+    runId: requireNumericId(value.runId, "Journal run ID"),
+    runAttempt: requireNumericId(value.runAttempt, "Journal run attempt"),
+  };
+  identity.transactionId = createMainTransactionId(identity);
+  if (
+    value.transactionId !== undefined &&
+    value.transactionId !== identity.transactionId
+  ) {
+    throw new Error("Journal transaction ID does not match its identity");
+  }
+  return identity;
+}
+
+function canonicalPrior(prior) {
+  assertOrderedExactKeys(prior, PROTECTED_TARGETS, "Journal prior state");
+  const canonical = Object.fromEntries(
+    PROTECTED_TARGETS.map((target) => [
+      target,
+      canonicalPriorRecord(prior[target], `Prior ${target}`),
+    ]),
+  );
+  const aliases = PROTECTED_TARGETS.flatMap(
+    (target) => canonical[target].aliases,
+  );
+  if (new Set(aliases).size !== aliases.length) {
+    throw new Error("Journal prior aliases overlap across protected targets");
+  }
+  return canonical;
+}
+
+function canonicalCandidates(candidates, identity, prior) {
+  assertOrderedExactKeys(
+    candidates,
+    CANDIDATE_TARGETS,
+    "Journal candidate state",
+  );
+  return Object.fromEntries(
+    CANDIDATE_TARGETS.map((target) => [
+      target,
+      canonicalCandidateRecord(
+        candidates[target],
+        target,
+        identity,
+        prior[target],
+      ),
+    ]),
+  );
+}
+
+function assertOperationTarget(type, target, alias, journal) {
+  const isOrdinary = ORDINARY_TARGETS.includes(target);
+  if (
+    (type === "promote" || type === "ordinary_rollback") &&
+    (!isOrdinary || alias !== null)
+  ) {
+    throw new Error(`${type} must bind one ordinary target without an alias`);
+  }
+  if (type === "app_v3_deploy" && (target !== "app" || alias !== null)) {
+    throw new Error("app_v3_deploy must bind the app target");
+  }
+  if (
+    (type === "app_alias_set" || type === "app_alias_restore") &&
+    (target !== "app" ||
+      alias === null ||
+      !journal.prior.app.aliases.includes(alias))
+  ) {
+    throw new Error(`${type} must bind one reviewed app-v3 alias`);
+  }
+  if (
+    type === "legacy_emergency_restore" &&
+    (target !== "legacy-app" ||
+      alias === null ||
+      !journal.prior["legacy-app"].aliases.includes(alias))
+  ) {
+    throw new Error(
+      "legacy_emergency_restore must bind a captured legacy alias",
+    );
+  }
+}
+
+function canonicalOperation(operation, journal) {
+  assertExactKeys(operation, OPERATION_KEYS, "Journal operation");
+  const operationId = requireString(
+    operation.operationId,
+    "Operation ID",
+    /^op-[0-9]{4}$/,
+  );
+  if (!PROTECTED_TARGETS.includes(operation.target)) {
+    throw new Error("Operation target is unsupported");
+  }
+  if (!OPERATION_TYPES.includes(operation.type)) {
+    throw new Error("Operation type is unsupported");
+  }
+  const alias =
+    operation.alias === null ? null : canonicalizeHostname(operation.alias);
+  assertOperationTarget(operation.type, operation.target, alias, journal);
+  const priorDeploymentId = requireDeploymentId(
+    operation.priorDeploymentId,
+    "Operation prior deployment ID",
+  );
+  const priorDeploymentUrl = canonicalizeDeploymentUrl(
+    operation.priorDeploymentUrl,
+  );
+  const expectedPrior = journal.prior[operation.target];
+  if (
+    priorDeploymentId !== expectedPrior.deploymentId ||
+    priorDeploymentUrl !== expectedPrior.deploymentUrl
+  ) {
+    throw new Error("Operation prior identity differs from the journal");
+  }
+  const candidateDeploymentId =
+    operation.candidateDeploymentId === null
+      ? null
+      : requireDeploymentId(
+          operation.candidateDeploymentId,
+          "Operation candidate deployment ID",
+        );
+  const candidateDeploymentUrl =
+    operation.candidateDeploymentUrl === null
+      ? null
+      : canonicalizeDeploymentUrl(operation.candidateDeploymentUrl);
+  if ((candidateDeploymentId === null) !== (candidateDeploymentUrl === null)) {
+    throw new Error(
+      "Operation candidate ID and URL must both be known or both be null",
+    );
+  }
+  if (candidateDeploymentId === null && operation.type !== "app_v3_deploy") {
+    throw new Error("Only app_v3_deploy may start before candidate discovery");
+  }
+  const expectedCandidate =
+    operation.target === "legacy-app"
+      ? journal.candidates.app
+      : journal.candidates[operation.target];
+  if (
+    candidateDeploymentId !== null &&
+    expectedCandidate?.deploymentId !== null &&
+    (candidateDeploymentId !== expectedCandidate?.deploymentId ||
+      candidateDeploymentUrl !== expectedCandidate?.deploymentUrl)
+  ) {
+    throw new Error("Operation candidate identity differs from the journal");
+  }
+  if (!OPERATION_STATES.includes(operation.state)) {
+    throw new Error("Operation state is unsupported");
+  }
+  if (!COMMAND_OUTCOMES.includes(operation.commandOutcome)) {
+    throw new Error("Operation command outcome is unsupported");
+  }
+  if (!MAPPING_STATES.includes(operation.mappingState)) {
+    throw new Error("Operation mapping state is unsupported");
+  }
+  if (!ROLLBACK_STATES.includes(operation.rollbackState)) {
+    throw new Error("Operation rollback state is unsupported");
+  }
+  if (
+    operation.rollbackState === "entered" &&
+    operation.type !== "ordinary_rollback"
+  ) {
+    throw new Error("Only an ordinary rollback may enter rollback state");
+  }
+  return {
+    operationId,
+    target: operation.target,
+    type: operation.type,
+    alias,
+    priorDeploymentId,
+    priorDeploymentUrl,
+    candidateDeploymentId,
+    candidateDeploymentUrl,
+    state: operation.state,
+    commandOutcome: operation.commandOutcome,
+    mappingState: operation.mappingState,
+    rollbackState: operation.rollbackState,
+  };
+}
+
+function canonicalOperations(operations, journal) {
+  if (!Array.isArray(operations)) {
+    throw new Error("Journal operations must be an array");
+  }
+  const canonical = operations.map((operation) =>
+    canonicalOperation(operation, journal),
+  );
+  const statesByOperation = new Map();
+  for (const operation of canonical) {
+    const events = statesByOperation.get(operation.operationId) ?? [];
+    if (events.length > 0) {
+      const first = events[0];
+      for (const key of [
+        "operationId",
+        "target",
+        "type",
+        "alias",
+        "priorDeploymentId",
+        "priorDeploymentUrl",
+      ]) {
+        if (operation[key] !== first[key]) {
+          throw new Error("Journal operation intent changed across events");
+        }
+      }
+      const previous = events.at(-1);
+      if (
+        previous.candidateDeploymentId !== null &&
+        (operation.candidateDeploymentId !== previous.candidateDeploymentId ||
+          operation.candidateDeploymentUrl !== previous.candidateDeploymentUrl)
+      ) {
+        throw new Error(
+          "Journal operation candidate changed after it was discovered",
+        );
+      }
+      if (
+        previous.commandOutcome !== null &&
+        operation.commandOutcome !== previous.commandOutcome
+      ) {
+        throw new Error("Journal operation command outcome changed");
+      }
+      if (
+        previous.mappingState !== null &&
+        operation.mappingState !== previous.mappingState
+      ) {
+        throw new Error("Journal operation mapping result changed");
+      }
+      if (
+        previous.rollbackState !== null &&
+        operation.rollbackState !== previous.rollbackState
+      ) {
+        throw new Error("Journal operation rollback marker changed");
+      }
+    }
+    events.push(operation);
+    statesByOperation.set(operation.operationId, events);
+  }
+  const operationIds = [...statesByOperation.keys()];
+  for (const [index, operationId] of operationIds.entries()) {
+    if (operationId !== `op-${String(index + 1).padStart(4, "0")}`) {
+      throw new Error("Journal operation IDs are not monotonic");
+    }
+    const states = statesByOperation
+      .get(operationId)
+      .map((operation) => operation.state);
+    if (states[0] !== "started") {
+      throw new Error("Every journal operation must begin with started");
+    }
+    const allowedTransitions = {
+      started: new Set([
+        "command_returned",
+        "recovering",
+        "manual_intervention",
+      ]),
+      command_returned: new Set([
+        "verified",
+        "recovering",
+        "manual_intervention",
+      ]),
+      verified: new Set(["recovering", "recovered", "manual_intervention"]),
+      recovering: new Set([
+        "command_returned",
+        "verified",
+        "recovered",
+        "manual_intervention",
+      ]),
+      recovered: new Set(),
+      manual_intervention: new Set(),
+    };
+    for (let stateIndex = 1; stateIndex < states.length; stateIndex += 1) {
+      if (!allowedTransitions[states[stateIndex - 1]].has(states[stateIndex])) {
+        throw new Error("Journal operation state transition is invalid");
+      }
+    }
+  }
+  return canonical;
+}
+
+function clone(value) {
+  return structuredClone(value);
+}
+
+function nextJournal(journal, changes) {
+  const current = assertMainTransactionJournal(journal);
+  const next = {
+    ...clone(current),
+    ...changes,
+    sequence: current.sequence + 1,
+  };
+  return assertMainTransactionJournal(next);
+}
+
+function operationIntent(journal, { target, type, alias = null }) {
+  const canonicalAlias = alias === null ? null : canonicalizeHostname(alias);
+  assertOperationTarget(type, target, canonicalAlias, journal);
+  const prior = journal.prior[target];
+  const candidate =
+    target === "legacy-app"
+      ? journal.candidates.app
+      : journal.candidates[target];
+  return {
+    target,
+    type,
+    alias: canonicalAlias,
+    priorDeploymentId: prior.deploymentId,
+    priorDeploymentUrl: prior.deploymentUrl,
+    candidateDeploymentId: candidate?.deploymentId ?? null,
+    candidateDeploymentUrl: candidate?.deploymentUrl ?? null,
+  };
+}
+
+function lastOperationEvent(journal, operationId) {
+  const events = journal.operations.filter(
+    (operation) => operation.operationId === operationId,
+  );
+  if (events.length === 0) throw new Error("Journal operation does not exist");
+  return events.at(-1);
+}
+
+function appendOperationEvent(journal, previous, changes) {
+  const event = {
+    ...previous,
+    ...changes,
+  };
+  const next = nextJournal(journal, {
+    status: event.state,
+    operations: [...journal.operations, event],
+  });
+  return next;
+}
+
+function sameJson(left, right) {
+  return JSON.stringify(left) === JSON.stringify(right);
+}
+
+function validateCandidateEvolution(previous, current) {
+  for (const target of CANDIDATE_TARGETS) {
+    if (sameJson(previous[target], current[target])) continue;
+    if (target !== "app") {
+      throw new Error("Journal candidates changed after preparation");
+    }
+    const before = previous.app;
+    const after = current.app;
+    if (
+      before === null ||
+      after === null ||
+      before.deploymentId !== null ||
+      before.deploymentUrl !== null ||
+      after.deploymentId === null ||
+      after.deploymentUrl === null ||
+      !sameJson(before.aliases, after.aliases) ||
+      !sameJson(before.discovery, after.discovery)
+    ) {
+      throw new Error("App candidate evolution is not monotonic");
+    }
+  }
+}
+
+function statusTransitionAllowed(previous, current) {
+  const transitions = {
+    prepared: new Set([
+      "prepared",
+      "started",
+      "committed",
+      "recovering",
+      "recovered",
+      "manual_intervention",
+    ]),
+    started: new Set([
+      "started",
+      "command_returned",
+      "recovering",
+      "manual_intervention",
+    ]),
+    command_returned: new Set([
+      "command_returned",
+      "verified",
+      "recovering",
+      "manual_intervention",
+    ]),
+    verified: new Set([
+      "verified",
+      "started",
+      "committed",
+      "recovering",
+      "recovered",
+      "manual_intervention",
+    ]),
+    committed: new Set(["committed"]),
+    recovering: new Set([
+      "started",
+      "command_returned",
+      "verified",
+      "recovering",
+      "recovered",
+      "manual_intervention",
+    ]),
+    recovered: new Set(["recovered"]),
+    manual_intervention: new Set(["manual_intervention"]),
+  };
+  return transitions[previous].has(current);
+}
+
+function canonicalCurrentMappings(currentMappings, aliases) {
+  if (!Array.isArray(currentMappings)) {
+    throw new Error("Current mappings must be an array");
+  }
+  const byAlias = new Map();
+  for (const mapping of currentMappings) {
+    assertExactKeys(mapping, CURRENT_MAPPING_KEYS, "Current mapping");
+    const canonical = {
+      alias: canonicalizeHostname(mapping.alias),
+      deploymentId: requireDeploymentId(
+        mapping.deploymentId,
+        "Current mapping deployment ID",
+      ),
+      deploymentUrl: canonicalizeDeploymentUrl(mapping.deploymentUrl),
+    };
+    if (byAlias.has(canonical.alias)) {
+      throw new Error("Current mapping contains a duplicate alias");
+    }
+    byAlias.set(canonical.alias, canonical);
+  }
+  const expectedAliases = [...new Set(aliases)].sort();
+  if (
+    JSON.stringify([...byAlias.keys()].sort()) !==
+    JSON.stringify(expectedAliases)
+  ) {
+    throw new Error("Current mappings do not exactly cover protected aliases");
+  }
+  return byAlias;
+}
+
+function sameDeployment(mapping, record) {
+  return (
+    mapping.deploymentId === record.deploymentId &&
+    mapping.deploymentUrl === record.deploymentUrl
+  );
+}
+
+function startedForwardOperations(journal) {
+  const starts = journal.operations.filter(
+    (operation) =>
+      operation.state === "started" &&
+      ["promote", "app_v3_deploy", "app_alias_set"].includes(operation.type),
+  );
+  return starts;
+}
+
+function isOperationVerified(journal, operationId) {
+  const last = lastOperationEvent(journal, operationId);
+  return (
+    last.state === "verified" &&
+    last.commandOutcome === "success" &&
+    last.mappingState === "candidate"
+  );
+}
+
+function appendStatus(journal, status) {
+  return nextJournal(journal, { status });
+}
+
+export function createMainTransactionId({
+  repository,
+  deploySha,
+  runId,
+  runAttempt,
+}) {
+  if (repository !== MAIN_TRANSACTION_REPOSITORY) {
+    throw new Error("Transaction repository is unexpected");
+  }
+  const sha = requireString(deploySha, "Transaction deploy SHA", SHA_PATTERN);
+  const canonicalRunId = requireNumericId(runId, "Transaction run ID");
+  const canonicalRunAttempt = requireNumericId(
+    runAttempt,
+    "Transaction run attempt",
+  );
+  const digest = createHash("sha256")
+    .update(
+      JSON.stringify([repository, sha, canonicalRunId, canonicalRunAttempt]),
+    )
+    .digest("hex")
+    .slice(0, 32);
+  return `main-${digest}`;
+}
+
+export function createPreparedMainTransactionJournal({
+  repository = MAIN_TRANSACTION_REPOSITORY,
+  deploySha,
+  runId,
+  runAttempt,
+  mode,
+  prior,
+  candidates,
+}) {
+  const identity = canonicalIdentity({
+    repository,
+    deploySha,
+    runId,
+    runAttempt,
+  });
+  if (!MODES.includes(mode)) throw new Error("Journal mode is unsupported");
+  const canonicalPriorState = canonicalPrior(prior);
+  const journal = {
+    schema: MAIN_TRANSACTION_SCHEMA,
+    repository: identity.repository,
+    deploySha: identity.deploySha,
+    runId: identity.runId,
+    runAttempt: identity.runAttempt,
+    transactionId: identity.transactionId,
+    mode,
+    sequence: 0,
+    status: "prepared",
+    prior: canonicalPriorState,
+    candidates: canonicalCandidates(candidates, identity, canonicalPriorState),
+    operations: [],
+  };
+  return assertMainTransactionJournal(journal);
+}
+
+export function assertMainTransactionJournal(journal, expected = {}) {
+  assertExactKeys(journal, JOURNAL_KEYS, "Main transaction journal");
+  if (journal.schema !== MAIN_TRANSACTION_SCHEMA) {
+    throw new Error("Journal schema is unsupported");
+  }
+  const identity = canonicalIdentity(journal);
+  if (!MODES.includes(journal.mode)) {
+    throw new Error("Journal mode is unsupported");
+  }
+  if (!Number.isSafeInteger(journal.sequence) || journal.sequence < 0) {
+    throw new Error("Journal sequence is malformed");
+  }
+  if (!STATUSES.includes(journal.status)) {
+    throw new Error("Journal status is unsupported");
+  }
+  const prior = canonicalPrior(journal.prior);
+  const canonical = {
+    schema: journal.schema,
+    repository: identity.repository,
+    deploySha: identity.deploySha,
+    runId: identity.runId,
+    runAttempt: identity.runAttempt,
+    transactionId: identity.transactionId,
+    mode: journal.mode,
+    sequence: journal.sequence,
+    status: journal.status,
+    prior,
+    candidates: canonicalCandidates(journal.candidates, identity, prior),
+    operations: [],
+  };
+  canonical.operations = canonicalOperations(journal.operations, canonical);
+  for (const [key, expectedValue] of Object.entries(expected)) {
+    if (!Object.hasOwn(canonical, key) || canonical[key] !== expectedValue) {
+      throw new Error(`Journal ${key} does not match the expected identity`);
+    }
+  }
+  return canonical;
+}
+
+export function mainTransactionJournalArtifactName(journal) {
+  const canonical = assertMainTransactionJournal(journal);
+  return `vercel-main-journal-${canonical.transactionId}-${String(
+    canonical.sequence,
+  ).padStart(6, "0")}`;
+}
+
+export async function persistMainTransactionJournal(journal, uploadJournal) {
+  const canonical = assertMainTransactionJournal(journal);
+  if (typeof uploadJournal !== "function") {
+    throw new Error("Journal upload adapter is required");
+  }
+  const artifactName = mainTransactionJournalArtifactName(canonical);
+  let receipt;
+  try {
+    receipt = await uploadJournal({
+      artifactName,
+      journal: clone(canonical),
+      retentionDays: 7,
+    });
+  } catch {
+    throw new MainTransactionError("Journal artifact upload failed", {
+      code: "JOURNAL_UPLOAD_FAILED",
+      journal: canonical,
+    });
+  }
+  if (
+    !receipt ||
+    receipt.acknowledged !== true ||
+    receipt.artifactName !== artifactName
+  ) {
+    throw new MainTransactionError(
+      "Journal artifact upload was not acknowledged",
+      {
+        code: "JOURNAL_UPLOAD_NOT_ACKNOWLEDGED",
+        journal: canonical,
+      },
+    );
+  }
+  return canonical;
+}
+
+export function startMainTransactionOperation(journal, intent) {
+  const canonical = assertMainTransactionJournal(journal);
+  if (!["prepared", "verified", "recovering"].includes(canonical.status)) {
+    throw new Error("Journal cannot start another operation in this state");
+  }
+  if (!OPERATION_TYPES.includes(intent?.type)) {
+    throw new Error("Operation type is unsupported");
+  }
+  const resolved = operationIntent(canonical, intent);
+  const startedCount = canonical.operations.filter(
+    (operation) => operation.state === "started",
+  ).length;
+  const event = {
+    operationId: `op-${String(startedCount + 1).padStart(4, "0")}`,
+    ...resolved,
+    state: "started",
+    commandOutcome: null,
+    mappingState: null,
+    rollbackState: null,
+  };
+  return nextJournal(canonical, {
+    status: "started",
+    operations: [...canonical.operations, event],
+  });
+}
+
+export function recordMainTransactionCommandReturned(
+  journal,
+  { operationId, outcome, candidate = null },
+) {
+  let canonical = assertMainTransactionJournal(journal);
+  const previous = lastOperationEvent(canonical, operationId);
+  if (!["started", "recovering"].includes(previous.state)) {
+    throw new Error("Operation is not waiting for a command result");
+  }
+  if (!["success", "unknown"].includes(outcome)) {
+    throw new Error("Command result must be success or unknown");
+  }
+  if (candidate !== null) {
+    if (previous.type !== "app_v3_deploy") {
+      throw new Error("Only app_v3_deploy may discover a candidate");
+    }
+    const app = canonical.candidates.app;
+    if (app === null) {
+      throw new Error("The transaction did not prepare an app candidate");
+    }
+    const discovered = canonicalizeAppCandidateMatch(candidate, app.discovery);
+    if (
+      app.deploymentId !== null &&
+      (app.deploymentId !== discovered.deploymentId ||
+        app.deploymentUrl !== discovered.deploymentUrl)
+    ) {
+      throw new Error("App candidate conflicts with the journal");
+    }
+    canonical = {
+      ...canonical,
+      candidates: {
+        ...canonical.candidates,
+        app: {
+          ...app,
+          deploymentId: discovered.deploymentId,
+          deploymentUrl: discovered.deploymentUrl,
+        },
+      },
+    };
+  }
+  const appCandidate = canonical.candidates.app;
+  const candidateIdentity =
+    previous.type === "app_v3_deploy" && appCandidate?.deploymentId
+      ? {
+          candidateDeploymentId: appCandidate.deploymentId,
+          candidateDeploymentUrl: appCandidate.deploymentUrl,
+        }
+      : {};
+  return appendOperationEvent(canonical, previous, {
+    ...candidateIdentity,
+    state: "command_returned",
+    commandOutcome: outcome,
+  });
+}
+
+export function recordMainTransactionVerified(
+  journal,
+  { operationId, mappingState, rollbackState = null },
+) {
+  const canonical = assertMainTransactionJournal(journal);
+  const previous = lastOperationEvent(canonical, operationId);
+  if (!["command_returned", "recovering"].includes(previous.state)) {
+    throw new Error("Operation command has not returned");
+  }
+  if (!MAPPING_STATES.includes(mappingState) || mappingState === null) {
+    throw new Error("Verified mapping state is unsupported");
+  }
+  if (!ROLLBACK_STATES.includes(rollbackState)) {
+    throw new Error("Verified rollback state is unsupported");
+  }
+  return appendOperationEvent(canonical, previous, {
+    state: "verified",
+    mappingState,
+    rollbackState,
+  });
+}
+
+export function attachDiscoveredAppCandidate(journal, match) {
+  const canonical = assertMainTransactionJournal(journal);
+  if (canonical.candidates.app === null) {
+    throw new Error("The transaction did not prepare an app candidate");
+  }
+  const candidate = canonicalizeAppCandidateMatch(
+    match,
+    canonical.candidates.app.discovery,
+  );
+  if (
+    canonical.candidates.app.deploymentId !== null &&
+    (canonical.candidates.app.deploymentId !== candidate.deploymentId ||
+      canonical.candidates.app.deploymentUrl !== candidate.deploymentUrl)
+  ) {
+    throw new Error("App candidate conflicts with the journal");
+  }
+  if (canonical.candidates.app.deploymentId !== null) return canonical;
+  return nextJournal(canonical, {
+    candidates: {
+      ...canonical.candidates,
+      app: {
+        ...canonical.candidates.app,
+        deploymentId: candidate.deploymentId,
+        deploymentUrl: candidate.deploymentUrl,
+      },
+    },
+  });
+}
+
+function canonicalizeAppCandidateMatch(match, discovery) {
+  assertExactKeys(match, APP_CANDIDATE_MATCH_KEYS, "App candidate match");
+  const canonical = {
+    deploymentId: requireDeploymentId(
+      match.deploymentId,
+      "App candidate deployment ID",
+    ),
+    deploymentUrl: canonicalizeDeploymentUrl(match.deploymentUrl),
+    projectId: requireString(
+      match.projectId,
+      "App candidate project ID",
+      IDENTIFIER_PATTERN,
+    ),
+    projectName: requireString(
+      match.projectName,
+      "App candidate project name",
+      IDENTIFIER_PATTERN,
+    ),
+    deploySha: requireString(
+      match.deploySha,
+      "App candidate deploy SHA",
+      SHA_PATTERN,
+    ),
+    runId: requireNumericId(match.runId, "App candidate run ID"),
+    runAttempt: requireNumericId(match.runAttempt, "App candidate run attempt"),
+    transactionId: requireString(
+      match.transactionId,
+      "App candidate transaction ID",
+      TRANSACTION_ID_PATTERN,
+    ),
+    customEnvironmentSlug: match.customEnvironmentSlug,
+  };
+  for (const key of DISCOVERY_KEYS) {
+    if (canonical[key] !== discovery[key]) {
+      throw new Error(`App candidate ${key} does not match discovery metadata`);
+    }
+  }
+  return canonical;
+}
+
+export function resolveUniqueAppTransactionCandidate(journal, matches) {
+  const canonical = assertMainTransactionJournal(journal);
+  const app = canonical.candidates.app;
+  if (app === null) throw new Error("The transaction has no app candidate");
+  if (app.deploymentId !== null) {
+    if (matches !== undefined && (!Array.isArray(matches) || matches.length)) {
+      throw new Error("Known app candidate must not be rediscovered");
+    }
+    return app;
+  }
+  if (!Array.isArray(matches)) {
+    throw new Error("App candidate discovery results must be an array");
+  }
+  const canonicalMatches = matches.map((match) =>
+    canonicalizeAppCandidateMatch(match, app.discovery),
+  );
+  if (canonicalMatches.length !== 1) {
+    throw new Error(
+      `App candidate discovery must return exactly one match; received ${canonicalMatches.length}`,
+    );
+  }
+  return {
+    ...app,
+    deploymentId: canonicalMatches[0].deploymentId,
+    deploymentUrl: canonicalMatches[0].deploymentUrl,
+  };
+}
+
+export function assertMainTransactionJournalHistory(
+  journals,
+  expectedIdentity = {},
+) {
+  if (!Array.isArray(journals) || journals.length === 0) {
+    throw new Error("Journal history must be a non-empty array");
+  }
+  const canonical = journals
+    .map((journal) => assertMainTransactionJournal(journal, expectedIdentity))
+    .sort((left, right) => left.sequence - right.sequence);
+  for (const [index, journal] of canonical.entries()) {
+    if (journal.sequence !== index) {
+      throw new Error("Journal history sequence is missing or duplicated");
+    }
+    if (index === 0) {
+      if (journal.status !== "prepared" || journal.operations.length !== 0) {
+        throw new Error("Journal history must begin with a prepared snapshot");
+      }
+      continue;
+    }
+    const previous = canonical[index - 1];
+    for (const key of [
+      "schema",
+      "repository",
+      "deploySha",
+      "runId",
+      "runAttempt",
+      "transactionId",
+      "mode",
+    ]) {
+      if (previous[key] !== journal[key]) {
+        throw new Error("Journal identity changed across history");
+      }
+    }
+    if (!sameJson(previous.prior, journal.prior)) {
+      throw new Error("Journal prior state changed across history");
+    }
+    validateCandidateEvolution(previous.candidates, journal.candidates);
+    if (
+      !sameJson(
+        journal.operations.slice(0, previous.operations.length),
+        previous.operations,
+      )
+    ) {
+      throw new Error("Journal operation history was rewritten");
+    }
+    if (!statusTransitionAllowed(previous.status, journal.status)) {
+      throw new Error("Journal status transition is invalid");
+    }
+  }
+  return canonical;
+}
+
+export function selectHighestMainTransactionJournal(
+  journals,
+  expectedIdentity = {},
+) {
+  return assertMainTransactionJournalHistory(journals, expectedIdentity).at(-1);
+}
+
+export function decideMainTransactionRecovery(journals, expectedIdentity = {}) {
+  const journal = selectHighestMainTransactionJournal(
+    journals,
+    expectedIdentity,
+  );
+  return decideRecoveryFromJournal(journal);
+}
+
+function decideRecoveryFromJournal(journal) {
+  if (journal.status === "committed") {
+    return { decision: "bypass", reason: "committed", journal };
+  }
+  if (journal.status === "recovered") {
+    return { decision: "bypass", reason: "already-recovered", journal };
+  }
+  if (journal.status === "manual_intervention") {
+    return {
+      decision: "manual_intervention",
+      reason: "manual-intervention-recorded",
+      journal,
+    };
+  }
+  const started = startedForwardOperations(journal);
+  if (started.length === 0) {
+    return {
+      decision: "verify-only",
+      reason: "no-mutation-started",
+      journal,
+    };
+  }
+  return {
+    decision: "recover",
+    reason: "incomplete-mutation-journal",
+    journal,
+  };
+}
+
+export function markMainTransactionCommitted(journal) {
+  const canonical = assertMainTransactionJournal(journal);
+  if (canonical.status === "committed") return canonical;
+  if (
+    !["prepared", "verified"].includes(canonical.status) ||
+    startedForwardOperations(canonical).some(
+      (operation) => !isOperationVerified(canonical, operation.operationId),
+    )
+  ) {
+    throw new Error("Transaction cannot commit with incomplete operations");
+  }
+  return appendStatus(canonical, "committed");
+}
+
+export function classifyMainTransactionMapping({
+  aliases,
+  currentMappings,
+  prior,
+  candidate,
+}) {
+  const canonicalPrior = canonicalPriorRecord(prior, "Mapping prior");
+  const canonicalCandidate = canonicalPriorRecord(
+    {
+      deploymentId: candidate?.deploymentId,
+      deploymentUrl: candidate?.deploymentUrl,
+      aliases: candidate?.aliases,
+    },
+    "Mapping candidate",
+  );
+  const canonicalAliasList = canonicalAliases(aliases, "Mapping aliases");
+  const mappings = canonicalCurrentMappings(
+    currentMappings,
+    canonicalAliasList,
+  );
+  const states = canonicalAliasList.map((alias) => {
+    const mapping = mappings.get(alias);
+    if (sameDeployment(mapping, canonicalPrior)) return "prior";
+    if (sameDeployment(mapping, canonicalCandidate)) return "candidate";
+    return "unexpected";
+  });
+  if (states.every((state) => state === "prior")) return "prior";
+  if (states.every((state) => state === "candidate")) return "candidate";
+  if (states.every((state) => state !== "unexpected")) return "partial";
+  return "unexpected";
+}
+
+function canonicalAllCurrentMappings(journal, currentMappings) {
+  const aliases = PROTECTED_TARGETS.flatMap(
+    (target) => journal.prior[target].aliases,
+  );
+  return canonicalCurrentMappings(currentMappings, aliases);
+}
+
+function action(kind, operation, additional = {}) {
+  return {
+    kind,
+    target: operation.target,
+    operationId: operation.operationId,
+    priorDeploymentId: operation.priorDeploymentId,
+    priorDeploymentUrl: operation.priorDeploymentUrl,
+    candidateDeploymentId: operation.candidateDeploymentId,
+    candidateDeploymentUrl: operation.candidateDeploymentUrl,
+    ...additional,
+  };
+}
+
+export function planMainTransactionRecovery({
+  journal,
+  currentMappings,
+  appCandidateMatches = [],
+}) {
+  let canonical = assertMainTransactionJournal(journal);
+  // The recovery job validates the complete immutable artifact history before
+  // passing its highest snapshot to this pure planner.
+  const recoveryDecision = decideRecoveryFromJournal(canonical);
+  if (recoveryDecision.decision !== "recover") {
+    return {
+      decision: recoveryDecision.decision,
+      reason: recoveryDecision.reason,
+      journal: canonical,
+      actions: [],
+      rollbackStateTargets: [],
+      forceFailure: false,
+    };
+  }
+  const mappings = canonicalAllCurrentMappings(canonical, currentMappings);
+  const starts = startedForwardOperations(canonical);
+  const appWasStarted = starts.some(
+    (operation) => operation.type === "app_v3_deploy",
+  );
+  let appCandidate = canonical.candidates.app;
+  let discoveredAppCandidate = null;
+  if (appWasStarted && appCandidate?.deploymentId === null) {
+    const appAliasesMoved = canonical.prior.app.aliases.some(
+      (alias) => !sameDeployment(mappings.get(alias), canonical.prior.app),
+    );
+    const legacyMoved = canonical.prior["legacy-app"].aliases.some(
+      (alias) =>
+        !sameDeployment(mappings.get(alias), canonical.prior["legacy-app"]),
+    );
+    if (appAliasesMoved || legacyMoved) {
+      try {
+        appCandidate = resolveUniqueAppTransactionCandidate(
+          canonical,
+          appCandidateMatches,
+        );
+        discoveredAppCandidate = {
+          deploymentId: appCandidate.deploymentId,
+          deploymentUrl: appCandidate.deploymentUrl,
+          ...appCandidate.discovery,
+        };
+      } catch {
+        return {
+          decision: "manual_intervention",
+          reason: "app-candidate-ambiguous-after-mapping-moved",
+          journal: canonical,
+          actions: [],
+          rollbackStateTargets: [],
+          forceFailure: true,
+          discoveredAppCandidate: null,
+        };
+      }
+    }
+  }
+  const actions = [];
+  const handledOrdinaryTargets = new Set();
+  const handledAppAliases = new Set();
+  let legacyHandled = false;
+  let manual = false;
+  let emergencyLegacyRestore = false;
+  for (const operation of [...starts].reverse()) {
+    if (operation.type === "promote") {
+      if (handledOrdinaryTargets.has(operation.target)) continue;
+      handledOrdinaryTargets.add(operation.target);
+      const candidate = canonical.candidates[operation.target];
+      const targetMappings = canonical.prior[operation.target].aliases.map(
+        (alias) => mappings.get(alias),
+      );
+      const mappingState = classifyMainTransactionMapping({
+        aliases: canonical.prior[operation.target].aliases,
+        currentMappings: targetMappings,
+        prior: canonical.prior[operation.target],
+        candidate,
+      });
+      if (mappingState === "prior") {
+        actions.push(
+          action("verified_noop", operation, { mappingState: "prior" }),
+        );
+      } else if (mappingState === "candidate") {
+        actions.push(
+          action("ordinary_rollback", operation, {
+            aliases: canonical.prior[operation.target].aliases,
+            entersRollbackState: true,
+          }),
+        );
+      } else {
+        manual = true;
+        actions.push(
+          action("manual_intervention", operation, { mappingState }),
+        );
+      }
+      continue;
+    }
+    if (
+      operation.type === "app_alias_set" &&
+      !handledAppAliases.has(operation.alias)
+    ) {
+      handledAppAliases.add(operation.alias);
+      const mapping = mappings.get(operation.alias);
+      if (sameDeployment(mapping, canonical.prior.app)) {
+        actions.push(
+          action("verified_noop", operation, {
+            alias: operation.alias,
+            mappingState: "prior",
+          }),
+        );
+      } else if (
+        appCandidate?.deploymentId &&
+        sameDeployment(mapping, appCandidate)
+      ) {
+        actions.push(
+          action("app_alias_restore", operation, {
+            alias: operation.alias,
+            candidateDeploymentId: appCandidate.deploymentId,
+            candidateDeploymentUrl: appCandidate.deploymentUrl,
+          }),
+        );
+      } else {
+        manual = true;
+        actions.push(
+          action("manual_intervention", operation, {
+            alias: operation.alias,
+            mappingState: "unexpected",
+          }),
+        );
+      }
+      continue;
+    }
+    if (operation.type === "app_v3_deploy") {
+      for (const alias of [...canonical.prior.app.aliases].reverse()) {
+        if (handledAppAliases.has(alias)) continue;
+        handledAppAliases.add(alias);
+        const mapping = mappings.get(alias);
+        if (sameDeployment(mapping, canonical.prior.app)) {
+          actions.push(
+            action("verified_noop", operation, {
+              alias,
+              mappingState: "prior",
+            }),
+          );
+        } else if (
+          appCandidate?.deploymentId &&
+          sameDeployment(mapping, appCandidate)
+        ) {
+          actions.push(
+            action("app_alias_restore", operation, {
+              alias,
+              candidateDeploymentId: appCandidate.deploymentId,
+              candidateDeploymentUrl: appCandidate.deploymentUrl,
+            }),
+          );
+        } else {
+          manual = true;
+          actions.push(
+            action("manual_intervention", operation, {
+              alias,
+              mappingState: "unexpected",
+            }),
+          );
+        }
+      }
+      if (!legacyHandled) {
+        legacyHandled = true;
+        for (const alias of canonical.prior["legacy-app"].aliases) {
+          const mapping = mappings.get(alias);
+          if (sameDeployment(mapping, canonical.prior["legacy-app"])) {
+            actions.push(
+              action("verified_noop", operation, {
+                target: "legacy-app",
+                alias,
+                mappingState: "prior",
+              }),
+            );
+          } else if (
+            appCandidate?.deploymentId &&
+            sameDeployment(mapping, appCandidate)
+          ) {
+            emergencyLegacyRestore = true;
+            actions.push(
+              action("legacy_emergency_restore", operation, {
+                target: "legacy-app",
+                alias,
+                priorDeploymentId: canonical.prior["legacy-app"].deploymentId,
+                priorDeploymentUrl: canonical.prior["legacy-app"].deploymentUrl,
+                candidateDeploymentId: appCandidate.deploymentId,
+                candidateDeploymentUrl: appCandidate.deploymentUrl,
+              }),
+            );
+          } else {
+            manual = true;
+            actions.push(
+              action("manual_intervention", operation, {
+                target: "legacy-app",
+                alias,
+                mappingState: "unexpected",
+              }),
+            );
+          }
+        }
+      }
+    }
+  }
+  return {
+    decision: manual ? "manual_intervention" : "recover",
+    reason: manual
+      ? "unexpected-protected-mapping"
+      : emergencyLegacyRestore
+        ? "legacy-alias-moved-to-transaction-candidate"
+        : "started-operations-require-verification-or-recovery",
+    journal: canonical,
+    actions,
+    rollbackStateTargets: actions
+      .filter((entry) => entry.kind === "ordinary_rollback")
+      .map((entry) => entry.target),
+    forceFailure: true, // Recovery never converts a failed activation into a green release.
+    discoveredAppCandidate,
+  };
+}
+
+async function assertFresh(assertFreshness, phase, journal) {
+  if (typeof assertFreshness !== "function") {
+    throw new Error("Freshness adapter is required");
+  }
+  let result;
+  try {
+    result = await assertFreshness({
+      phase,
+      deploySha: journal.deploySha,
+      transactionId: journal.transactionId,
+    });
+  } catch {
+    throw new MainTransactionError("Remote main freshness is unproven", {
+      code: "FRESHNESS_UNPROVEN",
+      journal,
+    });
+  }
+  if (!result || result.sha !== journal.deploySha) {
+    throw new MainTransactionError("Remote main advanced", {
+      code:
+        phase === "transaction-start"
+          ? "SUPERSEDED_BEFORE_MUTATION"
+          : "SUPERSEDED_DURING_MUTATION",
+      journal,
+    });
+  }
+}
+
+export async function executeJournaledMainMutation({
+  journal,
+  intent,
+  uploadJournal,
+  executeMutation,
+  verifyMapping,
+  inspectMutationState,
+  allowedPreMutationStates = ["prior"],
+  expectedVerifiedMappingState = "candidate",
+  assertFreshness,
+  requireFreshness = true,
+}) {
+  let highest = assertMainTransactionJournal(journal);
+  if (typeof executeMutation !== "function") {
+    throw new Error("Mutation adapter is required");
+  }
+  if (typeof verifyMapping !== "function") {
+    throw new Error("Mapping verification adapter is required");
+  }
+  if (typeof inspectMutationState !== "function") {
+    throw new Error("Pre-mutation state adapter is required");
+  }
+  if (
+    !Array.isArray(allowedPreMutationStates) ||
+    allowedPreMutationStates.length === 0 ||
+    allowedPreMutationStates.some(
+      (state) => !["prior", "candidate"].includes(state),
+    )
+  ) {
+    throw new Error("Allowed pre-mutation mapping states are malformed");
+  }
+  if (!["prior", "candidate"].includes(expectedVerifiedMappingState)) {
+    throw new Error("Expected verified mapping state is malformed");
+  }
+  const assertPreMutationState = async (phase) => {
+    let result;
+    try {
+      result = await inspectMutationState({
+        phase,
+        intent: clone(intent),
+        transactionId: highest.transactionId,
+      });
+    } catch {
+      throw new MainTransactionError(
+        "Protected mapping state is unproven before mutation",
+        {
+          code: "PROTECTED_MAPPING_DRIFT",
+          journal: highest,
+        },
+      );
+    }
+    if (!result || !allowedPreMutationStates.includes(result.mappingState)) {
+      throw new MainTransactionError(
+        "Protected mapping drifted before mutation",
+        {
+          code: "PROTECTED_MAPPING_DRIFT",
+          journal: highest,
+        },
+      );
+    }
+  };
+  if (requireFreshness) {
+    await assertFresh(assertFreshness, "pre-operation", highest);
+  }
+  await assertPreMutationState("pre-operation");
+  highest = startMainTransactionOperation(highest, intent);
+  highest = await persistMainTransactionJournal(highest, uploadJournal);
+  const durableStartedJournal = highest;
+  const operationId = highest.operations.at(-1).operationId;
+  if (requireFreshness) {
+    try {
+      await assertFresh(assertFreshness, "pre-command", highest);
+    } catch (error) {
+      if (error instanceof MainTransactionError) error.journal = highest;
+      throw error;
+    }
+  }
+  try {
+    await assertPreMutationState("pre-command");
+  } catch (error) {
+    if (error instanceof MainTransactionError) error.journal = highest;
+    throw error;
+  }
+  let commandResult;
+  try {
+    commandResult = await executeMutation({
+      operation: clone(highest.operations.at(-1)),
+      transactionId: highest.transactionId,
+    });
+  } catch {
+    commandResult = { outcome: "unknown" };
+  }
+  const outcome = commandResult?.outcome === "success" ? "success" : "unknown";
+  highest = recordMainTransactionCommandReturned(highest, {
+    operationId,
+    outcome,
+    candidate: commandResult?.candidate ?? null,
+  });
+  try {
+    highest = await persistMainTransactionJournal(highest, uploadJournal);
+  } catch (error) {
+    if (error instanceof MainTransactionError) {
+      // Only the started snapshot is guaranteed durable when this upload fails.
+      error.journal = durableStartedJournal;
+    }
+    throw error;
+  }
+  let freshnessError = null;
+  if (requireFreshness) {
+    try {
+      await assertFresh(assertFreshness, "post-command", highest);
+    } catch (error) {
+      freshnessError = error;
+    }
+  }
+  let mappingState = "unknown";
+  try {
+    const result = await verifyMapping({
+      operation: clone(lastOperationEvent(highest, operationId)),
+      transactionId: highest.transactionId,
+    });
+    if (result && MAPPING_STATES.includes(result.mappingState)) {
+      mappingState = result.mappingState;
+    }
+  } catch {
+    mappingState = "unknown";
+  }
+  if (freshnessError) mappingState = "unknown";
+  highest = recordMainTransactionVerified(highest, {
+    operationId,
+    mappingState,
+    rollbackState:
+      intent.type === "ordinary_rollback" && mappingState === "prior"
+        ? "entered"
+        : null,
+  });
+  highest = await persistMainTransactionJournal(highest, uploadJournal);
+  if (
+    freshnessError ||
+    outcome === "unknown" ||
+    mappingState !== expectedVerifiedMappingState
+  ) {
+    throw new MainTransactionError(
+      "Mutation outcome requires deterministic recovery",
+      {
+        code: freshnessError
+          ? "SUPERSEDED_DURING_MUTATION"
+          : outcome === "unknown"
+            ? "MUTATION_OUTCOME_UNKNOWN"
+            : "MUTATION_VERIFICATION_FAILED",
+        journal: highest,
+      },
+    );
+  }
+  return highest;
+}
+
+function recoveryIntent(action) {
+  if (action.kind === "ordinary_rollback") {
+    return {
+      type: "ordinary_rollback",
+      target: action.target,
+    };
+  }
+  if (action.kind === "app_alias_restore") {
+    return {
+      type: "app_alias_restore",
+      target: "app",
+      alias: action.alias,
+    };
+  }
+  if (action.kind === "legacy_emergency_restore") {
+    return {
+      type: "legacy_emergency_restore",
+      target: "legacy-app",
+      alias: action.alias,
+    };
+  }
+  throw new Error("Recovery action does not mutate a mapping");
+}
+
+export async function executeMainTransactionRecovery({
+  plan,
+  uploadJournal,
+  ordinaryRollback,
+  restoreAppAlias,
+  restoreLegacyAlias,
+  inspectMapping,
+  verifyMapping,
+}) {
+  let highest = assertMainTransactionJournal(plan?.journal);
+  if (!["recover", "manual_intervention"].includes(plan?.decision)) {
+    return highest;
+  }
+  const mutationKinds = new Set([
+    "ordinary_rollback",
+    "app_alias_restore",
+    "legacy_emergency_restore",
+  ]);
+  if (
+    !Array.isArray(plan.actions) ||
+    plan.actions.some(
+      (entry) =>
+        !["verified_noop", "manual_intervention", ...mutationKinds].includes(
+          entry?.kind,
+        ),
+    )
+  ) {
+    throw new Error("Recovery plan actions are malformed");
+  }
+  if (
+    plan.actions.some((entry) => mutationKinds.has(entry.kind)) &&
+    (typeof inspectMapping !== "function" ||
+      typeof verifyMapping !== "function")
+  ) {
+    throw new Error("Recovery mapping adapters are required");
+  }
+  for (const [kind, adapter] of [
+    ["ordinary_rollback", ordinaryRollback],
+    ["app_alias_restore", restoreAppAlias],
+    ["legacy_emergency_restore", restoreLegacyAlias],
+  ]) {
+    if (
+      plan.actions.some((entry) => entry.kind === kind) &&
+      typeof adapter !== "function"
+    ) {
+      throw new Error(`Recovery adapter for ${kind} is required`);
+    }
+  }
+  if (
+    plan.discoveredAppCandidate &&
+    highest.candidates.app?.deploymentId === null
+  ) {
+    highest = attachDiscoveredAppCandidate(
+      highest,
+      plan.discoveredAppCandidate,
+    );
+    highest = await persistMainTransactionJournal(highest, uploadJournal);
+  }
+  highest = appendStatus(highest, "recovering");
+  highest = await persistMainTransactionJournal(highest, uploadJournal);
+  for (const entry of plan.actions) {
+    if (entry.kind === "verified_noop") continue;
+    if (entry.kind === "manual_intervention") {
+      continue;
+    }
+    const adapter =
+      entry.kind === "ordinary_rollback"
+        ? ordinaryRollback
+        : entry.kind === "app_alias_restore"
+          ? restoreAppAlias
+          : restoreLegacyAlias;
+    highest = await executeJournaledMainMutation({
+      journal: highest,
+      intent: recoveryIntent(entry),
+      uploadJournal,
+      executeMutation: () => adapter(clone(entry)),
+      inspectMutationState: (context) => inspectMapping(clone(entry), context),
+      allowedPreMutationStates: ["candidate"],
+      expectedVerifiedMappingState: "prior",
+      verifyMapping: (context) => verifyMapping(clone(entry), context),
+      requireFreshness: false,
+    });
+  }
+  highest = appendStatus(
+    highest,
+    plan.decision === "manual_intervention"
+      ? "manual_intervention"
+      : "recovered",
+  );
+  return persistMainTransactionJournal(highest, uploadJournal);
+}
+
+export async function runMainTransaction({
+  mode = MAIN_TRANSACTION_MODE,
+  identity,
+  prior,
+  candidates,
+  existingJournals = [],
+  assertFreshness,
+  uploadJournal,
+  inspectRecoveryState,
+  mutationAdapters = {},
+}) {
+  if (mode !== "shadow") {
+    throw new Error(
+      "Active Vercel main transaction execution is unreachable in PR A",
+    );
+  }
+  const forbiddenAdapters = [
+    "promote",
+    "deployAppV3",
+    "assignAlias",
+    "ordinaryRollback",
+    "restoreAppAlias",
+    "restoreLegacyAlias",
+  ];
+  for (const name of forbiddenAdapters) {
+    if (
+      Object.hasOwn(mutationAdapters, name) &&
+      typeof mutationAdapters[name] !== "function"
+    ) {
+      throw new Error(`Mutation adapter ${name} is malformed`);
+    }
+  }
+  const prepared = createPreparedMainTransactionJournal({
+    ...identity,
+    mode,
+    prior,
+    candidates,
+  });
+  await assertFresh(assertFreshness, "transaction-start", prepared);
+  let journals;
+  let persisted;
+  if (existingJournals.length === 0) {
+    persisted = await persistMainTransactionJournal(prepared, uploadJournal);
+    journals = [persisted];
+  } else {
+    journals = assertMainTransactionJournalHistory(existingJournals, {
+      repository: prepared.repository,
+      deploySha: prepared.deploySha,
+      runId: prepared.runId,
+      runAttempt: prepared.runAttempt,
+      transactionId: prepared.transactionId,
+      mode: "shadow",
+    });
+    if (!sameJson(journals[0], prepared)) {
+      throw new Error(
+        "Existing journal history does not begin with this preparation",
+      );
+    }
+    persisted = journals.at(-1);
+  }
+  const decision = decideMainTransactionRecovery(journals, {
+    repository: persisted.repository,
+    deploySha: persisted.deploySha,
+    runId: persisted.runId,
+    runAttempt: persisted.runAttempt,
+    transactionId: persisted.transactionId,
+    mode: "shadow",
+  });
+  if (typeof inspectRecoveryState === "function") {
+    await inspectRecoveryState({
+      decision: decision.decision,
+      reason: decision.reason,
+      transactionId: persisted.transactionId,
+    });
+  }
+  return {
+    mode,
+    outcome: "shadow-prepared",
+    journal: persisted,
+    recoveryDecision: {
+      decision: decision.decision,
+      reason: decision.reason,
+    },
+    mutationCallbacksCalled: 0,
+  };
+}

--- a/scripts/vercel-main-transaction.mjs
+++ b/scripts/vercel-main-transaction.mjs
@@ -48,9 +48,6 @@ const OPERATION_STATES = Object.freeze([
   "started",
   "command_returned",
   "verified",
-  "recovering",
-  "recovered",
-  "manual_intervention",
 ]);
 const COMMAND_OUTCOMES = Object.freeze([null, "success", "unknown"]);
 const MAPPING_STATES = Object.freeze([
@@ -121,6 +118,24 @@ const APP_CANDIDATE_MATCH_KEYS = Object.freeze([
   "runAttempt",
   "transactionId",
   "customEnvironmentSlug",
+]);
+const RECOVERY_PLAN_KEYS = Object.freeze([
+  "decision",
+  "reason",
+  "journal",
+  "actions",
+  "rollbackStateTargets",
+  "forceFailure",
+  "discoveredAppCandidate",
+]);
+const RECOVERY_ACTION_BASE_KEYS = Object.freeze([
+  "kind",
+  "target",
+  "operationId",
+  "priorDeploymentId",
+  "priorDeploymentUrl",
+  "candidateDeploymentId",
+  "candidateDeploymentUrl",
 ]);
 
 export class MainTransactionError extends Error {
@@ -443,10 +458,36 @@ function canonicalOperation(operation, journal) {
     throw new Error("Operation rollback state is unsupported");
   }
   if (
-    operation.rollbackState === "entered" &&
-    operation.type !== "ordinary_rollback"
+    (operation.state === "started" &&
+      (operation.commandOutcome !== null ||
+        operation.mappingState !== null ||
+        operation.rollbackState !== null)) ||
+    (operation.state === "command_returned" &&
+      (operation.commandOutcome === null ||
+        operation.mappingState !== null ||
+        operation.rollbackState !== null)) ||
+    (operation.state === "verified" &&
+      (operation.commandOutcome === null || operation.mappingState === null))
   ) {
-    throw new Error("Only an ordinary rollback may enter rollback state");
+    throw new Error("Operation fields are inconsistent with its state");
+  }
+  if (
+    operation.rollbackState === "entered" &&
+    (operation.type !== "ordinary_rollback" ||
+      operation.state !== "verified" ||
+      operation.mappingState !== "prior")
+  ) {
+    throw new Error(
+      "Rollback marker requires a verified ordinary rollback at prior",
+    );
+  }
+  if (
+    operation.type === "ordinary_rollback" &&
+    operation.state === "verified" &&
+    operation.mappingState === "prior" &&
+    operation.rollbackState !== "entered"
+  ) {
+    throw new Error("Verified ordinary rollback must enter rollback state");
   }
   return {
     operationId,
@@ -532,25 +573,9 @@ function canonicalOperations(operations, journal) {
       throw new Error("Every journal operation must begin with started");
     }
     const allowedTransitions = {
-      started: new Set([
-        "command_returned",
-        "recovering",
-        "manual_intervention",
-      ]),
-      command_returned: new Set([
-        "verified",
-        "recovering",
-        "manual_intervention",
-      ]),
-      verified: new Set(["recovering", "recovered", "manual_intervention"]),
-      recovering: new Set([
-        "command_returned",
-        "verified",
-        "recovered",
-        "manual_intervention",
-      ]),
-      recovered: new Set(),
-      manual_intervention: new Set(),
+      started: new Set(["command_returned"]),
+      command_returned: new Set(["verified"]),
+      verified: new Set(),
     };
     for (let stateIndex = 1; stateIndex < states.length; stateIndex += 1) {
       if (!allowedTransitions[states[stateIndex - 1]].has(states[stateIndex])) {
@@ -641,47 +666,21 @@ function validateCandidateEvolution(previous, current) {
   }
 }
 
-function statusTransitionAllowed(previous, current) {
+function statusOnlyTransitionAllowed(previous, current) {
   const transitions = {
-    prepared: new Set([
-      "prepared",
-      "started",
-      "committed",
-      "recovering",
-      "recovered",
-      "manual_intervention",
-    ]),
-    started: new Set([
-      "started",
-      "command_returned",
-      "recovering",
-      "manual_intervention",
-    ]),
-    command_returned: new Set([
-      "command_returned",
-      "verified",
-      "recovering",
-      "manual_intervention",
-    ]),
+    prepared: new Set(["committed"]),
+    started: new Set(["recovering"]),
+    command_returned: new Set(["recovering"]),
     verified: new Set([
-      "verified",
-      "started",
       "committed",
       "recovering",
       "recovered",
       "manual_intervention",
     ]),
-    committed: new Set(["committed"]),
-    recovering: new Set([
-      "started",
-      "command_returned",
-      "verified",
-      "recovering",
-      "recovered",
-      "manual_intervention",
-    ]),
-    recovered: new Set(["recovered"]),
-    manual_intervention: new Set(["manual_intervention"]),
+    committed: new Set(),
+    recovering: new Set(["recovered", "manual_intervention"]),
+    recovered: new Set(),
+    manual_intervention: new Set(),
   };
   return transitions[previous].has(current);
 }
@@ -871,7 +870,8 @@ export async function persistMainTransactionJournal(journal, uploadJournal) {
   if (
     !receipt ||
     receipt.acknowledged !== true ||
-    receipt.artifactName !== artifactName
+    receipt.artifactName !== artifactName ||
+    !NUMERIC_ID_PATTERN.test(String(receipt.artifactId ?? ""))
   ) {
     throw new MainTransactionError(
       "Journal artifact upload was not acknowledged",
@@ -893,6 +893,24 @@ export function startMainTransactionOperation(journal, intent) {
     throw new Error("Operation type is unsupported");
   }
   const resolved = operationIntent(canonical, intent);
+  const forwardStarts = startedForwardOperations(canonical);
+  if (
+    (resolved.type === "promote" &&
+      forwardStarts.some(
+        (operation) =>
+          operation.type === "promote" && operation.target === resolved.target,
+      )) ||
+    (resolved.type === "app_v3_deploy" &&
+      forwardStarts.some((operation) => operation.type === "app_v3_deploy")) ||
+    (resolved.type === "app_alias_set" &&
+      forwardStarts.some(
+        (operation) =>
+          operation.type === "app_alias_set" &&
+          operation.alias === resolved.alias,
+      ))
+  ) {
+    throw new Error("Forward transaction operation is already recorded");
+  }
   const startedCount = canonical.operations.filter(
     (operation) => operation.state === "started",
   ).length;
@@ -916,7 +934,7 @@ export function recordMainTransactionCommandReturned(
 ) {
   let canonical = assertMainTransactionJournal(journal);
   const previous = lastOperationEvent(canonical, operationId);
-  if (!["started", "recovering"].includes(previous.state)) {
+  if (previous.state !== "started") {
     throw new Error("Operation is not waiting for a command result");
   }
   if (!["success", "unknown"].includes(outcome)) {
@@ -971,7 +989,7 @@ export function recordMainTransactionVerified(
 ) {
   const canonical = assertMainTransactionJournal(journal);
   const previous = lastOperationEvent(canonical, operationId);
-  if (!["command_returned", "recovering"].includes(previous.state)) {
+  if (previous.state !== "command_returned") {
     throw new Error("Operation command has not returned");
   }
   if (!MAPPING_STATES.includes(mappingState) || mappingState === null) {
@@ -1130,8 +1148,43 @@ export function assertMainTransactionJournalHistory(
     ) {
       throw new Error("Journal operation history was rewritten");
     }
-    if (!statusTransitionAllowed(previous.status, journal.status)) {
-      throw new Error("Journal status transition is invalid");
+    const appendedEvents =
+      journal.operations.length - previous.operations.length;
+    const candidateChanged = !sameJson(previous.candidates, journal.candidates);
+    if (appendedEvents === 0) {
+      const isCandidateAttachment =
+        candidateChanged && journal.status === previous.status;
+      const isStatusOnlyTransition =
+        !candidateChanged &&
+        statusOnlyTransitionAllowed(previous.status, journal.status);
+      if (!isCandidateAttachment && !isStatusOnlyTransition) {
+        throw new Error("Journal snapshot did not append one legal event");
+      }
+      continue;
+    }
+    if (appendedEvents !== 1) {
+      throw new Error("Journal snapshot batched operation events");
+    }
+    const appended = journal.operations.at(-1);
+    if (journal.status !== appended.state) {
+      throw new Error("Journal status does not match its appended operation");
+    }
+    const expectedPreviousStatuses = {
+      started: new Set(["prepared", "verified", "recovering"]),
+      command_returned: new Set(["started"]),
+      verified: new Set(["command_returned"]),
+    };
+    if (!expectedPreviousStatuses[appended.state].has(previous.status)) {
+      throw new Error("Journal operation append is invalid for its status");
+    }
+    if (
+      candidateChanged &&
+      (appended.type !== "app_v3_deploy" ||
+        appended.state !== "command_returned")
+    ) {
+      throw new Error(
+        "App candidate attachment must accompany its command-return event",
+      );
     }
   }
   return canonical;
@@ -1184,8 +1237,36 @@ function decideRecoveryFromJournal(journal) {
 export function markMainTransactionCommitted(journal) {
   const canonical = assertMainTransactionJournal(journal);
   if (canonical.status === "committed") return canonical;
+  const selectedOperations = [
+    ...ORDINARY_TARGETS.filter(
+      (target) => canonical.candidates[target] !== null,
+    ).map((target) => ({ target, type: "promote" })),
+    ...(canonical.candidates.app === null
+      ? []
+      : [{ target: "app", type: "app_v3_deploy" }]),
+  ];
+  // App alias completeness is owned by the final protected-mapping verifier.
+  // The journal commit gate binds the selected immutable deployment itself.
+  const selectedOperationsVerified = selectedOperations.every(
+    ({ target, type }) => {
+      if (
+        type === "app_v3_deploy" &&
+        canonical.candidates.app.deploymentId === null
+      ) {
+        return false;
+      }
+      const operation = startedForwardOperations(canonical).find(
+        (entry) => entry.type === type && entry.target === target,
+      );
+      return (
+        operation !== undefined &&
+        isOperationVerified(canonical, operation.operationId)
+      );
+    },
+  );
   if (
     !["prepared", "verified"].includes(canonical.status) ||
+    !selectedOperationsVerified ||
     startedForwardOperations(canonical).some(
       (operation) => !isOperationVerified(canonical, operation.operationId),
     )
@@ -1234,15 +1315,21 @@ function canonicalAllCurrentMappings(journal, currentMappings) {
   return canonicalCurrentMappings(currentMappings, aliases);
 }
 
-function action(kind, operation, additional = {}) {
+function action(kind, journal, operation, additional = {}) {
+  const target = additional.target ?? operation.target;
+  const prior = journal.prior[target];
+  const candidate =
+    target === "legacy-app"
+      ? journal.candidates.app
+      : journal.candidates[target];
   return {
     kind,
-    target: operation.target,
+    target,
     operationId: operation.operationId,
-    priorDeploymentId: operation.priorDeploymentId,
-    priorDeploymentUrl: operation.priorDeploymentUrl,
-    candidateDeploymentId: operation.candidateDeploymentId,
-    candidateDeploymentUrl: operation.candidateDeploymentUrl,
+    priorDeploymentId: prior.deploymentId,
+    priorDeploymentUrl: prior.deploymentUrl,
+    candidateDeploymentId: candidate?.deploymentId ?? null,
+    candidateDeploymentUrl: candidate?.deploymentUrl ?? null,
     ...additional,
   };
 }
@@ -1264,6 +1351,7 @@ export function planMainTransactionRecovery({
       actions: [],
       rollbackStateTargets: [],
       forceFailure: false,
+      discoveredAppCandidate: null,
     };
   }
   const mappings = canonicalAllCurrentMappings(canonical, currentMappings);
@@ -1305,6 +1393,10 @@ export function planMainTransactionRecovery({
       }
     }
   }
+  const recoveryJournal =
+    discoveredAppCandidate === null
+      ? canonical
+      : attachDiscoveredAppCandidate(canonical, discoveredAppCandidate);
   const actions = [];
   const handledOrdinaryTargets = new Set();
   const handledAppAliases = new Set();
@@ -1327,11 +1419,13 @@ export function planMainTransactionRecovery({
       });
       if (mappingState === "prior") {
         actions.push(
-          action("verified_noop", operation, { mappingState: "prior" }),
+          action("verified_noop", recoveryJournal, operation, {
+            mappingState: "prior",
+          }),
         );
       } else if (mappingState === "candidate") {
         actions.push(
-          action("ordinary_rollback", operation, {
+          action("ordinary_rollback", recoveryJournal, operation, {
             aliases: canonical.prior[operation.target].aliases,
             entersRollbackState: true,
           }),
@@ -1339,7 +1433,9 @@ export function planMainTransactionRecovery({
       } else {
         manual = true;
         actions.push(
-          action("manual_intervention", operation, { mappingState }),
+          action("manual_intervention", recoveryJournal, operation, {
+            mappingState,
+          }),
         );
       }
       continue;
@@ -1352,7 +1448,7 @@ export function planMainTransactionRecovery({
       const mapping = mappings.get(operation.alias);
       if (sameDeployment(mapping, canonical.prior.app)) {
         actions.push(
-          action("verified_noop", operation, {
+          action("verified_noop", recoveryJournal, operation, {
             alias: operation.alias,
             mappingState: "prior",
           }),
@@ -1362,16 +1458,14 @@ export function planMainTransactionRecovery({
         sameDeployment(mapping, appCandidate)
       ) {
         actions.push(
-          action("app_alias_restore", operation, {
+          action("app_alias_restore", recoveryJournal, operation, {
             alias: operation.alias,
-            candidateDeploymentId: appCandidate.deploymentId,
-            candidateDeploymentUrl: appCandidate.deploymentUrl,
           }),
         );
       } else {
         manual = true;
         actions.push(
-          action("manual_intervention", operation, {
+          action("manual_intervention", recoveryJournal, operation, {
             alias: operation.alias,
             mappingState: "unexpected",
           }),
@@ -1386,7 +1480,7 @@ export function planMainTransactionRecovery({
         const mapping = mappings.get(alias);
         if (sameDeployment(mapping, canonical.prior.app)) {
           actions.push(
-            action("verified_noop", operation, {
+            action("verified_noop", recoveryJournal, operation, {
               alias,
               mappingState: "prior",
             }),
@@ -1396,16 +1490,14 @@ export function planMainTransactionRecovery({
           sameDeployment(mapping, appCandidate)
         ) {
           actions.push(
-            action("app_alias_restore", operation, {
+            action("app_alias_restore", recoveryJournal, operation, {
               alias,
-              candidateDeploymentId: appCandidate.deploymentId,
-              candidateDeploymentUrl: appCandidate.deploymentUrl,
             }),
           );
         } else {
           manual = true;
           actions.push(
-            action("manual_intervention", operation, {
+            action("manual_intervention", recoveryJournal, operation, {
               alias,
               mappingState: "unexpected",
             }),
@@ -1418,7 +1510,7 @@ export function planMainTransactionRecovery({
           const mapping = mappings.get(alias);
           if (sameDeployment(mapping, canonical.prior["legacy-app"])) {
             actions.push(
-              action("verified_noop", operation, {
+              action("verified_noop", recoveryJournal, operation, {
                 target: "legacy-app",
                 alias,
                 mappingState: "prior",
@@ -1430,19 +1522,15 @@ export function planMainTransactionRecovery({
           ) {
             emergencyLegacyRestore = true;
             actions.push(
-              action("legacy_emergency_restore", operation, {
+              action("legacy_emergency_restore", recoveryJournal, operation, {
                 target: "legacy-app",
                 alias,
-                priorDeploymentId: canonical.prior["legacy-app"].deploymentId,
-                priorDeploymentUrl: canonical.prior["legacy-app"].deploymentUrl,
-                candidateDeploymentId: appCandidate.deploymentId,
-                candidateDeploymentUrl: appCandidate.deploymentUrl,
               }),
             );
           } else {
             manual = true;
             actions.push(
-              action("manual_intervention", operation, {
+              action("manual_intervention", recoveryJournal, operation, {
                 target: "legacy-app",
                 alias,
                 mappingState: "unexpected",
@@ -1466,6 +1554,268 @@ export function planMainTransactionRecovery({
       .filter((entry) => entry.kind === "ordinary_rollback")
       .map((entry) => entry.target),
     forceFailure: true, // Recovery never converts a failed activation into a green release.
+    discoveredAppCandidate,
+  };
+}
+
+function recoveryActionSlots(journal) {
+  const slots = [];
+  const handledOrdinaryTargets = new Set();
+  const handledAppAliases = new Set();
+  let legacyHandled = false;
+  for (const operation of [...startedForwardOperations(journal)].reverse()) {
+    if (operation.type === "promote") {
+      if (handledOrdinaryTargets.has(operation.target)) continue;
+      handledOrdinaryTargets.add(operation.target);
+      slots.push({
+        category: "ordinary",
+        target: operation.target,
+        alias: null,
+        operation,
+      });
+      continue;
+    }
+    if (
+      operation.type === "app_alias_set" &&
+      !handledAppAliases.has(operation.alias)
+    ) {
+      handledAppAliases.add(operation.alias);
+      slots.push({
+        category: "app",
+        target: "app",
+        alias: operation.alias,
+        operation,
+      });
+      continue;
+    }
+    if (operation.type !== "app_v3_deploy") continue;
+    for (const alias of [...journal.prior.app.aliases].reverse()) {
+      if (handledAppAliases.has(alias)) continue;
+      handledAppAliases.add(alias);
+      slots.push({
+        category: "app",
+        target: "app",
+        alias,
+        operation,
+      });
+    }
+    if (legacyHandled) continue;
+    legacyHandled = true;
+    for (const alias of journal.prior["legacy-app"].aliases) {
+      slots.push({
+        category: "legacy",
+        target: "legacy-app",
+        alias,
+        operation,
+      });
+    }
+  }
+  return slots;
+}
+
+function canonicalRecoveryAction(entry, slot, journal, index) {
+  const label = `Recovery action ${index + 1}`;
+  const allowedKinds = {
+    ordinary: new Set([
+      "verified_noop",
+      "manual_intervention",
+      "ordinary_rollback",
+    ]),
+    app: new Set(["verified_noop", "manual_intervention", "app_alias_restore"]),
+    legacy: new Set([
+      "verified_noop",
+      "manual_intervention",
+      "legacy_emergency_restore",
+    ]),
+  };
+  if (!allowedKinds[slot.category].has(entry?.kind)) {
+    throw new Error(`${label} kind does not match its recovery slot`);
+  }
+  const hasAlias = slot.alias !== null;
+  const expectedKeys =
+    entry.kind === "ordinary_rollback"
+      ? [...RECOVERY_ACTION_BASE_KEYS, "aliases", "entersRollbackState"]
+      : entry.kind === "app_alias_restore" ||
+          entry.kind === "legacy_emergency_restore"
+        ? [...RECOVERY_ACTION_BASE_KEYS, "alias"]
+        : [
+            ...RECOVERY_ACTION_BASE_KEYS,
+            ...(hasAlias ? ["alias"] : []),
+            "mappingState",
+          ];
+  assertExactKeys(entry, expectedKeys, label);
+
+  const expected = action(entry.kind, journal, slot.operation, {
+    target: slot.target,
+  });
+  for (const key of RECOVERY_ACTION_BASE_KEYS.slice(1)) {
+    if (entry[key] !== expected[key]) {
+      throw new Error(`${label} ${key} differs from the journal`);
+    }
+  }
+  if (hasAlias && entry.alias !== slot.alias) {
+    throw new Error(`${label} alias differs from the recovery order`);
+  }
+
+  if (entry.kind === "ordinary_rollback") {
+    if (
+      !sameJson(entry.aliases, journal.prior[slot.target].aliases) ||
+      entry.entersRollbackState !== true
+    ) {
+      throw new Error(`${label} rollback contract is malformed`);
+    }
+    return {
+      ...expected,
+      aliases: [...journal.prior[slot.target].aliases],
+      entersRollbackState: true,
+    };
+  }
+  if (
+    entry.kind === "app_alias_restore" ||
+    entry.kind === "legacy_emergency_restore"
+  ) {
+    if (expected.candidateDeploymentId === null) {
+      throw new Error(`${label} cannot restore an unknown app candidate`);
+    }
+    return { ...expected, alias: slot.alias };
+  }
+
+  const allowedMappingStates =
+    entry.kind === "verified_noop"
+      ? new Set(["prior"])
+      : slot.category === "ordinary"
+        ? new Set(["partial", "unexpected"])
+        : new Set(["unexpected"]);
+  if (!allowedMappingStates.has(entry.mappingState)) {
+    throw new Error(`${label} mapping state is inconsistent with its kind`);
+  }
+  return {
+    ...expected,
+    ...(hasAlias ? { alias: slot.alias } : {}),
+    mappingState: entry.mappingState,
+  };
+}
+
+function assertMainTransactionRecoveryPlan(plan) {
+  assertExactKeys(plan, RECOVERY_PLAN_KEYS, "Main transaction recovery plan");
+  const journal = assertMainTransactionJournal(plan.journal);
+  const recoveryDecision = decideRecoveryFromJournal(journal);
+  if (recoveryDecision.decision !== "recover") {
+    if (
+      plan.decision !== recoveryDecision.decision ||
+      plan.reason !== recoveryDecision.reason ||
+      !Array.isArray(plan.actions) ||
+      plan.actions.length !== 0 ||
+      !Array.isArray(plan.rollbackStateTargets) ||
+      plan.rollbackStateTargets.length !== 0 ||
+      plan.forceFailure !== false ||
+      plan.discoveredAppCandidate !== null
+    ) {
+      throw new Error(
+        "Recovery plan does not match the journal recovery decision",
+      );
+    }
+    return {
+      decision: recoveryDecision.decision,
+      reason: recoveryDecision.reason,
+      journal,
+      actions: [],
+      rollbackStateTargets: [],
+      forceFailure: false,
+      discoveredAppCandidate: null,
+    };
+  }
+
+  let effectiveJournal = journal;
+  let discoveredAppCandidate = null;
+  if (plan.discoveredAppCandidate !== null) {
+    if (journal.candidates.app?.deploymentId !== null) {
+      throw new Error("Known app candidate must not be rediscovered");
+    }
+    effectiveJournal = attachDiscoveredAppCandidate(
+      journal,
+      plan.discoveredAppCandidate,
+    );
+    discoveredAppCandidate = {
+      deploymentId: effectiveJournal.candidates.app.deploymentId,
+      deploymentUrl: effectiveJournal.candidates.app.deploymentUrl,
+      ...effectiveJournal.candidates.app.discovery,
+    };
+  }
+
+  const isAmbiguousAppCandidate =
+    plan.decision === "manual_intervention" &&
+    plan.reason === "app-candidate-ambiguous-after-mapping-moved" &&
+    Array.isArray(plan.actions) &&
+    plan.actions.length === 0;
+  if (isAmbiguousAppCandidate) {
+    const unknownStartedApp =
+      journal.candidates.app?.deploymentId === null &&
+      startedForwardOperations(journal).some(
+        (operation) => operation.type === "app_v3_deploy",
+      );
+    if (
+      !unknownStartedApp ||
+      !Array.isArray(plan.rollbackStateTargets) ||
+      plan.rollbackStateTargets.length !== 0 ||
+      plan.forceFailure !== true ||
+      plan.discoveredAppCandidate !== null
+    ) {
+      throw new Error("Ambiguous app recovery plan is malformed");
+    }
+    return {
+      decision: "manual_intervention",
+      reason: "app-candidate-ambiguous-after-mapping-moved",
+      journal,
+      actions: [],
+      rollbackStateTargets: [],
+      forceFailure: true,
+      discoveredAppCandidate: null,
+    };
+  }
+
+  if (!Array.isArray(plan.actions)) {
+    throw new Error("Recovery plan actions are malformed");
+  }
+  const slots = recoveryActionSlots(journal);
+  if (plan.actions.length !== slots.length) {
+    throw new Error("Recovery plan actions do not cover the journal exactly");
+  }
+  const actions = plan.actions.map((entry, index) =>
+    canonicalRecoveryAction(entry, slots[index], effectiveJournal, index),
+  );
+  const rollbackStateTargets = actions
+    .filter((entry) => entry.kind === "ordinary_rollback")
+    .map((entry) => entry.target);
+  if (!sameJson(plan.rollbackStateTargets, rollbackStateTargets)) {
+    throw new Error("Recovery rollback-state targets are malformed");
+  }
+  const hasManualAction = actions.some(
+    (entry) => entry.kind === "manual_intervention",
+  );
+  const hasLegacyEmergency = actions.some(
+    (entry) => entry.kind === "legacy_emergency_restore",
+  );
+  const decision = hasManualAction ? "manual_intervention" : "recover";
+  const reason = hasManualAction
+    ? "unexpected-protected-mapping"
+    : hasLegacyEmergency
+      ? "legacy-alias-moved-to-transaction-candidate"
+      : "started-operations-require-verification-or-recovery";
+  if (
+    plan.decision !== decision ||
+    plan.reason !== reason ||
+    plan.forceFailure !== true
+  ) {
+    throw new Error("Recovery plan outcome is inconsistent with its actions");
+  }
+  return {
+    decision,
+    reason,
+    journal,
+    actions,
+    rollbackStateTargets,
+    forceFailure: true,
     discoveredAppCandidate,
   };
 }
@@ -1511,6 +1861,22 @@ export async function executeJournaledMainMutation({
   requireFreshness = true,
 }) {
   let highest = assertMainTransactionJournal(journal);
+  let lastDurableJournal = highest;
+  const persistNext = async (next) => {
+    try {
+      const persisted = await persistMainTransactionJournal(
+        next,
+        uploadJournal,
+      );
+      lastDurableJournal = persisted;
+      return persisted;
+    } catch (error) {
+      if (error instanceof MainTransactionError) {
+        error.journal = lastDurableJournal;
+      }
+      throw error;
+    }
+  };
   if (typeof executeMutation !== "function") {
     throw new Error("Mutation adapter is required");
   }
@@ -1564,8 +1930,7 @@ export async function executeJournaledMainMutation({
   }
   await assertPreMutationState("pre-operation");
   highest = startMainTransactionOperation(highest, intent);
-  highest = await persistMainTransactionJournal(highest, uploadJournal);
-  const durableStartedJournal = highest;
+  highest = await persistNext(highest);
   const operationId = highest.operations.at(-1).operationId;
   if (requireFreshness) {
     try {
@@ -1596,15 +1961,7 @@ export async function executeJournaledMainMutation({
     outcome,
     candidate: commandResult?.candidate ?? null,
   });
-  try {
-    highest = await persistMainTransactionJournal(highest, uploadJournal);
-  } catch (error) {
-    if (error instanceof MainTransactionError) {
-      // Only the started snapshot is guaranteed durable when this upload fails.
-      error.journal = durableStartedJournal;
-    }
-    throw error;
-  }
+  highest = await persistNext(highest);
   let freshnessError = null;
   if (requireFreshness) {
     try {
@@ -1634,7 +1991,7 @@ export async function executeJournaledMainMutation({
         ? "entered"
         : null,
   });
-  highest = await persistMainTransactionJournal(highest, uploadJournal);
+  highest = await persistNext(highest);
   if (
     freshnessError ||
     outcome === "unknown" ||
@@ -1688,32 +2045,46 @@ export async function executeMainTransactionRecovery({
   inspectMapping,
   verifyMapping,
 }) {
-  let highest = assertMainTransactionJournal(plan?.journal);
-  if (!["recover", "manual_intervention"].includes(plan?.decision)) {
+  const canonicalPlan = assertMainTransactionRecoveryPlan(plan);
+  let highest = canonicalPlan.journal;
+  if (
+    !["recover", "manual_intervention"].includes(canonicalPlan.decision) ||
+    canonicalPlan.forceFailure === false
+  ) {
     return highest;
   }
+  let lastDurableJournal = highest;
+  const persistNext = async (next) => {
+    try {
+      const persisted = await persistMainTransactionJournal(
+        next,
+        uploadJournal,
+      );
+      lastDurableJournal = persisted;
+      return persisted;
+    } catch (error) {
+      if (error instanceof MainTransactionError) {
+        error.journal = lastDurableJournal;
+      }
+      throw error;
+    }
+  };
   const mutationKinds = new Set([
     "ordinary_rollback",
     "app_alias_restore",
     "legacy_emergency_restore",
   ]);
   if (
-    !Array.isArray(plan.actions) ||
-    plan.actions.some(
-      (entry) =>
-        !["verified_noop", "manual_intervention", ...mutationKinds].includes(
-          entry?.kind,
-        ),
-    )
+    canonicalPlan.actions.length > 0 &&
+    typeof inspectMapping !== "function"
   ) {
-    throw new Error("Recovery plan actions are malformed");
+    throw new Error("Recovery mapping inspection adapter is required");
   }
   if (
-    plan.actions.some((entry) => mutationKinds.has(entry.kind)) &&
-    (typeof inspectMapping !== "function" ||
-      typeof verifyMapping !== "function")
+    canonicalPlan.actions.some((entry) => mutationKinds.has(entry.kind)) &&
+    typeof verifyMapping !== "function"
   ) {
-    throw new Error("Recovery mapping adapters are required");
+    throw new Error("Recovery mapping verification adapter is required");
   }
   for (const [kind, adapter] of [
     ["ordinary_rollback", ordinaryRollback],
@@ -1721,25 +2092,62 @@ export async function executeMainTransactionRecovery({
     ["legacy_emergency_restore", restoreLegacyAlias],
   ]) {
     if (
-      plan.actions.some((entry) => entry.kind === kind) &&
+      canonicalPlan.actions.some((entry) => entry.kind === kind) &&
       typeof adapter !== "function"
     ) {
       throw new Error(`Recovery adapter for ${kind} is required`);
     }
   }
+  for (const entry of canonicalPlan.actions) {
+    let inspected;
+    try {
+      inspected = await inspectMapping(clone(entry), {
+        phase: "recovery-plan",
+        transactionId: highest.transactionId,
+      });
+    } catch {
+      inspected = null;
+    }
+    const mappingState = inspected?.mappingState;
+    const expectedKind =
+      mappingState === "prior"
+        ? "verified_noop"
+        : mappingState === "candidate"
+          ? entry.target === "legacy-app"
+            ? "legacy_emergency_restore"
+            : entry.target === "app"
+              ? "app_alias_restore"
+              : "ordinary_rollback"
+          : ["partial", "unexpected"].includes(mappingState)
+            ? "manual_intervention"
+            : null;
+    if (
+      entry.kind !== expectedKind ||
+      (entry.kind === "manual_intervention" &&
+        entry.mappingState !== mappingState)
+    ) {
+      throw new MainTransactionError(
+        "Recovery plan no longer matches protected mappings",
+        {
+          code: "PROTECTED_MAPPING_DRIFT",
+          journal: highest,
+        },
+      );
+    }
+  }
   if (
-    plan.discoveredAppCandidate &&
+    canonicalPlan.discoveredAppCandidate &&
     highest.candidates.app?.deploymentId === null
   ) {
     highest = attachDiscoveredAppCandidate(
       highest,
-      plan.discoveredAppCandidate,
+      canonicalPlan.discoveredAppCandidate,
     );
-    highest = await persistMainTransactionJournal(highest, uploadJournal);
+    highest = await persistNext(highest);
   }
   highest = appendStatus(highest, "recovering");
-  highest = await persistMainTransactionJournal(highest, uploadJournal);
-  for (const entry of plan.actions) {
+  highest = await persistNext(highest);
+  for (const entry of canonicalPlan.actions) {
     if (entry.kind === "verified_noop") continue;
     if (entry.kind === "manual_intervention") {
       continue;
@@ -1761,14 +2169,15 @@ export async function executeMainTransactionRecovery({
       verifyMapping: (context) => verifyMapping(clone(entry), context),
       requireFreshness: false,
     });
+    lastDurableJournal = highest;
   }
   highest = appendStatus(
     highest,
-    plan.decision === "manual_intervention"
+    canonicalPlan.decision === "manual_intervention"
       ? "manual_intervention"
       : "recovered",
   );
-  return persistMainTransactionJournal(highest, uploadJournal);
+  return persistNext(highest);
 }
 
 export async function runMainTransaction({

--- a/scripts/vercel-main-transaction.test.mjs
+++ b/scripts/vercel-main-transaction.test.mjs
@@ -431,10 +431,13 @@ test("operation event fields must match the constructor state", () => {
 
 test("adjacent journal snapshots append exactly one helper-legal event", () => {
   const initial = preparedForTargets(["governance"], { app: "known" });
-  const { started, returned } = transitionSuccessfulOperation(initial, {
-    type: "promote",
-    target: "governance",
-  });
+  const { started, returned, verified } = transitionSuccessfulOperation(
+    initial,
+    {
+      type: "promote",
+      target: "governance",
+    },
+  );
   assert.throws(
     () =>
       assertMainTransactionJournalHistory([
@@ -449,7 +452,7 @@ test("adjacent journal snapshots append exactly one helper-legal event", () => {
         initial,
         { ...started, status: "command_returned" },
       ]),
-    /status does not match/,
+    /differs from its legal helper append/,
   );
 
   const appInitial = preparedForTargets(["app"]);
@@ -470,6 +473,64 @@ test("adjacent journal snapshots append exactly one helper-legal event", () => {
       ]),
     /did not append one legal event/,
   );
+
+  const duplicate = {
+    ...verified,
+    sequence: verified.sequence + 1,
+    status: "started",
+    operations: [
+      ...verified.operations,
+      {
+        ...started.operations[0],
+        operationId: "op-0002",
+      },
+    ],
+  };
+  assert.throws(
+    () =>
+      assertMainTransactionJournalHistory([
+        initial,
+        started,
+        returned,
+        verified,
+        duplicate,
+      ]),
+    /already recorded/,
+  );
+});
+
+test("forged terminal artifacts cannot bypass transaction recovery", () => {
+  const selected = preparedForTargets(["governance"], { app: "known" });
+  assert.throws(
+    () =>
+      decideMainTransactionRecovery([
+        selected,
+        { ...selected, sequence: 1, status: "committed" },
+      ]),
+    /incomplete operations/,
+  );
+
+  const { started, returned, verified } = transitionSuccessfulOperation(
+    selected,
+    { type: "promote", target: "governance" },
+  );
+  for (const status of ["recovered", "manual_intervention"]) {
+    assert.throws(
+      () =>
+        decideMainTransactionRecovery([
+          selected,
+          started,
+          returned,
+          verified,
+          {
+            ...verified,
+            sequence: verified.sequence + 1,
+            status,
+          },
+        ]),
+      /requires a recovering snapshot/,
+    );
+  }
 });
 
 test("commit requires one verified forward operation for every selected candidate", () => {
@@ -548,6 +609,14 @@ test("duplicate forward mutations are rejected after a verified attempt", () => 
         target: "governance",
       }),
     /already recorded/,
+  );
+  assert.throws(
+    () =>
+      startMainTransactionOperation(preparedForTargets([], { app: "known" }), {
+        type: "app_v3_deploy",
+        target: "app",
+      }),
+    /not selected/,
   );
 
   const appDeploy = transitionSuccessfulOperation(
@@ -1066,7 +1135,9 @@ test("ordinary recovery is planned and executed in reverse activation order", as
     restoreLegacyAlias: async () => {
       throw new Error("unreachable");
     },
-    inspectMapping: async () => ({ mappingState: "candidate" }),
+    inspectMapping: async (_entry, context) => ({
+      mappingState: context.phase === "recovery-final" ? "prior" : "candidate",
+    }),
     verifyMapping: async (entry) => {
       calls.push(`verify:${entry.target}`);
       return { mappingState: "prior" };
@@ -1204,15 +1275,21 @@ test("forged recovery action fields never reach inspection or mutation adapters"
 test("every recovery upload failure exposes only the last durable journal", async () => {
   const plan = plannedOrdinaryRecovery();
   const expectedDurable = [
-    { offset: 0, status: "verified", mutations: 0 },
-    { offset: 1, status: "recovering", mutations: 0 },
-    { offset: 2, status: "started", mutations: 1 },
-    { offset: 3, status: "command_returned", mutations: 1 },
-    { offset: 4, status: "verified", mutations: 1 },
+    { offset: 0, status: "verified", mutations: 0, finalInspections: 0 },
+    { offset: 1, status: "recovering", mutations: 0, finalInspections: 0 },
+    { offset: 2, status: "started", mutations: 1, finalInspections: 0 },
+    {
+      offset: 3,
+      status: "command_returned",
+      mutations: 1,
+      finalInspections: 0,
+    },
+    { offset: 4, status: "verified", mutations: 1, finalInspections: 1 },
   ];
   for (const [index, expected] of expectedDurable.entries()) {
     let attempts = 0;
     let mutations = 0;
+    let finalInspections = 0;
     await assert.rejects(
       executeMainTransactionRecovery({
         plan,
@@ -1231,7 +1308,13 @@ test("every recovery upload failure exposes only the last durable journal", asyn
           mutations += 1;
           return { outcome: "success" };
         },
-        inspectMapping: async () => ({ mappingState: "candidate" }),
+        inspectMapping: async (_entry, context) => ({
+          mappingState: (() => {
+            if (context.phase !== "recovery-final") return "candidate";
+            finalInspections += 1;
+            return "prior";
+          })(),
+        }),
         verifyMapping: async () => ({ mappingState: "prior" }),
       }),
       (error) => {
@@ -1245,7 +1328,41 @@ test("every recovery upload failure exposes only the last durable journal", asyn
       },
     );
     assert.equal(mutations, expected.mutations);
+    assert.equal(finalInspections, expected.finalInspections);
   }
+});
+
+test("a noop that moves after planning cannot be recorded as recovered", async () => {
+  const initial = preparedForTargets(["governance"], { app: "known" });
+  const transitions = transitionSuccessfulOperation(initial, {
+    type: "promote",
+    target: "governance",
+  });
+  const plan = planMainTransactionRecovery({
+    journal: transitions.verified,
+    currentMappings: currentMappings(transitions.verified),
+  });
+  assert.equal(plan.actions[0].kind, "verified_noop");
+  const uploads = [];
+  await assert.rejects(
+    executeMainTransactionRecovery({
+      plan,
+      uploadJournal: acknowledgedUploader(uploads),
+      inspectMapping: async (_entry, context) => ({
+        mappingState:
+          context.phase === "recovery-final" ? "candidate" : "prior",
+      }),
+    }),
+    (error) => {
+      assert.equal(error.code, "RECOVERY_VERIFICATION_FAILED");
+      assert.equal(error.journal.status, "recovering");
+      return true;
+    },
+  );
+  assert.deepEqual(
+    uploads.map((entry) => entry.status),
+    ["recovering"],
+  );
 });
 
 test("app discovery and recovery-start uploads retain the prior durable snapshot", async () => {

--- a/scripts/vercel-main-transaction.test.mjs
+++ b/scripts/vercel-main-transaction.test.mjs
@@ -1,0 +1,1083 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { test } from "node:test";
+
+import {
+  MAIN_TRANSACTION_MODE,
+  MAIN_TRANSACTION_REPOSITORY,
+  MainTransactionError,
+  assertMainTransactionJournal,
+  assertMainTransactionJournalHistory,
+  attachDiscoveredAppCandidate,
+  classifyMainTransactionMapping,
+  createMainTransactionId,
+  createPreparedMainTransactionJournal,
+  decideMainTransactionRecovery,
+  executeJournaledMainMutation,
+  executeMainTransactionRecovery,
+  mainTransactionJournalArtifactName,
+  markMainTransactionCommitted,
+  persistMainTransactionJournal,
+  planMainTransactionRecovery,
+  recordMainTransactionCommandReturned,
+  recordMainTransactionVerified,
+  resolveUniqueAppTransactionCandidate,
+  runMainTransaction,
+  selectHighestMainTransactionJournal,
+  startMainTransactionOperation,
+} from "./vercel-main-transaction.mjs";
+
+const SHA = "0123456789abcdef0123456789abcdef01234567";
+const OTHER_SHA = "abcdef0123456789abcdef0123456789abcdef01";
+const identity = Object.freeze({
+  repository: MAIN_TRANSACTION_REPOSITORY,
+  deploySha: SHA,
+  runId: "987654321",
+  runAttempt: "2",
+});
+
+function deploymentRecord(name, aliases) {
+  return {
+    deploymentId: `dpl_${name}Prior123`,
+    deploymentUrl: `https://${name}-prior.vercel.app`,
+    aliases: [...aliases].sort(),
+  };
+}
+
+function candidateRecord(name, aliases) {
+  return {
+    deploymentId: `dpl_${name}Candidate123`,
+    deploymentUrl: `https://${name}-candidate.vercel.app`,
+    aliases: [...aliases].sort(),
+    discovery: null,
+  };
+}
+
+function priorState() {
+  return {
+    app: deploymentRecord("app", [
+      "app.mento.org",
+      "appmentoorg-env-v3-mentolabs.vercel.app",
+    ]),
+    governance: deploymentRecord("governance", [
+      "governance.mento.org",
+      "governancementoorg-mentolabs.vercel.app",
+    ]),
+    reserve: deploymentRecord("reserve", [
+      "reserve.mento.org",
+      "reservementoorg-mentolabs.vercel.app",
+    ]),
+    ui: deploymentRecord("ui", [
+      "ui.mento.org",
+      "uimentoorg-mentolabs.vercel.app",
+    ]),
+    "legacy-app": deploymentRecord("legacy", ["v2-app.mento.org"]),
+  };
+}
+
+function appDiscovery() {
+  return {
+    projectId: "prj_app123",
+    projectName: "app.mento.org",
+    deploySha: SHA,
+    runId: identity.runId,
+    runAttempt: identity.runAttempt,
+    transactionId: createMainTransactionId(identity),
+    customEnvironmentSlug: "v3",
+  };
+}
+
+function candidateState({ app = "unknown" } = {}) {
+  const prior = priorState();
+  return {
+    app:
+      app === null
+        ? null
+        : {
+            deploymentId: app === "known" ? "dpl_appCandidate123" : null,
+            deploymentUrl:
+              app === "known" ? "https://app-candidate.vercel.app" : null,
+            aliases: [...prior.app.aliases],
+            discovery: appDiscovery(),
+          },
+    governance: candidateRecord("governance", prior.governance.aliases),
+    reserve: candidateRecord("reserve", prior.reserve.aliases),
+    ui: candidateRecord("ui", prior.ui.aliases),
+  };
+}
+
+function prepared(options = {}) {
+  return createPreparedMainTransactionJournal({
+    ...identity,
+    mode: options.mode ?? "active",
+    prior: priorState(),
+    candidates: candidateState(options),
+  });
+}
+
+function appCandidateMatch(overrides = {}) {
+  return {
+    deploymentId: "dpl_appCandidate123",
+    deploymentUrl: "https://app-candidate.vercel.app",
+    ...appDiscovery(),
+    ...overrides,
+  };
+}
+
+function mapping(alias, record) {
+  return {
+    alias,
+    deploymentId: record.deploymentId,
+    deploymentUrl: record.deploymentUrl,
+  };
+}
+
+function currentMappings(journal, overrides = {}) {
+  return Object.values(journal.prior).flatMap((record) =>
+    record.aliases.map((alias) => {
+      const selected = overrides[alias] ?? record;
+      return mapping(alias, selected);
+    }),
+  );
+}
+
+function acknowledgedUploader(log = []) {
+  return async ({ artifactName, journal, retentionDays }) => {
+    log.push({
+      kind: "upload",
+      artifactName,
+      sequence: journal.sequence,
+      status: journal.status,
+      retentionDays,
+      journal,
+    });
+    return { acknowledged: true, artifactName };
+  };
+}
+
+function transitionSuccessfulOperation(journal, intent) {
+  const started = startMainTransactionOperation(journal, intent);
+  const operationId = started.operations.at(-1).operationId;
+  const returned = recordMainTransactionCommandReturned(started, {
+    operationId,
+    outcome: "success",
+  });
+  return {
+    started,
+    returned,
+    verified: recordMainTransactionVerified(returned, {
+      operationId,
+      mappingState: "candidate",
+    }),
+  };
+}
+
+test("transaction ID is deterministic and binds only immutable run identity", () => {
+  const transactionId = createMainTransactionId(identity);
+  assert.match(transactionId, /^main-[a-f0-9]{32}$/);
+  assert.equal(transactionId, createMainTransactionId({ ...identity }));
+  assert.notEqual(
+    transactionId,
+    createMainTransactionId({ ...identity, runAttempt: "3" }),
+  );
+  assert.notEqual(
+    transactionId,
+    createMainTransactionId({ ...identity, deploySha: OTHER_SHA }),
+  );
+  assert.throws(
+    () =>
+      createMainTransactionId({
+        ...identity,
+        repository: "fork/frontend-monorepo",
+      }),
+    /repository is unexpected/,
+  );
+});
+
+test("prepared journal is canonical, redacted, and names an immutable artifact", () => {
+  const journal = prepared();
+  assert.equal(journal.schema, 1);
+  assert.equal(journal.sequence, 0);
+  assert.equal(journal.status, "prepared");
+  assert.equal(journal.runId, identity.runId);
+  assert.equal(journal.runAttempt, identity.runAttempt);
+  assert.equal(journal.candidates.app.deploymentId, null);
+  assert.equal(
+    mainTransactionJournalArtifactName(journal),
+    `vercel-main-journal-${journal.transactionId}-000000`,
+  );
+  assert.doesNotMatch(
+    JSON.stringify(journal),
+    /token|secret|authorization|cookie|header|environmentValue/i,
+  );
+
+  assert.throws(
+    () => assertMainTransactionJournal({ ...journal, token: "forbidden" }),
+    /forbidden or missing fields/,
+  );
+  assert.throws(
+    () =>
+      assertMainTransactionJournal({
+        ...journal,
+        prior: {
+          ...journal.prior,
+          app: { ...journal.prior.app, rawResponse: {} },
+        },
+      }),
+    /forbidden or missing fields/,
+  );
+  assert.throws(
+    () =>
+      createPreparedMainTransactionJournal({
+        ...identity,
+        mode: "active",
+        prior: priorState(),
+        candidates: {
+          ...candidateState(),
+          app: {
+            ...candidateState().app,
+            discovery: {
+              ...appDiscovery(),
+              transactionId: "main-00000000000000000000000000000000",
+            },
+          },
+        },
+      }),
+    /does not match the journal identity/,
+  );
+});
+
+test("static fixture remains compatible with the canonical journal schema", () => {
+  const fixture = JSON.parse(
+    readFileSync(
+      new URL(
+        "./fixtures/vercel-main-transaction/prepared-shadow.json",
+        import.meta.url,
+      ),
+      "utf8",
+    ),
+  );
+  const canonical = assertMainTransactionJournal(fixture);
+  assert.equal(canonical.mode, "shadow");
+  assert.equal(canonical.status, "prepared");
+  assert.equal(canonical.transactionId, createMainTransactionId(canonical));
+});
+
+test("operation snapshots form an append-only monotonic history", () => {
+  const initial = prepared({ app: "known" });
+  const { started, returned, verified } = transitionSuccessfulOperation(
+    initial,
+    { type: "promote", target: "governance" },
+  );
+  const committed = markMainTransactionCommitted(verified);
+  const history = [initial, started, returned, verified, committed];
+
+  assert.equal(
+    selectHighestMainTransactionJournal(history).status,
+    "committed",
+  );
+  assert.deepEqual(decideMainTransactionRecovery(history), {
+    decision: "bypass",
+    reason: "committed",
+    journal: committed,
+  });
+  assert.equal(started.operations[0].state, "started");
+  assert.equal(returned.operations[1].state, "command_returned");
+  assert.equal(verified.operations[2].state, "verified");
+  assert.deepEqual(
+    returned.operations.slice(0, started.operations.length),
+    started.operations,
+  );
+
+  assert.throws(
+    () => assertMainTransactionJournalHistory([initial, returned]),
+    /sequence is missing or duplicated/,
+  );
+  assert.throws(
+    () =>
+      assertMainTransactionJournalHistory([
+        initial,
+        {
+          ...started,
+          operations: [
+            { ...started.operations[0], priorDeploymentId: "dpl_rewritten" },
+          ],
+        },
+      ]),
+    /differs from the journal|rewritten/,
+  );
+  assert.throws(
+    () =>
+      selectHighestMainTransactionJournal(history, {
+        runId: "123",
+      }),
+    /does not match the expected identity/,
+  );
+  assert.throws(
+    () =>
+      assertMainTransactionJournal({
+        ...verified,
+        operations: verified.operations.map((operation, index) =>
+          index === verified.operations.length - 1
+            ? { ...operation, commandOutcome: "unknown" }
+            : operation,
+        ),
+      }),
+    /command outcome changed/,
+  );
+});
+
+test("known app candidate may only evolve once from exact discovery metadata", () => {
+  const initial = prepared();
+  const attached = attachDiscoveredAppCandidate(initial, appCandidateMatch());
+  assert.equal(attached.sequence, 1);
+  assert.equal(attached.candidates.app.deploymentId, "dpl_appCandidate123");
+  assert.deepEqual(
+    resolveUniqueAppTransactionCandidate(initial, [appCandidateMatch()]),
+    attached.candidates.app,
+  );
+  assert.throws(
+    () => resolveUniqueAppTransactionCandidate(initial, []),
+    /exactly one match/,
+  );
+  assert.throws(
+    () =>
+      resolveUniqueAppTransactionCandidate(initial, [
+        appCandidateMatch(),
+        appCandidateMatch({
+          deploymentId: "dpl_appCandidate456",
+          deploymentUrl: "https://app-candidate-two.vercel.app",
+        }),
+      ]),
+    /exactly one match/,
+  );
+  assert.throws(
+    () =>
+      attachDiscoveredAppCandidate(
+        initial,
+        appCandidateMatch({ deploySha: OTHER_SHA }),
+      ),
+    /does not match discovery metadata/,
+  );
+});
+
+test("app candidate command return uses one monotonic journal sequence", () => {
+  const initial = prepared();
+  const started = startMainTransactionOperation(initial, {
+    type: "app_v3_deploy",
+    target: "app",
+  });
+  const returned = recordMainTransactionCommandReturned(started, {
+    operationId: started.operations.at(-1).operationId,
+    outcome: "success",
+    candidate: appCandidateMatch(),
+  });
+  assert.equal(started.sequence, 1);
+  assert.equal(returned.sequence, 2);
+  assert.equal(returned.candidates.app.deploymentId, "dpl_appCandidate123");
+  assert.doesNotThrow(() =>
+    assertMainTransactionJournalHistory([initial, started, returned]),
+  );
+});
+
+test("journal upload acknowledgement is exact and uses seven-day retention", async () => {
+  const journal = prepared();
+  const uploads = [];
+  await persistMainTransactionJournal(journal, acknowledgedUploader(uploads));
+  assert.equal(uploads.length, 1);
+  assert.equal(uploads[0].retentionDays, 7);
+  assert.equal(
+    uploads[0].artifactName,
+    mainTransactionJournalArtifactName(journal),
+  );
+  await assert.rejects(
+    persistMainTransactionJournal(journal, async ({ artifactName }) => ({
+      acknowledged: true,
+      artifactName: `${artifactName}-wrong`,
+    })),
+    (error) =>
+      error instanceof MainTransactionError &&
+      error.code === "JOURNAL_UPLOAD_NOT_ACKNOWLEDGED",
+  );
+});
+
+test("started journal is durably acknowledged before mutation callback", async () => {
+  const events = [];
+  const journal = await executeJournaledMainMutation({
+    journal: prepared({ app: "known" }),
+    intent: { type: "promote", target: "governance" },
+    uploadJournal: async (payload) => {
+      events.push(`upload:${payload.journal.status}`);
+      return { acknowledged: true, artifactName: payload.artifactName };
+    },
+    assertFreshness: async ({ phase }) => {
+      events.push(`fresh:${phase}`);
+      return { sha: SHA };
+    },
+    executeMutation: async () => {
+      events.push("mutate");
+      return { outcome: "success" };
+    },
+    inspectMutationState: async ({ phase }) => {
+      events.push(`mapping:${phase}`);
+      return { mappingState: "prior" };
+    },
+    verifyMapping: async () => {
+      events.push("verify");
+      return { mappingState: "candidate" };
+    },
+  });
+  assert.equal(journal.status, "verified");
+  assert.deepEqual(events, [
+    "fresh:pre-operation",
+    "mapping:pre-operation",
+    "upload:started",
+    "fresh:pre-command",
+    "mapping:pre-command",
+    "mutate",
+    "upload:command_returned",
+    "fresh:post-command",
+    "verify",
+    "upload:verified",
+  ]);
+});
+
+test("upload failure prevents mutation and leaves only prior durable state", async () => {
+  let mutations = 0;
+  await assert.rejects(
+    executeJournaledMainMutation({
+      journal: prepared({ app: "known" }),
+      intent: { type: "promote", target: "governance" },
+      uploadJournal: async () => {
+        throw new Error("artifact service unavailable");
+      },
+      assertFreshness: async () => ({ sha: SHA }),
+      executeMutation: async () => {
+        mutations += 1;
+        return { outcome: "success" };
+      },
+      inspectMutationState: async () => ({ mappingState: "prior" }),
+      verifyMapping: async () => ({ mappingState: "candidate" }),
+    }),
+    (error) =>
+      error instanceof MainTransactionError &&
+      error.code === "JOURNAL_UPLOAD_FAILED",
+  );
+  assert.equal(mutations, 0);
+});
+
+test("main advancing before an operation performs no mutation", async () => {
+  let uploads = 0;
+  let mutations = 0;
+  await assert.rejects(
+    executeJournaledMainMutation({
+      journal: prepared({ app: "known" }),
+      intent: { type: "promote", target: "governance" },
+      uploadJournal: async () => {
+        uploads += 1;
+      },
+      assertFreshness: async () => ({ sha: OTHER_SHA }),
+      executeMutation: async () => {
+        mutations += 1;
+      },
+      inspectMutationState: async () => ({ mappingState: "prior" }),
+      verifyMapping: async () => ({ mappingState: "prior" }),
+    }),
+    (error) =>
+      error instanceof MainTransactionError &&
+      error.code === "SUPERSEDED_DURING_MUTATION",
+  );
+  assert.equal(uploads, 0);
+  assert.equal(mutations, 0);
+});
+
+test("main advancing after started upload hands recovery a durable operation", async () => {
+  let mutations = 0;
+  const uploads = [];
+  await assert.rejects(
+    executeJournaledMainMutation({
+      journal: prepared({ app: "known" }),
+      intent: { type: "promote", target: "governance" },
+      uploadJournal: acknowledgedUploader(uploads),
+      assertFreshness: async ({ phase }) => ({
+        sha: phase === "pre-command" ? OTHER_SHA : SHA,
+      }),
+      executeMutation: async () => {
+        mutations += 1;
+      },
+      inspectMutationState: async () => ({ mappingState: "prior" }),
+      verifyMapping: async () => ({ mappingState: "prior" }),
+    }),
+    (error) => {
+      assert.equal(error.code, "SUPERSEDED_DURING_MUTATION");
+      assert.equal(error.journal.status, "started");
+      return true;
+    },
+  );
+  assert.equal(mutations, 0);
+  assert.equal(uploads.length, 1);
+  assert.equal(uploads[0].status, "started");
+});
+
+test("protected mapping drift before command prevents the mutation callback", async () => {
+  let mutations = 0;
+  let inspections = 0;
+  const uploads = [];
+  await assert.rejects(
+    executeJournaledMainMutation({
+      journal: prepared({ app: "known" }),
+      intent: { type: "promote", target: "governance" },
+      uploadJournal: acknowledgedUploader(uploads),
+      assertFreshness: async () => ({ sha: SHA }),
+      inspectMutationState: async () => {
+        inspections += 1;
+        return {
+          mappingState: inspections === 1 ? "prior" : "unexpected",
+        };
+      },
+      executeMutation: async () => {
+        mutations += 1;
+        return { outcome: "success" };
+      },
+      verifyMapping: async () => ({ mappingState: "prior" }),
+    }),
+    (error) => {
+      assert.equal(error.code, "PROTECTED_MAPPING_DRIFT");
+      assert.equal(error.journal.status, "started");
+      return true;
+    },
+  );
+  assert.equal(mutations, 0);
+  assert.equal(uploads.length, 1);
+});
+
+test("main advancing during or after a command forces recovery", async () => {
+  let currentSha = SHA;
+  const uploads = [];
+  await assert.rejects(
+    executeJournaledMainMutation({
+      journal: prepared({ app: "known" }),
+      intent: { type: "promote", target: "governance" },
+      uploadJournal: acknowledgedUploader(uploads),
+      assertFreshness: async () => ({ sha: currentSha }),
+      executeMutation: async () => {
+        currentSha = OTHER_SHA;
+        return { outcome: "success" };
+      },
+      inspectMutationState: async () => ({ mappingState: "prior" }),
+      verifyMapping: async () => ({ mappingState: "candidate" }),
+    }),
+    (error) => {
+      assert.equal(error.code, "SUPERSEDED_DURING_MUTATION");
+      assert.equal(error.journal.status, "verified");
+      return true;
+    },
+  );
+  assert.deepEqual(
+    uploads.map((entry) => entry.status),
+    ["started", "command_returned", "verified"],
+  );
+});
+
+test("a successful forward command that leaves the prior mapping cannot pass verification", async () => {
+  await assert.rejects(
+    executeJournaledMainMutation({
+      journal: prepared({ app: "known" }),
+      intent: { type: "promote", target: "ui" },
+      uploadJournal: acknowledgedUploader(),
+      assertFreshness: async () => ({ sha: SHA }),
+      inspectMutationState: async () => ({ mappingState: "prior" }),
+      executeMutation: async () => ({ outcome: "success" }),
+      verifyMapping: async () => ({ mappingState: "prior" }),
+    }),
+    (error) => {
+      assert.equal(error.code, "MUTATION_VERIFICATION_FAILED");
+      assert.equal(error.journal.operations.at(-1).mappingState, "prior");
+      return true;
+    },
+  );
+});
+
+for (const commandCase of [
+  {
+    name: "nonzero return",
+    execute: async () => ({ outcome: "nonzero" }),
+  },
+  {
+    name: "timeout return",
+    execute: async () => ({ outcome: "timeout" }),
+  },
+  {
+    name: "lost output",
+    execute: async () => undefined,
+  },
+  {
+    name: "runner callback error",
+    execute: async () => {
+      throw new Error("runner lost");
+    },
+  },
+]) {
+  test(`${commandCase.name} is an unknown outcome and remains failed`, async () => {
+    await assert.rejects(
+      executeJournaledMainMutation({
+        journal: prepared({ app: "known" }),
+        intent: { type: "promote", target: "reserve" },
+        uploadJournal: acknowledgedUploader(),
+        assertFreshness: async () => ({ sha: SHA }),
+        executeMutation: commandCase.execute,
+        inspectMutationState: async () => ({ mappingState: "prior" }),
+        verifyMapping: async () => ({ mappingState: "prior" }),
+      }),
+      (error) => {
+        assert.equal(error.code, "MUTATION_OUTCOME_UNKNOWN");
+        assert.equal(error.journal.status, "verified");
+        assert.equal(error.journal.operations.at(-1).commandOutcome, "unknown");
+        assert.equal(error.journal.operations.at(-1).mappingState, "prior");
+        return true;
+      },
+    );
+  });
+}
+
+test("a cancellation after started persistence is recoverable by a separate job", async () => {
+  const initial = prepared({ app: "known" });
+  const started = startMainTransactionOperation(initial, {
+    type: "promote",
+    target: "governance",
+  });
+  const uploads = [];
+  await persistMainTransactionJournal(started, acknowledgedUploader(uploads));
+
+  const decision = decideMainTransactionRecovery([initial, started]);
+  assert.equal(decision.decision, "recover");
+  assert.equal(decision.reason, "incomplete-mutation-journal");
+  assert.equal(uploads[0].status, "started");
+});
+
+test("mapping classifier distinguishes prior, candidate, partial, and unexpected", () => {
+  const journal = prepared({ app: "known" });
+  const prior = journal.prior.governance;
+  const candidate = journal.candidates.governance;
+  const aliases = prior.aliases;
+  const classify = (records) =>
+    classifyMainTransactionMapping({
+      aliases,
+      currentMappings: records,
+      prior,
+      candidate,
+    });
+  assert.equal(
+    classify(aliases.map((alias) => mapping(alias, prior))),
+    "prior",
+  );
+  assert.equal(
+    classify(aliases.map((alias) => mapping(alias, candidate))),
+    "candidate",
+  );
+  assert.equal(
+    classify([mapping(aliases[0], prior), mapping(aliases[1], candidate)]),
+    "partial",
+  );
+  assert.equal(
+    classify([
+      mapping(aliases[0], prior),
+      mapping(aliases[1], {
+        deploymentId: "dpl_operator123",
+        deploymentUrl: "https://operator.vercel.app",
+      }),
+    ]),
+    "unexpected",
+  );
+});
+
+test("ordinary recovery is planned and executed in reverse activation order", async () => {
+  const snapshots = [prepared({ app: "known" })];
+  let highest = snapshots[0];
+  for (const target of ["governance", "reserve", "ui"]) {
+    const transitions = transitionSuccessfulOperation(highest, {
+      type: "promote",
+      target,
+    });
+    snapshots.push(
+      transitions.started,
+      transitions.returned,
+      transitions.verified,
+    );
+    highest = transitions.verified;
+  }
+  const overrides = Object.fromEntries(
+    ["governance", "reserve", "ui"].flatMap((target) =>
+      highest.prior[target].aliases.map((alias) => [
+        alias,
+        highest.candidates[target],
+      ]),
+    ),
+  );
+  const plan = planMainTransactionRecovery({
+    journal: highest,
+    currentMappings: currentMappings(highest, overrides),
+  });
+  assert.equal(plan.decision, "recover");
+  assert.deepEqual(
+    plan.actions.map((entry) => `${entry.kind}:${entry.target}`),
+    [
+      "ordinary_rollback:ui",
+      "ordinary_rollback:reserve",
+      "ordinary_rollback:governance",
+    ],
+  );
+  assert.deepEqual(plan.rollbackStateTargets, ["ui", "reserve", "governance"]);
+  assert.ok(plan.actions.every((entry) => entry.entersRollbackState));
+
+  const calls = [];
+  const recovered = await executeMainTransactionRecovery({
+    plan,
+    uploadJournal: acknowledgedUploader(),
+    ordinaryRollback: async (entry) => {
+      calls.push(`rollback:${entry.target}:${entry.priorDeploymentId}`);
+      return { outcome: "success" };
+    },
+    restoreAppAlias: async () => {
+      throw new Error("unreachable");
+    },
+    restoreLegacyAlias: async () => {
+      throw new Error("unreachable");
+    },
+    inspectMapping: async () => ({ mappingState: "candidate" }),
+    verifyMapping: async (entry) => {
+      calls.push(`verify:${entry.target}`);
+      return { mappingState: "prior" };
+    },
+  });
+  assert.deepEqual(
+    calls.map((entry) => entry.split(":").slice(0, 2).join(":")),
+    [
+      "rollback:ui",
+      "verify:ui",
+      "rollback:reserve",
+      "verify:reserve",
+      "rollback:governance",
+      "verify:governance",
+    ],
+  );
+  assert.equal(recovered.status, "recovered");
+  const rollbackEvents = recovered.operations.filter(
+    (operation) =>
+      operation.type === "ordinary_rollback" && operation.state === "verified",
+  );
+  assert.equal(rollbackEvents.length, 3);
+  assert.ok(
+    rollbackEvents.every((operation) => operation.rollbackState === "entered"),
+  );
+});
+
+test("partial ordinary movement preserves possible operator intervention", () => {
+  const initial = prepared({ app: "known" });
+  const { started } = transitionSuccessfulOperation(initial, {
+    type: "promote",
+    target: "governance",
+  });
+  const aliases = started.prior.governance.aliases;
+  const plan = planMainTransactionRecovery({
+    journal: started,
+    currentMappings: currentMappings(started, {
+      [aliases[0]]: started.prior.governance,
+      [aliases[1]]: started.candidates.governance,
+    }),
+  });
+  assert.equal(plan.decision, "manual_intervention");
+  assert.equal(plan.actions[0].kind, "manual_intervention");
+  assert.equal(plan.actions[0].mappingState, "partial");
+});
+
+test("manual intervention on one target does not skip safe reverse recovery elsewhere", async () => {
+  let highest = prepared({ app: "known" });
+  for (const target of ["governance", "reserve"]) {
+    highest = transitionSuccessfulOperation(highest, {
+      type: "promote",
+      target,
+    }).verified;
+  }
+  const governanceAlias = highest.prior.governance.aliases[0];
+  const overrides = Object.fromEntries(
+    highest.prior.reserve.aliases.map((alias) => [
+      alias,
+      highest.candidates.reserve,
+    ]),
+  );
+  overrides[governanceAlias] = {
+    deploymentId: "dpl_operator123",
+    deploymentUrl: "https://operator.vercel.app",
+  };
+  const plan = planMainTransactionRecovery({
+    journal: highest,
+    currentMappings: currentMappings(highest, overrides),
+  });
+  assert.equal(plan.decision, "manual_intervention");
+  assert.equal(plan.actions[0].kind, "ordinary_rollback");
+  assert.ok(plan.actions.some((entry) => entry.kind === "manual_intervention"));
+
+  const calls = [];
+  const result = await executeMainTransactionRecovery({
+    plan,
+    uploadJournal: acknowledgedUploader(),
+    ordinaryRollback: async (entry) => {
+      calls.push(entry.target);
+      return { outcome: "success" };
+    },
+    inspectMapping: async () => ({ mappingState: "candidate" }),
+    verifyMapping: async () => ({ mappingState: "prior" }),
+  });
+  assert.deepEqual(calls, ["reserve"]);
+  assert.equal(result.status, "manual_intervention");
+});
+
+test("app recovery restores only exact transaction-candidate aliases", () => {
+  const initial = prepared();
+  const started = startMainTransactionOperation(initial, {
+    type: "app_v3_deploy",
+    target: "app",
+  });
+  const returned = recordMainTransactionCommandReturned(started, {
+    operationId: started.operations.at(-1).operationId,
+    outcome: "success",
+    candidate: appCandidateMatch(),
+  });
+  const aliases = returned.prior.app.aliases;
+  const plan = planMainTransactionRecovery({
+    journal: returned,
+    currentMappings: currentMappings(returned, {
+      [aliases[0]]: returned.prior.app,
+      [aliases[1]]: returned.candidates.app,
+    }),
+  });
+  assert.equal(plan.decision, "recover");
+  const appActions = plan.actions.filter((entry) => entry.target === "app");
+  assert.deepEqual(
+    appActions.map((entry) => [entry.kind, entry.alias]),
+    [
+      ["app_alias_restore", aliases[1]],
+      ["verified_noop", aliases[0]],
+    ],
+  );
+  assert.equal(
+    appActions[0].priorDeploymentUrl,
+    returned.prior.app.deploymentUrl,
+  );
+  assert.equal(
+    appActions[0].candidateDeploymentId,
+    returned.candidates.app.deploymentId,
+  );
+});
+
+test("unknown app candidate is required only after an app mapping moved", () => {
+  const initial = prepared();
+  const started = startMainTransactionOperation(initial, {
+    type: "app_v3_deploy",
+    target: "app",
+  });
+  const priorPlan = planMainTransactionRecovery({
+    journal: started,
+    currentMappings: currentMappings(started),
+    appCandidateMatches: [],
+  });
+  assert.equal(priorPlan.decision, "recover");
+  assert.ok(priorPlan.actions.every((entry) => entry.kind === "verified_noop"));
+
+  const movedAlias = started.prior.app.aliases[0];
+  const movedMappings = currentMappings(started, {
+    [movedAlias]: {
+      deploymentId: "dpl_appCandidate123",
+      deploymentUrl: "https://app-candidate.vercel.app",
+    },
+  });
+  for (const matches of [
+    [],
+    [
+      appCandidateMatch(),
+      appCandidateMatch({
+        deploymentId: "dpl_appCandidate456",
+        deploymentUrl: "https://app-candidate-two.vercel.app",
+      }),
+    ],
+  ]) {
+    const plan = planMainTransactionRecovery({
+      journal: started,
+      currentMappings: movedMappings,
+      appCandidateMatches: matches,
+    });
+    assert.equal(plan.decision, "manual_intervention");
+    assert.equal(plan.reason, "app-candidate-ambiguous-after-mapping-moved");
+  }
+  const unique = planMainTransactionRecovery({
+    journal: started,
+    currentMappings: movedMappings,
+    appCandidateMatches: [appCandidateMatch()],
+  });
+  assert.equal(unique.decision, "recover");
+  assert.equal(
+    unique.actions.find((entry) => entry.alias === movedAlias).kind,
+    "app_alias_restore",
+  );
+});
+
+test("unexpected app mapping is never overwritten", () => {
+  const initial = prepared({ app: "known" });
+  const started = startMainTransactionOperation(initial, {
+    type: "app_v3_deploy",
+    target: "app",
+  });
+  const alias = started.prior.app.aliases[0];
+  const plan = planMainTransactionRecovery({
+    journal: started,
+    currentMappings: currentMappings(started, {
+      [alias]: {
+        deploymentId: "dpl_operator123",
+        deploymentUrl: "https://operator.vercel.app",
+      },
+    }),
+  });
+  assert.equal(plan.decision, "manual_intervention");
+  assert.equal(
+    plan.actions.find((entry) => entry.alias === alias).kind,
+    "manual_intervention",
+  );
+});
+
+test("legacy v2 is untouched normally and restored only from the exact app candidate", () => {
+  const initial = prepared({ app: "known" });
+  const started = startMainTransactionOperation(initial, {
+    type: "app_v3_deploy",
+    target: "app",
+  });
+  const legacyAlias = started.prior["legacy-app"].aliases[0];
+  const untouched = planMainTransactionRecovery({
+    journal: started,
+    currentMappings: currentMappings(started),
+  });
+  assert.equal(
+    untouched.actions.find((entry) => entry.alias === legacyAlias).kind,
+    "verified_noop",
+  );
+
+  const emergency = planMainTransactionRecovery({
+    journal: started,
+    currentMappings: currentMappings(started, {
+      [legacyAlias]: started.candidates.app,
+    }),
+  });
+  const restore = emergency.actions.find(
+    (entry) => entry.alias === legacyAlias,
+  );
+  assert.equal(restore.kind, "legacy_emergency_restore");
+  assert.equal(
+    restore.priorDeploymentUrl,
+    started.prior["legacy-app"].deploymentUrl,
+  );
+  assert.equal(emergency.forceFailure, true);
+  assert.equal(emergency.reason, "legacy-alias-moved-to-transaction-candidate");
+
+  const operator = planMainTransactionRecovery({
+    journal: started,
+    currentMappings: currentMappings(started, {
+      [legacyAlias]: {
+        deploymentId: "dpl_operator123",
+        deploymentUrl: "https://operator.vercel.app",
+      },
+    }),
+  });
+  assert.equal(operator.decision, "manual_intervention");
+});
+
+test("recovered and committed histories bypass repeat recovery", () => {
+  const initial = prepared({ app: "known" });
+  const committed = markMainTransactionCommitted(initial);
+  assert.equal(
+    decideMainTransactionRecovery([initial, committed]).decision,
+    "bypass",
+  );
+  const verificationOnly = decideMainTransactionRecovery([initial]);
+  assert.equal(verificationOnly.decision, "verify-only");
+});
+
+test("shadow execution exercises preparation, freshness, persistence, and recovery decision only", async () => {
+  const events = [];
+  const forbidden = () => {
+    events.push("MUTATION");
+    throw new Error("unreachable");
+  };
+  const result = await runMainTransaction({
+    mode: MAIN_TRANSACTION_MODE,
+    identity,
+    prior: priorState(),
+    candidates: candidateState(),
+    assertFreshness: async ({ phase }) => {
+      events.push(`fresh:${phase}`);
+      return { sha: SHA };
+    },
+    uploadJournal: async (payload) => {
+      events.push(`upload:${payload.journal.status}`);
+      return { acknowledged: true, artifactName: payload.artifactName };
+    },
+    inspectRecoveryState: async ({ decision }) => {
+      events.push(`recovery:${decision}`);
+    },
+    mutationAdapters: {
+      promote: forbidden,
+      deployAppV3: forbidden,
+      assignAlias: forbidden,
+      ordinaryRollback: forbidden,
+      restoreAppAlias: forbidden,
+      restoreLegacyAlias: forbidden,
+    },
+  });
+  assert.equal(result.outcome, "shadow-prepared");
+  assert.equal(result.mutationCallbacksCalled, 0);
+  assert.deepEqual(events, [
+    "fresh:transaction-start",
+    "upload:prepared",
+    "recovery:verify-only",
+  ]);
+});
+
+test("shadow transaction superseded at start persists nothing", async () => {
+  let uploads = 0;
+  await assert.rejects(
+    runMainTransaction({
+      mode: "shadow",
+      identity,
+      prior: priorState(),
+      candidates: candidateState(),
+      assertFreshness: async () => ({ sha: OTHER_SHA }),
+      uploadJournal: async () => {
+        uploads += 1;
+      },
+    }),
+    (error) =>
+      error instanceof MainTransactionError &&
+      error.code === "SUPERSEDED_BEFORE_MUTATION",
+  );
+  assert.equal(uploads, 0);
+});
+
+test("active mode and every mutation callback remain unreachable in PR A", async () => {
+  let callbacks = 0;
+  await assert.rejects(
+    runMainTransaction({
+      mode: "active",
+      identity,
+      prior: priorState(),
+      candidates: candidateState(),
+      assertFreshness: async () => ({ sha: SHA }),
+      uploadJournal: acknowledgedUploader(),
+      mutationAdapters: {
+        promote: () => {
+          callbacks += 1;
+        },
+      },
+    }),
+    /unreachable in PR A/,
+  );
+  assert.equal(callbacks, 0);
+});

--- a/scripts/vercel-main-transaction.test.mjs
+++ b/scripts/vercel-main-transaction.test.mjs
@@ -59,18 +59,9 @@ function priorState() {
       "app.mento.org",
       "appmentoorg-env-v3-mentolabs.vercel.app",
     ]),
-    governance: deploymentRecord("governance", [
-      "governance.mento.org",
-      "governancementoorg-mentolabs.vercel.app",
-    ]),
-    reserve: deploymentRecord("reserve", [
-      "reserve.mento.org",
-      "reservementoorg-mentolabs.vercel.app",
-    ]),
-    ui: deploymentRecord("ui", [
-      "ui.mento.org",
-      "uimentoorg-mentolabs.vercel.app",
-    ]),
+    governance: deploymentRecord("governance", ["governance.mento.org"]),
+    reserve: deploymentRecord("reserve", ["reserve.mento.org"]),
+    ui: deploymentRecord("ui", ["ui.mento.org"]),
     "legacy-app": deploymentRecord("legacy", ["v2-app.mento.org"]),
   };
 }
@@ -115,6 +106,20 @@ function prepared(options = {}) {
   });
 }
 
+function preparedForTargets(targets, options = {}) {
+  const selected = new Set(targets);
+  const candidates = candidateState(options);
+  for (const target of ["app", "governance", "reserve", "ui"]) {
+    if (!selected.has(target)) candidates[target] = null;
+  }
+  return createPreparedMainTransactionJournal({
+    ...identity,
+    mode: options.mode ?? "active",
+    prior: priorState(),
+    candidates,
+  });
+}
+
 function appCandidateMatch(overrides = {}) {
   return {
     deploymentId: "dpl_appCandidate123",
@@ -151,7 +156,11 @@ function acknowledgedUploader(log = []) {
       retentionDays,
       journal,
     });
-    return { acknowledged: true, artifactName };
+    return {
+      acknowledged: true,
+      artifactName,
+      artifactId: String(1000 + journal.sequence),
+    };
   };
 }
 
@@ -170,6 +179,28 @@ function transitionSuccessfulOperation(journal, intent) {
       mappingState: "candidate",
     }),
   };
+}
+
+function plannedOrdinaryRecovery(targets = ["governance"]) {
+  let highest = prepared({ app: "known" });
+  for (const target of targets) {
+    highest = transitionSuccessfulOperation(highest, {
+      type: "promote",
+      target,
+    }).verified;
+  }
+  const overrides = Object.fromEntries(
+    targets.flatMap((target) =>
+      highest.prior[target].aliases.map((alias) => [
+        alias,
+        highest.candidates[target],
+      ]),
+    ),
+  );
+  return planMainTransactionRecovery({
+    journal: highest,
+    currentMappings: currentMappings(highest, overrides),
+  });
 }
 
 test("transaction ID is deterministic and binds only immutable run identity", () => {
@@ -264,7 +295,7 @@ test("static fixture remains compatible with the canonical journal schema", () =
 });
 
 test("operation snapshots form an append-only monotonic history", () => {
-  const initial = prepared({ app: "known" });
+  const initial = preparedForTargets(["governance"], { app: "known" });
   const { started, returned, verified } = transitionSuccessfulOperation(
     initial,
     { type: "promote", target: "governance" },
@@ -324,6 +355,228 @@ test("operation snapshots form an append-only monotonic history", () => {
         ),
       }),
     /command outcome changed/,
+  );
+});
+
+test("operation event fields must match the constructor state", () => {
+  const initial = preparedForTargets(["governance"], { app: "known" });
+  const { started, returned, verified } = transitionSuccessfulOperation(
+    initial,
+    { type: "promote", target: "governance" },
+  );
+  const cases = [
+    {
+      journal: {
+        ...started,
+        operations: [
+          {
+            ...started.operations[0],
+            commandOutcome: "success",
+          },
+        ],
+      },
+      pattern: /fields are inconsistent/,
+    },
+    {
+      journal: {
+        ...returned,
+        operations: returned.operations.map((operation, index) =>
+          index === returned.operations.length - 1
+            ? { ...operation, mappingState: "candidate" }
+            : operation,
+        ),
+      },
+      pattern: /fields are inconsistent/,
+    },
+    {
+      journal: {
+        ...verified,
+        operations: verified.operations.map((operation, index) =>
+          index === verified.operations.length - 1
+            ? { ...operation, mappingState: null }
+            : operation,
+        ),
+      },
+      pattern: /fields are inconsistent/,
+    },
+    {
+      journal: {
+        ...verified,
+        operations: verified.operations.map((operation, index) =>
+          index === verified.operations.length - 1
+            ? { ...operation, rollbackState: "entered" }
+            : operation,
+        ),
+      },
+      pattern: /Rollback marker requires/,
+    },
+    {
+      journal: {
+        ...started,
+        status: "recovering",
+        operations: [
+          {
+            ...started.operations[0],
+            state: "recovering",
+          },
+        ],
+      },
+      pattern: /state is unsupported/,
+    },
+  ];
+  for (const { journal, pattern } of cases) {
+    assert.throws(() => assertMainTransactionJournal(journal), pattern);
+  }
+});
+
+test("adjacent journal snapshots append exactly one helper-legal event", () => {
+  const initial = preparedForTargets(["governance"], { app: "known" });
+  const { started, returned } = transitionSuccessfulOperation(initial, {
+    type: "promote",
+    target: "governance",
+  });
+  assert.throws(
+    () =>
+      assertMainTransactionJournalHistory([
+        initial,
+        { ...returned, sequence: 1 },
+      ]),
+    /batched operation events/,
+  );
+  assert.throws(
+    () =>
+      assertMainTransactionJournalHistory([
+        initial,
+        { ...started, status: "command_returned" },
+      ]),
+    /status does not match/,
+  );
+
+  const appInitial = preparedForTargets(["app"]);
+  const appStarted = startMainTransactionOperation(appInitial, {
+    type: "app_v3_deploy",
+    target: "app",
+  });
+  const attached = attachDiscoveredAppCandidate(
+    appStarted,
+    appCandidateMatch(),
+  );
+  assert.throws(
+    () =>
+      assertMainTransactionJournalHistory([
+        appInitial,
+        appStarted,
+        { ...attached, status: "recovering" },
+      ]),
+    /did not append one legal event/,
+  );
+});
+
+test("commit requires one verified forward operation for every selected candidate", () => {
+  const selected = preparedForTargets(["governance", "reserve"], {
+    app: "known",
+  });
+  assert.throws(
+    () => markMainTransactionCommitted(selected),
+    /incomplete operations/,
+  );
+
+  const governanceVerified = transitionSuccessfulOperation(selected, {
+    type: "promote",
+    target: "governance",
+  }).verified;
+  assert.throws(
+    () => markMainTransactionCommitted(governanceVerified),
+    /incomplete operations/,
+  );
+
+  let fullyVerified = preparedForTargets(
+    ["app", "governance", "reserve", "ui"],
+    { app: "known" },
+  );
+  for (const intent of [
+    { type: "promote", target: "governance" },
+    { type: "promote", target: "reserve" },
+    { type: "promote", target: "ui" },
+    { type: "app_v3_deploy", target: "app" },
+  ]) {
+    fullyVerified = transitionSuccessfulOperation(
+      fullyVerified,
+      intent,
+    ).verified;
+  }
+  assert.equal(markMainTransactionCommitted(fullyVerified).status, "committed");
+});
+
+test("selected app commit requires its exact candidate discovery", () => {
+  const selected = preparedForTargets(["app"]);
+  const verifiedWithoutCandidate = transitionSuccessfulOperation(selected, {
+    type: "app_v3_deploy",
+    target: "app",
+  }).verified;
+  assert.equal(verifiedWithoutCandidate.candidates.app.deploymentId, null);
+  assert.throws(
+    () => markMainTransactionCommitted(verifiedWithoutCandidate),
+    /incomplete operations/,
+  );
+});
+
+test("app alias completeness is a final mapping-verification boundary", () => {
+  const selected = preparedForTargets(["app"], { app: "known" });
+  const appVerified = transitionSuccessfulOperation(selected, {
+    type: "app_v3_deploy",
+    target: "app",
+  }).verified;
+  assert.equal(
+    appVerified.operations.some(
+      (operation) => operation.type === "app_alias_set",
+    ),
+    false,
+  );
+  assert.equal(markMainTransactionCommitted(appVerified).status, "committed");
+});
+
+test("duplicate forward mutations are rejected after a verified attempt", () => {
+  const ordinary = transitionSuccessfulOperation(
+    preparedForTargets(["governance"], { app: "known" }),
+    { type: "promote", target: "governance" },
+  ).verified;
+  assert.throws(
+    () =>
+      startMainTransactionOperation(ordinary, {
+        type: "promote",
+        target: "governance",
+      }),
+    /already recorded/,
+  );
+
+  const appDeploy = transitionSuccessfulOperation(
+    preparedForTargets(["app"], { app: "known" }),
+    { type: "app_v3_deploy", target: "app" },
+  ).verified;
+  assert.throws(
+    () =>
+      startMainTransactionOperation(appDeploy, {
+        type: "app_v3_deploy",
+        target: "app",
+      }),
+    /already recorded/,
+  );
+
+  const alias = appDeploy.prior.app.aliases[0];
+  const aliasVerified = transitionSuccessfulOperation(appDeploy, {
+    type: "app_alias_set",
+    target: "app",
+    alias,
+  }).verified;
+  assert.throws(
+    () =>
+      startMainTransactionOperation(aliasVerified, {
+        type: "app_alias_set",
+        target: "app",
+        alias,
+      }),
+    /already recorded/,
   );
 });
 
@@ -394,12 +647,34 @@ test("journal upload acknowledgement is exact and uses seven-day retention", asy
     persistMainTransactionJournal(journal, async ({ artifactName }) => ({
       acknowledged: true,
       artifactName: `${artifactName}-wrong`,
+      artifactId: "1000",
     })),
     (error) =>
       error instanceof MainTransactionError &&
       error.code === "JOURNAL_UPLOAD_NOT_ACKNOWLEDGED",
   );
 });
+
+for (const [name, artifactId] of [
+  ["missing", undefined],
+  ["zero", "0"],
+  ["negative", "-1"],
+  ["non-numeric", "artifact-123"],
+]) {
+  test(`journal upload rejects a ${name} immutable artifact ID`, async () => {
+    const journal = prepared();
+    await assert.rejects(
+      persistMainTransactionJournal(journal, async ({ artifactName }) => ({
+        acknowledged: true,
+        artifactName,
+        ...(artifactId === undefined ? {} : { artifactId }),
+      })),
+      (error) =>
+        error instanceof MainTransactionError &&
+        error.code === "JOURNAL_UPLOAD_NOT_ACKNOWLEDGED",
+    );
+  });
+}
 
 test("started journal is durably acknowledged before mutation callback", async () => {
   const events = [];
@@ -408,7 +683,11 @@ test("started journal is durably acknowledged before mutation callback", async (
     intent: { type: "promote", target: "governance" },
     uploadJournal: async (payload) => {
       events.push(`upload:${payload.journal.status}`);
-      return { acknowledged: true, artifactName: payload.artifactName };
+      return {
+        acknowledged: true,
+        artifactName: payload.artifactName,
+        artifactId: String(1000 + payload.journal.sequence),
+      };
     },
     assertFreshness: async ({ phase }) => {
       events.push(`fresh:${phase}`);
@@ -464,6 +743,49 @@ test("upload failure prevents mutation and leaves only prior durable state", asy
       error.code === "JOURNAL_UPLOAD_FAILED",
   );
   assert.equal(mutations, 0);
+});
+
+test("every forward upload failure exposes only the last durable journal", async () => {
+  const expectedDurable = [
+    { sequence: 0, status: "prepared", mutations: 0 },
+    { sequence: 1, status: "started", mutations: 1 },
+    { sequence: 2, status: "command_returned", mutations: 1 },
+  ];
+  for (const [index, expected] of expectedDurable.entries()) {
+    let attempts = 0;
+    let mutations = 0;
+    await assert.rejects(
+      executeJournaledMainMutation({
+        journal: prepared({ app: "known" }),
+        intent: { type: "promote", target: "governance" },
+        uploadJournal: async ({ artifactName, journal }) => {
+          attempts += 1;
+          if (attempts === index + 1) {
+            throw new Error("artifact upload interrupted");
+          }
+          return {
+            acknowledged: true,
+            artifactName,
+            artifactId: String(1000 + journal.sequence),
+          };
+        },
+        assertFreshness: async () => ({ sha: SHA }),
+        executeMutation: async () => {
+          mutations += 1;
+          return { outcome: "success" };
+        },
+        inspectMutationState: async () => ({ mappingState: "prior" }),
+        verifyMapping: async () => ({ mappingState: "candidate" }),
+      }),
+      (error) => {
+        assert.equal(error.code, "JOURNAL_UPLOAD_FAILED");
+        assert.equal(error.journal.sequence, expected.sequence);
+        assert.equal(error.journal.status, expected.status);
+        return true;
+      },
+    );
+    assert.equal(mutations, expected.mutations);
+  }
 });
 
 test("main advancing before an operation performs no mutation", async () => {
@@ -657,8 +979,8 @@ test("a cancellation after started persistence is recoverable by a separate job"
 
 test("mapping classifier distinguishes prior, candidate, partial, and unexpected", () => {
   const journal = prepared({ app: "known" });
-  const prior = journal.prior.governance;
-  const candidate = journal.candidates.governance;
+  const prior = journal.prior.app;
+  const candidate = journal.candidates.app;
   const aliases = prior.aliases;
   const classify = (records) =>
     classifyMainTransactionMapping({
@@ -772,7 +1094,210 @@ test("ordinary recovery is planned and executed in reverse activation order", as
   );
 });
 
-test("partial ordinary movement preserves possible operator intervention", () => {
+test("forged recovery action fields never reach inspection or mutation adapters", async () => {
+  const basePlan = plannedOrdinaryRecovery(["governance", "reserve"]);
+  const mutations = [
+    ["target", (plan) => (plan.actions[0].target = "governance")],
+    ["operation ID", (plan) => (plan.actions[0].operationId = "op-0001")],
+    [
+      "prior deployment ID",
+      (plan) => (plan.actions[0].priorDeploymentId = "dpl_attackerPrior123"),
+    ],
+    [
+      "prior deployment URL",
+      (plan) =>
+        (plan.actions[0].priorDeploymentUrl =
+          "https://attacker-prior.vercel.app"),
+    ],
+    [
+      "candidate deployment ID",
+      (plan) =>
+        (plan.actions[0].candidateDeploymentId = "dpl_attackerCandidate123"),
+    ],
+    [
+      "candidate deployment URL",
+      (plan) =>
+        (plan.actions[0].candidateDeploymentUrl =
+          "https://attacker-candidate.vercel.app"),
+    ],
+    ["action order", (plan) => plan.actions.reverse()],
+    ["action kind", (plan) => (plan.actions[0].kind = "verified_noop")],
+    ["extra field", (plan) => (plan.actions[0].operator = "attacker")],
+    ["missing field", (plan) => delete plan.actions[0].candidateDeploymentUrl],
+    [
+      "rollback aliases",
+      (plan) => (plan.actions[0].aliases = ["attacker.mento.org"]),
+    ],
+    [
+      "rollback marker",
+      (plan) => (plan.actions[0].entersRollbackState = false),
+    ],
+  ];
+  for (const [name, tamper] of mutations) {
+    const plan = structuredClone(basePlan);
+    tamper(plan);
+    let inspections = 0;
+    let adapterCalls = 0;
+    let uploads = 0;
+    await assert.rejects(
+      executeMainTransactionRecovery({
+        plan,
+        uploadJournal: async () => {
+          uploads += 1;
+        },
+        ordinaryRollback: async () => {
+          adapterCalls += 1;
+        },
+        restoreAppAlias: async () => {
+          adapterCalls += 1;
+        },
+        restoreLegacyAlias: async () => {
+          adapterCalls += 1;
+        },
+        inspectMapping: async () => {
+          inspections += 1;
+          return { mappingState: "candidate" };
+        },
+        verifyMapping: async () => ({ mappingState: "prior" }),
+      }),
+      undefined,
+      name,
+    );
+    assert.equal(inspections, 0, name);
+    assert.equal(adapterCalls, 0, name);
+    assert.equal(uploads, 0, name);
+  }
+
+  const appStarted = startMainTransactionOperation(
+    preparedForTargets(["app"], { app: "known" }),
+    { type: "app_v3_deploy", target: "app" },
+  );
+  const movedAlias = appStarted.prior.app.aliases[0];
+  const appPlan = planMainTransactionRecovery({
+    journal: appStarted,
+    currentMappings: currentMappings(appStarted, {
+      [movedAlias]: appStarted.candidates.app,
+    }),
+  });
+  const restore = appPlan.actions.find(
+    (entry) => entry.kind === "app_alias_restore",
+  );
+  restore.alias = appStarted.prior.app.aliases.find(
+    (alias) => alias !== movedAlias,
+  );
+  let appInspections = 0;
+  await assert.rejects(
+    executeMainTransactionRecovery({
+      plan: appPlan,
+      uploadJournal: acknowledgedUploader(),
+      restoreAppAlias: async () => ({ outcome: "success" }),
+      inspectMapping: async () => {
+        appInspections += 1;
+        return { mappingState: "candidate" };
+      },
+      verifyMapping: async () => ({ mappingState: "prior" }),
+    }),
+  );
+  assert.equal(appInspections, 0);
+});
+
+test("every recovery upload failure exposes only the last durable journal", async () => {
+  const plan = plannedOrdinaryRecovery();
+  const expectedDurable = [
+    { offset: 0, status: "verified", mutations: 0 },
+    { offset: 1, status: "recovering", mutations: 0 },
+    { offset: 2, status: "started", mutations: 1 },
+    { offset: 3, status: "command_returned", mutations: 1 },
+    { offset: 4, status: "verified", mutations: 1 },
+  ];
+  for (const [index, expected] of expectedDurable.entries()) {
+    let attempts = 0;
+    let mutations = 0;
+    await assert.rejects(
+      executeMainTransactionRecovery({
+        plan,
+        uploadJournal: async ({ artifactName, journal }) => {
+          attempts += 1;
+          if (attempts === index + 1) {
+            throw new Error("artifact upload interrupted");
+          }
+          return {
+            acknowledged: true,
+            artifactName,
+            artifactId: String(2000 + journal.sequence),
+          };
+        },
+        ordinaryRollback: async () => {
+          mutations += 1;
+          return { outcome: "success" };
+        },
+        inspectMapping: async () => ({ mappingState: "candidate" }),
+        verifyMapping: async () => ({ mappingState: "prior" }),
+      }),
+      (error) => {
+        assert.equal(error.code, "JOURNAL_UPLOAD_FAILED");
+        assert.equal(
+          error.journal.sequence,
+          plan.journal.sequence + expected.offset,
+        );
+        assert.equal(error.journal.status, expected.status);
+        return true;
+      },
+    );
+    assert.equal(mutations, expected.mutations);
+  }
+});
+
+test("app discovery and recovery-start uploads retain the prior durable snapshot", async () => {
+  const started = startMainTransactionOperation(preparedForTargets(["app"]), {
+    type: "app_v3_deploy",
+    target: "app",
+  });
+  const movedAlias = started.prior.app.aliases[0];
+  const plan = planMainTransactionRecovery({
+    journal: started,
+    currentMappings: currentMappings(started, {
+      [movedAlias]: {
+        deploymentId: "dpl_appCandidate123",
+        deploymentUrl: "https://app-candidate.vercel.app",
+      },
+    }),
+    appCandidateMatches: [appCandidateMatch()],
+  });
+  for (const [failAt, expected] of [
+    [1, { sequence: started.sequence, status: "started" }],
+    [2, { sequence: started.sequence + 1, status: "started" }],
+  ]) {
+    let attempts = 0;
+    await assert.rejects(
+      executeMainTransactionRecovery({
+        plan,
+        uploadJournal: async ({ artifactName, journal }) => {
+          attempts += 1;
+          if (attempts === failAt) throw new Error("upload interrupted");
+          return {
+            acknowledged: true,
+            artifactName,
+            artifactId: String(3000 + journal.sequence),
+          };
+        },
+        restoreAppAlias: async () => ({ outcome: "success" }),
+        inspectMapping: async (entry) => ({
+          mappingState: entry.kind === "verified_noop" ? "prior" : "candidate",
+        }),
+        verifyMapping: async () => ({ mappingState: "prior" }),
+      }),
+      (error) => {
+        assert.equal(error.code, "JOURNAL_UPLOAD_FAILED");
+        assert.equal(error.journal.sequence, expected.sequence);
+        assert.equal(error.journal.status, expected.status);
+        return true;
+      },
+    );
+  }
+});
+
+test("unexpected ordinary movement preserves possible operator intervention", () => {
   const initial = prepared({ app: "known" });
   const { started } = transitionSuccessfulOperation(initial, {
     type: "promote",
@@ -782,13 +1307,15 @@ test("partial ordinary movement preserves possible operator intervention", () =>
   const plan = planMainTransactionRecovery({
     journal: started,
     currentMappings: currentMappings(started, {
-      [aliases[0]]: started.prior.governance,
-      [aliases[1]]: started.candidates.governance,
+      [aliases[0]]: {
+        deploymentId: "dpl_operator123",
+        deploymentUrl: "https://operator.vercel.app",
+      },
     }),
   });
   assert.equal(plan.decision, "manual_intervention");
   assert.equal(plan.actions[0].kind, "manual_intervention");
-  assert.equal(plan.actions[0].mappingState, "partial");
+  assert.equal(plan.actions[0].mappingState, "unexpected");
 });
 
 test("manual intervention on one target does not skip safe reverse recovery elsewhere", async () => {
@@ -826,7 +1353,10 @@ test("manual intervention on one target does not skip safe reverse recovery else
       calls.push(entry.target);
       return { outcome: "success" };
     },
-    inspectMapping: async () => ({ mappingState: "candidate" }),
+    inspectMapping: async (entry) => ({
+      mappingState:
+        entry.kind === "manual_intervention" ? "unexpected" : "candidate",
+    }),
     verifyMapping: async () => ({ mappingState: "prior" }),
   });
   assert.deepEqual(calls, ["reserve"]);
@@ -991,7 +1521,7 @@ test("legacy v2 is untouched normally and restored only from the exact app candi
 });
 
 test("recovered and committed histories bypass repeat recovery", () => {
-  const initial = prepared({ app: "known" });
+  const initial = preparedForTargets([], { app: "known" });
   const committed = markMainTransactionCommitted(initial);
   assert.equal(
     decideMainTransactionRecovery([initial, committed]).decision,
@@ -1018,7 +1548,11 @@ test("shadow execution exercises preparation, freshness, persistence, and recove
     },
     uploadJournal: async (payload) => {
       events.push(`upload:${payload.journal.status}`);
-      return { acknowledged: true, artifactName: payload.artifactName };
+      return {
+        acknowledged: true,
+        artifactName: payload.artifactName,
+        artifactId: String(1000 + payload.journal.sequence),
+      };
     },
     inspectRecoveryState: async ({ decision }) => {
       events.push(`recovery:${decision}`);

--- a/scripts/vercel-production-shadow-workflow.test.mjs
+++ b/scripts/vercel-production-shadow-workflow.test.mjs
@@ -1636,7 +1636,7 @@ test("shadow smoke strips protection headers and disables traces", () => {
   assert.match(redirectRegression, /chromium\.launch/);
   assert.match(redirectRegression, /received\.source, \[undefined\]/);
   assert.match(redirectRegression, /received\.destination, \[undefined\]/);
-  for (const target of ["governance", "reserve", "ui"]) {
+  for (const target of ["app", "governance", "reserve", "ui"]) {
     const nextConfig = readFileSync(
       new URL(`../apps/${target}.mento.org/next.config.ts`, import.meta.url),
       "utf8",


### PR DESCRIPTION
## The Problem

Moving `main` builds off Vercel requires more than changing the runner. The cutover must trust the exact successful `CI/CD` attempt, plan from the commits actually serving each domain, preserve App custom `v3` and legacy `v2`, and prove rollback inputs before GitHub Actions may own public deployment.

Issue #522 therefore requires an automatic shadow phase before any domain movement or Vercel Git ownership change.

## The Solution

- Add `Vercel Main Deployment`, triggered only by a successful default-branch `CI/CD` `workflow_run`, with exact-attempt API verification, the literal `Build and Test` sentinel, immutable source checks, and single-pending transaction concurrency.
- Plan each target from its currently served SHA. Ambiguous Git metadata selects safely; ambiguous alias, project, environment, health, or rollback identity aborts.
- Stage Governance, Reserve, and UI as unaliased production candidates, then verify their immutable URLs in the browser and prove protected mappings did not move. Build App custom `v3` in the coordinator without deploying it.
- Exercise durable transaction-journal and separate recovery decisions in literal shadow mode. Public-serving promotion, alias, rollback, App `v3` deployment, and recovery mutation commands remain structurally unreachable.
- Publish one redacted evidence artifact and summary with exact run/SHA identities, priors, planning reasons, candidates, runtime proof, timings, Turbo cache results, freshness barriers, journal identity, recovery outcome, and legacy `v2` health.
- Monitor failures through the existing CI failure notifier and update the ADR, runbooks, operator commands, ownership boundaries, and cost-validation documentation.

This is PR A of the mandatory two-PR cutover in #522. Native Vercel `main` ownership remains enabled. Governance QA remains deleted. PR B will enable public activation and change Git ownership together only after the automatic and superseded-run shadow canaries pass.

## Validation

- `pnpm test` — passed, including the Vercel main, preview, state, transaction, runtime, workflow, notifier, and workspace suites
- `pnpm check-types` — passed
- `pnpm knip` — passed; only the pre-existing Tailwind configuration hint remains
- `trunk check` — passed across all 37 changed files
- `pnpm ci:action-pins` — all 27 workflow/composite-action YAML files use immutable pins
- `pnpm ci:action-pins:test` — 59 tests passed
- `pnpm quality:budgets:test` — 34 tests passed
- `pnpm build` — all four applications and shared packages passed with non-secret local fixture values
- `pnpm quality:bundle:check` — all four route bundle budgets passed
- Browser verification — the exact-HEAD production App rendered and its theme interaction worked; the document response exposed `X-Mento-Deployment-Sha: f786bded7638bef008732d25008e5d92b5268cc3`. Console/network errors were limited to expected non-secret fixture failures: local Vercel Insights, the `example.com` image, and the dummy WalletConnect project ID.
- Independent exact-head reviews found no remaining workflow, credential-boundary, evidence, transaction, recovery, or documentation finding

The first real provider/runtime proof is intentionally the automatic shadow run after merge. Its canonical artifact is the gate for opening PR B.

## Risk and Rollout

- PR A can create unaliased Governance, Reserve, and UI staging deployments, so it is not provider-mutation-free. It cannot move a public domain.
- Any gate, planning, stage, smoke, protected-mapping, freshness, journal, or recovery ambiguity fails closed.
- App custom `v3` is build-only; App production/legacy `v2` remains untouched.
- Do not manually cancel a future active transaction after its first durable `started` journal. The runbook documents the exact-ID recovery and native-owner restoration procedures.

Part of #522 and #515.

## Ship Checklist

- [x] PR title follows the conventions
- [x] Performed a self-review of my own changes
- [x] Relevant automated checks and smoke tests pass
- [x] Architecture decision: [ADR 0001](./docs/adr/0001-github-actions-vercel-deployment-orchestration.md) is updated for this accepted implementation
