### PR TITLE
fix(ci): bind Vercel main release to exact CI attempt

### DIFF
--- a/docs/vercel-deployments.md
+++ b/docs/vercel-deployments.md
@@ -74,8 +74,10 @@ The job then requires `github.workflow_ref` to identify
 `github.workflow_sha == DEPLOY_SHA`, checked-out `HEAD == DEPLOY_SHA`, and
 `DEPLOY_SHA` reachable from freshly fetched `refs/heads/main`. A mismatched
 workflow definition or superseded definition exits before any Vercel
-environment or credential is available. The gate records only the upstream run
-URL and attempt, exact `Build and Test` job URL, and `DEPLOY_SHA`.
+environment or credential is available. The gate records only the
+attempt-qualified upstream run URL, exact `Build and Test` job URL, and
+`DEPLOY_SHA`; release execution validates the attempt suffix against the
+separately admitted run attempt.
 
 `provider-preplan` is the first credential-bearing main-release job. It captures
 the reviewed protected mappings and legacy App `v2` snapshot, then discovers

--- a/scripts/vercel-main-deployment.test.mjs
+++ b/scripts/vercel-main-deployment.test.mjs
@@ -211,7 +211,7 @@ function upstream() {
     runId: "123456",
     runAttempt: "2",
     runUrl:
-      "https://github.com/mento-protocol/frontend-monorepo/actions/runs/123456",
+      "https://github.com/mento-protocol/frontend-monorepo/actions/runs/123456/attempts/2",
     buildAndTestJobUrl:
       "https://github.com/mento-protocol/frontend-monorepo/actions/runs/123456/job/654321",
   };
