### PR TITLE
fix(ci): trust final brace-expansion runtime

### DIFF
--- a/scripts/vercel-cli-runtime-contract.mjs
+++ b/scripts/vercel-cli-runtime-contract.mjs
@@ -12,11 +12,11 @@ const BRACE_EXPANSION_ROOT_PATCH_PATH =
 // This one reviewed successor binds the runtime lockfile, override object, and
 // patch bytes. Replace all three together for any later reviewed patch update.
 const NEXT_BRACE_EXPANSION_RUNTIME_LOCKFILE_SHA256 =
-  "e9e0ff7ace696462de55c55644c4c4b743b9458636dea6bd5b8498d5601ecf3e";
+  "773226619ef0f73252aa2921cc3cedb69908bc21f08362857df25ae9777c0ff3";
 const NEXT_BRACE_EXPANSION_RUNTIME_OVERRIDE_SHA256 =
   "2a30c91c2e6d82386113535d8a0d03e3faeb2d4af0bc032b9200719e036b490a";
 const NEXT_BRACE_EXPANSION_PATCH_SHA256 =
-  "ba16c58317a7384674583eba75e1ea611f7173c8ce7dfad3bce294e02f15271c";
+  "7cf518c5d9dbf4290d0f48d3fa4673d4a163d0088d2d1294e417b9909c111833";
 
 // This reviewed controller-owned state permits the one-way runtime rotation
 // only with its matching canonical override and, when present, patch state. It


### PR DESCRIPTION
## The Problem

PR #645 head `525c76f889c8e30427e549927dbf2b9877074433` contains the
final reviewed standalone Vercel CLI runtime lockfile and brace-expansion patch.
The trusted controller on `main` at
`c91e1b4ae1751677f1a6dd82cb70b5623847a158` still admits the superseded
successor tuple from #649:

- runtime lockfile:
  `e9e0ff7ace696462de55c55644c4c4b743b9458636dea6bd5b8498d5601ecf3e`
- brace-expansion patch:
  `ba16c58317a7384674583eba75e1ea611f7173c8ce7dfad3bce294e02f15271c`

[Worker run 30215044523](https://github.com/mento-protocol/frontend-monorepo/actions/runs/30215044523)
loaded that exact controller and candidate, then stopped with
`Trusted Vercel CLI runtime lockfile is not exact`.

This creates a chicken-and-egg boundary: candidate code cannot change the
controller-owned trust state that must admit the candidate before its previews
can run.

## The Solution

Rotate only the two digest strings in the controller-owned successor tuple to
the exact final #645 values:

- runtime lockfile:
  `773226619ef0f73252aa2921cc3cedb69908bc21f08362857df25ae9777c0ff3`
- brace-expansion patch:
  `7cf518c5d9dbf4290d0f48d3fa4673d4a163d0088d2d1294e417b9909c111833`
- canonical overrides, unchanged:
  `2a30c91c2e6d82386113535d8a0d03e3faeb2d4af0bc032b9200719e036b490a`

The existing non-exported constant name, canonical override digest, and trust
structure stay unchanged. This precursor changes no dependency, lockfile, patch
payload, manifest, workflow, or other tracked file; #645 remains the OSV
remediation.

## Validation

- `node --test scripts/vercel-prebuilt.test.mjs scripts/vercel-prebuilt-workflow.test.mjs scripts/vercel-prebuilt-workflows.test.mjs scripts/vercel-production-shadow-workflow.test.mjs`
  — 116/116 passed
- `trunk fmt scripts/vercel-cli-runtime-contract.mjs` — clean
- `trunk check scripts/vercel-cli-runtime-contract.mjs` — clean
- `pnpm knip` — passed
- `pnpm adr:check` — passed
- `git diff --check` — passed
- SHA-256 recomputation from the exact #645 Git blobs — matched both values
- Structured autoreview deterministic guardrail — clean
- Fresh-context semantic autoreview — clean

Claude Security scan was unavailable in the Codex runtime.

## Ship Checklist

- [x] ship skill used
- [x] local review run
- [x] validation run
- [x] architecture decision: not applicable; this rotates exact digests inside
      the existing protected-runtime trust design
