### PR TITLE
fix(ci): unblock App cutover and complete recovery

### DIFF
--- a/docs/vercel-deployments.md
+++ b/docs/vercel-deployments.md
@@ -392,7 +392,13 @@ checkout, API reads, journal artifacts, and cleanup. If an App v3 command
 returned an unknown
 result and the captured mappings show possible movement,
 recovery uses the bounded exact transaction-metadata census; zero, multiple,
-or mismatched candidates remain manual intervention. Recovery, manual
+or mismatched candidates leave App untouched and require manual intervention.
+A started App deploy with no durable candidate identity also remains manual
+when every App and legacy mapping still resolves to its captured prior; prior
+mappings alone cannot prove that the provider created no detached candidate.
+App uncertainty does not skip independent compensation: the controller still
+restores exact Governance, Reserve, and UI candidate mappings in reverse
+activation order before it terminalizes manual intervention. Recovery, manual
 intervention, a missing journal after a possible mutation, and recovery failure
 all fail the release after publishing redacted evidence.
 
@@ -402,8 +408,11 @@ state specification records App as `recoveredPrior`. That narrow state expects
 no App candidate while still requiring the exact-SHA census to contain no
 unknown or manual duplicate deployment, the captured protected mappings to
 resolve to every prior, and the restored public runtime smoke. A started App
-deploy or any discovered App candidate remains incomplete and cannot use this
-path.
+deploy with no candidate identity remains incomplete for a recovered journal
+and cannot use this path. A manual-intervention journal may use the same
+zero-candidate expectation only to publish fail-closed terminal evidence: any
+observed App candidate makes that state proof unproven and never upgrades the
+manual outcome to recovered.
 
 If provider reconciliation cannot establish one safe manifest and canonical
 mapping prefix, do not delete or recreate evidence. Inspect the live protected

--- a/scripts/vercel-deployment-state.mjs
+++ b/scripts/vercel-deployment-state.mjs
@@ -1771,10 +1771,12 @@ function plannedDispositionForTarget(
   return null;
 }
 
