### PR TITLE
fix(ci): recognize independent Vercel ownership states

### DIFF
--- a/docs/vercel-deployments.md
+++ b/docs/vercel-deployments.md
@@ -302,7 +302,7 @@ accepted. It changes the controller from literal `shadow` to `active` and
 changes Vercel Git ownership in the same commit:
 
 - Governance, Reserve, and UI:
-  `git.deploymentEnabled` becomes `{"**": false}`;
+  `git.deploymentEnabled` becomes the boolean `false`;
 - App: `git.deploymentEnabled` becomes
   `{"**": false, "v2": true}`.
 

--- a/scripts/vercel-git-ownership.test.mjs
+++ b/scripts/vercel-git-ownership.test.mjs
@@ -4,9 +4,11 @@ import { test } from "node:test";
 
 import { parse } from "yaml";
 import {
+  MAIN_OWNERSHIP_MODES,
   PREVIEW_OWNERSHIP_MODES,
   PREVIEW_TARGET_CONFIG,
   PREVIEW_TARGETS,
+  vercelConfigurationForOwnership,
 } from "./vercel-preview-targets.mjs";
 
 const ACTIVE_CONTROLLER_MODE = "active";
@@ -18,6 +20,13 @@ const controller = parse(
       "../.github/workflows/vercel-preview-controller.yml",
       import.meta.url,
     ),
+    "utf8",
+  ),
+);
+
+const mainDeployment = parse(
+  readFileSync(
+    new URL("../.github/workflows/vercel-main-deployment.yml", import.meta.url),
     "utf8",
   ),
 );
@@ -49,36 +58,154 @@ function assertControllerMode(controllerMode) {
   );
 }
 
+function ownershipConfiguration(
+  targetConfiguration,
+  previewOwnershipMode = targetConfiguration.ownershipMode,
+  mainOwnershipMode = targetConfiguration.mainOwnershipMode,
+) {
+  return vercelConfigurationForOwnership({
+    previewOwnershipMode,
+    mainOwnershipMode,
+    active: targetConfiguration.activeVercelConfiguration,
+    mainShadow: targetConfiguration.mainShadowVercelConfiguration,
+    previewShadow: targetConfiguration.previewShadowVercelConfiguration,
+    native: targetConfiguration.nativeVercelConfiguration,
+  });
+}
+
+function assertMainWorkflowOwnershipModes(workflowMode, targetConfigurations) {
+  if (!["active", "shadow"].includes(workflowMode)) {
+    throw new Error("Main workflow mode must match a reviewed exact state");
+  }
+  if (
+    workflowMode === "shadow" &&
+    targetConfigurations.some(
+      ({ mainOwnershipMode }) =>
+        mainOwnershipMode !== MAIN_OWNERSHIP_MODES.SHADOW,
+    )
+  ) {
+    throw new Error("Shadow workflow requires every main owner to be native");
+  }
+}
+
 test("repository pairs every target with its canonical exact ownership configuration", () => {
   assertControllerMode(controller.env.VERCEL_PREVIEW_CONTROLLER_MODE);
   for (const target of PREVIEW_TARGETS) {
     const targetConfiguration = PREVIEW_TARGET_CONFIG[target];
-    const expected =
-      targetConfiguration.ownershipMode === PREVIEW_OWNERSHIP_MODES.GITHUB
-        ? targetConfiguration.githubVercelConfiguration
-        : targetConfiguration.nativeVercelConfiguration;
+    const expected = ownershipConfiguration(targetConfiguration);
+    assert.equal(targetConfiguration.trackedVercelConfiguration, expected);
     assertExactOwnership(configuration(target), expected);
   }
 });
 
