### PR TITLE
fix(ci): defer App candidate authority to receipt

### DIFF
--- a/scripts/vercel-main-active-controller.mjs
+++ b/scripts/vercel-main-active-controller.mjs
@@ -1133,21 +1133,16 @@ export function reduceMainActiveTransition({
       throw new Error("Command result does not bind the authorized operation");
     }
     const result = assertMainActiveCommandResult(input.result);
-    let candidate = null;
-    if (operation.type === "app_v3_deploy") {
-      if (result.candidate !== null) {
-        candidate = {
-          ...result.candidate,
-          ...highest.candidates.app.discovery,
-        };
-      }
-    } else if (result.candidate !== null) {
+    if (operation.type !== "app_v3_deploy" && result.candidate !== null) {
       throw new Error("Non-App command cannot report an App candidate");
     }
     const returned = recordMainTransactionCommandReturned(highest, {
       operationId: operation.operationId,
       outcome: result.outcome,
-      candidate,
+      // The App command result records only the deploy command outcome.
+      // The finalized receipt remains the sole authority for candidate identity
+      // and immutable smoke proof.
+      candidate: null,
     });
     return journalTransition(returned, "verify");
   }

--- a/scripts/vercel-main-active-controller.test.mjs
+++ b/scripts/vercel-main-active-controller.test.mjs
@@ -41,7 +41,9 @@ import {
   createMainReleaseManifest,
 } from "./vercel-main-release-reconciliation.mjs";
 import {
+  canonicalizeMainCandidateVercelMetadata,
   createMainCandidateIntent,
+  createMainCandidateReceipt,
   createMainCandidateVercelMetadata,
 } from "./vercel-main-candidate.mjs";
 
@@ -255,6 +257,85 @@ function prepared(
       }),
     ),
     candidates,
+  });
+}
+
+function preparedPendingApp() {
+  const initial = prepared(["app"]);
+  const intent = createMainCandidateIntent({
+    target: "app",
+    deploySha: initial.deploySha,
+    upstreamRunId: initial.release.upstreamRunId,
+    originRunId: initial.runId,
+    originAttempt: initial.runAttempt,
+    originTransactionId: initial.transactionId,
+    projectId: initial.release.originalPriors.app.projectId,
+    projectName: initial.release.originalPriors.app.projectName,
+    releaseManifest: initial.release,
+  });
+  return {
+    ...initial,
+    candidates: {
+      ...initial.candidates,
+      app: {
+        ...initial.candidates.app,
+        deploymentId: null,
+        deploymentUrl: null,
+        discovery: {
+          ...initial.candidates.app.discovery,
+          candidateId: intent.candidateId,
+          immutableSmoke: null,
+        },
+      },
+    },
+  };
+}
+
+function appCandidateReceipt(journal) {
+  const intent = createMainCandidateIntent({
+    target: "app",
+    deploySha: journal.deploySha,
+    upstreamRunId: journal.release.upstreamRunId,
+    originRunId: journal.runId,
+    originAttempt: journal.runAttempt,
+    originTransactionId: journal.transactionId,
+    projectId: journal.release.originalPriors.app.projectId,
+    projectName: journal.release.originalPriors.app.projectName,
+    releaseManifest: journal.release,
+  });
+  const metadata = canonicalizeMainCandidateVercelMetadata(
+    createMainCandidateVercelMetadata({ intent }),
+    {
+      target: "app",
+      deploySha: intent.deploySha,
+      projectId: intent.projectId,
+      projectName: intent.projectName,
+    },
+  );
+  return createMainCandidateReceipt({
+    intent,
+    candidate: {
+      deploymentId: "dpl_appCandidate123",
+      deploymentUrl: "https://app-candidate.vercel.app",
+      projectId: intent.projectId,
+      projectName: intent.projectName,
+      readyState: "READY",
+      target: null,
+      customEnvironmentSlug: "v3",
+      source: "cli",
+      git: {
+        org: "mento-protocol",
+        repo: "frontend-monorepo",
+        ref: "main",
+        sha: intent.deploySha,
+      },
+      metadata,
+    },
+    immutableSmoke: {
+      immutableUrl: "https://app-candidate.vercel.app",
+      servedSha: intent.deploySha,
+      status: "passed",
+    },
   });
 }
 
