### PR TITLE
docs(ui): restore layout comment for supersession proof

### DIFF
--- a/apps/ui.mento.org/app/layout.tsx
+++ b/apps/ui.mento.org/app/layout.tsx
@@ -6,7 +6,7 @@ import localFont from "next/font/local";
 
 import { AppShell } from "./components/app-shell";
 
-// Use the vendored font instead of next/font/google to keep production builds hermetic:
+// Vendored locally instead of next/font/google so the production build is hermetic:
 // no build-time Google Fonts fetch that could silently fall back to a different
 // metric and shift every glyph — the #1 source of visual-regression flake.
 const inter = localFont({


### PR DESCRIPTION
## The Problem

Issue #522 needs a controlled pair of independent UI-only main pushes to prove that an older GitHub-owned Vercel production run exits before journal creation or public-serving mutations when a newer main commit supersedes it.

## The Solution

Restore the prior wording of one existing comment in the UI layout. This creates the first harmless UI-only commit in the proof pair without changing runtime behavior or rendered output.

## Validation

- `pnpm vercel:plan --base eabe84db18d034da3d790d23e7b92c256b66018c --head f97350a30844f40561544c414ea9dfbc06858fbe` — selected only `ui` with reason `affected-packages`
- `trunk check apps/ui.mento.org/app/layout.tsx`
- Normal pre-push gate — ADR reminder, Trunk across 1,166 files, 8/8 type-check tasks, and Knip passed
- `git diff --check`
- Full file matches its `b0d9be21` content

## Operational Notes

Do not merge this PR outside the orchestrated #522 supersession canary.

## Ship Checklist

- [x] ship skill used
- [x] local review run
- [x] validation run