-test("every target exposes reviewed, distinct native and GitHub ownership states", () => {
+test("main workflow mode and both per-target Git owners change atomically", () => {
+  assertMainWorkflowOwnershipModes(
+    mainDeployment.env.VERCEL_MAIN_MODE,
+    Object.values(PREVIEW_TARGET_CONFIG),
+  );
   for (const target of PREVIEW_TARGETS) {
-    const { githubVercelConfiguration, nativeVercelConfiguration } =
-      PREVIEW_TARGET_CONFIG[target];
-    assert.notDeepEqual(githubVercelConfiguration, nativeVercelConfiguration);
-    assertExactOwnership(
-      structuredClone(githubVercelConfiguration),
-      githubVercelConfiguration,
-    );
-    assertExactOwnership(
-      structuredClone(nativeVercelConfiguration),
-      nativeVercelConfiguration,
-    );
-    assert.equal(githubVercelConfiguration.git.deploymentEnabled["**"], false);
-    assert.equal(githubVercelConfiguration.git.deploymentEnabled.main, true);
+    const targetConfiguration = PREVIEW_TARGET_CONFIG[target];
+    const expectedTrackedConfiguration =
+      ownershipConfiguration(targetConfiguration);
     assert.equal(
-      nativeVercelConfiguration.git.deploymentEnabled["dependabot/**"],
-      false,
+      targetConfiguration.trackedVercelConfiguration,
+      expectedTrackedConfiguration,
+    );
+    assertExactOwnership(configuration(target), expectedTrackedConfiguration);
+  }
+  assert.throws(
+    () =>
+      ownershipConfiguration(
+        PREVIEW_TARGET_CONFIG.app,
+        PREVIEW_OWNERSHIP_MODES.GITHUB,
+        "active",
+      ),
+    /Preview and main ownership modes must match a reviewed exact state/,
+  );
+  assert.doesNotThrow(() =>
+    assertMainWorkflowOwnershipModes("active", [
+      {
+        mainOwnershipMode: MAIN_OWNERSHIP_MODES.GITHUB,
+      },
+      {
+        mainOwnershipMode: MAIN_OWNERSHIP_MODES.SHADOW,
+      },
+    ]),
+  );
+  assert.doesNotThrow(() =>
+    assertMainWorkflowOwnershipModes("shadow", [
+      {
+        mainOwnershipMode: MAIN_OWNERSHIP_MODES.SHADOW,
+      },
+    ]),
+  );
+  assert.throws(
+    () =>
+      assertMainWorkflowOwnershipModes("shadow", [
+        {
+          mainOwnershipMode: MAIN_OWNERSHIP_MODES.GITHUB,
+        },
+      ]),
+    /Shadow workflow requires every main owner to be native/,
+  );
+  assert.throws(
+    () => assertMainWorkflowOwnershipModes("observe-only", []),
+    /Main workflow mode must match a reviewed exact state/,
+  );
+});
+
+test("every target exposes four distinct exact preview and main ownership states", () => {
+  for (const target of PREVIEW_TARGETS) {
+    const {
+      activeVercelConfiguration,
+      mainShadowVercelConfiguration,
+      previewShadowVercelConfiguration,
+      nativeVercelConfiguration,
+    } = PREVIEW_TARGET_CONFIG[target];
+    const exactStates = [
+      activeVercelConfiguration,
+      mainShadowVercelConfiguration,
+      previewShadowVercelConfiguration,
+      nativeVercelConfiguration,
+    ];
+    assert.equal(
+      new Set(exactStates.map((state) => JSON.stringify(state))).size,
+      exactStates.length,
+    );
+    for (const exactState of exactStates) {
+      assertExactOwnership(structuredClone(exactState), exactState);
+    }
+    assert.equal(
+      ownershipConfiguration(
+        PREVIEW_TARGET_CONFIG[target],
+        PREVIEW_OWNERSHIP_MODES.GITHUB,
+        MAIN_OWNERSHIP_MODES.GITHUB,
+      ),
+      activeVercelConfiguration,
+    );
+    assert.equal(
+      ownershipConfiguration(
+        PREVIEW_TARGET_CONFIG[target],
+        PREVIEW_OWNERSHIP_MODES.GITHUB,
+        MAIN_OWNERSHIP_MODES.SHADOW,
+      ),
+      mainShadowVercelConfiguration,
+    );
+    assert.equal(
+      ownershipConfiguration(
+        PREVIEW_TARGET_CONFIG[target],
+        PREVIEW_OWNERSHIP_MODES.SHADOW,
+        MAIN_OWNERSHIP_MODES.GITHUB,
+      ),
+      previewShadowVercelConfiguration,
+    );
+    assert.equal(
+      ownershipConfiguration(
+        PREVIEW_TARGET_CONFIG[target],
+        PREVIEW_OWNERSHIP_MODES.SHADOW,
+        MAIN_OWNERSHIP_MODES.SHADOW,
+      ),
+      nativeVercelConfiguration,
     );
   }
   assert.throws(
@@ -87,19 +214,56 @@ test("every target exposes reviewed, distinct native and GitHub ownership states
   );
 });
 
-test("ownership configurations keep only their reviewed branch exceptions", () => {
+test("active ownership disables every native branch except App v2", () => {
   assert.deepEqual(
-    PREVIEW_TARGET_CONFIG.app.githubVercelConfiguration.git.deploymentEnabled,
+    PREVIEW_TARGET_CONFIG.app.activeVercelConfiguration.git.deploymentEnabled,
+    { "**": false, v2: true },
+  );
+  for (const target of ["governance", "reserve", "ui"]) {
+    assert.equal(
+      PREVIEW_TARGET_CONFIG[target].activeVercelConfiguration.git
+        .deploymentEnabled,
+      false,
+    );
+  }
+});
+
+test("main-shadow rollback keeps previews GitHub-owned and main native", () => {
+  assert.deepEqual(
+    PREVIEW_TARGET_CONFIG.app.mainShadowVercelConfiguration.git
+      .deploymentEnabled,
     { "**": false, main: true, v2: true },
   );
   for (const target of ["governance", "reserve", "ui"]) {
     assert.deepEqual(
-      PREVIEW_TARGET_CONFIG[target].githubVercelConfiguration.git
+      PREVIEW_TARGET_CONFIG[target].mainShadowVercelConfiguration.git
         .deploymentEnabled,
       { "**": false, main: true },
     );
   }
-  for (const target of PREVIEW_TARGETS) {
+});
+
+test("preview-shadow rollback keeps native previews and GitHub-owned main independent", () => {
+  assert.deepEqual(
+    PREVIEW_TARGET_CONFIG.app.previewShadowVercelConfiguration.git
+      .deploymentEnabled,
+    { "dependabot/**": false, main: false, v2: true },
+  );
+  for (const target of ["governance", "reserve", "ui"]) {
+    assert.deepEqual(
+      PREVIEW_TARGET_CONFIG[target].previewShadowVercelConfiguration.git
+        .deploymentEnabled,
+      { "dependabot/**": false, main: false },
+    );
+  }
+});
+
+test("full native rollback keeps the Dependabot exclusion and App v2", () => {
+  assert.deepEqual(
+    PREVIEW_TARGET_CONFIG.app.nativeVercelConfiguration.git.deploymentEnabled,
+    { "dependabot/**": false, v2: true },
+  );
+  for (const target of ["governance", "reserve", "ui"]) {
     assert.deepEqual(
       PREVIEW_TARGET_CONFIG[target].nativeVercelConfiguration.git
         .deploymentEnabled,
@@ -124,6 +288,22 @@ test("current rollout keeps every branch-preview target GitHub-only", () => {
         PREVIEW_OWNERSHIP_MODES.GITHUB,
     ),
     PREVIEW_TARGETS,
+  );
+  assert.deepEqual(
+    PREVIEW_TARGETS.filter(
+      (target) =>
+        PREVIEW_TARGET_CONFIG[target].mainOwnershipMode ===
+        MAIN_OWNERSHIP_MODES.SHADOW,
+    ),
+    PREVIEW_TARGETS,
+  );
+  assert.deepEqual(
+    PREVIEW_TARGETS.filter(
+      (target) =>
+        PREVIEW_TARGET_CONFIG[target].mainOwnershipMode ===
+        MAIN_OWNERSHIP_MODES.GITHUB,
+    ),
+    [],
   );
   assert.equal(controller.env.VERCEL_PREVIEW_CONTROLLER_MODE, "active");
 });

--- a/scripts/vercel-git-ownership.test.mjs
+++ b/scripts/vercel-git-ownership.test.mjs
@@ -73,6 +73,9 @@ function ownershipConfiguration(
   });
 }
 
+// Active permits a mixed map for target-local rollback. The main planner
+// partitions GitHub-owned targets for mutation and native-owned targets for
+// shadow preparation; shadow mode requires every target to remain native-owned.
 function assertMainWorkflowOwnershipModes(workflowMode, targetConfigurations) {
   if (!["active", "shadow"].includes(workflowMode)) {
     throw new Error("Main workflow mode must match a reviewed exact state");
@@ -98,7 +101,7 @@ test("repository pairs every target with its canonical exact ownership configura
   }
 });
 
-test("main workflow mode and both per-target Git owners change atomically", () => {
+test("main shadow requires every owner to be native; active permits target-local rollback", () => {
   assertMainWorkflowOwnershipModes(
     mainDeployment.env.VERCEL_MAIN_MODE,
     Object.values(PREVIEW_TARGET_CONFIG),

--- a/scripts/vercel-git-ownership.test.mjs
+++ b/scripts/vercel-git-ownership.test.mjs
@@ -258,12 +258,8 @@ test("preview-shadow rollback keeps native previews and GitHub-owned main indepe
   }
 });
 
-test("full native rollback keeps the Dependabot exclusion and App v2", () => {
-  assert.deepEqual(
-    PREVIEW_TARGET_CONFIG.app.nativeVercelConfiguration.git.deploymentEnabled,
-    { "dependabot/**": false, v2: true },
-  );
-  for (const target of ["governance", "reserve", "ui"]) {
+test("full native rollback keeps only the Dependabot exclusion", () => {
+  for (const target of PREVIEW_TARGETS) {
     assert.deepEqual(
       PREVIEW_TARGET_CONFIG[target].nativeVercelConfiguration.git
         .deploymentEnabled,

--- a/scripts/vercel-preview-controller.mjs
+++ b/scripts/vercel-preview-controller.mjs
@@ -3759,15 +3759,26 @@ async function previewOwnerAtSha(github, context, target, sha) {
   } catch {
     throw new Error(`Candidate ${target} Vercel configuration is malformed`);
   }
+  return previewOwnerForVercelConfiguration(target, configuration);
+}
+
+export function previewOwnerForVercelConfiguration(target, configuration) {
+  const targetConfiguration = previewTargetConfig(target);
   plainObject(configuration, `Candidate ${target} Vercel configuration`);
   const candidate = canonicalJson(configuration);
   if (
-    candidate === canonicalJson(targetConfiguration.githubVercelConfiguration)
+    [
+      targetConfiguration.activeVercelConfiguration,
+      targetConfiguration.mainShadowVercelConfiguration,
+    ].some((expected) => candidate === canonicalJson(expected))
   ) {
     return PREVIEW_OWNER_GITHUB;
   }
   if (
-    candidate === canonicalJson(targetConfiguration.nativeVercelConfiguration)
+    [
+      targetConfiguration.previewShadowVercelConfiguration,
+      targetConfiguration.nativeVercelConfiguration,
+    ].some((expected) => candidate === canonicalJson(expected))
   ) {
     return PREVIEW_OWNER_NATIVE;
   }

--- a/scripts/vercel-preview-controller.test.mjs
+++ b/scripts/vercel-preview-controller.test.mjs
@@ -19,6 +19,7 @@ import {
   dependabotIntakeRunName,
   normalizePlannerResult,
   parseWorkerRunName,
+  previewOwnerForVercelConfiguration,
   publishDependabotUnsupported,
   postWorkerRecoveryError,
   prepareBootstrap,
@@ -43,7 +44,6 @@ import {
 } from "./vercel-preview-controller.mjs";
 import { validateGitBranch } from "./vercel-prebuilt-workflow.mjs";
 import {
-  PREVIEW_OWNERSHIP_MODES,
   PREVIEW_TARGET_CONFIG,
   PREVIEW_TARGETS,
 } from "./vercel-preview-targets.mjs";
@@ -57,15 +57,37 @@ const SHA = Object.fromEntries(
   ]),
 );
 const UI_VERCEL_CONFIGURATION_PATH = "apps/ui.mento.org/vercel.json";
-const GITHUB_OWNED_UI_VERCEL_CONFIGURATION = {
-  $schema: "https://openapi.vercel.sh/vercel.json",
-  git: { deploymentEnabled: { "**": false, main: true } },
-};
-const NATIVE_OWNED_UI_VERCEL_CONFIGURATION = {
-  $schema: "https://openapi.vercel.sh/vercel.json",
-  git: { deploymentEnabled: { "dependabot/**": false } },
-};
+const GITHUB_OWNED_UI_VERCEL_CONFIGURATION = structuredClone(
+  PREVIEW_TARGET_CONFIG.ui.trackedVercelConfiguration,
+);
+const NATIVE_OWNED_UI_VERCEL_CONFIGURATION = structuredClone(
+  PREVIEW_TARGET_CONFIG.ui.previewShadowVercelConfiguration,
+);
 const workerDispatchClients = new WeakMap();
+
+test("preview owner classification accepts both exact main states independently", () => {
+  for (const target of PREVIEW_TARGETS) {
+    const targetConfiguration = PREVIEW_TARGET_CONFIG[target];
+    for (const field of [
+      "activeVercelConfiguration",
+      "mainShadowVercelConfiguration",
+    ]) {
+      assert.equal(
+        previewOwnerForVercelConfiguration(target, targetConfiguration[field]),
+        "github-actions",
+      );
+    }
+    for (const field of [
+      "previewShadowVercelConfiguration",
+      "nativeVercelConfiguration",
+    ]) {
+      assert.equal(
+        previewOwnerForVercelConfiguration(target, targetConfiguration[field]),
+        "native-vercel",
+      );
+    }
+  }
+});
 
 function reconcilePreview(options) {
   const workerDispatchGithub = Object.hasOwn(options, "workerDispatchGithub")
@@ -3904,11 +3926,8 @@ function fakeGitHub({
             const targetConfiguration = PREVIEW_TARGET_CONFIG[target];
             const configuration =
               allCandidateTargetsNative && request.ref !== SHA.E
-                ? targetConfiguration.nativeVercelConfiguration
-                : targetConfiguration.ownershipMode ===
-                    PREVIEW_OWNERSHIP_MODES.GITHUB
-                  ? targetConfiguration.githubVercelConfiguration
-                  : targetConfiguration.nativeVercelConfiguration;
+                ? targetConfiguration.previewShadowVercelConfiguration
+                : targetConfiguration.trackedVercelConfiguration;
             const text = `${JSON.stringify(configuration, null, 2)}\n`;
             const content = Buffer.from(text, "utf8");
             return {

--- a/scripts/vercel-preview-targets.mjs
+++ b/scripts/vercel-preview-targets.mjs
@@ -3,6 +3,11 @@ export const PREVIEW_OWNERSHIP_MODES = Object.freeze({
   SHADOW: "shadow",
 });
 
+export const MAIN_OWNERSHIP_MODES = Object.freeze({
+  GITHUB: "github",
+  SHADOW: "shadow",
+});
+
 const NATIVE_VERCEL_CONFIGURATION = Object.freeze({
   $schema: "https://openapi.vercel.sh/vercel.json",
   git: Object.freeze({
@@ -10,59 +15,185 @@ const NATIVE_VERCEL_CONFIGURATION = Object.freeze({
   }),
 });
 
-const GITHUB_VERCEL_CONFIGURATION = Object.freeze({
+const APP_NATIVE_VERCEL_CONFIGURATION = Object.freeze({
+  $schema: "https://openapi.vercel.sh/vercel.json",
+  git: Object.freeze({
+    deploymentEnabled: Object.freeze({
+      "dependabot/**": false,
+      v2: true,
+    }),
+  }),
+});
+
+const ACTIVE_GITHUB_VERCEL_CONFIGURATION = Object.freeze({
+  $schema: "https://openapi.vercel.sh/vercel.json",
+  git: Object.freeze({
+    deploymentEnabled: false,
+  }),
+});
+
+const APP_ACTIVE_GITHUB_VERCEL_CONFIGURATION = Object.freeze({
+  $schema: "https://openapi.vercel.sh/vercel.json",
+  git: Object.freeze({
+    deploymentEnabled: Object.freeze({ "**": false, v2: true }),
+  }),
+});
+
+const MAIN_SHADOW_GITHUB_VERCEL_CONFIGURATION = Object.freeze({
   $schema: "https://openapi.vercel.sh/vercel.json",
   git: Object.freeze({
     deploymentEnabled: Object.freeze({ "**": false, main: true }),
   }),
 });
 
-const APP_GITHUB_VERCEL_CONFIGURATION = Object.freeze({
+const APP_MAIN_SHADOW_GITHUB_VERCEL_CONFIGURATION = Object.freeze({
   $schema: "https://openapi.vercel.sh/vercel.json",
   git: Object.freeze({
     deploymentEnabled: Object.freeze({ "**": false, main: true, v2: true }),
   }),
 });
 
+const PREVIEW_SHADOW_GITHUB_MAIN_VERCEL_CONFIGURATION = Object.freeze({
+  $schema: "https://openapi.vercel.sh/vercel.json",
+  git: Object.freeze({
+    deploymentEnabled: Object.freeze({
+      "dependabot/**": false,
+      main: false,
+    }),
+  }),
+});
+
+const APP_PREVIEW_SHADOW_GITHUB_MAIN_VERCEL_CONFIGURATION = Object.freeze({
+  $schema: "https://openapi.vercel.sh/vercel.json",
+  git: Object.freeze({
+    deploymentEnabled: Object.freeze({
+      "dependabot/**": false,
+      main: false,
+      v2: true,
+    }),
+  }),
+});
+
+export function vercelConfigurationForOwnership({
+  previewOwnershipMode,
+  mainOwnershipMode,
+  active,
+  mainShadow,
+  previewShadow,
+  native,
+}) {
+  if (previewOwnershipMode === PREVIEW_OWNERSHIP_MODES.GITHUB) {
+    if (mainOwnershipMode === MAIN_OWNERSHIP_MODES.GITHUB) {
+      return active;
+    }
+    if (mainOwnershipMode === MAIN_OWNERSHIP_MODES.SHADOW) {
+      return mainShadow;
+    }
+  }
+  if (previewOwnershipMode === PREVIEW_OWNERSHIP_MODES.SHADOW) {
+    if (mainOwnershipMode === MAIN_OWNERSHIP_MODES.GITHUB) {
+      return previewShadow;
+    }
+    if (mainOwnershipMode === MAIN_OWNERSHIP_MODES.SHADOW) {
+      return native;
+    }
+  }
+  throw new Error(
+    "Preview and main ownership modes must match a reviewed exact state",
+  );
+}
+
+function targetConfiguration({
+  logicalTarget,
+  workspacePackage,
+  expectedRootDirectory,
+  projectVariable,
+  ownershipMode,
+  mainOwnershipMode,
+  vercelConfigurationPath,
+  activeVercelConfiguration,
+  mainShadowVercelConfiguration,
+  previewShadowVercelConfiguration,
+  nativeVercelConfiguration,
+}) {
+  return Object.freeze({
+    logicalTarget,
+    workspacePackage,
+    expectedRootDirectory,
+    projectVariable,
+    ownershipMode,
+    mainOwnershipMode,
+    vercelConfigurationPath,
+    activeVercelConfiguration,
+    mainShadowVercelConfiguration,
+    previewShadowVercelConfiguration,
+    nativeVercelConfiguration,
+    trackedVercelConfiguration: vercelConfigurationForOwnership({
+      previewOwnershipMode: ownershipMode,
+      mainOwnershipMode,
+      active: activeVercelConfiguration,
+      mainShadow: mainShadowVercelConfiguration,
+      previewShadow: previewShadowVercelConfiguration,
+      native: nativeVercelConfiguration,
+    }),
+  });
+}
+
 export const PREVIEW_TARGET_CONFIG = Object.freeze({
-  app: Object.freeze({
+  app: targetConfiguration({
     logicalTarget: "app",
     workspacePackage: "app.mento.org",
     expectedRootDirectory: "apps/app.mento.org",
     projectVariable: "VERCEL_PROJECT_ID_APP",
     ownershipMode: PREVIEW_OWNERSHIP_MODES.GITHUB,
+    mainOwnershipMode: MAIN_OWNERSHIP_MODES.SHADOW,
     vercelConfigurationPath: "apps/app.mento.org/vercel.json",
-    githubVercelConfiguration: APP_GITHUB_VERCEL_CONFIGURATION,
-    nativeVercelConfiguration: NATIVE_VERCEL_CONFIGURATION,
+    activeVercelConfiguration: APP_ACTIVE_GITHUB_VERCEL_CONFIGURATION,
+    mainShadowVercelConfiguration: APP_MAIN_SHADOW_GITHUB_VERCEL_CONFIGURATION,
+    previewShadowVercelConfiguration:
+      APP_PREVIEW_SHADOW_GITHUB_MAIN_VERCEL_CONFIGURATION,
+    nativeVercelConfiguration: APP_NATIVE_VERCEL_CONFIGURATION,
   }),
-  governance: Object.freeze({
+  governance: targetConfiguration({
     logicalTarget: "governance",
     workspacePackage: "governance.mento.org",
     expectedRootDirectory: "apps/governance.mento.org",
     projectVariable: "VERCEL_PROJECT_ID_GOVERNANCE",
     ownershipMode: PREVIEW_OWNERSHIP_MODES.GITHUB,
+    mainOwnershipMode: MAIN_OWNERSHIP_MODES.SHADOW,
     vercelConfigurationPath: "apps/governance.mento.org/vercel.json",
-    githubVercelConfiguration: GITHUB_VERCEL_CONFIGURATION,
+    activeVercelConfiguration: ACTIVE_GITHUB_VERCEL_CONFIGURATION,
+    mainShadowVercelConfiguration: MAIN_SHADOW_GITHUB_VERCEL_CONFIGURATION,
+    previewShadowVercelConfiguration:
+      PREVIEW_SHADOW_GITHUB_MAIN_VERCEL_CONFIGURATION,
     nativeVercelConfiguration: NATIVE_VERCEL_CONFIGURATION,
   }),
-  reserve: Object.freeze({
+  reserve: targetConfiguration({
     logicalTarget: "reserve",
     workspacePackage: "reserve.mento.org",
     expectedRootDirectory: "apps/reserve.mento.org",
     projectVariable: "VERCEL_PROJECT_ID_RESERVE",
     ownershipMode: PREVIEW_OWNERSHIP_MODES.GITHUB,
+    mainOwnershipMode: MAIN_OWNERSHIP_MODES.SHADOW,
     vercelConfigurationPath: "apps/reserve.mento.org/vercel.json",
-    githubVercelConfiguration: GITHUB_VERCEL_CONFIGURATION,
+    activeVercelConfiguration: ACTIVE_GITHUB_VERCEL_CONFIGURATION,
+    mainShadowVercelConfiguration: MAIN_SHADOW_GITHUB_VERCEL_CONFIGURATION,
+    previewShadowVercelConfiguration:
+      PREVIEW_SHADOW_GITHUB_MAIN_VERCEL_CONFIGURATION,
     nativeVercelConfiguration: NATIVE_VERCEL_CONFIGURATION,
   }),
-  ui: Object.freeze({
+  ui: targetConfiguration({
     logicalTarget: "ui",
     workspacePackage: "ui.mento.org",
     expectedRootDirectory: "apps/ui.mento.org",
     projectVariable: "VERCEL_PROJECT_ID_UI",
     ownershipMode: PREVIEW_OWNERSHIP_MODES.GITHUB,
+    mainOwnershipMode: MAIN_OWNERSHIP_MODES.SHADOW,
     vercelConfigurationPath: "apps/ui.mento.org/vercel.json",
-    githubVercelConfiguration: GITHUB_VERCEL_CONFIGURATION,
+    activeVercelConfiguration: ACTIVE_GITHUB_VERCEL_CONFIGURATION,
+    mainShadowVercelConfiguration: MAIN_SHADOW_GITHUB_VERCEL_CONFIGURATION,
+    previewShadowVercelConfiguration:
+      PREVIEW_SHADOW_GITHUB_MAIN_VERCEL_CONFIGURATION,
     nativeVercelConfiguration: NATIVE_VERCEL_CONFIGURATION,
   }),
 });

--- a/scripts/vercel-preview-targets.mjs
+++ b/scripts/vercel-preview-targets.mjs
@@ -15,16 +15,6 @@ const NATIVE_VERCEL_CONFIGURATION = Object.freeze({
   }),
 });
 
-const APP_NATIVE_VERCEL_CONFIGURATION = Object.freeze({
-  $schema: "https://openapi.vercel.sh/vercel.json",
-  git: Object.freeze({
-    deploymentEnabled: Object.freeze({
-      "dependabot/**": false,
-      v2: true,
-    }),
-  }),
-});
-
 const ACTIVE_GITHUB_VERCEL_CONFIGURATION = Object.freeze({
   $schema: "https://openapi.vercel.sh/vercel.json",
   git: Object.freeze({
@@ -152,7 +142,7 @@ export const PREVIEW_TARGET_CONFIG = Object.freeze({
     mainShadowVercelConfiguration: APP_MAIN_SHADOW_GITHUB_VERCEL_CONFIGURATION,
     previewShadowVercelConfiguration:
       APP_PREVIEW_SHADOW_GITHUB_MAIN_VERCEL_CONFIGURATION,
-    nativeVercelConfiguration: APP_NATIVE_VERCEL_CONFIGURATION,
+    nativeVercelConfiguration: NATIVE_VERCEL_CONFIGURATION,
   }),
   governance: targetConfiguration({
     logicalTarget: "governance",


### PR DESCRIPTION
## The Problem

The trusted Vercel preview controller runs from the immutable default-branch SHA. It currently recognizes only two exact `vercel.json` ownership states: GitHub-owned previews with native `main`, and fully native Git integration.

The production cutover in #659 introduces a third tracked state: GitHub owns previews and `main`. Because `pull_request_target` correctly refuses to execute candidate controller code, current `main` rejects that future configuration before it can dispatch preview workers.

## The Solution

Teach the trusted controller and target model all four exact combinations of preview and `main` ownership before #659 changes the tracked configuration:

- GitHub previews + GitHub `main`;
- GitHub previews + native `main`;
- native previews + GitHub `main`;
- native previews + native `main`.

The classifier still fails closed for every unrecognized configuration. The current rollout remains GitHub-owned for previews and native for `main`.

## Safety

This prerequisite does not change deployment ownership or trigger a production cutover:

- all four `mainOwnershipMode` values remain `shadow`;
- App, Governance, Reserve, and UI `vercel.json` files are byte-identical to `origin/main`;
- `.github/workflows/vercel-main-deployment.yml` is byte-identical to `origin/main`;
- App's native `v2` branch remains preserved;
- Governance QA remains absent.

After this merges, #659 can rerun against trusted default-branch code that recognizes its exact future configuration.

## Validation

- focused preview-controller and ownership tests — 214 tests passed
- `pnpm vercel:preview:test` — 265 tests passed
- `pnpm adr:check`
- `trunk check --fix`
- `git diff --check`
- exact no-diff proof for all four tracked `vercel.json` files and the main deployment workflow
- fresh-context semantic autoreview and deterministic local autoreview — no findings

## Ship Checklist

- [x] ship skill used
- [x] local review run
- [x] validation run

Refs #522.
