### PR TITLE
fix(ci): run selected Vercel stages

### DIFF
--- a/.github/workflows/vercel-main-deployment.yml
+++ b/.github/workflows/vercel-main-deployment.yml
@@ -1366,7 +1366,9 @@ jobs:
     name: Build App after ordinary canaries and activate release
     needs:
       [wait-for-ci, prepare-release, stage-governance, stage-reserve, stage-ui]
-    if: ${{ always() && needs.prepare-release.result == 'success' }}
+    if: >-
+      always() && !cancelled() &&
+      needs.prepare-release.result == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 60
     environment:

--- a/.github/workflows/vercel-main-deployment.yml
+++ b/.github/workflows/vercel-main-deployment.yml
@@ -760,7 +760,7 @@ jobs:
     # Override GitHub's implicit success() so that skipped ancestor cannot poison
     # a selected stage after the release has been materialized successfully.
     if: >-
-      always() && needs.wait-for-ci.result == 'success' &&
+      always() && !cancelled() && needs.wait-for-ci.result == 'success' &&
       needs.prepare-release.result == 'success' &&
       contains(fromJSON(needs.prepare-release.outputs.targets), 'governance')
     runs-on: ubuntu-latest
@@ -963,7 +963,7 @@ jobs:
     name: Stage reserve candidate
     needs: [wait-for-ci, prepare-release]
     if: >-
-      always() && needs.wait-for-ci.result == 'success' &&
+      always() && !cancelled() && needs.wait-for-ci.result == 'success' &&
       needs.prepare-release.result == 'success' &&
       contains(fromJSON(needs.prepare-release.outputs.targets), 'reserve')
     runs-on: ubuntu-latest
@@ -1165,7 +1165,7 @@ jobs:
     name: Stage UI candidate
     needs: [wait-for-ci, prepare-release]
     if: >-
-      always() && needs.wait-for-ci.result == 'success' &&
+      always() && !cancelled() && needs.wait-for-ci.result == 'success' &&
       needs.prepare-release.result == 'success' &&
       contains(fromJSON(needs.prepare-release.outputs.targets), 'ui')
     runs-on: ubuntu-latest

--- a/.github/workflows/vercel-main-deployment.yml
+++ b/.github/workflows/vercel-main-deployment.yml
@@ -756,7 +756,13 @@ jobs:
   stage-governance:
     name: Stage governance candidate
     needs: [wait-for-ci, prepare-release]
-    if: contains(fromJSON(needs.prepare-release.outputs.targets), 'governance')
+    # `prepare-release` can succeed through its explicit skipped-restore route.
+    # Override GitHub's implicit success() so that skipped ancestor cannot poison
+    # a selected stage after the release has been materialized successfully.
+    if: >-
+      always() && needs.wait-for-ci.result == 'success' &&
+      needs.prepare-release.result == 'success' &&
+      contains(fromJSON(needs.prepare-release.outputs.targets), 'governance')
     runs-on: ubuntu-latest
     timeout-minutes: 50
     environment:
@@ -956,7 +962,10 @@ jobs:
   stage-reserve:
     name: Stage reserve candidate
     needs: [wait-for-ci, prepare-release]
-    if: contains(fromJSON(needs.prepare-release.outputs.targets), 'reserve')
+    if: >-
+      always() && needs.wait-for-ci.result == 'success' &&
+      needs.prepare-release.result == 'success' &&
+      contains(fromJSON(needs.prepare-release.outputs.targets), 'reserve')
     runs-on: ubuntu-latest
     timeout-minutes: 50
     environment:
@@ -1155,7 +1164,10 @@ jobs:
   stage-ui:
     name: Stage UI candidate
     needs: [wait-for-ci, prepare-release]
-    if: contains(fromJSON(needs.prepare-release.outputs.targets), 'ui')
+    if: >-
+      always() && needs.wait-for-ci.result == 'success' &&
+      needs.prepare-release.result == 'success' &&
+      contains(fromJSON(needs.prepare-release.outputs.targets), 'ui')
     runs-on: ubuntu-latest
     timeout-minutes: 50
     environment:
@@ -2165,6 +2177,10 @@ jobs:
       UPSTREAM_RUN_URL: ${{ needs.wait-for-ci.outputs.upstream_run_url }}
       BUILD_AND_TEST_JOB_URL: ${{ needs.wait-for-ci.outputs.build_and_test_job_url }}
       MAIN_RELEASE_EXECUTION: ${{ needs.prepare-release.outputs.execution }}
