### PR TITLE
fix(ci): repair protected preplan admission

### DIFF
--- a/.github/workflows/vercel-main-deployment.yml
+++ b/.github/workflows/vercel-main-deployment.yml
@@ -118,6 +118,7 @@ jobs:
           node scripts/vercel-main-deployment.mjs create-spec --scope legacy --output "$RUNNER_TEMP/legacy-spec.json"
           node scripts/vercel-deployment-state.mjs planning-snapshot --spec "$RUNNER_TEMP/main-spec.json" --output "$RUNNER_TEMP/planning.json"
           node scripts/vercel-deployment-state.mjs snapshot --spec "$RUNNER_TEMP/legacy-spec.json" --output "$RUNNER_TEMP/legacy.json"
+          umask 077
           jq -n --arg app "$VERCEL_PROJECT_ID_APP" --arg governance "$VERCEL_PROJECT_ID_GOVERNANCE" --arg reserve "$VERCEL_PROJECT_ID_RESERVE" --arg ui "$VERCEL_PROJECT_ID_UI" '{app:$app,governance:$governance,reserve:$reserve,ui:$ui}' > "$RUNNER_TEMP/projects.json"
       - name: Discover protected provider candidates
         env:
@@ -687,6 +688,7 @@ jobs:
         run: |
           node scripts/vercel-main-deployment.mjs create-spec --scope main --output "$RUNNER_TEMP/main-spec.json"
           node scripts/vercel-main-deployment.mjs create-spec --scope legacy --output "$RUNNER_TEMP/legacy-spec.json"
+          umask 077
           jq -n --arg app "$VERCEL_PROJECT_ID_APP" --arg governance "$VERCEL_PROJECT_ID_GOVERNANCE" --arg reserve "$VERCEL_PROJECT_ID_RESERVE" --arg ui "$VERCEL_PROJECT_ID_UI" '{app:$app,governance:$governance,reserve:$reserve,ui:$ui}' > "$RUNNER_TEMP/projects.json"
       - name: Capture wholly fresh main and full legacy snapshots
         env:

--- a/docs/adr/0005-stable-main-release-identity-and-rerun-admission.md
+++ b/docs/adr/0005-stable-main-release-identity-and-rerun-admission.md
@@ -44,9 +44,11 @@ repository + DEPLOY_SHA + validated upstream CI/CD run ID
 
 The target-specific candidate ID is `releaseId + target`. Before a release can
 mutate a protected mapping, the planner creates the canonical stable release
-manifest. It binds the release and candidate identities, exact source and
+manifest. It binds the release and candidate identities, exact source SHA and
 upstream provenance, selected and active targets, ownership mode, and the
-captured protected rollback priors. The provider stores that manifest with its
+captured protected rollback priors. It also binds `rollbackOnlyTargets`: every
+protected mapping that lacked complete canonical Mento candidate metadata when
+the baseline was captured. The provider stores that manifest with its
 candidates. It is the sole durable cross-attempt authority.
 
 The release and candidate IDs survive both a rerun of the downstream controller
@@ -77,6 +79,19 @@ planning.
   Ambiguous, non-prefix, conflicting, incomplete, or unverified provider state
   fails closed.
 
+Every unmarked protected mapping in a new baseline is rollback-only regardless
+of its optional Vercel `source`, Git metadata, or served SHA. The planner forces
+each rollback-only target into the staged set before served-SHA and path-aware
+planning. Its exact deployment ID, URL, project, environment, and served SHA
+remain compensation authority only. Complete canonical Mento metadata and the
+exact stable release manifest are the only evidence that can authorize an
+already-current GitHub candidate. Fresh discovery binds the rollback-only set
+into both preplan reconciliation and release execution. Same-release verify or
+resume may proceed only when the manifest already stages every freshly
+rollback-only target; a new baseline must persist exactly the discovered set.
+The legacy planning command has no candidate census, so it conservatively
+selects every target.
+
 No prior journal is resumed. Each workflow attempt creates and owns only its
 current-attempt journal; its transaction IDs, artifacts, snapshots, and
 recovery are attempt-scoped. A stable release identity is evidence lookup, not
@@ -86,7 +101,14 @@ Candidate reuse still requires one exact provider candidate and fresh
 inspection and immutable smoke. App `v3` remains restrictive because its upload
 can move protected generated aliases: its current-attempt journal records the
 discovered candidate and current mappings before aliases may proceed. Legacy App
-`v2 -> production` remains native and independently verified.
+`v2 -> production` remains independently verified through exact deployment,
+project, environment, ref, SHA, and alias-topology identity. Vercel's optional
+`source` value is telemetry only for both current and legacy deployments.
+Likewise, optional Git organization, repository, and ref fields cannot reject
+the exact manifest-bound rollback prior in the final census: its inspected
+response SHA remains mandatory and must equal the manifest-bound served SHA.
+Candidate admission still requires canonical
+`mento-protocol/frontend-monorepo@main` Git identity.
 
 When App belongs to `shadowTargets`, its protected custom-`v3` preparation is
 build-only terminal evidence. It never creates a provider deployment or gains
@@ -100,6 +122,11 @@ manifest, execution, final mapping, duplicate census, smoke, and terminal
 journal status while remaining redacted and size-bounded. A final-only rerun
 restores that terminal handoff; it does not download artifacts to reconstruct a
 verdict or infer a release from a prior journal.
+
+Generic JSON bridge documents retain a 256 KiB ceiling. Only complete active
+journal history and terminal proofs use dedicated 1 MiB ceilings, sized for the
+bounded maximum of six forward and nine recovery operations. The compact
+terminal receipt and evidence retain their separate smaller bounds.
 
 ## Alternatives considered
 
@@ -130,8 +157,15 @@ release. Replaying mutations adds risk without changing the public result.
   durable cross-attempt source of truth.
 - Every attempt has an independently auditable journal and recovery boundary.
 - An inherited partial release is restored before a new baseline can be planned.
+- An unmarked protected mapping always forces reviewed GitHub preparation before
+  it can become eligible for an already-current no-op. Only active-owned targets
+  replace the public mapping.
 - A completed release is reused after fresh reconciliation rather than rebuilt
   or mutated again.
+- The final duplicate census may observe at most the exact manifest-bound
+  same-SHA original prior alongside the canonical candidate. Separate mapping
+  proof must show the candidate owns every protected alias; any other same-SHA
+  deployment fails closed.
 - Final-only reruns use the terminal receipt/evidence handoff only.
 - Missing, conflicting, or ambiguous provider evidence stops the release rather
   than selecting a guess. Operators use the documented recovery and rollback

--- a/docs/vercel-deployments.md
+++ b/docs/vercel-deployments.md
@@ -93,6 +93,29 @@ conflicting, malformed, non-prefix, or incomplete provider state fails closed.
 GitHub artifacts and prior job history are not alternate cross-attempt
 authority.
 
+Vercel's optional deployment `source` field is diagnostic telemetry, not
+ownership authority. Every protected mapping without complete canonical Mento
+candidate metadata is rollback-only for a new baseline, regardless of its
+reported source, Git metadata, or served SHA. Provider discovery and the stable
+release manifest retain the exact rollback-only target set and its deployment
+ID, URL, project, environment, and served SHA for compensation. The planner
+selects those targets before served-SHA and path-aware planning, so an unmarked
+mapping cannot suppress reviewed GitHub preparation even when it reports
+`DEPLOY_SHA` or an ancestor with no runtime changes. Active-owned targets then
+replace the mapping; shadow-owned targets retain their non-mutation contract.
+Fresh discovery binds the rollback-only set into the preplan and execution
+artifacts. Same-release verify or resume is rejected if its manifest does not
+already stage every freshly rollback-only target, while a new baseline must
+persist exactly the discovered set. The standalone legacy planning command has
+no candidate census and therefore conservatively selects all four targets.
+
+Only complete canonical Mento candidate metadata and the exact stable release
+manifest can authorize an already-current GitHub candidate. The final census
+may observe the exact manifest-bound original prior, but that prior never
+authorizes a public GitHub mapping. Legacy App `v2` uses a separate continuity
+proof bound to its exact deployment ID, URL, project, environment, ref, SHA, and
+reviewed alias topology; its optional `source` value remains diagnostic.
+
 The reconciliation decision is made before ordinary planning:
 
 - `verify-existing-release` fully re-verifies a complete matching release and
@@ -166,6 +189,8 @@ the complete `served SHA..DEPLOY_SHA` range, which accumulates changes hidden by
 coalesced workflow runs. Proven non-runtime changes skip. Missing, malformed,
 non-ancestral, wrong-source, or otherwise ambiguous planning metadata selects
 the affected target so uncertainty cannot suppress a deployment.
+The stable manifest's `rollbackOnlyTargets` are selected before this comparison
+and cannot take either no-op path.
 Ambiguous alias ownership, project, environment, prior deployment, health, or
 rollback state aborts the whole transaction because selecting more targets
 cannot make compensation safe.
@@ -317,14 +342,14 @@ the highest valid snapshot. A prepared transaction with no started mutation is
 `verified-no-mutation`. Any started or uncertain operation is inspected and
 either verified as already restored or compensated in reverse mutation order
 to the exact captured prior mapping. An unexpected operator-owned mapping
-records manual intervention instead of overwriting it. The four legacy aliases
-remain exact topology-validation evidence; the durable recovery prior retains
-only the protected `v2-app.mento.org` alias. The workflow therefore has six
-static recovery turns for the maximum three ordinary, two App-alias, and one
-protected legacy-alias transitions, followed by one final terminalization
-invocation. The 24-minute job bound reserves 14 minutes for all seven composite
-invocations at the 120-second command limit and 10 minutes for checkout, API
-reads, journal artifacts, and cleanup. If an App v3 command returned an unknown
+records manual intervention instead of overwriting it. All four legacy aliases
+remain exact topology-validation and durable recovery evidence. The workflow
+therefore has nine static recovery turns for the maximum three ordinary, two
+App-alias, and four legacy-alias transitions, followed by one final
+terminalization invocation. The 24-minute job bound reserves 20 minutes for all
+ten composite invocations at the 120-second command limit and 4 minutes for
+checkout, API reads, journal artifacts, and cleanup. If an App v3 command
+returned an unknown
 result and the captured mappings show possible movement,
 recovery uses the bounded exact transaction-metadata census; zero, multiple,
 or mismatched candidates remain manual intervention. Recovery, manual
@@ -349,6 +374,13 @@ final-only rerun does the same. It never downloads verdict artifacts, resumes a
 prior journal, or reconstructs a final verdict from earlier attempts. An absent,
 malformed, mismatched, or incomplete receipt/evidence pair fails closed instead
 of treating the process outcome as deployment success.
+
+Generic JSON bridge inputs and outputs remain capped at 256 KiB. Full active
+journal history and terminal proofs alone use dedicated 1 MiB ceilings. That
+bound admits the structurally limited 15-operation transaction envelope: six
+forward operations plus three ordinary, two App-alias, and four legacy-alias
+recovery operations. It does not widen single-journal, provider-discovery, plan,
+mapping, smoke, or other workflow inputs.
 
 ### Historical PR-A shadow canary and copy-safe diagnostics
 
@@ -488,13 +520,26 @@ visible, the E2E Test Wallet must be absent, and no preview/mock-wallet
 local-storage flag may exist.
 
 After activation, the final evidence performs an active duplicate census for
-every selected target. It binds the inspected deployment attempts to the exact
-target, `DEPLOY_SHA`, source, and relevant release interval. A native Vercel
-attempt for a replaced `main` path is an ownership violation even if the public
-domain ultimately points to the GitHub-built candidate. App's independently
-allowlisted `v2 -> production` activity is reported separately and is not a
-duplicate `main -> v3` attempt. Missing, incomplete, ambiguous, or positive
-duplicate evidence fails the release.
+every selected target. It binds the exact candidate and original-prior
+deployment IDs and URLs, project, environment, `DEPLOY_SHA`, stable release
+manifest, and relevant release interval. Vercel's optional `source` value is
+retained only as telemetry and cannot admit or reject an attempt.
+
+For a GitHub-owned target, the census may contain the canonical candidate and
+at most the exact manifest-bound same-SHA original prior. The separate protected
+mapping proof must still show that the candidate owns every reviewed public
+alias; the historical prior never authorizes that mapping. Any different or
+third same-SHA deployment is an unexpected duplicate and fails the release.
+The prior match uses its bound deployment ID, URL, project, environment, and a
+freshly inspected response SHA equal to `DEPLOY_SHA`; optional Git organization,
+repository, ref, and `source` fields are telemetry and cannot reject that exact
+prior. Candidate classification still requires canonical
+`mento-protocol/frontend-monorepo@main` Git identity and exact Mento metadata.
+For a shadow-owned target, the exact bound prior may remain the public owner
+while the staged candidate is verified without mutation. App's independently
+verified `v2 -> production` identity is reported separately and is not a
+duplicate `main -> v3` attempt. Missing, incomplete, or ambiguous evidence
+fails the release.
 
 Record PR-B observed deployment IDs, mappings, mutation sequences, public smoke
 results, native-duplicate proof, and legacy-v2 evidence on PR B or issue #522.

--- a/scripts/fixtures/vercel-main-transaction/prepared-shadow.json
+++ b/scripts/fixtures/vercel-main-transaction/prepared-shadow.json
@@ -9,7 +9,7 @@
   "sequence": 0,
   "status": "prepared",
   "release": {
-    "schema": "vercel-main-release-manifest:v1",
+    "schema": "vercel-main-release-manifest:v2",
     "repository": "mento-protocol/frontend-monorepo",
     "releaseId": "mr-92e57318148798973a8f067a",
     "deploySha": "abcdef0123456789abcdef0123456789abcdef01",
@@ -23,6 +23,7 @@
     },
     "stagedTargets": ["governance", "reserve", "ui", "app"],
     "activeTargets": ["governance", "reserve", "ui", "app"],