-// A recovery journal may prove that App's v3 deployment was never started.
-// This is deliberately App-only: ordinary targets always have a staged
-// candidate before activation, and an App deploy that was started is unknown
-// until its immutable candidate is discovered.
+// App recovery evidence may carry a zero-candidate recoveredPrior expectation
+// when its v3 deploy never started or when a manual-intervention terminal cannot
+// prove whether a started command created a detached candidate. In the latter
+// case this is fail-closed evidence, not proof that no candidate exists: any
+// matching candidate makes the state proof unproven. Ordinary targets always
+// have an exact staged candidate before activation.
 function expectedActiveStateDisposition({
   logicalTarget,
   activeTargets,

--- a/scripts/vercel-main-active-cli.test.mjs
+++ b/scripts/vercel-main-active-cli.test.mjs
@@ -293,7 +293,9 @@ test("execute validates the descriptor and passes the token only through a filte
   });
   const descriptor = writePrivateJson(directory, "descriptor.json", command);
   const output = join(directory, "result.json");
-  const env = executionEnvironment(directory);
+  const env = executionEnvironment(directory, {
+    VERCEL_PROJECT_ID: "prj_untrusted",
+  });
   const calls = [];
   let stdout = "";
 
@@ -343,6 +345,14 @@ test("execute validates the descriptor and passes the token only through a filte
   assert.ok(calls[0].spawnOptions.stdio[3] >= 3);
   assert.equal(calls[0].spawnOptions.cwd, env.SOURCE_PATH);
   assert.equal(calls[0].spawnOptions.env.VERCEL_TOKEN, TOKEN);
+  assert.equal(
+    Object.hasOwn(calls[0].spawnOptions.env, "VERCEL_ORG_ID"),
+    false,
+  );
+  assert.equal(
+    Object.hasOwn(calls[0].spawnOptions.env, "VERCEL_PROJECT_ID"),
+    false,
+  );
   assert.equal(
     Object.hasOwn(calls[0].spawnOptions.env, "SENTRY_AUTH_TOKEN"),
     false,

--- a/scripts/vercel-main-active-controller.mjs
+++ b/scripts/vercel-main-active-controller.mjs
@@ -1368,10 +1368,14 @@ function recoveryMappingState(journal, currentMappings, operation) {
 
 function nextRecoveryAction(journal, plan, currentMappings) {
   const latest = lastEvents(journal);
+  let manualInterventionRequired = false;
   for (const action of plan.actions) {
     const live = liveRecoveryIntent(action, journal, currentMappings);
     if (live.kind === "noop") continue;
-    if (live.kind === "manual") return { kind: "manual" };
+    if (live.kind === "manual") {
+      manualInterventionRequired = true;
+      continue;
+    }
     const start = matchingRecoveryStart(journal, live.intent);
     if (start === null) {
       const intent = live.intent;
@@ -1385,7 +1389,10 @@ function nextRecoveryAction(journal, plan, currentMappings) {
               intent.target,
             );
       if (state === "prior") continue;
-      if (state !== "candidate") return { kind: "manual" };
+      if (state !== "candidate") {
+        manualInterventionRequired = true;
+        continue;
+      }
       return { kind: "intent", intent };
     }
     const last = latest.get(start.operationId);
@@ -1393,10 +1400,12 @@ function nextRecoveryAction(journal, plan, currentMappings) {
       throw new Error("A recovery operation is already in progress");
     }
     if (last.mappingState !== "prior") {
-      return { kind: "manual" };
+      manualInterventionRequired = true;
     }
   }
-  return { kind: "complete" };
+  return {
+    kind: manualInterventionRequired ? "manual" : "complete",
+  };
 }
 
 function canonicalActiveRecoveryPlan(recoveryPlan) {
@@ -1484,7 +1493,11 @@ export function reduceMainActiveRecoveryTransition({
       }
       if (next.kind === "complete") {
         try {
-          const terminal = finishMainTransactionRecovery(highest);
+          const terminal = finishMainTransactionRecovery(highest, {
+            manualIntervention:
+              canonicalPlan.kind === "failed-activation" &&
+              plan.decision === "manual_intervention",
+          });
           return journalTransition(
             terminal,
             canonicalPlan.kind === "inherited"

--- a/scripts/vercel-main-active-controller.test.mjs
+++ b/scripts/vercel-main-active-controller.test.mjs
@@ -1294,6 +1294,149 @@ test("recovery reducer checkpoints safe reverse recovery before manual intervent
   assert.equal(terminal.afterUploadAction, "fail-after-evidence");
 });
 
+test("unknown App recovery compensates ordinary targets before manual intervention", () => {
+  for (const appMovesAfterPlanning of [false, true]) {
+    const initial = prepared(["app", "governance", "reserve", "ui"]);
+    const history = [initial];
+    let highest = initial;
+    for (const target of ["governance", "reserve", "ui"]) {
+      const started = startMainTransactionOperation(highest, {
+        type: "promote",
+        target,
+      });
+      history.push(started);
+      const returned = recordMainTransactionCommandReturned(started, {
+        operationId: started.operations.at(-1).operationId,
+        outcome: "success",
+      });
+      history.push(returned);
+      highest = recordMainTransactionVerified(returned, {
+        operationId: started.operations.at(-1).operationId,
+        mappingState: "candidate",
+      });
+      history.push(highest);
+    }
+    const appStarted = startMainTransactionOperation(highest, {
+      type: "app_v3_deploy",
+      target: "app",
+    });
+    history.push(appStarted);
+    highest = recordMainTransactionCommandReturned(appStarted, {
+      operationId: appStarted.operations.at(-1).operationId,
+      outcome: "unknown",
+    });
+    history.push(highest);
+
+    const ordinaryStates = {
+      governance: "candidate",
+      reserve: "candidate",
+      ui: "candidate",
+    };
+    const plan = planMainTransactionRecovery({
+      journal: highest,
+      currentMappings: currentMappings(highest, ordinaryStates),
+    });
+    assert.equal(plan.decision, "manual_intervention");
+    assert.equal(plan.reason, "app-candidate-unresolved-after-start");
+
+    const recovering = reduceMainActiveRecoveryTransition({
+      recoveryPlan: plan,
+      history,
+      event: recoveryEvent("initialize", {
+        uploadReceipt: receipt(highest),
+      }),
+    });
+    history.push(recovering.journal);
+
+    const movedAppAlias = highest.prior.app.aliases[1];
+    const liveMappings = () =>
+      recoveryCurrentMappings(history.at(-1), ordinaryStates).map((mapping) =>
+        appMovesAfterPlanning && mapping.alias === movedAppAlias
+          ? {
+              ...mapping,
+              deploymentId: "dpl_unresolvedApp123",
+              deploymentUrl: "https://unresolved-app.vercel.app",
+            }
+          : mapping,
+      );
+
+    for (const target of ["ui", "reserve", "governance"]) {
+      const started = reduceMainActiveRecoveryTransition({
+        recoveryPlan: plan,
+        history,
+        event: recoveryEvent("dispatch", {
+          uploadReceipt: receipt(history.at(-1)),
+          currentMappings: liveMappings(),
+        }),
+      });
+      assert.equal(started.journal.operations.at(-1).type, "ordinary_rollback");
+      assert.equal(started.journal.operations.at(-1).target, target);
+      history.push(started.journal);
+
+      const authorized = reduceMainActiveRecoveryTransition({
+        recoveryPlan: plan,
+        history,
+        event: recoveryEvent("authorize", {
+          uploadReceipt: receipt(history.at(-1)),
+          currentMappings: liveMappings(),
+        }),
+      });
+      const returned = reduceMainActiveRecoveryTransition({
+        recoveryPlan: plan,
+        history,
+        event: recoveryEvent("command-returned", {
+          uploadReceipt: receipt(history.at(-1)),
+          operationId: authorized.operationId,
+          command: authorized.command,
+          result: { outcome: "success", reason: null, candidate: null },
+        }),
+      });
+      history.push(returned.journal);
+
+      delete ordinaryStates[target];
+      const verified = reduceMainActiveRecoveryTransition({
+        recoveryPlan: plan,
+        history,
+        event: recoveryEvent("verify", {
+          uploadReceipt: receipt(history.at(-1)),
+          currentMappings: liveMappings(),
+        }),
+      });
+      assert.equal(verified.journal.operations.at(-1).mappingState, "prior");
+      history.push(verified.journal);
+    }
+
+    const terminal = reduceMainActiveRecoveryTransition({
+      recoveryPlan: plan,
+      history,
+      event: recoveryEvent("dispatch", {
+        uploadReceipt: receipt(history.at(-1)),
+        currentMappings: liveMappings(),
+      }),
+    });
+    assert.equal(terminal.journal.status, "manual_intervention");
+    assert.equal(terminal.afterUploadAction, "fail-after-evidence");
+    assert.deepEqual(
+      terminal.journal.operations
+        .filter(
+          (operation) =>
+            operation.type === "ordinary_rollback" &&
+            operation.state === "started",
+        )
+        .map((operation) => operation.target),
+      ["ui", "reserve", "governance"],
+    );
+    assert.equal(
+      terminal.journal.operations.some(
+        (operation) =>
+          operation.type === "app_alias_restore" ||
+          operation.type === "legacy_emergency_restore",
+      ),
+      false,
+    );
+  }
+});
+
 test("legacy recovery command binds the full reviewed topology and App project", () => {
   const initial = prepared(["app"], { appKnown: true });
   const started = startMainTransactionOperation(initial, {

--- a/scripts/vercel-main-active.mjs
+++ b/scripts/vercel-main-active.mjs
@@ -871,6 +871,11 @@ export function runMainActiveVercelCommand({
     );
   }
   const commandEnvironment = environmentForCommand(environment);
+  const teamId = commandEnvironment.VERCEL_ORG_ID;
+  // Scope is explicit. A lone VERCEL_ORG_ID makes the Vercel CLI treat the
+  // environment as an incomplete project link instead of using the reviewed
+  // repo mapping for this target's nested prebuilt output.
+  delete commandEnvironment.VERCEL_ORG_ID;
   const loader = inheritedCliLoader(cliPath);
   let result;
   try {
@@ -884,7 +889,7 @@ export function runMainActiveVercelCommand({
         "--",
         ...canonicalCommand.arguments,
         "--scope",
-        commandEnvironment.VERCEL_ORG_ID,
+        teamId,
       ],
       {
         cwd: workingDirectory,

--- a/scripts/vercel-main-active.test.mjs
+++ b/scripts/vercel-main-active.test.mjs
@@ -683,15 +683,19 @@ test("runner sends the token only through a filtered process environment", () =>
     target: "ui",
     ...ORDINARY_CANDIDATE,
   });
-  const result = runCommand(command, (executable, argumentsList, options) => {
-    calls.push({ executable, argumentsList, options });
-    return {
-      status: 0,
-      signal: null,
-      stdout: "promotion complete",
-      stderr: "",
-    };
-  });
+  const result = runCommand(
+    command,
+    (executable, argumentsList, options) => {
+      calls.push({ executable, argumentsList, options });
+      return {
+        status: 0,
+        signal: null,
+        stdout: "promotion complete",
+        stderr: "",
+      };
+    },
+    { VERCEL_PROJECT_ID: "prj_untrusted" },
+  );
   assert.deepEqual(result, {
     outcome: "success",
     reason: null,
@@ -718,6 +722,8 @@ test("runner sends the token only through a filtered process environment", () =>
     false,
   );
   assert.equal(calls[0].options.env.VERCEL_TOKEN, TOKEN);
+  assert.equal(Object.hasOwn(calls[0].options.env, "VERCEL_ORG_ID"), false);
+  assert.equal(Object.hasOwn(calls[0].options.env, "VERCEL_PROJECT_ID"), false);
   assert.equal(Object.hasOwn(calls[0].options.env, "SENTRY_AUTH_TOKEN"), false);
   assert.equal(calls[0].options.timeout, MAIN_ACTIVE_COMMAND_TIMEOUT_MS);
 });

--- a/scripts/vercel-main-deployment.mjs
+++ b/scripts/vercel-main-deployment.mjs
@@ -2284,15 +2284,16 @@ export function createMainActiveRecoveryDeploymentStateSpec({
       const isActive = active.includes(target);
       const isShadow = shadow.includes(target);
       const candidate = highest.candidates[target];
+      const appDeployStarted = highest.operations.some(
+        (operation) => operation.type === "app_v3_deploy",
+      );
       const recoveredPriorApp =
         target === "app" &&
         isActive &&
         candidate !== null &&
         candidate.deploymentId === null &&
         candidate.deploymentUrl === null &&
-        !highest.operations.some(
-          (operation) => operation.type === "app_v3_deploy",
-        );
+        (!appDeployStarted || highest.status === "manual_intervention");
       if (
         (isActive || (isShadow && target !== "app")) &&
         (candidate === null ||

--- a/scripts/vercel-main-deployment.test.mjs
+++ b/scripts/vercel-main-deployment.test.mjs
@@ -5724,7 +5724,7 @@ test("active recovery planning and execution hand off exact reverse mutations an
   });
 });
 
-test("active recovery terminalizes the prior App only when its v3 deploy never started", async () => {
+test("active recovery terminal evidence handles unstarted and unresolved App candidates", async () => {
   const deploymentPlan = activePlan({ deployments: ["app", "governance"] });
   const prepared = createPreparedMainActiveJournal({
     plan: deploymentPlan,
@@ -5885,6 +5885,77 @@ test("active recovery terminalizes the prior App only when its v3 deploy never s
     type: "app_v3_deploy",
     target: "app",
   });
+  const manualRecovering = startMainTransactionRecovery(appDeployStarted);
+  const manualTerminal = finishMainTransactionRecovery(manualRecovering, {
+    manualIntervention: true,
+  });
+  const manualHistory = activeHistoryDocument([
+    prepared,
+    started,
+    governanceReturned,
+    governanceVerified,
+    appDeployStarted,
+    manualRecovering,
+    manualTerminal,
+  ]);
+  const manualSpec = createMainActiveRecoveryDeploymentStateSpec({
+    execution,
+    journalHistory: manualHistory,
+    runId: "800",
+    runAttempt: "3",
+  });
+  assert.equal(manualSpec.projects.app.expectedDisposition, "recoveredPrior");
+  assert.equal(manualSpec.projects.app.deploymentId, null);
+  const manualStateProof = activeStateProof({ spec: manualSpec });
+  assert.equal(manualStateProof.outcome, "proven");
+  const manualArtifacts = createMainActiveTerminalArtifacts({
+    execution,
+    outcome: "manual-intervention",
+    journalHistory: manualHistory,
+    finalMappings: providerMappings(execution, currentMappings),
+    publicSmokes: null,
+    stateProof: manualStateProof,
+    finalCensus: manualStateProof,
+    freshLegacyV2: deploymentPlan.legacySnapshot,
+    freshness: null,
+    runId: "800",
+    runAttempt: "3",
+  });
+  assert.equal(manualArtifacts.evidence.recoveryOutcome, "manual-intervention");
+  assert.equal(manualArtifacts.proofs.outcome, "manual-intervention");
+
+  const manualUnknownCandidateProof = activeStateProof({
+    spec: manualSpec,
+    additionalDeployments: {
+      app: [
+        {
+          deploymentId: "dpl_unresolvedapp123",
+          response: {
+            id: "dpl_unresolvedapp123",
+            url: "https://unresolved-app.vercel.app",
+            projectId: manualSpec.projects.app.projectId,
+            name: manualSpec.projects.app.projectName,
+            readyState: "READY",
+            target: null,
+            customEnvironment: { slug: "v3" },
+            source: "cli",
+            meta: {
+              githubCommitOrg: "mento-protocol",
+              githubCommitRepo: "frontend-monorepo",
+              githubCommitRef: "main",
+              githubCommitSha: manualSpec.deploySha,
+            },
+          },
+        },
+      ],
+    },
+  });
+  assert.equal(manualUnknownCandidateProof.outcome, "unproven");
+  assert.equal(
+    manualUnknownCandidateProof.projects.app.counts.manualDuplicates,
+    1,
+  );
+
   const unsafeRecovering = startMainTransactionRecovery(appDeployStarted);
   const unsafeRecovered = finishMainTransactionRecovery(unsafeRecovering);
   assert.throws(
@@ -5904,6 +5975,145 @@ test("active recovery terminalizes the prior App only when its v3 deploy never s
         runAttempt: "3",
       }),
     /app candidate is incomplete/,
+  );
+});
+
+test("unknown App controller recovery produces fail-closed terminal evidence after safe ordinary rollbacks", async () => {
+  const deploymentPlan = activePlan();
+  const execution = releaseExecutionForPlan(deploymentPlan);
+  const prepared = createPreparedMainActiveJournal({
+    plan: deploymentPlan,
+    stageJobs: stageJobs(deploymentPlan),
+    appBuildProof: appProof(deploymentPlan),
+    runId: "800",
+    runAttempt: "3",
+  });
+  const forwardHistory = [prepared];
+  let highest = prepared;
+  for (const target of ["governance", "reserve", "ui"]) {
+    const started = startMainTransactionOperation(highest, {
+      type: "promote",
+      target,
+    });
+    forwardHistory.push(started);
+    const returned = recordMainTransactionCommandReturned(started, {
+      operationId: started.operations.at(-1).operationId,
+      outcome: "success",
+    });
+    forwardHistory.push(returned);
+    highest = recordMainTransactionVerified(returned, {
+      operationId: started.operations.at(-1).operationId,
+      mappingState: "candidate",
+    });
+    forwardHistory.push(highest);
+  }
+  const appStarted = startMainTransactionOperation(highest, {
+    type: "app_v3_deploy",
+    target: "app",
+  });
+  forwardHistory.push(appStarted);
+  highest = recordMainTransactionCommandReturned(appStarted, {
+    operationId: appStarted.operations.at(-1).operationId,
+    outcome: "unknown",
+  });
+  forwardHistory.push(highest);
+
+  const mappingStates = {
+    app: "prior",
+    governance: "candidate",
+    "legacy-app": "prior",
+    reserve: "candidate",
+    ui: "candidate",
+  };
+  const currentMappings = Object.entries(highest.prior).flatMap(
+    ([target, prior]) =>
+      prior.aliases.map((alias) =>
+        mapping(
+          alias,
+          mappingStates[target] === "candidate"
+            ? highest.candidates[target]
+            : prior,
+        ),
+      ),
+  );
+  const recoveryPlan = planMainActiveRecovery({
+    journalHistory: forwardHistory,
+    deploySha: SHA,
+    runId: "800",
+    runAttempt: "3",
+    currentMappings,
+  });
+  assert.equal(recoveryPlan.decision, "manual_intervention");
+  assert.equal(recoveryPlan.reason, "app-candidate-unresolved-after-start");
+
+  const rollbackOrder = [];
+  const result = await runMainActiveRecovery({
+    recoveryPlan,
+    adapters: {
+      uploadJournal: async ({ artifactName, journal }) => ({
+        acknowledged: true,
+        artifactName,
+        artifactId: String(9000 + journal.sequence),
+      }),
+      inspectMapping: async ({ target }) => ({
+        mappingState: mappingStates[target],
+      }),
+      ordinaryRollback: async ({ target }) => {
+        rollbackOrder.push(target);
+        mappingStates[target] = "prior";
+        return { outcome: "success" };
+      },
+      verifyMapping: async ({ target }) => ({
+        mappingState: mappingStates[target],
+      }),
+    },
+  });
+  assert.equal(result.outcome, "manual-intervention");
+  assert.equal(result.journal.status, "manual_intervention");
+  assert.equal(result.publicServingMutationCommands, 3);
+  assert.deepEqual(rollbackOrder, ["ui", "reserve", "governance"]);
+
+  const history = activeHistoryDocument([
+    ...forwardHistory,
+    ...result.uploadedJournals,
+  ]);
+  const spec = createMainActiveRecoveryDeploymentStateSpec({
+    execution,
+    journalHistory: history,
+    runId: "800",
+    runAttempt: "3",
+  });
+  assert.equal(spec.projects.app.expectedDisposition, "recoveredPrior");
+  assert.equal(spec.projects.app.deploymentId, null);
+  const stateProof = activeStateProof({ spec });
+  assert.equal(stateProof.outcome, "proven");
+
+  const priorMappings = Object.values(result.journal.prior).flatMap((prior) =>
+    prior.aliases.map((alias) => mapping(alias, prior)),
+  );
+  const artifacts = createMainActiveTerminalArtifacts({
+    execution,
+    outcome: "manual-intervention",
+    journalHistory: history,
+    finalMappings: providerMappings(execution, priorMappings),
+    publicSmokes: null,
+    stateProof,
+    finalCensus: stateProof,
+    freshLegacyV2: deploymentPlan.legacySnapshot,
+    freshness: null,
+    runId: "800",
+    runAttempt: "3",
+  });
+  assert.equal(artifacts.evidence.recoveryOutcome, "manual-intervention");
+  assert.equal(artifacts.proofs.outcome, "manual-intervention");
+  assert.deepEqual(artifacts.proofs.rollbackTargets, [
+    "governance",
+    "reserve",
+    "ui",
+  ]);
+  assert.equal(
+    artifacts.proofs.stateProof.artifact.projects.app.expectedDisposition,
+    "recoveredPrior",
   );
 });
 

--- a/scripts/vercel-main-transaction.mjs
+++ b/scripts/vercel-main-transaction.mjs
@@ -1868,6 +1868,7 @@ export function planMainTransactionRecovery({
   );
   let appCandidate = canonical.candidates.app;
   let discoveredAppCandidate = null;
+  let appCandidateAmbiguous = false;
   if (appWasStarted && appCandidate?.deploymentId === null) {
     const appAliasesMoved = canonical.prior.app.aliases.some(
       (alias) => !sameDeployment(mappings.get(alias), canonical.prior.app),
@@ -1888,15 +1889,9 @@ export function planMainTransactionRecovery({
           ...appCandidate.discovery,
         };
       } catch {
-        return {
-          decision: "manual_intervention",
-          reason: "app-candidate-ambiguous-after-mapping-moved",
-          journal: canonical,
-          actions: [],
-          rollbackStateTargets: [],
-          forceFailure: true,
-          discoveredAppCandidate: null,
-        };
+        // Preserve the uncertain App mapping for manual intervention, but
+        // continue planning independent, exact ordinary-target compensation.
+        appCandidateAmbiguous = true;
       }
     }
   }
@@ -1904,6 +1899,10 @@ export function planMainTransactionRecovery({
     discoveredAppCandidate === null
       ? canonical
       : attachDiscoveredAppCandidate(canonical, discoveredAppCandidate);
+  const appCandidateUnresolved =
+    appWasStarted &&
+    recoveryJournal.candidates.app?.deploymentId === null &&
+    discoveredAppCandidate === null;
   const actions = [];
   const handledOrdinaryTargets = new Set();
   const handledAppAliases = new Set();
@@ -2049,12 +2048,18 @@ export function planMainTransactionRecovery({
     }
   }
   return {
-    decision: manual ? "manual_intervention" : "recover",
-    reason: manual
-      ? "unexpected-protected-mapping"
-      : emergencyLegacyRestore
-        ? "legacy-alias-moved-to-transaction-candidate"
-        : "started-operations-require-verification-or-recovery",
+    decision:
+      manual || appCandidateUnresolved ? "manual_intervention" : "recover",
+    reason:
+      manual || appCandidateUnresolved
+        ? appCandidateAmbiguous
+          ? "app-candidate-ambiguous-after-mapping-moved"
+          : manual
+            ? "unexpected-protected-mapping"
+            : "app-candidate-unresolved-after-start"
+        : emergencyLegacyRestore
+          ? "legacy-alias-moved-to-transaction-candidate"
+          : "started-operations-require-verification-or-recovery",
     journal: canonical,
     actions,
     rollbackStateTargets: actions
@@ -2250,37 +2255,6 @@ export function assertMainTransactionRecoveryPlan(plan) {
     };
   }
 
-  const isAmbiguousAppCandidate =
-    plan.decision === "manual_intervention" &&
-    plan.reason === "app-candidate-ambiguous-after-mapping-moved" &&
-    Array.isArray(plan.actions) &&
-    plan.actions.length === 0;
-  if (isAmbiguousAppCandidate) {
-    const unknownStartedApp =
-      journal.candidates.app?.deploymentId === null &&
-      startedForwardOperations(journal).some(
-        (operation) => operation.type === "app_v3_deploy",
-      );
-    if (
-      !unknownStartedApp ||
-      !Array.isArray(plan.rollbackStateTargets) ||
-      plan.rollbackStateTargets.length !== 0 ||
-      plan.forceFailure !== true ||
-      plan.discoveredAppCandidate !== null
-    ) {
-      throw new Error("Ambiguous app recovery plan is malformed");
-    }
-    return {
-      decision: "manual_intervention",
-      reason: "app-candidate-ambiguous-after-mapping-moved",
-      journal,
-      actions: [],
-      rollbackStateTargets: [],
-      forceFailure: true,
-      discoveredAppCandidate: null,
-    };
-  }
-
   if (!Array.isArray(plan.actions)) {
     throw new Error("Recovery plan actions are malformed");
   }
@@ -2300,15 +2274,36 @@ export function assertMainTransactionRecoveryPlan(plan) {
   const hasManualAction = actions.some(
     (entry) => entry.kind === "manual_intervention",
   );
+  const hasUnresolvedStartedApp =
+    discoveredAppCandidate === null &&
+    journal.candidates.app?.deploymentId === null &&
+    startedForwardOperations(journal).some(
+      (operation) => operation.type === "app_v3_deploy",
+    );
+  const hasAmbiguousAppAction =
+    hasUnresolvedStartedApp &&
+    actions.some(
+      (entry) =>
+        entry.kind === "manual_intervention" &&
+        (entry.target === "app" || entry.target === "legacy-app"),
+    );
   const hasLegacyEmergency = actions.some(
     (entry) => entry.kind === "legacy_emergency_restore",
   );
-  const decision = hasManualAction ? "manual_intervention" : "recover";
-  const reason = hasManualAction
-    ? "unexpected-protected-mapping"
-    : hasLegacyEmergency
-      ? "legacy-alias-moved-to-transaction-candidate"
-      : "started-operations-require-verification-or-recovery";
+  const decision =
+    hasManualAction || hasUnresolvedStartedApp
+      ? "manual_intervention"
+      : "recover";
+  const reason =
+    hasManualAction || hasUnresolvedStartedApp
+      ? hasAmbiguousAppAction
+        ? "app-candidate-ambiguous-after-mapping-moved"
+        : hasManualAction
+          ? "unexpected-protected-mapping"
+          : "app-candidate-unresolved-after-start"
+      : hasLegacyEmergency
+        ? "legacy-alias-moved-to-transaction-candidate"
+        : "started-operations-require-verification-or-recovery";
   if (
     plan.decision !== decision ||
     plan.reason !== reason ||

--- a/scripts/vercel-main-transaction.test.mjs
+++ b/scripts/vercel-main-transaction.test.mjs
@@ -2060,7 +2060,7 @@ test("app recovery restores only exact transaction-candidate aliases", () => {
   );
 });
 
-test("unknown app candidate is required only after an app mapping moved", () => {
+test("unknown App candidate remains manual with or without mapping movement", () => {
   const initial = prepared();
   const started = startMainTransactionOperation(initial, {
     type: "app_v3_deploy",
@@ -2071,7 +2071,8 @@ test("unknown app candidate is required only after an app mapping moved", () => 
     currentMappings: currentMappings(started),
     appCandidateMatches: [],
   });
-  assert.equal(priorPlan.decision, "recover");
+  assert.equal(priorPlan.decision, "manual_intervention");
+  assert.equal(priorPlan.reason, "app-candidate-unresolved-after-start");
   assert.ok(priorPlan.actions.every((entry) => entry.kind === "verified_noop"));
 
   const movedAlias = started.prior.app.aliases[0];
@@ -2098,6 +2099,7 @@ test("unknown app candidate is required only after an app mapping moved", () => 
     });
     assert.equal(plan.decision, "manual_intervention");
     assert.equal(plan.reason, "app-candidate-ambiguous-after-mapping-moved");
+    assert.ok(plan.actions.length > 0);
   }
   const unique = planMainTransactionRecovery({
     journal: started,
@@ -2109,6 +2111,61 @@ test("unknown app candidate is required only after an app mapping moved", () => 
     unique.actions.find((entry) => entry.alias === movedAlias).kind,
     "app_alias_restore",
   );
+});
+
+test("ambiguous App recovery retains safe ordinary rollback actions", () => {
+  let highest = prepared();
+  for (const target of ["governance", "reserve", "ui"]) {
+    highest = transitionSuccessfulOperation(highest, {
+      type: "promote",
+      target,
+    }).verified;
+  }
+  highest = startMainTransactionOperation(highest, {
+    type: "app_v3_deploy",
+    target: "app",
+  });
+  highest = recordMainTransactionCommandReturned(highest, {
+    operationId: highest.operations.at(-1).operationId,
+    outcome: "unknown",
+  });
+
+  const overrides = Object.fromEntries(
+    ["governance", "reserve", "ui"].flatMap((target) =>
+      highest.prior[target].aliases.map((alias) => [
+        alias,
+        highest.candidates[target],
+      ]),
+    ),
+  );
+  const movedAppAlias = highest.prior.app.aliases[1];
+  overrides[movedAppAlias] = {
+    deploymentId: "dpl_unresolvedApp123",
+    deploymentUrl: "https://unresolved-app.vercel.app",
+  };
+  const plan = planMainTransactionRecovery({
+    journal: highest,
+    currentMappings: currentMappings(highest, overrides),
+    appCandidateMatches: [],
+  });
+
+  assert.equal(plan.decision, "manual_intervention");
+  assert.equal(plan.reason, "app-candidate-ambiguous-after-mapping-moved");
+  assert.ok(
+    plan.actions.some(
+      (entry) =>
+        entry.kind === "manual_intervention" &&
+        entry.target === "app" &&
+        entry.alias === movedAppAlias,
+    ),
+  );
+  assert.deepEqual(
+    plan.actions
+      .filter((entry) => entry.kind === "ordinary_rollback")
+      .map((entry) => entry.target),
+    ["ui", "reserve", "governance"],
+  );
+  assert.deepEqual(plan.rollbackStateTargets, ["ui", "reserve", "governance"]);
 });
 
 test("unexpected app mapping is never overwritten", () => {


### PR DESCRIPTION
## The Problem

The first all-GitHub-owned production cutover reached App activation after successfully promoting Governance, Reserve, and UI. App then failed before deployment because the protected executor forwarded `VERCEL_ORG_ID` without `VERCEL_PROJECT_ID`; Vercel CLI 56.2.0 interprets that as an incomplete environment project link and exits before reading the reviewed repository link.

Recovery also stopped at the unresolved App action. It did not compensate the three independently safe ordinary promotions, and the unresolved App state could not produce canonical terminal evidence.

## The Solution

- Keep the validated Vercel team bound through the explicit `--scope` argument while omitting platform project-link variables from the child environment. This leaves the reviewed monorepo repository mapping authoritative for App's nested prebuilt output.
- Preserve App as fail-closed manual intervention when a started deploy has no durable candidate identity.
- Continue exact reverse compensation for UI, Reserve, and Governance before terminalizing manual intervention.
- Permit the zero-candidate App expectation only for manual terminal evidence; an exact-SHA candidate still makes the state proof unproven.
- Add a production-shaped regression from unknown App command through all three rollbacks and terminal artifact creation, plus focused adapter, planner, controller, and state-proof coverage.
- Update the deployment runbook with the new recovery contract.

Validation:

- `pnpm vercel:workflow:test` — 555 passed
- `pnpm vercel:deployment-state:test` — 56 passed
- `pnpm quality:budgets:test` — 34 passed
- `pnpm exec prettier --check ...` — passed for all 11 changed files
- `trunk check` — passed
- `pnpm adr:check` — passed
- Fresh correctness and security reviews — no actionable findings

Material risk: this changes the protected production App command boundary and failed-activation recovery ordering. The adapter still requires a canonical team ID, appends the exact explicit scope, keeps the token only in the filtered environment, and never converts recovery into a successful release.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes the protected production Vercel command environment and failed-activation recovery ordering for Governance, Reserve, UI, and App; incorrect behavior could mis-deploy or leave mappings inconsistent despite still failing the release.
> 
> **Overview**
> **Unblocks App activation** by stopping `VERCEL_ORG_ID` / `VERCEL_PROJECT_ID` from reaching the child CLI process while still passing the validated team through explicit `--scope`, so the reviewed repo mapping drives App’s nested prebuilt deploy instead of a partial env link.
> 
> **Tightens fail-closed App recovery**: a started `app_v3_deploy` with no durable candidate is always manual intervention (prior mappings alone are not proof). Ambiguous App census no longer returns an empty recovery plan—it keeps planning **independent** UI → Reserve → Governance rollbacks. The recovery controller no longer bails on the first manual App step; it finishes compensating ordinary targets, then terminalizes with `finishMainTransactionRecovery({ manualIntervention: true })`.
> 
> **Terminal evidence** allows a zero-candidate `recoveredPrior` expectation for manual journals (fail-closed: any discovered App candidate still makes state proof unproven). Docs and broad regression tests cover the new contract.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91f9e411c7bc975a5e8955e6bb6f4679cf53b4d4. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->