### PR TITLE
fix(ci): trust the reviewed brace-expansion patch

### DIFF
--- a/.github/actions/vercel-protected-runtime/action.yml
+++ b/.github/actions/vercel-protected-runtime/action.yml
@@ -391,9 +391,15 @@ runs:
             exit 1
           fi
         done
-        for immutable_file in \
-          "$TOOLS_PATH/vercel-cli-runtime/package.json" \
-          "$TOOLS_PATH/vercel-cli-runtime/pnpm-lock.yaml"; do
+        immutable_files=(
+          "$TOOLS_PATH/vercel-cli-runtime/package.json"
+          "$TOOLS_PATH/vercel-cli-runtime/pnpm-lock.yaml"
+        )
+        runtime_patch="$TOOLS_PATH/vercel-cli-runtime/patches/brace-expansion@2.1.2.patch"
+        if [ -e "$runtime_patch" ] || [ -L "$runtime_patch" ]; then
+          immutable_files+=("$runtime_patch")
+        fi
+        for immutable_file in "${immutable_files[@]}"; do
           if [ ! -f "$immutable_file" ] || [ -L "$immutable_file" ] ||
             [ "$(/usr/bin/realpath "$immutable_file")" != "$immutable_file" ] ||
             [ "$(/usr/bin/stat -c %u "$immutable_file")" != "$(/usr/bin/id -u)" ] ||

--- a/docs/dependency-overrides.md
+++ b/docs/dependency-overrides.md
@@ -86,6 +86,30 @@ Never run a general workspace install to regenerate this lockfile. That would
 allow workspace links into a runtime whose isolation depends on a standalone
 registry-only graph.
 
+### Reviewed brace-expansion patch rotation
+
+The controller has one reviewed successor state for the
+`brace-expansion@2.1.2` patch. Its three SHA-256 constants in
+`scripts/vercel-cli-runtime-contract.mjs` bind the standalone lockfile,
+canonical sorted root override object, and patch bytes. Replace all three
+together for any later reviewed patch revision; never generalize this into a
+candidate-provided allowlist.
+
+The later runtime-state PR must add exactly these matching entries together:
+
+- Root `pnpm.patchedDependencies`:
+  `brace-expansion@2.1.2: scripts/vercel-cli-runtime/patches/brace-expansion@2.1.2.patch`.
+- Standalone runtime `pnpm.patchedDependencies`:
+  `brace-expansion@2.1.2: patches/brace-expansion@2.1.2.patch`.
+- One regular, single-link patch file at
+  `scripts/vercel-cli-runtime/patches/brace-expansion@2.1.2.patch`.
+
+Protected staging copies that patch into the runtime as an independent `0444`
+file before frozen pnpm installation. It rejects a missing, extra, linked,
+hardlinked, drifted, or writable patch artifact. Keep both existing unpatched
+runtime states during the transition; remove them only in the reviewed cleanup
+after the patched state is serving on `main`.
+
 ## Wormhole Connect (`@wormhole-foundation/wormhole-connect`)
 
 `app.mento.org` uses Wormhole Connect only for the `/bridge` route. The widget

--- a/scripts/vercel-cli-runtime-contract.mjs
+++ b/scripts/vercel-cli-runtime-contract.mjs
@@ -3,18 +3,42 @@ import { readFileSync } from "node:fs";
 import { isDeepStrictEqual } from "node:util";
 
 export const PINNED_VERCEL_CLI_VERSION = "56.2.0";
