### PR TITLE
fix(ci): seal Vercel preplan runner output

### DIFF
--- a/docs/vercel-deployments.md
+++ b/docs/vercel-deployments.md
@@ -92,9 +92,18 @@ comes from the same epoch. A second drift, HTTP 429, malformed response,
 transport failure, or any candidate/reconciliation ambiguity fails closed
 without another epoch. A failed command prints only an allowlisted
 classification such as `planning-census-read-timeout`,
-`planning-census-unstable`, `planning-census-stale`, or
-`preplan-reconciliation-failed`; it never prints a request path, provider
-response, project or deployment identity, or credential.
+`planning-census-unstable`, `planning-census-stale`,
+`preplan-reconciliation-failed`, `preplan-private-output-write-failed`,
+`preplan-handoff-encode-failed`, or `preplan-github-output-append-failed`; it
+never prints a request path, provider response, project or deployment identity,
+or credential. The failure classifications are value-free. Before the preplan
+command appends its GitHub job outputs, it opens the existing command file
+without following links, requires one regular single-link inode with mode
+exactly `0600` or GitHub's `0644` default, seals the open descriptor to `0600`,
+then rechecks the same inode, its single link, non-symlink path, exact mode, and
+size both before and after the append. Group- or other-writable files, links,
+identity changes observed during validation, and oversized command files fail
+closed.
 
 The provider-side stable release manifest is the sole durable cross-attempt
 authority. It binds repository, release ID, `DEPLOY_SHA`, validated upstream

--- a/scripts/vercel-main-provider-cli.mjs
+++ b/scripts/vercel-main-provider-cli.mjs
@@ -111,6 +111,11 @@ const VERCEL_READ_FAILURE_KINDS = new Map([
   ["VERCEL_API_READ_HTTP", "read-http"],
   ["VERCEL_API_READ_MALFORMED", "read-malformed"],
 ]);
