### PR TITLE
docs(ui): clarify sidebar route map

### DIFF
--- a/apps/ui.mento.org/app/components/app-sidebar.tsx
+++ b/apps/ui.mento.org/app/components/app-sidebar.tsx
@@ -35,7 +35,7 @@ import {
   SidebarMenuSubItem,
 } from "@mento-protocol/ui";
 
-// Component categories, their page routes, and their individual components.
+// Sidebar categories map each route to the components shown on that page.
 const componentCategories = [
   {
     title: "Basic Components",


### PR DESCRIPTION
## The Problem

Issue #522 needs a controlled P2 push that can overlap its paired P1 push and prove exact-SHA production supersession. This canary must select only ui.mento.org and must not change runtime behavior.

## The Solution

Clarify one source comment in the UI sidebar. This single-file, comment-only P2 SHA starts from main `6e2f9110adf2ae3047d9c7edb30ba53bf879c8b6`; the exact planner selects only `ui` with reason `affected-packages`.

## Validation

- `pnpm vercel:plan --base 6e2f9110adf2ae3047d9c7edb30ba53bf879c8b6 --head 40ee1a5b2cdfb17cc3c4287c8cee787743544f58` → `{"deployments":["ui"],"base":"6e2f9110adf2ae3047d9c7edb30ba53bf879c8b6","head":"40ee1a5b2cdfb17cc3c4287c8cee787743544f58","reason":"affected-packages"}`
- `trunk check apps/ui.mento.org/app/components/app-sidebar.tsx`
- `git diff 6e2f9110adf2ae3047d9c7edb30ba53bf879c8b6..HEAD --check`
- `pnpm adr:check`
- Pre-push gate: 8/8 type-check tasks, Trunk on 1,166 files, and Knip passed
- Browser verification: not applicable because only a source comment changed; rendered output and runtime code are unchanged

## Ship Checklist

- [x] ship skill used
- [x] local review run
- [x] validation run
