### PR TITLE
docs(ui): restore sidebar comment for supersession proof

### DIFF
--- a/apps/ui.mento.org/app/components/app-sidebar.tsx
+++ b/apps/ui.mento.org/app/components/app-sidebar.tsx
@@ -35,7 +35,7 @@ import {
   SidebarMenuSubItem,
 } from "@mento-protocol/ui";
 
-// Sidebar categories map each route to the components shown on that page.
+// Component categories, their page routes, and their individual components.
 const componentCategories = [
   {
     title: "Basic Components",


### PR DESCRIPTION
## The Problem

Issue #522 needs a controlled pair of independent UI-only main pushes to prove that an older GitHub-owned Vercel production run exits before journal creation or public-serving mutations when a newer main commit supersedes it.

## The Solution

Restore the prior wording of one existing comment in the UI sidebar. This creates the second harmless UI-only commit in the proof pair without changing runtime behavior or rendered output.

## Validation

- `pnpm vercel:plan --base eabe84db18d034da3d790d23e7b92c256b66018c --head 69a23e13c18787e1c83bd503bcde62e18a4cb9e0` — selected only `ui` with reason `affected-packages`
- `trunk check apps/ui.mento.org/app/components/app-sidebar.tsx`
- Normal pre-push gate — ADR reminder, Trunk across 1,166 files, 8/8 type-check tasks, and Knip passed
- `git diff --check`
- Full file matches its `d5844009` and `b0d9be21` content

## Operational Notes

Do not merge this PR outside the orchestrated #522 supersession canary.

## Ship Checklist

- [x] ship skill used
- [x] local review run
- [x] validation run
