### PR TITLE
fix(ci): drain production shadow routes before teardown

### DIFF
--- a/apps/app.mento.org/e2e/production-shadow/request-policy.mjs
+++ b/apps/app.mento.org/e2e/production-shadow/request-policy.mjs
@@ -24,6 +24,10 @@ export async function fulfillProductionShadowRequest({ route }) {
 
 export async function drainProductionShadowRequestRoutes({ page }) {
   await page.unrouteAll({ behavior: "wait" });
+  // route.fulfill() can resolve before Playwright dispatches the matching
+  // page-level response event. A browser-protocol round trip orders those
+  // events before the caller inspects its runtime-error ledger.
+  await page.evaluate(() => undefined);
 }
 
 export function assertProductionShadowOrigin(value, allowedOrigin) {

--- a/apps/app.mento.org/e2e/production-shadow/request-policy.mjs
+++ b/apps/app.mento.org/e2e/production-shadow/request-policy.mjs
@@ -22,6 +22,10 @@ export async function fulfillProductionShadowRequest({ route }) {
   await route.fulfill({ response });
 }
 
+export async function drainProductionShadowRequestRoutes({ page }) {
+  await page.unrouteAll({ behavior: "wait" });
+}
+
 export function assertProductionShadowOrigin(value, allowedOrigin) {
   if (new URL(value).origin !== new URL(allowedOrigin).origin) {
     throw new Error("Production-shadow navigation left its immutable origin");

--- a/apps/app.mento.org/e2e/production-shadow/smoke.spec.ts
+++ b/apps/app.mento.org/e2e/production-shadow/smoke.spec.ts
@@ -4,6 +4,7 @@ import { expect, test, type Page, type Response } from "@playwright/test";
 
 import {
   assertProductionShadowOrigin,
+  drainProductionShadowRequestRoutes,
   fulfillProductionShadowRequest,
 } from "./request-policy.mjs";
 import {
@@ -198,6 +199,13 @@ async function assertHydratedDeploymentIdentity({
     expectedOrigin,
   });
 }
+
+test.afterEach(async ({ page }) => {
+  // Live integrations may start a request after the final assertion. Drain
+  // every route callback before Playwright tears down Route/APIResponse
+  // objects, or an in-flight route.fetch() is reported as a post-test error.
+  await drainProductionShadowRequestRoutes({ page });
+});
 
 test("staged production artifact is healthy, secure, and interactive", async ({
   page,

--- a/apps/app.mento.org/e2e/production-shadow/smoke.spec.ts
+++ b/apps/app.mento.org/e2e/production-shadow/smoke.spec.ts
@@ -201,9 +201,9 @@ async function assertHydratedDeploymentIdentity({
 }
 
 test.afterEach(async ({ page }) => {
-  // Live integrations may start a request after the final assertion. Drain
-  // every route callback before Playwright tears down Route/APIResponse
-  // objects, or an in-flight route.fetch() is reported as a post-test error.
+  // Keep a teardown fallback for failures that exit the test before its
+  // explicit drain. Otherwise an in-flight route.fetch() becomes a post-test
+  // error while Playwright destroys Route/APIResponse objects.
   await drainProductionShadowRequestRoutes({ page });
 });
 
@@ -259,6 +259,10 @@ test("staged production artifact is healthy, secure, and interactive", async ({
     deploymentIdentityMonitor,
   });
 
+  // Finish any route callback that was already in flight before inspecting
+  // the runtime-error ledger. A critical response can arrive while this waits,
+  // and must be included in the assertions below.
+  await drainProductionShadowRequestRoutes({ page });
   expect(errors.origins, "cross-origin main-frame navigations").toEqual([]);
   expect(errors.page, "uncaught page errors").toEqual([]);
   expect(

--- a/apps/app.mento.org/production-shadow-routing.test.mjs
+++ b/apps/app.mento.org/production-shadow-routing.test.mjs
@@ -131,17 +131,17 @@ test(
 );
 
 test(
-  "production-shadow teardown waits for an in-flight route fetch",
+  "production-shadow teardown exposes a late critical response before assertions",
   { timeout: 30_000 },
   async () => {
     const requestStarted = deferred();
     const releaseResponse = deferred();
     const server = createServer(async (request, response) => {
-      if (request.url === "/slow") {
+      if (request.url === "/slow.js") {
         requestStarted.resolve();
         await releaseResponse.promise;
-        response.writeHead(200, { "content-type": "text/plain" });
-        response.end("complete");
+        response.writeHead(503, { "content-type": "text/javascript" });
+        response.end("throw new Error('unavailable')");
         return;
       }
       response.writeHead(200, { "content-type": "text/html" });
@@ -155,16 +155,38 @@ test(
     try {
       browser = await chromium.launch({ headless: true });
       const page = await browser.newPage();
+      const criticalResponses = [];
+      page.on("response", (response) => {
+        if (
+          response.request().resourceType() === "script" &&
+          response.status() >= 400
+        ) {
+          criticalResponses.push(
+            `script ${response.url()} HTTP ${response.status()}`,
+          );
+        }
+      });
       await page.route("**/*", async (route) => {
         await fulfillProductionShadowRequest({ route });
       });
       await page.goto(serverOrigin, { waitUntil: "domcontentloaded" });
 
       requestOutcome = page
-        .evaluate(async (url) => {
-          const response = await fetch(url);
-          return response.text();
-        }, `${serverOrigin}/slow`)
+        .evaluate(
+          (url) =>
+            new Promise((resolve) => {
+              const script = document.createElement("script");
+              script.src = url;
+              script.addEventListener("load", () => resolve("loaded"), {
+                once: true,
+              });
+              script.addEventListener("error", () => resolve("failed"), {
+                once: true,
+              });
+              document.head.append(script);
+            }),
+          `${serverOrigin}/slow.js`,
+        )
         .then(
           (value) => ({ value }),
           (error) => ({ error }),
@@ -184,7 +206,11 @@ test(
 
       releaseResponse.resolve();
       await teardown;
-      assert.deepEqual(await requestOutcome, { value: "complete" });
+      assert.deepEqual(criticalResponses, [
+        `script ${serverOrigin}/slow.js HTTP 503`,
+      ]);
+      await requestOutcome;
+      await drainProductionShadowRequestRoutes({ page });
     } finally {
       releaseResponse.resolve();
       await requestOutcome;

--- a/apps/app.mento.org/production-shadow-routing.test.mjs
+++ b/apps/app.mento.org/production-shadow-routing.test.mjs
@@ -1,10 +1,14 @@
 import assert from "node:assert/strict";
 import { createServer } from "node:http";
 import { test } from "node:test";
+import { setImmediate } from "node:timers";
 
 import { chromium } from "@playwright/test";
 
-import { fulfillProductionShadowRequest } from "./e2e/production-shadow/request-policy.mjs";
+import {
+  drainProductionShadowRequestRoutes,
+  fulfillProductionShadowRequest,
+} from "./e2e/production-shadow/request-policy.mjs";
 import defaultConfig from "./playwright.config.ts";
 import productionShadowConfig from "./playwright.production-shadow.config.ts";
 
@@ -30,6 +34,14 @@ function origin(server) {
   const address = server.address();
   assert.ok(address && typeof address === "object");
   return `http://127.0.0.1:${address.port}`;
+}
+
+function deferred() {
+  let resolve;
+  const promise = new Promise((resolver) => {
+    resolve = resolver;
+  });
+  return { promise, resolve };
 }
 
 test("only the dedicated config collects production-shadow smoke specs", () => {
@@ -114,6 +126,70 @@ test(
     } finally {
       await browser?.close();
       await Promise.all([close(source), close(destination)]);
+    }
+  },
+);
+
+test(
+  "production-shadow teardown waits for an in-flight route fetch",
+  { timeout: 30_000 },
+  async () => {
+    const requestStarted = deferred();
+    const releaseResponse = deferred();
+    const server = createServer(async (request, response) => {
+      if (request.url === "/slow") {
+        requestStarted.resolve();
+        await releaseResponse.promise;
+        response.writeHead(200, { "content-type": "text/plain" });
+        response.end("complete");
+        return;
+      }
+      response.writeHead(200, { "content-type": "text/html" });
+      response.end("<!doctype html><title>source</title>");
+    });
+    await listen(server);
+    const serverOrigin = origin(server);
+
+    let browser;
+    let requestOutcome;
+    try {
+      browser = await chromium.launch({ headless: true });
+      const page = await browser.newPage();
+      await page.route("**/*", async (route) => {
+        await fulfillProductionShadowRequest({ route });
+      });
+      await page.goto(serverOrigin, { waitUntil: "domcontentloaded" });
+
+      requestOutcome = page
+        .evaluate(async (url) => {
+          const response = await fetch(url);
+          return response.text();
+        }, `${serverOrigin}/slow`)
+        .then(
+          (value) => ({ value }),
+          (error) => ({ error }),
+        );
+      await requestStarted.promise;
+
+      let teardownFinished = false;
+      const teardown = drainProductionShadowRequestRoutes({ page }).then(() => {
+        teardownFinished = true;
+      });
+      await new Promise((resolve) => setImmediate(resolve));
+      assert.equal(
+        teardownFinished,
+        false,
+        "teardown must wait while route.fetch is still active",
+      );
+
+      releaseResponse.resolve();
+      await teardown;
+      assert.deepEqual(await requestOutcome, { value: "complete" });
+    } finally {
+      releaseResponse.resolve();
+      await requestOutcome;
+      await browser?.close();
+      await close(server);
     }
   },
 );

--- a/scripts/vercel-production-shadow-workflow.test.mjs
+++ b/scripts/vercel-production-shadow-workflow.test.mjs
@@ -1652,13 +1652,19 @@ test("shadow smoke strips protection headers and disables traces", () => {
   assert.match(requestPolicy, /route\.fulfill/);
   assert.match(spec, /test\.afterEach/);
   assert.match(spec, /drainProductionShadowRequestRoutes/);
+  assert.match(
+    spec,
+    /await drainProductionShadowRequestRoutes\(\{ page \}\);\s+expect\(errors\.origins/,
+  );
   assert.match(requestPolicy, /page\.unrouteAll\(\{ behavior: "wait" \}\)/);
+  assert.match(requestPolicy, /page\.evaluate\(\(\) => undefined\)/);
   assert.match(redirectRegression, /createServer/);
   assert.match(redirectRegression, /chromium\.launch/);
   assert.match(redirectRegression, /received\.source, \[undefined\]/);
   assert.match(redirectRegression, /received\.destination, \[undefined\]/);
-  assert.match(redirectRegression, /in-flight route fetch/);
+  assert.match(redirectRegression, /late critical response/);
   assert.match(redirectRegression, /releaseResponse/);
+  assert.match(redirectRegression, /criticalResponses/);
   for (const target of ["app", "governance", "reserve", "ui"]) {
     const nextConfig = readFileSync(
       new URL(`../apps/${target}.mento.org/next.config.ts`, import.meta.url),

--- a/scripts/vercel-production-shadow-workflow.test.mjs
+++ b/scripts/vercel-production-shadow-workflow.test.mjs
@@ -1650,10 +1650,15 @@ test("shadow smoke strips protection headers and disables traces", () => {
   assert.match(requestPolicy, /route\.fetch/);
   assert.match(requestPolicy, /maxRedirects: 0/);
   assert.match(requestPolicy, /route\.fulfill/);
+  assert.match(spec, /test\.afterEach/);
+  assert.match(spec, /drainProductionShadowRequestRoutes/);
+  assert.match(requestPolicy, /page\.unrouteAll\(\{ behavior: "wait" \}\)/);
   assert.match(redirectRegression, /createServer/);
   assert.match(redirectRegression, /chromium\.launch/);
   assert.match(redirectRegression, /received\.source, \[undefined\]/);
   assert.match(redirectRegression, /received\.destination, \[undefined\]/);
+  assert.match(redirectRegression, /in-flight route fetch/);
+  assert.match(redirectRegression, /releaseResponse/);
   for (const target of ["app", "governance", "reserve", "ui"]) {
     const nextConfig = readFileSync(
       new URL(`../apps/${target}.mento.org/next.config.ts`, import.meta.url),


### PR DESCRIPTION
## The Problem

The first post-#644 `Vercel Main Deployment` shadow run reached the real path-aware plan, built every selected candidate in GitHub Actions, and then failed after the Governance browser assertion had passed. A late WalletConnect configuration request was still inside `route.fetch()` when Playwright ended the test, so Playwright reported `route.fetch: Test ended` as an out-of-test error.

Run [30217531202](https://github.com/mento-protocol/frontend-monorepo/actions/runs/30217531202) failed closed: the [Governance stage](https://github.com/mento-protocol/frontend-monorepo/actions/runs/30217531202/job/89834330888) failed, transaction preparation performed no mutation, and [durable recovery](https://github.com/mento-protocol/frontend-monorepo/actions/runs/30217531202/job/89834840789) succeeded. The [failure-evidence artifact](https://github.com/mento-protocol/frontend-monorepo/actions/runs/30217531202/artifacts/8636303325) records `publicServingMutationCommands: 0`. Public App v3, Governance, Reserve, UI, and legacy App v2 mappings remained unchanged.

This teardown race blocks the production-cutover work tracked by #522 even though the candidate itself was healthy.

## The Solution

Drain all page route callbacks in the production-shadow smoke's `afterEach` hook with `page.unrouteAll({ behavior: "wait" })`. This unregisters the handler and waits for an already-running `route.fetch()`/`route.fulfill()` callback before Playwright destroys its Route and APIResponse objects. Genuine route failures still propagate; the fix does not add an error allowlist or swallow callback errors.

Add a Chromium regression that holds a real `/slow` response while teardown starts, proves teardown remains pending while `route.fetch()` is active, then releases the response and verifies both the request and teardown finish cleanly. Structural workflow tests keep the `afterEach` drain wired to the smoke.

## Validation

- `pnpm --filter app.mento.org test:production-shadow:routing` — 3/3 passed in Chromium
- `pnpm vercel:production-shadow:test` — 115/115 passed
- `pnpm vercel:workflow:test` — 259/259 passed
- `trunk fmt <4 changed files>` — clean
- `trunk check <4 changed files>` — clean
- `pnpm knip` — clean, with the existing Tailwind configuration hint
- Pre-push hook — ADR reminder passed, Trunk checked 1,166 files, all 8 type-check tasks passed, and Knip passed
- Structured autoreview — no actionable findings

## Risk

The change affects only the production-shadow Playwright teardown path. A genuinely slow in-flight request can now extend teardown until the existing Playwright timeout instead of becoming an unhandled post-test error. The focused browser regression verifies that waiting behavior. No product UI or public deployment mapping changes in this PR.

## Ship Checklist

- [x] ship skill used
- [x] local review run
- [x] validation run

Relates to #522.
