### PR TITLE
fix(ci): repair Vercel main stage context

### DIFF
--- a/.github/workflows/vercel-main-deployment.yml
+++ b/.github/workflows/vercel-main-deployment.yml
@@ -776,6 +776,7 @@ jobs:
       UPSTREAM_RUN_ID: ${{ needs.wait-for-ci.outputs.upstream_run_id }}
       UPSTREAM_RUN_ATTEMPT: ${{ needs.wait-for-ci.outputs.upstream_run_attempt }}
       MAIN_RELEASE_EXECUTION: ${{ needs.prepare-release.outputs.execution }}
+      LOGICAL_TARGET: governance
       VERCEL_PROJECT_ID: ${{ vars.VERCEL_PROJECT_ID_GOVERNANCE }}
       VERCEL_PROJECT_ID_GOVERNANCE: ${{ vars.VERCEL_PROJECT_ID_GOVERNANCE }}
     steps:
@@ -979,6 +980,7 @@ jobs:
       UPSTREAM_RUN_ID: ${{ needs.wait-for-ci.outputs.upstream_run_id }}
       UPSTREAM_RUN_ATTEMPT: ${{ needs.wait-for-ci.outputs.upstream_run_attempt }}
       MAIN_RELEASE_EXECUTION: ${{ needs.prepare-release.outputs.execution }}
+      LOGICAL_TARGET: reserve
       VERCEL_PROJECT_ID: ${{ vars.VERCEL_PROJECT_ID_RESERVE }}
       VERCEL_PROJECT_ID_RESERVE: ${{ vars.VERCEL_PROJECT_ID_RESERVE }}
     steps:
@@ -1181,6 +1183,7 @@ jobs:
       UPSTREAM_RUN_ID: ${{ needs.wait-for-ci.outputs.upstream_run_id }}
       UPSTREAM_RUN_ATTEMPT: ${{ needs.wait-for-ci.outputs.upstream_run_attempt }}
       MAIN_RELEASE_EXECUTION: ${{ needs.prepare-release.outputs.execution }}
+      LOGICAL_TARGET: ui
       VERCEL_PROJECT_ID: ${{ vars.VERCEL_PROJECT_ID_UI }}
       VERCEL_PROJECT_ID_UI: ${{ vars.VERCEL_PROJECT_ID_UI }}
     steps:
@@ -2786,14 +2789,17 @@ jobs:
         id: final-active
         if: ${{ always() && needs.prepare-release.result == 'success' }}
         env:
-          COORDINATOR_OUTCOME: ${{ needs.activate-and-verify.outputs.outcome }}
+          COORDINATOR_OUTCOME: ${{ needs.activate-and-verify.outputs.outcome || needs.recover-main-deployment.outputs.outcome }}
           COORDINATOR_RESULT: ${{ needs.activate-and-verify.result }}
+          DEPLOY_SHA: ${{ needs.wait-for-ci.outputs.deploy_sha }}
           PLAN_RESULT: ${{ needs.prepare-release.result }}
           RECOVERY_OUTCOME: ${{ needs.recover-main-deployment.outputs.outcome || 'not-required' }}
           RECOVERY_RESULT: ${{ needs.recover-main-deployment.result }}
           STAGE_GOVERNANCE_RESULT: ${{ needs.stage-governance.result }}
           STAGE_RESERVE_RESULT: ${{ needs.stage-reserve.result }}
           STAGE_UI_RESULT: ${{ needs.stage-ui.result }}
+          UPSTREAM_RUN_ATTEMPT: ${{ needs.wait-for-ci.outputs.upstream_run_attempt }}
+          UPSTREAM_RUN_ID: ${{ needs.wait-for-ci.outputs.upstream_run_id }}
           WAIT_FOR_CI_RESULT: ${{ needs.wait-for-ci.result }}
         run: >-
           node scripts/vercel-main-deployment.mjs final-active