+      VERCEL_PROJECT_ID_APP: ${{ vars.VERCEL_PROJECT_ID_APP }}
+      VERCEL_PROJECT_ID_GOVERNANCE: ${{ vars.VERCEL_PROJECT_ID_GOVERNANCE }}
+      VERCEL_PROJECT_ID_RESERVE: ${{ vars.VERCEL_PROJECT_ID_RESERVE }}
+      VERCEL_PROJECT_ID_UI: ${{ vars.VERCEL_PROJECT_ID_UI }}
     steps:
       - name: Check out immutable recovery controller
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/scripts/vercel-main-deployment-workflow.test.mjs
+++ b/scripts/vercel-main-deployment-workflow.test.mjs
@@ -684,6 +684,7 @@ test("ordinary targets materialize execution and use create-or-reuse provider ha
     const stage = workflow.jobs[job];
     assert.equal(stage["timeout-minutes"], 50);
     assert.match(stage.if, /^always\(\)/, `${target} stage status override`);
+    assert.match(stage.if, /!cancelled\(\)/, `${target} cancellation guard`);
     assert.match(
       stage.if,
       /needs\.wait-for-ci\.result == 'success'/,
@@ -1401,7 +1402,7 @@ test("ordinary stages retain protected runtime isolation and create-only uploads
     const checkouts = checkoutSteps(job);
     assert.equal(
       workflow.jobs[job].if,
-      `always() && needs.wait-for-ci.result == 'success' && needs.prepare-release.result == 'success' && contains(fromJSON(needs.prepare-release.outputs.targets), '${target}')`,
+      `always() && !cancelled() && needs.wait-for-ci.result == 'success' && needs.prepare-release.result == 'success' && contains(fromJSON(needs.prepare-release.outputs.targets), '${target}')`,
     );
     assert.equal(workflow.jobs[job].env.VERCEL_TOKEN, undefined);
     assert.ok(

--- a/scripts/vercel-main-deployment-workflow.test.mjs
+++ b/scripts/vercel-main-deployment-workflow.test.mjs
@@ -734,6 +734,9 @@ test("active coordinator validates stage handoffs and prepares App without deplo
     "stage-reserve",
     "stage-ui",
   ]);
+  assert.match(coordinator.if, /^always\(\)/);
+  assert.match(coordinator.if, /!cancelled\(\)/);
+  assert.match(coordinator.if, /needs\.prepare-release\.result == 'success'/);
   assert.equal(coordinator["timeout-minutes"], 60);
   assert.deepEqual(coordinator.environment, {
     name: "vercel-cli-production",

--- a/scripts/vercel-main-deployment-workflow.test.mjs
+++ b/scripts/vercel-main-deployment-workflow.test.mjs
@@ -681,8 +681,26 @@ test("release preparation starts only after inherited recovery and replans from 
 test("ordinary targets materialize execution and use create-or-reuse provider handoffs", () => {
   for (const target of ["governance", "reserve", "ui"]) {
     const job = `stage-${target}`;
-    assert.equal(workflow.jobs[job]["timeout-minutes"], 50);
-    assert.notEqual(workflow.jobs[job].if, undefined, `${target} stage route`);
+    const stage = workflow.jobs[job];
+    assert.equal(stage["timeout-minutes"], 50);
+    assert.match(stage.if, /^always\(\)/, `${target} stage status override`);
+    assert.match(
+      stage.if,
+      /needs\.wait-for-ci\.result == 'success'/,
+      `${target} exact-CI admission`,
+    );
+    assert.match(
+      stage.if,
+      /needs\.prepare-release\.result == 'success'/,
+      `${target} release preparation`,
+    );
+    assert.match(
+      stage.if,
+      new RegExp(
+        `contains\\(fromJSON\\(needs\\.prepare-release\\.outputs\\.targets\\), '${target}'\\)`,
+      ),
+      `${target} selection`,
+    );
     assert.match(
       command(job, "materialize --output").run,
       /release-cli\.mjs materialize/,
@@ -913,6 +931,12 @@ test("recovery is a bounded exact-current-attempt transaction with no cross-atte
   assert.match(recoveryJob.if, /^always\(\)/);
   assert.match(recoveryJob.if, /prepare-release\.result == 'success'/);
   assert.match(recoveryJob.if, /activate-and-verify\.result != 'success'/);
+  for (const target of ["APP", "GOVERNANCE", "RESERVE", "UI"]) {
+    assert.equal(
+      recoveryJob.env[`VERCEL_PROJECT_ID_${target}`],
+      `\${{ vars.VERCEL_PROJECT_ID_${target} }}`,
+    );
+  }
   const controller = checkoutSteps("recover-main-deployment").find(
     (step) => step.with.path === undefined,
   );
@@ -1377,7 +1401,7 @@ test("ordinary stages retain protected runtime isolation and create-only uploads
     const checkouts = checkoutSteps(job);
     assert.equal(
       workflow.jobs[job].if,
-      `contains(fromJSON(needs.prepare-release.outputs.targets), '${target}')`,
+      `always() && needs.wait-for-ci.result == 'success' && needs.prepare-release.result == 'success' && contains(fromJSON(needs.prepare-release.outputs.targets), '${target}')`,
     );
     assert.equal(workflow.jobs[job].env.VERCEL_TOKEN, undefined);
     assert.ok(


### PR DESCRIPTION
## The Problem

The active production deployment run
[30303983062](https://github.com/mento-protocol/frontend-monorepo/actions/runs/30303983062)
selected App, Governance, Reserve, and UI, but GitHub skipped every ordinary
stage job. `prepare-release` had succeeded through a route with a skipped
inherited-restore ancestor, so the stage jobs' implicit `success()` status check
propagated that skip even though their direct prerequisites passed.

The coordinator rejected the mismatch before candidate staging, journal
creation, App build, or any public mutation. Its no-journal recovery route then
failed to create the legacy proof because that job did not receive the four
Vercel project IDs.

## The Solution

- Give each ordinary stage an explicit status override, while still requiring
  successful exact-CI admission, successful release preparation, and exact
  target selection.
- Pass the four configured Vercel project IDs to the recovery job so its legacy
  specification can be materialized on preparation failures.
- Pin both contracts in the workflow structural tests.

## Validation

- `node --test scripts/vercel-main-deployment-workflow.test.mjs` — 31 passed
- `pnpm vercel:workflow:test` — 547 passed
- `pnpm vercel:production-shadow:test` — 146 passed
- `pnpm quality:budgets:test` — 34 passed
- `trunk check .github/workflows/vercel-main-deployment.yml scripts/vercel-main-deployment-workflow.test.mjs`
- `pnpm adr:check`
- Push hook: type checks, Trunk over 1,200 files, and Knip passed
- Independent review: all clear

## Risk

This changes production workflow scheduling. The explicit stage conditions
remain fail closed: a stage runs only when both direct prerequisites succeed
and the materialized release selects that exact target. Recovery gains only
existing non-secret project IDs; credential scope and mutation authority do not
change.
