### PR TITLE
fix(ci): accept served-prior project aliases

### DIFF
--- a/docs/vercel-deployments.md
+++ b/docs/vercel-deployments.md
@@ -201,15 +201,16 @@ same validated upstream CI run. They are evidence lookup only and never
 authorize a public mutation.
 
 For Governance, Reserve, and UI, that protected runtime and rollback mapping
-contains only the literal public custom domain. Generated project/team and
-creator-scoped aliases are not protected aliases or rollback inputs. A fresh
-ordinary candidate must expose the required project/scope alias and may also
-expose only its exact canonical creator alias. An already-served prior may
-instead retain any canonical subset of those aliases plus the target's exact
-native-Git `main` branch alias, because later CLI or native-Git deployments can
-move generated aliases while the protected domain stays on that prior. The
-planner validates and then discards this provider evidence; project-default,
-custom, wrong-target, and unknown aliases fail closed.
+contains only the literal public custom domain. Generated project/team,
+project-default, and creator-scoped aliases are not protected aliases or
+rollback inputs. A fresh ordinary candidate must expose the required
+project/scope alias and may also expose only its exact canonical creator alias.
+An already-served prior may instead retain any canonical subset of those
+aliases plus the target's exact project-default alias and native-Git `main`
+branch alias, because later CLI or native-Git deployments can move generated
+aliases while the protected domain stays on that prior. The planner validates
+and then discards this provider evidence; custom, wrong-target, near-miss, and
+unknown aliases fail closed.
 
 Planning compares each target's served SHA with `DEPLOY_SHA`; it does not use
 the triggering push's `before` field. For a GitHub-owned target, an exact
@@ -1213,18 +1214,24 @@ That base-required topology applies to a newly staged or automatically reused
 ordinary candidate. Served-prior planning uses a separate finite contract
 because generated aliases can move independently of the protected custom
 domain. For Governance, Reserve, and UI, a served deployment may retain any
-canonical subset of its reviewed base project/scope alias, its exact canonical
-creator alias when that name is safe, and its literal native-Git `main` alias:
+canonical subset of its reviewed base project/scope alias, exact
+project-default alias, exact canonical creator alias when that name is safe,
+and literal native-Git `main` alias:
 
-- Governance: `governancementoorg-git-main-mentolabs.vercel.app`
-- Reserve: `reservementoorg-git-main-mentolabs.vercel.app`
-- UI: `uimentoorg-git-main-mentolabs.vercel.app`
+- Governance: `governancementoorg-mentolabs.vercel.app`,
+  `governancementoorg.vercel.app`, and
+  `governancementoorg-git-main-mentolabs.vercel.app`
+- Reserve: `reservementoorg-mentolabs.vercel.app`,
+  `reservementoorg.vercel.app`, and
+  `reservementoorg-git-main-mentolabs.vercel.app`
+- UI: `uimentoorg-mentolabs.vercel.app`, `uimentoorg.vercel.app`, and
+  `uimentoorg-git-main-mentolabs.vercel.app`
 
 After validating that finite set, the planner removes all generated-alias
 evidence from the canonical prior. None of these aliases is a protected mapping
-or rollback input. A project-default `project.vercel.app` form, another Git
-branch, a custom or wrong-target alias, a creator near miss, an unknown alias,
-or duplicate or unsorted canonical evidence fails closed.
+or rollback input. Another project's default alias, another Git branch, a
+custom or wrong-target alias, a creator or project-default near miss, an unknown
+alias, or duplicate or unsorted canonical evidence fails closed.
 For `restore-before-planning`, the workflow calls
 `candidate-finalize-inherited`, which is fixed to this served-prior mode only
 for inherited Governance, Reserve, and UI recovery. Ordinary

