### PR TITLE
docs(ui): clarify read-only Datepicker showcase

### DIFF
--- a/apps/ui.mento.org/app/form-components/page.tsx
+++ b/apps/ui.mento.org/app/form-components/page.tsx
@@ -189,6 +189,7 @@ export default function FormComponentsPage() {
             </CardDescription>
           </CardHeader>
           <CardContent>
+            {/* This showcase keeps Datepicker read-only so its display stays stable. */}
             <Datepicker
               value={DATEPICKER_DEFAULT_DATE}
               onChange={() => {}}

--- a/apps/ui.mento.org/app/form-components/page.tsx
+++ b/apps/ui.mento.org/app/form-components/page.tsx
@@ -189,7 +189,7 @@ export default function FormComponentsPage() {
             </CardDescription>
           </CardHeader>
           <CardContent>
-            {/* This showcase keeps Datepicker read-only so its display stays stable. */}
+            {/* This example leaves parent state unchanged to show Datepicker's internal interaction. */}
             <Datepicker
               value={DATEPICKER_DEFAULT_DATE}
               onChange={() => {}}


### PR DESCRIPTION
## The Problem

The Datepicker showcase passes a stable value with a no-op change handler, but the read-only example intent is implicit.

## The Solution

Document that the showcase keeps the Datepicker read-only so its displayed value remains stable.

## Validation

- `trunk check apps/ui.mento.org/app/form-components/page.tsx`
- `pnpm --filter ui.mento.org lint`
- `pnpm vercel:primitives:test`
- `pnpm vercel:plan --base b0d9be219eece17bcdda54dd24fcb5b770bdca12 --head fed00de50cbf2e1f484258637c7dd4c6fc35c46d` → `deployments:["ui"]`, `affected-packages`
- `pnpm vercel:plan --base fb6d8e909a3af65021a39416bf2c75ce4e6763d5 --head fed00de50cbf2e1f484258637c7dd4c6fc35c46d` → `deployments:["ui"]`, `affected-packages`