### PR TITLE
fix(ci): harden active cutover recovery

### DIFF
--- a/.github/actions/vercel-main-active-transition/action.yml
+++ b/.github/actions/vercel-main-active-transition/action.yml
@@ -198,8 +198,10 @@ runs:
         set -euo pipefail
         install -d -m 0700 "$JOURNAL_DIRECTORY/$ARTIFACT_NAME"
         install -m 0600 "$RUNNER_TEMP/active-$SLOT-returned.json" "$JOURNAL_DIRECTORY/$ARTIFACT_NAME/main-journal.json"
-        node "$CONTROLLER_PATH/scripts/vercel-main-deployment.mjs" active-journal-history --artifacts "$JOURNAL_DIRECTORY" --output "$JOURNAL_DIRECTORY/current-history.json"
-        node "$CONTROLLER_PATH/scripts/vercel-main-deployment.mjs" active-journal-receipt --journal "$RUNNER_TEMP/active-$SLOT-returned.json" --artifact-name "$ARTIFACT_NAME" --artifact-id "$ARTIFACT_ID" --output "$JOURNAL_DIRECTORY/current-receipt.json"
+        node "$CONTROLLER_PATH/scripts/vercel-main-deployment.mjs" active-journal-history --artifacts "$JOURNAL_DIRECTORY" --output "$RUNNER_TEMP/active-$SLOT-returned-history.json"
+        node "$CONTROLLER_PATH/scripts/vercel-main-deployment.mjs" active-journal-receipt --journal "$RUNNER_TEMP/active-$SLOT-returned.json" --artifact-name "$ARTIFACT_NAME" --artifact-id "$ARTIFACT_ID" --output "$RUNNER_TEMP/active-$SLOT-returned-receipt.json"
+        install -m 0600 "$RUNNER_TEMP/active-$SLOT-returned-history.json" "$JOURNAL_DIRECTORY/current-history.json"
+        install -m 0600 "$RUNNER_TEMP/active-$SLOT-returned-receipt.json" "$JOURNAL_DIRECTORY/current-receipt.json"
 
     - name: Finalize the authorized App provider candidate
       id: app-finalize

--- a/docs/vercel-deployments.md
+++ b/docs/vercel-deployments.md
@@ -353,6 +353,9 @@ Governance, Reserve, and UI use
 `vercel promote <exact-staged-id-or-url>` in canonical target order. App runs
 last because `vercel deploy --prebuilt --target=v3` can move attached custom
 domains; the controller then reconciles each reviewed alias independently.
+The protected executor binds every Vercel mutation to the validated
+`VERCEL_ORG_ID` with the CLI's explicit `--scope` option; the durable command
+descriptor cannot supply or override that runner-owned scope.
 Targets in `shadowTargets` use the same staged/build verification but never
 enter the mutation list. After all active operations and public smokes pass,
 the controller persists the committed journal state.
@@ -392,6 +395,15 @@ recovery uses the bounded exact transaction-metadata census; zero, multiple,
 or mismatched candidates remain manual intervention. Recovery, manual
 intervention, a missing journal after a possible mutation, and recovery failure
 all fail the release after publishing redacted evidence.
+
+If a recovered journal proves that App's `app_v3_deploy` operation never
+started and its prepared candidate still has no deployment identity, the final
+state specification records App as `recoveredPrior`. That narrow state expects
+no App candidate while still requiring the exact-SHA census to contain no
+unknown or manual duplicate deployment, the captured protected mappings to
+resolve to every prior, and the restored public runtime smoke. A started App
+deploy or any discovered App candidate remains incomplete and cannot use this
+path.
 
 If provider reconciliation cannot establish one safe manifest and canonical
 mapping prefix, do not delete or recreate evidence. Inspect the live protected
@@ -526,7 +538,9 @@ sequentially from exact immutable IDs. Before every command it uploads a
 uploads the verified next sequence. Governance, Reserve, and UI use
 `vercel promote <exact-staged-id-or-url>`. App activates last with
 `vercel deploy --prebuilt --target=v3`, then verifies or restores each reviewed
