### PR TITLE
docs(ui): add first main supersession probe

### DIFF
--- a/apps/ui.mento.org/app/layout.tsx
+++ b/apps/ui.mento.org/app/layout.tsx
@@ -6,7 +6,7 @@ import localFont from "next/font/local";
 
 import { AppShell } from "./components/app-shell";
 
-// Vendored locally (was next/font/google) so the production build is hermetic:
+// Vendored locally instead of next/font/google so the production build is hermetic:
 // no build-time Google Fonts fetch that could silently fall back to a different
 // metric and shift every glyph — the #1 source of visual-regression flake.
 const inter = localFont({


### PR DESCRIPTION
## The Problem

Issue #522 needs live proof that a newer UI-only `main` push supersedes an
earlier automatic Vercel Main Deployment run before that run writes a journal.
The proof must use harmless source changes and must not alter public-serving
behavior.

## The Solution

This PR targets `main` and changes one existing comment under
`apps/ui.mento.org`. The canonical planner selects only `ui`; rendered output
and runtime behavior are unchanged.

Merge P1 to `main`. While automatic Vercel Main Deployment R1 is still
performing its UI stage/upload/smoke work, and before `activate-and-verify`
runs its first `Check freshness before any App work` step, merge P2 to `main`.
R1 must end as `superseded-before-journal`: it creates no transaction journal,
performs no App transaction work, and recovery is `not-required`. The earlier
unaliased UI staging upload is expected; it must not change a public-serving
alias or invoke activation, promotion, rollback, or recovery. R2 must complete
the shadow run as `shadow-prepared`, with recovery
`verified-no-mutation`.

## Validation

- base: `6e35d67f36e194afade21a0efba02691ed5a0d22`
- head: `0c3d905a5ed556648cad3f47f7e15a8d354beda1`
- `pnpm vercel:plan --base 6e35d67f36e194afade21a0efba02691ed5a0d22 --head 0c3d905a5ed556648cad3f47f7e15a8d354beda1` — `deployments: ["ui"]`
- `pnpm vercel:primitives:test`
- `git diff --check 6e35d67f36e194afade21a0efba02691ed5a0d22..0c3d905a5ed556648cad3f47f7e15a8d354beda1`
- the diff changes only one UI source comment

## Risk

The source change has no runtime effect. The observation is invalid if R1
completes its first coordinator freshness check while `main` still points to
P1, or if it creates a journal before P2 merges; repeat with a fresh pair. The
R1 unaliased UI candidate upload is allowed and is distinct from
public-serving or transaction mutation.

Relates to #522 and #515.
