### PR TITLE
docs(ui): add final UI convergence proof

### DIFF
--- a/apps/ui.mento.org/app/components/app-shell.tsx
+++ b/apps/ui.mento.org/app/components/app-shell.tsx
@@ -8,6 +8,7 @@ import {
 import { CustomAppSidebar } from "./app-sidebar";
 import { ThemeProvider } from "next-themes";
 
+// ThemeProvider owns the document class so every showcase route shares one color-mode contract.
 export function AppShell({ children }: { children: React.ReactNode }) {
   return (
     <ThemeProvider


### PR DESCRIPTION
## The Problem

The deployment convergence work needs one final, non-empty UI-only source change from exact main so the production planner can prove it selects only the UI target.

## The Solution

Clarify that the showcase ThemeProvider owns the document class and therefore keeps every showcase route on one color-mode contract.

## Validation

- `pnpm --filter ui.mento.org lint`
- `pnpm --filter ui.mento.org check-types`
- `pnpm vercel:primitives:test`
- `pnpm vercel:plan --base b0d9be219eece17bcdda54dd24fcb5b770bdca12 --head 19db4dd8cedd8cd4b01eba5a162bb1640d0a3b1e` -> `deployments:["ui"]`, `reason:"affected-packages"`
- `pnpm vercel:plan --base fb6d8e909a3af65021a39416bf2c75ce4e6763d5 --head 19db4dd8cedd8cd4b01eba5a162bb1640d0a3b1e` -> `deployments:["ui"]`, `reason:"affected-packages"`

## Ship Checklist

- [x] ship skill used
- [x] local review run
- [x] validation run