### PR TITLE
docs(ui): add second main supersession probe

### DIFF
--- a/apps/ui.mento.org/app/components/app-sidebar.tsx
+++ b/apps/ui.mento.org/app/components/app-sidebar.tsx
@@ -35,7 +35,7 @@ import {
   SidebarMenuSubItem,
 } from "@mento-protocol/ui";
 
-// Component categories with their pages and individual components
+// Component categories, their page routes, and their individual components.
 const componentCategories = [
   {
     title: "Basic Components",

--- a/apps/ui.mento.org/app/layout.tsx
+++ b/apps/ui.mento.org/app/layout.tsx
@@ -6,7 +6,7 @@ import localFont from "next/font/local";
 
 import { AppShell } from "./components/app-shell";
 
-// Vendored locally (was next/font/google) so the production build is hermetic:
+// Vendored locally instead of next/font/google so the production build is hermetic:
 // no build-time Google Fonts fetch that could silently fall back to a different
 // metric and shift every glyph — the #1 source of visual-regression flake.
 const inter = localFont({


### PR DESCRIPTION
## The Problem

Issue #522 needs a newer UI-only `main` push while automatic Vercel Main
Deployment R1 is at the UI stage/upload/smoke boundary. The second source
change must be harmless and independently planner-selected.

## The Solution

This PR also targets `main`. Its local ancestry includes refreshed P1, and its
incremental change clarifies one existing sidebar comment under
`apps/ui.mento.org`. After P1 merges, the effective P2 diff against `main` is
that one comment. The canonical planner again selects only `ui`; rendered
output, routes, and runtime behavior are unchanged.

Merge P1 to `main`. While automatic Vercel Main Deployment R1 is still
performing its UI stage/upload/smoke work, and before `activate-and-verify`
runs its first `Check freshness before any App work` step, merge P2 to `main`.
R1 must end as `superseded-before-journal`: it creates no transaction journal,
performs no App transaction work, and recovery is `not-required`. The earlier
unaliased UI staging upload is expected; it must not change a public-serving
alias or invoke activation, promotion, rollback, or recovery. R2 must complete
the shadow run as `shadow-prepared`, with recovery
`verified-no-mutation`.

## Validation

- P1 parent: `0c3d905a5ed556648cad3f47f7e15a8d354beda1`
- P2 head: `467e09f4f317225b6375545d2cbc53a58cd6aa3e`
- `pnpm vercel:plan --base 0c3d905a5ed556648cad3f47f7e15a8d354beda1 --head 467e09f4f317225b6375545d2cbc53a58cd6aa3e` — `deployments: ["ui"]`
- `pnpm vercel:primitives:test`
- `git diff --check 0c3d905a5ed556648cad3f47f7e15a8d354beda1..467e09f4f317225b6375545d2cbc53a58cd6aa3e`
- the incremental diff changes only one UI source comment

## Risk

The source change has no runtime effect. The observation is invalid if R1
completes its first coordinator freshness check while `main` still points to
P1, or if it creates a journal before P2 merges; repeat with a fresh pair. The
R1 unaliased UI candidate upload is allowed and is distinct from
public-serving or transaction mutation.

Relates to #522 and #515.
