### PR TITLE
fix(ci): accept native Git mappings during cutover

### DIFF
--- a/scripts/vercel-main-candidate-provider.mjs
+++ b/scripts/vercel-main-candidate-provider.mjs
@@ -111,11 +111,8 @@ export function createMainCandidateVercelProvider({ client, intent }) {
     });
   }
 
-  async function inspectCandidateRecord(id, expected) {
+  async function inspectDeploymentRecord(id, expected) {
     const deploymentResponse = await client.inspectDeployment(id);
-    if (deploymentResponse?.source !== "cli") {
-      throw new Error("Main candidate Vercel source is not CLI");
-    }
     const aliasesResponse = await client.listDeploymentAliases(id);
     const state = canonicalizeMainPlanningDeploymentState({
       deploymentResponse,
@@ -128,7 +125,19 @@ export function createMainCandidateVercelProvider({ client, intent }) {
         customEnvironmentSlug: expected.environment.customEnvironmentSlug,
       },
     });
-    return { state, rawMetadata: deploymentResponse.meta };
+    return {
+      state,
+      rawMetadata: deploymentResponse.meta,
+      source: deploymentResponse.source,
+    };
+  }
+
+  async function inspectCandidateRecord(id, expected) {
+    const record = await inspectDeploymentRecord(id, expected);
+    if (record.source !== "cli") {
+      throw new Error("Main candidate Vercel source is not CLI");
+    }
+    return record;
   }
 
   async function inspectCandidateState(id) {
@@ -191,9 +200,18 @@ export function createMainCandidateVercelProvider({ client, intent }) {
           ? { target: null, customEnvironmentSlug: "v3" }
           : { target: "production", customEnvironmentSlug: null },
     };
-    const { state, rawMetadata } = await inspectCandidateRecord(id, expected);
+    const { state, rawMetadata, source } = await inspectDeploymentRecord(
+      id,
+      expected,
+    );
     if (!hasReservedCandidateMetadata(rawMetadata)) {
+      if (source !== "git") {
+        throw new Error("Main native mapped deployment source is not Git");
+      }
       return { canonicalState: state, metadata: null };
+    }
+    if (source !== "cli") {
+      throw new Error("Main candidate Vercel source is not CLI");
     }
     if (rawMetadata.mentoCandidateSchema === undefined) {
       throw new Error("Main mapped candidate metadata is partial");

--- a/scripts/vercel-main-candidate-provider.test.mjs
+++ b/scripts/vercel-main-candidate-provider.test.mjs
@@ -364,12 +364,72 @@ test("mapped inspection binds its observed project to the manifest rollback prio
   );
 });
 
-test("mapped App v3 inspection admits a native deployment only when no candidate markers exist", async () => {
-  const oldIntent = intent("app");
-  const response = deploymentResponse(oldIntent);
-  for (const key of Object.keys(response.meta)) {
-    if (key.startsWith("mento")) delete response.meta[key];
+test("mapped inspection admits native Git deployments for every live main environment only when no candidate markers exist", async () => {
+  for (const target of ["governance", "reserve", "ui", "app"]) {
+    const oldIntent = intent(target);
+    const response = deploymentResponse(oldIntent);
+    response.source = "git";
+    for (const key of Object.keys(response.meta)) {
+      if (key.startsWith("mento")) delete response.meta[key];
+    }
+    const provider = createMainCandidateVercelProvider({
+      client: {
+        requestWithRetry: async () =>
+          assert.fail("mapped inspection does not list"),
+        inspectDeployment: async () => response,
+        listDeploymentAliases: async () => ({ aliases: [] }),
+      },
+    });
+    const mapped = await provider.inspectMappedCandidate({
+      deploymentId: response.id,
+      target,
+      projectId: oldIntent.projectId,
+    });
+    assert.equal(mapped.metadata, null);
+    assert.deepEqual(
+      {
+        target: mapped.canonicalState.target,
+        customEnvironmentSlug: mapped.canonicalState.customEnvironmentSlug,
+      },
+      target === "app"
+        ? { target: null, customEnvironmentSlug: "v3" }
+        : { target: "production", customEnvironmentSlug: null },
+    );
   }
+});
+
+test("mapped inspection rejects non-Git native deployment sources", async () => {
+  const currentIntent = intent("reserve");
+  for (const source of ["cli", "manual", "unknown", undefined]) {
+    const response = deploymentResponse(currentIntent);
+    response.source = source;
+    for (const key of Object.keys(response.meta)) {
+      if (key.startsWith("mento")) delete response.meta[key];
+    }
+    const provider = createMainCandidateVercelProvider({
+      client: {
+        requestWithRetry: async () =>
+          assert.fail("mapped inspection does not list"),
+        inspectDeployment: async () => response,
+        listDeploymentAliases: async () => ({ aliases: [] }),
+      },
+    });
+    await assert.rejects(
+      () =>
+        provider.inspectMappedCandidate({
+          deploymentId: response.id,
+          target: "reserve",
+          projectId: currentIntent.projectId,
+        }),
+      /native mapped deployment source is not Git/,
+    );
+  }
+});
+
+test("mapped inspection keeps Mento-marked candidates CLI-only", async () => {
+  const currentIntent = intent("ui");
+  const response = deploymentResponse(currentIntent);
+  response.source = "git";
   const provider = createMainCandidateVercelProvider({
     client: {
       requestWithRetry: async () =>
@@ -378,13 +438,44 @@ test("mapped App v3 inspection admits a native deployment only when no candidate
       listDeploymentAliases: async () => ({ aliases: [] }),
     },
   });
-  const mapped = await provider.inspectMappedCandidate({
-    deploymentId: response.id,
-    target: "app",
-    projectId: oldIntent.projectId,
+  await assert.rejects(
+    () =>
+      provider.inspectMappedCandidate({
+        deploymentId: response.id,
+        target: "ui",
+        projectId: currentIntent.projectId,
+      }),
+    /candidate Vercel source is not CLI/,
+  );
+});
+
+test("candidate inspection and release reuse remain CLI-only", async () => {
+  const currentIntent = intent("ui");
+  const response = deploymentResponse(currentIntent);
+  response.source = "git";
+  const provider = createMainCandidateVercelProvider({
+    intent: currentIntent,
+    client: {
+      requestWithRetry: async () => ({
+        deployments: [{ uid: response.id }],
+        pagination: { next: null },
+      }),
+      inspectDeployment: async () => response,
+      listDeploymentAliases: async () => ({ aliases: [] }),
+    },
   });
-  assert.equal(mapped.metadata, null);
-  assert.equal(mapped.canonicalState.customEnvironmentSlug, "v3");
+  for (const inspect of [
+    () => provider.inspectCandidateState(response.id),
+    () => provider.inspectCandidate(response.id),
+    () =>
+      provider.resolveReleaseCandidate({
+        manifest: currentIntent.releaseManifest,
+        target: "ui",
+        projectId: currentIntent.projectId,
+      }),
+  ]) {
+    await assert.rejects(inspect, /candidate Vercel source is not CLI/);
+  }
 });
 
 test("mapped inspection rejects partial or unknown Mento candidate metadata instead of treating it as native", async () => {


### PR DESCRIPTION
## The Problem

The first active GitHub-driven `main` deployment failed during protected provider discovery because pre-plan inspection required every currently mapped deployment to report Vercel `source: "cli"`. The four pre-cutover mappings are native Vercel Git deployments and report `source: "git"`.

The workflow failed before staging or mutating any deployment or alias, so all public domains and legacy app v2 remained unchanged.

## The Solution

Separate neutral deployment-state inspection from CLI candidate inspection:

- admit an existing mapped deployment as the native baseline only when it has no reserved Mento candidate metadata and reports exact `source: "git"`;
- keep every Mento-marked mapping, candidate inspection, and release-reuse path CLI-only;
- reject manual, unknown, missing, or mismatched sources;
- cover App custom `v3` plus Governance, Reserve, and UI production mappings in the regression.

This lets the next main run inspect the native baseline while preserving the fail-closed ownership boundary for GitHub-built candidates.

## Validation

- `node --test scripts/vercel-main-candidate-provider.test.mjs scripts/vercel-main-candidate-controller.test.mjs scripts/vercel-main-provider-cli.test.mjs` — 31/31
- `pnpm vercel:workflow:test` — 497/497
- `pnpm vercel:deployment-state:test` — 54/54
- `pnpm check-types`
- `pnpm quality:budgets:test` — 34/34
- `pnpm knip`
- Prettier, ESLint, and `git diff --check`
- two focused reviewers plus a fresh-context autoreview — no actionable findings

Runtime proof remains the fresh protected `main` deployment after merge.

## Ship Checklist

- [x] ship skill used
- [x] local review run
- [x] validation run

Supports #522.
