### PR TITLE
fix(ci): retry transient Vercel state reads

### DIFF
--- a/scripts/vercel-deployment-state.mjs
+++ b/scripts/vercel-deployment-state.mjs
@@ -891,7 +891,7 @@ export class VercelStateClient {
 
   async resolveAlias(alias) {
     const hostname = canonicalizeHostname(alias);
-    return this.request(`/v4/aliases/${encodeURIComponent(hostname)}`);
+    return this.requestWithRetry(`/v4/aliases/${encodeURIComponent(hostname)}`);
   }
 
   async inspectDeployment(idOrUrl) {
@@ -904,17 +904,19 @@ export class VercelStateClient {
       API_ORIGIN,
     );
     url.searchParams.set("withGitRepoInfo", "true");
-    return this.request(`${url.pathname}${url.search}`);
+    return this.requestWithRetry(`${url.pathname}${url.search}`);
   }
 
   async listDeploymentAliases(deploymentId) {
     const id = requireIdentifier(deploymentId, "Vercel deployment ID");
-    return this.request(`/v2/deployments/${encodeURIComponent(id)}/aliases`);
+    return this.requestWithRetry(
+      `/v2/deployments/${encodeURIComponent(id)}/aliases`,
+    );
   }
 
   async inspectProject(projectId) {
     const id = requireIdentifier(projectId, "Vercel project ID");
-    return this.request(`/v9/projects/${encodeURIComponent(id)}`);
+    return this.requestWithRetry(`/v9/projects/${encodeURIComponent(id)}`);
   }
 
   async listAppTransactionDeploymentIds(expected, { maximumPages = 5 } = {}) {

--- a/scripts/vercel-deployment-state.test.mjs
+++ b/scripts/vercel-deployment-state.test.mjs
@@ -519,6 +519,67 @@ test("App transaction candidate discovery uses filtered bounded pagination and e
   assert.equal(attempts, 3);
 });
 
+test("canonical Vercel state reads retry transient failures and fail closed after bounded persistent failures", async () => {
+  const reads = [
+    {
+      name: "alias lookup",
+      path: "/v4/aliases/governance.mento.org",
+      invoke: (client) => client.resolveAlias("governance.mento.org"),
+    },
+    {
+      name: "deployment inspection",
+      path: "/v13/deployments/dpl_governance123",
+      invoke: (client) => client.inspectDeployment("dpl_governance123"),
+    },
+    {
+      name: "deployment alias listing",
+      path: "/v2/deployments/dpl_governance123/aliases",
+      invoke: (client) => client.listDeploymentAliases("dpl_governance123"),
+    },
+    {
+      name: "project inspection",
+      path: "/v9/projects/prj_governance123",
+      invoke: (client) => client.inspectProject("prj_governance123"),
+    },
+  ];
+
+  for (const read of reads) {
+    let transientCalls = 0;
+    const transientClient = new VercelStateClient({
+      token: "fixture-token",
+      teamId: "team_fixture123",
+      fetchImplementation: async (input, init) => {
+        transientCalls += 1;
+        const url = new URL(input);
+        assert.equal(url.pathname, read.path, read.name);
+        assert.equal(url.searchParams.get("teamId"), "team_fixture123");
+        assert.equal(init.method, "GET");
+        assert.equal(init.redirect, "error");
+        if (transientCalls < 3) throw new Error("transient transport failure");
+        return { ok: true, json: async () => ({ ok: true }) };
+      },
+    });
+    assert.deepEqual(await read.invoke(transientClient), { ok: true });
+    assert.equal(transientCalls, 3, `${read.name} must retry twice`);
+
+    let persistentCalls = 0;
+    const persistentClient = new VercelStateClient({
+      token: "fixture-token",
+      teamId: "team_fixture123",
+      fetchImplementation: async () => {
+        persistentCalls += 1;
+        throw new Error("persistent transport failure");
+      },
+    });
+    await assert.rejects(
+      () => read.invoke(persistentClient),
+      /Vercel API request failed/,
+      `${read.name} must fail closed after the bounded retry limit`,
+    );
+    assert.equal(persistentCalls, 3, `${read.name} must make at most 3 reads`);
+  }
+});
+
 test("App discovery stabilizes zero and exact pending candidates within a bounded window", async () => {
   const input = appCandidateFixture();
   const client = new VercelStateClient({


### PR DESCRIPTION
## The Problem

Automatic Vercel main shadow run
[30087766509](https://github.com/mento-protocol/frontend-monorepo/actions/runs/30087766509)
passed its exact CI and planning gates, then UI and reserve failed closed while
revalidating protected mappings. Each target had already built, uploaded, and
verified its unaliased candidate. The failures arrived after one 15-second
Vercel API timeout because the canonical state wrappers made only one read
attempt.

No public alias, activation, promotion, rollback, or recovery mutation ran.

## The Solution

Route the canonical alias, deployment, deployment-alias, and project reads
through the existing three-attempt retry helper.

The change keeps every request read-only, preserves redacted errors, retains all
canonical drift checks, and still fails closed after the bounded limit. Tests
cover success on the third attempt and persistent failure after exactly three
requests for every affected wrapper.

## Validation

- `pnpm vercel:deployment-state:test` — 39 passed
- `pnpm vercel:workflow:test` — 256 passed
- `pnpm quality:budgets:test` — 34 passed
- `trunk check scripts/vercel-deployment-state.mjs scripts/vercel-deployment-state.test.mjs`
- full pre-push type, Trunk, and Knip checks
- independent correctness and security review: no findings

## Risk

A persistent Vercel read failure can now take up to three 15-second attempts
before the workflow fails closed. Retries have no backoff and include
non-success HTTP responses; the bounded read-only behavior is acceptable for
this hotfix and does not weaken deployment-state validation.

Relates to #522.
