### PR TITLE
fix(ci): match legacy Vercel API alias topology

### DIFF
--- a/docs/vercel-deployments.md
+++ b/docs/vercel-deployments.md
@@ -246,13 +246,19 @@ IDs in this canonical runbook. The evidence contains only:
 - a zero count for public-serving activation, alias, promotion, rollback, and
   recovery commands.
 
-The legacy v2 proof requires exactly three canonical aliases: the protected
+The legacy v2 proof requires exactly four canonical API aliases: the protected
 `v2-app.mento.org` alias, the exact Vercel Git branch alias
-`appmentoorg-git-v2-mentolabs.vercel.app`, and the immutable hostname derived
-exactly from that state's canonical `deploymentUrl`. The controller does not
-authorize creator aliases, a guessed deployment hostname, another project,
-branch, scope, team, or custom-domain alias. Any topology difference fails
-before staging.
+`appmentoorg-git-v2-mentolabs.vercel.app`, the exact scope alias
+`appmentoorg-mentolabs.vercel.app`, and the exact project-default alias
+`appmentoorg.vercel.app`. Read-only Vercel API evidence from automatic run
+`30086024459` on 24 July 2026 reported that complete sorted alias set and
+creator username `chapati`.
+
+The canonical `deploymentUrl` is immutable deployment identity, not an API
+alias: its hostname is never added to or derived into the alias topology. The
+controller does not authorize creator aliases, arbitrary immutable hosts, or
+another project, branch, scope, default, suffix, team, or custom-domain alias.
+Any topology difference fails before staging.
 
 If only that generated-alias topology is rejected, the diagnostic contains only
 the canonical actual aliases, the canonical creator username (or `null`), and

--- a/docs/vercel-deployments.md
+++ b/docs/vercel-deployments.md
@@ -250,9 +250,7 @@ The legacy v2 proof requires exactly four canonical API aliases: the protected
 `v2-app.mento.org` alias, the exact Vercel Git branch alias
 `appmentoorg-git-v2-mentolabs.vercel.app`, the exact scope alias
 `appmentoorg-mentolabs.vercel.app`, and the exact project-default alias
-`appmentoorg.vercel.app`. Read-only Vercel API evidence from automatic run
-`30086024459` on 24 July 2026 reported that complete sorted alias set and
-creator username `chapati`.
+`appmentoorg.vercel.app`.
 
 The canonical `deploymentUrl` is immutable deployment identity, not an API
 alias: its hostname is never added to or derived into the alias topology. The

--- a/scripts/vercel-main-deployment.mjs
+++ b/scripts/vercel-main-deployment.mjs
@@ -109,6 +109,16 @@ const LEGACY_ALIAS = "v2-app.mento.org";
 const LEGACY_GENERATED_BRANCH_SLUG = "git-v2";
 const LEGACY_GENERATED_SCOPE_SLUG = "mentolabs";
 const LEGACY_GENERATED_BRANCH_ALIAS = `appmentoorg-${LEGACY_GENERATED_BRANCH_SLUG}-${LEGACY_GENERATED_SCOPE_SLUG}.vercel.app`;