@@ -1066,6 +1147,81 @@ test("lost App output routes to recovery without provider match authority", () =
   assert.equal(verified.journal.candidates.app.deploymentId, null);
   assert.equal(verified.journal.operations.at(-1).mappingState, "unknown");
   assert.equal(verified.afterUploadAction, "recover");
+});
+
+test("App command output remains pending until the finalized receipt attaches candidate authority", () => {
+  const initial = preparedPendingApp();
+  const history = [
+    reduceForward(initial, [], event("initialize"), ["app"]).journal,
+  ];
+  const dispatched = reduceForward(
+    initial,
+    history,
+    event("dispatch", {
+      uploadReceipt: receipt(history.at(-1)),
+      freshSha: SHA,
+      currentMappings: currentMappings(history.at(-1)),
+    }),
+    ["app"],
+  );
+  history.push(dispatched.journal);
+  const authorized = reduceForward(
+    initial,
+    history,
+    event("authorize", {
+      uploadReceipt: receipt(history.at(-1)),
+      freshSha: SHA,
+      currentMappings: currentMappings(history.at(-1)),
+    }),
+    ["app"],
+  );
+  const returned = reduceForward(
+    initial,
+    history,
+    event("command-returned", {
+      uploadReceipt: receipt(history.at(-1)),
+      operationId: authorized.operationId,
+      command: authorized.command,
+      result: {
+        outcome: "success",
+        reason: null,
+        candidate: {
+          deploymentId: "dpl_appCliOutput123",
+          deploymentUrl: "https://app-cli-output.vercel.app",
+        },
+      },
+    }),
+    ["app"],
+  );
+  assert.equal(returned.journal.candidates.app.deploymentId, null);
+  assert.equal(returned.journal.candidates.app.discovery.immutableSmoke, null);
+  history.push(returned.journal);
+
+  const finalizedReceipt = appCandidateReceipt(initial);
+  const attached = reduceForward(
+    initial,
+    history,
+    event("verify", {
+      uploadReceipt: receipt(history.at(-1)),
+      freshSha: SHA,
+      currentMappings: currentMappings(history.at(-1)),
+      appCandidateReceipt: finalizedReceipt,
+      appDeployment: null,
+    }),
+    ["app"],
+  );
+  assert.equal(
+    attached.journal.candidates.app.deploymentId,
+    finalizedReceipt.candidate.deploymentId,
+  );
+  assert.equal(
+    attached.journal.candidates.app.deploymentUrl,
+    finalizedReceipt.candidate.deploymentUrl,
+  );
+  assert.deepEqual(
+    attached.journal.candidates.app.discovery.immutableSmoke,
+    finalizedReceipt.immutableSmoke,
+  );
 });
 
 test("provider-stable App candidates replace recovery discovery", () => {

--- a/scripts/vercel-main-active-transition.test.mjs
+++ b/scripts/vercel-main-active-transition.test.mjs
@@ -155,7 +155,13 @@ function appCandidateReceipt(journal) {
   });
 }
 
-function driveToCommandReturn(initial, activeTargets) {
+function driveToCommandReturn(
+  initial,
+  activeTargets,
+  {
+    commandResult = { outcome: "success", reason: null, candidate: null },
+  } = {},
+) {
   const history = [];
   const initialized = reduce(
     initial,
@@ -192,19 +198,35 @@ function driveToCommandReturn(initial, activeTargets) {
       uploadReceipt: receipt(history.at(-1)),
       operationId: authorized.operationId,
       command: authorized.command,
-      result: { outcome: "success", reason: null, candidate: null },
+      result: commandResult,
     }),
     activeTargets,
   );
   history.push(returned.journal);
-  return { authorized, history };
+  return { authorized, returned, history };
 }
 