-// This reviewed controller-owned map permits the one-way #645 lockfile
-// rotation only with its matching canonical override state. It must never be
-// read from candidate source or PR input.
-const TRUSTED_VERCEL_CLI_RUNTIME_OVERRIDE_SHA256_BY_LOCKFILE_SHA256 = new Map([
-  [
-    "505674eac656c26fce2fe912a2b14228f8f4f3edd4b3d6d7b0f2c9f08c276d76",
-    "1470e9d2fb8aefb32cd1cfa0f8e6b626663b8ac0de27b52f2e646240c1ece08e",
-  ],
-  [
-    "884e3c4186c9d5faee0e6cf710b112e7e60cdae5d46be13da1b2b0ae9cf11eb0",
-    "0941482390a44f7e16c1f7182469e01162434f9e274059d53d6ebbef2ebed695",
-  ],
+const BRACE_EXPANSION_PATCHED_DEPENDENCY = "brace-expansion@2.1.2";
+export const BRACE_EXPANSION_RUNTIME_PATCH_PATH =
+  "patches/brace-expansion@2.1.2.patch";
+const BRACE_EXPANSION_ROOT_PATCH_PATH =
+  "scripts/vercel-cli-runtime/patches/brace-expansion@2.1.2.patch";
+
+// This one reviewed successor binds the runtime lockfile, override object, and
+// patch bytes. Replace all three together for any later reviewed patch update.
+const NEXT_BRACE_EXPANSION_RUNTIME_LOCKFILE_SHA256 =
+  "190bccb28051d5c006825163f9f589588c74f9bb1ed96e1afcfed6ede16560f4";
+const NEXT_BRACE_EXPANSION_RUNTIME_OVERRIDE_SHA256 =
+  "2a30c91c2e6d82386113535d8a0d03e3faeb2d4af0bc032b9200719e036b490a";
+const NEXT_BRACE_EXPANSION_PATCH_SHA256 =
+  "5d7a425f992e872546ea180bccc67f32848a1537176001c007cac001ff8be3b1";
+
+// This reviewed controller-owned state permits the one-way runtime rotation
+// only with its matching canonical override and, when present, patch state. It
+// must never be read from candidate source or PR input.
+const TRUSTED_VERCEL_CLI_RUNTIME_STATES = Object.freeze([
+  Object.freeze({
+    lockfileSha256:
+      "505674eac656c26fce2fe912a2b14228f8f4f3edd4b3d6d7b0f2c9f08c276d76",
+    overridesSha256:
+      "1470e9d2fb8aefb32cd1cfa0f8e6b626663b8ac0de27b52f2e646240c1ece08e",
+  }),
+  Object.freeze({
+    lockfileSha256:
+      "884e3c4186c9d5faee0e6cf710b112e7e60cdae5d46be13da1b2b0ae9cf11eb0",
+    overridesSha256:
+      "0941482390a44f7e16c1f7182469e01162434f9e274059d53d6ebbef2ebed695",
+  }),
+  Object.freeze({
+    lockfileSha256: NEXT_BRACE_EXPANSION_RUNTIME_LOCKFILE_SHA256,
+    overridesSha256: NEXT_BRACE_EXPANSION_RUNTIME_OVERRIDE_SHA256,
+    patchSha256: NEXT_BRACE_EXPANSION_PATCH_SHA256,
+  }),
 ]);
 
 function hasExactObjectKeys(value, expectedKeys) {
@@ -57,12 +81,15 @@ export function assertVercelCliRuntimeContract({
   rootPackageJsonPath,
   packageJsonPath,
   lockfilePath,
+  patchFilePath,
+  trustedRuntimeStates = TRUSTED_VERCEL_CLI_RUNTIME_STATES,
 }) {
   const rootPackageMetadata = JSON.parse(
     readFileSync(rootPackageJsonPath, "utf8"),
   );
   const packageMetadata = JSON.parse(readFileSync(packageJsonPath, "utf8"));
-  const rootOverrides = rootPackageMetadata.pnpm?.overrides;
+  const rootPnpm = rootPackageMetadata.pnpm;
+  const rootOverrides = rootPnpm?.overrides;
   if (
     rootPackageMetadata.devDependencies?.vercel !== PINNED_VERCEL_CLI_VERSION
   ) {
@@ -74,6 +101,29 @@ export function assertVercelCliRuntimeContract({
   } catch {
     throw new Error("Trusted root Vercel CLI contract is invalid");
   }
+  const lockfileContents = readFileSync(lockfilePath);
+  const lockfileDigest = createHash("sha256")
+    .update(lockfileContents)
+    .digest("hex");
+  const trustedRuntimeState = trustedRuntimeStates.find(
+    (state) => state?.lockfileSha256 === lockfileDigest,
+  );
+  if (trustedRuntimeState === undefined) {
+    throw new Error("Trusted Vercel CLI runtime lockfile is not exact");
+  }
+  const hasBraceExpansionPatch = trustedRuntimeState.patchSha256 !== undefined;
+  const expectedPnpmKeys = hasBraceExpansionPatch
+    ? ["overrides", "patchedDependencies"]
+    : ["overrides"];
+  const expectedPatchedDependencies = hasBraceExpansionPatch
+    ? {
+        [BRACE_EXPANSION_PATCHED_DEPENDENCY]:
+          BRACE_EXPANSION_RUNTIME_PATCH_PATH,
+      }
+    : undefined;
+  const expectedRootPatchedDependencies = hasBraceExpansionPatch
+    ? { [BRACE_EXPANSION_PATCHED_DEPENDENCY]: BRACE_EXPANSION_ROOT_PATCH_PATH }
+    : undefined;
   if (
     !hasExactObjectKeys(packageMetadata, [
       "dependencies",
@@ -90,27 +140,36 @@ export function assertVercelCliRuntimeContract({
       "Standalone pinned Vercel CLI runtime for protected GitHub Actions deployments" ||
     !hasExactObjectKeys(packageMetadata.dependencies, ["vercel"]) ||
     packageMetadata.dependencies.vercel !== PINNED_VERCEL_CLI_VERSION ||
-    !hasExactObjectKeys(packageMetadata.pnpm, ["overrides"]) ||
-    !isDeepStrictEqual(packageMetadata.pnpm.overrides, rootOverrides)
+    !hasExactObjectKeys(packageMetadata.pnpm, expectedPnpmKeys) ||
+    !isDeepStrictEqual(packageMetadata.pnpm.overrides, rootOverrides) ||
+    !isDeepStrictEqual(
+      packageMetadata.pnpm.patchedDependencies,
+      expectedPatchedDependencies,
+    ) ||
+    !isDeepStrictEqual(
+      rootPnpm.patchedDependencies,
+      expectedRootPatchedDependencies,
+    )
   ) {
     throw new Error("Trusted Vercel CLI runtime manifest is not exact");
   }
-
-  const lockfileContents = readFileSync(lockfilePath);
-  const lockfileDigest = createHash("sha256")
-    .update(lockfileContents)
-    .digest("hex");
-  const expectedOverridesSha256 =
-    TRUSTED_VERCEL_CLI_RUNTIME_OVERRIDE_SHA256_BY_LOCKFILE_SHA256.get(
-      lockfileDigest,
-    );
-  if (expectedOverridesSha256 === undefined) {
-    throw new Error("Trusted Vercel CLI runtime lockfile is not exact");
-  }
-  if (rootOverridesSha256 !== expectedOverridesSha256) {
+  if (rootOverridesSha256 !== trustedRuntimeState.overridesSha256) {
     throw new Error(
       "Trusted Vercel CLI runtime lockfile and overrides are not an approved pair",
     );
+  }
+  if (hasBraceExpansionPatch) {
+    if (typeof patchFilePath !== "string") {
+      throw new Error("Trusted Vercel CLI runtime patch is missing");
+    }
+    const patchDigest = createHash("sha256")
+      .update(readFileSync(patchFilePath))
+      .digest("hex");
+    if (patchDigest !== trustedRuntimeState.patchSha256) {
+      throw new Error("Trusted Vercel CLI runtime patch is not exact");
+    }
+  } else if (patchFilePath !== undefined) {
+    throw new Error("Trusted Vercel CLI runtime patch is unexpected");
   }
   const lockfileText = lockfileContents.toString("utf8");
   if (
@@ -127,6 +186,7 @@ export function assertVercelCliRuntimeContract({
 
   return {
     lockfileSha256: lockfileDigest,
+    patchRequired: hasBraceExpansionPatch,
     vercel: packageMetadata.dependencies.vercel,
   };
 }

--- a/scripts/vercel-prebuilt-workflow.mjs
+++ b/scripts/vercel-prebuilt-workflow.mjs
@@ -45,6 +45,7 @@ import {
 } from "./vercel-prebuilt.mjs";
 import {
   assertVercelCliRuntimeContract,
+  BRACE_EXPANSION_RUNTIME_PATCH_PATH,
   PINNED_VERCEL_CLI_VERSION,
 } from "./vercel-cli-runtime-contract.mjs";
 import {
@@ -2237,17 +2238,87 @@ function validatePinnedVercelCliRuntimeFiles({
   rootPackageJsonPath,
   packageJsonPath,
   lockfilePath,
+  patchFilePath,
+  trustedRuntimeStates,
 }) {
   return assertVercelCliRuntimeContract({
     rootPackageJsonPath,
     packageJsonPath,
     lockfilePath,
+    patchFilePath,
+    trustedRuntimeStates,
   });
+}
+
+function protectedVercelCliRuntimePatchArtifact({
+  runtimeRoot,
+  expectedUid,
+  expectedGid,
+}) {
+  const patchesRoot = join(runtimeRoot, "patches");
+  if (optionalEntry(patchesRoot) === undefined) return undefined;
+  assertProtectedRuntimeEntry(patchesRoot, {
+    directory: true,
+    expectedUid,
+    expectedGid,
+  });
+  const protectedPatchesRoot = assertProtectedRuntimeDescendant({
+    root: runtimeRoot,
+    path: patchesRoot,
+    directory: true,
+    expectedUid,
+    expectedGid,
+  });
+  const patchFilePath = join(runtimeRoot, BRACE_EXPANSION_RUNTIME_PATCH_PATH);
+  if (optionalEntry(patchFilePath) !== undefined) {
+    assertProtectedRuntimeEntry(patchFilePath, {
+      directory: false,
+      expectedUid,
+      expectedGid,
+    });
+  }
+  return {
+    patchesRoot: protectedPatchesRoot.path,
+    patchFile:
+      optionalEntry(patchFilePath) === undefined
+        ? undefined
+        : assertProtectedRuntimeDescendant({
+            root: runtimeRoot,
+            path: patchFilePath,
+            directory: false,
+            expectedUid,
+            expectedGid,
+          }),
+  };
+}
+
+function assertExactVercelCliRuntimePatchArtifact({
+  patchArtifact,
+  patchRequired,
+}) {
+  if (!patchRequired) {
+    if (patchArtifact !== undefined) {
+      throw new Error("Trusted Vercel CLI runtime patch is unexpected");
+    }
+    return undefined;
+  }
+  if (patchArtifact?.patchFile === undefined) {
+    throw new Error("Trusted Vercel CLI runtime patch is missing");
+  }
+  const entries = readdirSync(patchArtifact.patchesRoot).toSorted();
+  if (
+    entries.length !== 1 ||
+    entries[0] !== BRACE_EXPANSION_RUNTIME_PATCH_PATH.split("/").at(-1)
+  ) {
+    throw new Error("Trusted Vercel CLI runtime patch artifacts are not exact");
+  }
+  return patchArtifact.patchFile;
 }
 
 export function stageTrustedVercelCliRuntimeManifest({
   controllerRoot,
   toolsRoot,
+  runtimeContractStates,
 }) {
   requiredText(controllerRoot, "Trusted controller path");
   requiredText(toolsRoot, "Trusted Vercel tools path");
@@ -2316,10 +2387,21 @@ export function stageTrustedVercelCliRuntimeManifest({
     expectedUid: currentUid,
     expectedGid: currentGid,
   });
-  validatePinnedVercelCliRuntimeFiles({
+  const sourcePatchArtifact = protectedVercelCliRuntimePatchArtifact({
+    runtimeRoot: sourceRoot,
+    expectedUid: currentUid,
+    expectedGid: currentGid,
+  });
+  const sourceContract = validatePinnedVercelCliRuntimeFiles({
     rootPackageJsonPath: rootPackageJson.path,
     packageJsonPath: sourcePackageJson.path,
     lockfilePath: sourceLockfile.path,
+    patchFilePath: sourcePatchArtifact?.patchFile?.path,
+    trustedRuntimeStates: runtimeContractStates,
+  });
+  const sourcePatchFile = assertExactVercelCliRuntimePatchArtifact({
+    patchArtifact: sourcePatchArtifact,
+    patchRequired: sourceContract.patchRequired,
   });
 
   const runtimeRoot = join(canonicalToolsRoot, VERCEL_CLI_RUNTIME_DIRECTORY);
@@ -2339,8 +2421,12 @@ export function stageTrustedVercelCliRuntimeManifest({
     for (const [name, source] of [
       ["package.json", sourcePackageJson],
       ["pnpm-lock.yaml", sourceLockfile],
+      ...(sourcePatchFile === undefined
+        ? []
+        : [[BRACE_EXPANSION_RUNTIME_PATCH_PATH, sourcePatchFile]]),
     ]) {
       const destination = join(runtimeRoot, name);
+      mkdirSync(dirname(destination), { recursive: true, mode: 0o755 });
       copyFileSync(source.path, destination, fsConstants.COPYFILE_EXCL);
       chmodSync(destination, 0o444);
       const destinationEntry = assertProtectedRuntimeEntry(destination, {
@@ -2356,10 +2442,21 @@ export function stageTrustedVercelCliRuntimeManifest({
         throw new Error("Trusted Vercel CLI runtime copy is not independent");
       }
     }
-    validatePinnedVercelCliRuntimeFiles({
+    const runtimePatchArtifact = protectedVercelCliRuntimePatchArtifact({
+      runtimeRoot,
+      expectedUid: currentUid,
+      expectedGid: currentGid,
+    });
+    const runtimeContract = validatePinnedVercelCliRuntimeFiles({
       rootPackageJsonPath: rootPackageJson.path,
       packageJsonPath: join(runtimeRoot, "package.json"),
       lockfilePath: join(runtimeRoot, "pnpm-lock.yaml"),
+      patchFilePath: runtimePatchArtifact?.patchFile?.path,
+      trustedRuntimeStates: runtimeContractStates,
+    });
+    assertExactVercelCliRuntimePatchArtifact({
+      patchArtifact: runtimePatchArtifact,
+      patchRequired: runtimeContract.patchRequired,
     });
     return runtimeRoot;
   } catch (error) {
@@ -2438,10 +2535,20 @@ export function trustedStandaloneVercelCliPath({ controllerRoot, toolsRoot }) {
   ) {
     throw new Error("Trusted Vercel CLI runtime contract is writable");
   }
-  validatePinnedVercelCliRuntimeFiles({
+  const runtimePatchArtifact = protectedVercelCliRuntimePatchArtifact({
+    runtimeRoot,
+    expectedUid: currentUid,
+    expectedGid: currentGid,
+  });
+  const runtimeContract = validatePinnedVercelCliRuntimeFiles({
     rootPackageJsonPath: rootPackageJson.path,
     packageJsonPath: runtimePackageJson.path,
     lockfilePath: runtimeLockfile.path,
+    patchFilePath: runtimePatchArtifact?.patchFile?.path,
+  });
+  assertExactVercelCliRuntimePatchArtifact({
+    patchArtifact: runtimePatchArtifact,
+    patchRequired: runtimeContract.patchRequired,
   });
 
   const virtualStoreRoot = join(runtimeRoot, "node_modules", ".pnpm");

--- a/scripts/vercel-prebuilt-workflow.test.mjs
+++ b/scripts/vercel-prebuilt-workflow.test.mjs
@@ -2289,6 +2289,211 @@ test("standalone Vercel CLI runtime is exact, override-aligned, and independentl
   }
 });
 
+test("patched standalone Vercel CLI runtime stages one immutable reviewed patch", () => {
+  const fixtureRoot = mkdtempSync(join(tmpdir(), "vercel-cli-runtime-patch-"));
+  const controllerRoot = join(fixtureRoot, "controller");
+  const sourceRoot = join(controllerRoot, "scripts", "vercel-cli-runtime");
+  const toolsRoot = join(fixtureRoot, "trusted-tools");
+  const rootPackagePath = join(controllerRoot, "package.json");
+  const sourceManifestPath = join(sourceRoot, "package.json");
+  const sourceLockfilePath = join(sourceRoot, "pnpm-lock.yaml");
+  const patchDirectory = join(sourceRoot, "patches");
+  const patchPath = join(patchDirectory, "brace-expansion@2.1.2.patch");
+  const patchContents = "diff --git a/index.js b/index.js\n";
+  try {
+    mkdirSync(sourceRoot, { recursive: true });
+    mkdirSync(toolsRoot, { mode: 0o755 });
+    copyFileSync(join(REPOSITORY_ROOT, "package.json"), rootPackagePath);
+    for (const file of ["package.json", "pnpm-lock.yaml"]) {
+      copyFileSync(
+        join(REPOSITORY_ROOT, "scripts", "vercel-cli-runtime", file),
+        join(sourceRoot, file),
+      );
+      chmodSync(join(sourceRoot, file), 0o444);
+    }
+    mkdirSync(patchDirectory, { mode: 0o755 });
+    writeFileSync(patchPath, patchContents, { mode: 0o444 });
+    for (const path of [
+      controllerRoot,
+      join(controllerRoot, "scripts"),
+      sourceRoot,
+      patchDirectory,
+      toolsRoot,
+    ]) {
+      chmodSync(path, 0o755);
+    }
+
+    const rootPackage = JSON.parse(readFileSync(rootPackagePath, "utf8"));
+    const runtimePackage = JSON.parse(readFileSync(sourceManifestPath, "utf8"));
+    rootPackage.pnpm.patchedDependencies = {
+      "brace-expansion@2.1.2":
+        "scripts/vercel-cli-runtime/patches/brace-expansion@2.1.2.patch",
+    };
+    runtimePackage.pnpm.patchedDependencies = {
+      "brace-expansion@2.1.2": "patches/brace-expansion@2.1.2.patch",
+    };
+    const patchedLockfile = `${readFileSync(sourceLockfilePath, "utf8")}# patched fixture\n`;
+    chmodSync(sourceManifestPath, 0o644);
+    writeFileSync(sourceManifestPath, `${JSON.stringify(runtimePackage)}\n`);
+    chmodSync(sourceManifestPath, 0o444);
+    writeFileSync(rootPackagePath, `${JSON.stringify(rootPackage)}\n`);
+    chmodSync(sourceLockfilePath, 0o644);
+    writeFileSync(sourceLockfilePath, patchedLockfile);
+    chmodSync(sourceLockfilePath, 0o444);
+
+    const canonicalOverrides = JSON.stringify(
+      Object.fromEntries(
+        Object.entries(rootPackage.pnpm.overrides).toSorted(([left], [right]) =>
+          left.localeCompare(right),
+        ),
+      ),
+    );
+    const runtimeContractStates = [
+      {
+        lockfileSha256: createHash("sha256")
+          .update(patchedLockfile)
+          .digest("hex"),
+        overridesSha256: createHash("sha256")
+          .update(canonicalOverrides)
+          .digest("hex"),
+        patchSha256: createHash("sha256").update(patchContents).digest("hex"),
+      },
+    ];
+    const runtimeRoot = stageTrustedVercelCliRuntimeManifest({
+      controllerRoot,
+      toolsRoot,
+      runtimeContractStates,
+    });
+    const stagedPatchPath = join(
+      runtimeRoot,
+      "patches",
+      "brace-expansion@2.1.2.patch",
+    );
+    for (const [source, destination] of [
+      [sourceManifestPath, join(runtimeRoot, "package.json")],
+      [sourceLockfilePath, join(runtimeRoot, "pnpm-lock.yaml")],
+      [patchPath, stagedPatchPath],
+    ]) {
+      const sourceEntry = lstatSync(source);
+      const destinationEntry = lstatSync(destination);
+      assert.equal(destinationEntry.isFile(), true);
+      assert.equal(destinationEntry.isSymbolicLink(), false);
+      assert.equal(destinationEntry.mode & 0o777, 0o444);
+      assert.equal(destinationEntry.nlink, 1);
+      assert.notEqual(destinationEntry.ino, sourceEntry.ino);
+      assert.equal(
+        readFileSync(destination, "utf8"),
+        readFileSync(source, "utf8"),
+      );
+    }
+
+    rmSync(runtimeRoot, { force: true, recursive: true });
+    writeFileSync(join(patchDirectory, "extra.patch"), patchContents);
+    assert.throws(
+      () =>
+        stageTrustedVercelCliRuntimeManifest({
+          controllerRoot,
+          toolsRoot,
+          runtimeContractStates,
+        }),
+      /patch artifacts are not exact/,
+    );
+    rmSync(join(patchDirectory, "extra.patch"));
+
+    const externalPatch = join(fixtureRoot, "brace-expansion.patch");
+    writeFileSync(externalPatch, patchContents);
+    rmSync(patchPath);
+    symlinkSync(externalPatch, patchPath);
+    assert.throws(
+      () =>
+        stageTrustedVercelCliRuntimeManifest({
+          controllerRoot,
+          toolsRoot,
+          runtimeContractStates,
+        }),
+      /not runner-owned/,
+    );
+    rmSync(patchPath);
+    writeFileSync(patchPath, patchContents, { mode: 0o444 });
+
+    const inRootPatch = join(sourceRoot, "brace-expansion.patch-target");
+    writeFileSync(inRootPatch, patchContents, { mode: 0o444 });
+    rmSync(patchPath);
+    symlinkSync("../brace-expansion.patch-target", patchPath);
+    assert.throws(
+      () =>
+        stageTrustedVercelCliRuntimeManifest({
+          controllerRoot,
+          toolsRoot,
+          runtimeContractStates,
+        }),
+      /not runner-owned/,
+    );
+    rmSync(patchPath);
+    rmSync(inRootPatch);
+    writeFileSync(patchPath, patchContents, { mode: 0o444 });
+
+    const hardlinkSource = join(sourceRoot, "brace-expansion.patch-source");
+    writeFileSync(hardlinkSource, patchContents, { mode: 0o444 });
+    rmSync(patchPath);
+    linkSync(hardlinkSource, patchPath);
+    assert.throws(
+      () =>
+        stageTrustedVercelCliRuntimeManifest({
+          controllerRoot,
+          toolsRoot,
+          runtimeContractStates,
+        }),
+      /not runner-owned/,
+    );
+    rmSync(patchPath);
+    rmSync(hardlinkSource);
+    writeFileSync(patchPath, patchContents, { mode: 0o444 });
+
+    chmodSync(patchPath, 0o644);
+    writeFileSync(patchPath, `${patchContents}# drifted\n`);
+    chmodSync(patchPath, 0o444);
+    assert.throws(
+      () =>
+        stageTrustedVercelCliRuntimeManifest({
+          controllerRoot,
+          toolsRoot,
+          runtimeContractStates,
+        }),
+      /runtime patch is not exact/,
+    );
+    chmodSync(patchPath, 0o644);
+    writeFileSync(patchPath, patchContents);
+    chmodSync(patchPath, 0o444);
+
+    rmSync(patchPath);
+    assert.throws(
+      () =>
+        stageTrustedVercelCliRuntimeManifest({
+          controllerRoot,
+          toolsRoot,
+          runtimeContractStates,
+        }),
+      /runtime patch is missing/,
+    );
+    writeFileSync(patchPath, patchContents, { mode: 0o444 });
+
+    chmodSync(patchPath, 0o666);
+    assert.throws(
+      () =>
+        stageTrustedVercelCliRuntimeManifest({
+          controllerRoot,
+          toolsRoot,
+          runtimeContractStates,
+        }),
+      /not runner-owned/,
+    );
+    chmodSync(patchPath, 0o444);
+  } finally {
+    rmSync(fixtureRoot, { force: true, recursive: true });
+  }
+});
+
 test("installed root Vercel CLI executes the exact pinned release", () => {
   const cliPath = realpathSync(
     join(REPOSITORY_ROOT, "node_modules", "vercel", "dist", "index.js"),

--- a/scripts/vercel-prebuilt.mjs
+++ b/scripts/vercel-prebuilt.mjs
@@ -140,7 +140,10 @@ export function readResolvedNextVersion(lockfile) {
   return match[1];
 }
 
-export function assertDeploymentIdPrerequisites(repoRoot) {
+export function assertDeploymentIdPrerequisites(
+  repoRoot,
+  { runtimeContractStates } = {},
+) {
   const packageJson = JSON.parse(
     readFileSync(join(repoRoot, "package.json"), "utf8"),
   );
@@ -176,6 +179,16 @@ export function assertDeploymentIdPrerequisites(repoRoot) {
       "vercel-cli-runtime",
       "pnpm-lock.yaml",
     ),
+    patchFilePath: Object.hasOwn(packageJson.pnpm ?? {}, "patchedDependencies")
+      ? join(
+          repoRoot,
+          "scripts",
+          "vercel-cli-runtime",
+          "patches",
+          "brace-expansion@2.1.2.patch",
+        )
+      : undefined,
+    trustedRuntimeStates: runtimeContractStates,
   });
 
   return { next: nextVersion, vercel: vercelVersion, vercelCliRuntime };

--- a/scripts/vercel-prebuilt.test.mjs
+++ b/scripts/vercel-prebuilt.test.mjs
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import {
   copyFileSync,
   mkdirSync,
@@ -159,6 +160,22 @@ function writeVercelCliRuntimeOverrides({
   );
 }
 
+function sha256(value) {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function canonicalOverrideSha256(overrides) {
+  return sha256(
+    JSON.stringify(
+      Object.fromEntries(
+        Object.entries(overrides).toSorted(([left], [right]) =>
+          left.localeCompare(right),
+        ),
+      ),
+    ),
+  );
+}
+
 test("generated IDs satisfy every Vercel constraint for every target", () => {
   for (const target of VERCEL_TARGETS) {
     const value = deploymentId({ target });
@@ -261,6 +278,7 @@ test("resolved Next.js and exact Vercel CLI satisfy custom-ID prerequisites", ()
     vercel: "56.2.0",
     vercelCliRuntime: {
       lockfileSha256: prerequisites.vercelCliRuntime.lockfileSha256,
+      patchRequired: false,
       vercel: "56.2.0",
     },
   };
@@ -337,6 +355,16 @@ test("trusted controller accepts only the reviewed Vercel CLI runtime lockfile r
     const reviewedNextOverrides = toNextVercelCliRuntimeOverrides(
       repositoryRootOverrides,
     );
+    const prePatchStates = [
+      {
+        lockfileSha256: CURRENT_VERCEL_CLI_RUNTIME_LOCKFILE_SHA256,
+        overridesSha256: canonicalOverrideSha256(reviewedCurrentOverrides),
+      },
+      {
+        lockfileSha256: NEXT_VERCEL_CLI_RUNTIME_LOCKFILE_SHA256,
+        overridesSha256: canonicalOverrideSha256(reviewedNextOverrides),
+      },
+    ];
 
     writeVercelCliRuntimeOverrides({
       ...contractPaths,
@@ -344,7 +372,10 @@ test("trusted controller accepts only the reviewed Vercel CLI runtime lockfile r
     });
     writeFileSync(lockfilePath, reviewedCurrentLockfile);
     assert.equal(
-      assertVercelCliRuntimeContract(contractPaths).lockfileSha256,
+      assertVercelCliRuntimeContract({
+        ...contractPaths,
+        trustedRuntimeStates: prePatchStates,
+      }).lockfileSha256,
       CURRENT_VERCEL_CLI_RUNTIME_LOCKFILE_SHA256,
     );
 
@@ -354,7 +385,10 @@ test("trusted controller accepts only the reviewed Vercel CLI runtime lockfile r
     });
     writeFileSync(lockfilePath, reviewedNextLockfile);
     assert.equal(
-      assertVercelCliRuntimeContract(contractPaths).lockfileSha256,
+      assertVercelCliRuntimeContract({
+        ...contractPaths,
+        trustedRuntimeStates: prePatchStates,
+      }).lockfileSha256,
       NEXT_VERCEL_CLI_RUNTIME_LOCKFILE_SHA256,
     );
 
@@ -381,6 +415,94 @@ test("trusted controller accepts only the reviewed Vercel CLI runtime lockfile r
     assert.throws(
       () => assertVercelCliRuntimeContract(contractPaths),
       /runtime lockfile is not exact/,
+    );
+
+    const patchPath = join(
+      fixtureRoot,
+      "scripts",
+      "vercel-cli-runtime",
+      "patches",
+      "brace-expansion@2.1.2.patch",
+    );
+    mkdirSync(join(fixtureRoot, "scripts", "vercel-cli-runtime", "patches"), {
+      recursive: true,
+    });
+    const patchContents = "diff --git a/index.js b/index.js\n";
+    writeFileSync(patchPath, patchContents);
+    const patchedRootPackage = JSON.parse(
+      readFileSync(contractPaths.rootPackageJsonPath, "utf8"),
+    );
+    const patchedRuntimePackage = JSON.parse(
+      readFileSync(packageJsonPath, "utf8"),
+    );
+    const rootPatchPath =
+      "scripts/vercel-cli-runtime/patches/brace-expansion@2.1.2.patch";
+    const runtimePatchPath = "patches/brace-expansion@2.1.2.patch";
+    patchedRootPackage.pnpm.patchedDependencies = {
+      "brace-expansion@2.1.2": rootPatchPath,
+    };
+    patchedRuntimePackage.pnpm.patchedDependencies = {
+      "brace-expansion@2.1.2": runtimePatchPath,
+    };
+    const patchedLockfile = `${reviewedNextLockfile}# patched fixture\n`;
+    writeFileSync(
+      contractPaths.rootPackageJsonPath,
+      `${JSON.stringify(patchedRootPackage, null, 2)}\n`,
+    );
+    writeFileSync(
+      packageJsonPath,
+      `${JSON.stringify(patchedRuntimePackage, null, 2)}\n`,
+    );
+    writeFileSync(lockfilePath, patchedLockfile);
+    const patchedStates = [
+      {
+        lockfileSha256: CURRENT_VERCEL_CLI_RUNTIME_LOCKFILE_SHA256,
+        overridesSha256: canonicalOverrideSha256(reviewedCurrentOverrides),
+      },
+      {
+        lockfileSha256: NEXT_VERCEL_CLI_RUNTIME_LOCKFILE_SHA256,
+        overridesSha256: canonicalOverrideSha256(reviewedNextOverrides),
+      },
+      {
+        lockfileSha256: sha256(patchedLockfile),
+        overridesSha256: canonicalOverrideSha256(reviewedNextOverrides),
+        patchSha256: sha256(patchContents),
+      },
+    ];
+    assert.deepEqual(
+      assertVercelCliRuntimeContract({
+        ...contractPaths,
+        patchFilePath: patchPath,
+        trustedRuntimeStates: patchedStates,
+      }),
+      {
+        lockfileSha256: sha256(patchedLockfile),
+        patchRequired: true,
+        vercel: "56.2.0",
+      },
+    );
+    assert.equal(
+      assertDeploymentIdPrerequisites(fixtureRoot, {
+        runtimeContractStates: patchedStates,
+      }).vercelCliRuntime.patchRequired,
+      true,
+    );
+
+    patchedRuntimePackage.pnpm.patchedDependencies = {
+      "brace-expansion@2.1.2": rootPatchPath,
+    };
+    writeFileSync(
+      packageJsonPath,
+      `${JSON.stringify(patchedRuntimePackage, null, 2)}\n`,
+    );
+    assert.throws(
+      () =>
+        assertVercelCliRuntimeContract({
+          ...contractPaths,
+          patchFilePath: patchPath,
+          trustedRuntimeStates: patchedStates,
+        }),
+      /runtime manifest is not exact/,
     );
   } finally {
     rmSync(fixtureRoot, { force: true, recursive: true });

--- a/scripts/vercel-production-shadow-workflow.test.mjs
+++ b/scripts/vercel-production-shadow-workflow.test.mjs
@@ -390,6 +390,18 @@ test("protected build runtime installs the exact standalone Vercel CLI without w
     runtimeBlock,
     /\$TOOLS_PATH\/vercel-cli-runtime\/pnpm-lock\.yaml/,
   );
+  assert.match(
+    runtimeBlock,
+    /runtime_patch="\$TOOLS_PATH\/vercel-cli-runtime\/patches\/brace-expansion@2\.1\.2\.patch"/,
+  );
+  assert.match(
+    runtimeBlock,
+    /if \[ -e "\$runtime_patch" \] \|\| \[ -L "\$runtime_patch" \]; then\n\s+immutable_files\+=\("\$runtime_patch"\)/,
+  );
+  assert.match(
+    runtimeBlock,
+    /for immutable_file in "\$\{immutable_files\[@\]\}"/,
+  );
   assert.match(runtimeBlock, /stat -c %h "\$immutable_file"\)" != 1/);
   assert.match(runtimeBlock, /stat -c %a "\$immutable_file"\)" != 444/);
   assert.match(runtimeBlock, /stat -c %h "\$installed_file"\)" != 1/);


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## The Problem

PR #645 needs to patch the standalone Vercel CLI runtime's vulnerable
`brace-expansion@2.1.2` dependency. The protected controller currently accepts
only the two reviewed unpatched lockfile/override pairs, so it correctly rejects
the new manifest, lockfile, and patch before the OSV remediation can run.

## The Solution

- Add one controller-owned trusted state that binds the reviewed standalone
  lockfile, canonical root overrides, and patch bytes by exact SHA-256.
- Require the root and standalone manifests to name the one fixed patch path,
  reject missing, extra, drifted, writable, symlinked, or hardlinked artifacts,
  and copy the patch independently as a runner-owned `0444` file before the
  frozen install.
- Keep the two existing no-patch states only for the staged rotation. A later
  cleanup removes them after #645 is serving from `main`.
- Extend the protected-action and controller regression coverage, including the
  in-repository symlink case found during fresh-context security review.

## Validation

- `pnpm vercel:primitives:test` — 62 passed
- `pnpm vercel:workflow:test` — 257 passed
- `pnpm vercel:production-shadow:test` — 115 passed
- `pnpm vercel:versions:check`
- `pnpm check-types`
- `pnpm knip`
- `pnpm adr:check`
- `trunk check`
- `git diff --check`
- Fresh-context trust-boundary review — one in-repository symlink finding fixed
- Local deterministic autoreview — clean
- Claude security scan skipped because this session runs in Codex; the focused
  trust-boundary review and repository security tests ran instead.

## Ship Checklist

- [x] PR title follows the [conventions](https://www.notion.so/Git-Branching-and-Commit-Message-Conventions-18f66f7d06444cfcbac5725ffbc7c04a?pvs=4#9355048863c549ef92fe210a8a1298aa)
- [x] Performed a self-review of my own changes
- [x] Relevant automated checks and smoke tests pass
- [x] Architecture decision? Not applicable — this is a bounded security
  hardening and reviewed-state rotation within the existing GitHub-driven Vercel
  deployment architecture.