+const LEGACY_GENERATED_SCOPE_ALIAS = `appmentoorg-${LEGACY_GENERATED_SCOPE_SLUG}.vercel.app`;
+const LEGACY_GENERATED_PROJECT_DEFAULT_ALIAS = "appmentoorg.vercel.app";
+const LEGACY_REQUIRED_ALIAS_TOPOLOGY = Object.freeze(
+  [
+    LEGACY_ALIAS,
+    LEGACY_GENERATED_BRANCH_ALIAS,
+    LEGACY_GENERATED_SCOPE_ALIAS,
+    LEGACY_GENERATED_PROJECT_DEFAULT_ALIAS,
+  ].sort(),
+);
 const MAX_JSON_BYTES = 256 * 1024;
 const APP_BUILD_PROOF_SCHEMA = "vercel-main-app-build:v1";
 const CLI_COMMAND_OPTIONS = Object.freeze({
@@ -383,29 +393,12 @@ function canonicalPrior(value, label) {
   };
 }
 
-function allowedLegacyGeneratedAliasTopologies(deploymentUrl) {
-  const immutableHostname = new URL(canonicalizeDeploymentUrl(deploymentUrl))
-    .hostname;
-  const aliases = [
-    LEGACY_ALIAS,
-    LEGACY_GENERATED_BRANCH_ALIAS,
-    immutableHostname,
-  ].sort();
-  if (new Set(aliases).size !== aliases.length) {
-    throw new Error("Legacy app rollback state is ambiguous");
-  }
-  return [aliases];
-}
-
 function legacyPriorFromSnapshot(snapshot, projectId) {
   const states = snapshot.filter((state) => state.alias === LEGACY_ALIAS);
   if (states.length !== 1) {
     throw new Error("Legacy app rollback state is ambiguous");
   }
   const state = states[0];
-  const allowedAliasTopologies = allowedLegacyGeneratedAliasTopologies(
-    state.deploymentUrl,
-  );
   const legacyIdentityIsAmbiguous =
     state.projectId !== projectId ||
     state.projectName !== "app.mento.org" ||
@@ -419,13 +412,11 @@ function legacyPriorFromSnapshot(snapshot, projectId) {
     throw new Error("Legacy app rollback state is ambiguous");
   }
   if (
-    !allowedAliasTopologies.some(
-      (expectedAliases) =>
-        JSON.stringify(state.aliases) === JSON.stringify(expectedAliases),
-    )
+    JSON.stringify(state.aliases) !==
+    JSON.stringify(LEGACY_REQUIRED_ALIAS_TOPOLOGY)
   ) {
     throw new Error(
-      `Legacy app generated-alias topology mismatch: ${JSON.stringify({ actualAliases: state.aliases, creatorUsername: state.creatorUsername, expectedAliasTopologies: allowedAliasTopologies })}`,
+      `Legacy app generated-alias topology mismatch: ${JSON.stringify({ actualAliases: state.aliases, creatorUsername: state.creatorUsername, expectedAliasTopologies: [LEGACY_REQUIRED_ALIAS_TOPOLOGY] })}`,
     );
   }
   return canonicalPrior(

--- a/scripts/vercel-main-deployment.test.mjs
+++ b/scripts/vercel-main-deployment.test.mjs
@@ -68,8 +68,8 @@ function allProtectedStates() {
   states.push({
     alias: "v2-app.mento.org",
     deploymentId: "dpl_legacyV2123",
-    deploymentUrl: "https://app-v2-prior.vercel.app",
-    creatorUsername: "fixture-author",
+    deploymentUrl: "https://appmento-jbhj7crjl-mentolabs.vercel.app",
+    creatorUsername: "chapati",
     projectId: projectIds.app,
     projectName: "app.mento.org",
     readyState: "READY",
@@ -82,8 +82,9 @@ function allProtectedStates() {
       sha: "9999999999999999999999999999999999999999",
     },
     aliases: [
-      "app-v2-prior.vercel.app",
       "appmentoorg-git-v2-mentolabs.vercel.app",
+      "appmentoorg-mentolabs.vercel.app",
+      "appmentoorg.vercel.app",
       "v2-app.mento.org",
     ],
   });
@@ -828,7 +829,7 @@ test("plan handoff binds upstream receipt, protected state, served-SHA plan, and
   assert.equal(result.legacySnapshot.length, 1);
   assert.deepEqual(result.legacyPrior, {
     deploymentId: "dpl_legacyV2123",
-    deploymentUrl: "https://app-v2-prior.vercel.app",
+    deploymentUrl: "https://appmento-jbhj7crjl-mentolabs.vercel.app",
     aliases: ["v2-app.mento.org"],
   });
   assert.deepEqual(assertMainDeploymentHandoff(result), result);
@@ -1053,8 +1054,9 @@ test("selected stages must succeed and unselected stages must be skipped", () =>
 
 test("protected rollback identity remains stable while ordinary generated aliases move", () => {
   const legacyAliases = [
-    "app-v2-prior.vercel.app",
     "appmentoorg-git-v2-mentolabs.vercel.app",
+    "appmentoorg-mentolabs.vercel.app",
+    "appmentoorg.vercel.app",
     "v2-app.mento.org",
   ];
   const deploymentPlanWithGeneratedLegacyAlias = plan({ legacyAliases });
@@ -1062,65 +1064,46 @@ test("protected rollback identity remains stable while ordinary generated aliase
     "v2-app.mento.org",
   ]);
   for (const aliases of [
-    legacyAliases.filter((alias) => alias !== "v2-app.mento.org"),
-    legacyAliases.filter(
-      (alias) => alias !== "appmentoorg-git-v2-mentolabs.vercel.app",
+    // Missing protected, branch, scope, or project-default aliases.
+    ...legacyAliases.map((missing) =>
+      legacyAliases.filter((alias) => alias !== missing),
     ),
-    legacyAliases.filter((alias) => alias !== "app-v2-prior.vercel.app"),
+    // Wrong project, branch, scope, project default, or DNS suffix.
+    legacyAliases.map((alias) =>
+      alias === "appmentoorg-git-v2-mentolabs.vercel.app"
+        ? "otherproject-git-v2-mentolabs.vercel.app"
+        : alias,
+    ),
+    legacyAliases.map((alias) =>
+      alias === "appmentoorg-git-v2-mentolabs.vercel.app"
+        ? "appmentoorg-git-main-mentolabs.vercel.app"
+        : alias,
+    ),
+    legacyAliases.map((alias) =>
+      alias === "appmentoorg-mentolabs.vercel.app"
+        ? "appmentoorg-other.vercel.app"
+        : alias,
+    ),
+    legacyAliases.map((alias) =>
+      alias === "appmentoorg.vercel.app" ? "appmento.vercel.app" : alias,
+    ),
+    legacyAliases.map((alias) =>
+      alias === "appmentoorg.vercel.app"
+        ? "appmentoorg.vercel.app.attacker.example"
+        : alias,
+    ),
+    // Creator aliases and immutable deployment hosts are not API aliases.
+    [...legacyAliases, "appmentoorg-chapati-mentolabs.vercel.app"],
     [
-      "app-v2-prior.vercel.app",
-      "appmento-git-v2-mentolabs.vercel.app",
-      "v2-app.mento.org",
-    ],
-    [
-      "app-v2-prior.vercel.app",
-      "otherproject-git-v2-mentolabs.vercel.app",
-      "v2-app.mento.org",
-    ],
-    [
-      "app-v2-prior.vercel.app",
-      "appmentoorg-git-main-mentolabs.vercel.app",
-      "v2-app.mento.org",
-    ],
-    [
-      "app-v2-prior.vercel.app",
-      "appmentoorg-git-v2-other.vercel.app",
-      "v2-app.mento.org",
-    ],
-    [
-      "app-other-immutable-mentolabs.vercel.app",
+      "appmento-jbhj7crjl-mentolabs.vercel.app",
       "appmentoorg-git-v2-mentolabs.vercel.app",
-      "v2-app.mento.org",
-    ],
-    [
-      "appmento-fixture-author-mentolabs.vercel.app",
-      "appmentoorg-git-v2-mentolabs.vercel.app",
-      "v2-app.mento.org",
-    ],
-    [...legacyAliases, "appmento-fixture-author-mentolabs.vercel.app"],
-    [
-      "app-v2-prior.vercel.app.attacker.example",
-      "appmentoorg-git-v2-mentolabs.vercel.app",
+      "appmentoorg-mentolabs.vercel.app",
       "v2-app.mento.org",
     ],
   ]) {
-    assert.throws(() => plan({ legacyAliases: aliases.sort() }));
-  }
-  for (const unexpectedAlias of [
-    "unexpected.mento.org",
-    "appmento-git-main-mentolabs.vercel.app",
-    "appmento-git-v2-other.vercel.app",
-    "other-project-git-v2-mentolabs.vercel.app",
-    "appmento-other-author-mentolabs.vercel.app",
-    "appmento-mentolabs.vercel.app",
-    "vercel.app",
-    "notvercel.app",
-    "safe.vercel.app.attacker.example",
-  ]) {
-    assert.throws(() =>
-      plan({
-        legacyAliases: [unexpectedAlias, "v2-app.mento.org"].sort(),
-      }),
+    assert.throws(
+      () => plan({ legacyAliases: aliases.toSorted() }),
+      /Legacy app generated-alias topology mismatch/,
     );
   }
   const deploymentPlan = plan();
@@ -1202,7 +1185,11 @@ test("protected rollback identity remains stable while ordinary generated aliase
     }),
   );
   const missingLegacyAlias = structuredClone(legacySnapshot());
-  missingLegacyAlias[0].aliases = ["appmento-git-v2-mentolabs.vercel.app"];
+  missingLegacyAlias[0].aliases = [
+    "appmentoorg-git-v2-mentolabs.vercel.app",
+    "appmentoorg-mentolabs.vercel.app",
+    "appmentoorg.vercel.app",
+  ];
   assert.throws(() =>
     assertProtectedSnapshotMatchesPlan({
       plan: deploymentPlan,
@@ -1215,7 +1202,12 @@ test("protected rollback identity remains stable while ordinary generated aliase
       state.deploymentId = "dpl_operatorMove123";
     },
     (state) => {
-      state.aliases = ["appmento-git-v2-other.vercel.app", "v2-app.mento.org"];
+      state.aliases = [
+        "appmentoorg-git-v2-other.vercel.app",
+        "appmentoorg-mentolabs.vercel.app",
+        "appmentoorg.vercel.app",
+        "v2-app.mento.org",
+      ];
     },
   ]) {
     const changed = structuredClone(legacyGeneratedAliases);
@@ -1335,9 +1327,10 @@ test("remote-main freshness uses one bounded exact ls-remote ref", () => {
 test("legacy generated-alias topology mismatch is a copy-safe diagnostic", () => {
   const legacy = legacySnapshot();
   legacy[0].aliases = [
-    "app-v2-prior.vercel.app",
     "appmentoorg-git-v2-mentolabs.vercel.app",
-    "appmento-unexpected-mentolabs.vercel.app",
+    "appmentoorg-mentolabs.vercel.app",
+    "appmentoorg-unexpected-mentolabs.vercel.app",
+    "appmentoorg.vercel.app",
     "v2-app.mento.org",
   ].sort();
   let error;
@@ -1363,16 +1356,36 @@ test("legacy generated-alias topology mismatch is a copy-safe diagnostic", () =>
   assert.ok(error instanceof Error);
   assert.equal(
     error.message,
-    'Legacy app generated-alias topology mismatch: {"actualAliases":["app-v2-prior.vercel.app","appmento-unexpected-mentolabs.vercel.app","appmentoorg-git-v2-mentolabs.vercel.app","v2-app.mento.org"],"creatorUsername":"fixture-author","expectedAliasTopologies":[["app-v2-prior.vercel.app","appmentoorg-git-v2-mentolabs.vercel.app","v2-app.mento.org"]]}',
+    'Legacy app generated-alias topology mismatch: {"actualAliases":["appmentoorg-git-v2-mentolabs.vercel.app","appmentoorg-mentolabs.vercel.app","appmentoorg-unexpected-mentolabs.vercel.app","appmentoorg.vercel.app","v2-app.mento.org"],"creatorUsername":"chapati","expectedAliasTopologies":[["appmentoorg-git-v2-mentolabs.vercel.app","appmentoorg-mentolabs.vercel.app","appmentoorg.vercel.app","v2-app.mento.org"]]}',
   );
   for (const rawValue of [
     "dpl_legacyV2123",
-    "https://app-v2-prior.vercel.app",
+    "https://appmento-jbhj7crjl-mentolabs.vercel.app",
     projectIds.app,
     "9999999999999999999999999999999999999999",
   ]) {
     assert.doesNotMatch(error.message, new RegExp(rawValue));
   }
+
+  const alternateCreator = legacySnapshot();
+  alternateCreator[0].creatorUsername = "other-author";
+  assert.doesNotThrow(() =>
+    createMainDeploymentPlan({
+      mode: MAIN_DEPLOYMENT_MODE,
+      deploySha: SHA,
+      projectIds,
+      planningSnapshot: planningSnapshot(),
+      legacySnapshot: alternateCreator,
+      upstream: upstream(),
+      gitAdapter: gitAdapter(),
+      runPlanner: ({ base, head }) => ({
+        base,
+        head,
+        deployments: ["app"],
+        reason: "affected-packages",
+      }),
+    }),
+  );
 
   const wrongProject = legacySnapshot();
   wrongProject[0].projectId = "prj_wrongProject123";


### PR DESCRIPTION
## The Problem

Automatic shadow run
[30086024459](https://github.com/mento-protocol/frontend-monorepo/actions/runs/30086024459)
proved that Vercel's canonical alias API differs from the deployment page:
the immutable `deploymentUrl` appears in the dashboard's domain list but is not
an alias. The API instead reports the branch alias, scope alias,
project-default alias, and protected legacy domain.

The planner failed closed before staging. Its redacted evidence records all
stage jobs skipped, successful no-op recovery, and zero public-serving mutation
commands.

## The Solution

Require the exact four-alias API topology for legacy App v2:

- `v2-app.mento.org`;
- `appmentoorg-git-v2-mentolabs.vercel.app`;
- `appmentoorg-mentolabs.vercel.app`;
- `appmentoorg.vercel.app`.

The immutable deployment URL remains rollback identity only. Creator aliases,
immutable-host substitutions, missing or extra aliases, and wrong
project/branch/scope/default/suffix variants all fail before staging. The
bounded mismatch diagnostic remains copy-safe and excludes deployment/project
IDs, deployment URLs, Git metadata, provider responses, and secrets.

Closes no issue; this unblocks the automatic shadow evidence required by #522.

## Validation

- `pnpm vercel:workflow:test` — 256 passed
- `pnpm quality:budgets:test` — 34 passed
- `pnpm adr:check`
- pre-push Trunk, type checks, and Knip
- independent correctness/security review — all clear

## Risk

This changes only fail-closed shadow planning and documentation. It adds no
mutation path and does not change App v3 or legacy v2 ownership.

## Ship Checklist

- [x] ship skill used
- [x] local review run
- [x] validation run