+    "rollbackOnlyTargets": [],
     "originalPriors": {
       "governance": {
         "deploymentId": "dpl_governanceprior123",

--- a/scripts/vercel-deployment-state.mjs
+++ b/scripts/vercel-deployment-state.mjs
@@ -46,7 +46,7 @@ export const MAIN_PLANNING_SNAPSHOT_KEYS = Object.freeze(["schema", "states"]);
 export const ACTIVE_DEPLOYMENT_STATE_SPEC_SCHEMA =
   "vercel-active-deployment-state-spec:v3";
 export const ACTIVE_DEPLOYMENT_STATE_PROOF_SCHEMA =
-  "vercel-active-deployment-state-proof:v3";
+  "vercel-active-deployment-state-proof:v4";
 export const ACTIVE_ALIAS_MAPPING_SET_SCHEMA =
   "vercel-active-alias-mapping-set:v1";
 export const ACTIVE_ALIAS_MAPPING_SPEC_SCHEMA =
@@ -134,6 +134,9 @@ const ACTIVE_STATE_PROJECT_PROOF_KEYS = Object.freeze([
   "expectedDisposition",
   "expectedDeploymentId",
   "expectedDeploymentUrl",
+  "priorDeploymentId",
+  "priorDeploymentUrl",
+  "priorServedSha",
   "counts",
   "ids",
   "records",
@@ -439,6 +442,29 @@ function canonicalizeMainPlanningGit(raw) {
   }
   canonical.sha = canonical.sha.toLowerCase();
   return canonical;
+}
+
+function canonicalizeActiveCensusGit(raw, deploySha) {
+  const sha = canonicalizeInventoryGitSha(
+    raw,
+    "Active state inspected deployment",
+  );
+  if (sha === null || sha !== deploySha) {
+    throw new Error(
+      "Active state inspected deployment SHA does not match census",
+    );
+  }
+  const observed = canonicalizeMainPlanningGit(raw);
+  const hasCompleteObservedIdentity =
+    observed !== null &&
+    Object.keys(observed).length === CANONICAL_GIT_KEYS.length &&
+    observed.sha === sha;
+  return {
+    org: hasCompleteObservedIdentity ? observed.org : null,
+    repo: hasCompleteObservedIdentity ? observed.repo : null,
+    ref: hasCompleteObservedIdentity ? observed.ref : null,
+    sha,
+  };
 }
 
 function assertExpected(actual, expected, label) {
@@ -1344,11 +1370,8 @@ export class VercelStateClient {
     ) {
       throw new Error("Legacy App v2 alias mapping changed during inspection");
     }
-    if (deploymentResponse?.source !== "git") {
-      throw new Error("Legacy App v2 ownership is unproven");
-    }
     return {
-      source: "git",
+      ownership: "native-vercel-git",
       state: canonicalizeDeploymentState({
         alias: spec.alias,
         aliasResponse: confirmedAliasResponse,
@@ -1934,7 +1957,7 @@ export function assertActiveDeploymentStateSpec(spec) {
   return spec;
 }
 
-function canonicalActiveDeploymentIdentity(entry) {
+function canonicalActiveDeploymentIdentity(entry, deploySha) {
   if (
     !entry ||
     typeof entry !== "object" ||
@@ -1949,7 +1972,22 @@ function canonicalActiveDeploymentIdentity(entry) {
     "Active deployment requested ID",
   );
   const raw = entry.response;
-  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return null;
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+    throw new Error("Active state inspected deployment is malformed");
+  }
+  const git = canonicalizeActiveCensusGit(raw, deploySha);
+  const malformedIdentity = {
+    deploymentId: null,
+    deploymentUrl: null,
+    projectId: null,
+    projectName: null,
+    readyState: null,
+    target: null,
+    customEnvironmentSlug: null,
+    git,
+    source: null,
+    meta: null,
+  };
   try {
     const deploymentId = requireDeploymentId(
       consistentString("ID", [raw.id, raw.uid]),
@@ -1985,7 +2023,6 @@ function canonicalActiveDeploymentIdentity(entry) {
       }
       customEnvironmentSlug = raw.customEnvironment.slug;
     }
-    const git = canonicalizeGit(raw);
     const source =
       typeof raw.source === "string" && /^[a-z][a-z-]*$/.test(raw.source)
         ? raw.source
@@ -2007,11 +2044,11 @@ function canonicalActiveDeploymentIdentity(entry) {
       meta,
     };
   } catch {
-    return null;
+    return malformedIdentity;
   }
 }
 
-function matchesActiveProjectIdentity(identity, project, deploySha) {
+function matchesActiveProjectTopology(identity, project, deploySha) {
   return (
     identity !== null &&
     identity.projectId === project.projectId &&
@@ -2019,6 +2056,13 @@ function matchesActiveProjectIdentity(identity, project, deploySha) {
     identity.readyState === "READY" &&
     identity.target === project.target &&
     identity.customEnvironmentSlug === project.customEnvironmentSlug &&
+    identity.git.sha === deploySha
+  );
+}
+
+function matchesCanonicalMainCandidate(identity, project, deploySha) {
+  return (
+    matchesActiveProjectTopology(identity, project, deploySha) &&
     identity.git.org === "mento-protocol" &&
     identity.git.repo === "frontend-monorepo" &&
     identity.git.ref === "main" &&
@@ -2028,7 +2072,6 @@ function matchesActiveProjectIdentity(identity, project, deploySha) {
 
 function hasExpectedGitHubMetadata(identity, logicalTarget, spec) {
   if (
-    identity.source !== "cli" ||
     identity.meta === null ||
     Object.hasOwn(identity.meta, "githubDeployment")
   ) {
@@ -2086,18 +2129,20 @@ function matchesLegacyV2Identity(identity, legacy) {
     identity.git.org === "mento-protocol" &&
     identity.git.repo === "frontend-monorepo" &&
     identity.git.ref === "v2" &&
-    identity.git.sha === legacy.git.sha &&
-    identity.source === "git"
+    identity.git.sha === legacy.git.sha
   );
 }
 
 function canonicalLegacyV2Proof(spec, legacyV2) {
-  if (
-    !legacyV2 ||
-    typeof legacyV2 !== "object" ||
-    Array.isArray(legacyV2) ||
-    legacyV2.source !== "git"
-  ) {
+  if (!legacyV2 || typeof legacyV2 !== "object" || Array.isArray(legacyV2)) {
+    throw new Error("Legacy App v2 state is unproven");
+  }
+  assertExactKeys(
+    legacyV2,
+    ["ownership", "state"],
+    "Legacy App v2 capture proof",
+  );
+  if (legacyV2.ownership !== "native-vercel-git") {
     throw new Error("Legacy App v2 state is unproven");
   }
   const state = assertCanonicalOutput(legacyV2.state);
@@ -2129,6 +2174,25 @@ function canonicalLegacyV2Proof(spec, legacyV2) {
     git: { ...state.git },
     ownership: "native-vercel-git",
   };
+}
+
+function matchesReleaseRollbackPrior(identity, logicalTarget, spec) {
+  const prior = spec.releaseManifest.originalPriors[logicalTarget];
+  const project = spec.projects[logicalTarget];
+  return (
+    identity !== null &&
+    prior.servedSha === spec.deploySha &&
+    identity.deploymentId === prior.deploymentId &&
+    identity.deploymentUrl === prior.deploymentUrl &&
+    identity.projectId === prior.projectId &&
+    identity.projectName === prior.projectName &&
+    identity.projectId === project.projectId &&
+    identity.projectName === project.projectName &&
+    identity.readyState === "READY" &&
+    identity.target === project.target &&
+    identity.customEnvironmentSlug === project.customEnvironmentSlug &&
+    identity.git.sha === prior.servedSha
+  );
 }
 
 function sortedUniqueIds(values, label) {
@@ -2192,7 +2256,10 @@ export function createActiveDeploymentStateProof({
         );
       }
       seenIds.add(requestedId);
-      const identity = canonicalActiveDeploymentIdentity(entry);
+      const identity = canonicalActiveDeploymentIdentity(
+        entry,
+        canonicalSpec.deploySha,
+      );
       let classification = "unknown";
       if (
         logicalTarget === "app" &&
@@ -2201,21 +2268,27 @@ export function createActiveDeploymentStateProof({
       ) {
         classification = "legacyV2";
       } else if (
-        matchesActiveProjectIdentity(identity, project, canonicalSpec.deploySha)
+        matchesActiveProjectTopology(identity, project, canonicalSpec.deploySha)
       ) {
         if (
+          matchesCanonicalMainCandidate(
+            identity,
+            project,
+            canonicalSpec.deploySha,
+          ) &&
           identity.deploymentId === project.deploymentId &&
           identity.deploymentUrl === project.deploymentUrl &&
           hasExpectedGitHubMetadata(identity, logicalTarget, canonicalSpec)
         ) {
           classification = project.expectedDisposition;
-        } else if (identity.source === "git") {
-          classification = "nativeGitOwner";
         } else if (
-          identity.source === "cli" &&
-          identity.meta !== null &&
-          !Object.hasOwn(identity.meta, "githubDeployment")
+          matchesReleaseRollbackPrior(identity, logicalTarget, canonicalSpec)
         ) {
+          classification =
+            canonicalSpec.mainOwnershipMode[logicalTarget] === "shadow"
+              ? "nativeGitOwner"
+              : "nativeGitDuplicates";
+        } else {
           classification = "manualDuplicates";
         }
       }
@@ -2266,6 +2339,14 @@ export function createActiveDeploymentStateProof({
       expectedDisposition: project.expectedDisposition,
       expectedDeploymentId: project.deploymentId,
       expectedDeploymentUrl: project.deploymentUrl,
+      priorDeploymentId:
+        canonicalSpec.releaseManifest.originalPriors[logicalTarget]
+          .deploymentId,
+      priorDeploymentUrl:
+        canonicalSpec.releaseManifest.originalPriors[logicalTarget]
+          .deploymentUrl,
+      priorServedSha:
+        canonicalSpec.releaseManifest.originalPriors[logicalTarget].servedSha,
       counts,
       ids,
       records,
@@ -2285,7 +2366,8 @@ export function createActiveDeploymentStateProof({
         ids.githubShadowStage[0] === project.deploymentId) &&
       counts.nativeGitOwner <=
         (canonicalSpec.mainOwnershipMode[logicalTarget] === "shadow" ? 1 : 0) &&
-      counts.nativeGitDuplicates === 0 &&
+      counts.nativeGitDuplicates <=
+        (canonicalSpec.mainOwnershipMode[logicalTarget] === "github" ? 1 : 0) &&
       counts.manualDuplicates === 0 &&
       counts.unknown === 0
     );
@@ -2335,24 +2417,31 @@ function assertActiveDeploymentRecord(record, label) {
   ) {
     throw new Error(`${label} identity is malformed`);
   }
-  if (record.git !== null) {
-    assertExactKeys(record.git, CANONICAL_GIT_KEYS, `${label} Git identity`);
-    if (
-      record.git.org !== "mento-protocol" ||
-      record.git.repo !== "frontend-monorepo" ||
-      typeof record.git.ref !== "string" ||
-      record.git.ref.length === 0 ||
-      typeof record.git.sha !== "string" ||
-      !SHA_PATTERN.test(record.git.sha) ||
-      record.git.sha !== record.git.sha.toLowerCase()
-    ) {
-      throw new Error(`${label} Git identity is malformed`);
-    }
+  if (record.git === null) {
+    throw new Error(`${label} Git identity is missing`);
+  }
+  assertExactKeys(record.git, CANONICAL_GIT_KEYS, `${label} Git identity`);
+  if (
+    (record.git.org !== null &&
+      (typeof record.git.org !== "string" ||
+        !/^[A-Za-z0-9._-]+$/.test(record.git.org))) ||
+    (record.git.repo !== null &&
+      (typeof record.git.repo !== "string" ||
+        !/^[A-Za-z0-9._-]+$/.test(record.git.repo))) ||
+    (record.git.ref !== null &&
+      (typeof record.git.ref !== "string" ||
+        !/^[A-Za-z0-9._/-]+$/.test(record.git.ref) ||
+        record.git.ref.includes(".."))) ||
+    typeof record.git.sha !== "string" ||
+    !SHA_PATTERN.test(record.git.sha) ||
+    record.git.sha !== record.git.sha.toLowerCase()
+  ) {
+    throw new Error(`${label} Git identity is malformed`);
   }
   return record;
 }
 
-function recordMatchesActiveProject(record, project, deploySha) {
+function recordMatchesActiveProjectTopology(record, project, deploySha) {
   return (
     record.deploymentUrl !== null &&
     record.projectId === project.projectId &&
@@ -2360,6 +2449,13 @@ function recordMatchesActiveProject(record, project, deploySha) {
     record.readyState === "READY" &&
     record.target === project.target &&
     record.customEnvironmentSlug === project.customEnvironmentSlug &&
+    record.git.sha === deploySha
+  );
+}
+
+function recordMatchesCanonicalMainCandidate(record, project, deploySha) {
+  return (
+    recordMatchesActiveProjectTopology(record, project, deploySha) &&
     record.git?.org === "mento-protocol" &&
     record.git.repo === "frontend-monorepo" &&
     record.git.ref === "main" &&
@@ -2422,6 +2518,8 @@ export function assertActiveDeploymentStateProof(value) {
   const projectIds = new Set();
   const expectedDeploymentIds = new Set();
   const expectedDeploymentUrls = new Set();
+  const priorDeploymentIds = new Set();
+  const priorDeploymentUrls = new Set();
   const classifiedDeploymentIds = new Set();
   for (const logicalTarget of ACTIVE_STATE_TARGETS) {
     const project = value.projects[logicalTarget];
@@ -2442,6 +2540,24 @@ export function assertActiveDeploymentStateProof(value) {
     );
     let expectedDeploymentId = null;
     let expectedDeploymentUrl = null;
+    const priorDeploymentId = requireDeploymentId(
+      project.priorDeploymentId,
+      `${logicalTarget} active proof prior deployment ID`,
+    );
+    const priorDeploymentUrl = canonicalizeDeploymentUrl(
+      project.priorDeploymentUrl,
+    );
+    const priorServedSha = project.priorServedSha;
+    if (
+      priorServedSha !== null &&
+      (typeof priorServedSha !== "string" ||
+        !SHA_PATTERN.test(priorServedSha) ||
+        priorServedSha !== priorServedSha.toLowerCase())
+    ) {
+      throw new Error(
+        `${logicalTarget} active proof prior served SHA is malformed`,
+      );
+    }
     if (expectedDisposition === null) {
       if (
         project.expectedDeploymentId !== null ||
@@ -2468,17 +2584,24 @@ export function assertActiveDeploymentStateProof(value) {
       project.mainOwnershipMode !== mainOwnershipMode[logicalTarget] ||
       project.expectedDisposition !== expectedDisposition ||
       expectedDeploymentUrl !== project.expectedDeploymentUrl ||
+      priorDeploymentUrl !== project.priorDeploymentUrl ||
       projectIds.has(projectId) ||
+      priorDeploymentIds.has(priorDeploymentId) ||
+      priorDeploymentUrls.has(priorDeploymentUrl) ||
       (expectedDeploymentId !== null &&
-        expectedDeploymentIds.has(expectedDeploymentId)) ||
+        (expectedDeploymentIds.has(expectedDeploymentId) ||
+          expectedDeploymentId === priorDeploymentId)) ||
       (expectedDeploymentUrl !== null &&
-        expectedDeploymentUrls.has(expectedDeploymentUrl))
+        (expectedDeploymentUrls.has(expectedDeploymentUrl) ||
+          expectedDeploymentUrl === priorDeploymentUrl))
     ) {
       throw new Error(
         `${logicalTarget} active deployment state proof is malformed`,
       );
     }
     projectIds.add(projectId);
+    priorDeploymentIds.add(priorDeploymentId);
+    priorDeploymentUrls.add(priorDeploymentUrl);
     if (expectedDeploymentId !== null) {
       expectedDeploymentIds.add(expectedDeploymentId);
     }
@@ -2528,7 +2651,7 @@ export function assertActiveDeploymentStateProof(value) {
         if (
           classification !== "unknown" &&
           classification !== "legacyV2" &&
-          !recordMatchesActiveProject(record, project, value.deploySha)
+          !recordMatchesActiveProjectTopology(record, project, value.deploySha)
         ) {
           throw new Error(
             `${logicalTarget} ${classification} deployment record is malformed`,
@@ -2538,15 +2661,25 @@ export function assertActiveDeploymentStateProof(value) {
           (["githubPrebuilt", "githubShadowStage"].includes(classification) &&
             (record.deploymentId !== expectedDeploymentId ||
               record.deploymentUrl !== expectedDeploymentUrl ||
-              record.source !== "cli" ||
+              !recordMatchesCanonicalMainCandidate(
+                record,
+                project,
+                value.deploySha,
+              ) ||
               record.workflowMetadataMatches !== true)) ||
-          (["nativeGitOwner", "nativeGitDuplicates"].includes(classification) &&
-            record.source !== "git") ||
-          (classification === "manualDuplicates" && record.source !== "cli") ||
+          (classification === "nativeGitOwner" &&
+            (mainOwnershipMode[logicalTarget] !== "shadow" ||
+              priorServedSha !== value.deploySha ||
+              record.deploymentId !== priorDeploymentId ||
+              record.deploymentUrl !== priorDeploymentUrl)) ||
+          (classification === "nativeGitDuplicates" &&
+            (mainOwnershipMode[logicalTarget] !== "github" ||
+              priorServedSha !== value.deploySha ||
+              record.deploymentId !== priorDeploymentId ||
+              record.deploymentUrl !== priorDeploymentUrl)) ||
           (classification === "legacyV2" &&
             (logicalTarget !== "app" ||
-              record.deploymentId !== value.legacyAppV2.deploymentId ||
-              record.source !== "git"))
+              record.deploymentId !== value.legacyAppV2.deploymentId))
         ) {
           throw new Error(
             `${logicalTarget} ${classification} deployment classification is malformed`,
@@ -2581,8 +2714,8 @@ export function assertActiveDeploymentStateProof(value) {
         `${logicalTarget} active deployment state proof count is malformed`,
       );
     }
-    // Native same-SHA ownership is observational. It is allowed only under
-    // shadow ownership and never satisfies the required GitHub disposition
+    // An exact manifest-bound rollback prior may remain in the same-SHA census
+    // after replacement. It never satisfies the required GitHub disposition
     // or the separate protected-mapping proof.
     proven &&=
       project.counts.githubPrebuilt ===
@@ -2595,7 +2728,8 @@ export function assertActiveDeploymentStateProof(value) {
         project.ids.githubShadowStage[0] === expectedDeploymentId) &&
       project.counts.nativeGitOwner <=
         (mainOwnershipMode[logicalTarget] === "shadow" ? 1 : 0) &&
-      project.counts.nativeGitDuplicates === 0 &&
+      project.counts.nativeGitDuplicates <=
+        (mainOwnershipMode[logicalTarget] === "github" ? 1 : 0) &&
       project.counts.manualDuplicates === 0 &&
       project.counts.unknown === 0;
   }
@@ -2648,7 +2782,6 @@ export function assertActiveDeploymentStateProof(value) {
         record.customEnvironmentSlug !==
           value.legacyAppV2.customEnvironmentSlug ||
         JSON.stringify(record.git) !== JSON.stringify(value.legacyAppV2.git) ||
-        record.source !== "git" ||
         record.workflowMetadataMatches !== false,
     ) ||
     ACTIVE_STATE_TARGETS.filter((target) => target !== "app").some(

--- a/scripts/vercel-deployment-state.test.mjs
+++ b/scripts/vercel-deployment-state.test.mjs
@@ -95,8 +95,12 @@ function privateTestDirectory(testContext) {
   return directory;
 }
 
-function activeReleaseManifest({ deploySha, projects }) {
-  const priorSha = "b".repeat(40);
+function activeReleaseManifest({
+  deploySha,
+  projects,
+  priorSha = "b".repeat(40),
+  rollbackOnly = false,
+}) {
   const targets = ["app", "governance", "reserve", "ui"];
   const plan = {
     schema: "vercel-main-plan:v2",
@@ -116,20 +120,24 @@ function activeReleaseManifest({ deploySha, projects }) {
       aliases: [...MAIN_TARGET_CONTRACTS[target].aliases].sort(),
       servedSha: priorSha,
     })),
-    ranges: [
-      {
-        base: priorSha,
-        head: deploySha,
-        kind: "served",
-        reason: "global-build-input",
-        targets,
-        deployments: targets,
-      },
-    ],
+    ranges: rollbackOnly
+      ? []
+      : [
+          {
+            base: priorSha,
+            head: deploySha,
+            kind: "served",
+            reason: "global-build-input",
+            targets,
+            deployments: targets,
+          },
+        ],
     reasons: targets.map((target) => ({
       target,
       base: priorSha,
-      reason: "global-build-input",
+      reason: rollbackOnly
+        ? "served-mapping-rollback-only"
+        : "global-build-input",
     })),
   };
   const originalPriors = Object.fromEntries(
@@ -173,7 +181,7 @@ function activeReleaseManifest({ deploySha, projects }) {
   });
 }
 
-function activeStateSpec() {
+function activeStateSpec({ rollbackOnly = false } = {}) {
   const deploySha = "abcdef0123456789abcdef0123456789abcdef01";
   const projects = {
     app: {
@@ -219,7 +227,12 @@ function activeStateSpec() {
     runId: "12345",
     runAttempt: "2",
     transactionId: "main-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-    releaseManifest: activeReleaseManifest({ deploySha, projects }),
+    releaseManifest: activeReleaseManifest({
+      deploySha,
+      projects,
+      priorSha: rollbackOnly ? deploySha : undefined,
+      rollbackOnly,
+    }),
     mainOwnershipMode: {
       app: "github",
       governance: "github",
@@ -316,7 +329,7 @@ function activeDeploymentInspections(spec) {
 function legacyAppV2Proof(spec) {
   const legacy = spec.legacyAppV2;
   return {
-    source: "git",
+    ownership: "native-vercel-git",
     state: {
       alias: legacy.alias,
       deploymentId: legacy.deployment,
@@ -2178,6 +2191,179 @@ test("active deployment proof binds every GitHub prebuilt and keeps legacy App v
   assert.equal(assertActiveDeploymentStateProof(proof), proof);
 });
 
+test("first-cutover proof accepts source-free candidates and the exact same-SHA rollback prior", () => {
+  for (const candidateSource of [undefined, "git", "cli", "redeploy"]) {
+    for (const priorSource of [undefined, "git", "cli", "redeploy"]) {
+      const spec = activeStateSpec({ rollbackOnly: true });
+      const deployments = activeDeploymentInspections(spec);
+      deployments.governance[0].response.source = candidateSource;
+      const prior = spec.releaseManifest.originalPriors.governance;
+      const priorResponse = activeDeploymentResponse(spec, "governance", {
+        deploymentId: prior.deploymentId,
+        deploymentUrl: prior.deploymentUrl,
+        source: priorSource,
+      });
+      for (const key of Object.keys(priorResponse.meta)) {
+        if (key.startsWith("mento")) delete priorResponse.meta[key];
+      }
+      deployments.governance.push({
+        deploymentId: prior.deploymentId,
+        response: priorResponse,
+      });
+      const proof = createActiveDeploymentStateProof({
+        spec,
+        deployments,
+        legacyV2: legacyAppV2Proof(spec),
+      });
+      assert.equal(
+        proof.outcome,
+        "proven",
+        `candidate=${candidateSource} prior=${priorSource}`,
+      );
+      assert.deepEqual(proof.projects.governance.ids.nativeGitDuplicates, [
+        prior.deploymentId,
+      ]);
+      assert.equal(
+        proof.projects.governance.records.githubPrebuilt[0]
+          .workflowMetadataMatches,
+        true,
+      );
+      assert.equal(
+        proof.projects.governance.priorDeploymentId,
+        prior.deploymentId,
+      );
+      assert.equal(
+        proof.projects.governance.priorDeploymentUrl,
+        prior.deploymentUrl,
+      );
+      assert.equal(proof.projects.governance.priorServedSha, spec.deploySha);
+    }
+  }
+
+  const gitTelemetryCases = [
+    {
+      label: "wrong organization",
+      mutate(response) {
+        response.meta.githubCommitOrg = "foreign-org";
+      },
+      expectedPriorGit: {
+        org: "foreign-org",
+        repo: "frontend-monorepo",
+        ref: "main",
+      },
+    },
+    {
+      label: "wrong ref",
+      mutate(response) {
+        response.meta.githubCommitRef = "feature";
+      },
+      expectedPriorGit: {
+        org: "mento-protocol",
+        repo: "frontend-monorepo",
+        ref: "feature",
+      },
+    },
+    {
+      label: "missing organization and ref",
+      mutate(response) {
+        delete response.meta.githubCommitOrg;
+        delete response.meta.githubCommitRef;
+      },
+      expectedPriorGit: {
+        org: null,
+        repo: null,
+        ref: null,
+      },
+    },
+    {
+      label: "conflicting organization",
+      mutate(response, spec) {
+        response.gitSource = {
+          org: "foreign-org",
+          repo: "frontend-monorepo",
+          ref: "main",
+          sha: spec.deploySha,
+        };
+      },
+      expectedPriorGit: {
+        org: null,
+        repo: null,
+        ref: null,
+      },
+    },
+  ];
+  for (const telemetryCase of gitTelemetryCases) {
+    const spec = activeStateSpec({ rollbackOnly: true });
+    const prior = spec.releaseManifest.originalPriors.governance;
+    const priorResponse = activeDeploymentResponse(spec, "governance", {
+      deploymentId: prior.deploymentId,
+      deploymentUrl: prior.deploymentUrl,
+    });
+    for (const key of Object.keys(priorResponse.meta)) {
+      if (key.startsWith("mento")) delete priorResponse.meta[key];
+    }
+    telemetryCase.mutate(priorResponse, spec);
+    const deployments = activeDeploymentInspections(spec);
+    deployments.governance.push({
+      deploymentId: prior.deploymentId,
+      response: priorResponse,
+    });
+    const proof = createActiveDeploymentStateProof({
+      spec,
+      deployments,
+      legacyV2: legacyAppV2Proof(spec),
+    });
+    assert.equal(proof.outcome, "proven", telemetryCase.label);
+    assert.deepEqual(
+      proof.projects.governance.records.nativeGitDuplicates[0].git,
+      {
+        ...telemetryCase.expectedPriorGit,
+        sha: spec.deploySha,
+      },
+      telemetryCase.label,
+    );
+
+    const candidateDeployments = activeDeploymentInspections(spec);
+    telemetryCase.mutate(candidateDeployments.governance[0].response, spec);
+    const candidateProof = createActiveDeploymentStateProof({
+      spec,
+      deployments: candidateDeployments,
+      legacyV2: legacyAppV2Proof(spec),
+    });
+    assert.equal(candidateProof.outcome, "unproven", telemetryCase.label);
+    assert.deepEqual(
+      candidateProof.projects.governance.ids.githubPrebuilt,
+      [],
+      telemetryCase.label,
+    );
+    assert.deepEqual(
+      candidateProof.projects.governance.ids.manualDuplicates,
+      [spec.projects.governance.deploymentId],
+      telemetryCase.label,
+    );
+  }
+
+  const spec = activeStateSpec({ rollbackOnly: true });
+  const deployments = activeDeploymentInspections(spec);
+  deployments.governance.push({
+    deploymentId: "dpl_governanceSpoofedPrior123",
+    response: activeDeploymentResponse(spec, "governance", {
+      deploymentId: "dpl_governanceSpoofedPrior123",
+      deploymentUrl: "https://governance-spoofed-prior.vercel.app",
+      source: "git",
+    }),
+  });
+  const proof = createActiveDeploymentStateProof({
+    spec,
+    deployments,
+    legacyV2: legacyAppV2Proof(spec),
+  });
+  assert.equal(proof.outcome, "unproven");
+  assert.deepEqual(proof.projects.governance.ids.manualDuplicates, [
+    "dpl_governanceSpoofedPrior123",
+  ]);
+});
+
 test("active deployment proof accepts a stable candidate from an earlier audit attempt", () => {
   const spec = activeStateSpec();
   const deployments = activeDeploymentInspections(spec);
@@ -2291,7 +2477,7 @@ test("active deployment proof rejects retired and mismatched candidate metadata"
   );
 });
 
-test("active deployment proof classifies native, manual, and unknown duplicates without treating v2 as a duplicate", () => {
+test("active deployment proof treats non-prior same-SHA identities as duplicates regardless of source", () => {
   const spec = activeStateSpec();
   const deployments = activeDeploymentInspections(spec);
   const project = spec.projects.app;
@@ -2317,6 +2503,7 @@ test("active deployment proof classifies native, manual, and unknown duplicates 
         id: "dpl_appunknown456",
         url: "app-unknown-duplicate.vercel.app",
         projectId: project.projectId,
+        project: { id: "prj_conflictingproject123" },
         name: project.projectName,
         readyState: "READY",
         target: null,
@@ -2326,25 +2513,7 @@ test("active deployment proof classifies native, manual, and unknown duplicates 
           githubCommitOrg: "mento-protocol",
           githubCommitRepo: "frontend-monorepo",
           githubCommitRef: "main",
-        },
-      },
-    },
-    {
-      deploymentId: spec.legacyAppV2.deployment,
-      response: {
-        id: spec.legacyAppV2.deployment,
-        url: spec.legacyAppV2.deploymentUrl,
-        projectId: spec.legacyAppV2.projectId,
-        name: spec.legacyAppV2.projectName,
-        readyState: "READY",
-        target: "production",
-        customEnvironment: null,
-        source: "git",
-        meta: {
-          githubCommitOrg: "mento-protocol",
-          githubCommitRepo: "frontend-monorepo",
-          githubCommitRef: "v2",
-          githubCommitSha: spec.legacyAppV2.git.sha,
+          githubCommitSha: spec.deploySha,
         },
       },
     },
@@ -2357,36 +2526,21 @@ test("active deployment proof classifies native, manual, and unknown duplicates 
   });
   assert.equal(proof.outcome, "unproven");
   assert.deepEqual(proof.projects.app.counts, {
-    scanned: 5,
+    scanned: 4,
     githubPrebuilt: 1,
     githubShadowStage: 0,
     nativeGitOwner: 0,
-    nativeGitDuplicates: 1,
-    manualDuplicates: 1,
+    nativeGitDuplicates: 0,
+    manualDuplicates: 2,
     unknown: 1,
-    legacyV2: 1,
+    legacyV2: 0,
   });
-  assert.deepEqual(proof.projects.app.ids.nativeGitDuplicates, [
-    "dpl_appnative456",
-  ]);
   assert.deepEqual(proof.projects.app.ids.manualDuplicates, [
     "dpl_appmanual456",
+    "dpl_appnative456",
   ]);
   assert.deepEqual(proof.projects.app.ids.unknown, ["dpl_appunknown456"]);
-  assert.deepEqual(proof.projects.app.ids.legacyV2, [
-    spec.legacyAppV2.deployment,
-  ]);
-
-  const onlyLegacy = activeDeploymentInspections(spec);
-  onlyLegacy.app.push(deployments.app.at(-1));
-  assert.equal(
-    createActiveDeploymentStateProof({
-      spec,
-      deployments: onlyLegacy,
-      legacyV2: legacyAppV2Proof(spec),
-    }).outcome,
-    "proven",
-  );
+  assert.deepEqual(proof.projects.app.ids.legacyV2, []);
 });
 
 test("active deployment state validation rejects ambiguity and noncanonical or expanded evidence", () => {
@@ -2466,15 +2620,9 @@ test("active deployment proof fails closed for missing or mismatched expected de
     },
     {
       label: "ref",
+      classification: "manualDuplicates",
       mutate(entries) {
         entries[0].response.meta.githubCommitRef = "feature";
-      },
-    },
-    {
-      label: "SHA",
-      mutate(entries) {
-        entries[0].response.meta.githubCommitSha =
-          "2222222222222222222222222222222222222222";
       },
     },
     {
@@ -2516,6 +2664,46 @@ test("active deployment proof fails closed for missing or mismatched expected de
       assert.equal(proof.projects.app.counts.unknown, 1, scenario.label);
     }
     assert.equal(proof.projects.app.counts.githubPrebuilt, 0, scenario.label);
+  }
+
+  for (const [label, mutate] of [
+    [
+      "missing SHA",
+      (response) => {
+        delete response.meta.githubCommitSha;
+      },
+    ],
+    [
+      "mismatched SHA",
+      (response) => {
+        response.meta.githubCommitSha =
+          "2222222222222222222222222222222222222222";
+      },
+    ],
+    [
+      "conflicting SHA",
+      (response) => {
+        response.gitSource = {
+          org: "mento-protocol",
+          repo: "frontend-monorepo",
+          ref: "main",
+          sha: "2222222222222222222222222222222222222222",
+        };
+      },
+    ],
+  ]) {
+    const deployments = activeDeploymentInspections(spec);
+    mutate(deployments.app[0].response);
+    assert.throws(
+      () =>
+        createActiveDeploymentStateProof({
+          spec,
+          deployments,
+          legacyV2: legacyAppV2Proof(spec),
+        }),
+      /Git SHA|SHA does not match census/,
+      label,
+    );
   }
 });
 
@@ -2778,7 +2966,7 @@ test("active deployment capture verifies detail-only Git source SHA fields once"
   );
 });
 
-test("legacy App v2 proof rejects alias, source, ref, and mapping drift", async () => {
+test("legacy App v2 proof ignores source telemetry but rejects identity and mapping drift", async () => {
   const spec = activeStateSpec();
   const legacy = spec.legacyAppV2;
   const clientFor = ({
@@ -2835,18 +3023,16 @@ test("legacy App v2 proof rejects alias, source, ref, and mapping drift", async 
     });
   };
 
-  const result = await clientFor().canonicalLegacyV2State(legacy);
-  assert.deepEqual(result, legacyAppV2Proof(spec));
-  assert.doesNotMatch(JSON.stringify(result), /legacy-secret-never-output/);
+  for (const source of [undefined, "git", "cli", "redeploy"]) {
+    const result = await clientFor({ source }).canonicalLegacyV2State(legacy);
+    assert.deepEqual(result, legacyAppV2Proof(spec));
+    assert.doesNotMatch(JSON.stringify(result), /legacy-secret-never-output/);
+  }
 
   const wrongAlias = { ...legacy, alias: "app.mento.org" };
   await assert.rejects(
     () => clientFor().canonicalLegacyV2State(wrongAlias),
     /expectation is malformed/,
-  );
-  await assert.rejects(
-    () => clientFor({ source: "cli" }).canonicalLegacyV2State(legacy),
-    /ownership is unproven/,
   );
   await assert.rejects(
     () => clientFor({ ref: "main" }).canonicalLegacyV2State(legacy),
@@ -2967,7 +3153,7 @@ test("active-proof CLI writes canonical duplicate evidence before failing unprov
   const proofText = readFileSync(outputPath, "utf8");
   const proof = JSON.parse(proofText);
   assert.equal(proof.outcome, "unproven");
-  assert.deepEqual(proof.projects.governance.ids.nativeGitDuplicates, [
+  assert.deepEqual(proof.projects.governance.ids.manualDuplicates, [
     duplicateId,
   ]);
   assert.equal(statSync(outputPath).mode & 0o777, 0o600);

--- a/scripts/vercel-main-active-controller.mjs
+++ b/scripts/vercel-main-active-controller.mjs
@@ -934,6 +934,7 @@ function canonicalStateProof(journal, planning, value) {
   }
   for (const target of DEPLOYMENT_TARGETS) {
     const project = proof.projects[target];
+    const originalPrior = journal.release.originalPriors[target];
     const active = planning.activeTargets.includes(target);
     const shadowStage =
       target !== "app" && planning.shadowTargets.includes(target);
@@ -951,7 +952,10 @@ function canonicalStateProof(journal, planning, value) {
       project.projectId !== planning.projectIds[target] ||
       project.expectedDisposition !== disposition ||
       project.expectedDeploymentId !== (expected?.deploymentId ?? null) ||
-      project.expectedDeploymentUrl !== (expected?.deploymentUrl ?? null)
+      project.expectedDeploymentUrl !== (expected?.deploymentUrl ?? null) ||
+      project.priorDeploymentId !== originalPrior.deploymentId ||
+      project.priorDeploymentUrl !== originalPrior.deploymentUrl ||
+      project.priorServedSha !== originalPrior.servedSha
     ) {
       throw new Error(
         `Active deployment state proof ${target} expectation is inconsistent`,

--- a/scripts/vercel-main-active-controller.test.mjs
+++ b/scripts/vercel-main-active-controller.test.mjs
@@ -512,7 +512,7 @@ function activeStateProof(
     spec,
     deployments,
     legacyV2: {
-      source: "git",
+      ownership: "native-vercel-git",
       state: {
         alias: "v2-app.mento.org",
         deploymentId: legacy.deploymentId,
@@ -825,6 +825,30 @@ test("finalize commits only after exact mappings, smokes, census, and v2 proof",
   assert.equal(committed.possibleMutationCommands, 1);
   assert.equal(committed.confirmedMutationCommands, 1);
 
+  const tamperedPriorProof = activeStateProof(history.at(-1), {
+    activeTargets: ["governance"],
+  });
+  tamperedPriorProof.projects.governance.priorDeploymentId =
+    "dpl_otherGovernancePrior123";
+  assert.throws(
+    () =>
+      reduceForward(
+        initial,
+        history,
+        event("finalize", {
+          uploadReceipt: receipt(history.at(-1)),
+          freshSha: SHA,
+          currentMappings: currentMappings(history.at(-1), {
+            governance: "candidate",
+          }),
+          publicSmokes: publicSmokes(["governance"]),
+          stateProof: tamperedPriorProof,
+        }),
+        ["governance"],
+      ),
+    /governance expectation is inconsistent/,
+  );
+
   for (const [name, mutate, pattern] of [
     [
       "wrong final URL",
@@ -913,7 +937,7 @@ test("mixed active and shadow planning validates shadow stages without journalin
   );
 });
 
-test("shadow final mapping accepts proven native or prior and rejects stage or third deployment", () => {
+test("shadow final mapping accepts the bound prior and rejects unbound same-SHA identities", () => {
   const { initial, history } = runOrdinaryForward();
   const stagedCandidates = {
     app: null,
@@ -936,7 +960,6 @@ test("shadow final mapping accepts proven native or prior and rejects stage or t
     shadowTargets: ["reserve"],
     stagedCandidates,
     mainOwnershipMode,
-    nativeOwners: { reserve: nativeReserve },
   });
   const finalize = (reserveDeployment) => {
     const mappings = currentMappings(history.at(-1), {
@@ -967,9 +990,9 @@ test("shadow final mapping accepts proven native or prior and rejects stage or t
       }),
     });
   };
-  assert.equal(finalize(nativeReserve).journal.status, "committed");
   assert.equal(finalize(initial.prior.reserve).journal.status, "committed");
   for (const forbidden of [
+    nativeReserve,
     stagedCandidates.reserve,
     {
       deploymentId: "dpl_reserveUnexpected123",

--- a/scripts/vercel-main-candidate-controller.mjs
+++ b/scripts/vercel-main-candidate-controller.mjs
@@ -12,6 +12,7 @@ import {
   canonicalizeDeploymentUrl,
   canonicalizeHostname,
 } from "./vercel-deployment-state.mjs";
+import { MAIN_DEPLOYMENT_TARGETS } from "./vercel-main-plan.mjs";
 import {
   MAIN_RELEASE_ACTIVATION_ORDER,
   assertMainReleaseManifest,
@@ -20,7 +21,7 @@ import {
 const MAIN_CANDIDATE_PREFLIGHT_SCHEMA = "vercel-main-candidate-preflight:v1";
 const MAIN_CANDIDATE_HANDOFF_SCHEMA = "vercel-main-candidate-handoff:v1";
 const MAIN_PREPLAN_CANDIDATE_DISCOVERY_SCHEMA =
-  "vercel-main-preplan-candidate-discovery:v1";
+  "vercel-main-preplan-candidate-discovery:v2";
 
 const EMPTY_REUSE_METRICS = Object.freeze({
   buildDurationMs: null,
@@ -133,6 +134,7 @@ export async function discoverMainPreplanCandidateReleases({
     throw new Error("Main pre-plan candidate provider is required");
   }
   const manifests = new Map();
+  const rollbackOnlyTargets = new Set();
   for (const target of MAIN_RELEASE_ACTIVATION_ORDER) {
     const deploymentIds = [
       ...new Set(mappings[target].map(({ deploymentId }) => deploymentId)),
@@ -143,7 +145,10 @@ export async function discoverMainPreplanCandidateReleases({
         target,
         projectId: projects[target],
       });
-      if (mapped.metadata === null) continue;
+      if (mapped.metadata === null) {
+        rollbackOnlyTargets.add(target);
+        continue;
+      }
       const manifest = assertMainReleaseManifest(
         mapped.metadata.releaseManifest,
       );
@@ -182,6 +187,9 @@ export async function discoverMainPreplanCandidateReleases({
   }
   return {
     schema: MAIN_PREPLAN_CANDIDATE_DISCOVERY_SCHEMA,
+    rollbackOnlyTargets: MAIN_DEPLOYMENT_TARGETS.filter((target) =>
+      rollbackOnlyTargets.has(target),
+    ),
     candidateReleases,
   };
 }

--- a/scripts/vercel-main-candidate-controller.test.mjs
+++ b/scripts/vercel-main-candidate-controller.test.mjs
@@ -31,6 +31,7 @@ function intent() {
     deploySha: input.deploySha,
     projectIds: input.projectIds,
     priorStates: input.priorStates,
+    rollbackOnlyTargets: [],
     gitAdapter: {
       firstParent: () => input.firstParent,
       isAncestor: () => true,
@@ -228,6 +229,8 @@ test("pre-plan discovery expands mapped release metadata into exact staged candi
       },
     },
   });
+  assert.equal(result.schema, "vercel-main-preplan-candidate-discovery:v2");
+  assert.deepEqual(result.rollbackOnlyTargets, ["app", "reserve", "ui"]);
   assert.equal(result.candidateReleases.length, 1);
   assert.deepEqual(
     Object.keys(result.candidateReleases[0].candidates),
@@ -241,17 +244,19 @@ test("pre-plan discovery expands mapped release metadata into exact staged candi
   );
 });
 
-test("pre-plan discovery ignores fully native mappings", async () => {
+test("pre-plan discovery marks every fully native mapping rollback-only", async () => {
   const manifest = intent().releaseManifest;
   let resolutions = 0;
   const result = await discoverMainPreplanCandidateReleases({
     currentMappings: mappingsFromManifest(manifest),
     projectIds: projectIdsFromManifest(manifest),
     provider: {
-      inspectMappedCandidate: async () => ({
-        canonicalState: {},
-        metadata: null,
-      }),
+      inspectMappedCandidate: async () => {
+        return {
+          canonicalState: {},
+          metadata: null,
+        };
+      },
       resolveReleaseCandidate: async () => {
         resolutions += 1;
         return null;
@@ -259,5 +264,11 @@ test("pre-plan discovery ignores fully native mappings", async () => {
     },
   });
   assert.deepEqual(result.candidateReleases, []);
+  assert.deepEqual(result.rollbackOnlyTargets, [
+    "app",
+    "governance",
+    "reserve",
+    "ui",
+  ]);
   assert.equal(resolutions, 0);
 });

--- a/scripts/vercel-main-candidate-provider.mjs
+++ b/scripts/vercel-main-candidate-provider.mjs
@@ -128,16 +128,7 @@ export function createMainCandidateVercelProvider({ client, intent }) {
     return {
       state,
       rawMetadata: deploymentResponse.meta,
-      source: deploymentResponse.source,
     };
-  }
-
-  async function inspectCandidateRecord(id, expected) {
-    const record = await inspectDeploymentRecord(id, expected);
-    if (record.source !== "cli") {
-      throw new Error("Main candidate Vercel source is not CLI");
-    }
-    return record;
   }
 
   async function inspectCandidateState(id) {
@@ -146,7 +137,7 @@ export function createMainCandidateVercelProvider({ client, intent }) {
         "Main candidate provider intent is required for inspection",
       );
     }
-    return (await inspectCandidateRecord(id, canonicalIntent)).state;
+    return (await inspectDeploymentRecord(id, canonicalIntent)).state;
   }
 
   async function inspectCandidate(id) {
@@ -155,7 +146,7 @@ export function createMainCandidateVercelProvider({ client, intent }) {
         "Main candidate provider intent is required for inspection",
       );
     }
-    const { state, rawMetadata } = await inspectCandidateRecord(
+    const { state, rawMetadata } = await inspectDeploymentRecord(
       id,
       canonicalIntent,
     );
@@ -200,18 +191,9 @@ export function createMainCandidateVercelProvider({ client, intent }) {
           ? { target: null, customEnvironmentSlug: "v3" }
           : { target: "production", customEnvironmentSlug: null },
     };
-    const { state, rawMetadata, source } = await inspectDeploymentRecord(
-      id,
-      expected,
-    );
+    const { state, rawMetadata } = await inspectDeploymentRecord(id, expected);
     if (!hasReservedCandidateMetadata(rawMetadata)) {
-      if (source !== "git") {
-        throw new Error("Main native mapped deployment source is not Git");
-      }
       return { canonicalState: state, metadata: null };
-    }
-    if (source !== "cli") {
-      throw new Error("Main candidate Vercel source is not CLI");
     }
     if (rawMetadata.mentoCandidateSchema === undefined) {
       throw new Error("Main mapped candidate metadata is partial");
@@ -279,7 +261,7 @@ export function createMainCandidateVercelProvider({ client, intent }) {
           ? { target: null, customEnvironmentSlug: "v3" }
           : { target: "production", customEnvironmentSlug: null },
     };
-    const { state, rawMetadata } = await inspectCandidateRecord(
+    const { state, rawMetadata } = await inspectDeploymentRecord(
       firstIds[0],
       expected,
     );

--- a/scripts/vercel-main-candidate-provider.test.mjs
+++ b/scripts/vercel-main-candidate-provider.test.mjs
@@ -364,14 +364,49 @@ test("mapped inspection binds its observed project to the manifest rollback prio
   );
 });
 
-test("mapped inspection admits native Git deployments for every live main environment only when no candidate markers exist", async () => {
+test("mapped inspection admits unmarked priors regardless of optional provider source", async () => {
   for (const target of ["governance", "reserve", "ui", "app"]) {
-    const oldIntent = intent(target);
-    const response = deploymentResponse(oldIntent);
-    response.source = "git";
-    for (const key of Object.keys(response.meta)) {
-      if (key.startsWith("mento")) delete response.meta[key];
+    for (const source of [undefined, "git", "cli", "redeploy"]) {
+      const oldIntent = intent(target);
+      const response = deploymentResponse(oldIntent);
+      if (source === undefined) delete response.source;
+      else response.source = source;
+      for (const key of Object.keys(response.meta)) {
+        if (key.startsWith("mento")) delete response.meta[key];
+      }
+      const provider = createMainCandidateVercelProvider({
+        client: {
+          requestWithRetry: async () =>
+            assert.fail("mapped inspection does not list"),
+          inspectDeployment: async () => response,
+          listDeploymentAliases: async () => ({ aliases: [] }),
+        },
+      });
+      const mapped = await provider.inspectMappedCandidate({
+        deploymentId: response.id,
+        target,
+        projectId: oldIntent.projectId,
+      });
+      assert.equal(mapped.metadata, null);
+      assert.deepEqual(
+        {
+          target: mapped.canonicalState.target,
+          customEnvironmentSlug: mapped.canonicalState.customEnvironmentSlug,
+        },
+        target === "app"
+          ? { target: null, customEnvironmentSlug: "v3" }
+          : { target: "production", customEnvironmentSlug: null },
+      );
     }
+  }
+});
+
+test("mapped inspection admits complete Mento candidates regardless of optional provider source", async () => {
+  const currentIntent = intent("ui");
+  for (const source of [undefined, "git", "cli", "redeploy"]) {
+    const response = deploymentResponse(currentIntent);
+    if (source === undefined) delete response.source;
+    else response.source = source;
     const provider = createMainCandidateVercelProvider({
       client: {
         requestWithRetry: async () =>
@@ -382,30 +417,79 @@ test("mapped inspection admits native Git deployments for every live main enviro
     });
     const mapped = await provider.inspectMappedCandidate({
       deploymentId: response.id,
-      target,
-      projectId: oldIntent.projectId,
+      target: "ui",
+      projectId: currentIntent.projectId,
     });
-    assert.equal(mapped.metadata, null);
-    assert.deepEqual(
-      {
-        target: mapped.canonicalState.target,
-        customEnvironmentSlug: mapped.canonicalState.customEnvironmentSlug,
-      },
-      target === "app"
-        ? { target: null, customEnvironmentSlug: "v3" }
-        : { target: "production", customEnvironmentSlug: null },
+    assert.equal(mapped.metadata.candidateId, currentIntent.candidateId);
+    assert.equal(
+      mapped.metadata.releaseManifest.releaseId,
+      currentIntent.releaseId,
     );
   }
 });
 
-test("mapped inspection rejects non-Git native deployment sources", async () => {
-  const currentIntent = intent("reserve");
-  for (const source of ["cli", "manual", "unknown", undefined]) {
+test("candidate inspection and release reuse ignore optional provider source", async () => {
+  const currentIntent = intent("ui");
+  for (const source of [undefined, "git", "cli", "redeploy"]) {
     const response = deploymentResponse(currentIntent);
-    response.source = source;
-    for (const key of Object.keys(response.meta)) {
-      if (key.startsWith("mento")) delete response.meta[key];
-    }
+    if (source === undefined) delete response.source;
+    else response.source = source;
+    const provider = createMainCandidateVercelProvider({
+      intent: currentIntent,
+      client: {
+        requestWithRetry: async () => ({
+          deployments: [{ uid: response.id }],
+          pagination: { next: null },
+        }),
+        inspectDeployment: async () => response,
+        listDeploymentAliases: async () => ({ aliases: [] }),
+      },
+    });
+    const state = await provider.inspectCandidateState(response.id);
+    assert.equal(state.git.sha, currentIntent.deploySha);
+    const candidate = await provider.inspectCandidate(response.id);
+    assert.equal(candidate.metadata.candidateId, currentIntent.candidateId);
+    const resolved = await provider.resolveReleaseCandidate({
+      manifest: currentIntent.releaseManifest,
+      target: "ui",
+      projectId: currentIntent.projectId,
+    });
+    assert.equal(resolved.candidate.deploymentId, response.id);
+    assert.equal(resolved.intent.digest, currentIntent.digest);
+  }
+});
+
+test("optional provider source does not bypass canonical mapped identity", async () => {
+  const currentIntent = intent("reserve");
+  for (const [patch, error] of [
+    [
+      (response) => {
+        response.readyState = "BUILDING";
+      },
+      /Unexpected deployment readiness/,
+    ],
+    [
+      (response) => {
+        response.projectId = "prj_wrong";
+      },
+      /Unexpected deployment project ID/,
+    ],
+    [
+      (response) => {
+        response.target = "preview";
+      },
+      /Unexpected deployment target/,
+    ],
+    [
+      (response) => {
+        delete response.meta.githubCommitRepo;
+      },
+      /Main candidate SHA is malformed/,
+    ],
+  ]) {
+    const response = deploymentResponse(currentIntent);
+    response.source = "redeploy";
+    patch(response);
     const provider = createMainCandidateVercelProvider({
       client: {
         requestWithRetry: async () =>
@@ -421,60 +505,8 @@ test("mapped inspection rejects non-Git native deployment sources", async () => 
           target: "reserve",
           projectId: currentIntent.projectId,
         }),
-      /native mapped deployment source is not Git/,
+      error,
     );
-  }
-});
-
-test("mapped inspection keeps Mento-marked candidates CLI-only", async () => {
-  const currentIntent = intent("ui");
-  const response = deploymentResponse(currentIntent);
-  response.source = "git";
-  const provider = createMainCandidateVercelProvider({
-    client: {
-      requestWithRetry: async () =>
-        assert.fail("mapped inspection does not list"),
-      inspectDeployment: async () => response,
-      listDeploymentAliases: async () => ({ aliases: [] }),
-    },
-  });
-  await assert.rejects(
-    () =>
-      provider.inspectMappedCandidate({
-        deploymentId: response.id,
-        target: "ui",
-        projectId: currentIntent.projectId,
-      }),
-    /candidate Vercel source is not CLI/,
-  );
-});
-
-test("candidate inspection and release reuse remain CLI-only", async () => {
-  const currentIntent = intent("ui");
-  const response = deploymentResponse(currentIntent);
-  response.source = "git";
-  const provider = createMainCandidateVercelProvider({
-    intent: currentIntent,
-    client: {
-      requestWithRetry: async () => ({
-        deployments: [{ uid: response.id }],
-        pagination: { next: null },
-      }),
-      inspectDeployment: async () => response,
-      listDeploymentAliases: async () => ({ aliases: [] }),
-    },
-  });
-  for (const inspect of [
-    () => provider.inspectCandidateState(response.id),
-    () => provider.inspectCandidate(response.id),
-    () =>
-      provider.resolveReleaseCandidate({
-        manifest: currentIntent.releaseManifest,
-        target: "ui",
-        projectId: currentIntent.projectId,
-      }),
-  ]) {
-    await assert.rejects(inspect, /candidate Vercel source is not CLI/);
   }
 });
 

--- a/scripts/vercel-main-candidate-provider.test.mjs
+++ b/scripts/vercel-main-candidate-provider.test.mjs
@@ -29,6 +29,7 @@ function releaseManifest() {
     deploySha: input.deploySha,
     projectIds: input.projectIds,
     priorStates: input.priorStates,
+    rollbackOnlyTargets: [],
     gitAdapter: {
       firstParent: () => input.firstParent,
       isAncestor: () => true,
@@ -397,6 +398,37 @@ test("mapped inspection admits unmarked priors regardless of optional provider s
           ? { target: null, customEnvironmentSlug: "v3" }
           : { target: "production", customEnvironmentSlug: null },
       );
+    }
+  }
+});
+
+test("unmarked mappings that self-report the reviewed SHA remain rollback-only", async () => {
+  const reviewedSha = "e".repeat(40);
+  for (const target of ["governance", "reserve", "ui", "app"]) {
+    for (const source of [undefined, "git", "cli", "redeploy"]) {
+      const oldIntent = intent(target);
+      const response = deploymentResponse(oldIntent);
+      if (source === undefined) delete response.source;
+      else response.source = source;
+      for (const key of Object.keys(response.meta)) {
+        if (key.startsWith("mento")) delete response.meta[key];
+      }
+      response.meta.githubCommitSha = reviewedSha;
+      const provider = createMainCandidateVercelProvider({
+        client: {
+          requestWithRetry: async () =>
+            assert.fail("mapped inspection does not list"),
+          inspectDeployment: async () => response,
+          listDeploymentAliases: async () => ({ aliases: [] }),
+        },
+      });
+      const mapped = await provider.inspectMappedCandidate({
+        deploymentId: response.id,
+        target,
+        projectId: oldIntent.projectId,
+      });
+      assert.equal(mapped.metadata, null);
+      assert.equal(mapped.canonicalState.git.sha, reviewedSha);
     }
   }
 });

--- a/scripts/vercel-main-candidate.test.mjs
+++ b/scripts/vercel-main-candidate.test.mjs
@@ -51,6 +51,7 @@ function planContext() {
     deploySha: input.deploySha,
     projectIds: input.projectIds,
     priorStates: input.priorStates,
+    rollbackOnlyTargets: [],
     gitAdapter,
     runPlanner: ({ base, head }) => ({
       base,

--- a/scripts/vercel-main-deployment-workflow.test.mjs
+++ b/scripts/vercel-main-deployment-workflow.test.mjs
@@ -171,6 +171,28 @@ test("provider preplan captures both reviewed snapshots then discovers and decid
   );
 });
 
+test("project ID files are materialized privately before shell redirection", () => {
+  const writers = Object.entries(workflow.jobs).flatMap(([jobName, job]) =>
+    (job.steps ?? [])
+      .filter((step) => step.run?.includes('> "$RUNNER_TEMP/projects.json"'))
+      .map((step) => ({ jobName, run: step.run })),
+  );
+
+  assert.deepEqual(
+    writers.map(({ jobName }) => jobName),
+    ["provider-preplan", "prepare-release"],
+  );
+  for (const { jobName, run } of writers) {
+    const privateUmask = run.indexOf("umask 077");
+    const projectIdsRedirect = run.indexOf('> "$RUNNER_TEMP/projects.json"');
+    assert.notEqual(privateUmask, -1, `${jobName} must set a private umask`);
+    assert.ok(
+      privateUmask < projectIdsRedirect,
+      `${jobName} must set its private umask before writing project IDs`,
+    );
+  }
+});
+
 test("preplan installs the admitted source without lifecycle scripts before protected state access", () => {
   const install = steps("provider-preplan").find(
     (step) => step.uses === "./.github/actions/pnpm-install",

--- a/scripts/vercel-main-deployment.mjs
+++ b/scripts/vercel-main-deployment.mjs
@@ -209,6 +209,8 @@ export const MAIN_ACTIVE_MAX_RECOVERY_TRANSITIONS =
   MAIN_TARGET_CONTRACTS.app.aliases.length +
   MAIN_DURABLE_LEGACY_RECOVERY_ALIASES.length;
 const MAX_JSON_BYTES = 256 * 1024;
+export const MAIN_ACTIVE_JOURNAL_HISTORY_MAX_JSON_BYTES = 1024 * 1024;
+export const MAIN_ACTIVE_TERMINAL_PROOFS_MAX_JSON_BYTES = 1024 * 1024;
 const APP_BUILD_PROOF_SCHEMA = "vercel-main-app-build:v2";
 const CLI_COMMAND_OPTIONS = Object.freeze({
   "active-event-authorize": Object.freeze([
@@ -519,9 +521,9 @@ function parseJson(raw, label) {
   }
 }
 
-function readJson(path, label) {
+function readJson(path, label, maxBytes = MAX_JSON_BYTES) {
   const raw = readFileSync(path);
-  if (raw.byteLength > MAX_JSON_BYTES) {
+  if (raw.byteLength > maxBytes) {
     throw new Error(`${label} exceeds its size limit`);
   }
   try {
@@ -529,6 +531,10 @@ function readJson(path, label) {
   } catch {
     throw new Error(`${label} is not valid JSON`);
   }
+}
+
+function readActiveJournalHistory(path, label) {
+  return readJson(path, label, MAIN_ACTIVE_JOURNAL_HISTORY_MAX_JSON_BYTES);
 }
 
 function writeCanonicalJson(path, value) {
@@ -820,6 +826,7 @@ export function createMainDeploymentPlan({
   projectIds,
   planningSnapshot,
   legacySnapshot,
+  rollbackOnlyTargets,
   upstream,
   repoRoot = process.cwd(),
   gitAdapter,
@@ -850,6 +857,7 @@ export function createMainDeploymentPlan({
     deploySha: sha,
     projectIds: ids,
     priorStates,
+    rollbackOnlyTargets,
     repoRoot,
     ...(gitAdapter ? { gitAdapter } : {}),
     ...(runPlanner ? { runPlanner } : {}),
@@ -2571,6 +2579,17 @@ function canonicalTerminalStateProof(value, { execution, runId, runAttempt }) {
         "Main terminal deployment state proof identity conflicts",
       );
     }
+    for (const target of MAIN_DEPLOYMENT_TARGETS) {
+      const project = deploymentStateProof.projects[target];
+      const prior = current.execution.manifest.originalPriors[target];
+      if (
+        project.priorDeploymentId !== prior.deploymentId ||
+        project.priorDeploymentUrl !== prior.deploymentUrl ||
+        project.priorServedSha !== prior.servedSha
+      ) {
+        throw new Error("Main terminal deployment state proof prior conflicts");
+      }
+    }
   }
   assertExactKeys(
     value.currentReleaseCandidates,
@@ -4088,6 +4107,7 @@ function summarizeActiveDeploymentStateProof(
     shadowTargets,
     projectIds = null,
     expectedDeploymentIds = null,
+    originalPriors = null,
     legacyState = null,
     requireProven = false,
   },
@@ -4118,11 +4138,17 @@ function summarizeActiveDeploymentStateProof(
   }
   for (const target of MAIN_DEPLOYMENT_TARGETS) {
     const project = proof.projects[target];
+    const originalPrior = originalPriors?.[target];
     if (
       (projectIds !== null && project.projectId !== projectIds[target]) ||
       (expectedDeploymentIds !== null &&
         expectedDeploymentIds[target] !== undefined &&
-        project.expectedDeploymentId !== expectedDeploymentIds[target])
+        project.expectedDeploymentId !== expectedDeploymentIds[target]) ||
+      (originalPriors !== null &&
+        (originalPrior === undefined ||
+          project.priorDeploymentId !== originalPrior.deploymentId ||
+          project.priorDeploymentUrl !== originalPrior.deploymentUrl ||
+          project.priorServedSha !== originalPrior.servedSha))
     ) {
       throw new Error(
         "Active deployment state proof does not match the release plan",
@@ -4281,6 +4307,9 @@ export function createMainActiveDeploymentEvidence({
             ? undefined
             : null,
       ]),
+    ),
+    originalPriors: Object.fromEntries(
+      handoff.planning.priors.map((prior) => [prior.target, prior]),
     ),
     legacyState: handoff.legacySnapshot[0],
     requireProven: true,
@@ -5488,6 +5517,7 @@ function canonicalCompleteTerminalStateProof({
     projectIds: execution.projection.projectIds,
     expectedDeploymentIds:
       expectedCandidateIds ?? terminalExpectedCandidateIds(highest, planning),
+    originalPriors: execution.manifest.originalPriors,
     legacyState: execution.legacyAppV2,
     requireProven: true,
   });
@@ -5968,6 +5998,7 @@ export function createMainActiveTerminalArtifacts({
         shadowTargets: planning.shadowTargets,
         projectIds: releaseExecution.projection.projectIds,
         expectedDeploymentIds,
+        originalPriors: manifest.originalPriors,
         legacyState: releaseExecution.legacyAppV2,
         requireProven: true,
       },
@@ -6253,6 +6284,7 @@ export function createMainActiveTerminalArtifacts({
               runAttempt: canonicalRunAttempt,
               transactionId: highest.transactionId,
               mainOwnershipMode: planning.mainOwnershipMode,
+              originalPriors: manifest.originalPriors,
             });
             return stateProof;
           })()
@@ -6335,6 +6367,7 @@ export function createMainActiveTerminalArtifacts({
               highest,
               planning,
             ),
+            originalPriors: manifest.originalPriors,
             legacyState: releaseExecution.legacyAppV2,
             requireProven: true,
           },
@@ -6649,7 +6682,7 @@ function canonicalNestedStateProofSummary(
     "Nested active state proof summary",
   );
   if (
-    value.proofSchema !== "vercel-active-deployment-state-proof:v3" ||
+    value.proofSchema !== "vercel-active-deployment-state-proof:v4" ||
     !["proven", "unproven"].includes(value.outcome) ||
     (requireProven && value.outcome !== "proven") ||
     value.transactionId !== transactionId
@@ -7617,6 +7650,7 @@ function assertTerminalStateProofMatchesEvidence({
                 : null,
           ]),
         ),
+        originalPriors: execution.manifest.originalPriors,
         legacyState: execution.legacyAppV2,
         requireProven: true,
       })
@@ -7626,6 +7660,7 @@ function assertTerminalStateProofMatchesEvidence({
         runAttempt: evidence.runAttempt,
         transactionId,
         mainOwnershipMode: evidence.mainOwnershipMode,
+        originalPriors: execution.manifest.originalPriors,
       });
   assertSameJson(
     summary,
@@ -8390,7 +8425,11 @@ export async function runMainDeploymentCli({
         options.execution,
         "Canonical main release execution",
       ),
-      proofs: readJson(options.proofs, "Canonical active terminal proofs"),
+      proofs: readJson(
+        options.proofs,
+        "Canonical active terminal proofs",
+        MAIN_ACTIVE_TERMINAL_PROOFS_MAX_JSON_BYTES,
+      ),
       deploySha: values.DEPLOY_SHA,
       upstreamRunId: values.UPSTREAM_RUN_ID,
       upstreamRunAttempt: values.UPSTREAM_RUN_ATTEMPT,
@@ -8674,7 +8713,7 @@ export async function runMainDeploymentCli({
     const spec = createMainCurrentActiveDeploymentStateSpec({
       execution: readJson(options.execution, "Main release execution"),
       barrier: readJson(options["stage-barrier"], "Current main stage barrier"),
-      journalHistory: readJson(
+      journalHistory: readActiveJournalHistory(
         options["journal-history"],
         "Active state spec journal history",
       ),
@@ -8722,7 +8761,7 @@ export async function runMainDeploymentCli({
   }
   if (command === "active-recovery-mapping-spec") {
     const spec = createMainActiveRecoveryMappingSpec({
-      journalHistory: readJson(
+      journalHistory: readActiveJournalHistory(
         options["journal-history"],
         "Active recovery mapping-spec journal history",
       ),
@@ -8734,7 +8773,7 @@ export async function runMainDeploymentCli({
   }
   if (command === "active-recovery-canonical-mappings") {
     const mappings = createMainActiveRecoveryCanonicalMappings({
-      journalHistory: readJson(
+      journalHistory: readActiveJournalHistory(
         options["journal-history"],
         "Active recovery canonical-mappings journal history",
       ),
@@ -8750,7 +8789,7 @@ export async function runMainDeploymentCli({
   }
   if (command === "active-recovery-state-spec") {
     const spec = createMainActiveRecoveryDeploymentStateSpec({
-      journalHistory: readJson(
+      journalHistory: readActiveJournalHistory(
         options["journal-history"],
         "Active recovery state-spec journal history",
       ),
@@ -8779,7 +8818,7 @@ export async function runMainDeploymentCli({
     const spec = createMainCurrentActiveAliasMappingSet({
       execution: readJson(options.execution, "Main release execution"),
       barrier: readJson(options["stage-barrier"], "Current main stage barrier"),
-      journalHistory: readJson(
+      journalHistory: readActiveJournalHistory(
         options["journal-history"],
         "Active mapping set journal history",
       ),
@@ -8846,7 +8885,10 @@ export async function runMainDeploymentCli({
       preparedJournal,
       ...inputs.planning,
       history: activeJournalArray(
-        readJson(options["journal-history"], "Active journal history"),
+        readActiveJournalHistory(
+          options["journal-history"],
+          "Active journal history",
+        ),
         "Active journal history",
       ),
       event: readJson(options.event, "Active transition event"),
@@ -8861,7 +8903,10 @@ export async function runMainDeploymentCli({
   if (command === "plan-active-recovery") {
     const recoveryPlan = planMainActiveRecovery({
       journalHistory: activeJournalArray(
-        readJson(options["journal-history"], "Active recovery journal history"),
+        readActiveJournalHistory(
+          options["journal-history"],
+          "Active recovery journal history",
+        ),
         "Active recovery journal history",
       ),
       deploySha: values.DEPLOY_SHA,
@@ -8894,7 +8939,10 @@ export async function runMainDeploymentCli({
     const result = reduceMainActiveRecoveryTransition({
       recoveryPlan: readJson(options.plan, "Active recovery plan"),
       history: activeJournalArray(
-        readJson(options["journal-history"], "Active recovery journal history"),
+        readActiveJournalHistory(
+          options["journal-history"],
+          "Active recovery journal history",
+        ),
         "Active recovery journal history",
       ),
       event: readJson(options.event, "Active recovery transition event"),
@@ -8957,7 +9005,10 @@ export async function runMainDeploymentCli({
     const evidence = createMainActiveDeploymentEvidence({
       plan: parseJson(values.PLAN_JSON, "Main deployment plan"),
       journalHistory: activeJournalArray(
-        readJson(options["journal-history"], "Active evidence journal history"),
+        readActiveJournalHistory(
+          options["journal-history"],
+          "Active evidence journal history",
+        ),
         "Active evidence journal history",
       ),
       freshness: parseJson(
@@ -9008,7 +9059,10 @@ export async function runMainDeploymentCli({
       workflowRunUrl: activeWorkflowRunUrlFromEnvironment(values),
       mainOwnershipMode: mainOwnershipModeFromEnvironment(values),
       journalHistory: activeJournalArray(
-        readJson(options["journal-history"], "Active failure journal history"),
+        readActiveJournalHistory(
+          options["journal-history"],
+          "Active failure journal history",
+        ),
         "Active failure journal history",
       ),
       freshness: parseJson(
@@ -9148,6 +9202,7 @@ export async function runMainDeploymentCli({
         options["legacy-snapshot"],
         "Legacy app snapshot",
       ),
+      rollbackOnlyTargets: MAIN_DEPLOYMENT_TARGETS,
       upstream: {
         runId: values.UPSTREAM_RUN_ID,
         runAttempt: values.UPSTREAM_RUN_ATTEMPT,

--- a/scripts/vercel-main-deployment.test.mjs
+++ b/scripts/vercel-main-deployment.test.mjs
@@ -25,7 +25,9 @@ import {
   MAIN_ACTIVE_CURRENT_RELEASE_EVIDENCE_SCHEMA,
   MAIN_ACTIVE_EVIDENCE_SCHEMA,
   MAIN_ACTIVE_FAILURE_EVIDENCE_SCHEMA,
+  MAIN_ACTIVE_JOURNAL_HISTORY_MAX_JSON_BYTES,
   MAIN_ACTIVE_SAFE_NOOP_EVIDENCE_SCHEMA,
+  MAIN_ACTIVE_TERMINAL_PROOFS_MAX_JSON_BYTES,
   MAIN_ACTIVE_TERMINAL_PROOFS_SCHEMA,
   MAIN_DEPLOYMENT_MODE,
   MAIN_DEPLOYMENT_SCHEMA,
@@ -125,6 +127,7 @@ import {
   generateVercelDeploymentId,
   generateVercelMainCandidateDeploymentId,
 } from "./vercel-prebuilt.mjs";
+import { MAIN_DEPLOYMENT_TARGETS } from "./vercel-main-plan.mjs";
 
 const SHA = "dddddddddddddddddddddddddddddddddddddddd";
 const OTHER_SHA = "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee";
@@ -233,6 +236,7 @@ function plan({
     projectIds,
     planningSnapshot: planningSnapshot(),
     legacySnapshot: legacySnapshot(),
+    rollbackOnlyTargets: [],
     upstream: upstream(),
     gitAdapter: gitAdapter(),
     runPlanner: ({ base, head }) => ({
@@ -306,6 +310,7 @@ function releaseExecutionForPlan(deploymentPlan) {
   const selection = createMainReleaseSelection({
     providerDiscoveryDigest: "f".repeat(64),
     planningSnapshotDigest: "e".repeat(64),
+    rollbackOnlyTargets: manifest.rollbackOnlyTargets,
     legacyAppV2,
     projectIds: Object.fromEntries(
       ["governance", "reserve", "ui", "app"].map((target) => [
@@ -756,7 +761,7 @@ function activeStateProof({
     spec,
     deployments,
     legacyV2: {
-      source: "git",
+      ownership: "native-vercel-git",
       state: {
         alias: spec.legacyAppV2.alias,
         deploymentId: spec.legacyAppV2.deployment,
@@ -2297,6 +2302,91 @@ test("plan handoff binds upstream receipt, protected state, served-SHA plan, and
   );
 });
 
+test("legacy plan CLI conservatively selects every rollback-only main target", () => {
+  const directory = mkdtempSync(join(tmpdir(), "vercel-main-plan-"));
+  try {
+    const sourcePath = fileURLToPath(new URL("..", import.meta.url));
+    const head = spawnSync("git", ["rev-parse", "--verify", "HEAD^{commit}"], {
+      cwd: sourcePath,
+      encoding: "utf8",
+    });
+    assert.equal(head.status, 0, head.stderr);
+
+    const planPath = join(directory, "plan.json");
+    const planningSnapshotPath = join(directory, "planning-snapshot.json");
+    const legacySnapshotPath = join(directory, "legacy-snapshot.json");
+    const githubOutput = join(directory, "github-output");
+    writeFileSync(planningSnapshotPath, JSON.stringify(planningSnapshot()));
+    writeFileSync(legacySnapshotPath, JSON.stringify(legacySnapshot()));
+    writeFileSync(githubOutput, "");
+
+    const result = spawnSync(
+      process.execPath,
+      [
+        fileURLToPath(new URL("./vercel-main-deployment.mjs", import.meta.url)),
+        "plan",
+        "--planning-snapshot",
+        planningSnapshotPath,
+        "--legacy-snapshot",
+        legacySnapshotPath,
+        "--output",
+        planPath,
+      ],
+      {
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          VERCEL_MAIN_MODE: MAIN_ACTIVE_DEPLOYMENT_MODE,
+          MAIN_OWNERSHIP_MODE_JSON: JSON.stringify(
+            Object.fromEntries(
+              MAIN_DEPLOYMENT_TARGETS.map((target) => [
+                target,
+                MAIN_OWNERSHIP_MODES.GITHUB,
+              ]),
+            ),
+          ),
+          DEPLOY_SHA: head.stdout.trim(),
+          VERCEL_PROJECT_ID_APP: projectIds.app,
+          VERCEL_PROJECT_ID_GOVERNANCE: projectIds.governance,
+          VERCEL_PROJECT_ID_RESERVE: projectIds.reserve,
+          VERCEL_PROJECT_ID_UI: projectIds.ui,
+          UPSTREAM_RUN_ID: "123456",
+          UPSTREAM_RUN_ATTEMPT: "2",
+          UPSTREAM_RUN_URL:
+            "https://github.com/mento-protocol/frontend-monorepo/actions/runs/123456",
+          BUILD_AND_TEST_JOB_URL:
+            "https://github.com/mento-protocol/frontend-monorepo/actions/runs/123456/job/654321",
+          SOURCE_PATH: sourcePath,
+          GITHUB_OUTPUT: githubOutput,
+        },
+      },
+    );
+    assert.equal(result.status, 0, result.stderr);
+
+    const handoff = JSON.parse(readFileSync(planPath, "utf8"));
+    assert.deepEqual(handoff.planning.plan, [...MAIN_DEPLOYMENT_TARGETS]);
+    assert.deepEqual(handoff.planning.stagedTargets, [
+      ...MAIN_DEPLOYMENT_TARGETS,
+    ]);
+    assert.deepEqual(handoff.planning.activeTargets, [
+      ...MAIN_DEPLOYMENT_TARGETS,
+    ]);
+    assert.deepEqual(handoff.planning.shadowTargets, []);
+    assert.deepEqual(
+      handoff.planning.reasons,
+      MAIN_DEPLOYMENT_TARGETS.map((target) => ({
+        target,
+        reason: "served-mapping-rollback-only",
+        base: handoff.planning.priors.find((prior) => prior.target === target)
+          .servedSha,
+      })),
+    );
+    assert.deepEqual(handoff.planning.ranges, []);
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
 for (const [name, mutate, reason] of [
   [
     "missing Git",
@@ -2367,6 +2457,7 @@ for (const [name, mutate, reason] of [
       projectIds,
       planningSnapshot: snapshot,
       legacySnapshot: legacySnapshot(),
+      rollbackOnlyTargets: [],
       upstream: upstream(),
       gitAdapter: gitAdapter(),
       runPlanner: ({ base, head }) => ({
@@ -2528,6 +2619,7 @@ test("protected rollback identity remains stable while ordinary generated aliase
         projectIds,
         planningSnapshot: planningSnapshot(),
         legacySnapshot: incompleteLegacyTopology,
+        rollbackOnlyTargets: [],
         upstream: upstream(),
         gitAdapter: gitAdapter(),
         runPlanner: ({ base, head }) => ({
@@ -2668,6 +2760,7 @@ test("protected rollback identity remains stable while ordinary generated aliase
       projectIds,
       planningSnapshot: captured,
       legacySnapshot: legacySnapshot(),
+      rollbackOnlyTargets: [],
       upstream: upstream(),
       gitAdapter: gitAdapter(),
       runPlanner: ({ base, head }) => ({
@@ -3306,7 +3399,7 @@ test("active controller commits exact ordered mutations and emits canonical reda
   assert.equal(evidence.finalMappings.length, 9);
   assert.equal(
     evidence.stateProofSummary.proofSchema,
-    "vercel-active-deployment-state-proof:v3",
+    "vercel-active-deployment-state-proof:v4",
   );
   assert.deepEqual(evidence.recovery.rollbackStateTargets, []);
   assert.match(
@@ -3397,6 +3490,29 @@ test("execution-bound terminal artifacts derive committed and verified-noop proo
   assert.deepEqual(
     assertMainActiveTerminalProofs(committedArtifacts.proofs).journal.artifact,
     committed.journalHistory,
+  );
+  const tamperedPriorProof = structuredClone(committedTerminalStateProof);
+  tamperedPriorProof.deploymentStateProof.projects.governance.priorDeploymentId =
+    "dpl_otherGovernancePrior123";
+  assert.throws(
+    () =>
+      createMainActiveTerminalArtifacts({
+        execution: committedExecution,
+        outcome: "active-committed",
+        journalHistory: activeHistoryDocument(committed.journalHistory),
+        finalMappings: providerMappings(
+          committedExecution,
+          activeFinalMappings(committedHarness),
+        ),
+        publicSmokes: activePublicSmokes(committed),
+        stateProof: tamperedPriorProof,
+        finalCensus: tamperedPriorProof,
+        freshLegacyV2: committedHarness.plan.legacySnapshot,
+        freshness: null,
+        runId: "800",
+        runAttempt: "3",
+      }),
+    /deployment state proof prior conflicts/,
   );
 
   const noopPlan = activePlan({ deployments: ["governance"] });
@@ -4217,6 +4333,12 @@ test("terminal evidence CLI creates a bounded receipt and restores committed evi
       stateProof,
       execution,
     });
+    const canonicalProofJson = `${JSON.stringify(proofs)}\n`;
+    const canonicalProofBytes = Buffer.byteLength(canonicalProofJson, "utf8");
+    assert.ok(
+      canonicalProofBytes <= MAIN_ACTIVE_TERMINAL_PROOFS_MAX_JSON_BYTES,
+      `canonical terminal proofs use ${canonicalProofBytes} bytes`,
+    );
     assert.equal(
       assertMainActiveTerminalProofs(proofs).outcome,
       "active-committed",
@@ -4259,6 +4381,101 @@ test("terminal evidence CLI creates a bounded receipt and restores committed evi
           repository: "mento-protocol/frontend-monorepo",
         }),
       /final census proof conflicts with canonical evidence/,
+    );
+
+    let recoveryJournal = startMainTransactionRecovery(
+      transaction.journalHistory.at(-2),
+    );
+    const maximalRecoveryHistory = [
+      ...transaction.journalHistory.slice(0, -1),
+      recoveryJournal,
+    ];
+    const maximalRecoveryIntents = [
+      ...["governance", "reserve", "ui"].map((target) => ({
+        type: "ordinary_rollback",
+        target,
+        alias: null,
+      })),
+      ...recoveryJournal.prior.app.aliases.map((alias) => ({
+        type: "app_alias_restore",
+        target: "app",
+        alias,
+      })),
+      ...recoveryJournal.prior["legacy-app"].aliases.map((alias) => ({
+        type: "legacy_emergency_restore",
+        target: "legacy-app",
+        alias,
+      })),
+    ];
+    for (const intent of maximalRecoveryIntents) {
+      recoveryJournal = startMainTransactionOperation(recoveryJournal, intent);
+      maximalRecoveryHistory.push(recoveryJournal);
+      const operationId = recoveryJournal.operations.at(-1).operationId;
+      recoveryJournal = recordMainTransactionCommandReturned(recoveryJournal, {
+        operationId,
+        outcome: "success",
+      });
+      maximalRecoveryHistory.push(recoveryJournal);
+      recoveryJournal = recordMainTransactionVerified(recoveryJournal, {
+        operationId,
+        mappingState: "prior",
+        rollbackState: intent.type === "ordinary_rollback" ? "entered" : null,
+      });
+      maximalRecoveryHistory.push(recoveryJournal);
+    }
+    recoveryJournal = finishMainTransactionRecovery(recoveryJournal);
+    maximalRecoveryHistory.push(recoveryJournal);
+    assertMainActiveJournalHistory({
+      journals: maximalRecoveryHistory,
+      deploySha: SHA,
+      runId: "800",
+      runAttempt: "3",
+    });
+    const maximalHistoryDocument = activeHistoryDocument(
+      maximalRecoveryHistory,
+    );
+    const maximalHistoryJson = `${JSON.stringify(maximalHistoryDocument)}\n`;
+    const maximalHistoryBytes = Buffer.byteLength(maximalHistoryJson, "utf8");
+    assert.ok(
+      maximalHistoryBytes > 256 * 1024,
+      `maximal journal history unexpectedly uses only ${maximalHistoryBytes} bytes`,
+    );
+    assert.ok(
+      maximalHistoryBytes <= MAIN_ACTIVE_JOURNAL_HISTORY_MAX_JSON_BYTES,
+      `maximal journal history uses ${maximalHistoryBytes} bytes`,
+    );
+    const maximalPriorMappings = Object.values(recoveryJournal.prior).flatMap(
+      (prior) => prior.aliases.map((alias) => mapping(alias, prior)),
+    );
+    const maximalRecoveryStateProof = activeStateProof({
+      deploymentPlan: harness.plan,
+      journalHistory: maximalRecoveryHistory,
+      jobs: harness.stageJobs,
+      runId: "800",
+      runAttempt: "3",
+    });
+    const maximalRecoveryArtifacts = createMainActiveTerminalArtifacts({
+      execution,
+      outcome: "recovered",
+      journalHistory: maximalHistoryDocument,
+      finalMappings: providerMappings(execution, maximalPriorMappings),
+      publicSmokes: priorPublicSmokes(execution),
+      stateProof: maximalRecoveryStateProof,
+      finalCensus: maximalRecoveryStateProof,
+      freshLegacyV2: harness.plan.legacySnapshot,
+      freshness: null,
+      runId: "800",
+      runAttempt: "3",
+    });
+    const maximalProofJson = `${JSON.stringify(maximalRecoveryArtifacts.proofs)}\n`;
+    const maximalProofBytes = Buffer.byteLength(maximalProofJson, "utf8");
+    assert.ok(
+      maximalProofBytes > 512 * 1024,
+      `maximal recovery proofs unexpectedly use only ${maximalProofBytes} bytes`,
+    );
+    assert.ok(
+      maximalProofBytes <= MAIN_ACTIVE_TERMINAL_PROOFS_MAX_JSON_BYTES,
+      `maximal recovery proofs use ${maximalProofBytes} bytes`,
     );
 
     const executionPath = join(directory, "execution.json");
@@ -4324,6 +4541,160 @@ test("terminal evidence CLI creates a bounded receipt and restores committed evi
     assert.ok(Buffer.byteLength(createResult.encodedEvidence) < 64 * 1024);
     assert.equal(statSync(receiptPath).mode & 0o777, 0o600);
     assert.equal(statSync(terminalEvidencePath).mode & 0o777, 0o600);
+    const maximalHistoryPath = join(directory, "maximal-journal-history.json");
+    writeFileSync(maximalHistoryPath, maximalHistoryJson);
+    await runMainDeploymentCli({
+      argv: [
+        "active-recovery-mapping-spec",
+        "--journal-history",
+        maximalHistoryPath,
+        "--output",
+        join(directory, "maximal-recovery-mapping-spec.json"),
+      ],
+      values: {
+        DEPLOY_SHA: SHA,
+        GITHUB_RUN_ID: "800",
+        GITHUB_RUN_ATTEMPT: "3",
+      },
+    });
+    const oversizedHistoryPath = join(
+      directory,
+      "oversized-journal-history.json",
+    );
+    writeFileSync(
+      oversizedHistoryPath,
+      `${maximalHistoryJson}${" ".repeat(
+        MAIN_ACTIVE_JOURNAL_HISTORY_MAX_JSON_BYTES - maximalHistoryBytes + 1,
+      )}`,
+    );
+    await assert.rejects(
+      runMainDeploymentCli({
+        argv: [
+          "active-recovery-mapping-spec",
+          "--journal-history",
+          oversizedHistoryPath,
+          "--output",
+          join(directory, "oversized-recovery-mapping-spec.json"),
+        ],
+        values: {
+          DEPLOY_SHA: SHA,
+          GITHUB_RUN_ID: "800",
+          GITHUB_RUN_ATTEMPT: "3",
+        },
+      }),
+      /Active recovery mapping-spec journal history exceeds its size limit/,
+    );
+    const maximalProofPath = join(directory, "maximal-recovery-proofs.json");
+    const maximalEvidencePath = join(
+      directory,
+      "maximal-recovery-active-evidence.json",
+    );
+    writeFileSync(maximalProofPath, maximalProofJson);
+    writeFileSync(
+      maximalEvidencePath,
+      `${JSON.stringify(maximalRecoveryArtifacts.evidence)}\n`,
+    );
+    const maximalGithubOutput = join(
+      directory,
+      "github-output-maximal-recovery",
+    );
+    writeFileSync(maximalGithubOutput, "");
+    const maximalCreateResult = await runMainDeploymentCli({
+      argv: [
+        "terminal-evidence-create",
+        "--active-evidence",
+        maximalEvidencePath,
+        "--evidence-output",
+        join(directory, "maximal-recovery-terminal-evidence.json"),
+        "--execution",
+        executionPath,
+        "--manifest",
+        manifestPath,
+        "--proofs",
+        maximalProofPath,
+        "--receipt-output",
+        join(directory, "maximal-recovery-receipt.json"),
+      ],
+      values: {
+        DEPLOY_SHA: SHA,
+        UPSTREAM_RUN_ID: "123456",
+        UPSTREAM_RUN_ATTEMPT: "2",
+        GITHUB_RUN_ID: "800",
+        GITHUB_RUN_ATTEMPT: "3",
+        GITHUB_REPOSITORY: "mento-protocol/frontend-monorepo",
+        GITHUB_OUTPUT: maximalGithubOutput,
+      },
+    });
+    assert.equal(maximalCreateResult.receipt.outcome, "recovered");
+    const boundaryProofPath = join(directory, "proofs-at-size-limit.json");
+    const boundaryBytes =
+      MAIN_ACTIVE_TERMINAL_PROOFS_MAX_JSON_BYTES - maximalProofBytes;
+    writeFileSync(
+      boundaryProofPath,
+      `${maximalProofJson}${" ".repeat(boundaryBytes)}`,
+    );
+    const boundaryGithubOutput = join(directory, "github-output-at-size-limit");
+    writeFileSync(boundaryGithubOutput, "");
+    await runMainDeploymentCli({
+      argv: [
+        "terminal-evidence-create",
+        "--active-evidence",
+        maximalEvidencePath,
+        "--evidence-output",
+        join(directory, "terminal-evidence-at-size-limit.json"),
+        "--execution",
+        executionPath,
+        "--manifest",
+        manifestPath,
+        "--proofs",
+        boundaryProofPath,
+        "--receipt-output",
+        join(directory, "receipt-at-size-limit.json"),
+      ],
+      values: {
+        DEPLOY_SHA: SHA,
+        UPSTREAM_RUN_ID: "123456",
+        UPSTREAM_RUN_ATTEMPT: "2",
+        GITHUB_RUN_ID: "800",
+        GITHUB_RUN_ATTEMPT: "3",
+        GITHUB_REPOSITORY: "mento-protocol/frontend-monorepo",
+        GITHUB_OUTPUT: boundaryGithubOutput,
+      },
+    });
+    const oversizedProofPath = join(directory, "proofs-over-size-limit.json");
+    writeFileSync(
+      oversizedProofPath,
+      `${maximalProofJson}${" ".repeat(boundaryBytes + 1)}`,
+    );
+    await assert.rejects(
+      runMainDeploymentCli({
+        argv: [
+          "terminal-evidence-create",
+          "--active-evidence",
+          maximalEvidencePath,
+          "--evidence-output",
+          join(directory, "terminal-evidence-over-size-limit.json"),
+          "--execution",
+          executionPath,
+          "--manifest",
+          manifestPath,
+          "--proofs",
+          oversizedProofPath,
+          "--receipt-output",
+          join(directory, "receipt-over-size-limit.json"),
+        ],
+        values: {
+          DEPLOY_SHA: SHA,
+          UPSTREAM_RUN_ID: "123456",
+          UPSTREAM_RUN_ATTEMPT: "2",
+          GITHUB_RUN_ID: "800",
+          GITHUB_RUN_ATTEMPT: "3",
+          GITHUB_REPOSITORY: "mento-protocol/frontend-monorepo",
+          GITHUB_OUTPUT: boundaryGithubOutput,
+        },
+      }),
+      /Canonical active terminal proofs exceeds its size limit/,
+    );
     const outputs = Object.fromEntries(
       readFileSync(githubOutput, "utf8")
         .trim()
@@ -4398,6 +4769,7 @@ test("terminal evidence CLI creates a bounded receipt and restores committed evi
     const changedLegacySelection = createMainReleaseSelection({
       providerDiscoveryDigest: execution.selection.providerDiscoveryDigest,
       planningSnapshotDigest: execution.selection.planningSnapshotDigest,
+      rollbackOnlyTargets: execution.selection.rollbackOnlyTargets,
       legacyAppV2: changedLegacyAppV2,
       projectIds: execution.selection.projectIds,
       mode: execution.selection.mode,

--- a/scripts/vercel-main-plan.mjs
+++ b/scripts/vercel-main-plan.mjs
@@ -55,6 +55,7 @@ const SELECTION_REASONS = new Set([
   "served-git-metadata-wrong-source",
   "served-git-sha-not-ancestor",
   "served-git-sha-unresolvable",
+  "served-mapping-rollback-only",
   "shadow-first-parent-unresolved",
   "shadow-native-already-current",
 ]);
@@ -869,6 +870,7 @@ export function planMainDeployments({
   deploySha,
   projectIds,
   priorStates,
+  rollbackOnlyTargets,
   repoRoot = process.cwd(),
   gitAdapter = createMainPlanGitAdapter({ repoRoot }),
   runPlanner = ({ base, head }) =>
@@ -880,6 +882,14 @@ export function planMainDeployments({
     mainOwnershipMode,
   });
   const canonicalDeploySha = requireSha(deploySha, "DEPLOY_SHA");
+  if (
+    !Array.isArray(rollbackOnlyTargets) ||
+    JSON.stringify(stableTargets(rollbackOnlyTargets)) !==
+      JSON.stringify(rollbackOnlyTargets)
+  ) {
+    throw new Error("Main rollback-only targets are malformed");
+  }
+  const rollbackOnly = new Set(rollbackOnlyTargets);
   assertTargetObject(projectIds, "Main project IDs");
   assertTargetObject(priorStates, "Main prior states");
   if (typeof runPlanner !== "function") {
@@ -930,6 +940,14 @@ export function planMainDeployments({
   }
 
   for (const entry of normalized) {
+    if (rollbackOnly.has(entry.target)) {
+      addSelection(
+        entry.target,
+        "served-mapping-rollback-only",
+        entry.prior.servedSha,
+      );
+      continue;
+    }
     if (entry.planningGit.reason !== null) {
       addSelection(
         entry.target,

--- a/scripts/vercel-main-plan.test.mjs
+++ b/scripts/vercel-main-plan.test.mjs
@@ -93,9 +93,14 @@ function createPlannerFixture(responses = new Map()) {
   };
 }
 
-function runFixture(input, options = {}) {
-  const git = options.git ?? createGitFixture(input);
-  const planner = options.planner ?? createPlannerFixture();
+function runFixture(
+  input,
+  {
+    git = createGitFixture(input),
+    planner = createPlannerFixture(),
+    rollbackOnlyTargets = [],
+  } = {},
+) {
   return {
     git,
     planner,
@@ -105,6 +110,7 @@ function runFixture(input, options = {}) {
       deploySha: input.deploySha,
       projectIds: input.projectIds,
       priorStates: input.priorStates,
+      rollbackOnlyTargets,
       gitAdapter: git.adapter,
       runPlanner: planner.runPlanner,
     }),
@@ -923,6 +929,132 @@ test("active mode has no first-parent fallback for an already-current target", (
   ]);
 });
 
+test("rollback-only mappings force selection before SHA and path-aware planning", () => {
+  const cases = [
+    {
+      name: "exact-current",
+      mutate(input) {
+        setTargetSha(input, "governance", input.deploySha);
+      },
+      servedSha(input) {
+        return input.deploySha;
+      },
+    },
+    {
+      name: "ancestor-with-no-runtime-diff",
+      mutate(input) {
+        setTargetSha(input, "governance", "a".repeat(40));
+      },
+      servedSha() {
+        return "a".repeat(40);
+      },
+    },
+    {
+      name: "missing-git",
+      mutate(input) {
+        for (const state of input.priorStates.governance.states) {
+          delete state.git;
+        }
+      },
+      servedSha() {
+        return null;
+      },
+    },
+    {
+      name: "malformed-git",
+      mutate(input) {
+        for (const state of input.priorStates.governance.states) {
+          state.git.sha = "not-a-sha";
+        }
+      },
+      servedSha() {
+        return null;
+      },
+    },
+  ];
+  for (const scenario of cases) {
+    const input = fixture();
+    input.mode = "active";
+    input.mainOwnershipMode = ownershipMode("github");
+    setAllTargetShas(input, input.deploySha);
+    scenario.mutate(input);
+    const { plan, planner } = runFixture(input, {
+      rollbackOnlyTargets: ["governance"],
+    });
+    assert.deepEqual(
+      plan.activeTargets,
+      ["governance"],
+      `${scenario.name} must remain selected`,
+    );
+    assert.deepEqual(plan.reasons, [
+      {
+        target: "governance",
+        reason: "served-mapping-rollback-only",
+        base: scenario.servedSha(input),
+      },
+    ]);
+    assert.equal(
+      planner.calls.length,
+      0,
+      `${scenario.name} must bypass path-aware planning`,
+    );
+    assert.deepEqual(
+      plan.priors.find(({ target }) => target === "governance"),
+      {
+        target: "governance",
+        aliases: ["governance.mento.org"],
+        deploymentId: input.priorStates.governance.states[0].deploymentId,
+        deploymentUrl: input.priorStates.governance.states[0].deploymentUrl,
+        servedSha: scenario.servedSha(input),
+      },
+      `${scenario.name} must preserve the exact rollback prior`,
+    );
+  }
+});
+
+test("all-four first-cutover rollback priors use canonical target order", () => {
+  const input = fixture();
+  input.mode = "active";
+  input.mainOwnershipMode = ownershipMode("github");
+  setAllTargetShas(input, input.deploySha);
+  const { plan, planner } = runFixture(input, {
+    rollbackOnlyTargets: [...MAIN_DEPLOYMENT_TARGETS],
+  });
+  assert.deepEqual(plan.stagedTargets, [...MAIN_DEPLOYMENT_TARGETS]);
+  assert.deepEqual(plan.activeTargets, [...MAIN_DEPLOYMENT_TARGETS]);
+  assert.deepEqual(
+    plan.reasons.map(({ reason }) => reason),
+    MAIN_DEPLOYMENT_TARGETS.map(() => "served-mapping-rollback-only"),
+  );
+  assert.equal(planner.calls.length, 0);
+});
+
+test("rollback-only target input rejects unknown, duplicate, or noncanonical values", () => {
+  const input = fixture();
+  for (const rollbackOnlyTargets of [
+    undefined,
+    ["unknown"],
+    ["app", "app"],
+    ["ui", "app"],
+    "app",
+  ]) {
+    assert.throws(
+      () =>
+        planMainDeployments({
+          mode: input.mode,
+          mainOwnershipMode: input.mainOwnershipMode,
+          deploySha: input.deploySha,
+          projectIds: input.projectIds,
+          priorStates: input.priorStates,
+          rollbackOnlyTargets,
+          gitAdapter: createGitFixture(input).adapter,
+          runPlanner: () => assert.fail("planner must remain inert"),
+        }),
+      /rollback-only targets are malformed/,
+    );
+  }
+});
+
 test("cross-run ordinary planning no-ops a candidate already serving the exact SHA", () => {
   const input = fixture();
   input.mode = "active";
@@ -1199,6 +1331,7 @@ for (const scenario of activationAmbiguities) {
           deploySha: input.deploySha,
           projectIds: input.projectIds,
           priorStates: input.priorStates,
+          rollbackOnlyTargets: [],
           gitAdapter,
           runPlanner: () => {
             plannerCalled = true;
@@ -1236,6 +1369,7 @@ test("invalid global input fails before any served-range planning", () => {
         deploySha: input.deploySha,
         projectIds: input.projectIds,
         priorStates: input.priorStates,
+        rollbackOnlyTargets: [],
         gitAdapter: createGitFixture(input).adapter,
         runPlanner: () => assert.fail("planner must remain inert"),
         ...override,

--- a/scripts/vercel-main-provider-cli.mjs
+++ b/scripts/vercel-main-provider-cli.mjs
@@ -53,14 +53,17 @@ import {
   assertMainPreplanReconciliation,
   decideMainPreplanReconciliation,
 } from "./vercel-main-release-reconciliation.mjs";
-import { MAIN_TARGET_CONTRACTS } from "./vercel-main-plan.mjs";
+import {
+  MAIN_DEPLOYMENT_TARGETS,
+  MAIN_TARGET_CONTRACTS,
+} from "./vercel-main-plan.mjs";
 import { generateVercelMainReleaseId } from "./vercel-prebuilt.mjs";
 
 export const MAIN_PROVIDER_CLI_MAX_JSON_BYTES = 256 * 1024;
 export const MAIN_PREPLAN_HANDOFF_MAX_ENCODED_BYTES = 64 * 1024;
 export const MAIN_CANONICAL_MAPPINGS_SCHEMA =
   "vercel-main-canonical-mappings:v1";
-const MAIN_PROVIDER_DISCOVERY_SCHEMA = "vercel-main-provider-discovery:v1";
+const MAIN_PROVIDER_DISCOVERY_SCHEMA = "vercel-main-provider-discovery:v2";
 
 const PROJECT_TARGETS = Object.freeze(["app", "governance", "reserve", "ui"]);
 const LEGACY_ALIAS = "v2-app.mento.org";
@@ -94,7 +97,7 @@ const CLI_OPTIONS = Object.freeze({
 const OPTIONAL_OPTIONS = Object.freeze({
   "canonical-mappings": new Set(["legacy-snapshot"]),
 });
-const DISCOVERY_SCHEMA = "vercel-main-preplan-candidate-discovery:v1";
+const DISCOVERY_SCHEMA = "vercel-main-preplan-candidate-discovery:v2";
 const DIGEST_PATTERN = /^[a-f0-9]{64}$/;
 const SHA_PATTERN = /^[a-f0-9]{40}$/;
 const POSITIVE_ID_PATTERN = /^[1-9][0-9]*$/;
@@ -273,11 +276,17 @@ export function createMainCanonicalMappings({
 function assertDiscovery(value) {
   assertExactKeys(
     value,
-    ["schema", "candidateReleases"],
+    ["schema", "rollbackOnlyTargets", "candidateReleases"],
     "Main pre-plan candidate discovery",
   );
   if (
     value.schema !== DISCOVERY_SCHEMA ||
+    !Array.isArray(value.rollbackOnlyTargets) ||
+    JSON.stringify(
+      MAIN_DEPLOYMENT_TARGETS.filter((target) =>
+        value.rollbackOnlyTargets.includes(target),
+      ),
+    ) !== JSON.stringify(value.rollbackOnlyTargets) ||
     !Array.isArray(value.candidateReleases)
   ) {
     throw new Error("Main pre-plan candidate discovery is malformed");
@@ -479,10 +488,18 @@ function containedPath(path, runnerTemp, label) {
   return path;
 }
 
-export function readPrivateJson(path, label, runnerTemp) {
+export function readPrivateJson(
+  path,
+  label,
+  runnerTemp,
+  maxBytes = MAIN_PROVIDER_CLI_MAX_JSON_BYTES,
+) {
   const inputPath = privatePath(path, runnerTemp, label);
   let descriptor;
   try {
+    if (!Number.isSafeInteger(maxBytes) || maxBytes < 1) {
+      throw new Error("unsafe");
+    }
     descriptor = openSync(inputPath, constants.O_RDONLY | constants.O_NOFOLLOW);
     const stats = fstatSync(descriptor);
     const pathStats = lstatSync(inputPath);
@@ -494,7 +511,7 @@ export function readPrivateJson(path, label, runnerTemp) {
       stats.ino !== pathStats.ino ||
       (stats.mode & 0o077) !== 0 ||
       stats.size < 2 ||
-      stats.size > MAIN_PROVIDER_CLI_MAX_JSON_BYTES
+      stats.size > maxBytes
     ) {
       throw new Error("unsafe");
     }
@@ -506,11 +523,18 @@ export function readPrivateJson(path, label, runnerTemp) {
   }
 }
 
-export function writePrivateJson(path, value, runnerTemp) {
+export function writePrivateJson(
+  path,
+  value,
+  runnerTemp,
+  maxBytes = MAIN_PROVIDER_CLI_MAX_JSON_BYTES,
+) {
   const outputPath = privatePath(path, runnerTemp, "Main provider output");
   const serialized = `${JSON.stringify(value)}\n`;
   if (
-    Buffer.byteLength(serialized, "utf8") > MAIN_PROVIDER_CLI_MAX_JSON_BYTES
+    !Number.isSafeInteger(maxBytes) ||
+    maxBytes < 1 ||
+    Buffer.byteLength(serialized, "utf8") > maxBytes
   ) {
     throw new Error("Main provider output exceeds its size bound");
   }
@@ -713,11 +737,15 @@ async function captureStableBoundLegacyV2Snapshot({
   const expectation = legacyV2Expectation(legacySnapshot);
   const capture = async () => {
     const proof = await client.canonicalLegacyV2State(expectation);
-    if (
-      !isPlainObject(proof) ||
-      proof.source !== "git" ||
-      !Object.hasOwn(proof, "state")
-    ) {
+    if (!isPlainObject(proof)) {
+      throw new Error("Fresh legacy v2 state proof is malformed");
+    }
+    assertExactKeys(
+      proof,
+      ["ownership", "state"],
+      "Fresh legacy v2 state proof",
+    );
+    if (proof.ownership !== "native-vercel-git") {
       throw new Error("Fresh legacy v2 state proof is malformed");
     }
     return assertCanonicalOutput([proof.state]);
@@ -1033,6 +1061,7 @@ export async function runMainProviderCli({
         nextUpstreamRunId: env.UPSTREAM_RUN_ID,
         candidateReleases: discovery.discovery.candidateReleases,
         currentMappings,
+        rollbackOnlyTargets: discovery.discovery.rollbackOnlyTargets,
       }),
       {
         nextDeploySha: env.DEPLOY_SHA,

--- a/scripts/vercel-main-provider-cli.test.mjs
+++ b/scripts/vercel-main-provider-cli.test.mjs
@@ -30,6 +30,7 @@ import { planMainDeployments } from "./vercel-main-plan.mjs";
 import { generateVercelMainReleaseId } from "./vercel-prebuilt.mjs";
 import {
   appendGithubOutputs,
+  assertMainProviderDiscovery,
   createMainCanonicalMappings,
   decodeMainPreplanHandoff,
   encodeMainPreplanHandoff,
@@ -81,6 +82,7 @@ function releaseManifest({
     deploySha,
     projectIds: input.projectIds,
     priorStates: input.priorStates,
+    rollbackOnlyTargets: [],
     gitAdapter: {
       firstParent: () => input.firstParent,
       isAncestor: () => true,
@@ -250,7 +252,10 @@ function planningStateClient(
       const source =
         legacyCalls === 0 ? firstLegacySnapshot : secondLegacySnapshot;
       legacyCalls += 1;
-      return { source: "git", state: structuredClone(source[0]) };
+      return {
+        ownership: "native-vercel-git",
+        state: structuredClone(source[0]),
+      };
     },
     calls: () => calls,
     legacyCalls: () => legacyCalls,
@@ -394,7 +399,7 @@ test("canonical mappings preserve all reviewed aliases and optional fresh legacy
   );
 });
 
-test("preplan discovery groups multiple mapped manifests and ignores native mappings", async (t) => {
+test("preplan discovery groups mapped manifests and marks unowned mappings rollback-only", async (t) => {
   const context = testContext(t);
   const first = releaseManifest({
     deploySha: "c".repeat(40),
@@ -431,15 +436,17 @@ test("preplan discovery groups multiple mapped manifests and ignores native mapp
       "pre-plan discovery must not use a current intent",
     );
     return {
-      inspectMappedCandidate: async ({ deploymentId }) => ({
-        canonicalState: {},
-        metadata:
-          deploymentId === "dpl_governanceCandidate123"
-            ? { releaseManifest: first }
-            : deploymentId === "dpl_reserveCandidate123"
-              ? { releaseManifest: second }
-              : null,
-      }),
+      inspectMappedCandidate: async ({ deploymentId }) => {
+        return {
+          canonicalState: {},
+          metadata:
+            deploymentId === "dpl_governanceCandidate123"
+              ? { releaseManifest: first }
+              : deploymentId === "dpl_reserveCandidate123"
+                ? { releaseManifest: second }
+                : null,
+        };
+      },
       resolveReleaseCandidate: async ({ manifest, target }) => {
         const selectedTarget =
           manifest.releaseId === first.releaseId ? "governance" : "reserve";
@@ -483,6 +490,19 @@ test("preplan discovery groups multiple mapped manifests and ignores native mapp
     [first.releaseId, second.releaseId].sort(),
   );
   assert.equal(readJson(output).discovery.candidateReleases.length, 2);
+  assert.deepEqual(result.discovery.rollbackOnlyTargets, ["app", "ui"]);
+  for (const rollbackOnlyTargets of [
+    ["ui", "app"],
+    ["app", "app"],
+    ["unknown"],
+  ]) {
+    const malformed = structuredClone(result);
+    malformed.discovery.rollbackOnlyTargets = rollbackOnlyTargets;
+    assert.throws(
+      () => assertMainProviderDiscovery(malformed),
+      /candidate discovery is malformed/,
+    );
+  }
   assert.deepEqual(result.projectIds, projectIds());
   assert.match(result.planningSnapshotDigest, /^[a-f0-9]{64}$/);
   assert.doesNotMatch(
@@ -522,10 +542,12 @@ test("preplan decision binds current SHA and upstream run to one exact release I
     stdout: context.stdout,
     stateClientFactory: () => ({ kind: "discovery-client" }),
     providerFactory: () => ({
-      inspectMappedCandidate: async () => ({
-        canonicalState: {},
-        metadata: null,
-      }),
+      inspectMappedCandidate: async () => {
+        return {
+          canonicalState: {},
+          metadata: null,
+        };
+      },
       resolveReleaseCandidate: async () =>
         assert.fail("native mappings have no release candidates"),
     }),
@@ -655,6 +677,7 @@ test("preplan materialization accepts only inherited restore and exposes ordered
       },
     ],
     currentMappings,
+    rollbackOnlyTargets: [],
   });
   assert.equal(decision.decision, "restore-before-planning");
   const encoded = encodeMainPreplanHandoff(decision, {
@@ -705,10 +728,12 @@ test("preplan decision rejects alias drift after discovery before baseline or ro
     stdout: context.stdout,
     stateClientFactory: () => ({ kind: "discovery-client" }),
     providerFactory: () => ({
-      inspectMappedCandidate: async () => ({
-        canonicalState: {},
-        metadata: null,
-      }),
+      inspectMappedCandidate: async () => {
+        return {
+          canonicalState: {},
+          metadata: null,
+        };
+      },
       resolveReleaseCandidate: async () => null,
     }),
   });
@@ -1206,6 +1231,46 @@ test("private bridge IO rejects noncanonical, permissive, oversized, and existin
     /could not be written safely/,
   );
   assert.equal(readFileSync(existingOutput, "utf8"), "{}\n");
+
+  const extendedLimit = MAIN_PROVIDER_CLI_MAX_JSON_BYTES * 4;
+  const serializedEnvelopeBytes = Buffer.byteLength(
+    `${JSON.stringify({ value: "" })}\n`,
+    "utf8",
+  );
+  const extendedValue = {
+    value: "x".repeat(extendedLimit - serializedEnvelopeBytes),
+  };
+  const extendedOutput = join(context.directory, "extended-output.json");
+  writePrivateJson(
+    extendedOutput,
+    extendedValue,
+    context.directory,
+    extendedLimit,
+  );
+  assert.equal(statSync(extendedOutput).size, extendedLimit);
+  assert.equal(
+    readPrivateJson(
+      extendedOutput,
+      "extended input",
+      context.directory,
+      extendedLimit,
+    ).value.length,
+    extendedValue.value.length,
+  );
+  assert.throws(
+    () => readPrivateJson(extendedOutput, "extended input", context.directory),
+    /missing, unsafe, or malformed/,
+  );
+  assert.throws(
+    () =>
+      writePrivateJson(
+        join(context.directory, "oversized-extended-output.json"),
+        { value: `${extendedValue.value}x` },
+        context.directory,
+        extendedLimit,
+      ),
+    /exceeds its size bound/,
+  );
 
   assert.throws(
     () => reviewedRunnerTemp(`${context.directory}/.`),

--- a/scripts/vercel-main-release-cli.mjs
+++ b/scripts/vercel-main-release-cli.mjs
@@ -39,6 +39,8 @@ import {
   createMainInheritedRecoveryJournal,
 } from "./vercel-main-release-journal.mjs";
 import {
+  MAIN_ACTIVE_JOURNAL_HISTORY_MAX_JSON_BYTES,
+  MAIN_ACTIVE_TERMINAL_PROOFS_MAX_JSON_BYTES,
   createMainActiveTerminalArtifacts,
   createMainTerminalStageResults,
 } from "./vercel-main-deployment.mjs";
@@ -466,6 +468,7 @@ export async function runMainReleaseCli({
         options["journal-history"],
         "Main terminal journal history",
         runnerTemp,
+        MAIN_ACTIVE_JOURNAL_HISTORY_MAX_JSON_BYTES,
       ),
       finalMappings: readPrivateJson(
         options["final-mappings"],
@@ -509,7 +512,12 @@ export async function runMainReleaseCli({
       artifacts.evidence,
       runnerTemp,
     );
-    writePrivateJson(options["proofs-output"], artifacts.proofs, runnerTemp);
+    writePrivateJson(
+      options["proofs-output"],
+      artifacts.proofs,
+      runnerTemp,
+      MAIN_ACTIVE_TERMINAL_PROOFS_MAX_JSON_BYTES,
+    );
     return artifacts;
   }
 
@@ -660,6 +668,7 @@ export async function runMainReleaseCli({
         currentMappings[target],
       ]),
     ),
+    rollbackOnlyTargets: discovery.discovery.rollbackOnlyTargets,
   });
   if (JSON.stringify(recomputedPreplan) !== JSON.stringify(preplan)) {
     throw new Error(
@@ -678,6 +687,7 @@ export async function runMainReleaseCli({
         upstreamRunId: identity.upstreamRunId,
         projectIds,
         planningSnapshot,
+        rollbackOnlyTargets: discovery.discovery.rollbackOnlyTargets,
         repoRoot: env.SOURCE_PATH,
       })
     ).manifest;
@@ -693,6 +703,7 @@ export async function runMainReleaseCli({
   const selection = createMainReleaseSelection({
     providerDiscoveryDigest: digest(discovery),
     planningSnapshotDigest: discovery.planningSnapshotDigest,
+    rollbackOnlyTargets: discovery.discovery.rollbackOnlyTargets,
     legacyAppV2,
     projectIds: Object.fromEntries(
       ["governance", "reserve", "ui", "app"].map((target) => [

--- a/scripts/vercel-main-release-cli.test.mjs
+++ b/scripts/vercel-main-release-cli.test.mjs
@@ -52,7 +52,10 @@ const PRIOR_SHA = "b".repeat(40);
 const TARGETS = ["app", "governance", "reserve", "ui"];
 const RELEASE_ORDER = ["governance", "reserve", "ui", "app"];
 
-function planning(stagedTargets = ["app", "governance"]) {
+function planning(
+  stagedTargets = ["app", "governance"],
+  rollbackOnlyTargets = [],
+) {
   return {
     schema: "vercel-main-plan:v2",
     mode: "active",
@@ -75,15 +78,20 @@ function planning(stagedTargets = ["app", "governance"]) {
       servedSha: PRIOR_SHA,
     })),
     ranges: [],
-    reasons: [],
+    reasons: rollbackOnlyTargets.map((target) => ({
+      target,
+      base: PRIOR_SHA,
+      reason: "served-mapping-rollback-only",
+    })),
   };
 }
 
 function manifest(
   stagedTargets = ["app", "governance"],
   upstreamRunId = "123",
+  rollbackOnlyTargets = [],
 ) {
-  const plan = planning(stagedTargets);
+  const plan = planning(stagedTargets, rollbackOnlyTargets);
   const priors = Object.fromEntries(
     RELEASE_ORDER.map((target) => {
       const prior = plan.priors.find((entry) => entry.target === target);
@@ -199,9 +207,10 @@ function preplan(releaseManifest, decision = "resume-existing-release") {
     currentMappings,
   });
   return {
-    schema: "vercel-main-preplan-reconciliation:v1",
+    schema: "vercel-main-preplan-reconciliation:v2",
     decision,
     reason,
+    rollbackOnlyTargets: [],
     reconciliation,
     rollbackAuthorization: null,
   };
@@ -256,10 +265,14 @@ function planningSnapshot(
   };
 }
 
-function discovery(releaseManifest, snapshot, { empty = false } = {}) {
+function discovery(
+  releaseManifest,
+  snapshot,
+  { empty = false, rollbackOnlyTargets = [] } = {},
+) {
   const legacyState = legacy()[0];
   return {
-    schema: "vercel-main-provider-discovery:v1",
+    schema: "vercel-main-provider-discovery:v2",
     planningSnapshotDigest: createHash("sha256")
       .update(JSON.stringify(snapshot))
       .digest("hex"),
@@ -273,7 +286,8 @@ function discovery(releaseManifest, snapshot, { empty = false } = {}) {
       ui: "prj_ui",
     },
     discovery: {
-      schema: "vercel-main-preplan-candidate-discovery:v1",
+      schema: "vercel-main-preplan-candidate-discovery:v2",
+      rollbackOnlyTargets,
       candidateReleases: empty ? [] : [candidateRelease(releaseManifest)],
     },
   };
@@ -327,6 +341,7 @@ function executionFor(releaseManifest) {
     selection: createMainReleaseSelection({
       providerDiscoveryDigest: "c".repeat(64),
       planningSnapshotDigest: "d".repeat(64),
+      rollbackOnlyTargets: releaseManifest.rollbackOnlyTargets,
       legacyAppV2: legacyState,
       projectIds: Object.fromEntries(
         RELEASE_ORDER.map((target) => [target, `prj_${target}`]),
@@ -515,7 +530,7 @@ function currentReleaseFixture() {
     spec: stateSpec,
     deployments,
     legacyV2: {
-      source: "git",
+      ownership: "native-vercel-git",
       state: {
         alias: stateSpec.legacyAppV2.alias,
         deploymentId: stateSpec.legacyAppV2.deployment,
@@ -659,6 +674,41 @@ test("execution consumes the exact provider manifest without a new baseline", as
   assert.deepEqual(JSON.parse(readFileSync(output, "utf8")), value);
 });
 
+test("execution rejects same-release reuse that omits a fresh rollback-only target", async (t) => {
+  const directory = realpathSync(
+    mkdtempSync(join(tmpdir(), "main-release-rollback-coverage-")),
+  );
+  t.after(() => rmSync(directory, { recursive: true, force: true }));
+
+  for (const [name, stagedTargets, decision] of [
+    ["verify", ["governance"], "verify-existing-release"],
+    ["resume", ["governance", "reserve"], "resume-existing-release"],
+  ]) {
+    const release = manifest(stagedTargets);
+    const census = planningSnapshot(release, decision);
+    const preplanValue = {
+      ...preplan(release, decision),
+      rollbackOnlyTargets: ["ui"],
+    };
+    await assert.rejects(
+      runMainReleaseCli({
+        argv: executionArguments(directory, {
+          release,
+          census,
+          preplanValue,
+          discoveryValue: discovery(release, census, {
+            rollbackOnlyTargets: ["ui"],
+          }),
+          suffix: `-${name}`,
+        }),
+        env: environment(directory),
+      }),
+      /omits fresh rollback-only targets: ui/,
+      name,
+    );
+  }
+});
+
 test("existing release execution rejects a replacement baseline", async (t) => {
   const directory = realpathSync(
     mkdtempSync(join(tmpdir(), "main-release-cli-")),
@@ -694,12 +744,13 @@ test("only capture-new execution invokes the baseline planner", async (t) => {
     mkdtempSync(join(tmpdir(), "main-release-cli-")),
   );
   t.after(() => rmSync(directory, { recursive: true, force: true }));
-  const release = manifest();
+  const release = manifest(TARGETS, "123", TARGETS);
   const census = planningSnapshot(release);
   const capturePreplan = {
-    schema: "vercel-main-preplan-reconciliation:v1",
+    schema: "vercel-main-preplan-reconciliation:v2",
     decision: "capture-new-baseline",
     reason: "no-mapped-release-metadata",
+    rollbackOnlyTargets: ["app", "governance", "reserve", "ui"],
     reconciliation: null,
     rollbackAuthorization: null,
   };
@@ -709,12 +760,21 @@ test("only capture-new execution invokes the baseline planner", async (t) => {
       release,
       census,
       preplanValue: capturePreplan,
-      discoveryValue: discovery(release, census, { empty: true }),
+      discoveryValue: discovery(release, census, {
+        empty: true,
+        rollbackOnlyTargets: ["app", "governance", "reserve", "ui"],
+      }),
     }),
     env: environment(directory),
     baselineFactory: (options) => {
       captured += 1;
       assert.deepEqual(options.planningSnapshot, census);
+      assert.deepEqual(options.rollbackOnlyTargets, [
+        "app",
+        "governance",
+        "reserve",
+        "ui",
+      ]);
       return { manifest: release };
     },
   });
@@ -915,6 +975,7 @@ test("release CLI rejects linked private inputs and outputs", async (t) => {
     selection: createMainReleaseSelection({
       providerDiscoveryDigest: "c".repeat(64),
       planningSnapshotDigest: "d".repeat(64),
+      rollbackOnlyTargets: release.rollbackOnlyTargets,
       legacyAppV2: legacy()[0],
       projectIds: Object.fromEntries(
         RELEASE_ORDER.map((target) => [target, `prj_${target}`]),
@@ -961,6 +1022,7 @@ test("materialize binds retained output to the exact SHA and upstream run", asyn
     selection: createMainReleaseSelection({
       providerDiscoveryDigest: "c".repeat(64),
       planningSnapshotDigest: "d".repeat(64),
+      rollbackOnlyTargets: release.rollbackOnlyTargets,
       legacyAppV2: legacyState,
       projectIds: Object.fromEntries(
         RELEASE_ORDER.map((target) => [target, `prj_${target}`]),
@@ -1179,6 +1241,7 @@ test("inherited recovery requires current-attempt receipts only for moved candid
     nextUpstreamRunId: "123",
     candidateReleases: [candidateRelease(release)],
     currentMappings,
+    rollbackOnlyTargets: [],
   });
   assert.equal(inheritedPreplan.decision, "restore-before-planning");
   assert.deepEqual(inheritedPreplan.rollbackAuthorization.targets, [
@@ -1636,6 +1699,7 @@ test("forward journal uses only asserted execution, fresh mappings, and current-
     selection: createMainReleaseSelection({
       providerDiscoveryDigest: "c".repeat(64),
       planningSnapshotDigest: "d".repeat(64),
+      rollbackOnlyTargets: release.rollbackOnlyTargets,
       legacyAppV2: legacyState,
       projectIds: Object.fromEntries(
         RELEASE_ORDER.map((target) => [target, `prj_${target}`]),
@@ -1734,6 +1798,7 @@ test("inherited recovery journal binds a partial prefix to current-attempt recei
     nextUpstreamRunId: "123",
     candidateReleases: [candidateRelease(release)],
     currentMappings,
+    rollbackOnlyTargets: [],
   });
   assert.equal(inheritedPreplan.decision, "restore-before-planning");
   assert.deepEqual(inheritedPreplan.rollbackAuthorization.targets, [

--- a/scripts/vercel-main-release-execution.mjs
+++ b/scripts/vercel-main-release-execution.mjs
@@ -10,9 +10,10 @@ import {
   MAIN_RELEASE_ACTIVATION_ORDER,
   assertMainReleaseManifest,
 } from "./vercel-main-release-reconciliation.mjs";
+import { MAIN_DEPLOYMENT_TARGETS } from "./vercel-main-plan.mjs";
 
-const MAIN_RELEASE_EXECUTION_SCHEMA = "vercel-main-release-execution:v1";
-const MAIN_RELEASE_SELECTION_SCHEMA = "vercel-main-release-selection:v1";
+const MAIN_RELEASE_EXECUTION_SCHEMA = "vercel-main-release-execution:v2";
+const MAIN_RELEASE_SELECTION_SCHEMA = "vercel-main-release-selection:v2";
 const MAIN_RELEASE_EXECUTION_MAX_ENCODED_BYTES = 64 * 1024;
 
 const SHA_PATTERN = /^[a-f0-9]{40}$/;
@@ -42,6 +43,7 @@ const SELECTION_KEYS = Object.freeze([
   "schema",
   "providerDiscoveryDigest",
   "planningSnapshotDigest",
+  "rollbackOnlyTargets",
   "legacyAppV2Digest",
   "projectIds",
   "mode",
@@ -186,6 +188,27 @@ function digest(value) {
   return createHash("sha256").update(JSON.stringify(value)).digest("hex");
 }
 
+function canonicalRollbackOnlyTargets(value) {
+  if (
+    !Array.isArray(value) ||
+    value.some((target) => !MAIN_DEPLOYMENT_TARGETS.includes(target)) ||
+    new Set(value).size !== value.length
+  ) {
+    throw new Error(
+      "Main release selection rollback-only targets are malformed",
+    );
+  }
+  const canonical = MAIN_DEPLOYMENT_TARGETS.filter((target) =>
+    value.includes(target),
+  );
+  if (JSON.stringify(canonical) !== JSON.stringify(value)) {
+    throw new Error(
+      "Main release selection rollback-only targets are not canonical",
+    );
+  }
+  return canonical;
+}
+
 function canonicalSelection(value, manifest, legacyAppV2) {
   assertExactKeys(value, SELECTION_KEYS, "Main release selection");
   if (value.schema !== MAIN_RELEASE_SELECTION_SCHEMA) {
@@ -209,6 +232,9 @@ function canonicalSelection(value, manifest, legacyAppV2) {
       }
       return [target, projectId];
     }),
+  );
+  const rollbackOnlyTargets = canonicalRollbackOnlyTargets(
+    value.rollbackOnlyTargets,
   );
   if (
     !isPlainObject(value.projectIds) ||
@@ -235,6 +261,7 @@ function canonicalSelection(value, manifest, legacyAppV2) {
       "Main release selection planning snapshot digest",
       DIGEST_PATTERN,
     ),
+    rollbackOnlyTargets,
     legacyAppV2Digest: value.legacyAppV2Digest,
     projectIds,
     mode: manifest.mode,
@@ -246,6 +273,7 @@ function canonicalSelection(value, manifest, legacyAppV2) {
 export function createMainReleaseSelection({
   providerDiscoveryDigest,
   planningSnapshotDigest,
+  rollbackOnlyTargets,
   legacyAppV2,
   projectIds,
   mode,
@@ -259,6 +287,7 @@ export function createMainReleaseSelection({
       schema: MAIN_RELEASE_SELECTION_SCHEMA,
       providerDiscoveryDigest,
       planningSnapshotDigest,
+      rollbackOnlyTargets,
       legacyAppV2Digest: digest(legacy),
       projectIds,
       mode,
@@ -268,6 +297,26 @@ export function createMainReleaseSelection({
     manifest,
     legacy,
   );
+}
+
+function assertSelectionRollbackCoverage(decision, manifest, selection) {
+  const missing = selection.rollbackOnlyTargets.filter(
+    (target) => !manifest.stagedTargets.includes(target),
+  );
+  if (missing.length > 0) {
+    throw new Error(
+      `Main release selection omits fresh rollback-only targets: ${missing.join(", ")}`,
+    );
+  }
+  if (
+    decision === "capture-new-baseline" &&
+    JSON.stringify(selection.rollbackOnlyTargets) !==
+      JSON.stringify(manifest.rollbackOnlyTargets)
+  ) {
+    throw new Error(
+      "New main release manifest conflicts with fresh rollback-only targets",
+    );
+  }
 }
 
 function projectionFromManifest(manifest) {
@@ -340,6 +389,8 @@ export function assertMainReleaseExecution(value, expected = {}) {
   const manifest = assertMainReleaseManifest(value.manifest);
   const selected = canonicalDecision(value.decision, value.reason);
   const legacyAppV2 = canonicalLegacyAppV2(value.legacyAppV2, manifest);
+  const selection = canonicalSelection(value.selection, manifest, legacyAppV2);
+  assertSelectionRollbackCoverage(selected.decision, manifest, selection);
   const canonical = {
     schema: MAIN_RELEASE_EXECUTION_SCHEMA,
     decision: selected.decision,
@@ -347,7 +398,7 @@ export function assertMainReleaseExecution(value, expected = {}) {
     manifest,
     upstream: canonicalUpstream(value.upstream, manifest),
     legacyAppV2,
-    selection: canonicalSelection(value.selection, manifest, legacyAppV2),
+    selection,
     projection: canonicalProjection(value.projection, manifest),
   };
   if (

--- a/scripts/vercel-main-release-execution.test.mjs
+++ b/scripts/vercel-main-release-execution.test.mjs
@@ -144,6 +144,7 @@ function execution(stagedTargets = TARGETS) {
     selection: createMainReleaseSelection({
       providerDiscoveryDigest: "c".repeat(64),
       planningSnapshotDigest: "d".repeat(64),
+      rollbackOnlyTargets: release.rollbackOnlyTargets,
       legacyAppV2: legacy,
       projectIds: Object.fromEntries(
         RELEASE_ORDER.map((target) => [target, `prj_${target}`]),
@@ -270,6 +271,59 @@ test("execution selection binds discovery, projects, manifest, ownership, and le
       /selection|manifest/,
     );
   }
+});
+
+test("execution rechecks fresh rollback-only coverage for reuse", () => {
+  const value = execution(["governance"]);
+  for (const [decision, reason] of [
+    [
+      "resume-existing-release",
+      "current-main-release-is-an-interrupted-prefix",
+    ],
+    ["verify-existing-release", "current-main-release-already-complete"],
+  ]) {
+    assert.throws(
+      () =>
+        assertMainReleaseExecution({
+          ...value,
+          decision,
+          reason,
+          selection: {
+            ...value.selection,
+            rollbackOnlyTargets: ["ui"],
+          },
+        }),
+      /omits fresh rollback-only targets: ui/,
+      decision,
+    );
+  }
+  assert.deepEqual(
+    assertMainReleaseExecution({
+      ...value,
+      selection: {
+        ...value.selection,
+        rollbackOnlyTargets: ["governance"],
+      },
+    }).selection.rollbackOnlyTargets,
+    ["governance"],
+  );
+});
+
+test("capture-new execution binds the fresh rollback-only set exactly", () => {
+  const value = execution(["governance"]);
+  assert.throws(
+    () =>
+      assertMainReleaseExecution({
+        ...value,
+        decision: "capture-new-baseline",
+        reason: "no-mapped-release-metadata",
+        selection: {
+          ...value.selection,
+          rollbackOnlyTargets: ["governance"],
+        },
+      }),
+    /manifest conflicts with fresh rollback-only targets/,
+  );
 });
 
 test("execution binds both upstream URLs to the exact repository run", () => {

--- a/scripts/vercel-main-release-planner.mjs
+++ b/scripts/vercel-main-release-planner.mjs
@@ -151,6 +151,7 @@ export function createMainReleaseBaseline({
   upstreamRunId,
   projectIds,
   planningSnapshot,
+  rollbackOnlyTargets,
   repoRoot,
   gitAdapter,
   runPlanner,
@@ -168,6 +169,7 @@ export function createMainReleaseBaseline({
     mainOwnershipMode,
     deploySha,
     projectIds: projects,
+    rollbackOnlyTargets,
     priorStates: Object.fromEntries(
       MAIN_DEPLOYMENT_TARGETS.map((target) => [
         target,

--- a/scripts/vercel-main-release-planner.test.mjs
+++ b/scripts/vercel-main-release-planner.test.mjs
@@ -58,6 +58,7 @@ function baseline(planningSnapshot = snapshot()) {
       TARGETS.map((target) => [target, `prj_${target}`]),
     ),
     planningSnapshot,
+    rollbackOnlyTargets: [],
     gitAdapter: {
       resolveCommit: (sha) => sha,
       isAncestor: () => true,

--- a/scripts/vercel-main-release-reconciliation.mjs
+++ b/scripts/vercel-main-release-reconciliation.mjs
@@ -13,11 +13,11 @@ import {
 } from "./vercel-deployment-url.mjs";
 import { generateVercelMainReleaseId } from "./vercel-prebuilt.mjs";
 
-const MAIN_RELEASE_MANIFEST_SCHEMA = "vercel-main-release-manifest:v1";
+const MAIN_RELEASE_MANIFEST_SCHEMA = "vercel-main-release-manifest:v2";
 const MAIN_RELEASE_RECONCILIATION_SCHEMA =
   "vercel-main-release-reconciliation:v1";
 const MAIN_PREPLAN_RECONCILIATION_SCHEMA =
-  "vercel-main-preplan-reconciliation:v1";
+  "vercel-main-preplan-reconciliation:v2";
 export const MAIN_RELEASE_ACTIVATION_ORDER = Object.freeze([
   "governance",
   "reserve",
@@ -40,6 +40,7 @@ const MANIFEST_KEYS = Object.freeze([
   "mainOwnershipMode",
   "stagedTargets",
   "activeTargets",
+  "rollbackOnlyTargets",
   "originalPriors",
   "releasePlanDigest",
 ]);
@@ -91,6 +92,7 @@ const PREPLAN_KEYS = Object.freeze([
   "schema",
   "decision",
   "reason",
+  "rollbackOnlyTargets",
   "reconciliation",
   "rollbackAuthorization",
 ]);
@@ -131,6 +133,34 @@ function canonicalTargets(value, label, { allowEmpty = false } = {}) {
     throw new Error(`${label} is not canonical`);
   }
   return canonical;
+}
+
+function canonicalRollbackOnlyTargets(value, label) {
+  if (
+    !Array.isArray(value) ||
+    value.some((target) => !MAIN_DEPLOYMENT_TARGETS.includes(target)) ||
+    new Set(value).size !== value.length
+  ) {
+    throw new Error(`${label} is malformed`);
+  }
+  const canonical = MAIN_DEPLOYMENT_TARGETS.filter((target) =>
+    value.includes(target),
+  );
+  if (JSON.stringify(value) !== JSON.stringify(canonical)) {
+    throw new Error(`${label} is not canonical`);
+  }
+  return canonical;
+}
+
+function assertFreshRollbackCoverage(manifest, rollbackOnlyTargets) {
+  const missing = rollbackOnlyTargets.filter(
+    (target) => !manifest.stagedTargets.includes(target),
+  );
+  if (missing.length > 0) {
+    throw new Error(
+      `Current main release omits fresh rollback-only targets: ${missing.join(", ")}`,
+    );
+  }
 }
 
 function canonicalOwnership(mode, mainOwnershipMode) {
@@ -364,6 +394,13 @@ export function createMainReleaseManifest({
   const canonicalActiveTargets = MAIN_RELEASE_ACTIVATION_ORDER.filter(
     (target) => canonicalPlan.activeTargets.includes(target),
   );
+  const rollbackOnlyTargets = MAIN_DEPLOYMENT_TARGETS.filter((target) =>
+    canonicalPlan.reasons.some(
+      (reason) =>
+        reason.target === target &&
+        reason.reason === "served-mapping-rollback-only",
+    ),
+  );
   const ownership = canonicalOwnership(
     canonicalPlan.mode,
     canonicalPlan.mainOwnershipMode,
@@ -378,6 +415,13 @@ export function createMainReleaseManifest({
       canonicalActiveTargets,
       "Main release manifest active targets",
     );
+  }
+  if (
+    rollbackOnlyTargets.some(
+      (target) => !canonicalStagedTargets.includes(target),
+    )
+  ) {
+    throw new Error("Main release rollback-only targets were not staged");
   }
   assertExactKeys(
     originalPriors,
@@ -423,6 +467,7 @@ export function createMainReleaseManifest({
     mainOwnershipMode: ownership.mainOwnershipMode,
     stagedTargets: canonicalStagedTargets,
     activeTargets: canonicalActiveTargets,
+    rollbackOnlyTargets,
     originalPriors: canonicalPriors,
     releasePlanDigest: digest(canonicalPlan),
   };
@@ -471,9 +516,14 @@ export function assertMainReleaseManifest(value) {
   const shadowTargets = stagedTargets.filter(
     (target) => !activeTargets.includes(target),
   );
+  const rollbackOnlyTargets = canonicalRollbackOnlyTargets(
+    value.rollbackOnlyTargets,
+    "Main release manifest rollback-only targets",
+  );
   if (
     activeTargets.some((target) => !ownership.githubTargets.includes(target)) ||
-    shadowTargets.some((target) => !ownership.shadowTargets.includes(target))
+    shadowTargets.some((target) => !ownership.shadowTargets.includes(target)) ||
+    rollbackOnlyTargets.some((target) => !stagedTargets.includes(target))
   ) {
     throw new Error("Main release manifest target ownership conflicts");
   }
@@ -513,6 +563,7 @@ export function assertMainReleaseManifest(value) {
     mainOwnershipMode: ownership.mainOwnershipMode,
     stagedTargets,
     activeTargets,
+    rollbackOnlyTargets,
     originalPriors,
     releasePlanDigest: value.releasePlanDigest,
   };
@@ -572,6 +623,7 @@ export function recomputeMainReleasePlan({
     deploySha: manifest.deploySha,
     projectIds,
     priorStates,
+    rollbackOnlyTargets: manifest.rollbackOnlyTargets,
     ...(repoRoot === undefined ? {} : { repoRoot }),
     ...(gitAdapter === undefined ? {} : { gitAdapter }),
     ...(runPlanner === undefined ? {} : { runPlanner }),
@@ -799,6 +851,7 @@ export function decideMainPreplanReconciliation({
   nextUpstreamRunId,
   candidateReleases,
   currentMappings,
+  rollbackOnlyTargets,
 }) {
   const canonicalNextSha = requireString(
     nextDeploySha,
@@ -815,6 +868,10 @@ export function decideMainPreplanReconciliation({
     commitSha: canonicalNextSha,
     upstreamRunId: canonicalNextUpstreamRunId,
   });
+  const canonicalRollbackOnly = canonicalRollbackOnlyTargets(
+    rollbackOnlyTargets,
+    "Fresh main rollback-only targets",
+  );
   assertExactKeys(
     currentMappings,
     MAIN_RELEASE_ACTIVATION_ORDER,
@@ -828,6 +885,7 @@ export function decideMainPreplanReconciliation({
       schema: MAIN_PREPLAN_RECONCILIATION_SCHEMA,
       decision: "capture-new-baseline",
       reason: "no-mapped-release-metadata",
+      rollbackOnlyTargets: canonicalRollbackOnly,
       reconciliation: null,
       rollbackAuthorization: null,
     };
@@ -866,6 +924,9 @@ export function decideMainPreplanReconciliation({
   const [reconciliation] = compatible;
   const { manifest } = reconciliation;
   const sameRelease = manifest.releaseId === expectedReleaseId;
+  if (sameRelease) {
+    assertFreshRollbackCoverage(manifest, canonicalRollbackOnly);
+  }
   if (reconciliation.allCandidate) {
     return {
       schema: MAIN_PREPLAN_RECONCILIATION_SCHEMA,
@@ -875,6 +936,7 @@ export function decideMainPreplanReconciliation({
       reason: sameRelease
         ? "current-main-release-already-complete"
         : "older-mapped-release-is-complete",
+      rollbackOnlyTargets: canonicalRollbackOnly,
       reconciliation,
       rollbackAuthorization: null,
     };
@@ -884,6 +946,7 @@ export function decideMainPreplanReconciliation({
       schema: MAIN_PREPLAN_RECONCILIATION_SCHEMA,
       decision: "resume-existing-release",
       reason: "current-main-release-is-an-interrupted-prefix",
+      rollbackOnlyTargets: canonicalRollbackOnly,
       reconciliation,
       rollbackAuthorization: null,
     };
@@ -892,6 +955,7 @@ export function decideMainPreplanReconciliation({
     schema: MAIN_PREPLAN_RECONCILIATION_SCHEMA,
     decision: "restore-before-planning",
     reason: "older-main-release-is-an-interrupted-prefix",
+    rollbackOnlyTargets: canonicalRollbackOnly,
     reconciliation,
     rollbackAuthorization: createInheritedRollbackAuthorization({
       reconciliation,
@@ -957,6 +1021,10 @@ export function assertMainPreplanReconciliation(
       POSITIVE_ID_PATTERN,
     ),
   });
+  const rollbackOnlyTargets = canonicalRollbackOnlyTargets(
+    value.rollbackOnlyTargets,
+    "Main pre-plan rollback-only targets",
+  );
   const reconciliation = canonicalEmbeddedReconciliation(value.reconciliation);
   let decision;
   let reason;
@@ -971,6 +1039,9 @@ export function assertMainPreplanReconciliation(
       );
     }
     const sameRelease = reconciliation.manifest.releaseId === expectedReleaseId;
+    if (sameRelease) {
+      assertFreshRollbackCoverage(reconciliation.manifest, rollbackOnlyTargets);
+    }
     if (reconciliation.allCandidate) {
       decision = sameRelease
         ? "verify-existing-release"
@@ -1002,6 +1073,7 @@ export function assertMainPreplanReconciliation(
     schema: MAIN_PREPLAN_RECONCILIATION_SCHEMA,
     decision,
     reason,
+    rollbackOnlyTargets,
     reconciliation,
     rollbackAuthorization,
   };

--- a/scripts/vercel-main-release-reconciliation.test.mjs
+++ b/scripts/vercel-main-release-reconciliation.test.mjs
@@ -298,6 +298,7 @@ test("release manifest binds the canonical planner result and all four rollback 
   assert.deepEqual(first, second);
   assert.deepEqual(first.stagedTargets, ["governance", "reserve", "ui", "app"]);
   assert.deepEqual(first.activeTargets, first.stagedTargets);
+  assert.deepEqual(first.rollbackOnlyTargets, []);
   assert.deepEqual(assertMainReleaseManifest(first), first);
   assert.equal(Object.hasOwn(first, "plan"), false);
   assert.equal(
@@ -344,6 +345,69 @@ test("release manifest binds the canonical planner result and all four rollback 
   );
 });
 
+test("rollback-only targets persist canonically and reproduce the forced plan", () => {
+  const originalPriors = Object.fromEntries(
+    MAIN_RELEASE_ACTIVATION_ORDER.map((target) => [
+      target,
+      prior(target, {
+        git: gitEvidence({ sha: target === "app" ? SHA : PRIOR_SHA }),
+        servedSha: target === "app" ? SHA : PRIOR_SHA,
+      }),
+    ]),
+  );
+  const { projectIds, priorStates } = plannerInputs(originalPriors);
+  const gitAdapter = {
+    firstParent() {
+      return "b".repeat(40);
+    },
+    isAncestor() {
+      return true;
+    },
+    resolveCommit(sha) {
+      return sha;
+    },
+  };
+  const runPlanner = () =>
+    assert.fail("rollback-only targets must bypass path-aware planning");
+  const releasePlan = planMainDeployments({
+    mode: "active",
+    mainOwnershipMode: {
+      app: "github",
+      governance: "github",
+      reserve: "github",
+      ui: "github",
+    },
+    deploySha: SHA,
+    projectIds,
+    priorStates,
+    rollbackOnlyTargets: [...TARGET_ORDER],
+    gitAdapter,
+    runPlanner,
+  });
+  const releaseManifest = createMainReleaseManifest({
+    upstreamRunId: "700",
+    plan: releasePlan,
+    originalPriors,
+  });
+  assert.equal(releaseManifest.schema, "vercel-main-release-manifest:v2");
+  assert.deepEqual(releaseManifest.rollbackOnlyTargets, [...TARGET_ORDER]);
+  assert.deepEqual(
+    recomputeMainReleasePlan({
+      manifest: releaseManifest,
+      gitAdapter,
+      runPlanner,
+    }),
+    releasePlan,
+  );
+
+  const noncanonical = structuredClone(releaseManifest);
+  noncanonical.rollbackOnlyTargets = ["governance", "app"];
+  assert.throws(
+    () => assertMainReleaseManifest(noncanonical),
+    /rollback-only targets is not canonical/,
+  );
+});
+
 test("no-target plan keeps an exact empty release identity and recomputes", () => {
   const originalPriors = Object.fromEntries(
     MAIN_RELEASE_ACTIVATION_ORDER.map((target) => [target, prior(target)]),
@@ -377,6 +441,7 @@ test("no-target plan keeps an exact empty release identity and recomputes", () =
     deploySha: SHA,
     projectIds,
     priorStates,
+    rollbackOnlyTargets: [],
     gitAdapter,
     runPlanner,
   });
@@ -388,6 +453,7 @@ test("no-target plan keeps an exact empty release identity and recomputes", () =
   });
   assert.deepEqual(noTargetManifest.stagedTargets, []);
   assert.deepEqual(noTargetManifest.activeTargets, []);
+  assert.deepEqual(noTargetManifest.rollbackOnlyTargets, []);
   assert.deepEqual(
     assertMainReleaseManifest(noTargetManifest),
     noTargetManifest,
@@ -539,6 +605,7 @@ for (const [name, appGit, servedSha, plannerSelectsApp] of [
       deploySha: SHA,
       projectIds,
       priorStates,
+      rollbackOnlyTargets: [],
       gitAdapter,
       runPlanner,
     });
@@ -817,6 +884,7 @@ for (const inheritedCount of [1, 2, 3]) {
       nextUpstreamRunId: "800",
       candidateReleases: [candidateRelease(state)],
       currentMappings: state.currentMappings,
+      rollbackOnlyTargets: [],
     });
     assert.equal(decision.decision, "restore-before-planning");
     assert.equal(
@@ -838,6 +906,7 @@ test("pre-plan inspection resumes the same interrupted release and accepts a com
       nextUpstreamRunId: "700",
       candidateReleases: [candidateRelease(partial)],
       currentMappings: partial.currentMappings,
+      rollbackOnlyTargets: [],
     }).decision,
     "resume-existing-release",
   );
@@ -847,6 +916,7 @@ test("pre-plan inspection resumes the same interrupted release and accepts a com
       nextUpstreamRunId: "701",
       candidateReleases: [candidateRelease(partial)],
       currentMappings: partial.currentMappings,
+      rollbackOnlyTargets: [],
     }).decision,
     "restore-before-planning",
   );
@@ -858,6 +928,7 @@ test("pre-plan inspection resumes the same interrupted release and accepts a com
       nextUpstreamRunId: "800",
       candidateReleases: [candidateRelease(complete)],
       currentMappings: complete.currentMappings,
+      rollbackOnlyTargets: [],
     }).decision,
     "capture-new-baseline",
   );
@@ -867,8 +938,84 @@ test("pre-plan inspection resumes the same interrupted release and accepts a com
       nextUpstreamRunId: "701",
       candidateReleases: [candidateRelease(complete)],
       currentMappings: complete.currentMappings,
+      rollbackOnlyTargets: [],
     }).decision,
     "capture-new-baseline",
+  );
+});
+
+test("same-release reuse requires every fresh rollback-only target to be staged", () => {
+  const verifyState = releaseState({
+    selected: ["governance"],
+    candidateCount: 1,
+  });
+  assert.throws(
+    () =>
+      decideMainPreplanReconciliation({
+        nextDeploySha: SHA,
+        nextUpstreamRunId: "700",
+        candidateReleases: [candidateRelease(verifyState)],
+        currentMappings: verifyState.currentMappings,
+        rollbackOnlyTargets: ["ui"],
+      }),
+    /omits fresh rollback-only targets: ui/,
+  );
+
+  const resumeState = releaseState({
+    selected: ["governance", "reserve"],
+    candidateCount: 1,
+  });
+  assert.throws(
+    () =>
+      decideMainPreplanReconciliation({
+        nextDeploySha: SHA,
+        nextUpstreamRunId: "700",
+        candidateReleases: [candidateRelease(resumeState)],
+        currentMappings: resumeState.currentMappings,
+        rollbackOnlyTargets: ["ui"],
+      }),
+    /omits fresh rollback-only targets: ui/,
+  );
+  const covered = decideMainPreplanReconciliation({
+    nextDeploySha: SHA,
+    nextUpstreamRunId: "700",
+    candidateReleases: [candidateRelease(resumeState)],
+    currentMappings: resumeState.currentMappings,
+    rollbackOnlyTargets: ["reserve"],
+  });
+  assert.equal(covered.decision, "resume-existing-release");
+  assert.deepEqual(covered.rollbackOnlyTargets, ["reserve"]);
+});
+
+test("fresh uncovered targets preserve safe older-release recovery decisions", () => {
+  const olderComplete = releaseState({
+    selected: ["governance"],
+    candidateCount: 1,
+  });
+  assert.equal(
+    decideMainPreplanReconciliation({
+      nextDeploySha: "2222222222222222222222222222222222222222",
+      nextUpstreamRunId: "800",
+      candidateReleases: [candidateRelease(olderComplete)],
+      currentMappings: olderComplete.currentMappings,
+      rollbackOnlyTargets: ["ui"],
+    }).decision,
+    "capture-new-baseline",
+  );
+
+  const olderPartial = releaseState({
+    selected: ["governance", "reserve"],
+    candidateCount: 1,
+  });
+  assert.equal(
+    decideMainPreplanReconciliation({
+      nextDeploySha: "2222222222222222222222222222222222222222",
+      nextUpstreamRunId: "800",
+      candidateReleases: [candidateRelease(olderPartial)],
+      currentMappings: olderPartial.currentMappings,
+      rollbackOnlyTargets: ["ui"],
+    }).decision,
+    "restore-before-planning",
   );
 });
 
@@ -879,6 +1026,7 @@ test("pre-plan inspection restores an older mixed App frontier", () => {
     nextUpstreamRunId: "800",
     candidateReleases: [candidateRelease(state)],
     currentMappings: state.currentMappings,
+    rollbackOnlyTargets: [],
   });
   assert.equal(decision.decision, "restore-before-planning");
   assert.deepEqual(decision.rollbackAuthorization.targets, [
@@ -962,6 +1110,7 @@ test("pre-plan inspection selects the unique partial frontier across completed p
       },
     ],
     currentMappings,
+    rollbackOnlyTargets: [],
   });
   assert.equal(decision.decision, "restore-before-planning");
   assert.equal(


### PR DESCRIPTION
## The Problem

The first two active GitHub-driven `main` deployment attempts failed before contacting Vercel because two workflow paths created private `projects.json` inputs with mode `0644` instead of `0600`.

The initial fix also removed admission decisions based on Vercel's optional top-level `deployment.source`, but that exposed a fail-open planning path: an unmarked/manual mapping that self-reported the current SHA could be treated as already current and left live without preparing the reviewed GitHub candidate.

Closing that gap required preserving the rollback-only decision across reruns and final proof. Two related edge cases also surfaced during review:

- terminal census incorrectly required canonical Git org/repo/ref metadata from the exact manifest-bound rollback prior, even though those optional fields are not ownership authority;
- the structurally valid maximum recovery journal and terminal proof exceeded the generic 256 KiB JSON ceiling.

## The Solution

- Create both private `projects.json` inputs under `umask 077`.
- Treat every protected mapping without complete canonical Mento candidate metadata as rollback-only, regardless of optional Vercel source/Git telemetry or served SHA.
- Force rollback-only targets into the staged set before served-SHA and path-aware planning, and persist the canonical target set through provider discovery, preplan reconciliation, the stable release manifest, release selection, and execution.
- Reject same-release verification/resume when its durable manifest does not already stage every freshly rollback-only target. A new baseline must persist the exact discovered set.
- Keep the standalone legacy planning command safe without a provider census by selecting all four targets.
- Admit the exact manifest-bound rollback prior in the final same-SHA census using its deployment ID, URL, project, environment, readiness, and freshly inspected response SHA. Candidate authority still requires canonical `mento-protocol/frontend-monorepo@main` Git identity plus complete Mento metadata.
- Bind original-prior identity through active proof v4, terminal artifacts, the summarizer, and the active controller.
- Retain the generic 256 KiB JSON limit. Raise only complete active journal history and terminal proofs to a tested 1 MiB ceiling for the bounded six-forward/nine-recovery operation envelope.
- Update the deployment runbook and ADR with the authority, rerun, capacity, and legacy-v2 contracts.

## Validation

- `pnpm vercel:workflow:test` — 509/509
- authority/reconciliation/controller suites — 244/244
- `pnpm vercel:deployment-state:test` — 55/55
- `pnpm quality:budgets:test` — 34/34
- `pnpm check-types` — 8/8
- `pnpm ci:action-pins` — all 29 actions pinned
- `pnpm adr:check`
- Trunk/Prettier checks on all 28 modified files
- `git diff --check`
- deterministic autoreview and a fresh-context semantic review — no findings

`pnpm format:check` could not download `@trunkio/launcher` in the sandbox (`ENOTFOUND`). The installed equivalent `trunk check --no-fix --filter=prettier` passed on all modified files.

Runtime proof remains the fresh protected `main` deployment after merge. The release is fail-closed before public mutation if provider identity, rerun coverage, terminal proof, or artifact bounds do not match.

## Ship Checklist

- [x] ship skill used
- [x] local review run
- [x] validation run
- [x] every actionable review comment replied to

Supports #522.
