### PR TITLE
fix(ci): expose safe Vercel main release failure phases

### DIFF
--- a/scripts/vercel-main-deployment-workflow.test.mjs
+++ b/scripts/vercel-main-deployment-workflow.test.mjs
@@ -510,6 +510,26 @@ test("release preparation starts only after inherited recovery and replans from 
     deployment: false,
   });
   assert.equal(job.env.MAIN_PREPLAN_HANDOFF, undefined);
+  assert.deepEqual(
+    Object.fromEntries(
+      [
+        "DEPLOY_SHA",
+        "UPSTREAM_RUN_ID",
+        "UPSTREAM_RUN_ATTEMPT",
+        "UPSTREAM_RUN_URL",
+        "BUILD_AND_TEST_JOB_URL",
+      ].map((name) => [name, job.env[name]]),
+    ),
+    {
+      DEPLOY_SHA: "${{ needs.wait-for-ci.outputs.deploy_sha }}",
+      UPSTREAM_RUN_ID: "${{ needs.wait-for-ci.outputs.upstream_run_id }}",
+      UPSTREAM_RUN_ATTEMPT:
+        "${{ needs.wait-for-ci.outputs.upstream_run_attempt }}",
+      UPSTREAM_RUN_URL: "${{ needs.wait-for-ci.outputs.upstream_run_url }}",
+      BUILD_AND_TEST_JOB_URL:
+        "${{ needs.wait-for-ci.outputs.build_and_test_job_url }}",
+    },
+  );
 
   const checkouts = checkoutSteps(jobName);
   assert.equal(checkouts.length, 2);

