### PR TITLE
fix(ci): probe the direct UI candidate route

### DIFF
--- a/docs/vercel-deployments.md
+++ b/docs/vercel-deployments.md
@@ -281,6 +281,13 @@ provider candidate from that manifest after fresh inspection and smoke. Provider
 metadata that lacks the canonical manifest, a matching URL, a matching custom
 identifier, or zero/multiple provider candidates is insufficient.
 
+The candidate HTTP smoke reads the immutable deployment root directly for App,
+Governance, and Reserve. UI reads `/basic-components` on that same immutable
+host because its root intentionally redirects there. Each request uses manual
+redirect handling and requires an exact same-URL 2xx response with the expected
+`X-Mento-Deployment-Sha`; the candidate receipt continues to record the root
+immutable deployment URL.
+
 App has no separate staged Vercel deployment because its custom `v3` upload is
 itself activation. When App is selected, the workflow performs `vercel pull`
 plus the protected custom-`v3` build and output validation before the

--- a/scripts/vercel-main-provider-cli.mjs
+++ b/scripts/vercel-main-provider-cli.mjs
@@ -69,6 +69,9 @@ export const MAIN_CANONICAL_MAPPINGS_SCHEMA =
 const MAIN_PROVIDER_DISCOVERY_SCHEMA = "vercel-main-provider-discovery:v2";
 
 const PROJECT_TARGETS = Object.freeze(["app", "governance", "reserve", "ui"]);
