### PR TITLE
fix(ci): accept generated legacy deployment aliases

### DIFF
--- a/docs/vercel-deployments.md
+++ b/docs/vercel-deployments.md
@@ -246,6 +246,15 @@ IDs in this canonical runbook. The evidence contains only:
 - a zero count for public-serving activation, alias, promotion, rollback, and
   recovery commands.
 
+The legacy v2 proof requires the protected `v2-app.mento.org` alias and the
+exact Vercel Git branch alias
+`appmento-git-v2-mentolabs.vercel.app`. It permits at most one additional
+creator alias derived exactly as
+`appmento-<creator-username>-mentolabs.vercel.app` from the same deployment's
+canonical creator metadata. Creator names in Vercel's reserved `git-` or `env-`
+alias namespaces cannot authorize that optional alias. Any other project,
+branch, team, creator, or custom-domain alias fails before staging.
+
 Use these copy-safe diagnostics:
 
 ```bash

--- a/scripts/vercel-main-deployment.mjs
+++ b/scripts/vercel-main-deployment.mjs
@@ -380,6 +380,13 @@ function canonicalPrior(value, label) {
   };
 }
 
+function isVercelGeneratedAlias(alias) {
+  const labels = alias.split(".");
+  return (
+    labels.length >= 3 && labels.at(-2) === "vercel" && labels.at(-1) === "app"
+  );
+}
+
 function legacyPriorFromSnapshot(snapshot, projectId) {
   const states = snapshot.filter((state) => state.alias === LEGACY_ALIAS);
   if (states.length !== 1) {
@@ -395,9 +402,9 @@ function legacyPriorFromSnapshot(snapshot, projectId) {
     state.git.repo !== "frontend-monorepo" ||
     state.git.ref !== "v2" ||
     state.readyState !== "READY" ||
-    !state.aliases.includes(LEGACY_ALIAS) ||
+    !state.aliases.some((alias) => alias === LEGACY_ALIAS) ||
     state.aliases.some(
-      (alias) => alias !== LEGACY_ALIAS && !alias.endsWith(".vercel.app"),
+      (alias) => alias !== LEGACY_ALIAS && !isVercelGeneratedAlias(alias),
     )
   ) {
     throw new Error("Legacy app rollback state is ambiguous");

--- a/scripts/vercel-main-deployment.mjs
+++ b/scripts/vercel-main-deployment.mjs
@@ -395,7 +395,10 @@ function legacyPriorFromSnapshot(snapshot, projectId) {
     state.git.repo !== "frontend-monorepo" ||
     state.git.ref !== "v2" ||
     state.readyState !== "READY" ||
-    JSON.stringify(state.aliases) !== JSON.stringify([LEGACY_ALIAS])
+    !state.aliases.includes(LEGACY_ALIAS) ||
+    state.aliases.some(
+      (alias) => alias !== LEGACY_ALIAS && !alias.endsWith(".vercel.app"),
+    )
   ) {
     throw new Error("Legacy app rollback state is ambiguous");
   }

--- a/scripts/vercel-main-deployment.mjs
+++ b/scripts/vercel-main-deployment.mjs
@@ -106,6 +106,14 @@ const VERIFICATION_KEYS = Object.freeze([
   "protectedMappings",
 ]);
 const LEGACY_ALIAS = "v2-app.mento.org";
+const LEGACY_GENERATED_PROJECT_SLUG = "appmento";
+const LEGACY_GENERATED_BRANCH_SLUG = "git-v2";
+const LEGACY_GENERATED_SCOPE_SLUG = "mentolabs";
+const LEGACY_GENERATED_BRANCH_ALIAS = `${LEGACY_GENERATED_PROJECT_SLUG}-${LEGACY_GENERATED_BRANCH_SLUG}-${LEGACY_GENERATED_SCOPE_SLUG}.vercel.app`;
+const RESERVED_GENERATED_ALIAS_CREATOR_PREFIXES = Object.freeze([
+  "git-",
+  "env-",
+]);
 const MAX_JSON_BYTES = 256 * 1024;
 const APP_BUILD_PROOF_SCHEMA = "vercel-main-app-build:v1";
 const CLI_COMMAND_OPTIONS = Object.freeze({
@@ -380,11 +388,23 @@ function canonicalPrior(value, label) {
   };
 }
 
-function isVercelGeneratedAlias(alias) {
-  const labels = alias.split(".");
-  return (
-    labels.length >= 3 && labels.at(-2) === "vercel" && labels.at(-1) === "app"
-  );
+function allowedLegacyGeneratedAliasTopologies(creatorUsername) {
+  const branchTopology = [LEGACY_ALIAS, LEGACY_GENERATED_BRANCH_ALIAS].sort();
+  if (
+    creatorUsername === null ||
+    RESERVED_GENERATED_ALIAS_CREATOR_PREFIXES.some((prefix) =>
+      creatorUsername.startsWith(prefix),
+    )
+  ) {
+    return [branchTopology];
+  }
+
+  const creatorLabel = `${LEGACY_GENERATED_PROJECT_SLUG}-${creatorUsername}-${LEGACY_GENERATED_SCOPE_SLUG}`;
+  if (creatorLabel.length > 63) return [branchTopology];
+
+  const creatorAlias = canonicalizeHostname(`${creatorLabel}.vercel.app`);
+  if (creatorAlias === LEGACY_GENERATED_BRANCH_ALIAS) return [branchTopology];
+  return [branchTopology, [...branchTopology, creatorAlias].sort()];
 }
 
 function legacyPriorFromSnapshot(snapshot, projectId) {
@@ -402,9 +422,9 @@ function legacyPriorFromSnapshot(snapshot, projectId) {
     state.git.repo !== "frontend-monorepo" ||
     state.git.ref !== "v2" ||
     state.readyState !== "READY" ||
-    !state.aliases.some((alias) => alias === LEGACY_ALIAS) ||
-    state.aliases.some(
-      (alias) => alias !== LEGACY_ALIAS && !isVercelGeneratedAlias(alias),
+    !allowedLegacyGeneratedAliasTopologies(state.creatorUsername).some(
+      (expectedAliases) =>
+        JSON.stringify(state.aliases) === JSON.stringify(expectedAliases),
     )
   ) {
     throw new Error("Legacy app rollback state is ambiguous");

--- a/scripts/vercel-main-deployment.test.mjs
+++ b/scripts/vercel-main-deployment.test.mjs
@@ -81,7 +81,7 @@ function allProtectedStates() {
       ref: "v2",
       sha: "9999999999999999999999999999999999999999",
     },
-    aliases: ["v2-app.mento.org"],
+    aliases: ["appmento-git-v2-mentolabs.vercel.app", "v2-app.mento.org"],
   });
   return states.sort((left, right) => left.alias.localeCompare(right.alias));
 }
@@ -1059,8 +1059,42 @@ test("protected rollback identity remains stable while ordinary generated aliase
   assert.throws(() =>
     plan({ legacyAliases: ["appmento-git-v2-mentolabs.vercel.app"] }),
   );
+  const creatorAlias = "appmento-fixture-author-mentolabs.vercel.app";
+  assert.doesNotThrow(() =>
+    plan({ legacyAliases: [...legacyAliases, creatorAlias].sort() }),
+  );
+  for (const reservedCreator of ["git-main", "env-v3"]) {
+    const legacy = legacySnapshot();
+    legacy[0].creatorUsername = reservedCreator;
+    legacy[0].aliases = [
+      ...legacyAliases,
+      `appmento-${reservedCreator}-mentolabs.vercel.app`,
+    ].sort();
+    assert.throws(() =>
+      createMainDeploymentPlan({
+        mode: MAIN_DEPLOYMENT_MODE,
+        deploySha: SHA,
+        projectIds,
+        planningSnapshot: planningSnapshot(),
+        legacySnapshot: legacy,
+        upstream: upstream(),
+        gitAdapter: gitAdapter(),
+        runPlanner: ({ base, head }) => ({
+          base,
+          head,
+          deployments: ["app"],
+          reason: "affected-packages",
+        }),
+      }),
+    );
+  }
   for (const unexpectedAlias of [
     "unexpected.mento.org",
+    "appmento-git-main-mentolabs.vercel.app",
+    "appmento-git-v2-other.vercel.app",
+    "other-project-git-v2-mentolabs.vercel.app",
+    "appmento-other-author-mentolabs.vercel.app",
+    "appmento-mentolabs.vercel.app",
     "vercel.app",
     "notvercel.app",
     "safe.vercel.app.attacker.example",

--- a/scripts/vercel-main-deployment.test.mjs
+++ b/scripts/vercel-main-deployment.test.mjs
@@ -126,13 +126,18 @@ function upstream() {
   };
 }
 
-function plan({ deployments = ["app", "governance", "reserve", "ui"] } = {}) {
+function plan({
+  deployments = ["app", "governance", "reserve", "ui"],
+  legacyAliases = null,
+} = {}) {
+  const legacy = legacySnapshot();
+  if (legacyAliases !== null) legacy[0].aliases = legacyAliases;
   return createMainDeploymentPlan({
     mode: MAIN_DEPLOYMENT_MODE,
     deploySha: SHA,
     projectIds,
     planningSnapshot: planningSnapshot(),
-    legacySnapshot: legacySnapshot(),
+    legacySnapshot: legacy,
     upstream: upstream(),
     gitAdapter: gitAdapter(),
     runPlanner: ({ base, head }) => ({
@@ -1043,6 +1048,22 @@ test("selected stages must succeed and unselected stages must be skipped", () =>
 });
 
 test("protected rollback identity remains stable while ordinary generated aliases move", () => {
+  const legacyAliases = [
+    "appmento-git-v2-mentolabs.vercel.app",
+    "v2-app.mento.org",
+  ];
+  const deploymentPlanWithGeneratedLegacyAlias = plan({ legacyAliases });
+  assert.deepEqual(deploymentPlanWithGeneratedLegacyAlias.legacyPrior.aliases, [
+    "v2-app.mento.org",
+  ]);
+  assert.throws(() =>
+    plan({ legacyAliases: ["appmento-git-v2-mentolabs.vercel.app"] }),
+  );
+  assert.throws(() =>
+    plan({
+      legacyAliases: ["unexpected.mento.org", "v2-app.mento.org"],
+    }),
+  );
   const deploymentPlan = plan();
   assert.deepEqual(
     assertProtectedSnapshotMatchesPlan({
@@ -1112,18 +1133,42 @@ test("protected rollback identity remains stable while ordinary generated aliase
       legacySnapshot: legacySnapshot(),
     }),
   );
-  const legacyAliasDrift = structuredClone(legacySnapshot());
-  legacyAliasDrift[0].aliases = [
-    "v2-app.mento.org",
-    "unexpected-legacy-alias.vercel.app",
-  ];
+  const legacyGeneratedAliases = structuredClone(legacySnapshot());
+  legacyGeneratedAliases[0].aliases = legacyAliases;
+  assert.doesNotThrow(() =>
+    assertProtectedSnapshotMatchesPlan({
+      plan: deploymentPlanWithGeneratedLegacyAlias,
+      planningSnapshot: planningSnapshot(),
+      legacySnapshot: legacyGeneratedAliases,
+    }),
+  );
+  const missingLegacyAlias = structuredClone(legacySnapshot());
+  missingLegacyAlias[0].aliases = ["appmento-git-v2-mentolabs.vercel.app"];
   assert.throws(() =>
     assertProtectedSnapshotMatchesPlan({
       plan: deploymentPlan,
       planningSnapshot: planningSnapshot(),
-      legacySnapshot: legacyAliasDrift,
+      legacySnapshot: missingLegacyAlias,
     }),
   );
+  for (const mutate of [
+    (state) => {
+      state.deploymentId = "dpl_operatorMove123";
+    },
+    (state) => {
+      state.aliases = ["appmento-git-v2-other.vercel.app", "v2-app.mento.org"];
+    },
+  ]) {
+    const changed = structuredClone(legacyGeneratedAliases);
+    mutate(changed[0]);
+    assert.throws(() =>
+      assertProtectedSnapshotMatchesPlan({
+        plan: deploymentPlanWithGeneratedLegacyAlias,
+        planningSnapshot: planningSnapshot(),
+        legacySnapshot: changed,
+      }),
+    );
+  }
   for (const mutate of [
     (state) => {
       state.deploymentId = "dpl_operatorMove123";

--- a/scripts/vercel-main-deployment.test.mjs
+++ b/scripts/vercel-main-deployment.test.mjs
@@ -1059,11 +1059,18 @@ test("protected rollback identity remains stable while ordinary generated aliase
   assert.throws(() =>
     plan({ legacyAliases: ["appmento-git-v2-mentolabs.vercel.app"] }),
   );
-  assert.throws(() =>
-    plan({
-      legacyAliases: ["unexpected.mento.org", "v2-app.mento.org"],
-    }),
-  );
+  for (const unexpectedAlias of [
+    "unexpected.mento.org",
+    "vercel.app",
+    "notvercel.app",
+    "safe.vercel.app.attacker.example",
+  ]) {
+    assert.throws(() =>
+      plan({
+        legacyAliases: [unexpectedAlias, "v2-app.mento.org"].sort(),
+      }),
+    );
+  }
   const deploymentPlan = plan();
   assert.deepEqual(
     assertProtectedSnapshotMatchesPlan({


### PR DESCRIPTION
## The Problem

The first automatic main shadow run failed during target planning before staging or mutation: https://github.com/mento-protocol/frontend-monorepo/actions/runs/30080466044

The strict legacy-v2 snapshot correctly proved the expected project, production target, v2 Git ref, readiness, and protected v2-app.mento.org mapping. Planning then rejected the same deployment because Vercel also attached generated vercel.app aliases.

## The Solution

Keep v2-app.mento.org mandatory and pinned to the exact captured legacy deployment while allowing additional Vercel-generated aliases under vercel.app. Reject any additional custom domain, a missing protected v2 alias, or any post-capture deployment identity or alias-topology drift.

This changes no deployment command, ownership setting, or public mapping. It lets the shadow planner model Vercel production alias topology without weakening the protected legacy-domain rollback contract.

Part of #522.

## Validation

- pnpm vercel:workflow:test — 255 passed
- pnpm quality:budgets:test — 34 passed
- pnpm adr:check
- repository pre-push checks — formatting, Trunk, type checks, Knip
- independent review after the final patch — all clear

## Risk

The relaxation is limited to canonical aliases ending in .vercel.app. Unknown custom domains remain fail-closed, and the complete captured legacy snapshot must remain byte-for-byte stable through revalidation.