--- a/scripts/vercel-main-release-cli.mjs
+++ b/scripts/vercel-main-release-cli.mjs
@@ -53,6 +53,81 @@ import {
 const SHA_PATTERN = /^[a-f0-9]{40}$/;
 const POSITIVE_ID_PATTERN = /^[1-9][0-9]*$/;
 const TARGETS = ["app", "governance", "reserve", "ui"];
+const EXECUTION_DIAGNOSTIC_PHASES = Object.freeze({
+  INPUT: "input",
+  PREPLAN: "preplan",
+  DISCOVERY: "discovery",
+  PLANNING_SNAPSHOT: "planning-snapshot",
+  PROJECT_CENSUS: "project-census",
+  LEGACY: "legacy",
+  CANONICAL_MAPPINGS: "canonical-mappings",
+  PREPLAN_RECOMPUTE: "preplan-recompute",
+  OWNERSHIP: "ownership",
+  BASELINE_SOURCE_GIT: "baseline-source-git",
+  BASELINE_PRIOR_APP: "baseline-prior-app",
+  BASELINE_PRIOR_GOVERNANCE: "baseline-prior-governance",
+  BASELINE_PRIOR_RESERVE: "baseline-prior-reserve",
+  BASELINE_PRIOR_UI: "baseline-prior-ui",
+  BASELINE_PLANNER_RANGE: "baseline-planner-range",
+  BASELINE_MANIFEST: "baseline-manifest",
+  BASELINE_UNKNOWN: "baseline-unknown",
+  MANIFEST_ASSERTION: "manifest-assertion",
+  SELECTION: "selection",
+  EXECUTION_ASSEMBLY: "execution-assembly",
+  PRIVATE_OUTPUT: "private-output",
+  EXECUTION_ENCODE: "execution-encode",
+  GITHUB_OUTPUT: "github-output",
+});
+
+export const MAIN_RELEASE_EXECUTION_DIAGNOSTIC_CODES = Object.freeze({
+  [EXECUTION_DIAGNOSTIC_PHASES.INPUT]: "main-release-execution-input",
+  [EXECUTION_DIAGNOSTIC_PHASES.PREPLAN]: "main-release-execution-preplan",
+  [EXECUTION_DIAGNOSTIC_PHASES.DISCOVERY]: "main-release-execution-discovery",
+  [EXECUTION_DIAGNOSTIC_PHASES.PLANNING_SNAPSHOT]:
+    "main-release-execution-planning-snapshot",
+  [EXECUTION_DIAGNOSTIC_PHASES.PROJECT_CENSUS]:
+    "main-release-execution-project-census",
+  [EXECUTION_DIAGNOSTIC_PHASES.LEGACY]: "main-release-execution-legacy",
+  [EXECUTION_DIAGNOSTIC_PHASES.CANONICAL_MAPPINGS]:
+    "main-release-execution-canonical-mappings",
+  [EXECUTION_DIAGNOSTIC_PHASES.PREPLAN_RECOMPUTE]:
+    "main-release-execution-preplan-recompute",
+  [EXECUTION_DIAGNOSTIC_PHASES.OWNERSHIP]: "main-release-execution-ownership",
+  [EXECUTION_DIAGNOSTIC_PHASES.BASELINE_SOURCE_GIT]:
+    "main-release-execution-baseline-source-git",
+  [EXECUTION_DIAGNOSTIC_PHASES.BASELINE_PRIOR_APP]:
+    "main-release-execution-baseline-prior-app",
+  [EXECUTION_DIAGNOSTIC_PHASES.BASELINE_PRIOR_GOVERNANCE]:
+    "main-release-execution-baseline-prior-governance",
+  [EXECUTION_DIAGNOSTIC_PHASES.BASELINE_PRIOR_RESERVE]:
+    "main-release-execution-baseline-prior-reserve",
+  [EXECUTION_DIAGNOSTIC_PHASES.BASELINE_PRIOR_UI]:
+    "main-release-execution-baseline-prior-ui",
+  [EXECUTION_DIAGNOSTIC_PHASES.BASELINE_PLANNER_RANGE]:
+    "main-release-execution-baseline-planner-range",
+  [EXECUTION_DIAGNOSTIC_PHASES.BASELINE_MANIFEST]:
+    "main-release-execution-baseline-manifest",
+  [EXECUTION_DIAGNOSTIC_PHASES.BASELINE_UNKNOWN]:
+    "main-release-execution-baseline-unknown",
+  [EXECUTION_DIAGNOSTIC_PHASES.MANIFEST_ASSERTION]:
+    "main-release-execution-manifest-assertion",
+  [EXECUTION_DIAGNOSTIC_PHASES.SELECTION]: "main-release-execution-selection",
+  [EXECUTION_DIAGNOSTIC_PHASES.EXECUTION_ASSEMBLY]:
+    "main-release-execution-assembly",
+  [EXECUTION_DIAGNOSTIC_PHASES.PRIVATE_OUTPUT]:
+    "main-release-execution-private-output",
+  [EXECUTION_DIAGNOSTIC_PHASES.EXECUTION_ENCODE]:
+    "main-release-execution-encode",
+  [EXECUTION_DIAGNOSTIC_PHASES.GITHUB_OUTPUT]:
+    "main-release-execution-github-output",
+});
+
+const BASELINE_PRIOR_PHASE_BY_TARGET = Object.freeze({
+  app: EXECUTION_DIAGNOSTIC_PHASES.BASELINE_PRIOR_APP,
+  governance: EXECUTION_DIAGNOSTIC_PHASES.BASELINE_PRIOR_GOVERNANCE,
+  reserve: EXECUTION_DIAGNOSTIC_PHASES.BASELINE_PRIOR_RESERVE,
+  ui: EXECUTION_DIAGNOSTIC_PHASES.BASELINE_PRIOR_UI,
+});
 const OPTIONS = Object.freeze({
   "candidate-receipts": Object.freeze([
     "app",
@@ -118,6 +193,70 @@ const OPTIONS = Object.freeze({
     "state-proof",
   ]),
 });
+
+function createExecutionDiagnostics() {
+  let phase = EXECUTION_DIAGNOSTIC_PHASES.INPUT;
+  return Object.freeze({
+    mark(nextPhase) {
+      if (!Object.hasOwn(MAIN_RELEASE_EXECUTION_DIAGNOSTIC_CODES, nextPhase)) {
+        throw new Error(
+          "Main release execution diagnostic phase is unsupported",
+        );
+      }
+      phase = nextPhase;
+    },
+    current() {
+      return phase;
+    },
+  });
+}
+
+function markExecutionPhase(diagnostics, phase) {
+  diagnostics?.mark(phase);
+}
+
+function baselineFailurePhase(error) {
+  const target =
+    error !== null &&
+    typeof error === "object" &&
+    Object.hasOwn(error, "target") &&
+    typeof error.target === "string"
+      ? error.target
+      : null;
+  if (
+    target !== null &&
+    Object.hasOwn(BASELINE_PRIOR_PHASE_BY_TARGET, target)
+  ) {
+    return BASELINE_PRIOR_PHASE_BY_TARGET[target];
+  }
+  const message = error instanceof Error ? error.message : "";
+  if (
+    /DEPLOY_SHA cannot be resolved|DEPLOY_SHA did not resolve exactly|Git proof failed|Git ancestry proof failed|First-parent proof failed/.test(
+      message,
+    )
+  ) {
+    return EXECUTION_DIAGNOSTIC_PHASES.BASELINE_SOURCE_GIT;
+  }
+  const priorTarget = TARGETS.find((targetName) =>
+    new RegExp(
+      `Main release baseline ${targetName} (state is incomplete|prior is ambiguous)`,
+    ).test(message),
+  );
+  if (priorTarget !== undefined) {
+    return BASELINE_PRIOR_PHASE_BY_TARGET[priorTarget];
+  }
+  if (
+    /planner|Main deployment plan|Main deployment range|Main deployment final plan/.test(
+      message,
+    )
+  ) {
+    return EXECUTION_DIAGNOSTIC_PHASES.BASELINE_PLANNER_RANGE;
+  }
+  if (/Main release manifest|original prior/.test(message)) {
+    return EXECUTION_DIAGNOSTIC_PHASES.BASELINE_MANIFEST;
+  }
+  return EXECUTION_DIAGNOSTIC_PHASES.BASELINE_UNKNOWN;
+}
 
 function parseArguments(argv) {
   if (!Array.isArray(argv) || !Object.hasOwn(OPTIONS, argv[0])) {
@@ -372,7 +511,9 @@ export async function runMainReleaseCli({
   argv = process.argv.slice(2),
   env = process.env,
   baselineFactory = createMainReleaseBaseline,
+  executionDiagnostics = null,
 } = {}) {
+  markExecutionPhase(executionDiagnostics, EXECUTION_DIAGNOSTIC_PHASES.INPUT);
   const { command, options } = parseArguments(argv);
   const identity = requireEnvironment(env);
   const runnerTemp = reviewedRunnerTemp(env.RUNNER_TEMP);
@@ -604,6 +745,7 @@ export async function runMainReleaseCli({
     return result;
   }
 
+  markExecutionPhase(executionDiagnostics, EXECUTION_DIAGNOSTIC_PHASES.PREPLAN);
   const preplan = assertMainPreplanReconciliation(
     readPrivateJson(
       options.preplan,
@@ -620,8 +762,16 @@ export async function runMainReleaseCli({
       "Inherited release recovery must finish before execution creation",
     );
   }
+  markExecutionPhase(
+    executionDiagnostics,
+    EXECUTION_DIAGNOSTIC_PHASES.DISCOVERY,
+  );
   const discovery = assertMainProviderDiscovery(
     readPrivateJson(options.discovery, "Main provider discovery", runnerTemp),
+  );
+  markExecutionPhase(
+    executionDiagnostics,
+    EXECUTION_DIAGNOSTIC_PHASES.PLANNING_SNAPSHOT,
   );
   const planningSnapshot = assertMainPlanningSnapshot(
     readPrivateJson(
@@ -629,6 +779,10 @@ export async function runMainReleaseCli({
       "Main release planning snapshot",
       runnerTemp,
     ),
+  );
+  markExecutionPhase(
+    executionDiagnostics,
+    EXECUTION_DIAGNOSTIC_PHASES.PROJECT_CENSUS,
   );
   const projectIds = projectIdsFromEnvironment(env);
   if (
@@ -639,6 +793,7 @@ export async function runMainReleaseCli({
       "Main release provider discovery conflicts with the supplied census",
     );
   }
+  markExecutionPhase(executionDiagnostics, EXECUTION_DIAGNOSTIC_PHASES.LEGACY);
   const legacyAppV2 = exactLegacyState(
     readPrivateJson(
       options["legacy-snapshot"],
@@ -653,11 +808,19 @@ export async function runMainReleaseCli({
       "Main release legacy v2 state changed after provider discovery",
     );
   }
+  markExecutionPhase(
+    executionDiagnostics,
+    EXECUTION_DIAGNOSTIC_PHASES.CANONICAL_MAPPINGS,
+  );
   const currentMappings = createMainCanonicalMappings({
     planningSnapshot,
     projectIds,
     legacySnapshot: [legacyAppV2],
   }).mappings;
+  markExecutionPhase(
+    executionDiagnostics,
+    EXECUTION_DIAGNOSTIC_PHASES.PREPLAN_RECOMPUTE,
+  );
   const recomputedPreplan = decideMainPreplanReconciliation({
     nextDeploySha: identity.deploySha,
     nextUpstreamRunId: identity.upstreamRunId,
@@ -675,31 +838,48 @@ export async function runMainReleaseCli({
       "Main release pre-plan decision conflicts with provider discovery",
     );
   }
+  markExecutionPhase(
+    executionDiagnostics,
+    EXECUTION_DIAGNOSTIC_PHASES.OWNERSHIP,
+  );
   const mode = env.VERCEL_MAIN_MODE;
   const mainOwnershipMode = ownershipFromEnvironment(env);
   let manifest;
   if (preplan.decision === "capture-new-baseline") {
-    manifest = (
-      await baselineFactory({
-        mode,
-        mainOwnershipMode,
-        deploySha: identity.deploySha,
-        upstreamRunId: identity.upstreamRunId,
-        projectIds,
-        planningSnapshot,
-        rollbackOnlyTargets: discovery.discovery.rollbackOnlyTargets,
-        repoRoot: env.SOURCE_PATH,
-      })
-    ).manifest;
+    try {
+      manifest = (
+        await baselineFactory({
+          mode,
+          mainOwnershipMode,
+          deploySha: identity.deploySha,
+          upstreamRunId: identity.upstreamRunId,
+          projectIds,
+          planningSnapshot,
+          rollbackOnlyTargets: discovery.discovery.rollbackOnlyTargets,
+          repoRoot: env.SOURCE_PATH,
+        })
+      ).manifest;
+    } catch (error) {
+      markExecutionPhase(executionDiagnostics, baselineFailurePhase(error));
+      throw error;
+    }
   } else {
     manifest = preplan.reconciliation?.manifest;
   }
+  markExecutionPhase(
+    executionDiagnostics,
+    EXECUTION_DIAGNOSTIC_PHASES.MANIFEST_ASSERTION,
+  );
   assertManifestEnvironment({
     manifest,
     mode,
     mainOwnershipMode,
     projectIds,
   });
+  markExecutionPhase(
+    executionDiagnostics,
+    EXECUTION_DIAGNOSTIC_PHASES.SELECTION,
+  );
   const selection = createMainReleaseSelection({
     providerDiscoveryDigest: digest(discovery),
     planningSnapshotDigest: discovery.planningSnapshotDigest,
@@ -715,6 +895,10 @@ export async function runMainReleaseCli({
     mainOwnershipMode,
     selectedManifest: manifest,
   });
+  markExecutionPhase(
+    executionDiagnostics,
+    EXECUTION_DIAGNOSTIC_PHASES.EXECUTION_ASSEMBLY,
+  );
   const execution = createMainReleaseExecution({
     decision: preplan.decision,
     reason: preplan.reason,
@@ -724,9 +908,22 @@ export async function runMainReleaseCli({
     selection,
   });
   const canonical = assertMainReleaseExecution(execution, identity);
+  markExecutionPhase(
+    executionDiagnostics,
+    EXECUTION_DIAGNOSTIC_PHASES.PRIVATE_OUTPUT,
+  );
   writePrivateJson(options.output, canonical, runnerTemp);
+  markExecutionPhase(
+    executionDiagnostics,
+    EXECUTION_DIAGNOSTIC_PHASES.EXECUTION_ENCODE,
+  );
+  const encodedExecution = encodeMainReleaseExecution(canonical, identity);
+  markExecutionPhase(
+    executionDiagnostics,
+    EXECUTION_DIAGNOSTIC_PHASES.GITHUB_OUTPUT,
+  );
   appendGithubOutputs(env, {
-    execution: encodeMainReleaseExecution(canonical, identity),
+    execution: encodedExecution,
     decision: canonical.decision,
     release_id: canonical.manifest.releaseId,
     targets: JSON.stringify(canonical.projection.stagedTargets),
@@ -742,6 +939,35 @@ export function renderMainReleaseCliFailure() {
   return "Vercel main release command failed\n";
 }
 
+export function renderMainReleaseExecutionCliFailure(phase) {
+  const code = MAIN_RELEASE_EXECUTION_DIAGNOSTIC_CODES[phase];
+  if (code === undefined) {
+    throw new Error("Main release execution diagnostic phase is unsupported");
+  }
+  return `Vercel main release execution failed phase=${phase} code=${code}\n`;
+}
+
+export async function runMainReleaseCliEntrypoint({
+  argv = process.argv.slice(2),
+  env = process.env,
+  writeStderr = (line) => process.stderr.write(line),
+  run = runMainReleaseCli,
+} = {}) {
+  const diagnostics =
+    argv[0] === "execution" ? createExecutionDiagnostics() : null;
+  try {
+    await run({ argv, env, executionDiagnostics: diagnostics });
+    return 0;
+  } catch {
+    writeStderr(
+      diagnostics === null
+        ? renderMainReleaseCliFailure()
+        : renderMainReleaseExecutionCliFailure(diagnostics.current()),
+    );
+    return 1;
+  }
+}
+
 function isCliEntrypoint() {
   return (
     process.argv[1] !== undefined &&
@@ -750,10 +976,5 @@ function isCliEntrypoint() {
 }
 
 if (isCliEntrypoint()) {
-  try {
-    await runMainReleaseCli();
-  } catch {
-    process.stderr.write(renderMainReleaseCliFailure());
-    process.exitCode = 1;
-  }
+  process.exitCode = await runMainReleaseCliEntrypoint();
 }

--- a/scripts/vercel-main-release-cli.test.mjs
+++ b/scripts/vercel-main-release-cli.test.mjs
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { Buffer } from "node:buffer";
+import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import {
   closeSync,
@@ -14,9 +15,17 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import process from "node:process";
 import { test } from "node:test";
+import { fileURLToPath } from "node:url";
 
-import { runMainReleaseCli } from "./vercel-main-release-cli.mjs";
+import {
+  MAIN_RELEASE_EXECUTION_DIAGNOSTIC_CODES,
+  renderMainReleaseCliFailure,
+  renderMainReleaseExecutionCliFailure,
+  runMainReleaseCli,
+  runMainReleaseCliEntrypoint,
+} from "./vercel-main-release-cli.mjs";
 import {
   canonicalizeMainCandidateVercelMetadata,
   createMainCandidateIntent,
@@ -51,6 +60,9 @@ const SHA = "a".repeat(40);
 const PRIOR_SHA = "b".repeat(40);
 const TARGETS = ["app", "governance", "reserve", "ui"];
 const RELEASE_ORDER = ["governance", "reserve", "ui", "app"];
+const RELEASE_CLI_PATH = fileURLToPath(
+  new URL("./vercel-main-release-cli.mjs", import.meta.url),
+);
 
 function planning(
   stagedTargets = ["app", "governance"],
@@ -630,6 +642,266 @@ function executionArguments(
   ];
 }
 
+test("execution diagnostics use an exhaustive fixed allowlist", () => {
+  const expected = {
+    input: "main-release-execution-input",
+    preplan: "main-release-execution-preplan",
+    discovery: "main-release-execution-discovery",
+    "planning-snapshot": "main-release-execution-planning-snapshot",
+    "project-census": "main-release-execution-project-census",
+    legacy: "main-release-execution-legacy",
+    "canonical-mappings": "main-release-execution-canonical-mappings",
+    "preplan-recompute": "main-release-execution-preplan-recompute",
+    ownership: "main-release-execution-ownership",
+    "baseline-source-git": "main-release-execution-baseline-source-git",
+    "baseline-prior-app": "main-release-execution-baseline-prior-app",
+    "baseline-prior-governance":
+      "main-release-execution-baseline-prior-governance",
+    "baseline-prior-reserve": "main-release-execution-baseline-prior-reserve",
+    "baseline-prior-ui": "main-release-execution-baseline-prior-ui",
+    "baseline-planner-range": "main-release-execution-baseline-planner-range",
+    "baseline-manifest": "main-release-execution-baseline-manifest",
+    "baseline-unknown": "main-release-execution-baseline-unknown",
+    "manifest-assertion": "main-release-execution-manifest-assertion",
+    selection: "main-release-execution-selection",
+    "execution-assembly": "main-release-execution-assembly",
+    "private-output": "main-release-execution-private-output",
+    "execution-encode": "main-release-execution-encode",
+    "github-output": "main-release-execution-github-output",
+  };
+  assert.deepEqual(MAIN_RELEASE_EXECUTION_DIAGNOSTIC_CODES, expected);
+  for (const [phase, code] of Object.entries(expected)) {
+    assert.equal(
+      renderMainReleaseExecutionCliFailure(phase),
+      `Vercel main release execution failed phase=${phase} code=${code}\n`,
+    );
+  }
+  assert.equal(
+    renderMainReleaseCliFailure(),
+    "Vercel main release command failed\n",
+  );
+});
+
+test("execution entrypoint emits one fixed secret-free line for injected failures", async () => {
+  const secret = "secret-value-never-print";
+  for (const phase of Object.keys(MAIN_RELEASE_EXECUTION_DIAGNOSTIC_CODES)) {
+    let stderr = "";
+    const status = await runMainReleaseCliEntrypoint({
+      argv: ["execution"],
+      writeStderr: (line) => {
+        stderr += line;
+      },
+      run: ({ executionDiagnostics }) => {
+        executionDiagnostics.mark(phase);
+        throw new Error(secret);
+      },
+    });
+    assert.equal(status, 1, phase);
+    assert.equal(stderr, renderMainReleaseExecutionCliFailure(phase), phase);
+    assert.doesNotMatch(stderr, new RegExp(secret), phase);
+  }
+});
+
+test("real execution failures report the phase reached by the entrypoint", async (t) => {
+  const directory = realpathSync(
+    mkdtempSync(join(tmpdir(), "main-release-cli-real-diagnostics-")),
+  );
+  t.after(() => rmSync(directory, { recursive: true, force: true }));
+  const release = manifest();
+  const census = planningSnapshot(release);
+  const providerDiscovery = discovery(release, census);
+  const changedLegacy = legacy();
+  changedLegacy[0] = {
+    ...changedLegacy[0],
+    deploymentId: "dpl_changedLegacyV2Prior123",
+    deploymentUrl: "https://changed-legacy-v2-prior.vercel.app",
+  };
+  const cases = [
+    {
+      phase: "discovery",
+      inputs: { discoveryValue: {} },
+    },
+    {
+      phase: "planning-snapshot",
+      inputs: { census: {}, discoveryValue: providerDiscovery },
+    },
+    {
+      phase: "project-census",
+      mutateEnvironment(env) {
+        env.VERCEL_PROJECT_ID_UI = "prj_other";
+      },
+    },
+    {
+      phase: "legacy",
+      inputs: { legacyValue: changedLegacy },
+    },
+    {
+      phase: "preplan-recompute",
+      inputs: {
+        discoveryValue: discovery(release, census, { empty: true }),
+      },
+    },
+    {
+      phase: "manifest-assertion",
+      mutateEnvironment(env) {
+        env.MAIN_OWNERSHIP_MODE_JSON =
+          '{"app":"shadow","governance":"github","reserve":"github","ui":"github"}';
+      },
+    },
+    {
+      phase: "private-output",
+      mutateArguments(argv) {
+        writeFileSync(argv.at(-1), "{}\n", { mode: 0o600 });
+      },
+    },
+    {
+      phase: "github-output",
+      mutateEnvironment(env) {
+        env.GITHUB_OUTPUT = join(directory, "missing-github-output");
+      },
+    },
+  ];
+  for (const [index, scenario] of cases.entries()) {
+    const inputs = {
+      release,
+      census,
+      suffix: `-${index}`,
+      ...scenario.inputs,
+    };
+    const argv = executionArguments(directory, inputs);
+    const env = environment(directory);
+    scenario.mutateArguments?.(argv);
+    scenario.mutateEnvironment?.(env);
+    let stderr = "";
+    const status = await runMainReleaseCliEntrypoint({
+      argv,
+      env,
+      writeStderr: (line) => {
+        stderr += line;
+      },
+    });
+    assert.equal(status, 1, scenario.phase);
+    assert.equal(
+      stderr,
+      renderMainReleaseExecutionCliFailure(scenario.phase),
+      scenario.phase,
+    );
+  }
+});
+
+test("CLI entrypoint does not leak execution input paths or environment values", (t) => {
+  const directory = realpathSync(
+    mkdtempSync(join(tmpdir(), "main-release-cli-secret-")),
+  );
+  t.after(() => rmSync(directory, { recursive: true, force: true }));
+  const secret = "do-not-print-this-secret";
+  const env = {
+    ...process.env,
+    ...environment(directory),
+    RUNNER_TEMP: directory,
+    MAIN_RELEASE_PRIVATE_TEST_SECRET: secret,
+  };
+  const result = spawnSync(
+    process.execPath,
+    [
+      RELEASE_CLI_PATH,
+      "execution",
+      "--preplan",
+      join(directory, `${secret}-preplan.json`),
+      "--discovery",
+      join(directory, "discovery.json"),
+      "--planning-snapshot",
+      join(directory, "planning.json"),
+      "--legacy-snapshot",
+      join(directory, "legacy.json"),
+      "--output",
+      join(directory, "execution.json"),
+    ],
+    { encoding: "utf8", env },
+  );
+  assert.equal(result.status, 1);
+  assert.equal(result.stderr, renderMainReleaseExecutionCliFailure("preplan"));
+  assert.doesNotMatch(result.stderr, new RegExp(secret));
+  assert.doesNotMatch(result.stderr, new RegExp(directory));
+});
+
+test("non-execution CLI failures retain the generic diagnostic", async () => {
+  let stderr = "";
+  const status = await runMainReleaseCliEntrypoint({
+    argv: ["materialize", "--output", "missing.json"],
+    env: {},
+    writeStderr: (line) => {
+      stderr += line;
+    },
+  });
+  assert.equal(status, 1);
+  assert.equal(stderr, renderMainReleaseCliFailure());
+});
+
+test("baseline failures map known invariants to fixed diagnostics without replacing errors", async (t) => {
+  const directory = realpathSync(
+    mkdtempSync(join(tmpdir(), "main-release-cli-baseline-diagnostics-")),
+  );
+  t.after(() => rmSync(directory, { recursive: true, force: true }));
+  const release = manifest(TARGETS, "123", TARGETS);
+  const census = planningSnapshot(release);
+  const capturePreplan = {
+    schema: "vercel-main-preplan-reconciliation:v2",
+    decision: "capture-new-baseline",
+    reason: "no-mapped-release-metadata",
+    rollbackOnlyTargets: [...TARGETS],
+    reconciliation: null,
+    rollbackAuthorization: null,
+  };
+  const argv = executionArguments(directory, {
+    release,
+    census,
+    preplanValue: capturePreplan,
+    discoveryValue: discovery(release, census, {
+      empty: true,
+      rollbackOnlyTargets: [...TARGETS],
+    }),
+  });
+  const cases = [
+    ["DEPLOY_SHA cannot be resolved", "baseline-source-git"],
+    ["Main release baseline app state is incomplete", "baseline-prior-app"],
+    ["Main deployment planner range is malformed", "baseline-planner-range"],
+    ["Main release manifest schema is unsupported", "baseline-manifest"],
+    ["unclassified baseline failure", "baseline-unknown"],
+  ];
+  for (const [message, phase] of cases) {
+    const failure = new Error(message);
+    let stderr = "";
+    const status = await runMainReleaseCliEntrypoint({
+      argv,
+      env: environment(directory),
+      writeStderr: (line) => {
+        stderr += line;
+      },
+      run: (options) =>
+        runMainReleaseCli({
+          ...options,
+          baselineFactory: () => {
+            throw failure;
+          },
+        }),
+    });
+    assert.equal(status, 1, message);
+    assert.equal(stderr, renderMainReleaseExecutionCliFailure(phase), message);
+    await assert.rejects(
+      runMainReleaseCli({
+        argv,
+        env: environment(directory),
+        baselineFactory: () => {
+          throw failure;
+        },
+      }),
+      (error) => error === failure,
+      message,
+    );
+  }
+});
+
 test("execution consumes the exact provider manifest without a new baseline", async (t) => {
   const directory = realpathSync(
     mkdtempSync(join(tmpdir(), "main-release-cli-")),
@@ -672,6 +944,40 @@ test("execution consumes the exact provider manifest without a new baseline", as
     value,
   );
   assert.deepEqual(JSON.parse(readFileSync(output, "utf8")), value);
+});
+
+test("execution rejects missing or malformed upstream attempt and URL handoff values", async (t) => {
+  const directory = realpathSync(
+    mkdtempSync(join(tmpdir(), "main-release-cli-upstream-handoff-")),
+  );
+  t.after(() => rmSync(directory, { recursive: true, force: true }));
+  const release = manifest();
+  const census = planningSnapshot(release);
+  const cases = [
+    ["UPSTREAM_RUN_ATTEMPT", undefined],
+    ["UPSTREAM_RUN_ATTEMPT", "not-an-attempt"],
+    ["UPSTREAM_RUN_URL", undefined],
+    ["UPSTREAM_RUN_URL", "https://example.invalid/private"],
+    ["BUILD_AND_TEST_JOB_URL", undefined],
+    ["BUILD_AND_TEST_JOB_URL", "https://example.invalid/private"],
+  ];
+  for (const [index, [name, value]] of cases.entries()) {
+    const env = environment(directory);
+    if (value === undefined) delete env[name];
+    else env[name] = value;
+    await assert.rejects(
+      runMainReleaseCli({
+        argv: executionArguments(directory, {
+          release,
+          census,
+          suffix: `-${index}`,
+        }),
+        env,
+      }),
+      /upstream .* malformed|build job URL is malformed/,
+      `${name}=${value}`,
+    );
+  }
 });
 
 test("execution rejects same-release reuse that omits a fresh rollback-only target", async (t) => {


### PR DESCRIPTION
## The Problem

Active main deployment runs 30286956353 and 30289574782 both failed safely in
`Create and encode release execution`, before any candidate staging, journal,
alias, or activation mutation. The CLI collapsed every exception into
`Vercel main release command failed`, so retained Actions evidence could not
identify the remaining invariant.

## The Solution

- Emit one fixed, allowlisted phase and code for execution-command failures.
- Keep every non-execution failure on the existing generic diagnostic.
- Never emit the caught message, stack, arguments, environment, paths, URLs,
  provider data, or credentials.
- Distinguish each top-level execution phase and classify baseline failures as
  source/Git, target prior, planner range, manifest, or unknown.
- Preserve raw exceptions for programmatic callers and tests.
- Test real execution failures across the diagnostic phases and pin the exact
  five-value CI-to-release workflow handoff.

Advances #522.

## Validation

- `pnpm vercel:workflow:test` (517 passed)
- `pnpm quality:budgets:test` (34 passed)
- `pnpm check-types`
- `pnpm ci:action-pins`
- `trunk fmt`
- `trunk check`
- `pnpm adr:check`
- Independent security and simplicity reviews found no remaining actionable
  issues.

## Risk

The patch changes failure-only stderr for the `execution` command. Deployment
authority, workflow permissions, provider calls, job outputs, and success
behavior are unchanged. All emitted values come from a fixed source allowlist.
