### PR TITLE
fix(ci): bind shadow legacy v2 to live Vercel aliases

### DIFF
--- a/docs/vercel-deployments.md
+++ b/docs/vercel-deployments.md
@@ -246,14 +246,18 @@ IDs in this canonical runbook. The evidence contains only:
 - a zero count for public-serving activation, alias, promotion, rollback, and
   recovery commands.
 
-The legacy v2 proof requires the protected `v2-app.mento.org` alias and the
-exact Vercel Git branch alias
-`appmento-git-v2-mentolabs.vercel.app`. It permits at most one additional
-creator alias derived exactly as
-`appmento-<creator-username>-mentolabs.vercel.app` from the same deployment's
-canonical creator metadata. Creator names in Vercel's reserved `git-` or `env-`
-alias namespaces cannot authorize that optional alias. Any other project,
-branch, team, creator, or custom-domain alias fails before staging.
+The legacy v2 proof requires exactly three canonical aliases: the protected
+`v2-app.mento.org` alias, the exact Vercel Git branch alias
+`appmentoorg-git-v2-mentolabs.vercel.app`, and the immutable hostname derived
+exactly from that state's canonical `deploymentUrl`. The controller does not
+authorize creator aliases, a guessed deployment hostname, another project,
+branch, scope, team, or custom-domain alias. Any topology difference fails
+before staging.
+
+If only that generated-alias topology is rejected, the diagnostic contains only
+the canonical actual aliases, the canonical creator username (or `null`), and
+the finite expected canonical alias topologies. It excludes deployment and
+project IDs, deployment URLs, Git metadata, raw provider responses, and secrets.
 
 Use these copy-safe diagnostics:
 

--- a/scripts/vercel-main-deployment.mjs
+++ b/scripts/vercel-main-deployment.mjs
@@ -106,14 +106,9 @@ const VERIFICATION_KEYS = Object.freeze([
   "protectedMappings",
 ]);
 const LEGACY_ALIAS = "v2-app.mento.org";
-const LEGACY_GENERATED_PROJECT_SLUG = "appmento";
 const LEGACY_GENERATED_BRANCH_SLUG = "git-v2";
 const LEGACY_GENERATED_SCOPE_SLUG = "mentolabs";
