### PR TITLE
fix(ci): retry stable Vercel preplan epochs

### DIFF
--- a/.github/workflows/vercel-main-deployment.yml
+++ b/.github/workflows/vercel-main-deployment.yml
@@ -133,10 +133,37 @@ jobs:
         env:
           VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN_PRODUCTION }}
-        run: >-
-          node scripts/vercel-main-provider-cli.mjs preplan-decide --discovery "$RUNNER_TEMP/discovery.json"
-          --planning-snapshot "$RUNNER_TEMP/planning.json" --legacy-snapshot "$RUNNER_TEMP/legacy.json"
-          --output "$RUNNER_TEMP/preplan.json"
+        run: |
+          status=0
+          node scripts/vercel-main-provider-cli.mjs preplan-decide \
+            --discovery "$RUNNER_TEMP/discovery.json" \
+            --planning-snapshot "$RUNNER_TEMP/planning.json" \
+            --legacy-snapshot "$RUNNER_TEMP/legacy.json" \
+            --output "$RUNNER_TEMP/preplan.json" || status=$?
+          if [ "$status" -eq 0 ]; then
+            exit 0
+          fi
+          if [ "$status" -ne 75 ]; then
+            exit "$status"
+          fi
+
+          echo "Provider state changed during the decision census; repeating one complete observation epoch."
+          node scripts/vercel-deployment-state.mjs planning-snapshot \
+            --spec "$RUNNER_TEMP/main-spec.json" \
+            --output "$RUNNER_TEMP/planning-retry.json"
+          node scripts/vercel-deployment-state.mjs snapshot \
+            --spec "$RUNNER_TEMP/legacy-spec.json" \
+            --output "$RUNNER_TEMP/legacy-retry.json"
+          node scripts/vercel-main-provider-cli.mjs preplan-discover \
+            --planning-snapshot "$RUNNER_TEMP/planning-retry.json" \
+            --legacy-snapshot "$RUNNER_TEMP/legacy-retry.json" \
+            --project-ids "$RUNNER_TEMP/projects.json" \
+            --output "$RUNNER_TEMP/discovery-retry.json"
+          node scripts/vercel-main-provider-cli.mjs preplan-decide \
+            --discovery "$RUNNER_TEMP/discovery-retry.json" \
+            --planning-snapshot "$RUNNER_TEMP/planning-retry.json" \
+            --legacy-snapshot "$RUNNER_TEMP/legacy-retry.json" \
+            --output "$RUNNER_TEMP/preplan-retry.json"
 
   restore-inherited-release:
     name: Restore inherited active release into this attempt

--- a/docs/vercel-deployments.md
+++ b/docs/vercel-deployments.md
@@ -83,6 +83,19 @@ provider candidates that carry canonical stable release manifests. The exact-CI
 source gate remains token-free with respect to Vercel; there is no GitHub
 artifact or prior-attempt gate between it and provider reconciliation.
 
+One observation epoch captures the complete main and legacy snapshots,
+rediscovers provider candidates, and decides from two fresh sequential main
+censuses plus two fresh sequential legacy `v2` proofs. If that decision reports
+typed planning or legacy state drift, the job discards the epoch and repeats
+that whole sequence once. Every read, digest, and candidate check therefore
+comes from the same epoch. A second drift, HTTP 429, malformed response,
+transport failure, or any candidate/reconciliation ambiguity fails closed
+without another epoch. A failed command prints only an allowlisted
+classification such as `planning-census-read-timeout`,
+`planning-census-unstable`, `planning-census-stale`, or
+`preplan-reconciliation-failed`; it never prints a request path, provider
+response, project or deployment identity, or credential.
+
 The provider-side stable release manifest is the sole durable cross-attempt
 authority. It binds repository, release ID, `DEPLOY_SHA`, validated upstream
 run, ownership mode, staged and active targets, release-plan digest, and every