-v3 alias independently. `--prod`, `--skip-domain`, and `vercel promote` remain
+v3 alias independently. The executor adds the validated runner-owned
+`VERCEL_ORG_ID` as the exact CLI `--scope`; command descriptors cannot select a
+different account. `--prod`, `--skip-domain`, and `vercel promote` remain
 forbidden for App.
 
 After active-mode activation, run the credential-free public smoke for every

--- a/scripts/vercel-deployment-state.mjs
+++ b/scripts/vercel-deployment-state.mjs
@@ -1771,6 +1771,41 @@ function plannedDispositionForTarget(
   return null;
 }
 
+// A recovery journal may prove that App's v3 deployment was never started.
+// This is deliberately App-only: ordinary targets always have a staged
+// candidate before activation, and an App deploy that was started is unknown
+// until its immutable candidate is discovered.
+function expectedActiveStateDisposition({
+  logicalTarget,
+  activeTargets,
+  shadowTargets,
+  project,
+}) {
+  const planned = plannedDispositionForTarget(
+    logicalTarget,
+    activeTargets,
+    shadowTargets,
+  );
+  if (project.expectedDisposition !== "recoveredPrior") return planned;
+  const deploymentId = Object.hasOwn(project, "deploymentId")
+    ? project.deploymentId
+    : project.expectedDeploymentId;
+  const deploymentUrl = Object.hasOwn(project, "deploymentUrl")
+    ? project.deploymentUrl
+    : project.expectedDeploymentUrl;
+  if (
+    logicalTarget !== "app" ||
+    planned !== "githubPrebuilt" ||
+    deploymentId !== null ||
+    deploymentUrl !== null
+  ) {
+    throw new Error(
+      `${logicalTarget} recovered-prior deployment expectation is malformed`,
+    );
+  }
+  return "recoveredPrior";
+}
+
 function canonicalMainOwnershipMode(value) {
   assertExactKeys(value, ACTIVE_STATE_TARGETS, "Main ownership mode");
   for (const logicalTarget of ACTIVE_STATE_TARGETS) {
@@ -1890,14 +1925,18 @@ export function assertActiveDeploymentStateSpec(spec) {
       project.projectId,
       `${logicalTarget} planned active project ID`,
     );
-    const expectedDisposition = plannedDispositionForTarget(
+    const expectedDisposition = expectedActiveStateDisposition({
       logicalTarget,
       activeTargets,
       shadowTargets,
-    );
+      project,
+    });
     let deploymentId = null;
     let deploymentUrl = null;
-    if (expectedDisposition === null) {
+    if (
+      expectedDisposition === null ||
+      expectedDisposition === "recoveredPrior"
+    ) {
       if (project.deploymentId !== null || project.deploymentUrl !== null) {
         throw new Error(
           `${logicalTarget} planned active deployment expectation is malformed`,
@@ -2545,11 +2584,12 @@ export function assertActiveDeploymentStateProof(value) {
       `${logicalTarget} active deployment state proof`,
     );
     const expectedEnvironment = activeProjectEnvironment(logicalTarget);
-    const expectedDisposition = plannedDispositionForTarget(
+    const expectedDisposition = expectedActiveStateDisposition({
       logicalTarget,
       activeTargets,
       shadowTargets,
-    );
+      project,
+    });
     const projectId = requireIdentifier(
       project.projectId,
       `${logicalTarget} active proof project ID`,
@@ -2574,7 +2614,10 @@ export function assertActiveDeploymentStateProof(value) {
         `${logicalTarget} active proof prior served SHA is malformed`,
       );
     }
-    if (expectedDisposition === null) {
+    if (
+      expectedDisposition === null ||
+      expectedDisposition === "recoveredPrior"
+    ) {
       if (
         project.expectedDeploymentId !== null ||
         project.expectedDeploymentUrl !== null

--- a/scripts/vercel-deployment-state.test.mjs
+++ b/scripts/vercel-deployment-state.test.mjs
@@ -262,6 +262,59 @@ function activeStateSpec({ rollbackOnly = false } = {}) {
   };
 }
 
+test("recovered-prior App state accepts no candidate and rejects an unexpected one", () => {
+  const spec = activeStateSpec();
+  spec.projects.app = {
+    ...spec.projects.app,
+    expectedDisposition: "recoveredPrior",
+    deploymentId: null,
+    deploymentUrl: null,
+  };
+  const emptyCandidateSet = activeDeploymentInspections(spec);
+  emptyCandidateSet.app = [];
+  const recovered = createActiveDeploymentStateProof({
+    spec,
+    deployments: emptyCandidateSet,
+    legacyV2: legacyAppV2Proof(spec),
+  });
+  assert.equal(recovered.outcome, "proven");
+  assert.equal(recovered.projects.app.counts.scanned, 0);
+
+  const unexpectedCandidateSet = activeDeploymentInspections(spec);
+  unexpectedCandidateSet.app = [];
+  unexpectedCandidateSet.app.push({
+    deploymentId: "dpl_unexpectedapp123",
+    response: activeDeploymentResponse(spec, "app", {
+      deploymentId: "dpl_unexpectedapp123",
+      deploymentUrl: "https://unexpected-app.vercel.app",
+    }),
+  });
+  const unexpected = createActiveDeploymentStateProof({
+    spec,
+    deployments: unexpectedCandidateSet,
+    legacyV2: legacyAppV2Proof(spec),
+  });
+  assert.equal(unexpected.outcome, "unproven");
+  assert.equal(unexpected.projects.app.counts.manualDuplicates, 1);
+
+  const invalidTarget = structuredClone(spec);
+  invalidTarget.projects.governance = {
+    ...invalidTarget.projects.governance,
+    expectedDisposition: "recoveredPrior",
+    deploymentId: null,
+    deploymentUrl: null,
+  };
+  assert.throws(
+    () =>
+      createActiveDeploymentStateProof({
+        spec: invalidTarget,
+        deployments: activeDeploymentInspections(invalidTarget),
+        legacyV2: legacyAppV2Proof(invalidTarget),
+      }),
+    /governance recovered-prior deployment expectation is malformed/,
+  );
+});
+
 function activeDeploymentResponse(
   spec,
   logicalTarget,

--- a/scripts/vercel-main-active-cli.test.mjs
+++ b/scripts/vercel-main-active-cli.test.mjs
@@ -334,7 +334,11 @@ test("execute validates the descriptor and passes the token only through a filte
     `process.argv.splice(1, 0, ${JSON.stringify(env.TRUSTED_VERCEL_CLI_PATH)}); await import(${JSON.stringify(env.TRUSTED_VERCEL_CLI_PATH)});`,
   );
   assert.equal(calls[0].argumentsList[4], "--");
-  assert.deepEqual(calls[0].argumentsList.slice(5), command.arguments);
+  assert.deepEqual(calls[0].argumentsList.slice(5), [
+    ...command.arguments,
+    "--scope",
+    env.VERCEL_ORG_ID,
+  ]);
   assert.equal(Number.isInteger(calls[0].spawnOptions.stdio[3]), true);
   assert.ok(calls[0].spawnOptions.stdio[3] >= 3);
   assert.equal(calls[0].spawnOptions.cwd, env.SOURCE_PATH);
@@ -419,7 +423,10 @@ test("fd loader runs the pinned Vercel ESM entrypoint", () => {
       cliPath,
       cliFileDescriptor: descriptor,
       workingDirectory: process.cwd(),
-      environment: { VERCEL_TOKEN: TOKEN },
+      environment: {
+        VERCEL_ORG_ID: "team_mainactive123",
+        VERCEL_TOKEN: TOKEN,
+      },
       nodeExecutable: process.execPath,
       spawn: (executable, argumentsList, spawnOptions) => {
         const child = spawnSync(

--- a/scripts/vercel-main-active-transition.test.mjs
+++ b/scripts/vercel-main-active-transition.test.mjs
@@ -18,9 +18,10 @@ import { mainTransactionJournalArtifactName } from "./vercel-main-transaction.mj
 
 const read = (path) =>
   readFileSync(new URL(`../${path}`, import.meta.url), "utf8");
-const action = parse(
-  read(".github/actions/vercel-main-active-transition/action.yml"),
+const actionSource = read(
+  ".github/actions/vercel-main-active-transition/action.yml",
 );
+const action = parse(actionSource);
 const preparedFixture = JSON.parse(
   read("scripts/fixtures/vercel-main-transaction/prepared-shadow.json"),
 );
@@ -285,6 +286,53 @@ test("ordinary mappings remain a one-turn verification", () => {
   assert.equal(verified.journal.status, "verified");
   assert.equal(verified.journal.operations.at(-1).state, "verified");
   assert.equal(verified.afterUploadAction, "dispatch");
+});
+
+test("active checkpoints stage canonical files before replacing pre-existing destinations", () => {
+  const checkpoints = [
+    ["checkpoint-started", "started"],
+    ["checkpoint-returned", "returned"],
+    ["checkpoint-verified", "verified"],
+    ["checkpoint-app-verified", "app-verified"],
+  ];
+
+  for (const [checkpointId, checkpointName] of checkpoints) {
+    const checkpoint = action.runs.steps.find(
+      (step) => step.id === checkpointId,
+    );
+    const tempPrefix = `\\$RUNNER_TEMP/active-\\$SLOT-${checkpointName}`;
+
+    assert.ok(checkpoint, `missing ${checkpointId}`);
+    assert.match(
+      checkpoint.run,
+      new RegExp(
+        `active-journal-history .*--output "${tempPrefix}-history\\.json"`,
+      ),
+    );
+    assert.match(
+      checkpoint.run,
+      new RegExp(
+        `active-journal-receipt .*--output "${tempPrefix}-receipt\\.json"`,
+      ),
+    );
+    assert.match(
+      checkpoint.run,
+      new RegExp(
+        `install -m 0600 "${tempPrefix}-history\\.json" "\\$JOURNAL_DIRECTORY/current-history\\.json"`,
+      ),
+    );
+    assert.match(
+      checkpoint.run,
+      new RegExp(
+        `install -m 0600 "${tempPrefix}-receipt\\.json" "\\$JOURNAL_DIRECTORY/current-receipt\\.json"`,
+      ),
+    );
+  }
+
+  assert.doesNotMatch(
+    actionSource,
+    /active-journal-(?:history|receipt)[^\n]*--output "\$JOURNAL_DIRECTORY\/current-(?:history|receipt)\.json"/,
+  );
 });
 
 test("the composite checkpoints the App attachment before a receipt-free second turn", () => {

--- a/scripts/vercel-main-active.mjs
+++ b/scripts/vercel-main-active.mjs
@@ -19,6 +19,7 @@ const IDENTIFIER_PATTERN = /^[A-Za-z0-9._-]+$/;
 const NEXT_DEPLOYMENT_ID_PATTERN = /^(?!dpl_)[A-Za-z0-9_-]{1,32}$/;
 const POSITIVE_ID_PATTERN = /^[1-9][0-9]*$/;
 const SHA_PATTERN = /^[a-f0-9]{40}$/;
+const TEAM_ID_PATTERN = /^team_[A-Za-z0-9]+$/;
 const TRANSACTION_ID_PATTERN = /^main-[a-f0-9]{32}$/;
 const MAX_COMMAND_OUTPUT_BYTES = 64 * 1024;
 const MAX_COMMAND_TIMEOUT_MS = 180_000;
@@ -745,6 +746,12 @@ function environmentForCommand(environment) {
     }
     filtered[name] = value;
   }
+  if (!TEAM_ID_PATTERN.test(filtered.VERCEL_ORG_ID ?? "")) {
+    throw new MainActiveAdapterError(
+      "VERCEL_ORG_ID is missing or malformed",
+      "MAIN_ACTIVE_COMMAND_REJECTED",
+    );
+  }
   return filtered;
 }
 
@@ -876,6 +883,8 @@ export function runMainActiveVercelCommand({
         inheritedCliEvaluation(cliPath),
         "--",
         ...canonicalCommand.arguments,
+        "--scope",
+        commandEnvironment.VERCEL_ORG_ID,
       ],
       {
         cwd: workingDirectory,

--- a/scripts/vercel-main-active.test.mjs
+++ b/scripts/vercel-main-active.test.mjs
@@ -655,6 +655,14 @@ test("descriptor allowlist rejects token arguments and forged commands", () => {
     () =>
       assertMainActiveCommandDescriptor({
         ...command,
+        arguments: [...command.arguments, "--scope", "team_attacker"],
+      }),
+    /descriptor was altered/,
+  );
+  assert.throws(
+    () =>
+      assertMainActiveCommandDescriptor({
+        ...command,
         kind: "project-remove",
       }),
     /kind is not allowlisted/,
@@ -699,7 +707,11 @@ test("runner sends the token only through a filtered process environment", () =>
     'process.argv.splice(1, 0, "/trusted/vercel/dist/vc.js"); await import("/trusted/vercel/dist/vc.js");',
   );
   assert.equal(calls[0].argumentsList[4], "--");
-  assert.deepEqual(calls[0].argumentsList.slice(5), command.arguments);
+  assert.deepEqual(calls[0].argumentsList.slice(5), [
+    ...command.arguments,
+    "--scope",
+    "team_mento",
+  ]);
   assert.equal(calls[0].argumentsList.includes(TOKEN), false);
   assert.equal(
     calls[0].argumentsList.some((argument) => argument.startsWith("--token")),
@@ -708,6 +720,33 @@ test("runner sends the token only through a filtered process environment", () =>
   assert.equal(calls[0].options.env.VERCEL_TOKEN, TOKEN);
   assert.equal(Object.hasOwn(calls[0].options.env, "SENTRY_AUTH_TOKEN"), false);
   assert.equal(calls[0].options.timeout, MAIN_ACTIVE_COMMAND_TIMEOUT_MS);
+});
+
+test("runner requires a canonical Vercel team ID before binding command scope", () => {
+  const command = buildMainActivePromotionCommand({
+    target: "ui",
+    ...ORDINARY_CANDIDATE,
+  });
+  let calls = 0;
+  for (const VERCEL_ORG_ID of [
+    undefined,
+    "mento",
+    "team_bad-id",
+    "team_bad\n",
+  ]) {
+    assert.throws(
+      () =>
+        runCommand(
+          command,
+          () => {
+            calls += 1;
+          },
+          { VERCEL_ORG_ID },
+        ),
+      /VERCEL_ORG_ID is missing or malformed/,
+    );
+  }
+  assert.equal(calls, 0);
 });
 
 test("nonzero, timeout, and thrown execution outcomes stay unknown and redacted", () => {

--- a/scripts/vercel-main-deployment.mjs
+++ b/scripts/vercel-main-deployment.mjs
@@ -2251,9 +2251,12 @@ export function createMainActiveRecoveryDeploymentStateSpec({
       "Active recovery state spec execution does not match journal release",
     );
   }
-  const active = [...release.activeTargets];
-  const shadow = release.stagedTargets.filter(
-    (target) => !active.includes(target),
+  const active = STAGE_BARRIER_TARGETS.filter((target) =>
+    release.activeTargets.includes(target),
+  );
+  const shadow = STAGE_BARRIER_TARGETS.filter(
+    (target) =>
+      release.stagedTargets.includes(target) && !active.includes(target),
   );
   const legacy = releaseExecution.legacyAppV2;
   const capturedLegacy = highest.prior["legacy-app"];
@@ -2281,11 +2284,21 @@ export function createMainActiveRecoveryDeploymentStateSpec({
       const isActive = active.includes(target);
       const isShadow = shadow.includes(target);
       const candidate = highest.candidates[target];
+      const recoveredPriorApp =
+        target === "app" &&
+        isActive &&
+        candidate !== null &&
+        candidate.deploymentId === null &&
+        candidate.deploymentUrl === null &&
+        !highest.operations.some(
+          (operation) => operation.type === "app_v3_deploy",
+        );
       if (
         (isActive || (isShadow && target !== "app")) &&
         (candidate === null ||
           candidate.deploymentId === null ||
-          candidate.deploymentUrl === null)
+          candidate.deploymentUrl === null) &&
+        !recoveredPriorApp
       ) {
         throw new Error(
           `Active recovery state spec ${target} candidate is incomplete`,
@@ -2302,11 +2315,13 @@ export function createMainActiveRecoveryDeploymentStateSpec({
         {
           projectId: prior.projectId,
           projectName: `${target}.mento.org`,
-          expectedDisposition: isActive
-            ? "githubPrebuilt"
-            : isShadow && target !== "app"
-              ? "githubShadowStage"
-              : null,
+          expectedDisposition: recoveredPriorApp
+            ? "recoveredPrior"
+            : isActive
+              ? "githubPrebuilt"
+              : isShadow && target !== "app"
+                ? "githubShadowStage"
+                : null,
           deploymentId: candidate?.deploymentId ?? null,
           deploymentUrl: candidate?.deploymentUrl ?? null,
           target: target === "app" ? null : "production",
@@ -2323,7 +2338,9 @@ export function createMainActiveRecoveryDeploymentStateSpec({
     transactionId: highest.transactionId,
     releaseManifest: release,
     mainOwnershipMode: release.mainOwnershipMode,
-    stagedTargets: [...release.stagedTargets],
+    stagedTargets: STAGE_BARRIER_TARGETS.filter((target) =>
+      release.stagedTargets.includes(target),
+    ),
     activeTargets: active,
     shadowTargets: shadow,
     projects,

--- a/scripts/vercel-main-deployment.test.mjs
+++ b/scripts/vercel-main-deployment.test.mjs
@@ -696,6 +696,7 @@ function activeStateProof({
   jobs,
   runId,
   runAttempt,
+  additionalDeployments = {},
 }) {
   const spec =
     suppliedSpec ??
@@ -708,7 +709,8 @@ function activeStateProof({
     });
   const deployments = Object.fromEntries(
     Object.entries(spec.projects).map(([target, project]) => {
-      if (project.deploymentId === null) return [target, []];
+      const additional = additionalDeployments[target] ?? [];
+      if (project.deploymentId === null) return [target, [...additional]];
       return [
         target,
         [
@@ -753,6 +755,7 @@ function activeStateProof({
               },
             },
           },
+          ...additional,
         ],
       ];
     }),
@@ -5719,6 +5722,189 @@ test("active recovery planning and execution hand off exact reverse mutations an
     failAfterEvidence: true,
     reason: "activation-recovered",
   });
+});
+
+test("active recovery terminalizes the prior App only when its v3 deploy never started", async () => {
+  const deploymentPlan = activePlan({ deployments: ["app", "governance"] });
+  const prepared = createPreparedMainActiveJournal({
+    plan: deploymentPlan,
+    stageJobs: stageJobs(deploymentPlan),
+    appBuildProof: appProof(deploymentPlan),
+    runId: "800",
+    runAttempt: "3",
+  });
+  const started = startMainTransactionOperation(prepared, {
+    type: "promote",
+    target: "governance",
+  });
+  const currentMappings = Object.values(started.prior).flatMap((prior) =>
+    prior.aliases.map((alias) =>
+      mapping(
+        alias,
+        alias === "governance.mento.org"
+          ? started.candidates.governance
+          : prior,
+      ),
+    ),
+  );
+  const recoveryPlan = planMainActiveRecovery({
+    journalHistory: [prepared, started],
+    deploySha: SHA,
+    runId: "800",
+    runAttempt: "3",
+    currentMappings,
+    appCandidateMatches: [],
+  });
+  let mappingState = "candidate";
+  const result = await runMainActiveRecovery({
+    recoveryPlan,
+    adapters: {
+      uploadJournal: async ({ artifactName, journal }) => ({
+        acknowledged: true,
+        artifactName,
+        artifactId: String(8000 + journal.sequence),
+      }),
+      inspectMapping: async () => ({ mappingState }),
+      ordinaryRollback: async () => {
+        mappingState = "prior";
+        return { outcome: "success" };
+      },
+      verifyMapping: async () => ({ mappingState }),
+    },
+  });
+  assert.equal(result.journal.status, "recovered");
+  const execution = releaseExecutionForPlan(deploymentPlan);
+  const history = activeHistoryDocument([
+    prepared,
+    started,
+    ...result.uploadedJournals,
+  ]);
+  const spec = createMainActiveRecoveryDeploymentStateSpec({
+    execution,
+    journalHistory: history,
+    runId: "800",
+    runAttempt: "3",
+  });
+  assert.equal(spec.projects.app.expectedDisposition, "recoveredPrior");
+  assert.equal(spec.projects.app.deploymentId, null);
+  const stateProof = activeStateProof({ spec });
+  assert.equal(stateProof.outcome, "proven");
+
+  const priorMappings = Object.values(result.journal.prior).flatMap((prior) =>
+    prior.aliases.map((alias) => mapping(alias, prior)),
+  );
+  const artifacts = createMainActiveTerminalArtifacts({
+    execution,
+    outcome: "recovered",
+    journalHistory: history,
+    finalMappings: providerMappings(execution, priorMappings),
+    publicSmokes: priorPublicSmokes(execution),
+    stateProof,
+    finalCensus: stateProof,
+    freshLegacyV2: deploymentPlan.legacySnapshot,
+    freshness: null,
+    runId: "800",
+    runAttempt: "3",
+  });
+  assert.equal(artifacts.evidence.recoveryOutcome, "recovered");
+  assert.equal(artifacts.proofs.outcome, "recovered");
+  assert.equal(
+    artifacts.proofs.stateProof.artifact.projects.app.expectedDisposition,
+    "recoveredPrior",
+  );
+  assert.ok(
+    priorMappings.every(({ alias, deploymentId, deploymentUrl }) => {
+      const target = Object.values(result.journal.prior).find((prior) =>
+        prior.aliases.includes(alias),
+      );
+      return (
+        target?.deploymentId === deploymentId &&
+        target.deploymentUrl === deploymentUrl
+      );
+    }),
+  );
+
+  const unexpectedAppCandidateProof = activeStateProof({
+    spec,
+    additionalDeployments: {
+      app: [
+        {
+          deploymentId: "dpl_unexpectedapp123",
+          response: {
+            id: "dpl_unexpectedapp123",
+            url: "https://unexpected-app.vercel.app",
+            projectId: spec.projects.app.projectId,
+            name: spec.projects.app.projectName,
+            readyState: "READY",
+            target: null,
+            customEnvironment: { slug: "v3" },
+            source: "cli",
+            meta: {
+              githubCommitOrg: "mento-protocol",
+              githubCommitRepo: "frontend-monorepo",
+              githubCommitRef: "main",
+              githubCommitSha: spec.deploySha,
+            },
+          },
+        },
+      ],
+    },
+  });
+  assert.equal(unexpectedAppCandidateProof.outcome, "unproven");
+  assert.equal(
+    unexpectedAppCandidateProof.projects.app.counts.manualDuplicates,
+    1,
+  );
+  assert.throws(
+    () =>
+      createMainActiveTerminalArtifacts({
+        execution,
+        outcome: "recovered",
+        journalHistory: history,
+        finalMappings: providerMappings(execution, priorMappings),
+        publicSmokes: priorPublicSmokes(execution),
+        stateProof: unexpectedAppCandidateProof,
+        finalCensus: unexpectedAppCandidateProof,
+        freshLegacyV2: deploymentPlan.legacySnapshot,
+        freshness: null,
+        runId: "800",
+        runAttempt: "3",
+      }),
+    /not proven/,
+  );
+
+  const governanceReturned = recordMainTransactionCommandReturned(started, {
+    operationId: started.operations.at(-1).operationId,
+    outcome: "success",
+  });
+  const governanceVerified = recordMainTransactionVerified(governanceReturned, {
+    operationId: started.operations.at(-1).operationId,
+    mappingState: "candidate",
+  });
+  const appDeployStarted = startMainTransactionOperation(governanceVerified, {
+    type: "app_v3_deploy",
+    target: "app",
+  });
+  const unsafeRecovering = startMainTransactionRecovery(appDeployStarted);
+  const unsafeRecovered = finishMainTransactionRecovery(unsafeRecovering);
+  assert.throws(
+    () =>
+      createMainActiveRecoveryDeploymentStateSpec({
+        execution,
+        journalHistory: activeHistoryDocument([
+          prepared,
+          started,
+          governanceReturned,
+          governanceVerified,
+          appDeployStarted,
+          unsafeRecovering,
+          unsafeRecovered,
+        ]),
+        runId: "800",
+        runAttempt: "3",
+      }),
+    /app candidate is incomplete/,
+  );
 });
 
 test("active recovery public-smoke materializer accepts only exact runtime results", async () => {


### PR DESCRIPTION
## The Problem

Production cutover run [30311189780](https://github.com/mento-protocol/frontend-monorepo/actions/runs/30311189780) exposed three activation-path defects after every candidate stage passed:

- The protected Vercel CLI ran `promote` without the explicit team scope that the command requires. Governance returned a nonzero result before its mapping could be verified.
- The command-return checkpoint wrote its history and receipt directly over existing canonical files. The history write failed with `EEXIST`, and the receipt had the same latent collision.
- Recovery restored the prior mappings and produced a terminal `recovered` journal, but terminal evidence rejected the intentionally absent App candidate even though `app_v3_deploy` had never started.

The public sites remained on the prior known-good deployment, but the workflow could neither complete the cutover nor publish complete recovered-state evidence.

## The Solution

- Validate the runner-owned `VERCEL_ORG_ID` as a Vercel team ID and append it as the CLI's exact `--scope` after command-descriptor validation. Command descriptors cannot inject or override scope, and malformed or missing scope fails before process spawn.
- Generate returned history and receipt files under slot-specific `RUNNER_TEMP` paths, then install both over their canonical checkpoint paths. Structural tests prohibit direct generator output to an existing canonical file.
- Add the narrow App-only `recoveredPrior` disposition when the terminal recovery journal proves that no `app_v3_deploy` operation started and the prepared App candidate has no deployment identity. The exact-SHA census still rejects any unexpected App candidate, and a started App deployment remains incomplete.
- Document the protected scope and recovery proof contracts.

This supports #522 and the cutover work tracked by #515.

## Validation

- `pnpm vercel:workflow:test` — 552 passed
- `pnpm vercel:deployment-state:test` — 56 passed
- `pnpm quality:budgets:test` — 34 passed
- `trunk check <10 changed files>`
- `pnpm adr:check`
- `git diff --check`
- Two fresh-context fail-closed reviews — all clear
- Repository variable check confirmed `VERCEL_ORG_ID` matches `^team_[A-Za-z0-9]+$` without printing its value

## Risk

This changes the production mutation executor and terminal recovery evidence. The executor fails closed before spawning Vercel if the configured team scope is absent or malformed. `recoveredPrior` applies only to App, only after a terminal recovery journal, and only when no App deployment operation ever started; provider census, prior mappings, public smokes, and legacy v2 proof remain required.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches the production Vercel mutation executor and terminal recovery evidence; scope misconfiguration fails closed before spawn, while `recoveredPrior` is narrowly gated to App-only recovery journals.
> 
> **Overview**
> Hardens the production **active main** Vercel cutover path after failures where `promote` lacked team scope, checkpoint writes collided on canonical journal files, and **recovered** terminal evidence rejected App when `app_v3_deploy` never ran.
> 
> The protected executor now **requires** a validated runner `VERCEL_ORG_ID` (`team_…`) and appends it as the CLI `--scope` after descriptor validation; descriptors cannot supply or override scope. Active transition checkpoints write journal **history** and **receipt** to slot-specific `RUNNER_TEMP` paths first, then `install` over `current-history.json` / `current-receipt.json`, with tests blocking direct generator output to those canonical paths.
> 
> Recovery state specs gain an App-only **`recoveredPrior`** disposition when the journal shows no `app_v3_deploy` and the prepared App candidate has no deployment id/url—proof and census still reject unexpected App deployments and refuse this path if App deploy started. Docs describe scope binding and the narrow recovery proof contract.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2eaf836949d109ac3bffd78034add8a240d63338. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->