+const MAIN_CANDIDATE_SMOKE_PATHS = Object.freeze({
+  ui: "/basic-components",
+});
 const LEGACY_ALIAS = "v2-app.mento.org";
 const LEGACY_ALIASES = Object.freeze(
   [
@@ -1009,9 +1012,13 @@ async function smokeMainCandidateUrl({
   ) {
     throw new Error("Main candidate immutable URL is outside Vercel");
   }
+  const smokeUrl = new URL(
+    MAIN_CANDIDATE_SMOKE_PATHS[canonicalIntent.target] ?? "/",
+    url,
+  );
   let response;
   try {
-    response = await fetchImpl(url.toString(), {
+    response = await fetchImpl(smokeUrl.toString(), {
       method: "GET",
       redirect: "manual",
       signal: AbortSignal.timeout(15_000),
@@ -1026,7 +1033,7 @@ async function smokeMainCandidateUrl({
   try {
     responseUrl =
       typeof response?.url === "string"
-        ? canonicalizeDeploymentUrl(response.url)
+        ? new URL(response.url).toString()
         : null;
   } catch {
     responseUrl = null;
@@ -1037,7 +1044,7 @@ async function smokeMainCandidateUrl({
     response.status < 200 ||
     response.status >= 300 ||
     response.redirected !== false ||
-    responseUrl !== canonicalCandidate.deploymentUrl ||
+    responseUrl !== smokeUrl.toString() ||
     servedSha !== canonicalIntent.deploySha
   ) {
     throw new Error("Main candidate immutable HTTP smoke is inconsistent");

--- a/scripts/vercel-main-provider-cli.test.mjs
+++ b/scripts/vercel-main-provider-cli.test.mjs
@@ -1364,13 +1364,75 @@ test("inherited ordinary candidate finalization uses the fixed served-prior alia
   }
 });
 
-test("candidate smoke performs one exact-origin no-redirect SHA-bound HTTP read", async (t) => {
+test("candidate smoke uses the target's direct immutable route and preserves the SHA-bound receipt URL", async (t) => {
   const context = testContext(t);
-  const intent = candidateIntent();
+  for (const target of ["app", "governance", "reserve", "ui"]) {
+    const intent = candidateIntent(target);
+    const response = deploymentResponse(intent);
+    const intentPath = writeJson(
+      context.directory,
+      `${target}-intent.json`,
+      intent,
+    );
+    const output = join(context.directory, `${target}-candidate-smoke.json`);
+    let cancelled = false;
+    const stateClientFactory = () => ({
+      requestWithRetry: async () => ({
+        deployments: [{ uid: response.id }],
+        pagination: { next: null },
+      }),
+      inspectDeployment: async () => response,
+      listDeploymentAliases: async () => ({ aliases: [] }),
+    });
+    const expectedUrl = new URL(
+      target === "ui" ? "/basic-components" : "/",
+      `https://${response.url}`,
+    ).toString();
+    const result = await runMainProviderCli({
+      argv: ["candidate-smoke", "--intent", intentPath, "--output", output],
+      env: context.env,
+      stdout: context.stdout,
+      stateClientFactory,
+      fetchImpl: async (url, options) => {
+        assert.equal(url, expectedUrl, target);
+        assert.equal(options.method, "GET");
+        assert.equal(options.redirect, "manual");
+        return {
+          status: 200,
+          redirected: false,
+          url,
+          headers: {
+            get: (name) =>
+              name === "x-mento-deployment-sha" ? intent.deploySha : null,
+          },
+          body: {
+            cancel: async () => {
+              cancelled = true;
+            },
+          },
+        };
+      },
+    });
+    assert.deepEqual(result, {
+      immutableUrl: `https://${response.url}`,
+      servedSha: intent.deploySha,
+      status: "passed",
+    });
+    assert.equal(cancelled, true, target);
+    assert.deepEqual(readJson(output), result);
+    assert.equal(
+      readFileSync(context.githubOutput, "utf8"),
+      `deployment_id=${response.id}\n`,
+    );
+    writeFileSync(context.githubOutput, "", { mode: 0o600 });
+  }
+});
+
+test("candidate smoke fails closed for UI redirects, host or path changes, SHA mismatches, and non-2xx responses", async (t) => {
+  const context = testContext(t);
+  const intent = candidateIntent("ui");
   const response = deploymentResponse(intent);
   const intentPath = writeJson(context.directory, "intent.json", intent);
-  const output = join(context.directory, "candidate-smoke.json");
-  let cancelled = false;
   const stateClientFactory = () => ({
     requestWithRetry: async () => ({
       deployments: [{ uid: response.id }],
@@ -1379,47 +1441,12 @@ test("candidate smoke performs one exact-origin no-redirect SHA-bound HTTP read"
     inspectDeployment: async () => response,
     listDeploymentAliases: async () => ({ aliases: [] }),
   });
-  const fetchImpl = async (url, options) => {
-    assert.equal(url, new URL(`https://${response.url}`).toString());
-    assert.equal(options.method, "GET");
-    assert.equal(options.redirect, "manual");
-    return {
-      status: 200,
-      redirected: false,
-      url,
-      headers: {
-        get: (name) =>
-          name === "x-mento-deployment-sha" ? intent.deploySha : null,
-      },
-      body: {
-        cancel: async () => {
-          cancelled = true;
-        },
-      },
-    };
-  };
-  const result = await runMainProviderCli({
-    argv: ["candidate-smoke", "--intent", intentPath, "--output", output],
-    env: context.env,
-    stdout: context.stdout,
-    stateClientFactory,
-    fetchImpl,
-  });
-  assert.deepEqual(result, {
-    immutableUrl: `https://${response.url}`,
-    servedSha: intent.deploySha,
-    status: "passed",
-  });
-  assert.equal(cancelled, true);
-  assert.deepEqual(readJson(output), result);
-  assert.equal(
-    readFileSync(context.githubOutput, "utf8"),
-    `deployment_id=${response.id}\n`,
-  );
 
   for (const [name, patch] of [
-    ["redirect", { status: 307, redirected: false }],
-    ["wrong-origin", { url: "https://attacker.example/" }],
+    ["redirect", { status: 307 }],
+    ["followed-redirect", { redirected: true }],
+    ["wrong-host", { url: "https://attacker.example/basic-components" }],
+    ["wrong-path", { url: `https://${response.url}/form-components` }],
     [
       "wrong-sha",
       {
@@ -1428,6 +1455,7 @@ test("candidate smoke performs one exact-origin no-redirect SHA-bound HTTP read"
         },
       },
     ],
+    ["bad-status", { status: 503 }],
   ]) {
     await assert.rejects(
       () =>


### PR DESCRIPTION
## The Problem

The first production attempt after #672 staged all three ordinary targets, but the UI candidate failed its immutable HTTP smoke even though the deployment was healthy and served the exact source SHA. `ui.mento.org` intentionally redirects `/` to `/basic-components`; the generic candidate smoke rejected that expected 307 before any public activation.

Failed run: https://github.com/mento-protocol/frontend-monorepo/actions/runs/30309340334

## The Solution

Keep the canonical candidate and receipt bound to the immutable root URL, but probe UI directly at `/basic-components`. Preserve manual redirect handling, exact immutable URL matching, 2xx status, no followed redirect, and exact deployment-SHA validation. App, Governance, and Reserve continue probing `/`.

Add target-matrix and fail-closed regression coverage for redirects, host or path changes, SHA mismatch, and non-2xx responses. Document the target-bound probe route.

## Validation

- `node --test scripts/vercel-main-provider-cli.test.mjs` — 14 passed
- `pnpm vercel:workflow:test` — 550 passed
- `pnpm quality:budgets:test` — 34 passed
- `trunk check scripts/vercel-main-provider-cli.mjs scripts/vercel-main-provider-cli.test.mjs docs/vercel-deployments.md`
- `pnpm adr:check`
- `git diff --check`
- Fresh-context closeout review — ALL_CLEAR
- Existing immutable UI candidate `/basic-components` — HTTP 200, exact host/path, expected `X-Mento-Deployment-Sha`, rendered Basic Components, no browser console errors

## Risk

This changes only the pre-activation immutable candidate HTTP probe. It does not change build, upload, alias, or activation behavior. The failed production attempt ended before the active journal and public mutation boundary; all public v3 domains remained on the prior deployment SHA and legacy v2 remained healthy.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scope is limited to the pre-activation immutable candidate HTTP probe; build, upload, alias, and activation behavior are unchanged.
> 
> **Overview**
> **Main Vercel candidate smoke** no longer GETs the immutable deployment root for every target. **App, Governance, and Reserve** still probe `/`; **UI** probes **`/basic-components`** on the same host because `/` intentionally returns a redirect that the smoke correctly rejects.
> 
> The probe still uses **manual redirects**, requires a **2xx on the exact request URL** (not a followed redirect), and validates **`X-Mento-Deployment-Sha`**. The **candidate receipt** continues to record the **root immutable deployment URL**—only the HTTP check path changes.
> 
> **Docs** (`vercel-deployments.md`) describe target-bound probe routes. **Tests** cover all four targets plus fail-closed cases (redirects, host/path drift, SHA mismatch, non-2xx).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d2d9dbad58f1383b52a2e9e27e6d2b91ea9eadbd. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->