--- a/scripts/vercel-deployment-state.mjs
+++ b/scripts/vercel-deployment-state.mjs
@@ -1024,6 +1024,7 @@ export class VercelStateClient {
 
   async request(path) {
     let response;
+    const signal = AbortSignal.timeout(15_000);
     try {
       response = await this.fetchImplementation(
         appendTeamId(path, this.teamId),
@@ -1034,14 +1035,23 @@ export class VercelStateClient {
             Authorization: `Bearer ${this.token}`,
             "Content-Type": "application/json",
           },
-          signal: AbortSignal.timeout(15_000),
+          signal,
         },
       );
     } catch {
-      throw new Error("Vercel API request failed");
+      const timedOut = signal.aborted && signal.reason?.name === "TimeoutError";
+      const error = new Error(
+        timedOut ? "Vercel API request timed out" : "Vercel API request failed",
+      );
+      error.code = timedOut
+        ? "VERCEL_API_READ_TIMEOUT"
+        : "VERCEL_API_READ_TRANSPORT";
+      throw error;
     }
     if (!response || typeof response.ok !== "boolean") {
-      throw new Error("Vercel API returned a malformed response");
+      const error = new Error("Vercel API returned a malformed response");
+      error.code = "VERCEL_API_READ_MALFORMED";
+      throw error;
     }
     if (!response.ok) {
       // API error bodies can include environment or protection data. Never
@@ -1053,13 +1063,19 @@ export class VercelStateClient {
           ? response.status
           : "unknown";
       const error = new Error(`Vercel API request failed with HTTP ${status}`);
+      error.code =
+        status === 429
+          ? "VERCEL_API_READ_RATE_LIMITED"
+          : "VERCEL_API_READ_HTTP";
       if (status === 429) error.status = status;
       throw error;
     }
     try {
       return await response.json();
     } catch {
-      throw new Error("Vercel API returned malformed JSON");
+      const error = new Error("Vercel API returned malformed JSON");
+      error.code = "VERCEL_API_READ_MALFORMED";
+      throw error;
     }
   }
 

--- a/scripts/vercel-deployment-state.test.mjs
+++ b/scripts/vercel-deployment-state.test.mjs
@@ -956,7 +956,11 @@ test("App transaction candidate discovery uses filtered bounded pagination and e
   });
   await assert.rejects(
     () => rateLimitedClient.requestWithRetry("/read-only", { attempts: 3 }),
-    /HTTP 429/,
+    (error) => {
+      assert.match(error.message, /HTTP 429/);
+      assert.equal(error.code, "VERCEL_API_READ_RATE_LIMITED");
+      return true;
+    },
   );
   assert.equal(rateLimitedCalls, 1);
 });
@@ -1015,7 +1019,11 @@ test("canonical Vercel state reads retry transient failures and fail closed afte
     });
     await assert.rejects(
       () => read.invoke(persistentClient),
-      /Vercel API request failed/,
+      (error) => {
+        assert.match(error.message, /Vercel API request failed/);
+        assert.equal(error.code, "VERCEL_API_READ_TRANSPORT");
+        return true;
+      },
       `${read.name} must fail closed after the bounded retry limit`,
     );
     assert.equal(persistentCalls, 3, `${read.name} must make at most 3 reads`);

--- a/scripts/vercel-main-deployment-workflow.test.mjs
+++ b/scripts/vercel-main-deployment-workflow.test.mjs
@@ -147,7 +147,7 @@ test("workflow admission keeps immutable controller and exact source isolation",
   );
 });
 
