### PR TITLE
fix(ci): omit App v3 Sentry caller token

### DIFF
--- a/.github/workflows/vercel-main-deployment.yml
+++ b/.github/workflows/vercel-main-deployment.yml
@@ -1091,7 +1091,6 @@ jobs:
           LOGICAL_TARGET: app
           MENTO_NEXT_DEPLOYMENT_ID: ${{ steps.app-identity.outputs.next_deployment_id }}
           NEXT_PUBLIC_VERCEL_ENV: preview
-          SENTRY_AUTH_TOKEN: ""
           TURBO_REMOTE_CACHE_SIGNATURE_KEY: ${{ secrets.TURBO_REMOTE_CACHE_SIGNATURE_KEY }}
           TURBO_TEAM: ${{ vars.TURBO_TEAM }}
           TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}

--- a/docs/vercel-deployments.md
+++ b/docs/vercel-deployments.md
@@ -136,9 +136,10 @@ environment:
 Never reference the generic `Production` environment. Map the production token
 only as a step-scoped `VERCEL_TOKEN`; never put it in a command argument. Expose
 each mirrored build secret only to the literal target build step that consumes
-it. App `v3` explicitly receives an empty `SENTRY_AUTH_TOKEN`. Missing
-configuration fails by variable name. Automation must never inspect 1Password
-or another credential store.
+it. The App `v3` composite caller omits `SENTRY_AUTH_TOKEN`; only its isolated
+child build materializes an explicit empty override. Missing configuration fails
+by variable name. Automation must never inspect 1Password or another credential
+store.
 
 The three ordinary stage jobs use production build semantics and
 `vercel deploy --prebuilt --prod --skip-domain`. They reuse the protected #521

--- a/scripts/vercel-main-deployment-workflow.test.mjs
+++ b/scripts/vercel-main-deployment-workflow.test.mjs
@@ -9,6 +9,13 @@ const workflowSource = readFileSync(
   "utf8",
 );
 const workflow = parse(workflowSource);
+const candidateActionSource = readFileSync(
+  new URL(
+    "../.github/actions/vercel-candidate-build/action.yml",
+    import.meta.url,
+  ),
+  "utf8",
+);
 
 const CHECKOUT = "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0";
 const UPLOAD =
@@ -337,7 +344,11 @@ test("coordinator revalidates, builds App only, durably journals, and stays muta
   );
   assert.equal(appBuild.env.VERCEL_ENV, "preview");
   assert.equal(appBuild.env.VERCEL_TARGET_ENV, "v3");
-  assert.equal(appBuild.env.SENTRY_AUTH_TOKEN, "");
+  assert.equal(Object.hasOwn(appBuild.env, "SENTRY_AUTH_TOKEN"), false);
+  assert.match(
+    candidateActionSource,
+    /SENTRY_AUTH_TOKEN="\$\{SENTRY_AUTH_TOKEN:-\}"/,
+  );
   const restore = stepNamed(
     name,
     "Restore fresh trusted transaction controller",


### PR DESCRIPTION
## The Problem

The automatic main-shadow run reached the App custom-`v3` build after all three legacy-v2 candidates passed, then failed closed because the composite caller declared `SENTRY_AUTH_TOKEN: ""`. App `v3` forbids every caller-provided Sentry credential source, including an empty declaration, so the credential preflight rejected the build before journal creation or any public-serving mutation.

## The Solution

Remove `SENTRY_AUTH_TOKEN` from the App custom-`v3` composite caller. The isolated candidate child still materializes an explicit empty value inside its clean `env -i` build process, which preserves the existing no-source-map-upload behavior without exposing Sentry authority to the caller or candidate preflight.

Strengthen the workflow test to prove both sides of that boundary and clarify the runbook wording.

Validation:

- `pnpm vercel:workflow:test` — 256 passed
- `pnpm vercel:primitives:test` — 61 passed
- `pnpm quality:budgets:test` — 34 passed
- `pnpm format`
- `pnpm adr:check`
- `git diff --check`

Related: #522
