### PR TITLE
fix(vercel): allow reviewed runtime digest rotation

### DIFF
--- a/docs/dependency-overrides.md
+++ b/docs/dependency-overrides.md
@@ -60,14 +60,17 @@ runtime in the same PR:
    shasum -a 256 scripts/vercel-cli-runtime/pnpm-lock.yaml
    ```
 
-   Rotate the digest in two PRs. First, land a trusted default-branch
-   controller change that adds the reviewed next digest to the literal
-   allowlist in `scripts/vercel-cli-runtime-contract.mjs`; it must continue to
-   accept the current digest and must never read an allowlist from candidate or
-   PR-authored source. Then land the lockfile change in #645, keeping the
-   manifest's exact `vercel@56.2.0` pin and all registry-only checks intact.
-   Immediately after #645 merges, remove the former digest from the controller
-   allowlist and restore the single-digest contract.
+   Rotate the manifest and lockfile state in two PRs. First, land a trusted
+   default-branch controller change that maps each reviewed current/next
+   lockfile digest to the SHA-256 of its matching canonical, sorted root
+   override object. The standalone manifest must remain an exact mirror of
+   that root state, and cross-paired old-lock/new-manifest or
+   new-lock/old-manifest hybrids must reject. Candidate or PR-authored source
+   must never supply or extend this mapping. Then land the matching manifest
+   and lockfile state in #645, keeping the manifest's exact `vercel@56.2.0`
+   pin and all registry-only checks intact. Immediately after #645 merges,
+   remove the former digest/override pair from the controller mapping and
+   restore the single-pair contract.
 
 4. Verify the root/standalone pins, exact manifest, override mirror, reviewed
    lockfile digest, and registry-only lockfile policy:

--- a/docs/dependency-overrides.md
+++ b/docs/dependency-overrides.md
@@ -54,13 +54,20 @@ runtime in the same PR:
      --ignore-workspace
    ```
 
-3. Review the lockfile diff, calculate its exact digest, and replace
-   `PINNED_VERCEL_CLI_RUNTIME_LOCKFILE_SHA256` in
-   `scripts/vercel-cli-runtime-contract.mjs`:
+3. Review the lockfile diff and calculate its exact digest:
 
    ```bash
    shasum -a 256 scripts/vercel-cli-runtime/pnpm-lock.yaml
    ```
+
+   Rotate the digest in two PRs. First, land a trusted default-branch
+   controller change that adds the reviewed next digest to the literal
+   allowlist in `scripts/vercel-cli-runtime-contract.mjs`; it must continue to
+   accept the current digest and must never read an allowlist from candidate or
+   PR-authored source. Then land the lockfile change in #645, keeping the
+   manifest's exact `vercel@56.2.0` pin and all registry-only checks intact.
+   Immediately after #645 merges, remove the former digest from the controller
+   allowlist and restore the single-digest contract.
 
 4. Verify the root/standalone pins, exact manifest, override mirror, reviewed
    lockfile digest, and registry-only lockfile policy:

--- a/docs/vercel-deployments.md
+++ b/docs/vercel-deployments.md
@@ -810,6 +810,14 @@ only the two reviewed package-name false positives for Vercel's unrelated
 `sandbox` CLI dependency, so root application suppressions cannot mask a
 standalone CLI vulnerability.
 
+For the two-PR lockfile rotation before #645, the trusted default-branch
+controller has a literal temporary allowlist for the current and reviewed next
+SHA-256 values. Candidate source cannot supply or extend that allowlist. The
+ordinary current-main lockfile therefore continues to verify until #645 changes
+it; then remove the old digest immediately so the controller returns to a
+single-digest binding. The manifest's exact `vercel@56.2.0` pin and every other
+lockfile check remain in force throughout the rotation.
+
 The raw Vercel-pulled `.env.<target>.local` remains private and runner-owned.
 Before staging settings into candidate storage, the trusted controller parses
 that file, selects only the target/environment variables classified

--- a/docs/vercel-deployments.md
+++ b/docs/vercel-deployments.md
@@ -810,13 +810,17 @@ only the two reviewed package-name false positives for Vercel's unrelated
 `sandbox` CLI dependency, so root application suppressions cannot mask a
 standalone CLI vulnerability.
 