-test("provider preplan captures both reviewed snapshots then discovers and decides", () => {
+test("provider preplan retries only typed drift with one wholly fresh observation epoch", () => {
   const job = workflow.jobs["provider-preplan"];
   assert.deepEqual(job.needs, ["wait-for-ci"]);
   assert.equal(job["timeout-minutes"], 20);
@@ -161,12 +161,36 @@ test("provider preplan captures both reviewed snapshots then discovers and decid
     command("provider-preplan", "preplan-discover").run,
     /--planning-snapshot .*--legacy-snapshot/,
   );
+  const decision = command("provider-preplan", "preplan-decide");
+  assert.equal((decision.run.match(/preplan-decide/g) ?? []).length, 2);
   assert.match(
-    command("provider-preplan", "preplan-decide").run,
-    /preplan-decide/,
+    decision.run,
+    new RegExp(
+      `preplan\\.json" \\|\\| status=\\$\\?[\\s\\S]*` +
+        `if \\[ "\\$status" -eq 0 \\]; then[\\s\\S]*exit 0[\\s\\S]*` +
+        `if \\[ "\\$status" -ne 75 \\]; then[\\s\\S]*` +
+        `exit "\\$status"[\\s\\S]*planning-snapshot`,
+    ),
   );
+  assert.doesNotMatch(decision.run, /\b(?:for|while|until)\b/);
+  assert.match(
+    decision.run,
+    /planning-snapshot[\s\S]*planning-retry\.json[\s\S]*snapshot[\s\S]*legacy-retry\.json[\s\S]*preplan-discover[\s\S]*discovery-retry\.json[\s\S]*preplan-decide[\s\S]*preplan-retry\.json/,
+  );
+  for (const [retryFile, expectedReferences] of Object.entries({
+    "planning-retry.json": 3,
+    "legacy-retry.json": 3,
+    "discovery-retry.json": 2,
+    "preplan-retry.json": 1,
+  })) {
+    assert.equal(
+      (decision.run.match(new RegExp(retryFile.replace(".", "\\."), "g")) ?? [])
+        .length,
+      expectedReferences,
+    );
+  }
   assert.equal(
-    command("provider-preplan", "preplan-decide").env.VERCEL_TOKEN,
+    decision.env.VERCEL_TOKEN,
     "${{ secrets.VERCEL_TOKEN_PRODUCTION }}",
   );
 });

--- a/scripts/vercel-main-provider-cli.mjs
+++ b/scripts/vercel-main-provider-cli.mjs
@@ -61,6 +61,7 @@ import { generateVercelMainReleaseId } from "./vercel-prebuilt.mjs";
 
 export const MAIN_PROVIDER_CLI_MAX_JSON_BYTES = 256 * 1024;
 export const MAIN_PREPLAN_HANDOFF_MAX_ENCODED_BYTES = 64 * 1024;
+export const MAIN_PROVIDER_CLI_RETRY_EXIT_CODE = 75;
 export const MAIN_CANONICAL_MAPPINGS_SCHEMA =
   "vercel-main-canonical-mappings:v1";
 const MAIN_PROVIDER_DISCOVERY_SCHEMA = "vercel-main-provider-discovery:v2";
@@ -103,6 +104,38 @@ const SHA_PATTERN = /^[a-f0-9]{40}$/;
 const POSITIVE_ID_PATTERN = /^[1-9][0-9]*$/;
 const DEPLOYMENT_ID_PATTERN = /^dpl_[A-Za-z0-9]+$/;
 const PROJECT_ID_PATTERN = /^[A-Za-z0-9._-]+$/;
+const VERCEL_READ_FAILURE_KINDS = new Map([
+  ["VERCEL_API_READ_TIMEOUT", "read-timeout"],
+  ["VERCEL_API_READ_TRANSPORT", "read-transport"],
+  ["VERCEL_API_READ_RATE_LIMITED", "read-rate-limited"],
+  ["VERCEL_API_READ_HTTP", "read-http"],
+  ["VERCEL_API_READ_MALFORMED", "read-malformed"],
+]);
+const SAFE_MAIN_PROVIDER_FAILURE_CODES = new Set([
+  ...["planning-census", "legacy-census"].flatMap((stage) => [
+    `${stage}-read-timeout`,
+    `${stage}-read-transport`,
+    `${stage}-read-rate-limited`,
+    `${stage}-read-http`,
+    `${stage}-read-malformed`,
+    `${stage}-unstable`,
+    `${stage}-stale`,
+    `${stage}-failed`,
+  ]),
+  "preplan-reconciliation-failed",
+]);
+const RETRYABLE_MAIN_PROVIDER_FAILURE_CODES = new Set([
+  "planning-census-unstable",
+  "planning-census-stale",
+  "legacy-census-unstable",
+  "legacy-census-stale",
+]);
+const MAIN_PROVIDER_OBSERVATION_FAILURE = Object.freeze({
+  planningUnstable: "planning-census-unstable",
+  planningStale: "planning-census-stale",
+  legacyUnstable: "legacy-census-unstable",
+  legacyStale: "legacy-census-stale",
+});
 
 function isPlainObject(value) {
   return (
@@ -708,6 +741,46 @@ async function captureLivePlanningSnapshot(client, projectIds) {
   });
 }
 
+function classifyProviderCensusFailure(stage, error) {
+  const readFailure = VERCEL_READ_FAILURE_KINDS.get(error?.code);
+  const typedObservationFailure =
+    RETRYABLE_MAIN_PROVIDER_FAILURE_CODES.has(error?.mainProviderFailureCode) &&
+    error.mainProviderFailureCode.startsWith(`${stage}-`)
+      ? error.mainProviderFailureCode
+      : null;
+  const classified = new Error("Vercel provider census failed");
+  classified.mainProviderFailureCode =
+    typedObservationFailure ?? `${stage}-${readFailure ?? "failed"}`;
+  return classified;
+}
+
+function providerObservationFailure(failureCode, message) {
+  if (!RETRYABLE_MAIN_PROVIDER_FAILURE_CODES.has(failureCode)) {
+    throw new Error("Main provider observation failure code is malformed");
+  }
+  const error = new Error(message);
+  error.mainProviderFailureCode = failureCode;
+  return error;
+}
+
+async function runClassifiedProviderCensus(stage, capture) {
+  try {
+    return await capture();
+  } catch (error) {
+    throw classifyProviderCensusFailure(stage, error);
+  }
+}
+
+function runClassifiedProviderReconciliation(reconcile) {
+  try {
+    return reconcile();
+  } catch {
+    const classified = new Error("Vercel preplan reconciliation failed");
+    classified.mainProviderFailureCode = "preplan-reconciliation-failed";
+    throw classified;
+  }
+}
+
 async function captureStableBoundPlanningSnapshot({
   client,
   projectIds,
@@ -715,11 +788,15 @@ async function captureStableBoundPlanningSnapshot({
 }) {
   const first = await captureLivePlanningSnapshot(client, projectIds);
   const second = await captureLivePlanningSnapshot(client, projectIds);
-  if (
-    JSON.stringify(first) !== JSON.stringify(second) ||
-    planningSnapshotDigest(second) !== expectedDigest
-  ) {
-    throw new Error(
+  if (JSON.stringify(first) !== JSON.stringify(second)) {
+    throw providerObservationFailure(
+      MAIN_PROVIDER_OBSERVATION_FAILURE.planningUnstable,
+      "Main planning aliases changed during decision census",
+    );
+  }
+  if (planningSnapshotDigest(second) !== expectedDigest) {
+    throw providerObservationFailure(
+      MAIN_PROVIDER_OBSERVATION_FAILURE.planningStale,
       "Main planning aliases changed between discovery and decision",
     );
   }
@@ -752,11 +829,17 @@ async function captureStableBoundLegacyV2Snapshot({
   };
   const first = await capture();
   const second = await capture();
-  if (
-    JSON.stringify(first) !== JSON.stringify(second) ||
-    digestMainLegacyV2Snapshot(second) !== expectedDigest
-  ) {
-    throw new Error("Legacy v2 mapping changed between discovery and decision");
+  if (JSON.stringify(first) !== JSON.stringify(second)) {
+    throw providerObservationFailure(
+      MAIN_PROVIDER_OBSERVATION_FAILURE.legacyUnstable,
+      "Legacy v2 mapping changed during decision census",
+    );
+  }
+  if (digestMainLegacyV2Snapshot(second) !== expectedDigest) {
+    throw providerObservationFailure(
+      MAIN_PROVIDER_OBSERVATION_FAILURE.legacyStale,
+      "Legacy v2 mapping changed between discovery and decision",
+    );
   }
   return second;
 }
@@ -1033,45 +1116,58 @@ export async function runMainProviderCli({
       token: env.VERCEL_TOKEN,
       teamId: env.VERCEL_ORG_ID,
     });
-    const freshSnapshot = await captureStableBoundPlanningSnapshot({
-      client: liveClient,
-      projectIds: projects,
-      expectedDigest: discovery.planningSnapshotDigest,
-    });
-    const freshLegacySnapshot = await captureStableBoundLegacyV2Snapshot({
-      client: liveClient,
-      legacySnapshot: suppliedLegacySnapshot,
-      expectedDigest: discovery.legacyAppV2Digest,
-    });
-    const { mappings: allMappings } = createMainCanonicalMappings({
-      planningSnapshot: freshSnapshot,
-      projectIds: projects,
-      legacySnapshot: freshLegacySnapshot,
-    });
-    const currentMappings = Object.fromEntries(
-      MAIN_RELEASE_ACTIVATION_ORDER.map((target) => [
-        target,
-        allMappings[target],
-      ]),
+    const freshSnapshot = await runClassifiedProviderCensus(
+      "planning-census",
+      () =>
+        captureStableBoundPlanningSnapshot({
+          client: liveClient,
+          projectIds: projects,
+          expectedDigest: discovery.planningSnapshotDigest,
+        }),
     );
-    const nextReleaseId = expectedNextReleaseId(env);
-    const result = assertMainPreplanReconciliation(
-      decideMainPreplanReconciliation({
-        nextDeploySha: env.DEPLOY_SHA,
-        nextUpstreamRunId: env.UPSTREAM_RUN_ID,
-        candidateReleases: discovery.discovery.candidateReleases,
-        currentMappings,
-        rollbackOnlyTargets: discovery.discovery.rollbackOnlyTargets,
-      }),
-      {
-        nextDeploySha: env.DEPLOY_SHA,
-        nextUpstreamRunId: env.UPSTREAM_RUN_ID,
-      },
+    const freshLegacySnapshot = await runClassifiedProviderCensus(
+      "legacy-census",
+      () =>
+        captureStableBoundLegacyV2Snapshot({
+          client: liveClient,
+          legacySnapshot: suppliedLegacySnapshot,
+          expectedDigest: discovery.legacyAppV2Digest,
+        }),
     );
-    const releaseId =
-      result.decision === "restore-before-planning"
-        ? result.reconciliation.manifest.releaseId
-        : nextReleaseId;
+    const { result, releaseId } = runClassifiedProviderReconciliation(() => {
+      const { mappings: allMappings } = createMainCanonicalMappings({
+        planningSnapshot: freshSnapshot,
+        projectIds: projects,
+        legacySnapshot: freshLegacySnapshot,
+      });
+      const currentMappings = Object.fromEntries(
+        MAIN_RELEASE_ACTIVATION_ORDER.map((target) => [
+          target,
+          allMappings[target],
+        ]),
+      );
+      const nextReleaseId = expectedNextReleaseId(env);
+      const decision = assertMainPreplanReconciliation(
+        decideMainPreplanReconciliation({
+          nextDeploySha: env.DEPLOY_SHA,
+          nextUpstreamRunId: env.UPSTREAM_RUN_ID,
+          candidateReleases: discovery.discovery.candidateReleases,
+          currentMappings,
+          rollbackOnlyTargets: discovery.discovery.rollbackOnlyTargets,
+        }),
+        {
+          nextDeploySha: env.DEPLOY_SHA,
+          nextUpstreamRunId: env.UPSTREAM_RUN_ID,
+        },
+      );
+      return {
+        result: decision,
+        releaseId:
+          decision.decision === "restore-before-planning"
+            ? decision.reconciliation.manifest.releaseId
+            : nextReleaseId,
+      };
+    });
     writePrivateJson(options.output, result, runnerTemp);
     appendGithubOutputs(env, {
       decision: result.decision,
@@ -1151,8 +1247,23 @@ export async function runMainProviderCli({
   return result;
 }
 
-export function renderMainProviderCliFailure() {
+export function renderMainProviderCliFailure(error) {
+  const failureCode = error?.mainProviderFailureCode;
+  if (
+    typeof failureCode === "string" &&
+    SAFE_MAIN_PROVIDER_FAILURE_CODES.has(failureCode)
+  ) {
+    return `Vercel main provider command failed (${failureCode})\n`;
+  }
   return "Vercel main provider command failed\n";
+}
+
+export function mainProviderCliFailureExitCode(error) {
+  return RETRYABLE_MAIN_PROVIDER_FAILURE_CODES.has(
+    error?.mainProviderFailureCode,
+  )
+    ? MAIN_PROVIDER_CLI_RETRY_EXIT_CODE
+    : 1;
 }
 
 function isCliEntrypoint() {
@@ -1165,8 +1276,8 @@ function isCliEntrypoint() {
 if (isCliEntrypoint()) {
   try {
     await runMainProviderCli({ argv: process.argv.slice(2) });
-  } catch {
-    process.stderr.write(renderMainProviderCliFailure());
-    process.exitCode = 1;
+  } catch (error) {
+    process.stderr.write(renderMainProviderCliFailure(error));
+    process.exitCode = mainProviderCliFailureExitCode(error);
   }
 }

--- a/scripts/vercel-main-provider-cli.test.mjs
+++ b/scripts/vercel-main-provider-cli.test.mjs
@@ -34,7 +34,9 @@ import {
   createMainCanonicalMappings,
   decodeMainPreplanHandoff,
   encodeMainPreplanHandoff,
+  mainProviderCliFailureExitCode,
   MAIN_PROVIDER_CLI_MAX_JSON_BYTES,
+  MAIN_PROVIDER_CLI_RETRY_EXIT_CODE,
   MAIN_PREPLAN_HANDOFF_MAX_ENCODED_BYTES,
   readPrivateJson,
   renderMainProviderCliFailure,
@@ -229,6 +231,16 @@ function writeJson(directory, name, value) {
 
 function readJson(path) {
   return JSON.parse(readFileSync(path, "utf8"));
+}
+
+async function captureRejection(operation, pattern) {
+  try {
+    await operation();
+  } catch (error) {
+    assert.match(error.message, pattern);
+    return error;
+  }
+  assert.fail("Expected operation to reject");
 }
 
 function planningStateClient(
@@ -743,15 +755,15 @@ test("preplan decision rejects alias drift after discovery before baseline or ro
       deploymentUrl: "https://changed-after-discovery.vercel.app",
     },
   });
-  for (const client of [
-    planningStateClient(changed),
-    planningStateClient(original, changed),
+  for (const [client, failureCode] of [
+    [planningStateClient(changed), "planning-census-stale"],
+    [planningStateClient(original, changed), "planning-census-unstable"],
   ]) {
     const output = join(
       context.directory,
       `decision-drift-${client.calls()}.json`,
     );
-    await assert.rejects(
+    const planningDriftError = await captureRejection(
       () =>
         runMainProviderCli({
           argv: [
@@ -769,10 +781,103 @@ test("preplan decision rejects alias drift after discovery before baseline or ro
           stdout: context.stdout,
           stateClientFactory: () => client,
         }),
-      /changed between discovery and decision/,
+      /Vercel provider census failed/,
     );
     assert.throws(() => statSync(output));
+    assert.equal(
+      renderMainProviderCliFailure(planningDriftError),
+      `Vercel main provider command failed (${failureCode})\n`,
+    );
+    assert.equal(
+      mainProviderCliFailureExitCode(planningDriftError),
+      MAIN_PROVIDER_CLI_RETRY_EXIT_CODE,
+    );
+    assert.equal(readFileSync(context.githubOutput, "utf8"), "");
   }
+
+  const timeoutError = new Error(
+    `${context.env.VERCEL_TOKEN} prj_private123 /v13/deployments/private`,
+  );
+  timeoutError.code = "VERCEL_API_READ_TIMEOUT";
+  const planningTimeoutError = await captureRejection(
+    () =>
+      runMainProviderCli({
+        argv: [
+          "preplan-decide",
+          "--discovery",
+          discoveryPath,
+          "--planning-snapshot",
+          planningPath,
+          "--legacy-snapshot",
+          legacyPath,
+          "--output",
+          join(context.directory, "planning-timeout.json"),
+        ],
+        env: context.env,
+        stdout: context.stdout,
+        stateClientFactory: () => ({
+          mainPlanningAliasState: async () => {
+            throw timeoutError;
+          },
+        }),
+      }),
+    /Vercel provider census failed/,
+  );
+  assert.equal(
+    renderMainProviderCliFailure(planningTimeoutError),
+    "Vercel main provider command failed (planning-census-read-timeout)\n",
+  );
+  assert.doesNotMatch(
+    renderMainProviderCliFailure(planningTimeoutError),
+    /test-secret-token|prj_private123|v13|deployments|private/,
+  );
+  assert.equal(mainProviderCliFailureExitCode(planningTimeoutError), 1);
+
+  const reconciliationOutput = join(
+    context.directory,
+    "reconciliation-failure.json",
+  );
+  const reconciliationError = await captureRejection(
+    () =>
+      runMainProviderCli({
+        argv: [
+          "preplan-decide",
+          "--discovery",
+          discoveryPath,
+          "--planning-snapshot",
+          planningPath,
+          "--legacy-snapshot",
+          legacyPath,
+          "--output",
+          reconciliationOutput,
+        ],
+        env: { ...context.env, DEPLOY_SHA: context.env.VERCEL_TOKEN },
+        stdout: context.stdout,
+        stateClientFactory: () => planningStateClient(original),
+      }),
+    /Vercel preplan reconciliation failed/,
+  );
+  assert.throws(() => statSync(reconciliationOutput));
+  assert.equal(
+    renderMainProviderCliFailure(reconciliationError),
+    "Vercel main provider command failed (preplan-reconciliation-failed)\n",
+  );
+  assert.equal(mainProviderCliFailureExitCode(reconciliationError), 1);
+  assert.equal(readFileSync(context.githubOutput, "utf8"), "");
+
+  const secretSemanticError = new Error(
+    `${context.env.VERCEL_TOKEN} prj_private123 /private/provider/path`,
+  );
+  secretSemanticError.mainProviderFailureCode = "preplan-reconciliation-failed";
+  assert.equal(
+    renderMainProviderCliFailure(secretSemanticError),
+    "Vercel main provider command failed (preplan-reconciliation-failed)\n",
+  );
+  assert.doesNotMatch(
+    renderMainProviderCliFailure(secretSemanticError),
+    /test-secret-token|prj_private123|\/private\/provider\/path/,
+  );
+
   const changedLegacy = legacySnapshot();
   changedLegacy[0] = {
     ...changedLegacy[0],
@@ -806,32 +911,48 @@ test("preplan decision rejects alias drift after discovery before baseline or ro
   );
   assert.equal(readFileSync(context.githubOutput, "utf8"), "");
 
-  const liveLegacyDrift = planningStateClient(
-    original,
-    original,
-    legacySnapshot(),
-    changedLegacy,
-  );
-  await assert.rejects(
-    () =>
-      runMainProviderCli({
-        argv: [
-          "preplan-decide",
-          "--discovery",
-          discoveryPath,
-          "--planning-snapshot",
-          planningPath,
-          "--legacy-snapshot",
-          legacyPath,
-          "--output",
-          join(context.directory, "live-legacy-drift.json"),
-        ],
-        env: context.env,
-        stdout: context.stdout,
-        stateClientFactory: () => liveLegacyDrift,
-      }),
-    /Legacy v2 mapping changed between discovery and decision/,
-  );
+  for (const [client, failureCode] of [
+    [
+      planningStateClient(original, original, legacySnapshot(), changedLegacy),
+      "legacy-census-unstable",
+    ],
+    [
+      planningStateClient(original, original, changedLegacy, changedLegacy),
+      "legacy-census-stale",
+    ],
+  ]) {
+    const output = join(context.directory, `${failureCode}-decision.json`);
+    const legacyDriftError = await captureRejection(
+      () =>
+        runMainProviderCli({
+          argv: [
+            "preplan-decide",
+            "--discovery",
+            discoveryPath,
+            "--planning-snapshot",
+            planningPath,
+            "--legacy-snapshot",
+            legacyPath,
+            "--output",
+            output,
+          ],
+          env: context.env,
+          stdout: context.stdout,
+          stateClientFactory: () => client,
+        }),
+      /Vercel provider census failed/,
+    );
+    assert.throws(() => statSync(output));
+    assert.equal(
+      renderMainProviderCliFailure(legacyDriftError),
+      `Vercel main provider command failed (${failureCode})\n`,
+    );
+    assert.equal(
+      mainProviderCliFailureExitCode(legacyDriftError),
+      MAIN_PROVIDER_CLI_RETRY_EXIT_CODE,
+    );
+    assert.equal(readFileSync(context.githubOutput, "utf8"), "");
+  }
 });
 
 test("candidate preflight performs a stable double census and emits create", async (t) => {
@@ -1100,6 +1221,10 @@ test("CLI rejects malformed arguments, token options, and non-private paths with
   assert.equal(
     renderMainProviderCliFailure(new Error(context.env.VERCEL_TOKEN)),
     "Vercel main provider command failed\n",
+  );
+  assert.equal(
+    mainProviderCliFailureExitCode(new Error(context.env.VERCEL_TOKEN)),
+    1,
   );
 });
 


### PR DESCRIPTION
## The Problem

The first protected main cutover attempt failed safely in the read-only provider pre-plan after completing its Vercel state census. The CLI intentionally suppressed provider details, but it also suppressed the safe failure category. A transient alias-state change could therefore stop every cutover attempt without a bounded recovery path, while operators could not distinguish drift from a read or reconciliation failure.

## The Solution

Classify pre-plan failures with fixed, value-free codes and return exit code 75 only for planning or legacy census drift. The workflow discards a drifting observation epoch and performs one complete fresh epoch: main snapshot, legacy snapshot, candidate discovery, and decision. A second drift and every timeout, transport, rate-limit, malformed-response, HTTP, or reconciliation failure still fail closed before any deployment or alias mutation.

The runbook now documents the retry boundary and the redacted diagnostic contract.

Advances #522. That issue remains open until the cutover proof and follow-up verification are complete.

## Validation

- `pnpm vercel:workflow:test` — 509 passed
- `pnpm vercel:deployment-state:test` — 55 passed
- Focused deployment-state, provider CLI, and parsed-workflow tests — 96 passed
- `pnpm quality:budgets:test` — 34 passed
- `pnpm check-types` — 8 tasks passed
- `pnpm ci:action-pins` — all 29 workflow files pinned
- `pnpm adr:check`
- Prettier on all changed files
- `git diff --check`
- Two independent code reviews; one test-contract finding fixed before publishing

## Ship Checklist

- [x] PR title follows the conventions
- [x] Performed a self-review of my own changes
- [x] Relevant automated checks and smoke tests pass
- [x] Architecture decision: Not applicable — this preserves the accepted GitHub-driven deployment architecture and hardens one existing pre-plan control.

## Risk

The retry intentionally applies only to typed state drift and runs at most once. Provider read failures and reconciliation ambiguity remain terminal. The change affects only the protected, read-only pre-plan job; mutation jobs remain downstream of a successful decision.