--- a/scripts/fixtures/vercel-main-plan/valid-priors.json
+++ b/scripts/fixtures/vercel-main-plan/valid-priors.json
@@ -83,7 +83,9 @@
           },
           "aliases": [
             "governance.mento.org",
-            "governancementoorg-mentolabs.vercel.app"
+            "governancementoorg-git-main-mentolabs.vercel.app",
+            "governancementoorg-mentolabs.vercel.app",
+            "governancementoorg.vercel.app"
           ]
         }
       ]
@@ -109,7 +111,9 @@
           },
           "aliases": [
             "reserve.mento.org",
-            "reservementoorg-mentolabs.vercel.app"
+            "reservementoorg-git-main-mentolabs.vercel.app",
+            "reservementoorg-mentolabs.vercel.app",
+            "reservementoorg.vercel.app"
           ]
         }
       ]
@@ -133,7 +137,12 @@
             "ref": "main",
             "sha": "cccccccccccccccccccccccccccccccccccccccc"
           },
-          "aliases": ["ui.mento.org", "uimentoorg-mentolabs.vercel.app"]
+          "aliases": [
+            "ui.mento.org",
+            "uimentoorg-git-main-mentolabs.vercel.app",
+            "uimentoorg-mentolabs.vercel.app",
+            "uimentoorg.vercel.app"
+          ]
         }
       ]
     }