-For the two-PR lockfile rotation before #645, the trusted default-branch
-controller has a literal temporary allowlist for the current and reviewed next
-SHA-256 values. Candidate source cannot supply or extend that allowlist. The
-ordinary current-main lockfile therefore continues to verify until #645 changes
-it; then remove the old digest immediately so the controller returns to a
-single-digest binding. The manifest's exact `vercel@56.2.0` pin and every other
-lockfile check remain in force throughout the rotation.
+For the two-PR manifest and lockfile rotation before #645, the trusted
+default-branch controller has a literal temporary mapping from each current or
+reviewed-next lockfile SHA-256 to the SHA-256 of its matching canonical, sorted
+root override object. The standalone manifest must exactly mirror that root
+override state, so old-lock/new-manifest and new-lock/old-manifest hybrids
+reject. Candidate source cannot supply or extend this mapping. The ordinary
+current-main manifest and lockfile pair therefore continues to verify until
+#645 changes both; then remove the old digest/override pair immediately so the
+controller returns to a single-pair binding. The manifest's exact
+`vercel@56.2.0` pin and every other lockfile check remain in force throughout
+the rotation.
 
 The raw Vercel-pulled `.env.<target>.local` remains private and runner-owned.
 Before staging settings into candidate storage, the trusted controller parses

--- a/scripts/vercel-cli-runtime-contract.mjs
+++ b/scripts/vercel-cli-runtime-contract.mjs
@@ -3,11 +3,18 @@ import { readFileSync } from "node:fs";
 import { isDeepStrictEqual } from "node:util";
 
 export const PINNED_VERCEL_CLI_VERSION = "56.2.0";
