### PR TITLE
fix(ci): trust revised brace-expansion patch

### DIFF
--- a/scripts/vercel-cli-runtime-contract.mjs
+++ b/scripts/vercel-cli-runtime-contract.mjs
@@ -12,11 +12,11 @@ const BRACE_EXPANSION_ROOT_PATCH_PATH =
 // This one reviewed successor binds the runtime lockfile, override object, and
 // patch bytes. Replace all three together for any later reviewed patch update.
 const NEXT_BRACE_EXPANSION_RUNTIME_LOCKFILE_SHA256 =
-  "190bccb28051d5c006825163f9f589588c74f9bb1ed96e1afcfed6ede16560f4";
+  "34a95c137dde8278ee54abf81f2c3cc54effc40f25c95f28a4fba80a8225d982";
 const NEXT_BRACE_EXPANSION_RUNTIME_OVERRIDE_SHA256 =
   "2a30c91c2e6d82386113535d8a0d03e3faeb2d4af0bc032b9200719e036b490a";
 const NEXT_BRACE_EXPANSION_PATCH_SHA256 =
-  "5d7a425f992e872546ea180bccc67f32848a1537176001c007cac001ff8be3b1";
+  "36cc1afb1cde27a55fa0d111d0134cb5f1eee9201b0ded7990e0b3654113f24b";
 
 // This reviewed controller-owned state permits the one-way runtime rotation
 // only with its matching canonical override and, when present, patch state. It

--- a/scripts/vercel-cli-runtime-contract.mjs
+++ b/scripts/vercel-cli-runtime-contract.mjs
@@ -12,11 +12,11 @@ const BRACE_EXPANSION_ROOT_PATCH_PATH =
 // This one reviewed successor binds the runtime lockfile, override object, and
 // patch bytes. Replace all three together for any later reviewed patch update.
 const NEXT_BRACE_EXPANSION_RUNTIME_LOCKFILE_SHA256 =
-  "34a95c137dde8278ee54abf81f2c3cc54effc40f25c95f28a4fba80a8225d982";
+  "e9e0ff7ace696462de55c55644c4c4b743b9458636dea6bd5b8498d5601ecf3e";
 const NEXT_BRACE_EXPANSION_RUNTIME_OVERRIDE_SHA256 =
   "2a30c91c2e6d82386113535d8a0d03e3faeb2d4af0bc032b9200719e036b490a";
 const NEXT_BRACE_EXPANSION_PATCH_SHA256 =
-  "36cc1afb1cde27a55fa0d111d0134cb5f1eee9201b0ded7990e0b3654113f24b";
+  "ba16c58317a7384674583eba75e1ea611f7173c8ce7dfad3bce294e02f15271c";
 
 // This reviewed controller-owned state permits the one-way runtime rotation
 // only with its matching canonical override and, when present, patch state. It


### PR DESCRIPTION
## The Problem

PR #645 carries the final reviewed brace-expansion patch revision whose exact
standalone runtime lockfile and patch digests differ from the successor tuple on
`main`. The protected controller rejects that candidate before it can prove and
deploy the remediation.

## The Solution

Replace the controller-owned successor lockfile and patch SHA-256 values with
the exact values recomputed from the final #645 head. Keep the canonical
override digest unchanged and remove trust in the superseded successor values.

This is the reviewed trust precursor for #645. It does not contain the
dependency remediation, patch payload, lockfile, manifests, or package changes;
#645 remains the actual OSV remediation.

## Validation

- `node --test scripts/vercel-prebuilt.test.mjs
  scripts/vercel-prebuilt-workflow.test.mjs
  scripts/vercel-prebuilt-workflows.test.mjs
  scripts/vercel-production-shadow-workflow.test.mjs` — 116/116 passed
- `trunk fmt scripts/vercel-cli-runtime-contract.mjs` — clean
- `trunk check scripts/vercel-cli-runtime-contract.mjs` — clean
- `pnpm adr:check` — passed
- `git diff --check` — passed
- Independent fresh-context runtime-contract review — clean
- Final #645 compatibility review — 80,000 uncapped and 280,000 capped
  comparisons against unmodified brace-expansion 2.1.2, with zero differences
- Final #645 current-head Codex review — no major issues

Recomputed exact values from the final #645 candidate:

- standalone runtime lockfile:
  `e9e0ff7ace696462de55c55644c4c4b743b9458636dea6bd5b8498d5601ecf3e`
- brace-expansion patch:
  `ba16c58317a7384674583eba75e1ea611f7173c8ce7dfad3bce294e02f15271c`
- canonical overrides, unchanged:
  `2a30c91c2e6d82386113535d8a0d03e3faeb2d4af0bc032b9200719e036b490a`

The two hosted OSV failures on this precursor are expected: this PR only admits
the final successor tuple, while #645 contains the patched dependency graph that
clears those scans.

## Ship Checklist

- [x] PR title follows the conventions
- [x] Performed a self-review of my own changes
- [x] Relevant automated checks and smoke tests pass
- [x] Architecture decision: Not applicable — this rotates reviewed SHA-256
      values inside the existing protected-runtime design without changing the
      architecture
- [x] ship skill used
- [x] local review run
- [x] validation run