@@ -2353,7 +2353,7 @@ test("legacy plan CLI conservatively selects every rollback-only main target", (
           UPSTREAM_RUN_ID: "123456",
           UPSTREAM_RUN_ATTEMPT: "2",
           UPSTREAM_RUN_URL:
-            "https://github.com/mento-protocol/frontend-monorepo/actions/runs/123456",
+            "https://github.com/mento-protocol/frontend-monorepo/actions/runs/123456/attempts/2",
           BUILD_AND_TEST_JOB_URL:
             "https://github.com/mento-protocol/frontend-monorepo/actions/runs/123456/job/654321",
           SOURCE_PATH: sourcePath,
@@ -4802,7 +4802,12 @@ test("terminal evidence CLI creates a bounded receipt and restores committed evi
       [
         {
           ...execution,
-          upstream: { ...execution.upstream, runAttempt: "3" },
+          upstream: {
+            ...execution.upstream,
+            runAttempt: "3",
+            runUrl:
+              "https://github.com/mento-protocol/frontend-monorepo/actions/runs/123456/attempts/3",
+          },
         },
         "3",
       ],

--- a/scripts/vercel-main-release-cli.test.mjs
+++ b/scripts/vercel-main-release-cli.test.mjs
@@ -302,7 +302,7 @@ function environment(directory) {
     UPSTREAM_RUN_ID: "123",
     UPSTREAM_RUN_ATTEMPT: "2",
     UPSTREAM_RUN_URL:
-      "https://github.com/mento-protocol/frontend-monorepo/actions/runs/123",
+      "https://github.com/mento-protocol/frontend-monorepo/actions/runs/123/attempts/2",
     BUILD_AND_TEST_JOB_URL:
       "https://github.com/mento-protocol/frontend-monorepo/actions/runs/123/job/456",
     VERCEL_MAIN_MODE: "active",
@@ -334,7 +334,7 @@ function executionFor(releaseManifest) {
     upstream: {
       runId: releaseManifest.upstreamRunId,
       runAttempt: "2",
-      runUrl: `https://github.com/mento-protocol/frontend-monorepo/actions/runs/${releaseManifest.upstreamRunId}`,
+      runUrl: `https://github.com/mento-protocol/frontend-monorepo/actions/runs/${releaseManifest.upstreamRunId}/attempts/2`,
       buildAndTestJobUrl: `https://github.com/mento-protocol/frontend-monorepo/actions/runs/${releaseManifest.upstreamRunId}/job/456`,
     },
     legacyAppV2: legacyState,
@@ -967,7 +967,7 @@ test("release CLI rejects linked private inputs and outputs", async (t) => {
       runId: "123",
       runAttempt: "2",
       runUrl:
-        "https://github.com/mento-protocol/frontend-monorepo/actions/runs/123",
+        "https://github.com/mento-protocol/frontend-monorepo/actions/runs/123/attempts/2",
       buildAndTestJobUrl:
         "https://github.com/mento-protocol/frontend-monorepo/actions/runs/123/job/456",
     },
@@ -1014,7 +1014,7 @@ test("materialize binds retained output to the exact SHA and upstream run", asyn
       runId: "123",
       runAttempt: "2",
       runUrl:
-        "https://github.com/mento-protocol/frontend-monorepo/actions/runs/123",
+        "https://github.com/mento-protocol/frontend-monorepo/actions/runs/123/attempts/2",
       buildAndTestJobUrl:
         "https://github.com/mento-protocol/frontend-monorepo/actions/runs/123/job/456",
     },
@@ -1691,7 +1691,7 @@ test("forward journal uses only asserted execution, fresh mappings, and current-
       runId: "123",
       runAttempt: "2",
       runUrl:
-        "https://github.com/mento-protocol/frontend-monorepo/actions/runs/123",
+        "https://github.com/mento-protocol/frontend-monorepo/actions/runs/123/attempts/2",
       buildAndTestJobUrl:
         "https://github.com/mento-protocol/frontend-monorepo/actions/runs/123/job/456",
     },

--- a/scripts/vercel-main-release-execution.mjs
+++ b/scripts/vercel-main-release-execution.mjs
@@ -129,7 +129,13 @@ function canonicalUpstream(value, manifest) {
       "Main release execution upstream run differs from its stable manifest",
     );
   }
-  const expectedRunUrl = `https://github.com/mento-protocol/frontend-monorepo/actions/runs/${runId}`;
+  const runAttempt = requireString(
+    String(value.runAttempt),
+    "Main release execution upstream run attempt",
+    POSITIVE_ID_PATTERN,
+  );
+  const expectedJobUrlPrefix = `https://github.com/mento-protocol/frontend-monorepo/actions/runs/${runId}`;
+  const expectedRunUrl = `${expectedJobUrlPrefix}/attempts/${runAttempt}`;
   const runUrl = requireGithubUrl(
     value.runUrl,
     "Main release execution upstream run URL",
@@ -141,7 +147,7 @@ function canonicalUpstream(value, manifest) {
   if (
     runUrl !== expectedRunUrl ||
     !new RegExp(
-      `^${expectedRunUrl.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}/job/[1-9][0-9]*$`,
+      `^${expectedJobUrlPrefix.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}/job/[1-9][0-9]*$`,
     ).test(buildAndTestJobUrl)
   ) {
     throw new Error(
@@ -150,11 +156,7 @@ function canonicalUpstream(value, manifest) {
   }
   return {
     runId,
-    runAttempt: requireString(
-      String(value.runAttempt),
-      "Main release execution upstream run attempt",
-      POSITIVE_ID_PATTERN,
-    ),
+    runAttempt,
     runUrl,
     buildAndTestJobUrl,
   };

--- a/scripts/vercel-main-release-execution.test.mjs
+++ b/scripts/vercel-main-release-execution.test.mjs
@@ -136,7 +136,7 @@ function execution(stagedTargets = TARGETS) {
       runId: "123",
       runAttempt: "2",
       runUrl:
-        "https://github.com/mento-protocol/frontend-monorepo/actions/runs/123",
+        "https://github.com/mento-protocol/frontend-monorepo/actions/runs/123/attempts/2",
       buildAndTestJobUrl:
         "https://github.com/mento-protocol/frontend-monorepo/actions/runs/123/job/456",
     },
@@ -326,7 +326,7 @@ test("capture-new execution binds the fresh rollback-only set exactly", () => {
   );
 });
 
-test("execution binds both upstream URLs to the exact repository run", () => {
+test("execution binds both upstream URLs to the exact repository run and attempt", () => {
   const value = execution(["governance"]);
   for (const upstream of [
     {
@@ -337,6 +337,16 @@ test("execution binds both upstream URLs to the exact repository run", () => {
       ...value.upstream,
       runUrl:
         "https://github.com/mento-protocol/frontend-monorepo/actions/runs/124",
+    },
+    {
+      ...value.upstream,
+      runUrl:
+        "https://github.com/mento-protocol/frontend-monorepo/actions/runs/123",
+    },
+    {
+      ...value.upstream,
+      runUrl:
+        "https://github.com/mento-protocol/frontend-monorepo/actions/runs/123/attempts/3",
     },
     {
       ...value.upstream,


### PR DESCRIPTION
## The Problem

The active main deployment run 30286956353 passed its provider pre-plan, then
failed before release execution existed. The trusted CI-attempt gate emits an
attempt-qualified run URL, while the release validator accepted only the
attemptless run URL. Test fixtures modeled the impossible attemptless handoff,
so CI did not catch the producer-consumer mismatch.

No Vercel deployment, staging, alias, or promotion mutation ran in the failed
workflow.

## The Solution

- Bind the release execution run URL to both the admitted run ID and run
  attempt.
- Keep the immutable Build and Test job URL bound to the same run ID.
- Update every direct fixture to the real CI-attempt producer shape.
- Reject missing and mismatched attempt suffixes.
- Document the attempt-qualified handoff contract.

Advances #522.

## Validation

- `node --test scripts/vercel-main-ci-attempt.test.mjs scripts/vercel-main-release-execution.test.mjs scripts/vercel-main-release-cli.test.mjs scripts/vercel-main-deployment.test.mjs` (99 passed)
- `pnpm vercel:workflow:test` (510 passed)
- `pnpm quality:budgets:test` (34 passed)
- `pnpm check-types`
- `pnpm ci:action-pins`
- `trunk fmt`
- `trunk check`
- `pnpm adr:check`
- Two independent correctness and security reviews found no actionable issues.

## Risk

The change tightens one trusted job-output identity contract. Release execution
is handed only between jobs in the same workflow run; durable recovery journals
retain the stable manifest rather than this URL-bearing execution object.