-// This reviewed controller-owned allowlist permits the one-way lockfile
-// rotation in #645. It must never be read from candidate source or PR input.
-const TRUSTED_VERCEL_CLI_RUNTIME_LOCKFILE_SHA256 = new Set([
-  "505674eac656c26fce2fe912a2b14228f8f4f3edd4b3d6d7b0f2c9f08c276d76",
-  "884e3c4186c9d5faee0e6cf710b112e7e60cdae5d46be13da1b2b0ae9cf11eb0",
+// This reviewed controller-owned map permits the one-way #645 lockfile
+// rotation only with its matching canonical override state. It must never be
+// read from candidate source or PR input.
+const TRUSTED_VERCEL_CLI_RUNTIME_OVERRIDE_SHA256_BY_LOCKFILE_SHA256 = new Map([
+  [
+    "505674eac656c26fce2fe912a2b14228f8f4f3edd4b3d6d7b0f2c9f08c276d76",
+    "1470e9d2fb8aefb32cd1cfa0f8e6b626663b8ac0de27b52f2e646240c1ece08e",
+  ],
+  [
+    "884e3c4186c9d5faee0e6cf710b112e7e60cdae5d46be13da1b2b0ae9cf11eb0",
+    "0941482390a44f7e16c1f7182469e01162434f9e274059d53d6ebbef2ebed695",
+  ],
 ]);
 
 function hasExactObjectKeys(value, expectedKeys) {
@@ -23,6 +30,29 @@ function hasExactObjectKeys(value, expectedKeys) {
   );
 }
 
+function canonicalOverrideSha256(overrides) {
+  if (
+    overrides === null ||
+    typeof overrides !== "object" ||
+    Array.isArray(overrides) ||
+    Object.entries(overrides).some(
+      ([name, value]) =>
+        typeof name !== "string" ||
+        name.length === 0 ||
+        typeof value !== "string" ||
+        value.length === 0,
+    )
+  ) {
+    throw new Error("Trusted root Vercel CLI overrides are invalid");
+  }
+  const canonical = Object.fromEntries(
+    Object.entries(overrides).toSorted(([left], [right]) =>
+      left.localeCompare(right),
+    ),
+  );
+  return createHash("sha256").update(JSON.stringify(canonical)).digest("hex");
+}
+
 export function assertVercelCliRuntimeContract({
   rootPackageJsonPath,
   packageJsonPath,
@@ -34,11 +64,14 @@ export function assertVercelCliRuntimeContract({
   const packageMetadata = JSON.parse(readFileSync(packageJsonPath, "utf8"));
   const rootOverrides = rootPackageMetadata.pnpm?.overrides;
   if (
-    rootPackageMetadata.devDependencies?.vercel !== PINNED_VERCEL_CLI_VERSION ||
-    rootOverrides === null ||
-    typeof rootOverrides !== "object" ||
-    Array.isArray(rootOverrides)
+    rootPackageMetadata.devDependencies?.vercel !== PINNED_VERCEL_CLI_VERSION
   ) {
+    throw new Error("Trusted root Vercel CLI contract is invalid");
+  }
+  let rootOverridesSha256;
+  try {
+    rootOverridesSha256 = canonicalOverrideSha256(rootOverrides);
+  } catch {
     throw new Error("Trusted root Vercel CLI contract is invalid");
   }
   if (
@@ -67,8 +100,17 @@ export function assertVercelCliRuntimeContract({
   const lockfileDigest = createHash("sha256")
     .update(lockfileContents)
     .digest("hex");
-  if (!TRUSTED_VERCEL_CLI_RUNTIME_LOCKFILE_SHA256.has(lockfileDigest)) {
+  const expectedOverridesSha256 =
+    TRUSTED_VERCEL_CLI_RUNTIME_OVERRIDE_SHA256_BY_LOCKFILE_SHA256.get(
+      lockfileDigest,
+    );
+  if (expectedOverridesSha256 === undefined) {
     throw new Error("Trusted Vercel CLI runtime lockfile is not exact");
+  }
+  if (rootOverridesSha256 !== expectedOverridesSha256) {
+    throw new Error(
+      "Trusted Vercel CLI runtime lockfile and overrides are not an approved pair",
+    );
   }
   const lockfileText = lockfileContents.toString("utf8");
   if (

--- a/scripts/vercel-cli-runtime-contract.mjs
+++ b/scripts/vercel-cli-runtime-contract.mjs
@@ -3,8 +3,12 @@ import { readFileSync } from "node:fs";
 import { isDeepStrictEqual } from "node:util";
 
 export const PINNED_VERCEL_CLI_VERSION = "56.2.0";
-const PINNED_VERCEL_CLI_RUNTIME_LOCKFILE_SHA256 =
-  "505674eac656c26fce2fe912a2b14228f8f4f3edd4b3d6d7b0f2c9f08c276d76";
+// This reviewed controller-owned allowlist permits the one-way lockfile
+// rotation in #645. It must never be read from candidate source or PR input.
+const TRUSTED_VERCEL_CLI_RUNTIME_LOCKFILE_SHA256 = new Set([
+  "505674eac656c26fce2fe912a2b14228f8f4f3edd4b3d6d7b0f2c9f08c276d76",
+  "884e3c4186c9d5faee0e6cf710b112e7e60cdae5d46be13da1b2b0ae9cf11eb0",
+]);
 
 function hasExactObjectKeys(value, expectedKeys) {
   if (value === null || typeof value !== "object" || Array.isArray(value)) {
@@ -63,7 +67,7 @@ export function assertVercelCliRuntimeContract({
   const lockfileDigest = createHash("sha256")
     .update(lockfileContents)
     .digest("hex");
-  if (lockfileDigest !== PINNED_VERCEL_CLI_RUNTIME_LOCKFILE_SHA256) {
+  if (!TRUSTED_VERCEL_CLI_RUNTIME_LOCKFILE_SHA256.has(lockfileDigest)) {
     throw new Error("Trusted Vercel CLI runtime lockfile is not exact");
   }
   const lockfileText = lockfileContents.toString("utf8");

--- a/scripts/vercel-prebuilt.test.mjs
+++ b/scripts/vercel-prebuilt.test.mjs
@@ -112,6 +112,53 @@ function toCurrentVercelCliRuntimeLockfile(lockfile) {
     );
 }
 
+function toNextVercelCliRuntimeOverrides(overrides) {
+  const next = {
+    ...overrides,
+    "@mysten/sui": "1.45.2",
+    "postcss@<8.5.18": "8.5.18",
+    "tar@>=7.0.0 <7.5.21": "7.5.21",
+    "valibot@>=1.0.0 <1.4.2": "1.4.2",
+  };
+  delete next["postcss@<8.5.10"];
+  delete next["tar@>=7.0.0 <7.5.16"];
+  return next;
+}
+
+function toCurrentVercelCliRuntimeOverrides(overrides) {
+  const current = {
+    ...overrides,
+    "postcss@<8.5.10": ">=8.5.10",
+    "tar@>=7.0.0 <7.5.16": "7.5.20",
+  };
+  delete current["@mysten/sui"];
+  delete current["postcss@<8.5.18"];
+  delete current["tar@>=7.0.0 <7.5.21"];
+  delete current["valibot@>=1.0.0 <1.4.2"];
+  return current;
+}
+
+function writeVercelCliRuntimeOverrides({
+  rootPackageJsonPath,
+  packageJsonPath,
+  overrides,
+}) {
+  const rootPackageMetadata = JSON.parse(
+    readFileSync(rootPackageJsonPath, "utf8"),
+  );
+  const packageMetadata = JSON.parse(readFileSync(packageJsonPath, "utf8"));
+  rootPackageMetadata.pnpm.overrides = overrides;
+  packageMetadata.pnpm.overrides = overrides;
+  writeFileSync(
+    rootPackageJsonPath,
+    `${JSON.stringify(rootPackageMetadata, null, 2)}\n`,
+  );
+  writeFileSync(
+    packageJsonPath,
+    `${JSON.stringify(packageMetadata, null, 2)}\n`,
+  );
+}
+
 test("generated IDs satisfy every Vercel constraint for every target", () => {
   for (const target of VERCEL_TARGETS) {
     const value = deploymentId({ target });
@@ -258,6 +305,9 @@ test("trusted controller accepts only the reviewed Vercel CLI runtime lockfile r
   };
   try {
     const repositoryLockfile = readFileSync(lockfilePath, "utf8");
+    const repositoryRootOverrides = JSON.parse(
+      readFileSync(contractPaths.rootPackageJsonPath, "utf8"),
+    ).pnpm.overrides;
     const repositoryDigest =
       assertVercelCliRuntimeContract(contractPaths).lockfileSha256;
     assert.ok(
@@ -281,18 +331,49 @@ test("trusted controller accepts only the reviewed Vercel CLI runtime lockfile r
       reviewedNextLockfile,
     );
 
+    const reviewedCurrentOverrides = toCurrentVercelCliRuntimeOverrides(
+      repositoryRootOverrides,
+    );
+    const reviewedNextOverrides = toNextVercelCliRuntimeOverrides(
+      repositoryRootOverrides,
+    );
+
+    writeVercelCliRuntimeOverrides({
+      ...contractPaths,
+      overrides: reviewedCurrentOverrides,
+    });
     writeFileSync(lockfilePath, reviewedCurrentLockfile);
     assert.equal(
       assertVercelCliRuntimeContract(contractPaths).lockfileSha256,
       CURRENT_VERCEL_CLI_RUNTIME_LOCKFILE_SHA256,
     );
 
+    writeVercelCliRuntimeOverrides({
+      ...contractPaths,
+      overrides: reviewedNextOverrides,
+    });
     writeFileSync(lockfilePath, reviewedNextLockfile);
     assert.equal(
       assertVercelCliRuntimeContract(contractPaths).lockfileSha256,
       NEXT_VERCEL_CLI_RUNTIME_LOCKFILE_SHA256,
     );
 
+    for (const [overrides, lockfile] of [
+      [reviewedCurrentOverrides, reviewedNextLockfile],
+      [reviewedNextOverrides, reviewedCurrentLockfile],
+    ]) {
+      writeVercelCliRuntimeOverrides({ ...contractPaths, overrides });
+      writeFileSync(lockfilePath, lockfile);
+      assert.throws(
+        () => assertVercelCliRuntimeContract(contractPaths),
+        /lockfile and overrides are not an approved pair/,
+      );
+    }
+
+    writeVercelCliRuntimeOverrides({
+      ...contractPaths,
+      overrides: reviewedNextOverrides,
+    });
     writeFileSync(
       lockfilePath,
       `${reviewedNextLockfile}\n# unreviewed digest\n`,

--- a/scripts/vercel-prebuilt.test.mjs
+++ b/scripts/vercel-prebuilt.test.mjs
@@ -39,6 +39,14 @@ const scriptPath = fileURLToPath(
   new URL("./vercel-prebuilt.mjs", import.meta.url),
 );
 const COMMIT_SHA = "0123456789abcdef0123456789abcdef01234567";
+const CURRENT_VERCEL_CLI_RUNTIME_LOCKFILE_SHA256 =
+  "505674eac656c26fce2fe912a2b14228f8f4f3edd4b3d6d7b0f2c9f08c276d76";
+const NEXT_VERCEL_CLI_RUNTIME_LOCKFILE_SHA256 =
+  "884e3c4186c9d5faee0e6cf710b112e7e60cdae5d46be13da1b2b0ae9cf11eb0";
+const REVIEWED_VERCEL_CLI_RUNTIME_LOCKFILE_SHA256 = new Set([
+  CURRENT_VERCEL_CLI_RUNTIME_LOCKFILE_SHA256,
+  NEXT_VERCEL_CLI_RUNTIME_LOCKFILE_SHA256,
+]);
 
 function deploymentId(overrides = {}) {
   return generateVercelDeploymentId({
@@ -62,6 +70,46 @@ function createVersionContractFixture() {
     );
   }
   return fixtureRoot;
+}
+
+function toNextVercelCliRuntimeLockfile(lockfile) {
+  return lockfile
+    .replace(
+      "  '@opentelemetry/core@<2.8.0': '>=2.8.0'",
+      "  '@mysten/sui': 1.45.2\n  '@opentelemetry/core@<2.8.0': '>=2.8.0'",
+    )
+    .replace("  postcss@<8.5.10: '>=8.5.10'", "  postcss@<8.5.18: 8.5.18")
+    .replace("  tar@>=7.0.0 <7.5.16: 7.5.20", "  tar@>=7.0.0 <7.5.21: 7.5.21")
+    .replace(
+      "  vite@>=7.0.0 <7.3.5: 7.3.5",
+      "  valibot@>=1.0.0 <1.4.2: 1.4.2\n  vite@>=7.0.0 <7.3.5: 7.3.5",
+    )
+    .replace(
+      "  tar@7.5.20:\n    resolution: {integrity: sha512-9FcyK4PA6+WbzlTM9WhQm6vB5W7cP7dUiPsv1g7YDwEQnQ1CGpK3MGlKk/ITVWMk05kHZuBhmVhiv8LZoy/PFQ==}",
+      "  tar@7.5.21:\n    resolution: {integrity: sha512-XdhtCvlMywwxpCW8YEq3lOXBJpUPTR2OHHcwLPO3HwsJqOHa2Ok/oJ7ruGzp+JrKoRPVCzJwAdEjqLW/vNRPHA==}",
+    )
+    .replaceAll("      tar: 7.5.20", "      tar: 7.5.21")
+    .replace(
+      "  tar@7.5.20:\n    dependencies:",
+      "  tar@7.5.21:\n    dependencies:",
+    );
+}
+
+function toCurrentVercelCliRuntimeLockfile(lockfile) {
+  return lockfile
+    .replace("  '@mysten/sui': 1.45.2\n", "")
+    .replace("  postcss@<8.5.18: 8.5.18", "  postcss@<8.5.10: '>=8.5.10'")
+    .replace("  tar@>=7.0.0 <7.5.21: 7.5.21", "  tar@>=7.0.0 <7.5.16: 7.5.20")
+    .replace("  valibot@>=1.0.0 <1.4.2: 1.4.2\n", "")
+    .replace(
+      "  tar@7.5.21:\n    resolution: {integrity: sha512-XdhtCvlMywwxpCW8YEq3lOXBJpUPTR2OHHcwLPO3HwsJqOHa2Ok/oJ7ruGzp+JrKoRPVCzJwAdEjqLW/vNRPHA==}",
+      "  tar@7.5.20:\n    resolution: {integrity: sha512-9FcyK4PA6+WbzlTM9WhQm6vB5W7cP7dUiPsv1g7YDwEQnQ1CGpK3MGlKk/ITVWMk05kHZuBhmVhiv8LZoy/PFQ==}",
+    )
+    .replaceAll("      tar: 7.5.21", "      tar: 7.5.20")
+    .replace(
+      "  tar@7.5.21:\n    dependencies:",
+      "  tar@7.5.20:\n    dependencies:",
+    );
 }
 
 test("generated IDs satisfy every Vercel constraint for every target", () => {
@@ -160,10 +208,6 @@ test("prebuilt assertion rejects missing, malformed, or mismatched output", () =
 });
 
 test("resolved Next.js and exact Vercel CLI satisfy custom-ID prerequisites", () => {
-  const reviewedRuntimeDigests = new Set([
-    "505674eac656c26fce2fe912a2b14228f8f4f3edd4b3d6d7b0f2c9f08c276d76",
-    "884e3c4186c9d5faee0e6cf710b112e7e60cdae5d46be13da1b2b0ae9cf11eb0",
-  ]);
   const prerequisites = assertDeploymentIdPrerequisites(repoRoot);
   const expected = {
     next: "16.2.11",
@@ -174,7 +218,9 @@ test("resolved Next.js and exact Vercel CLI satisfy custom-ID prerequisites", ()
     },
   };
   assert.ok(
-    reviewedRuntimeDigests.has(prerequisites.vercelCliRuntime.lockfileSha256),
+    REVIEWED_VERCEL_CLI_RUNTIME_LOCKFILE_SHA256.has(
+      prerequisites.vercelCliRuntime.lockfileSha256,
+    ),
   );
   assert.deepEqual(prerequisites, expected);
   assert.deepEqual(
@@ -211,36 +257,40 @@ test("trusted controller accepts only the reviewed Vercel CLI runtime lockfile r
     lockfilePath,
   };
   try {
+    const repositoryLockfile = readFileSync(lockfilePath, "utf8");
+    const repositoryDigest =
+      assertVercelCliRuntimeContract(contractPaths).lockfileSha256;
+    assert.ok(
+      REVIEWED_VERCEL_CLI_RUNTIME_LOCKFILE_SHA256.has(repositoryDigest),
+    );
+    const reviewedCurrentLockfile =
+      repositoryDigest === CURRENT_VERCEL_CLI_RUNTIME_LOCKFILE_SHA256
+        ? repositoryLockfile
+        : toCurrentVercelCliRuntimeLockfile(repositoryLockfile);
+    const reviewedNextLockfile =
+      repositoryDigest === NEXT_VERCEL_CLI_RUNTIME_LOCKFILE_SHA256
+        ? repositoryLockfile
+        : toNextVercelCliRuntimeLockfile(repositoryLockfile);
+
     assert.equal(
-      assertVercelCliRuntimeContract(contractPaths).lockfileSha256,
-      "505674eac656c26fce2fe912a2b14228f8f4f3edd4b3d6d7b0f2c9f08c276d76",
+      toCurrentVercelCliRuntimeLockfile(reviewedNextLockfile),
+      reviewedCurrentLockfile,
+    );
+    assert.equal(
+      toNextVercelCliRuntimeLockfile(reviewedCurrentLockfile),
+      reviewedNextLockfile,
     );
 
-    const reviewedNextLockfile = readFileSync(lockfilePath, "utf8")
-      .replace(
-        "  '@opentelemetry/core@<2.8.0': '>=2.8.0'",
-        "  '@mysten/sui': 1.45.2\n  '@opentelemetry/core@<2.8.0': '>=2.8.0'",
-      )
-      .replace("  postcss@<8.5.10: '>=8.5.10'", "  postcss@<8.5.18: 8.5.18")
-      .replace("  tar@>=7.0.0 <7.5.16: 7.5.20", "  tar@>=7.0.0 <7.5.21: 7.5.21")
-      .replace(
-        "  vite@>=7.0.0 <7.3.5: 7.3.5",
-        "  valibot@>=1.0.0 <1.4.2: 1.4.2\n  vite@>=7.0.0 <7.3.5: 7.3.5",
-      )
-      .replace(
-        "  tar@7.5.20:\n    resolution: {integrity: sha512-9FcyK4PA6+WbzlTM9WhQm6vB5W7cP7dUiPsv1g7YDwEQnQ1CGpK3MGlKk/ITVWMk05kHZuBhmVhiv8LZoy/PFQ==}",
-        "  tar@7.5.21:\n    resolution: {integrity: sha512-XdhtCvlMywwxpCW8YEq3lOXBJpUPTR2OHHcwLPO3HwsJqOHa2Ok/oJ7ruGzp+JrKoRPVCzJwAdEjqLW/vNRPHA==}",
-      )
-      .replace("      tar: 7.5.20", "      tar: 7.5.21")
-      .replace("      tar: 7.5.20", "      tar: 7.5.21")
-      .replace(
-        "  tar@7.5.20:\n    dependencies:",
-        "  tar@7.5.21:\n    dependencies:",
-      );
+    writeFileSync(lockfilePath, reviewedCurrentLockfile);
+    assert.equal(
+      assertVercelCliRuntimeContract(contractPaths).lockfileSha256,
+      CURRENT_VERCEL_CLI_RUNTIME_LOCKFILE_SHA256,
+    );
+
     writeFileSync(lockfilePath, reviewedNextLockfile);
     assert.equal(
       assertVercelCliRuntimeContract(contractPaths).lockfileSha256,
-      "884e3c4186c9d5faee0e6cf710b112e7e60cdae5d46be13da1b2b0ae9cf11eb0",
+      NEXT_VERCEL_CLI_RUNTIME_LOCKFILE_SHA256,
     );
 
     writeFileSync(

--- a/scripts/vercel-prebuilt.test.mjs
+++ b/scripts/vercel-prebuilt.test.mjs
@@ -160,16 +160,23 @@ test("prebuilt assertion rejects missing, malformed, or mismatched output", () =
 });
 
 test("resolved Next.js and exact Vercel CLI satisfy custom-ID prerequisites", () => {
+  const reviewedRuntimeDigests = new Set([
+    "505674eac656c26fce2fe912a2b14228f8f4f3edd4b3d6d7b0f2c9f08c276d76",
+    "884e3c4186c9d5faee0e6cf710b112e7e60cdae5d46be13da1b2b0ae9cf11eb0",
+  ]);
+  const prerequisites = assertDeploymentIdPrerequisites(repoRoot);
   const expected = {
     next: "16.2.11",
     vercel: "56.2.0",
     vercelCliRuntime: {
-      lockfileSha256:
-        "505674eac656c26fce2fe912a2b14228f8f4f3edd4b3d6d7b0f2c9f08c276d76",
+      lockfileSha256: prerequisites.vercelCliRuntime.lockfileSha256,
       vercel: "56.2.0",
     },
   };
-  assert.deepEqual(assertDeploymentIdPrerequisites(repoRoot), expected);
+  assert.ok(
+    reviewedRuntimeDigests.has(prerequisites.vercelCliRuntime.lockfileSha256),
+  );
+  assert.deepEqual(prerequisites, expected);
   assert.deepEqual(
     JSON.parse(
       execFileSync(

--- a/scripts/vercel-prebuilt.test.mjs
+++ b/scripts/vercel-prebuilt.test.mjs
@@ -23,6 +23,7 @@ import {
   isVersionGreaterThan,
   VERCEL_TARGETS,
 } from "./vercel-prebuilt.mjs";
+import { assertVercelCliRuntimeContract } from "./vercel-cli-runtime-contract.mjs";
 import {
   assertSharpOutputTrace,
   isSharpManifestPath,
@@ -181,6 +182,71 @@ test("resolved Next.js and exact Vercel CLI satisfy custom-ID prerequisites", ()
   );
   assert.equal(isVersionGreaterThan("16.2.10", "16.2.0-canary.15"), true);
   assert.equal(isVersionGreaterThan("56.2.0", "50.3.3"), true);
+});
+
+test("trusted controller accepts only the reviewed Vercel CLI runtime lockfile rotation", () => {
+  const fixtureRoot = createVersionContractFixture();
+  const packageJsonPath = join(
+    fixtureRoot,
+    "scripts",
+    "vercel-cli-runtime",
+    "package.json",
+  );
+  const lockfilePath = join(
+    fixtureRoot,
+    "scripts",
+    "vercel-cli-runtime",
+    "pnpm-lock.yaml",
+  );
+  const contractPaths = {
+    rootPackageJsonPath: join(fixtureRoot, "package.json"),
+    packageJsonPath,
+    lockfilePath,
+  };
+  try {
+    assert.equal(
+      assertVercelCliRuntimeContract(contractPaths).lockfileSha256,
+      "505674eac656c26fce2fe912a2b14228f8f4f3edd4b3d6d7b0f2c9f08c276d76",
+    );
+
+    const reviewedNextLockfile = readFileSync(lockfilePath, "utf8")
+      .replace(
+        "  '@opentelemetry/core@<2.8.0': '>=2.8.0'",
+        "  '@mysten/sui': 1.45.2\n  '@opentelemetry/core@<2.8.0': '>=2.8.0'",
+      )
+      .replace("  postcss@<8.5.10: '>=8.5.10'", "  postcss@<8.5.18: 8.5.18")
+      .replace("  tar@>=7.0.0 <7.5.16: 7.5.20", "  tar@>=7.0.0 <7.5.21: 7.5.21")
+      .replace(
+        "  vite@>=7.0.0 <7.3.5: 7.3.5",
+        "  valibot@>=1.0.0 <1.4.2: 1.4.2\n  vite@>=7.0.0 <7.3.5: 7.3.5",
+      )
+      .replace(
+        "  tar@7.5.20:\n    resolution: {integrity: sha512-9FcyK4PA6+WbzlTM9WhQm6vB5W7cP7dUiPsv1g7YDwEQnQ1CGpK3MGlKk/ITVWMk05kHZuBhmVhiv8LZoy/PFQ==}",
+        "  tar@7.5.21:\n    resolution: {integrity: sha512-XdhtCvlMywwxpCW8YEq3lOXBJpUPTR2OHHcwLPO3HwsJqOHa2Ok/oJ7ruGzp+JrKoRPVCzJwAdEjqLW/vNRPHA==}",
+      )
+      .replace("      tar: 7.5.20", "      tar: 7.5.21")
+      .replace("      tar: 7.5.20", "      tar: 7.5.21")
+      .replace(
+        "  tar@7.5.20:\n    dependencies:",
+        "  tar@7.5.21:\n    dependencies:",
+      );
+    writeFileSync(lockfilePath, reviewedNextLockfile);
+    assert.equal(
+      assertVercelCliRuntimeContract(contractPaths).lockfileSha256,
+      "884e3c4186c9d5faee0e6cf710b112e7e60cdae5d46be13da1b2b0ae9cf11eb0",
+    );
+
+    writeFileSync(
+      lockfilePath,
+      `${reviewedNextLockfile}\n# unreviewed digest\n`,
+    );
+    assert.throws(
+      () => assertVercelCliRuntimeContract(contractPaths),
+      /runtime lockfile is not exact/,
+    );
+  } finally {
+    rmSync(fixtureRoot, { force: true, recursive: true });
+  }
 });
 
 test("version check rejects standalone pin, override, and lockfile drift", () => {


### PR DESCRIPTION
## The Problem

The trusted default-branch preview controller binds the standalone Vercel CLI
runtime to one exact lockfile SHA-256. PR #645 must change that lockfile to patch
new OSV advisories, but candidate code cannot authorize its own replacement
digest. Its App preview therefore fails closed at `check-versions` before any
build or upload.

## The Solution

- Add the byte-exact reviewed PR #645 lockfile digest to a temporary,
  controller-owned allowlist alongside the current digest.
- Keep Vercel pinned to `56.2.0` and preserve the exact manifest, mirrored
  overrides, registry-only lockfile, and source-structure checks.
- Prove the full contract accepts the current and reviewed-next lockfiles while
  rejecting any third digest.
- Document the two-PR rotation: merge this trusted-controller precursor, rerun
  and merge #645, then immediately remove the former digest.

The allowlist is literal default-branch controller code. Candidate source and PR
inputs cannot supply or extend it.

### Validation

- `node --test scripts/vercel-prebuilt.test.mjs`
- `pnpm vercel:versions:check`
- `pnpm vercel:workflow:test` (256 passing)
- `pnpm adr:check`
- `git diff --check`

### Expected bootstrap failure

The root and standalone OSV jobs remain red because this precursor intentionally
keeps the vulnerable current lockfiles unchanged. Updating the standalone
lockfile in this PR would recreate the trust cycle: the current default-branch
controller would reject the replacement digest before this controller change
could merge. After every unrelated check and review passes, this PR therefore
requires the already-authorized admin merge; #645 then applies the patched
lockfiles immediately and must pass all OSV jobs before it can merge.

### Material risk

The controller temporarily accepts two exact reviewed lockfile byte sequences.
The cleanup PR must remove
`505674eac656c26fce2fe912a2b14228f8f4f3edd4b3d6d7b0f2c9f08c276d76`
immediately after #645 merges, leaving only the patched digest.