--- a/scripts/vercel-main-candidate-provider.test.mjs
+++ b/scripts/vercel-main-candidate-provider.test.mjs
@@ -391,6 +391,7 @@ test("automatic inherited ordinary finalization requires its protected alias and
     let validHandoff;
     for (const residualAliases of subsets([
       contract.generatedProjectAlias,
+      contract.generatedProjectDefaultAlias,
       generatedCreatorAlias(target),
       contract.generatedGitMainAlias,
     ])) {

--- a/scripts/vercel-main-plan.test.mjs
+++ b/scripts/vercel-main-plan.test.mjs
@@ -132,6 +132,7 @@ function ordinaryGeneratedAliasSubsets(target) {
   const contract = PRODUCTION_GENERATED_ALIAS_CONTRACTS[target];
   const values = [
     contract.generatedProjectAlias,
+    contract.generatedProjectDefaultAlias,
     `${contract.generatedProjectSlug}-fixture-author-${contract.generatedScopeSlug}.vercel.app`,
     contract.generatedGitMainAlias,
   ];
@@ -1359,12 +1360,12 @@ const activationAmbiguities = [
     },
   },
   {
-    name: "project-default alias",
+    name: "project-default near-miss alias",
     target: "governance",
     code: "alias-set-ambiguous",
     mutate(input) {
       input.priorStates.governance.states[0].aliases.push(
-        "governancementoorg.vercel.app",
+        "governancementoorg2.vercel.app",
       );
       input.priorStates.governance.states[0].aliases.sort();
     },

--- a/scripts/vercel-main-provider-cli.test.mjs
+++ b/scripts/vercel-main-provider-cli.test.mjs
@@ -1292,6 +1292,7 @@ test("inherited ordinary candidate finalization uses the fixed served-prior alia
     const protectedAlias = MAIN_TARGET_CONTRACTS[target].aliases[0];
     for (const [index, residualAliases] of aliasSubsets([
       contract.generatedProjectAlias,
+      contract.generatedProjectDefaultAlias,
       generatedCreatorAlias(target),
       contract.generatedGitMainAlias,
     ]).entries()) {

--- a/scripts/vercel-main-release-planner.test.mjs
+++ b/scripts/vercel-main-release-planner.test.mjs
@@ -102,6 +102,7 @@ function ordinaryGeneratedAliasSubsets(target) {
   const contract = PRODUCTION_GENERATED_ALIAS_CONTRACTS[target];
   return [
     contract.generatedProjectAlias,
+    contract.generatedProjectDefaultAlias,
     `${contract.generatedProjectSlug}-fixture-author-${contract.generatedScopeSlug}.vercel.app`,
     contract.generatedGitMainAlias,
   ].reduce(
@@ -172,6 +173,22 @@ test("baseline canonicalizes production generated-alias supersets and recomputes
     recomputeMainReleasePlan({ manifest, gitAdapter, runPlanner }),
     planning,
   );
+});
+
+test("production fixture matches the observed native-Git generated-alias topology", () => {
+  for (const target of ["governance", "reserve", "ui"]) {
+    const contract = PRODUCTION_GENERATED_ALIAS_CONTRACTS[target];
+    assert.deepEqual(
+      PRODUCTION_PRIORS.priorStates[target].states[0].aliases,
+      [
+        ...MAIN_TARGET_CONTRACTS[target].aliases,
+        contract.generatedGitMainAlias,
+        contract.generatedProjectAlias,
+        contract.generatedProjectDefaultAlias,
+      ].toSorted(),
+      target,
+    );
+  }
 });
 
 test("baseline accepts every finite ordinary generated-alias subset and recomputes exactly", () => {

--- a/scripts/vercel-production-generated-aliases.mjs
+++ b/scripts/vercel-production-generated-aliases.mjs
@@ -7,18 +7,21 @@ const RESERVED_CREATOR_PREFIXES = Object.freeze(["env-", "git-"]);
 export const PRODUCTION_GENERATED_ALIAS_CONTRACTS = Object.freeze({
   governance: Object.freeze({
     generatedGitMainAlias: "governancementoorg-git-main-mentolabs.vercel.app",
+    generatedProjectDefaultAlias: "governancementoorg.vercel.app",
     generatedProjectAlias: "governancementoorg-mentolabs.vercel.app",
     generatedProjectSlug: "governancementoorg",
     generatedScopeSlug: "mentolabs",
   }),
   reserve: Object.freeze({
     generatedGitMainAlias: "reservementoorg-git-main-mentolabs.vercel.app",
+    generatedProjectDefaultAlias: "reservementoorg.vercel.app",
     generatedProjectAlias: "reservementoorg-mentolabs.vercel.app",
     generatedProjectSlug: "reservementoorg",
     generatedScopeSlug: "mentolabs",
   }),
   ui: Object.freeze({
     generatedGitMainAlias: "uimentoorg-git-main-mentolabs.vercel.app",
+    generatedProjectDefaultAlias: "uimentoorg.vercel.app",
     generatedProjectAlias: "uimentoorg-mentolabs.vercel.app",
     generatedProjectSlug: "uimentoorg",
     generatedScopeSlug: "mentolabs",
@@ -88,6 +91,7 @@ export function assertOnlyExpectedProductionGeneratedAliases({
 
   const {
     generatedGitMainAlias,
+    generatedProjectDefaultAlias,
     generatedProjectAlias,
     generatedProjectSlug,
     generatedScopeSlug,
@@ -96,6 +100,9 @@ export function assertOnlyExpectedProductionGeneratedAliases({
     canonicalizeHostname(generatedGitMainAlias) !== generatedGitMainAlias ||
     generatedGitMainAlias !==
       `${generatedProjectSlug}-git-main-${generatedScopeSlug}.vercel.app` ||
+    canonicalizeHostname(generatedProjectDefaultAlias) !==
+      generatedProjectDefaultAlias ||
+    generatedProjectDefaultAlias !== `${generatedProjectSlug}.vercel.app` ||
     canonicalizeHostname(generatedProjectAlias) !== generatedProjectAlias ||
     generatedProjectAlias !==
       `${generatedProjectSlug}-${generatedScopeSlug}.vercel.app`
@@ -120,6 +127,7 @@ export function assertOnlyExpectedProductionGeneratedAliases({
     mode === PRODUCTION_GENERATED_ALIAS_TOPOLOGY_MODES.SERVED_PRIOR
       ? new Set([
           generatedGitMainAlias,
+          generatedProjectDefaultAlias,
           generatedProjectAlias,
           ...allowedCreatorAliases,
         ])

--- a/scripts/vercel-production-generated-aliases.test.mjs
+++ b/scripts/vercel-production-generated-aliases.test.mjs
@@ -32,6 +32,7 @@ test("served-prior mode accepts every exact reviewed generated-alias subset", ()
     const contract = PRODUCTION_GENERATED_ALIAS_CONTRACTS[logicalTarget];
     for (const aliases of subsets([
       contract.generatedProjectAlias,
+      contract.generatedProjectDefaultAlias,
       creatorAlias(logicalTarget),
       contract.generatedGitMainAlias,
     ])) {
@@ -92,10 +93,6 @@ test("served-prior mode rejects aliases outside the finite reviewed set", () => 
       ],
     ],
     [
-      "unreviewed project-default alias",
-      [`${contract.generatedProjectSlug}.vercel.app`],
-    ],
-    [
       "duplicate",
       [contract.generatedProjectAlias, contract.generatedProjectAlias],
     ],
@@ -124,9 +121,14 @@ test("candidate mode rejects missing-base and non-candidate generated aliases", 
     ["empty", []],
     ["creator only", [creatorAlias("governance")]],
     ["git-main only", [contract.generatedGitMainAlias]],
+    ["project-default only", [contract.generatedProjectDefaultAlias]],
     [
       "base plus git-main",
       [contract.generatedGitMainAlias, contract.generatedProjectAlias],
+    ],
+    [
+      "base plus project-default",
+      [contract.generatedProjectAlias, contract.generatedProjectDefaultAlias],
     ],
     [
       "unreviewed Git branch",


### PR DESCRIPTION
## The Problem

The active deployment for merged SHA
`61188f5b909af46c9c31c6dd1f90ecc1a88920d8` passed exact-main CI and the fresh
provider pre-plan, then failed safely while materializing its rollback baseline:

`phase=baseline-prior-governance code=main-release-execution-baseline-prior-governance`

Read-only Vercel inspection showed that each currently served ordinary
native-Git deployment has four aliases: its protected public domain, exact
project/scope alias, exact project-default alias, and exact Git-main alias.
The served-prior contract added in #669 omitted the project-default form, such
as `governancementoorg.vercel.app`. Fresh CLI production candidates do not
carry that alias.

No candidate build, journal, promotion, alias mutation, recovery command, or
public smoke ran in the failed attempt.

## The Solution

- Pin the exact Governance, Reserve, and UI project-default aliases in the
  reviewed provider contract.
- Permit those literals only in `served-prior` mode, where every canonical
  subset remains valid after generated aliases move independently.
- Keep fresh and reused candidate mode unchanged: the project/scope alias
  remains required, only its exact safe creator alias is optional, and a
  project-default alias still fails closed.
- Update the production fixture to the observed native-Git topology:
  protected domain + project-default + project/scope + Git-main.
- Exercise every served-prior subset through helper, planner, release,
  in-memory provider, serialized handoff, and inherited CLI paths.
- Retain negative coverage for candidate project-default aliases and
  project-default near misses.
- Correct the deployment runbook to document the split contract.

Advances #522.

## Validation

- Live read-only provider inspection for Governance, Reserve, and UI
- Exact observed Governance residual passes `served-prior` and fails
  `candidate`
- `pnpm vercel:workflow:test` (547 passed)
- `pnpm vercel:production-shadow:test` (146 passed)
- `pnpm quality:budgets:test` (34 passed)
- `pnpm check-types` (8/8 tasks)
- `pnpm adr:check`
- Trunk, Knip, and `git diff --check`
- Fresh-context security and correctness review: `ALL_CLEAR`

## Risk

The new aliases are literal, target-specific values derived from the already
pinned project slugs. They are accepted only while validating an existing
served prior. Project identity, environment, readiness, Git provenance,
protected-domain ownership, deployment identity, canonical ordering, and
near-miss rejection remain unchanged. Fresh candidates and App v3 do not gain
this alias.
