### PR TITLE
fix(ci): bind inherited recovery journal identity

### DIFF
--- a/.github/workflows/vercel-main-deployment.yml
+++ b/.github/workflows/vercel-main-deployment.yml
@@ -217,6 +217,16 @@ jobs:
       - name: Materialize strict inherited recovery decision
         id: inherited
         run: node scripts/vercel-main-provider-cli.mjs preplan-materialize --output "$RUNNER_TEMP/inherited-preplan.json"
+      - name: Bind inherited journal deployment SHA
+        env:
+          INHERITED_JOURNAL_DEPLOY_SHA: ${{ steps.inherited.outputs.inherited_journal_deploy_sha }}
+        run: |
+          set -euo pipefail
+          if [[ ! "$INHERITED_JOURNAL_DEPLOY_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "Inherited journal deployment SHA must be lowercase hexadecimal" >&2
+            exit 1
+          fi
+          printf 'MAIN_ACTIVE_JOURNAL_DEPLOY_SHA=%s\n' "$INHERITED_JOURNAL_DEPLOY_SHA" >> "$GITHUB_ENV"
       - name: Materialize inherited mapping specifications
         run: |
           node scripts/vercel-main-deployment.mjs create-spec --scope main --output "$RUNNER_TEMP/main-spec.json"

--- a/docs/vercel-deployments.md
+++ b/docs/vercel-deployments.md
@@ -156,6 +156,13 @@ Each attempt owns only its current journal, transaction IDs, snapshots, and
 recovery. Do not infer safety from artifact retention, an empty download
 directory, or GitHub's rerun count.
 
+For `restore-before-planning`, that fresh current-attempt journal keeps the
+interrupted release manifest's `DEPLOY_SHA` together with the current
+downstream run ID and attempt. The incoming release `DEPLOY_SHA` remains the
+source and planning identity. The restore job binds the validated interrupted
+release SHA only to active-journal history lookup so it cannot mistake the
+incoming release for the transaction being recovered.
+
 ### Served-SHA planning and prior-state handoff
 
 The planning job reads canonical protected state for App, Governance, Reserve,

--- a/scripts/vercel-main-deployment-workflow.test.mjs
+++ b/scripts/vercel-main-deployment-workflow.test.mjs
@@ -308,6 +308,27 @@ test("inherited restoration proves and validates reuse before a durable bounded 
     inherited.run,
     /--output "\$RUNNER_TEMP\/inherited-preplan\.json"/,
   );
+  const journalDeploySha = named(
+    jobName,
+    "Bind inherited journal deployment SHA",
+  );
+  assert.deepEqual(journalDeploySha.env, {
+    INHERITED_JOURNAL_DEPLOY_SHA:
+      "${{ steps.inherited.outputs.inherited_journal_deploy_sha }}",
+  });
+  assert.match(
+    journalDeploySha.run,
+    /INHERITED_JOURNAL_DEPLOY_SHA" =~ \^\[0-9a-f\]\{40\}\$/,
+  );
+  assert.match(
+    journalDeploySha.run,
+    /MAIN_ACTIVE_JOURNAL_DEPLOY_SHA=%s\\n.*INHERITED_JOURNAL_DEPLOY_SHA.*GITHUB_ENV/,
+  );
+  assert.doesNotMatch(journalDeploySha.run, /(?:^|[^A-Z_])DEPLOY_SHA=/);
+  assert.equal(
+    jobSteps.indexOf(inherited) + 1,
+    jobSteps.indexOf(journalDeploySha),
+  );
   const mappingSpecs = named(jobName, "inherited mapping specifications");
   assert.match(mappingSpecs.run, /create-spec --scope main/);
   assert.match(mappingSpecs.run, /create-spec --scope legacy/);
@@ -392,6 +413,7 @@ test("inherited restoration proves and validates reuse before a durable bounded 
     journal.run,
     /--preplan[\s\S]*--legacy-snapshot[\s\S]*--current-mappings[\s\S]*--candidate-receipts[\s\S]*--journal-output[\s\S]*--plan-output/,
   );
+  assert.ok(jobSteps.indexOf(journalDeploySha) < jobSteps.indexOf(journal));
 
   const preparedUpload = named(
     jobName,
@@ -419,6 +441,9 @@ test("inherited restoration proves and validates reuse before a durable bounded 
   assert.ok(jobSteps.indexOf(journal) < jobSteps.indexOf(preparedUpload));
   assert.ok(
     jobSteps.indexOf(preparedUpload) < jobSteps.indexOf(preparedCheckpoint),
+  );
+  assert.ok(
+    jobSteps.indexOf(journalDeploySha) < jobSteps.indexOf(preparedCheckpoint),
   );
   assert.ok(jobSteps.indexOf(preparedCheckpoint) < jobSteps.indexOf(runtime));
 
@@ -472,6 +497,18 @@ test("inherited restoration proves and validates reuse before a durable bounded 
       "${{ steps.recovery-runtime.outputs.vercel-cli }}",
     );
   }
+  const inheritedHistorySteps = jobSteps.filter((step) =>
+    step.run?.includes("active-journal-history"),
+  );
+  assert.ok(inheritedHistorySteps.length > 0);
+  for (const history of inheritedHistorySteps) {
+    assert.ok(jobSteps.indexOf(journalDeploySha) < jobSteps.indexOf(history));
+  }
+  for (const transition of transitions) {
+    assert.ok(
+      jobSteps.indexOf(journalDeploySha) < jobSteps.indexOf(transition),
+    );
+  }
   assert.ok(
     jobSteps.indexOf(initializedCheckpoint) < jobSteps.indexOf(transitions[0]),
   );
@@ -506,6 +543,14 @@ test("inherited restoration proves and validates reuse before a durable bounded 
   assert.ok(jobSteps.indexOf(finalHead) < jobSteps.indexOf(requireRecovered));
   assert.ok(jobSteps.indexOf(requireRecovered) < jobSteps.indexOf(cleanup));
   assert.ok(jobSteps.indexOf(cleanup) < jobSteps.indexOf(outcome));
+  for (const [name, otherJob] of Object.entries(workflow.jobs)) {
+    if (name === jobName) continue;
+    assert.doesNotMatch(
+      JSON.stringify(otherJob),
+      /MAIN_ACTIVE_JOURNAL_DEPLOY_SHA/,
+      `${name} must not override the inherited journal deployment SHA`,
+    );
+  }
 });
 
 test("only inherited ordinary restoration uses inherited candidate finalization", () => {

--- a/scripts/vercel-main-deployment.mjs
+++ b/scripts/vercel-main-deployment.mjs
@@ -7538,6 +7538,10 @@ function finalJobsFromEnvironment(values) {
   };
 }
 
+function mainActiveJournalDeployShaFromEnvironment(values) {
+  return values.MAIN_ACTIVE_JOURNAL_DEPLOY_SHA ?? values.DEPLOY_SHA;
+}
+
 function finalActiveExecution(values, executionPath) {
   const deploySha = requireSha(
     values.DEPLOY_SHA,
@@ -8680,7 +8684,7 @@ export async function runMainDeploymentCli({
   }
   if (command === "active-journal-history") {
     const identity = createMainActiveJournalHistoryIdentity({
-      deploySha: values.DEPLOY_SHA,
+      deploySha: mainActiveJournalDeployShaFromEnvironment(values),
       runId: values.GITHUB_RUN_ID,
       runAttempt: values.GITHUB_RUN_ATTEMPT,
     });
@@ -8722,7 +8726,7 @@ export async function runMainDeploymentCli({
   }
   if (command === "active-journal-identity") {
     const identity = createMainActiveJournalHistoryIdentity({
-      deploySha: values.DEPLOY_SHA,
+      deploySha: mainActiveJournalDeployShaFromEnvironment(values),
       runId: values.GITHUB_RUN_ID,
       runAttempt: values.GITHUB_RUN_ATTEMPT,
     });

--- a/scripts/vercel-main-deployment.test.mjs
+++ b/scripts/vercel-main-deployment.test.mjs
@@ -4,6 +4,7 @@ import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import {
   mkdtempSync,
+  mkdirSync,
   readFileSync,
   rmSync,
   statSync,
@@ -5398,6 +5399,87 @@ test("active journal identity rejects missing and ambiguous artifact histories",
       }),
     /mode/,
   );
+});
+
+test("active journal CLI accepts an inherited release SHA only through its dedicated override", async () => {
+  const directory = mkdtempSync(
+    join(tmpdir(), "vercel-main-inherited-journal-"),
+  );
+  try {
+    const artifactsDirectory = join(directory, "journals");
+    const output = join(directory, "history.json");
+    const githubOutput = join(directory, "github-output");
+    const journal = createPreparedMainActiveJournal({
+      plan: activePlan(),
+      stageJobs: stageJobs(activePlan()),
+      appBuildProof: appProof(activePlan()),
+      runId: "800",
+      runAttempt: "3",
+    });
+    const artifactName = mainTransactionJournalArtifactName(journal);
+    mkdirSync(join(artifactsDirectory, artifactName), { recursive: true });
+    writeFileSync(
+      join(artifactsDirectory, artifactName, "main-journal.json"),
+      `${JSON.stringify(journal)}\n`,
+    );
+    writeFileSync(githubOutput, "");
+
+    const currentAttemptValues = {
+      DEPLOY_SHA: OTHER_SHA,
+      GITHUB_OUTPUT: githubOutput,
+      GITHUB_RUN_ID: "800",
+      GITHUB_RUN_ATTEMPT: "3",
+    };
+    const historyArguments = [
+      "active-journal-history",
+      "--artifacts",
+      artifactsDirectory,
+      "--output",
+      output,
+    ];
+
+    await assert.rejects(
+      runMainDeploymentCli({
+        argv: historyArguments,
+        values: currentAttemptValues,
+      }),
+      /No active journal artifacts match the transaction/,
+    );
+
+    const inheritedIdentity = await runMainDeploymentCli({
+      argv: ["active-journal-identity"],
+      values: {
+        ...currentAttemptValues,
+        MAIN_ACTIVE_JOURNAL_DEPLOY_SHA: SHA,
+      },
+    });
+    assert.equal(inheritedIdentity.deploySha, SHA);
+    assert.equal(inheritedIdentity.transactionId, journal.transactionId);
+
+    const history = await runMainDeploymentCli({
+      argv: historyArguments,
+      values: {
+        ...currentAttemptValues,
+        MAIN_ACTIVE_JOURNAL_DEPLOY_SHA: SHA,
+      },
+    });
+    assert.deepEqual(history.journals, [journal]);
+    assert.deepEqual(JSON.parse(readFileSync(output, "utf8")), history);
+
+    await assert.rejects(
+      runMainDeploymentCli({
+        argv: historyArguments,
+        values: {
+          ...currentAttemptValues,
+          MAIN_ACTIVE_JOURNAL_DEPLOY_SHA: SHA,
+          GITHUB_RUN_ATTEMPT: "4",
+        },
+      }),
+      /No active journal artifacts match the transaction/,
+    );
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
 });
 
 test("active recovery planning and execution hand off exact reverse mutations and stay release-failing", async () => {

--- a/scripts/vercel-main-provider-cli.mjs
+++ b/scripts/vercel-main-provider-cli.mjs
@@ -1160,6 +1160,7 @@ export async function runMainProviderCli({
       inherited_candidate_targets: JSON.stringify(
         result.rollbackAuthorization.targets,
       ),
+      inherited_journal_deploy_sha: result.reconciliation.manifest.deploySha,
     });
     stdout.write("Canonical pre-plan handoff materialized\n");
     return result;

--- a/scripts/vercel-main-provider-cli.test.mjs
+++ b/scripts/vercel-main-provider-cli.test.mjs
@@ -770,7 +770,11 @@ test("preplan materialization accepts only inherited restore and exposes ordered
   assert.deepEqual(readJson(output), decision);
   assert.equal(
     readFileSync(context.githubOutput, "utf8"),
-    'inherited_candidate_targets=["governance"]\n',
+    [
+      'inherited_candidate_targets=["governance"]',
+      `inherited_journal_deploy_sha=${inherited.deploySha}`,
+      "",
+    ].join("\n"),
   );
 });
 


### PR DESCRIPTION
## The Problem

The exact-main production cutover failed closed while restoring an interrupted release. The recovery job uploaded the correct current-attempt journal, but `active-journal-history` searched with the incoming release SHA instead of the interrupted release SHA, so it rejected the artifact before any production mutation.

## The Solution

Bind active-journal history lookup to the interrupted release SHA emitted by the validated pre-plan handoff. Keep the incoming `DEPLOY_SHA` unchanged for source and planning identity, and scope the override to the inherited-recovery job.

The regression coverage recreates the production identity boundary: an old release SHA with the current run and attempt, alongside a different incoming SHA. It proves the default lookup rejects that journal, the dedicated inherited identity accepts it, and a wrong run attempt still fails closed.

## Validation

- `pnpm vercel:workflow:test` — 556 passed
- `pnpm vercel:deployment-state:test` — 56 passed
- `pnpm quality:budgets:test` — 34 passed
- `pnpm adr:check` — passed
- `trunk fmt <7 changed files>` — no issues
- `trunk check <7 changed files>` — no issues
- Nine-lens specialist review — no findings
- Fresh-context semantic autoreview — clean
- Local deterministic autoreview — clean

Material risk: this changes production recovery identity wiring. The override comes from a decoded and validated handoff, is checked as an exact lowercase 40-hex SHA before entering the job environment, and is absent from ordinary deployment jobs.

## Ship Checklist

- [x] PR title follows the conventions
- [x] Performed a self-review of my own changes
- [x] Relevant automated checks and smoke tests pass
- [x] Architecture decision: not applicable — this repairs the implementation of the existing GitHub Actions deployment ADR without changing the decision

Relates to #522.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes production recovery identity wiring for journal history; the override is validated and scoped to the inherited-recovery job, but a wrong SHA would still affect which journals authorize recovery mutations.
> 
> **Overview**
> Fixes **restore-before-planning** so active-journal lookup uses the **interrupted release’s** deploy SHA instead of the incoming release’s `DEPLOY_SHA`, which had caused `active-journal-history` to reject the current-attempt journal before recovery could run.
> 
> `preplan-materialize` now emits **`inherited_journal_deploy_sha`** from the validated handoff manifest. The inherited-recovery job adds a step that checks a 40-character lowercase hex SHA and sets **`MAIN_ACTIVE_JOURNAL_DEPLOY_SHA`** on `GITHUB_ENV` (without changing job-level `DEPLOY_SHA` for checkout/planning). **`active-journal-history`** and **`active-journal-identity`** resolve journal identity via `MAIN_ACTIVE_JOURNAL_DEPLOY_SHA` when set, otherwise `DEPLOY_SHA`.
> 
> Docs describe this split for `restore-before-planning`. Workflow and CLI tests lock step order, env scoping to that job only, and the mismatch scenario (different incoming vs interrupted SHA, same run/attempt).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 669c54521a7e5b6e15cf513288868d7a61c9c6d1. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->