-test("App receipt attachment is durably followed by a receipt-free verification", () => {
+test("App command output stays pending until its receipt attaches canonical smoke", () => {
   const activeTargets = ["app"];
   const initial = preparedFor(activeTargets, { pendingApp: true });
-  const { history } = driveToCommandReturn(initial, activeTargets);
   const providerReceipt = appCandidateReceipt(initial);
+  const { history, returned } = driveToCommandReturn(initial, activeTargets, {
+    commandResult: {
+      outcome: "success",
+      reason: null,
+      candidate: {
+        deploymentId: "dpl_appCliOutput123",
+        deploymentUrl: "https://app-cli-output.vercel.app",
+      },
+    },
+  });
+
+  assert.equal(returned.journal.status, "command_returned");
+  assert.equal(returned.journal.operations.at(-1).state, "command_returned");
+  assert.equal(returned.journal.candidates.app.deploymentId, null);
+  assert.equal(returned.journal.candidates.app.deploymentUrl, null);
+  assert.equal(returned.journal.candidates.app.discovery.immutableSmoke, null);
+
   const appDeployment = {
     deploymentId: providerReceipt.candidate.deploymentId,
     deploymentUrl: providerReceipt.candidate.deploymentUrl,
@@ -228,6 +250,10 @@ test("App receipt attachment is durably followed by a receipt-free verification"
   assert.equal(
     attached.journal.candidates.app.deploymentId,
     "dpl_appCandidate123",
+  );
+  assert.deepEqual(
+    attached.journal.candidates.app.discovery.immutableSmoke,
+    providerReceipt.immutableSmoke,
   );
   assert.equal(attached.afterUploadAction, "verify");
   history.push(attached.journal);


### PR DESCRIPTION
## The Problem

Production cutover run 30318518128 built and staged every target, completed the three ordinary promotions, and returned a successful App deployment identity. The active controller then combined that identity with the still-pending discovery record before immutable smoke existed. Canonicalization rejected the incomplete record with `App candidate immutable smoke is malformed`, after the App mutation had already happened, and recovery had to fail closed.

## The Solution

Keep the App deploy command result as execution evidence only. The active controller now records the command outcome without attaching candidate identity, then lets the exact finalized provider receipt remain the sole authority for the App deployment identity and immutable smoke.

Production-shaped regressions use a deliberately conflicting but valid CLI deployment identity and prove that:

- the command-return checkpoint remains pending;
- no CLI identity or smoke enters the durable journal;
- the exact finalized receipt attaches the canonical identity and immutable smoke;
- receipt-free verification can continue from that durable checkpoint.

Relates to #522.

## Validation

- `pnpm vercel:workflow:test` — 557 passed
- `pnpm vercel:deployment-state:test` — 56 passed
- `pnpm quality:budgets:test` — 34 passed
- `pnpm adr:check`
- `trunk fmt scripts/vercel-main-active-controller.mjs scripts/vercel-main-active-controller.test.mjs scripts/vercel-main-active-transition.test.mjs`
- `trunk check scripts/vercel-main-active-controller.mjs scripts/vercel-main-active-controller.test.mjs scripts/vercel-main-active-transition.test.mjs`
- `git diff --check`
- Pre-push type checks, Trunk checks, and Knip
- Three focused read-only reviews plus fresh-context autoreview

## Ship Checklist

- [x] PR title follows the [conventions](https://www.notion.so/Git-Branching-and-Commit-Message-Conventions-18f66f7d06444cfcbac5725ffbc7c04a?pvs=4#9355048863c549ef92fe210a8a1298aa)
- [x] Performed a self-review of my own changes
- [x] Relevant automated checks and smoke tests pass
- [x] Architecture decision? Not applicable — this restores the receipt-authority contract documented by the existing GitHub-driven Vercel deployment architecture.

## Risk

The change affects only the App command-return checkpoint in the active main-deployment controller. It does not weaken canonical candidate or smoke validation. The next exact-main run must prove the full provider transition, rollback journal behavior, final public state, and browser smokes before the cutover is considered complete.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the App forward checkpoint in the main active deployment controller—a critical cutover path—but narrows authority rather than weakening validation; remaining risk is behavioral regression in the App deploy → receipt → alias sequence.
> 
> **Overview**
> Fixes a production failure where a successful App CLI return was merged into discovery **before** immutable smoke existed, causing canonicalization to reject the journal after the deploy mutation.
> 
> **`reduceMainActiveTransition` (`command-returned`):** For `app_v3_deploy`, the handler no longer builds a candidate from `result.candidate` merged with discovery. It always calls `recordMainTransactionCommandReturned` with `candidate: null`, so the checkpoint records **outcome only**. Non-App operations still error if `result.candidate` is set.
> 
> **Verify path (unchanged in this diff but exercised by tests):** App deployment identity and immutable smoke are attached later via `appCandidateReceipt` on verify (`attachMainTransactionAppCandidateReceipt`).
> 
> **Tests:** New helpers (`preparedPendingApp`, `appCandidateReceipt`) and cases assert that a conflicting successful CLI candidate leaves the journal pending (null deployment URLs, null smoke) until verify applies the finalized receipt; transition tests cover the two-turn verify flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a05305ecb683bb40ca1c092aa784316309ebaeb. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->