--- a/scripts/vercel-main-deployment-workflow.test.mjs
+++ b/scripts/vercel-main-deployment-workflow.test.mjs
@@ -1,6 +1,17 @@
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import {
+  chmodSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import process from "node:process";
 import { test } from "node:test";
+import { fileURLToPath } from "node:url";
 import { parse } from "yaml";
 
 import {
@@ -30,6 +41,9 @@ const recovery = parse(recoverySource);
 const deploymentDocs = read("docs/vercel-deployments.md");
 const deploymentSource = read("scripts/vercel-main-deployment.mjs");
 const terminalReceiptSource = read("scripts/vercel-main-terminal-receipt.mjs");
+const productionShadowCli = fileURLToPath(
+  new URL("./vercel-production-shadow.mjs", import.meta.url),
+);
 const pnpmInstallAction = parse(
   read(".github/actions/pnpm-install/action.yml"),
 );
@@ -1407,6 +1421,7 @@ test("ordinary stages retain protected runtime isolation and create-only uploads
       workflow.jobs[job].if,
       `always() && !cancelled() && needs.wait-for-ci.result == 'success' && needs.prepare-release.result == 'success' && contains(fromJSON(needs.prepare-release.outputs.targets), '${target}')`,
     );
+    assert.equal(workflow.jobs[job].env.LOGICAL_TARGET, target);
     assert.equal(workflow.jobs[job].env.VERCEL_TOKEN, undefined);
     assert.ok(
       checkouts.some(
@@ -1531,6 +1546,59 @@ test("ordinary stages retain protected runtime isolation and create-only uploads
     const diagnostics = named(job, "browser diagnostics on failure");
     assert.equal(diagnostics.uses, UPLOAD_PIN);
     assert.doesNotMatch(JSON.stringify(workflow.jobs[job]), /\.vercel\/output/);
+  }
+});
+
+test("ordinary stage job targets reach the production-shadow CLI at runtime", () => {
+  const contracts = {
+    governance: "apps/governance.mento.org",
+    reserve: "apps/reserve.mento.org",
+    ui: "apps/ui.mento.org",
+  };
+  for (const [target, rootDirectory] of Object.entries(contracts)) {
+    const isolationRoot = realpathSync(
+      mkdtempSync(join(tmpdir(), `vercel-main-stage-${target}-`)),
+    );
+    const stagingRoot = join(
+      isolationRoot,
+      "mento-vercel-production-pull-staging",
+    );
+    const projectId = `prj_${target}123`;
+    const orgId = "team_fixture123";
+    try {
+      chmodSync(isolationRoot, 0o711);
+      const result = spawnSync(
+        process.execPath,
+        [productionShadowCli, "prepare-pull-staging"],
+        {
+          encoding: "utf8",
+          env: {
+            ...process.env,
+            LOGICAL_TARGET: workflow.jobs[`stage-${target}`].env.LOGICAL_TARGET,
+            PULL_STAGING_PATH: stagingRoot,
+            VERCEL_ISOLATION_ROOT: isolationRoot,
+            VERCEL_ORG_ID: orgId,
+            VERCEL_PROJECT_ID: projectId,
+          },
+        },
+      );
+      assert.equal(result.status, 0, `${target}: ${result.stderr}`);
+      assert.equal(
+        result.stdout,
+        "Runner-owned Vercel pull staging prepared\n",
+      );
+      assert.deepEqual(
+        JSON.parse(
+          readFileSync(join(stagingRoot, ".vercel", "repo.json"), "utf8"),
+        ),
+        {
+          remoteName: "origin",
+          projects: [{ id: projectId, directory: rootDirectory, orgId }],
+        },
+      );
+    } finally {
+      rmSync(isolationRoot, { recursive: true, force: true });
+    }
   }
 });
 
@@ -1900,12 +1968,28 @@ test("result restores the compact handoff then fails closed from the literal fin
   const finalActive = command("result", "final-active");
   assert.match(finalActive.run, /final-active[\s\S]*--execution/);
   assert.equal(
+    finalActive.env.DEPLOY_SHA,
+    "${{ needs.wait-for-ci.outputs.deploy_sha }}",
+  );
+  assert.equal(
+    finalActive.env.UPSTREAM_RUN_ID,
+    "${{ needs.wait-for-ci.outputs.upstream_run_id }}",
+  );
+  assert.equal(
+    finalActive.env.UPSTREAM_RUN_ATTEMPT,
+    "${{ needs.wait-for-ci.outputs.upstream_run_attempt }}",
+  );
+  assert.equal(
     finalActive.env.WAIT_FOR_CI_RESULT,
     "${{ needs.wait-for-ci.result }}",
   );
   assert.equal(
     finalActive.env.PLAN_RESULT,
     "${{ needs.prepare-release.result }}",
+  );
+  assert.equal(
+    finalActive.env.COORDINATOR_OUTCOME,
+    "${{ needs.activate-and-verify.outputs.outcome || needs.recover-main-deployment.outputs.outcome }}",
   );
   assert.equal(
     finalActive.env.STAGE_GOVERNANCE_RESULT,

--- a/scripts/vercel-main-deployment.mjs
+++ b/scripts/vercel-main-deployment.mjs
@@ -4620,6 +4620,33 @@ export function renderMainCurrentReleaseVerificationEvidence(evidence) {
   ].join("\n");
 }
 
+export function renderMainActivePreparationFailureEvidence(evidence) {
+  if (
+    !isPlainObject(evidence) ||
+    evidence.schema !== MAIN_ACTIVE_PREPARATION_FAILURE_EVIDENCE_SCHEMA ||
+    evidence.outcome !== "failed" ||
+    evidence.reason !== "preparation-failed-before-journal" ||
+    evidence.publicServingMutationCommands !== 0 ||
+    !isPlainObject(evidence.stageResults) ||
+    !isPlainObject(evidence.stageResults.results)
+  ) {
+    throw new Error("Active preparation failure evidence is malformed");
+  }
+  return [
+    "### Vercel main active preparation failure evidence",
+    "",
+    `- DEPLOY_SHA: \`${evidence.deploySha}\``,
+    `- Downstream workflow: [run ${evidence.runId}, attempt ${evidence.runAttempt}](${evidence.workflowRunUrl})`,
+    `- Stage results: ${MAIN_DEPLOYMENT_TARGETS.map(
+      (target) => `\`${target}:${evidence.stageResults.results[target]}\``,
+    ).join(", ")}; \`coordinator:${evidence.stageResults.coordinatorResult}\``,
+    "- Active journal: `not-created`",
+    "- Public-serving mutation commands: `0`",
+    "- Outcome: `failed` before the forward journal; this attempt authorized no public mapping mutation.",
+    "",
+  ].join("\n");
+}
+
 export function renderMainActiveDeploymentFailureEvidence(evidence) {
   if (
     !isPlainObject(evidence) ||
@@ -8470,9 +8497,12 @@ export async function runMainDeploymentCli({
           : result.artifact.schema ===
               MAIN_ACTIVE_CURRENT_RELEASE_EVIDENCE_SCHEMA
             ? renderMainCurrentReleaseVerificationEvidence
-            : result.artifact.schema === MAIN_ACTIVE_SAFE_NOOP_EVIDENCE_SCHEMA
-              ? renderMainActiveSafeNoopEvidence
-              : renderMainActiveDeploymentFailureEvidence;
+            : result.artifact.schema ===
+                MAIN_ACTIVE_PREPARATION_FAILURE_EVIDENCE_SCHEMA
+              ? renderMainActivePreparationFailureEvidence
+              : result.artifact.schema === MAIN_ACTIVE_SAFE_NOOP_EVIDENCE_SCHEMA
+                ? renderMainActiveSafeNoopEvidence
+                : renderMainActiveDeploymentFailureEvidence;
       appendFileSync(values.GITHUB_STEP_SUMMARY, render(result.artifact));
     }
     return result;

--- a/scripts/vercel-main-deployment.test.mjs
+++ b/scripts/vercel-main-deployment.test.mjs
@@ -4291,6 +4291,102 @@ test("preparation failure terminal artifacts bind exact target results without p
   );
 });
 
+test("terminal evidence restore renders preparation failure evidence", async () => {
+  const directory = mkdtempSync(
+    join(tmpdir(), "vercel-main-preparation-failure-restore-"),
+  );
+  try {
+    const deploymentPlan = activePlan();
+    const execution = releaseExecutionForPlan(deploymentPlan);
+    const artifacts = createMainActiveTerminalArtifacts({
+      execution,
+      outcome: "preparation-failed-before-journal",
+      journalHistory: [],
+      finalMappings: null,
+      publicSmokes: null,
+      stateProof: null,
+      finalCensus: null,
+      freshLegacyV2: deploymentPlan.legacySnapshot,
+      freshness: null,
+      stageResults: {
+        schema: "vercel-main-stage-results:v2",
+        deploySha: SHA,
+        runId: "800",
+        runAttempt: "3",
+        results: {
+          app: "skipped",
+          governance: "failure",
+          reserve: "failure",
+          ui: "failure",
+        },
+        coordinatorResult: "failure",
+      },
+      runId: "800",
+      runAttempt: "3",
+    });
+    const terminal = createMainActiveTerminalHandoff({
+      activeEvidence: artifacts.evidence,
+      releaseManifest: execution.manifest,
+      execution,
+      proofs: artifacts.proofs,
+      deploySha: SHA,
+      upstreamRunId: "123456",
+      upstreamRunAttempt: "2",
+      workflowRunId: "800",
+      producerRunAttempt: "3",
+      repository: "mento-protocol/frontend-monorepo",
+    });
+    const executionPath = join(directory, "execution.json");
+    const manifestPath = join(directory, "manifest.json");
+    const evidencePath = join(directory, "evidence.json");
+    const summaryPath = join(directory, "summary.md");
+    writeFileSync(executionPath, JSON.stringify(execution));
+    writeFileSync(manifestPath, JSON.stringify(execution.manifest));
+    writeFileSync(summaryPath, "");
+
+    const restored = await runMainDeploymentCli({
+      argv: [
+        "terminal-evidence-restore",
+        "--evidence",
+        terminal.encodedEvidence,
+        "--execution",
+        executionPath,
+        "--manifest",
+        manifestPath,
+        "--output",
+        evidencePath,
+        "--receipt",
+        terminal.encodedReceipt,
+      ],
+      values: {
+        DEPLOY_SHA: SHA,
+        UPSTREAM_RUN_ID: "123456",
+        UPSTREAM_RUN_ATTEMPT: "2",
+        GITHUB_RUN_ID: "800",
+        GITHUB_RUN_ATTEMPT: "4",
+        GITHUB_REPOSITORY: "mento-protocol/frontend-monorepo",
+        GITHUB_STEP_SUMMARY: summaryPath,
+      },
+    });
+
+    assert.deepEqual(restored.artifact, artifacts.evidence);
+    assert.deepEqual(
+      JSON.parse(readFileSync(evidencePath, "utf8")),
+      artifacts.evidence,
+    );
+    const summary = readFileSync(summaryPath, "utf8");
+    assert.match(
+      summary,
+      /^### Vercel main active preparation failure evidence/m,
+    );
+    assert.match(summary, /`governance:failure`/);
+    assert.match(summary, /Public-serving mutation commands: `0`/);
+    assert.doesNotMatch(summary, /active deployment failure evidence/);
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
 test("terminal evidence CLI creates a bounded receipt and restores committed evidence on a later attempt", async () => {
   const directory = mkdtempSync(join(tmpdir(), "vercel-main-terminal-"));
   try {
@@ -6443,6 +6539,34 @@ test("final-active CLI exposes fail-after-evidence without ending evidence produ
     assert.match(readFileSync(output, "utf8"), /release_outcome=failure/);
     assert.match(readFileSync(output, "utf8"), /fail_after_evidence=true/);
     assert.match(readFileSync(output, "utf8"), /evidence_kind=failure/);
+
+    writeFileSync(output, "");
+    const preparationFailure = await runMainDeploymentCli({
+      argv: ["final-active", "--execution", executionPath],
+      values: {
+        WAIT_FOR_CI_RESULT: "success",
+        PLAN_RESULT: "success",
+        STAGE_GOVERNANCE_RESULT: "failure",
+        STAGE_RESERVE_RESULT: "failure",
+        STAGE_UI_RESULT: "failure",
+        COORDINATOR_RESULT: "failure",
+        COORDINATOR_OUTCOME: "preparation-failed-before-journal",
+        RECOVERY_RESULT: "failure",
+        RECOVERY_OUTCOME: "preparation-failed-before-journal",
+        DEPLOY_SHA: SHA,
+        UPSTREAM_RUN_ID: "123456",
+        UPSTREAM_RUN_ATTEMPT: "2",
+        GITHUB_RUN_ID: "800",
+        GITHUB_RUN_ATTEMPT: "3",
+        GITHUB_REPOSITORY: "mento-protocol/frontend-monorepo",
+        GITHUB_OUTPUT: output,
+      },
+    });
+    assert.equal(preparationFailure.releaseOutcome, "failure");
+    assert.equal(preparationFailure.failAfterEvidence, true);
+    assert.equal(preparationFailure.reason, "stage-governance-invalid");
+    assert.match(readFileSync(output, "utf8"), /release_outcome=failure/);
+    assert.match(readFileSync(output, "utf8"), /fail_after_evidence=true/);
   } finally {
     rmSync(directory, { recursive: true, force: true });
   }


### PR DESCRIPTION
## The Problem

The first production attempt after #671 started every selected ordinary stage, but Governance, Reserve, and UI failed before Vercel pull, build, or upload because their production-shadow CLI calls received no `LOGICAL_TARGET`. The safe failure also exposed two terminal-closeout defects: preparation-failure evidence had no renderer, and `final-active` lacked exact deployment identity plus a recovery-outcome fallback.

Failed production run: https://github.com/mento-protocol/frontend-monorepo/actions/runs/30306948797

## The Solution

Bind each ordinary stage to its literal logical target at job scope, render the supported pre-journal failure evidence explicitly, and give the final sentinel the exact deployment and upstream identity plus the recovery-produced outcome fallback.

Add runtime and structural regressions covering all three stage targets, preparation-failure receipt restoration and summary rendering, and final-sentinel wiring.

## Validation

- `node --test scripts/vercel-main-deployment.test.mjs scripts/vercel-main-deployment-workflow.test.mjs` — 91/91
- `pnpm vercel:workflow:test` — 549/549
- `pnpm vercel:production-shadow:test` — 146/146
- `pnpm quality:budgets:test` — 34/34
- targeted Trunk check — clean
- `pnpm adr:check`
- `git diff --check`
- fresh-context autoreview — ALL_CLEAR

## Risk

This changes the GitHub-owned production deployment workflow. It does not alter aliases directly. The prior failed attempt produced zero deployments and zero public mutations; the next merged SHA must prove the full candidate, activation, recovery-skip, and browser paths.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the production main deployment GitHub workflow and terminal evidence paths; changes are corrective (no new public mutation paths) but the next merge must validate full staging and closeout in production.
> 
> **Overview**
> Ordinary **governance**, **reserve**, and **UI** stage jobs now set job-scoped **`LOGICAL_TARGET`** so production-shadow **`prepare-pull-staging`** (and related CLI steps) receive the correct logical target instead of failing before Vercel pull/build.
> 
> Terminal closeout is tightened: a dedicated **`renderMainActivePreparationFailureEvidence`** path handles **`preparation-failed-before-journal`** evidence during **`terminal-evidence-restore`** and step summaries. The **`result`** job’s **`final-active`** step now passes **`DEPLOY_SHA`**, upstream run id/attempt, and **`COORDINATOR_OUTCOME`** as **`activate-and-verify` outcome OR `recover-main-deployment` outcome** so recovery-produced outcomes are not dropped.
> 
> Workflow and deployment tests assert **`LOGICAL_TARGET`** on stage jobs, runtime **`prepare-pull-staging`** for all three targets, preparation-failure restore/summary behavior, and the new **`final-active`** env wiring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c0948976a315fa02a2c3d030e6259b2d30048c2. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->