+const PREPLAN_POST_CENSUS_FAILURE_CODES = new Set([
+  "preplan-private-output-write-failed",
+  "preplan-handoff-encode-failed",
+  "preplan-github-output-append-failed",
+]);
 const SAFE_MAIN_PROVIDER_FAILURE_CODES = new Set([
   ...["planning-census", "legacy-census"].flatMap((stage) => [
     `${stage}-read-timeout`,
@@ -123,6 +128,7 @@ const SAFE_MAIN_PROVIDER_FAILURE_CODES = new Set([
     `${stage}-failed`,
   ]),
   "preplan-reconciliation-failed",
+  ...PREPLAN_POST_CENSUS_FAILURE_CODES,
 ]);
 const RETRYABLE_MAIN_PROVIDER_FAILURE_CODES = new Set([
   "planning-census-unstable",
@@ -669,13 +675,44 @@ export function appendGithubOutputs(env, values) {
       pathStats.isSymbolicLink() ||
       stats.dev !== pathStats.dev ||
       stats.ino !== pathStats.ino ||
-      (stats.mode & 0o077) !== 0 ||
+      ![0o600, 0o644].includes(stats.mode & 0o7777) ||
       stats.size + serializedBytes > MAIN_PROVIDER_CLI_MAX_JSON_BYTES
+    ) {
+      throw new Error("unsafe");
+    }
+    fchmodSync(descriptor, 0o600);
+    const sealedStats = fstatSync(descriptor);
+    const sealedPathStats = lstatSync(outputPath);
+    if (
+      !sealedStats.isFile() ||
+      sealedStats.nlink !== 1 ||
+      sealedPathStats.nlink !== 1 ||
+      sealedPathStats.isSymbolicLink() ||
+      sealedStats.dev !== sealedPathStats.dev ||
+      sealedStats.ino !== sealedPathStats.ino ||
+      (sealedStats.mode & 0o7777) !== 0o600 ||
+      (sealedPathStats.mode & 0o7777) !== 0o600 ||
+      sealedStats.size + serializedBytes > MAIN_PROVIDER_CLI_MAX_JSON_BYTES
     ) {
       throw new Error("unsafe");
     }
     writeFileSync(descriptor, serialized);
     fsyncSync(descriptor);
+    const committedStats = fstatSync(descriptor);
+    const committedPathStats = lstatSync(outputPath);
+    if (
+      !committedStats.isFile() ||
+      committedStats.nlink !== 1 ||
+      committedPathStats.nlink !== 1 ||
+      committedPathStats.isSymbolicLink() ||
+      committedStats.dev !== committedPathStats.dev ||
+      committedStats.ino !== committedPathStats.ino ||
+      (committedStats.mode & 0o7777) !== 0o600 ||
+      (committedPathStats.mode & 0o7777) !== 0o600 ||
+      committedStats.size > MAIN_PROVIDER_CLI_MAX_JSON_BYTES
+    ) {
+      throw new Error("unsafe");
+    }
   } catch {
     throw new Error("GITHUB_OUTPUT could not be written safely");
   } finally {
@@ -777,6 +814,19 @@ function runClassifiedProviderReconciliation(reconcile) {
   } catch {
     const classified = new Error("Vercel preplan reconciliation failed");
     classified.mainProviderFailureCode = "preplan-reconciliation-failed";
+    throw classified;
+  }
+}
+
+function runClassifiedPreplanPostCensusOperation(failureCode, operation) {
+  if (!PREPLAN_POST_CENSUS_FAILURE_CODES.has(failureCode)) {
+    throw new Error("Main provider post-census failure code is malformed");
+  }
+  try {
+    return operation();
+  } catch {
+    const classified = new Error("Vercel preplan post-census operation failed");
+    classified.mainProviderFailureCode = failureCode;
     throw classified;
   }
 }
@@ -892,6 +942,42 @@ export function decodeMainPreplanHandoff(
     nextDeploySha,
     nextUpstreamRunId,
   });
+}
+
+export function writeMainPreplanDecisionOutputs({
+  output,
+  result,
+  releaseId,
+  runnerTemp,
+  env,
+  operations = {
+    writePrivateJson,
+    encodeMainPreplanHandoff,
+    appendGithubOutputs,
+  },
+}) {
+  const handoff = runClassifiedPreplanPostCensusOperation(
+    "preplan-handoff-encode-failed",
+    () =>
+      operations.encodeMainPreplanHandoff(result, {
+        nextDeploySha: env.DEPLOY_SHA,
+        nextUpstreamRunId: env.UPSTREAM_RUN_ID,
+      }),
+  );
+  runClassifiedPreplanPostCensusOperation(
+    "preplan-private-output-write-failed",
+    () => operations.writePrivateJson(output, result, runnerTemp),
+  );
+  runClassifiedPreplanPostCensusOperation(
+    "preplan-github-output-append-failed",
+    () =>
+      operations.appendGithubOutputs(env, {
+        decision: result.decision,
+        reason: result.reason,
+        release_id: releaseId,
+        handoff,
+      }),
+  );
 }
 
 async function smokeMainCandidateUrl({
@@ -1168,15 +1254,12 @@ export async function runMainProviderCli({
             : nextReleaseId,
       };
     });
-    writePrivateJson(options.output, result, runnerTemp);
-    appendGithubOutputs(env, {
-      decision: result.decision,
-      reason: result.reason,
-      release_id: releaseId,
-      handoff: encodeMainPreplanHandoff(result, {
-        nextDeploySha: env.DEPLOY_SHA,
-        nextUpstreamRunId: env.UPSTREAM_RUN_ID,
-      }),
+    writeMainPreplanDecisionOutputs({
+      output: options.output,
+      result,
+      releaseId,
+      runnerTemp,
+      env,
     });
     stdout.write("Canonical pre-plan reconciliation decision written\n");
     return result;

--- a/scripts/vercel-main-provider-cli.test.mjs
+++ b/scripts/vercel-main-provider-cli.test.mjs
@@ -42,6 +42,7 @@ import {
   renderMainProviderCliFailure,
   reviewedRunnerTemp,
   runMainProviderCli,
+  writeMainPreplanDecisionOutputs,
   writePrivateJson,
 } from "./vercel-main-provider-cli.mjs";
 
@@ -525,6 +526,7 @@ test("preplan discovery groups mapped manifests and marks unowned mappings rollb
 
 test("preplan decision binds current SHA and upstream run to one exact release ID", async (t) => {
   const context = testContext(t);
+  chmodSync(context.githubOutput, 0o644);
   const snapshot = planningSnapshot();
   const planningPath = writeJson(context.directory, "planning.json", snapshot);
   const legacyPath = writeJson(
@@ -603,6 +605,7 @@ test("preplan decision binds current SHA and upstream run to one exact release I
       "",
     ].join("\n"),
   );
+  assert.equal(statSync(context.githubOutput).mode & 0o777, 0o600);
   assert.deepEqual(readJson(output), result);
 
   const encoded = encodeMainPreplanHandoff(result, {
@@ -696,6 +699,52 @@ test("preplan materialization accepts only inherited restore and exposes ordered
     nextDeploySha: SHA,
     nextUpstreamRunId: "700",
   });
+  const completeCandidates = Object.fromEntries(
+    ["governance", "reserve", "ui", "app"].map((target) => [
+      target,
+      {
+        deploymentId: `dpl_${target}MaximumShape123`,
+        deploymentUrl: `https://${target}-maximum-shape.vercel.app`,
+        manifest: inherited,
+      },
+    ]),
+  );
+  const maximumShapeDecision = decideMainPreplanReconciliation({
+    nextDeploySha: SHA,
+    nextUpstreamRunId: "700",
+    candidateReleases: [
+      {
+        manifest: inherited,
+        candidates: completeCandidates,
+      },
+    ],
+    currentMappings: Object.fromEntries(
+      ["governance", "reserve", "ui", "app"].map((target) => [
+        target,
+        inherited.originalPriors[target].aliases.map((alias) => ({
+          alias,
+          deploymentId: completeCandidates[target].deploymentId,
+          deploymentUrl: completeCandidates[target].deploymentUrl,
+        })),
+      ]),
+    ),
+    rollbackOnlyTargets: [],
+  });
+  const maximumShapeHandoff = encodeMainPreplanHandoff(maximumShapeDecision, {
+    nextDeploySha: SHA,
+    nextUpstreamRunId: "700",
+  });
+  assert.ok(
+    Buffer.byteLength(maximumShapeHandoff, "utf8") <=
+      MAIN_PREPLAN_HANDOFF_MAX_ENCODED_BYTES,
+  );
+  assert.deepEqual(
+    decodeMainPreplanHandoff(maximumShapeHandoff, {
+      nextDeploySha: SHA,
+      nextUpstreamRunId: "700",
+    }),
+    maximumShapeDecision,
+  );
   const output = join(context.directory, "restore-before-planning.json");
   await runMainProviderCli({
     argv: ["preplan-materialize", "--output", output],
@@ -707,6 +756,79 @@ test("preplan materialization accepts only inherited restore and exposes ordered
     readFileSync(context.githubOutput, "utf8"),
     'inherited_candidate_targets=["governance"]\n',
   );
+});
+
+test("post-census preplan output failures are typed, non-retryable, and value-free", (t) => {
+  const context = testContext(t);
+  const result = {
+    schema: "vercel-main-preplan-reconciliation:v2",
+    decision: "capture-new-baseline",
+    reason: "no-mapped-release-metadata",
+    rollbackOnlyTargets: [],
+    reconciliation: null,
+    rollbackAuthorization: null,
+  };
+  const output = join(context.directory, "decision.json");
+  const secret = `${context.env.VERCEL_TOKEN} /private/provider/path`;
+  const cases = [
+    [
+      "preplan-handoff-encode-failed",
+      {
+        encodeMainPreplanHandoff: () => {
+          throw new Error(secret);
+        },
+        writePrivateJson: assert.fail,
+        appendGithubOutputs: assert.fail,
+      },
+    ],
+    [
+      "preplan-private-output-write-failed",
+      {
+        encodeMainPreplanHandoff: () => "safe-handoff",
+        writePrivateJson: () => {
+          throw new Error(secret);
+        },
+        appendGithubOutputs: assert.fail,
+      },
+    ],
+    [
+      "preplan-github-output-append-failed",
+      {
+        encodeMainPreplanHandoff: () => "safe-handoff",
+        writePrivateJson: () => undefined,
+        appendGithubOutputs: () => {
+          throw new Error(secret);
+        },
+      },
+    ],
+  ];
+
+  for (const [failureCode, operations] of cases) {
+    let error;
+    try {
+      writeMainPreplanDecisionOutputs({
+        output,
+        result,
+        releaseId: "release_fixture",
+        runnerTemp: context.directory,
+        env: context.env,
+        operations,
+      });
+    } catch (caught) {
+      error = caught;
+    }
+    assert.ok(error instanceof Error);
+    assert.equal(
+      renderMainProviderCliFailure(error),
+      `Vercel main provider command failed (${failureCode})\n`,
+    );
+    assert.equal(mainProviderCliFailureExitCode(error), 1);
+    assert.doesNotMatch(
+      renderMainProviderCliFailure(error),
+      /test-secret-token|private\/provider\/path/,
+    );
+  }
+  assert.throws(() => statSync(output), /ENOENT/);
 });
 
 test("preplan decision rejects alias drift after discovery before baseline or rollback authorization", async (t) => {
@@ -1409,10 +1531,18 @@ test("private bridge IO rejects noncanonical, permissive, oversized, and existin
   );
 
   chmodSync(context.githubOutput, 0o644);
-  assert.throws(
-    () => appendGithubOutputs(context.env, { result: "value" }),
-    /could not be written safely/,
-  );
+  appendGithubOutputs(context.env, { result: "value" });
+  assert.equal(readFileSync(context.githubOutput, "utf8"), "result=value\n");
+  assert.equal(statSync(context.githubOutput).mode & 0o777, 0o600);
+  writeFileSync(context.githubOutput, "", { mode: 0o600 });
+  for (const mode of [0o664, 0o666]) {
+    chmodSync(context.githubOutput, mode);
+    assert.throws(
+      () => appendGithubOutputs(context.env, { result: "value" }),
+      /could not be written safely/,
+    );
+    assert.equal(statSync(context.githubOutput).mode & 0o777, mode);
+  }
   chmodSync(context.githubOutput, 0o600);
   writeFileSync(
     context.githubOutput,


### PR DESCRIPTION
## The Problem

The protected production cutover completed its Vercel state census, then failed before mutation when it first tried to append the pre-plan decision to GitHub's runner-created command file. The runner creates that file as `0644`, while our helper required it to already be `0600`. Unit tests had forced their fixture to `0600`, so they missed the real runner contract.

Run 30284143769 failed closed: no journal, deployment, alias mutation, public smoke, or terminal receipt was created. Its generic fallback also did not identify whether the private result, compact handoff, or GitHub output append failed.

## The Solution

Accept the runner-created command file only when it is a regular, single-link `0600` or `0644` file at the expected inode. Seal the already-open descriptor to `0600`, revalidate the descriptor and pathname before and after the append, and continue rejecting writable, linked, substituted, or oversized files.

Classify the three post-census output boundaries with fixed, value-free, non-retryable codes. This preserves redaction while making any future failure actionable.

The end-to-end pre-plan test now starts from a real runner-style `0644` command file and proves it finishes as `0600`. Additional tests cover every new failure code, hostile modes, existing link defenses, and a complete four-target handoff.

Advances #522. The issue remains open until production cutover, idempotency, rollback, and browser proof are complete.

## Validation

- `node --test scripts/vercel-main-provider-cli.test.mjs` — 12 passed
- `pnpm vercel:workflow:test` — 510 passed
- `pnpm quality:budgets:test` — 34 passed
- `pnpm ci:action-pins` — all 29 workflow files pinned
- `pnpm ci:action-pins:test` — 48 policy and 11 REST materializer tests passed
- Pre-push type checks — 8 tasks passed
- Pre-push Trunk and Knip gates passed
- `pnpm adr:check`
- `trunk fmt` on all changed files
- `git diff --check`
- Two independent reviews; one pathname-race documentation finding fixed and re-reviewed

## Ship Checklist

- [x] PR title follows the conventions
- [x] Performed a self-review of my own changes
- [x] Relevant automated checks and smoke tests pass
- [x] Architecture decision: Not applicable — this repairs the runner-file boundary in the accepted GitHub-driven deployment architecture.

## Risk

The helper changes the runner command file from `0644` to `0600` before writing. GitHub's runner processes the file under the same host identity after the step, so this preserves runner access while reducing exposure. Every failure remains terminal before release execution; none of the new post-census codes can trigger the state-drift retry.