-const LEGACY_GENERATED_BRANCH_ALIAS = `${LEGACY_GENERATED_PROJECT_SLUG}-${LEGACY_GENERATED_BRANCH_SLUG}-${LEGACY_GENERATED_SCOPE_SLUG}.vercel.app`;
-const RESERVED_GENERATED_ALIAS_CREATOR_PREFIXES = Object.freeze([
-  "git-",
-  "env-",
-]);
+const LEGACY_GENERATED_BRANCH_ALIAS = `appmentoorg-${LEGACY_GENERATED_BRANCH_SLUG}-${LEGACY_GENERATED_SCOPE_SLUG}.vercel.app`;
 const MAX_JSON_BYTES = 256 * 1024;
 const APP_BUILD_PROOF_SCHEMA = "vercel-main-app-build:v1";
 const CLI_COMMAND_OPTIONS = Object.freeze({
@@ -388,23 +383,18 @@ function canonicalPrior(value, label) {
   };
 }
 
-function allowedLegacyGeneratedAliasTopologies(creatorUsername) {
-  const branchTopology = [LEGACY_ALIAS, LEGACY_GENERATED_BRANCH_ALIAS].sort();
-  if (
-    creatorUsername === null ||
-    RESERVED_GENERATED_ALIAS_CREATOR_PREFIXES.some((prefix) =>
-      creatorUsername.startsWith(prefix),
-    )
-  ) {
-    return [branchTopology];
+function allowedLegacyGeneratedAliasTopologies(deploymentUrl) {
+  const immutableHostname = new URL(canonicalizeDeploymentUrl(deploymentUrl))
+    .hostname;
+  const aliases = [
+    LEGACY_ALIAS,
+    LEGACY_GENERATED_BRANCH_ALIAS,
+    immutableHostname,
+  ].sort();
+  if (new Set(aliases).size !== aliases.length) {
+    throw new Error("Legacy app rollback state is ambiguous");
   }
-
-  const creatorLabel = `${LEGACY_GENERATED_PROJECT_SLUG}-${creatorUsername}-${LEGACY_GENERATED_SCOPE_SLUG}`;
-  if (creatorLabel.length > 63) return [branchTopology];
-
-  const creatorAlias = canonicalizeHostname(`${creatorLabel}.vercel.app`);
-  if (creatorAlias === LEGACY_GENERATED_BRANCH_ALIAS) return [branchTopology];
-  return [branchTopology, [...branchTopology, creatorAlias].sort()];
+  return [aliases];
 }
 
 function legacyPriorFromSnapshot(snapshot, projectId) {
@@ -413,7 +403,10 @@ function legacyPriorFromSnapshot(snapshot, projectId) {
     throw new Error("Legacy app rollback state is ambiguous");
   }
   const state = states[0];
-  if (
+  const allowedAliasTopologies = allowedLegacyGeneratedAliasTopologies(
+    state.deploymentUrl,
+  );
+  const legacyIdentityIsAmbiguous =
     state.projectId !== projectId ||
     state.projectName !== "app.mento.org" ||
     state.target !== "production" ||
@@ -421,13 +414,19 @@ function legacyPriorFromSnapshot(snapshot, projectId) {
     state.git.org !== "mento-protocol" ||
     state.git.repo !== "frontend-monorepo" ||
     state.git.ref !== "v2" ||
-    state.readyState !== "READY" ||
-    !allowedLegacyGeneratedAliasTopologies(state.creatorUsername).some(
+    state.readyState !== "READY";
+  if (legacyIdentityIsAmbiguous) {
+    throw new Error("Legacy app rollback state is ambiguous");
+  }
+  if (
+    !allowedAliasTopologies.some(
       (expectedAliases) =>
         JSON.stringify(state.aliases) === JSON.stringify(expectedAliases),
     )
   ) {
-    throw new Error("Legacy app rollback state is ambiguous");
+    throw new Error(
+      `Legacy app generated-alias topology mismatch: ${JSON.stringify({ actualAliases: state.aliases, creatorUsername: state.creatorUsername, expectedAliasTopologies: allowedAliasTopologies })}`,
+    );
   }
   return canonicalPrior(
     {

--- a/scripts/vercel-main-deployment.test.mjs
+++ b/scripts/vercel-main-deployment.test.mjs
@@ -81,7 +81,11 @@ function allProtectedStates() {
       ref: "v2",
       sha: "9999999999999999999999999999999999999999",
     },
-    aliases: ["appmento-git-v2-mentolabs.vercel.app", "v2-app.mento.org"],
+    aliases: [
+      "app-v2-prior.vercel.app",
+      "appmentoorg-git-v2-mentolabs.vercel.app",
+      "v2-app.mento.org",
+    ],
   });
   return states.sort((left, right) => left.alias.localeCompare(right.alias));
 }
@@ -1049,44 +1053,58 @@ test("selected stages must succeed and unselected stages must be skipped", () =>
 
 test("protected rollback identity remains stable while ordinary generated aliases move", () => {
   const legacyAliases = [
-    "appmento-git-v2-mentolabs.vercel.app",
+    "app-v2-prior.vercel.app",
+    "appmentoorg-git-v2-mentolabs.vercel.app",
     "v2-app.mento.org",
   ];
   const deploymentPlanWithGeneratedLegacyAlias = plan({ legacyAliases });
   assert.deepEqual(deploymentPlanWithGeneratedLegacyAlias.legacyPrior.aliases, [
     "v2-app.mento.org",
   ]);
-  assert.throws(() =>
-    plan({ legacyAliases: ["appmento-git-v2-mentolabs.vercel.app"] }),
-  );
-  const creatorAlias = "appmento-fixture-author-mentolabs.vercel.app";
-  assert.doesNotThrow(() =>
-    plan({ legacyAliases: [...legacyAliases, creatorAlias].sort() }),
-  );
-  for (const reservedCreator of ["git-main", "env-v3"]) {
-    const legacy = legacySnapshot();
-    legacy[0].creatorUsername = reservedCreator;
-    legacy[0].aliases = [
-      ...legacyAliases,
-      `appmento-${reservedCreator}-mentolabs.vercel.app`,
-    ].sort();
-    assert.throws(() =>
-      createMainDeploymentPlan({
-        mode: MAIN_DEPLOYMENT_MODE,
-        deploySha: SHA,
-        projectIds,
-        planningSnapshot: planningSnapshot(),
-        legacySnapshot: legacy,
-        upstream: upstream(),
-        gitAdapter: gitAdapter(),
-        runPlanner: ({ base, head }) => ({
-          base,
-          head,
-          deployments: ["app"],
-          reason: "affected-packages",
-        }),
-      }),
-    );
+  for (const aliases of [
+    legacyAliases.filter((alias) => alias !== "v2-app.mento.org"),
+    legacyAliases.filter(
+      (alias) => alias !== "appmentoorg-git-v2-mentolabs.vercel.app",
+    ),
+    legacyAliases.filter((alias) => alias !== "app-v2-prior.vercel.app"),
+    [
+      "app-v2-prior.vercel.app",
+      "appmento-git-v2-mentolabs.vercel.app",
+      "v2-app.mento.org",
+    ],
+    [
+      "app-v2-prior.vercel.app",
+      "otherproject-git-v2-mentolabs.vercel.app",
+      "v2-app.mento.org",
+    ],
+    [
+      "app-v2-prior.vercel.app",
+      "appmentoorg-git-main-mentolabs.vercel.app",
+      "v2-app.mento.org",
+    ],
+    [
+      "app-v2-prior.vercel.app",
+      "appmentoorg-git-v2-other.vercel.app",
+      "v2-app.mento.org",
+    ],
+    [
+      "app-other-immutable-mentolabs.vercel.app",
+      "appmentoorg-git-v2-mentolabs.vercel.app",
+      "v2-app.mento.org",
+    ],
+    [
+      "appmento-fixture-author-mentolabs.vercel.app",
+      "appmentoorg-git-v2-mentolabs.vercel.app",
+      "v2-app.mento.org",
+    ],
+    [...legacyAliases, "appmento-fixture-author-mentolabs.vercel.app"],
+    [
+      "app-v2-prior.vercel.app.attacker.example",
+      "appmentoorg-git-v2-mentolabs.vercel.app",
+      "v2-app.mento.org",
+    ],
+  ]) {
+    assert.throws(() => plan({ legacyAliases: aliases.sort() }));
   }
   for (const unexpectedAlias of [
     "unexpected.mento.org",
@@ -1311,6 +1329,71 @@ test("remote-main freshness uses one bounded exact ls-remote ref", () => {
         spawn: () => ({ status: 1, stdout: "" }),
       }),
     /could not be proven/,
+  );
+});
+
+test("legacy generated-alias topology mismatch is a copy-safe diagnostic", () => {
+  const legacy = legacySnapshot();
+  legacy[0].aliases = [
+    "app-v2-prior.vercel.app",
+    "appmentoorg-git-v2-mentolabs.vercel.app",
+    "appmento-unexpected-mentolabs.vercel.app",
+    "v2-app.mento.org",
+  ].sort();
+  let error;
+  try {
+    createMainDeploymentPlan({
+      mode: MAIN_DEPLOYMENT_MODE,
+      deploySha: SHA,
+      projectIds,
+      planningSnapshot: planningSnapshot(),
+      legacySnapshot: legacy,
+      upstream: upstream(),
+      gitAdapter: gitAdapter(),
+      runPlanner: ({ base, head }) => ({
+        base,
+        head,
+        deployments: ["app"],
+        reason: "affected-packages",
+      }),
+    });
+  } catch (caught) {
+    error = caught;
+  }
+  assert.ok(error instanceof Error);
+  assert.equal(
+    error.message,
+    'Legacy app generated-alias topology mismatch: {"actualAliases":["app-v2-prior.vercel.app","appmento-unexpected-mentolabs.vercel.app","appmentoorg-git-v2-mentolabs.vercel.app","v2-app.mento.org"],"creatorUsername":"fixture-author","expectedAliasTopologies":[["app-v2-prior.vercel.app","appmentoorg-git-v2-mentolabs.vercel.app","v2-app.mento.org"]]}',
+  );
+  for (const rawValue of [
+    "dpl_legacyV2123",
+    "https://app-v2-prior.vercel.app",
+    projectIds.app,
+    "9999999999999999999999999999999999999999",
+  ]) {
+    assert.doesNotMatch(error.message, new RegExp(rawValue));
+  }
+
+  const wrongProject = legacySnapshot();
+  wrongProject[0].projectId = "prj_wrongProject123";
+  assert.throws(
+    () =>
+      createMainDeploymentPlan({
+        mode: MAIN_DEPLOYMENT_MODE,
+        deploySha: SHA,
+        projectIds,
+        planningSnapshot: planningSnapshot(),
+        legacySnapshot: wrongProject,
+        upstream: upstream(),
+        gitAdapter: gitAdapter(),
+        runPlanner: ({ base, head }) => ({
+          base,
+          head,
+          deployments: ["app"],
+          reason: "affected-packages",
+        }),
+      }),
+    /Legacy app rollback state is ambiguous/,
   );
 });
 


### PR DESCRIPTION
## The Problem

The first automatic `main` shadow run after #635 failed safely while capturing
the legacy App v2 rollback state. Our fixture assumed the generated Vercel Git
branch alias used project slug `appmento`, but the live project uses
`appmentoorg`. The live deployment also reports its immutable deployment
hostname as the third alias.

The run stopped before staging and recorded zero public-serving mutations, but
the incorrect topology prevented the #522 shadow canary from completing.

## The Solution

Bind the legacy v2 rollback proof to the exact live, documented Vercel topology:

- protected alias `v2-app.mento.org`;
- branch alias `appmentoorg-git-v2-mentolabs.vercel.app`;
- immutable hostname derived from that state's canonical `deploymentUrl`.

The planner now rejects missing, extra, creator-derived, wrong-project,
wrong-branch, wrong-scope, look-alike immutable, and suffix-spoofed aliases.
When only this topology differs, it emits a bounded copy-safe diagnostic without
deployment IDs, project IDs, deployment URLs, Git metadata, provider responses,
or secrets.

Closes no issue; this unblocks the automatic shadow evidence required by #522.

## Validation

- `pnpm vercel:workflow:test` — 256 passed
- `pnpm quality:budgets:test` — 34 passed
- `pnpm adr:check`
- pre-push Trunk, type checks, and Knip
- independent correctness/security review — all clear

## Risk

This remains fail-closed and changes only read-only shadow planning. It adds no
Vercel mutation path and does not change App v3 or legacy v2 ownership.

## Ship Checklist

- [x] ship skill used
- [x] local review run
- [x] validation run
