### PR TITLE
fix(ci): recover App-only release residuals

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,12 +76,12 @@ provider's protected mappings and candidates against that manifest. It reuses
 a complete release, resumes or restores an interrupted forward prefix as
 appropriate, or restores the exact terminal App recovery residual through a
 fresh current-attempt journal before new planning can proceed. That residual
-requires every active non-App target at its original prior and every reviewed
-App alias at one manifest-bound candidate; it grants App restoration authority
-only and never forward resumption. It never resumes or treats a prior attempt's
-journal artifact as cross-attempt authority. Every other non-prefix,
-ambiguous, conflicting, or incomplete provider state fails closed before the
-release continues.
+requires at least one active non-App target, every active non-App target at its
+original prior, and every reviewed App alias at one manifest-bound candidate;
+it grants App restoration authority only and never forward resumption. It never
+resumes or treats a prior attempt's journal artifact as cross-attempt authority.
+Every other non-prefix, ambiguous, conflicting, or incomplete provider state
+fails closed before the release continues.
 
 Every selected Governance, Reserve, and UI target stages and verifies an
 immutable candidate with `--prod --skip-domain`. Only an `activeTargets` member

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,12 +72,16 @@ upstream CI run ID—and the target-specific candidate identity adds the target.
 The provider-side stable release manifest is the sole durable cross-attempt
 authority. Mutation transaction IDs and journals remain downstream
 run-and-attempt scoped. Before planning, a later attempt reconciles the
-provider's protected mappings and candidates against that manifest. It either
-reuses a complete release or, for an interrupted prefix, restores the inherited
-state through a fresh current-attempt journal before new planning can proceed.
-It never resumes or treats a prior attempt's journal artifact as cross-attempt
-authority. Ambiguous, conflicting, or incomplete provider state fails closed
-before the release continues.
+provider's protected mappings and candidates against that manifest. It reuses
+a complete release, resumes or restores an interrupted forward prefix as
+appropriate, or restores the exact terminal App recovery residual through a
+fresh current-attempt journal before new planning can proceed. That residual
+requires every active non-App target at its original prior and every reviewed
+App alias at one manifest-bound candidate; it grants App restoration authority
+only and never forward resumption. It never resumes or treats a prior attempt's
+journal artifact as cross-attempt authority. Every other non-prefix,
+ambiguous, conflicting, or incomplete provider state fails closed before the
+release continues.
 
 Every selected Governance, Reserve, and UI target stages and verifies an
 immutable candidate with `--prod --skip-domain`. Only an `activeTargets` member

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -178,18 +178,18 @@ journals remain downstream run-and-attempt scoped. Before planning, a later
 attempt reconciles provider mappings and candidates with that manifest. It
 reuses a completed release, resumes or restores an interrupted forward prefix
 as appropriate, or restores the exact terminal App recovery residual through a
-fresh current-attempt journal before new planning. That residual requires every
-active non-App target at its original prior and every reviewed App alias at one
-manifest-bound candidate; it grants App restoration authority only and never
-forward resumption. It never resumes a prior journal or treats GitHub artifacts
-as cross-attempt authority. The compact terminal receipt and evidence are the
-only final-verdict handoff and support final-only reruns. A completed release
-emits `current-release-verified` only after fresh mapping, census/state, raw
-public-runtime-smoke, legacy `v2`, and freshness proof; it creates no journal
-and executes no public mutation. App shadow preparation is build-only terminal
-evidence and never creates a provider deployment. Every other non-prefix,
-ambiguous, conflicting, or incomplete provider state fails closed before
-production work continues.
+fresh current-attempt journal before new planning. That residual requires at
+least one active non-App target, every active non-App target at its original
+prior, and every reviewed App alias at one manifest-bound candidate; it grants
+App restoration authority only and never forward resumption. It never resumes a
+prior journal or treats GitHub artifacts as cross-attempt authority. The compact
+terminal receipt and evidence are the only final-verdict handoff and support
+final-only reruns. A completed release emits `current-release-verified` only
+after fresh mapping, census/state, raw public-runtime-smoke, legacy `v2`, and
+freshness proof; it creates no journal and executes no public mutation. App
+shadow preparation is build-only terminal evidence and never creates a provider
+deployment. Every other non-prefix, ambiguous, conflicting, or incomplete
+provider state fails closed before production work continues.
 
 ## Coding Conventions
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,15 +176,19 @@ candidate identity adds the target. The provider-side stable release manifest
 is the sole durable cross-attempt authority. Mutation transaction IDs and
 journals remain downstream run-and-attempt scoped. Before planning, a later
 attempt reconciles provider mappings and candidates with that manifest. It
-reuses a completed release, or restores an inherited partial release through a
-fresh current-attempt journal before new planning. It never resumes a prior
-journal or treats GitHub artifacts as cross-attempt authority. The compact
-terminal receipt and evidence are the only final-verdict handoff and support
-final-only reruns. A completed release emits `current-release-verified` only
-after fresh mapping, census/state, raw public-runtime-smoke, legacy `v2`, and
-freshness proof; it creates no journal and executes no public mutation. App
-shadow preparation is build-only terminal evidence and never creates a provider
-deployment. Ambiguous or incomplete provider state fails closed before
+reuses a completed release, resumes or restores an interrupted forward prefix
+as appropriate, or restores the exact terminal App recovery residual through a
+fresh current-attempt journal before new planning. That residual requires every
+active non-App target at its original prior and every reviewed App alias at one
+manifest-bound candidate; it grants App restoration authority only and never
+forward resumption. It never resumes a prior journal or treats GitHub artifacts
+as cross-attempt authority. The compact terminal receipt and evidence are the
+only final-verdict handoff and support final-only reruns. A completed release
+emits `current-release-verified` only after fresh mapping, census/state, raw
+public-runtime-smoke, legacy `v2`, and freshness proof; it creates no journal
+and executes no public mutation. App shadow preparation is build-only terminal
+evidence and never creates a provider deployment. Every other non-prefix,
+ambiguous, conflicting, or incomplete provider state fails closed before
 production work continues.
 
 ## Coding Conventions

--- a/README.md
+++ b/README.md
@@ -490,16 +490,19 @@ The repository is set up with GitHub Actions for CI:
   validated upstream CI run, candidate identities, and captured rollback priors;
   it is the sole durable cross-attempt authority. Mutation journals remain
   run-and-attempt scoped. A complete release is reused after fresh provider
-  validation. An interrupted prefix is restored through a fresh
-  current-attempt journal before new planning. No prior journal is resumed and
+  validation. An interrupted forward prefix is resumed or restored as
+  appropriate through a fresh current-attempt journal. The exact terminal App
+  recovery residual—every active non-App target at its original prior and every
+  reviewed App alias at one manifest-bound candidate—may restore App before new
+  planning, but may never resume forward. No prior journal is resumed and
   GitHub artifacts do not authorize cross-attempt work. The compact terminal
   receipt and evidence are the only final-verdict handoff and support
   final-only reruns. A completed release emits `current-release-verified` only
   after fresh mapping, census/state, raw public-runtime-smoke, legacy `v2`, and
   freshness proof; it creates no journal and executes no public mutation. App
   shadow preparation is build-only terminal evidence, never a provider
-  deployment. Ambiguous, conflicting, or incomplete provider state fails closed
-  before production work continues.
+  deployment. Every other non-prefix, ambiguous, conflicting, or incomplete
+  provider state fails closed before production work continues.
   The version-controlled preview-controller mode is `active`; per-target
   preview ownership and exact expected Vercel configurations are executable
   invariants. The trusted preview controller reads every selected target's

--- a/README.md
+++ b/README.md
@@ -492,17 +492,18 @@ The repository is set up with GitHub Actions for CI:
   run-and-attempt scoped. A complete release is reused after fresh provider
   validation. An interrupted forward prefix is resumed or restored as
   appropriate through a fresh current-attempt journal. The exact terminal App
-  recovery residual—every active non-App target at its original prior and every
-  reviewed App alias at one manifest-bound candidate—may restore App before new
-  planning, but may never resume forward. No prior journal is resumed and
-  GitHub artifacts do not authorize cross-attempt work. The compact terminal
-  receipt and evidence are the only final-verdict handoff and support
-  final-only reruns. A completed release emits `current-release-verified` only
-  after fresh mapping, census/state, raw public-runtime-smoke, legacy `v2`, and
-  freshness proof; it creates no journal and executes no public mutation. App
-  shadow preparation is build-only terminal evidence, never a provider
-  deployment. Every other non-prefix, ambiguous, conflicting, or incomplete
-  provider state fails closed before production work continues.
+  recovery residual—at least one active non-App target with every such target
+  at its original prior, and every reviewed App alias at one manifest-bound
+  candidate—may restore App before new planning, but may never resume forward.
+  No prior journal is resumed and GitHub artifacts do not authorize
+  cross-attempt work. The compact terminal receipt and evidence are the only
+  final-verdict handoff and support final-only reruns. A completed release emits
+  `current-release-verified` only after fresh mapping, census/state, raw
+  public-runtime-smoke, legacy `v2`, and freshness proof; it creates no journal
+  and executes no public mutation. App shadow preparation is build-only terminal
+  evidence, never a provider deployment. Every other non-prefix, ambiguous,
+  conflicting, or incomplete provider state fails closed before production work
+  continues.
   The version-controlled preview-controller mode is `active`; per-target
   preview ownership and exact expected Vercel configurations are executable
   invariants. The trusted preview controller reads every selected target's

--- a/docs/adr/0005-stable-main-release-identity-and-rerun-admission.md
+++ b/docs/adr/0005-stable-main-release-identity-and-rerun-admission.md
@@ -3,7 +3,7 @@ title: Stable active-main release identity and provider-side rerun reconciliatio
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-07-27
+last_verified: 2026-07-28
 scope: ci/deployment/main-reruns
 date: 2026-07
 ---
@@ -77,11 +77,12 @@ planning.
   capture a baseline.
 - If either an older or matching release explains the exact terminal App
   recovery residual, the controller restores only App through a fresh
-  current-attempt journal before new planning. This residual requires every
-  active non-App target at its original prior and every reviewed App alias at
-  one manifest-bound candidate. It can occur when the App command moves aliases
-  before the controller checkpoints its return while recovery has already
-  restored the ordinary targets. It never authorizes forward resumption.
+  current-attempt journal before new planning. This residual requires at least
+  one active non-App target, every active non-App target at its original prior,
+  and every reviewed App alias at one manifest-bound candidate. It can occur
+  when the App command moves aliases before the controller checkpoints its
+  return while recovery has already restored the ordinary targets. It never
+  authorizes forward resumption.
 - If no mapped release explains the protected state, it captures a new baseline.
   Every other non-prefix, ambiguous, conflicting, incomplete, or unverified
   provider state fails closed.

--- a/docs/adr/0005-stable-main-release-identity-and-rerun-admission.md
+++ b/docs/adr/0005-stable-main-release-identity-and-rerun-admission.md
@@ -75,9 +75,16 @@ planning.
   restores the inherited partial release into a fresh current-attempt journal.
   Only after that recovery reaches its terminal state may new-release planning
   capture a baseline.
+- If either an older or matching release explains the exact terminal App
+  recovery residual, the controller restores only App through a fresh
+  current-attempt journal before new planning. This residual requires every
+  active non-App target at its original prior and every reviewed App alias at
+  one manifest-bound candidate. It can occur when the App command moves aliases
+  before the controller checkpoints its return while recovery has already
+  restored the ordinary targets. It never authorizes forward resumption.
 - If no mapped release explains the protected state, it captures a new baseline.
-  Ambiguous, non-prefix, conflicting, incomplete, or unverified provider state
-  fails closed.
+  Every other non-prefix, ambiguous, conflicting, incomplete, or unverified
+  provider state fails closed.
 
 Every unmarked protected mapping in a new baseline is rollback-only regardless
 of its optional Vercel `source`, Git metadata, or served SHA. The planner forces
@@ -151,12 +158,23 @@ matching URL alone cannot prove a safe release state.
 Rejected. The provider reconciliation already establishes the completed
 release. Replaying mutations adds risk without changing the public result.
 
+### Require manual recovery for every non-prefix provider state
+
+Rejected. The terminal App recovery residual is fully explained by one
+canonical manifest, exact captured priors, and complete reviewed App aliases.
+Restricting automation to reverse-only App restoration preserves the same
+compensation authority while avoiding a manual alias rollback after a
+checkpoint failure. Partial App mappings, ordinary candidate suffixes, and
+every other non-prefix state still require manual intervention.
+
 ## Consequences
 
 - The provider-side release manifest, not GitHub artifact history, is the
   durable cross-attempt source of truth.
 - Every attempt has an independently auditable journal and recovery boundary.
 - An inherited partial release is restored before a new baseline can be planned.
+- The exact terminal App recovery residual may restore only App before a new
+  baseline; it never authorizes forward resumption.
 - An unmarked protected mapping always forces reviewed GitHub preparation before
   it can become eligible for an already-current no-op. Only active-owned targets
   replace the public mapping.

--- a/docs/adr/0005-stable-main-release-identity-and-rerun-admission.md
+++ b/docs/adr/0005-stable-main-release-identity-and-rerun-admission.md
@@ -211,7 +211,8 @@ The implementation and tests are the current repository evidence:
 
 - `scripts/vercel-main-release-planner.mjs` and
   `scripts/vercel-main-release-reconciliation.mjs` — canonical manifest,
-  provider census, reconciliation, and inherited-prefix decisions;
+  provider census, reconciliation, inherited-prefix decisions, and terminal App
+  residual restoration;
 - `scripts/vercel-main-release-journal.mjs` and
   `scripts/vercel-main-release-execution.mjs` — fresh current-attempt journals
   and bounded execution handoffs;

--- a/docs/vercel-deployments.md
+++ b/docs/vercel-deployments.md
@@ -113,12 +113,13 @@ run, ownership mode, staged and active targets, release-plan digest, and every
 captured protected rollback prior. A provider census must be complete and
 stable, each candidate must carry one exact canonical manifest, and the current
 protected mappings must form one canonical forward release prefix or the exact
-terminal App recovery residual: all active non-App targets at their original
-priors and every reviewed App alias at one canonical candidate. That residual
-authorizes `restore-before-planning`, even for the matching release; it never
-authorizes forward resumption. Missing, ambiguous, conflicting, malformed,
-non-prefix, or incomplete provider state fails closed. GitHub artifacts and
-prior job history are not alternate cross-attempt authority.
+terminal App recovery residual: at least one active non-App target with every
+such target at its original prior, and every reviewed App alias at one canonical
+candidate. That residual authorizes `restore-before-planning`, even for the
+matching release; it never authorizes forward resumption. Missing, ambiguous,
+conflicting, malformed, non-prefix, or incomplete provider state fails closed.
+GitHub artifacts and prior job history are not alternate cross-attempt
+authority.
 
 Vercel's optional deployment `source` field is diagnostic telemetry, not
 ownership authority. Every protected mapping without complete canonical Mento

--- a/docs/vercel-deployments.md
+++ b/docs/vercel-deployments.md
@@ -425,13 +425,13 @@ zero-candidate expectation only to publish fail-closed terminal evidence: any
 observed App candidate makes that state proof unproven and never upgrades the
 manual outcome to recovered.
 
-If provider reconciliation cannot establish one safe manifest and canonical
-mapping prefix, do not delete or recreate evidence. Inspect the live protected
-state and use the current-attempt recovery contract where the reconciliation
-decision permits it. Otherwise follow the target-local or full-native rollback
-procedure, verify the protected mappings, and begin a new release only from a
-new validated upstream CI run. Do not create a GitHub-artifact or prior-journal
-fallback path.
+If provider reconciliation cannot establish one safe manifest and either a
+canonical forward mapping prefix or the exact terminal App recovery residual,
+do not delete or recreate evidence. Inspect the live protected state and use
+the current-attempt recovery contract where the reconciliation decision permits
+it. Otherwise follow the target-local or full-native rollback procedure, verify
+the protected mappings, and begin a new release only from a new validated
+upstream CI run. Do not create a GitHub-artifact or prior-journal fallback path.
 
 The terminal producer emits one canonical, redacted terminal receipt and
 terminal evidence before the `result` job selects the final outcome. They bind

--- a/docs/vercel-deployments.md
+++ b/docs/vercel-deployments.md
@@ -112,10 +112,13 @@ authority. It binds repository, release ID, `DEPLOY_SHA`, validated upstream
 run, ownership mode, staged and active targets, release-plan digest, and every
 captured protected rollback prior. A provider census must be complete and
 stable, each candidate must carry one exact canonical manifest, and the current
-protected mappings must form one canonical release prefix. Missing, ambiguous,
-conflicting, malformed, non-prefix, or incomplete provider state fails closed.
-GitHub artifacts and prior job history are not alternate cross-attempt
-authority.
+protected mappings must form one canonical forward release prefix or the exact
+terminal App recovery residual: all active non-App targets at their original
+priors and every reviewed App alias at one canonical candidate. That residual
+authorizes `restore-before-planning`, even for the matching release; it never
+authorizes forward resumption. Missing, ambiguous, conflicting, malformed,
+non-prefix, or incomplete provider state fails closed. GitHub artifacts and
+prior job history are not alternate cross-attempt authority.
 
 Vercel's optional deployment `source` field is diagnostic telemetry, not
 ownership authority. Every protected mapping without complete canonical Mento
@@ -144,10 +147,11 @@ The reconciliation decision is made before ordinary planning:
 
 - `verify-existing-release` fully re-verifies a complete matching release and
   reuses it through the journal-free `current-release-verified` terminal route;
-- `resume-existing-release` continues a matching interrupted prefix through a
-  fresh current-attempt journal;
-- `restore-before-planning` restores an older interrupted prefix through a
-  fresh current-attempt journal before a new baseline is captured; and
+- `resume-existing-release` continues a matching interrupted forward prefix
+  through a fresh current-attempt journal;
+- `restore-before-planning` restores an older interrupted prefix, or the exact
+  terminal App recovery residual, through a fresh current-attempt journal before
+  a new baseline is captured; and
 - `capture-new-baseline` starts only when no mapped release explains the
   protected state or a completed older release is the baseline.
 

--- a/scripts/vercel-main-active-controller.mjs
+++ b/scripts/vercel-main-active-controller.mjs
@@ -22,8 +22,10 @@ import {
   startMainTransactionRecovery,
 } from "./vercel-main-transaction.mjs";
 import {
+  MAIN_RELEASE_ACTIVATION_ORDER,
   assertMainReleaseManifest,
   reconcileMainRelease,
+  reconcileMainReleaseForRecovery,
 } from "./vercel-main-release-reconciliation.mjs";
 import {
   assertMainActiveCommandDescriptor,
@@ -433,6 +435,41 @@ function canonicalCurrentMappings(
 function mappingsForAliases(currentMappings, aliases) {
   const selected = new Set(aliases);
   return currentMappings.filter((mapping) => selected.has(mapping.alias));
+}
+
+function groupedReleaseMappings(journal, currentMappings) {
+  return Object.fromEntries(
+    MAIN_RELEASE_ACTIVATION_ORDER.map((target) => [
+      target,
+      mappingsForAliases(currentMappings, journal.prior[target].aliases),
+    ]),
+  );
+}
+
+function assertForwardReleaseOrdering(journal, currentMappings) {
+  const grouped = groupedReleaseMappings(journal, currentMappings);
+  const onlyKnownReleaseMappings = MAIN_RELEASE_ACTIVATION_ORDER.every(
+    (target) => {
+      const prior = journal.prior[target];
+      const candidate = journal.candidates[target];
+      return grouped[target].every(
+        (mapping) =>
+          sameDeployment(mapping, prior) ||
+          (candidate !== null &&
+            candidate.deploymentId !== null &&
+            sameDeployment(mapping, candidate)),
+      );
+    },
+  );
+  // Unexpected provider identities follow the existing deterministic recovery
+  // route. When every leaf belongs to this release, the activation-order
+  // reconciler must reject any state that is not a forward prefix.
+  if (!onlyKnownReleaseMappings) return;
+  reconcileMainRelease({
+    manifest: journal.release,
+    candidates: releaseCandidatesFromJournal(journal),
+    currentMappings: grouped,
+  });
 }
 
 function mappingState(journal, currentMappings, target) {
@@ -1081,6 +1118,7 @@ export function reduceMainActiveTransition({
       highest,
       input.currentMappings,
     );
+    assertForwardReleaseOrdering(highest, currentMappings);
     assertLegacyPrior(highest, currentMappings);
     if (input.kind === "dispatch") {
       if (highest.status === "committed") {
@@ -1584,7 +1622,7 @@ function releaseCandidatesFromJournal(journal) {
       const candidate = journal.candidates[target];
       return [
         target,
-        candidate === null
+        candidate === null || candidate.deploymentId === null
           ? null
           : {
               deploymentId: candidate.deploymentId,
@@ -1618,6 +1656,22 @@ export function reconcileFreshMainActiveRelease({ journal, currentMappings }) {
   const canonicalJournal = assertMainTransactionJournal(journal);
   const manifest = assertMainReleaseManifest(canonicalJournal.release);
   return reconcileMainRelease({
+    manifest,
+    candidates: releaseCandidatesFromJournal(canonicalJournal),
+    currentMappings: releaseMappingsFromJournal(
+      canonicalJournal,
+      currentMappings,
+    ),
+  });
+}
+
+function reconcileFreshMainActiveReleaseForRecovery({
+  journal,
+  currentMappings,
+}) {
+  const canonicalJournal = assertMainTransactionJournal(journal);
+  const manifest = assertMainReleaseManifest(canonicalJournal.release);
+  return reconcileMainReleaseForRecovery({
     manifest,
     candidates: releaseCandidatesFromJournal(canonicalJournal),
     currentMappings: releaseMappingsFromJournal(
@@ -1704,7 +1758,7 @@ export function createCurrentMainActiveRecoveryJournal({
   currentMappings,
 }) {
   const inherited = assertMainTransactionJournal(inheritedJournal);
-  const reconciliation = reconcileFreshMainActiveRelease({
+  const reconciliation = reconcileFreshMainActiveReleaseForRecovery({
     journal: inherited,
     currentMappings,
   });
@@ -1721,6 +1775,7 @@ export function createCurrentMainActiveRecoveryJournal({
     prior,
     startMappings: currentMappings,
     candidates: inherited.candidates,
+    allowTerminalAppRecoveryResidual: true,
   });
   return { journal: recovery, reconciliation };
 }
@@ -1736,7 +1791,7 @@ export function planFreshInheritedMainActiveRecovery({
   const inherited = assertMainTransactionJournal(inheritedJournal);
   let reconciliation;
   try {
-    reconciliation = reconcileFreshMainActiveRelease({
+    reconciliation = reconcileFreshMainActiveReleaseForRecovery({
       journal: inherited,
       currentMappings,
     });

--- a/scripts/vercel-main-active-controller.test.mjs
+++ b/scripts/vercel-main-active-controller.test.mjs
@@ -21,6 +21,7 @@ import {
   loadMainActiveJournalHistory,
   reduceMainActiveRecoveryTransition,
   reduceMainActiveTransition,
+  reconcileFreshMainActiveRelease,
 } from "./vercel-main-active-controller.mjs";
 import {
   ACTIVE_DEPLOYMENT_STATE_SPEC_SCHEMA,
@@ -1949,6 +1950,82 @@ test("fresh App provider census accepts one stable candidate and rejects a third
     currentMappings: mappings,
   });
   assert.equal(plan.decision, "manual-intervention");
+});
+
+test("fresh forward reconciliation rejects an App-only recovery residual", () => {
+  const journal = prepared(TARGETS, { appKnown: true });
+  const mappings = groupedCurrentMappings(journal, { app: "candidate" });
+
+  assert.throws(
+    () =>
+      reconcileFreshMainActiveRelease({
+        journal,
+        currentMappings: mappings,
+      }),
+    /activation prefix/,
+  );
+
+  const recovery = planFreshInheritedMainActiveRecovery({
+    inheritedJournal: journal,
+    reason: "forward-operation-failed",
+    currentMappings: mappings,
+  });
+  assert.equal(recovery.decision, "restore-inherited");
+  assert.deepEqual(
+    recovery.actions.map(({ kind, alias }) => ({ kind, alias })),
+    [...journal.prior.app.aliases]
+      .reverse()
+      .map((alias) => ({ kind: "app_alias_restore", alias })),
+  );
+});
+
+test("forward dispatch and authorize reject a fresh App-only recovery residual", () => {
+  const initial = prepared(TARGETS, { appKnown: true });
+  const initialized = reduceForward(initial, [], event("initialize"), TARGETS);
+  const residual = currentMappings(initialized.journal, {
+    app: "candidate",
+  });
+
+  assert.throws(
+    () =>
+      reduceForward(
+        initial,
+        [initialized.journal],
+        event("dispatch", {
+          uploadReceipt: receipt(initialized.journal),
+          freshSha: SHA,
+          currentMappings: residual,
+        }),
+        TARGETS,
+      ),
+    /activation prefix/,
+  );
+
+  const dispatched = reduceForward(
+    initial,
+    [initialized.journal],
+    event("dispatch", {
+      uploadReceipt: receipt(initialized.journal),
+      freshSha: SHA,
+      currentMappings: currentMappings(initialized.journal),
+    }),
+    TARGETS,
+  );
+  assert.equal(dispatched.journal.operations.at(-1).target, "governance");
+  assert.throws(
+    () =>
+      reduceForward(
+        initial,
+        [initialized.journal, dispatched.journal],
+        event("authorize", {
+          uploadReceipt: receipt(dispatched.journal),
+          freshSha: SHA,
+          currentMappings: residual,
+        }),
+        TARGETS,
+      ),
+    /activation prefix/,
+  );
 });
 
 test("current-attempt inherited recovery binds the inherited release SHA and completes", () => {

--- a/scripts/vercel-main-active-controller.test.mjs
+++ b/scripts/vercel-main-active-controller.test.mjs
@@ -39,6 +39,7 @@ import { MAIN_TARGET_CONTRACTS } from "./vercel-main-plan.mjs";
 import {
   MAIN_RELEASE_ACTIVATION_ORDER,
   createMainReleaseManifest,
+  decideMainPreplanReconciliation,
 } from "./vercel-main-release-reconciliation.mjs";
 import {
   canonicalizeMainCandidateVercelMetadata,
@@ -2046,6 +2047,126 @@ test("current-attempt inherited recovery binds the inherited release SHA and com
   });
   assert.equal(terminal.journal.status, "recovered");
   assert.equal(terminal.afterUploadAction, "continue-after-recovery");
+});
+
+test("App-only recovery residual restores both aliases before a fresh baseline", () => {
+  const inherited = prepared(TARGETS, { appKnown: true });
+  const observed = groupedCurrentMappings(inherited, { app: "candidate" });
+  const { journal: current } = createCurrentMainActiveRecoveryJournal({
+    inheritedJournal: inherited,
+    identity: {
+      repository: MAIN_TRANSACTION_REPOSITORY,
+      deploySha: "2222222222222222222222222222222222222222",
+      runId: "987654321",
+      runAttempt: "7",
+    },
+    currentMappings: observed,
+  });
+  const plan = decideMainActiveAppRecoverySafety({
+    inheritedJournal: inherited,
+    currentJournal: current,
+    reason: "forward-operation-failed",
+    currentMappings: observed,
+  });
+  assert.equal(plan.decision, "restore-inherited");
+  assert.deepEqual(
+    plan.actions.map(({ kind, alias }) => ({ kind, alias })),
+    [...inherited.prior.app.aliases]
+      .reverse()
+      .map((alias) => ({ kind: "app_alias_restore", alias })),
+  );
+
+  const history = [current];
+  const initialized = reduceMainActiveRecoveryTransition({
+    recoveryPlan: plan,
+    history,
+    event: recoveryEvent("initialize", {
+      uploadReceipt: receipt(current),
+    }),
+  });
+  history.push(initialized.journal);
+  const movedAliases = new Set(inherited.prior.app.aliases);
+  const liveMappings = () =>
+    recoveryCurrentMappings(history.at(-1)).map((mapping) =>
+      movedAliases.has(mapping.alias)
+        ? {
+            ...mapping,
+            deploymentId: history.at(-1).candidates.app.deploymentId,
+            deploymentUrl: history.at(-1).candidates.app.deploymentUrl,
+          }
+        : mapping,
+    );
+
+  for (const expectedAlias of [...inherited.prior.app.aliases].reverse()) {
+    const started = reduceMainActiveRecoveryTransition({
+      recoveryPlan: plan,
+      history,
+      event: recoveryEvent("dispatch", {
+        uploadReceipt: receipt(history.at(-1)),
+        currentMappings: liveMappings(),
+      }),
+    });
+    history.push(started.journal);
+    const authorized = reduceMainActiveRecoveryTransition({
+      recoveryPlan: plan,
+      history,
+      event: recoveryEvent("authorize", {
+        uploadReceipt: receipt(history.at(-1)),
+        currentMappings: liveMappings(),
+      }),
+    });
+    assert.equal(authorized.command.kind, "app-alias-restore");
+    assert.equal(authorized.command.alias, expectedAlias);
+
+    const returned = reduceMainActiveRecoveryTransition({
+      recoveryPlan: plan,
+      history,
+      event: recoveryEvent("command-returned", {
+        uploadReceipt: receipt(history.at(-1)),
+        operationId: authorized.operationId,
+        command: authorized.command,
+        result: { outcome: "success", reason: null, candidate: null },
+      }),
+    });
+    history.push(returned.journal);
+    movedAliases.delete(expectedAlias);
+    const verified = reduceMainActiveRecoveryTransition({
+      recoveryPlan: plan,
+      history,
+      event: recoveryEvent("verify", {
+        uploadReceipt: receipt(history.at(-1)),
+        currentMappings: liveMappings(),
+      }),
+    });
+    history.push(verified.journal);
+  }
+
+  const terminal = reduceMainActiveRecoveryTransition({
+    recoveryPlan: plan,
+    history,
+    event: recoveryEvent("dispatch", {
+      uploadReceipt: receipt(history.at(-1)),
+      currentMappings: liveMappings(),
+    }),
+  });
+  assert.equal(terminal.journal.status, "recovered");
+  assert.equal(terminal.afterUploadAction, "continue-after-recovery");
+
+  const recoveredMappings = groupedCurrentMappings(terminal.journal);
+  const next = decideMainPreplanReconciliation({
+    nextDeploySha: "2222222222222222222222222222222222222222",
+    nextUpstreamRunId: "987654321",
+    candidateReleases: [],
+    currentMappings: Object.fromEntries(
+      MAIN_RELEASE_ACTIVATION_ORDER.map((target) => [
+        target,
+        recoveredMappings[target],
+      ]),
+    ),
+    rollbackOnlyTargets: [],
+  });
+  assert.equal(next.decision, "capture-new-baseline");
+  assert.equal(next.reason, "no-mapped-release-metadata");
 });
 
 test("inherited recovery refuses missing, divergent, and all-candidate current journals", () => {

--- a/scripts/vercel-main-provider-cli.test.mjs
+++ b/scripts/vercel-main-provider-cli.test.mjs
@@ -667,6 +667,106 @@ test("preplan decision binds current SHA and upstream run to one exact release I
   );
 });
 
+test("preplan decision restores a manifest-bound App recovery residual", async (t) => {
+  const context = testContext(t);
+  const inherited = releaseManifest({
+    deploySha: "c".repeat(40),
+    upstreamRunId: "699",
+    active: true,
+  });
+  const appCandidate = {
+    deploymentId: "dpl_appRecoveryResidual123",
+    deploymentUrl: "https://app-recovery-residual.vercel.app",
+  };
+  const snapshot = planningSnapshot(
+    Object.fromEntries(
+      inherited.originalPriors.app.aliases.map((alias) => [
+        alias,
+        {
+          ...appCandidate,
+          git: {
+            org: "mento-protocol",
+            repo: "frontend-monorepo",
+            ref: "main",
+            sha: inherited.deploySha,
+          },
+        },
+      ]),
+    ),
+  );
+  const planningPath = writeJson(context.directory, "planning.json", snapshot);
+  const legacyPath = writeJson(
+    context.directory,
+    "legacy.json",
+    legacySnapshot(),
+  );
+  const projectsPath = writeJson(
+    context.directory,
+    "projects.json",
+    projectIds(),
+  );
+  const discoveryPath = join(context.directory, "discovery.json");
+  await runMainProviderCli({
+    argv: [
+      "preplan-discover",
+      "--planning-snapshot",
+      planningPath,
+      "--legacy-snapshot",
+      legacyPath,
+      "--project-ids",
+      projectsPath,
+      "--output",
+      discoveryPath,
+    ],
+    env: context.env,
+    stdout: context.stdout,
+    stateClientFactory: () => ({ kind: "discovery-client" }),
+    providerFactory: () => ({
+      inspectMappedCandidate: async ({ deploymentId, target }) => ({
+        canonicalState: {},
+        metadata:
+          target === "app" && deploymentId === appCandidate.deploymentId
+            ? { releaseManifest: inherited }
+            : null,
+      }),
+      resolveReleaseCandidate: async ({ manifest, target }) => {
+        assert.equal(manifest.releaseId, inherited.releaseId);
+        return target === "app"
+          ? { intent: {}, candidate: appCandidate }
+          : null;
+      },
+    }),
+  });
+
+  const output = join(context.directory, "decision.json");
+  const result = await runMainProviderCli({
+    argv: [
+      "preplan-decide",
+      "--discovery",
+      discoveryPath,
+      "--planning-snapshot",
+      planningPath,
+      "--legacy-snapshot",
+      legacyPath,
+      "--output",
+      output,
+    ],
+    env: context.env,
+    stdout: context.stdout,
+    stateClientFactory: () => planningStateClient(snapshot),
+  });
+
+  assert.equal(result.decision, "restore-before-planning");
+  assert.equal(result.reason, "older-main-release-is-an-app-recovery-residual");
+  assert.deepEqual(result.rollbackAuthorization, {
+    reason: "restore-inherited",
+    targets: ["app"],
+    aliases: inherited.originalPriors.app.aliases.toSorted(),
+  });
+  assert.deepEqual(result.rollbackOnlyTargets, ["governance", "reserve", "ui"]);
+  assert.deepEqual(readJson(output), result);
+});
+
 test("preplan materialization accepts only inherited restore and exposes ordered active targets", async (t) => {
   const context = testContext(t);
   const inherited = releaseManifest({

--- a/scripts/vercel-main-release-cli.test.mjs
+++ b/scripts/vercel-main-release-cli.test.mjs
@@ -2146,6 +2146,102 @@ test("forward journal uses only asserted execution, fresh mappings, and current-
   );
 });
 
+test("an App-only residual creates only an inherited recovery journal", async (t) => {
+  const directory = realpathSync(
+    mkdtempSync(join(tmpdir(), "main-release-app-residual-journal-")),
+  );
+  t.after(() => rmSync(directory, { recursive: true, force: true }));
+  const release = manifest(TARGETS);
+  const legacyState = legacy()[0];
+  const mappings = createMainCanonicalMappings({
+    planningSnapshot: planningSnapshot(release),
+    projectIds: {
+      app: "prj_app",
+      governance: "prj_governance",
+      reserve: "prj_reserve",
+      ui: "prj_ui",
+    },
+    legacySnapshot: [legacyState],
+  });
+  for (const target of RELEASE_ORDER) {
+    const prior = release.originalPriors[target];
+    const deployment =
+      target === "app"
+        ? {
+            deploymentId: "dpl_appCandidate123",
+            deploymentUrl: "https://app-candidate.vercel.app",
+          }
+        : prior;
+    mappings.mappings[target] = prior.aliases.map((alias) => ({
+      alias,
+      deploymentId: deployment.deploymentId,
+      deploymentUrl: deployment.deploymentUrl,
+    }));
+  }
+  const candidateReceipts = Object.fromEntries(
+    TARGETS.map((target) => [target, currentAttemptReceipt(release, target)]),
+  );
+  const currentMappings = Object.fromEntries(
+    RELEASE_ORDER.map((target) => [target, mappings.mappings[target]]),
+  );
+  const inheritedPreplan = decideMainPreplanReconciliation({
+    nextDeploySha: SHA,
+    nextUpstreamRunId: release.upstreamRunId,
+    candidateReleases: [candidateRelease(release)],
+    currentMappings,
+    rollbackOnlyTargets: [],
+  });
+  assert.equal(inheritedPreplan.decision, "restore-before-planning");
+  assert.deepEqual(inheritedPreplan.rollbackAuthorization.targets, ["app"]);
+
+  await assert.rejects(
+    runMainReleaseCli({
+      argv: [
+        "forward-journal",
+        "--execution",
+        write(directory, "execution.json", executionFor(release)),
+        "--current-mappings",
+        write(directory, "forward-mappings.json", mappings),
+        "--candidate-receipts",
+        write(directory, "forward-receipts.json", candidateReceipts),
+        "--output",
+        join(directory, "forbidden-forward-journal.json"),
+      ],
+      env: environment(directory),
+    }),
+    /activation prefix/,
+  );
+
+  const result = await runMainReleaseCli({
+    argv: [
+      "inherited-recovery-journal",
+      "--preplan",
+      write(directory, "preplan.json", inheritedPreplan),
+      "--legacy-snapshot",
+      write(directory, "legacy.json", [legacyState]),
+      "--current-mappings",
+      write(directory, "recovery-mappings.json", mappings),
+      "--candidate-receipts",
+      write(directory, "recovery-receipts.json", candidateReceipts),
+      "--journal-output",
+      join(directory, "recovery-journal.json"),
+      "--plan-output",
+      join(directory, "recovery-plan.json"),
+    ],
+    env: environment(directory),
+  });
+  assert.deepEqual(
+    result.recoveryPlan.actions.map(({ kind, target, alias }) => ({
+      kind,
+      target,
+      alias,
+    })),
+    [...release.originalPriors.app.aliases]
+      .reverse()
+      .map((alias) => ({ kind: "app_alias_restore", target: "app", alias })),
+  );
+});
+
 test("inherited recovery journal binds a partial prefix to current-attempt receipts and exact outputs", async (t) => {
   const directory = realpathSync(
     mkdtempSync(join(tmpdir(), "main-release-inherited-journal-")),

--- a/scripts/vercel-main-release-journal.mjs
+++ b/scripts/vercel-main-release-journal.mjs
@@ -300,6 +300,7 @@ function createJournal({
   candidateReceipts,
   identity,
   pendingApp,
+  allowTerminalAppRecoveryResidual = false,
 }) {
   const mappings = canonicalMappings({
     value: currentMappings,
@@ -323,6 +324,7 @@ function createJournal({
       candidateReceipts,
       pendingApp,
     }),
+    allowTerminalAppRecoveryResidual,
   });
 }
 
@@ -385,6 +387,7 @@ export function createMainInheritedRecoveryJournal({
     candidateReceipts,
     identity,
     pendingApp: false,
+    allowTerminalAppRecoveryResidual: true,
   });
   const recoveryPlan = planInheritedMainTransactionRecovery({
     journal,

--- a/scripts/vercel-main-release-reconciliation.mjs
+++ b/scripts/vercel-main-release-reconciliation.mjs
@@ -744,8 +744,16 @@ function isTerminalAppRecoveryResidual(targets) {
   );
 }
 
-function assertActivationPrefix(targets) {
-  if (isTerminalAppRecoveryResidual(targets)) return;
+function assertActivationPrefix(
+  targets,
+  { allowTerminalAppRecoveryResidual = false } = {},
+) {
+  if (
+    allowTerminalAppRecoveryResidual &&
+    isTerminalAppRecoveryResidual(targets)
+  ) {
+    return;
+  }
 
   let reachedFrontier = false;
   for (const [index, target] of targets.entries()) {
@@ -770,11 +778,10 @@ function assertActivationPrefix(targets) {
   }
 }
 
-export function reconcileMainRelease({
-  manifest: rawManifest,
-  candidates,
-  currentMappings,
-}) {
+function reconcileMainReleaseWithPolicy(
+  { manifest: rawManifest, candidates, currentMappings },
+  { allowTerminalAppRecoveryResidual },
+) {
   const manifest = assertMainReleaseManifest(rawManifest);
   assertExactKeys(
     candidates,
@@ -832,7 +839,7 @@ export function reconcileMainRelease({
   const targets = observedTargets.filter(({ target }) =>
     manifest.activeTargets.includes(target),
   );
-  assertActivationPrefix(targets);
+  assertActivationPrefix(targets, { allowTerminalAppRecoveryResidual });
   const inheritedCandidateTargets = targets
     .filter(({ state }) => state === "candidate")
     .map(({ target }) => target);
@@ -857,6 +864,18 @@ export function reconcileMainRelease({
     allPrior,
     frontier,
   };
+}
+
+export function reconcileMainRelease(input) {
+  return reconcileMainReleaseWithPolicy(input, {
+    allowTerminalAppRecoveryResidual: false,
+  });
+}
+
+export function reconcileMainReleaseForRecovery(input) {
+  return reconcileMainReleaseWithPolicy(input, {
+    allowTerminalAppRecoveryResidual: true,
+  });
 }
 
 export function decideMainPreplanReconciliation({
@@ -917,7 +936,7 @@ export function decideMainPreplanReconciliation({
     }
     seenReleases.add(manifest.releaseId);
     try {
-      const reconciliation = reconcileMainRelease({
+      const reconciliation = reconcileMainReleaseForRecovery({
         manifest,
         candidates: release.candidates,
         currentMappings,
@@ -984,9 +1003,8 @@ export function decideMainPreplanReconciliation({
   };
 }
 
-function canonicalEmbeddedReconciliation(value) {
-  if (value === null) return null;
-  const canonical = reconcileMainRelease({
+function reconciliationInput(value) {
+  return {
     manifest: value?.manifest,
     candidates: Object.fromEntries(
       (value?.observedTargets ?? [])
@@ -1013,7 +1031,12 @@ function canonicalEmbeddedReconciliation(value) {
         }),
       ]),
     ),
-  });
+  };
+}
+
+function canonicalEmbeddedReconciliation(value) {
+  if (value === null) return null;
+  const canonical = reconcileMainReleaseForRecovery(reconciliationInput(value));
   if (JSON.stringify(value) !== JSON.stringify(canonical)) {
     throw new Error("Pre-plan reconciliation is not canonical");
   }
@@ -1117,34 +1140,9 @@ export function decideMainReleaseReconciliation({
   ) {
     throw new Error("Main release reconciliation is required");
   }
-  const canonical = reconcileMainRelease({
-    manifest: reconciliation.manifest,
-    candidates: Object.fromEntries(
-      reconciliation.observedTargets
-        .filter(({ target }) =>
-          reconciliation.manifest.stagedTargets.includes(target),
-        )
-        .map(({ target, candidate }) => [
-          target,
-          candidate === null
-            ? null
-            : {
-                deploymentId: candidate.deploymentId,
-                deploymentUrl: candidate.deploymentUrl,
-                manifest: candidate.manifest,
-              },
-        ]),
-    ),
-    currentMappings: Object.fromEntries(
-      reconciliation.observedTargets.map(({ target, startMappings }) => [
-        target,
-        startMappings.map(({ state: _state, ...mapping }) => {
-          void _state;
-          return mapping;
-        }),
-      ]),
-    ),
-  });
+  const canonical = reconcileMainReleaseForRecovery(
+    reconciliationInput(reconciliation),
+  );
   if (
     typeof currentMain !== "boolean" ||
     !PREPARATION_STATES.has(preparation)
@@ -1229,34 +1227,11 @@ export function createInheritedRollbackAuthorization({
   if (!["first-forward-command", "restore-inherited"].includes(reason)) {
     throw new Error("Inherited rollback authorization reason is unsupported");
   }
-  const canonical = reconcileMainRelease({
-    manifest: reconciliation.manifest,
-    candidates: Object.fromEntries(
-      reconciliation.observedTargets
-        .filter(({ target }) =>
-          reconciliation.manifest.stagedTargets.includes(target),
-        )
-        .map(({ target, candidate }) => [
-          target,
-          candidate === null
-            ? null
-            : {
-                deploymentId: candidate.deploymentId,
-                deploymentUrl: candidate.deploymentUrl,
-                manifest: candidate.manifest,
-              },
-        ]),
-    ),
-    currentMappings: Object.fromEntries(
-      reconciliation.observedTargets.map(({ target, startMappings }) => [
-        target,
-        startMappings.map(({ state: _state, ...mapping }) => {
-          void _state;
-          return mapping;
-        }),
-      ]),
-    ),
-  });
+  const input = reconciliationInput(reconciliation);
+  const canonical =
+    reason === "restore-inherited"
+      ? reconcileMainReleaseForRecovery(input)
+      : reconcileMainRelease(input);
   if (canonical.allCandidate && reason === "restore-inherited") {
     throw new Error(
       "A complete release cannot be auto-rolled back by a reader",

--- a/scripts/vercel-main-release-reconciliation.mjs
+++ b/scripts/vercel-main-release-reconciliation.mjs
@@ -732,7 +732,21 @@ function classifyTarget({ target, prior, candidate, mappings }) {
   };
 }
 
+function isTerminalAppRecoveryResidual(targets) {
+  // A failed App command can leave its manifest-bound candidate mapped after
+  // recovery has already restored every ordinary target. That exact terminal
+  // shape is recoverable only by restoring App; it is never a forward prefix.
+  return (
+    targets.length > 1 &&
+    targets.at(-1)?.target === "app" &&
+    targets.at(-1)?.state === "candidate" &&
+    targets.slice(0, -1).every(({ state }) => state === "prior")
+  );
+}
+
 function assertActivationPrefix(targets) {
+  if (isTerminalAppRecoveryResidual(targets)) return;
+
   let reachedFrontier = false;
   for (const [index, target] of targets.entries()) {
     if (target.state === "candidate") {
@@ -923,6 +937,9 @@ export function decideMainPreplanReconciliation({
   const [reconciliation] = compatible;
   const { manifest } = reconciliation;
   const sameRelease = manifest.releaseId === expectedReleaseId;
+  const terminalAppRecoveryResidual = isTerminalAppRecoveryResidual(
+    reconciliation.targets,
+  );
   if (sameRelease) {
     assertFreshRollbackCoverage(manifest, canonicalRollbackOnly);
   }
@@ -940,7 +957,7 @@ export function decideMainPreplanReconciliation({
       rollbackAuthorization: null,
     };
   }
-  if (sameRelease) {
+  if (sameRelease && !terminalAppRecoveryResidual) {
     return {
       schema: MAIN_PREPLAN_RECONCILIATION_SCHEMA,
       decision: "resume-existing-release",
@@ -953,7 +970,11 @@ export function decideMainPreplanReconciliation({
   return {
     schema: MAIN_PREPLAN_RECONCILIATION_SCHEMA,
     decision: "restore-before-planning",
-    reason: "older-main-release-is-an-interrupted-prefix",
+    reason: terminalAppRecoveryResidual
+      ? sameRelease
+        ? "current-main-release-is-an-app-recovery-residual"
+        : "older-main-release-is-an-app-recovery-residual"
+      : "older-main-release-is-an-interrupted-prefix",
     rollbackOnlyTargets: canonicalRollbackOnly,
     reconciliation,
     rollbackAuthorization: createInheritedRollbackAuthorization({
@@ -1038,6 +1059,9 @@ export function assertMainPreplanReconciliation(
       );
     }
     const sameRelease = reconciliation.manifest.releaseId === expectedReleaseId;
+    const terminalAppRecoveryResidual = isTerminalAppRecoveryResidual(
+      reconciliation.targets,
+    );
     if (sameRelease) {
       assertFreshRollbackCoverage(reconciliation.manifest, rollbackOnlyTargets);
     }
@@ -1048,12 +1072,16 @@ export function assertMainPreplanReconciliation(
       reason = sameRelease
         ? "current-main-release-already-complete"
         : "older-mapped-release-is-complete";
-    } else if (sameRelease) {
+    } else if (sameRelease && !terminalAppRecoveryResidual) {
       decision = "resume-existing-release";
       reason = "current-main-release-is-an-interrupted-prefix";
     } else {
       decision = "restore-before-planning";
-      reason = "older-main-release-is-an-interrupted-prefix";
+      reason = terminalAppRecoveryResidual
+        ? sameRelease
+          ? "current-main-release-is-an-app-recovery-residual"
+          : "older-main-release-is-an-app-recovery-residual"
+        : "older-main-release-is-an-interrupted-prefix";
       rollbackAuthorization = createInheritedRollbackAuthorization({
         reconciliation,
         reason: "restore-inherited",

--- a/scripts/vercel-main-release-reconciliation.mjs
+++ b/scripts/vercel-main-release-reconciliation.mjs
@@ -1155,6 +1155,9 @@ export function decideMainReleaseReconciliation({
     !canonical.allPrior &&
     !canonical.allCandidate &&
     canonical.inheritedCandidateAliases.length > 0;
+  const terminalAppRecoveryResidual = isTerminalAppRecoveryResidual(
+    canonical.targets,
+  );
   if (canonical.allCandidate) {
     return {
       decision: currentMain ? "verify-noop" : "superseded-noop",
@@ -1162,6 +1165,13 @@ export function decideMainReleaseReconciliation({
       reason: currentMain
         ? "release-already-candidate"
         : "release-complete-before-main-advanced",
+    };
+  }
+  if (terminalAppRecoveryResidual) {
+    return {
+      decision: "restore-inherited",
+      rollbackInherited: true,
+      reason: "terminal-app-recovery-residual",
     };
   }
   if (!currentMain) {

--- a/scripts/vercel-main-release-reconciliation.test.mjs
+++ b/scripts/vercel-main-release-reconciliation.test.mjs
@@ -11,6 +11,7 @@ import {
   decideMainReleaseReconciliation,
   recomputeMainReleasePlan,
   reconcileMainRelease,
+  reconcileMainReleaseForRecovery,
 } from "./vercel-main-release-reconciliation.mjs";
 import {
   MAIN_TARGET_CONTRACTS,
@@ -795,7 +796,8 @@ test("App mixed mappings are accepted only at the activation frontier", () => {
 
 test("only a full terminal App candidate remains recoverable after at least one ordinary rollback", () => {
   const state = appRecoveryResidualState();
-  const reconciliation = reconcileMainRelease(state);
+  assert.throws(() => reconcileMainRelease(state), /activation prefix/);
+  const reconciliation = reconcileMainReleaseForRecovery(state);
   assert.deepEqual(
     reconciliation.targets.map(({ target, state: targetState }) => [
       target,
@@ -818,6 +820,14 @@ test("only a full terminal App candidate remains recoverable after at least one 
       targets: ["app"],
       aliases: [...state.manifest.originalPriors.app.aliases].sort(),
     },
+  );
+  assert.throws(
+    () =>
+      createInheritedRollbackAuthorization({
+        reconciliation,
+        reason: "first-forward-command",
+      }),
+    /activation prefix/,
   );
   for (const currentMain of [true, false]) {
     for (const preparation of ["ready", "failed", "pending", "producer-live"]) {
@@ -916,6 +926,14 @@ test("unsupported non-prefix, third-party, missing-candidate, and disagreeing-ma
   const mixedAppResidual = releaseState({ appMixed: true });
   assert.throws(
     () => reconcileMainRelease(mixedAppResidual),
+    /Mixed App mappings are outside the release frontier/,
+  );
+  assert.throws(
+    () => reconcileMainReleaseForRecovery(ordinarySuffix),
+    /activation prefix/,
+  );
+  assert.throws(
+    () => reconcileMainReleaseForRecovery(mixedAppResidual),
     /Mixed App mappings are outside the release frontier/,
   );
 });

--- a/scripts/vercel-main-release-reconciliation.test.mjs
+++ b/scripts/vercel-main-release-reconciliation.test.mjs
@@ -819,6 +819,23 @@ test("only a full terminal App candidate remains recoverable after at least one 
       aliases: [...state.manifest.originalPriors.app.aliases].sort(),
     },
   );
+  for (const currentMain of [true, false]) {
+    for (const preparation of ["ready", "failed", "pending", "producer-live"]) {
+      assert.deepEqual(
+        decideMainReleaseReconciliation({
+          reconciliation,
+          currentMain,
+          preparation,
+        }),
+        {
+          decision: "restore-inherited",
+          rollbackInherited: true,
+          reason: "terminal-app-recovery-residual",
+        },
+        `${currentMain ? "current" : "stale"} main with ${preparation} preparation`,
+      );
+    }
+  }
 });
 
 test("an App-only active candidate is a complete release, not a recovery residual", () => {

--- a/scripts/vercel-main-release-reconciliation.test.mjs
+++ b/scripts/vercel-main-release-reconciliation.test.mjs
@@ -793,7 +793,7 @@ test("App mixed mappings are accepted only at the activation frontier", () => {
   ]);
 });
 
-test("only a full terminal App candidate remains recoverable after ordinary rollback", () => {
+test("only a full terminal App candidate remains recoverable after at least one ordinary rollback", () => {
   const state = appRecoveryResidualState();
   const reconciliation = reconcileMainRelease(state);
   assert.deepEqual(
@@ -819,6 +819,35 @@ test("only a full terminal App candidate remains recoverable after ordinary roll
       aliases: [...state.manifest.originalPriors.app.aliases].sort(),
     },
   );
+});
+
+test("an App-only active candidate is a complete release, not a recovery residual", () => {
+  const state = releaseState({ selected: ["app"], candidateCount: 1 });
+  const reconciliation = reconcileMainRelease(state);
+  assert.equal(reconciliation.allCandidate, true);
+  assert.deepEqual(reconciliation.inheritedCandidateTargets, ["app"]);
+
+  const matching = decideMainPreplanReconciliation({
+    nextDeploySha: state.manifest.deploySha,
+    nextUpstreamRunId: state.manifest.upstreamRunId,
+    candidateReleases: [candidateRelease(state)],
+    currentMappings: state.currentMappings,
+    rollbackOnlyTargets: [],
+  });
+  assert.equal(matching.decision, "verify-existing-release");
+  assert.equal(matching.reason, "current-main-release-already-complete");
+  assert.equal(matching.rollbackAuthorization, null);
+
+  const older = decideMainPreplanReconciliation({
+    nextDeploySha: "2222222222222222222222222222222222222222",
+    nextUpstreamRunId: "800",
+    candidateReleases: [candidateRelease(state)],
+    currentMappings: state.currentMappings,
+    rollbackOnlyTargets: [],
+  });
+  assert.equal(older.decision, "capture-new-baseline");
+  assert.equal(older.reason, "older-mapped-release-is-complete");
+  assert.equal(older.rollbackAuthorization, null);
 });
 
 test("unsupported non-prefix, third-party, missing-candidate, and disagreeing-manifest states fail closed", () => {
@@ -1116,7 +1145,7 @@ test("pre-plan inspection restores an older mixed App frontier", () => {
   ]);
 });
 
-test("pre-plan restores the App-only recovery residual for older and matching releases", () => {
+test("pre-plan restores the App-candidate-only residual for older and matching releases", () => {
   const state = appRecoveryResidualState();
   const cases = [
     {

--- a/scripts/vercel-main-release-reconciliation.test.mjs
+++ b/scripts/vercel-main-release-reconciliation.test.mjs
@@ -821,7 +821,7 @@ test("only a full terminal App candidate remains recoverable after ordinary roll
   );
 });
 
-test("non-prefix, third-party, missing-candidate, and disagreeing-manifest states fail closed", () => {
+test("unsupported non-prefix, third-party, missing-candidate, and disagreeing-manifest states fail closed", () => {
   const nonPrefix = releaseState({ candidateCount: 2 });
   nonPrefix.currentMappings.governance = [
     mapping("governance.mento.org", "governance", "prior"),

--- a/scripts/vercel-main-release-reconciliation.test.mjs
+++ b/scripts/vercel-main-release-reconciliation.test.mjs
@@ -301,6 +301,15 @@ function candidateRelease(state) {
   };
 }
 
+function appRecoveryResidualState() {
+  const state = releaseState();
+  state.candidates.app = candidate("app", state.manifest);
+  state.currentMappings.app = state.manifest.originalPriors.app.aliases.map(
+    (alias) => mappingFor(alias, state.candidates.app),
+  );
+  return state;
+}
+
 test("release manifest binds the canonical planner result and all four rollback priors", () => {
   const first = manifest();
   const second = manifest();
@@ -784,6 +793,34 @@ test("App mixed mappings are accepted only at the activation frontier", () => {
   ]);
 });
 
+test("only a full terminal App candidate remains recoverable after ordinary rollback", () => {
+  const state = appRecoveryResidualState();
+  const reconciliation = reconcileMainRelease(state);
+  assert.deepEqual(
+    reconciliation.targets.map(({ target, state: targetState }) => [
+      target,
+      targetState,
+    ]),
+    [
+      ["governance", "prior"],
+      ["reserve", "prior"],
+      ["ui", "prior"],
+      ["app", "candidate"],
+    ],
+  );
+  assert.deepEqual(
+    createInheritedRollbackAuthorization({
+      reconciliation,
+      reason: "restore-inherited",
+    }),
+    {
+      reason: "restore-inherited",
+      targets: ["app"],
+      aliases: [...state.manifest.originalPriors.app.aliases].sort(),
+    },
+  );
+});
+
 test("non-prefix, third-party, missing-candidate, and disagreeing-manifest states fail closed", () => {
   const nonPrefix = releaseState({ candidateCount: 2 });
   nonPrefix.currentMappings.governance = [
@@ -814,6 +851,26 @@ test("non-prefix, third-party, missing-candidate, and disagreeing-manifest state
   assert.throws(
     () => reconcileMainRelease(disagreeing),
     /disagree on their stable manifest/,
+  );
+
+  const ordinarySuffix = releaseState();
+  ordinarySuffix.candidates.reserve = candidate(
+    "reserve",
+    ordinarySuffix.manifest,
+  );
+  ordinarySuffix.currentMappings.reserve =
+    ordinarySuffix.manifest.originalPriors.reserve.aliases.map((alias) =>
+      mappingFor(alias, ordinarySuffix.candidates.reserve),
+    );
+  assert.throws(
+    () => reconcileMainRelease(ordinarySuffix),
+    /activation prefix/,
+  );
+
+  const mixedAppResidual = releaseState({ appMixed: true });
+  assert.throws(
+    () => reconcileMainRelease(mixedAppResidual),
+    /Mixed App mappings are outside the release frontier/,
   );
 });
 
@@ -1057,6 +1114,41 @@ test("pre-plan inspection restores an older mixed App frontier", () => {
     "reserve.mento.org",
     "ui.mento.org",
   ]);
+});
+
+test("pre-plan restores the App-only recovery residual for older and matching releases", () => {
+  const state = appRecoveryResidualState();
+  const cases = [
+    {
+      name: "older",
+      nextDeploySha: "2222222222222222222222222222222222222222",
+      nextUpstreamRunId: "800",
+      reason: "older-main-release-is-an-app-recovery-residual",
+    },
+    {
+      name: "matching",
+      nextDeploySha: state.manifest.deploySha,
+      nextUpstreamRunId: state.manifest.upstreamRunId,
+      reason: "current-main-release-is-an-app-recovery-residual",
+    },
+  ];
+
+  for (const current of cases) {
+    const decision = decideMainPreplanReconciliation({
+      nextDeploySha: current.nextDeploySha,
+      nextUpstreamRunId: current.nextUpstreamRunId,
+      candidateReleases: [candidateRelease(state)],
+      currentMappings: state.currentMappings,
+      rollbackOnlyTargets: [],
+    });
+    assert.equal(decision.decision, "restore-before-planning", current.name);
+    assert.equal(decision.reason, current.reason, current.name);
+    assert.deepEqual(decision.rollbackAuthorization, {
+      reason: "restore-inherited",
+      targets: ["app"],
+      aliases: [...state.manifest.originalPriors.app.aliases].sort(),
+    });
+  }
 });
 
 test("pre-plan inspection selects the unique partial frontier across completed path-aware releases", () => {

--- a/scripts/vercel-main-transaction.mjs
+++ b/scripts/vercel-main-transaction.mjs
@@ -10,6 +10,7 @@ import {
   assertMainReleaseManifest,
   MAIN_RELEASE_ACTIVATION_ORDER,
   reconcileMainRelease,
+  reconcileMainReleaseForRecovery,
 } from "./vercel-main-release-reconciliation.mjs";
 import {
   assertMainCandidateReceipt,
@@ -494,6 +495,7 @@ function assertJournalReleaseBindings({
   prior,
   candidates,
   startMappings,
+  allowTerminalAppRecoveryResidual = false,
 }) {
   if (release.mode !== mode) {
     throw new Error("Journal mode conflicts with the durable release manifest");
@@ -526,7 +528,10 @@ function assertJournalReleaseBindings({
           },
     ]),
   );
-  reconcileMainRelease({
+  const reconcile = allowTerminalAppRecoveryResidual
+    ? reconcileMainReleaseForRecovery
+    : reconcileMainRelease;
+  reconcile({
     manifest: release,
     candidates: reconciliationCandidates,
     currentMappings: Object.fromEntries(
@@ -981,6 +986,7 @@ export function createPreparedMainTransactionJournal({
   prior,
   startMappings,
   candidates,
+  allowTerminalAppRecoveryResidual = false,
 }) {
   const identity = canonicalIdentity({
     repository,
@@ -989,6 +995,9 @@ export function createPreparedMainTransactionJournal({
     runAttempt,
   });
   if (!MODES.includes(mode)) throw new Error("Journal mode is unsupported");
+  if (typeof allowTerminalAppRecoveryResidual !== "boolean") {
+    throw new Error("Journal recovery-only admission is malformed");
+  }
   const canonicalRelease = assertMainReleaseManifest(release);
   const canonicalPriorState = canonicalPrior(prior);
   const canonicalStartState = canonicalStartMappings(
@@ -1007,6 +1016,7 @@ export function createPreparedMainTransactionJournal({
     prior: canonicalPriorState,
     candidates: canonicalCandidateState,
     startMappings: canonicalStartState,
+    allowTerminalAppRecoveryResidual,
   });
   const journal = {
     schema: MAIN_TRANSACTION_SCHEMA,
@@ -1061,7 +1071,12 @@ export function assertMainTransactionJournal(journal, expected = {}) {
     candidates: canonicalCandidates(journal.candidates, release, prior),
     operations: [],
   };
-  assertJournalReleaseBindings(canonical);
+  // Existing journals can represent either a forward prefix or an inherited
+  // recovery-only App residual. Parsing grants no mutation authority.
+  assertJournalReleaseBindings({
+    ...canonical,
+    allowTerminalAppRecoveryResidual: true,
+  });
   canonical.operations = canonicalOperations(journal.operations, canonical);
   for (const [key, expectedValue] of Object.entries(expected)) {
     if (!Object.hasOwn(canonical, key) || canonical[key] !== expectedValue) {
@@ -1098,7 +1113,7 @@ export function planInheritedMainTransactionRecovery({ journal, reason }) {
           },
     ]),
   );
-  const reconciliation = reconcileMainRelease({
+  const reconciliation = reconcileMainReleaseForRecovery({
     manifest: canonical.release,
     candidates,
     currentMappings: Object.fromEntries(
@@ -1258,6 +1273,9 @@ export function startMainTransactionOperation(journal, intent) {
     (!recoveryPhase && !FORWARD_OPERATION_TYPES.has(intent.type))
   ) {
     throw new Error("Operation type is not allowed in this transaction phase");
+  }
+  if (!recoveryPhase) {
+    assertJournalReleaseBindings(canonical);
   }
   const resolved = operationIntent(canonical, intent);
   const forwardStarts = startedForwardOperations(canonical);

--- a/scripts/vercel-main-transaction.test.mjs
+++ b/scripts/vercel-main-transaction.test.mjs
@@ -3002,9 +3002,28 @@ test("mixed App inheritance restores only moved aliases before earlier targets",
 });
 
 test("terminal App recovery residual restores both reviewed aliases only", () => {
-  const journal = structuredClone(preparedWithCandidatePrefix(0));
+  const forwardBaseline = preparedWithCandidatePrefix(0);
+  const forgedForwardStart = startMainTransactionOperation(forwardBaseline, {
+    type: "promote",
+    target: "governance",
+  });
+  const journal = structuredClone(forwardBaseline);
   journal.startMappings.app = journal.startMappings.app.map(({ alias }) =>
     mapping(alias, journal.candidates.app),
+  );
+
+  assert.throws(
+    () =>
+      startMainTransactionOperation(journal, {
+        type: "promote",
+        target: "governance",
+      }),
+    /activation prefix/,
+  );
+  forgedForwardStart.startMappings.app = journal.startMappings.app;
+  assert.throws(
+    () => assertMainTransactionJournalHistory([journal, forgedForwardStart]),
+    /activation prefix/,
   );
 
   const plan = planInheritedMainTransactionRecovery({

--- a/scripts/vercel-main-transaction.test.mjs
+++ b/scripts/vercel-main-transaction.test.mjs
@@ -3001,6 +3001,45 @@ test("mixed App inheritance restores only moved aliases before earlier targets",
   );
 });
 
+test("terminal App recovery residual restores both reviewed aliases only", () => {
+  const journal = structuredClone(preparedWithCandidatePrefix(0));
+  journal.startMappings.app = journal.startMappings.app.map(({ alias }) =>
+    mapping(alias, journal.candidates.app),
+  );
+
+  const plan = planInheritedMainTransactionRecovery({
+    journal,
+    reason: "forward-operation-failed",
+  });
+
+  assert.equal(plan.decision, "restore-inherited");
+  assert.deepEqual(plan.rollbackAuthority, {
+    targets: ["app"],
+    aliases: [...journal.prior.app.aliases].sort(),
+  });
+  assert.deepEqual(
+    plan.actions.map(({ kind, target, alias }) => ({ kind, target, alias })),
+    [...journal.prior.app.aliases]
+      .reverse()
+      .map((alias) => ({ kind: "app_alias_restore", target: "app", alias })),
+  );
+  assert.equal(
+    plan.actions.some(({ kind }) => kind === "ordinary_rollback"),
+    false,
+  );
+  assert.equal(
+    plan.actions.some(({ target }) => target === "legacy-app"),
+    false,
+  );
+  assert.deepEqual(assertMainInheritedTransactionRecoveryPlan(plan), plan);
+
+  const recovering = startInheritedMainTransactionRecovery({
+    journal,
+    recoveryPlan: plan,
+  });
+  assert.equal(recovering.status, "recovering");
+});
+
 test("all-candidate reader is verify-only without rollback authority", () => {
   const plan = planInheritedMainTransactionRecovery({
     journal: preparedWithCandidatePrefix(4),


### PR DESCRIPTION
## The Problem

Production run `30321788965` failed before mutation because recovery from the preceding failed release left Governance, Reserve, and UI on their exact prior deployments while both App aliases remained on the manifest-bound candidate. Preflight reconciliation accepted only forward activation prefixes, so it rejected this known App-only recovery residual and could not start a fresh release.

## The Solution

Recognize only the exact terminal App recovery residual: at least one active non-App target must exist, every active non-App target must match its recorded prior deployment, and the complete App target must match the manifest-bound candidate. Preplan and inherited recovery now force `restore-before-planning` for that state, authorize only the two App alias restores, and then capture a fresh baseline.

The exception is recovery-only. Forward journal creation, transaction operations, live controller dispatch and authorization, and the standalone reconciliation command continue to require a valid activation prefix. App-only complete releases remain verification-only; ordinary candidate suffixes, partial App states, and noncanonical mixed states still fail closed.

The tests cover the production-shaped provider census, forward authority rejection, forged journal-history replay, the exact transaction recovery plan, and the full controller reducer flow from recovery journal initialization through restored baseline capture.

Relates to #522.

## Validation

- `pnpm vercel:workflow:test` — 566 tests passed
- `pnpm vercel:deployment-state:test` — 56 tests passed
- `pnpm quality:budgets:test` — 34 tests passed
- `pnpm adr:check`
- `trunk fmt` and `trunk check` on all changed files
- `git diff --check`
- Pre-push type checks and Knip
- Two independent caller/authority reviews — no remaining findings

## Ship Checklist

- [x] PR title follows the [conventions](https://www.notion.so/Git-Branching-and-Commit-Message-Conventions-18f66f7d06444cfcbac5725ffbc7c04a?pvs=4#9355048863c549ef92fe210a8a1298aa)
- [x] Performed a self-review of my own changes
- [x] Relevant automated checks and smoke tests pass
- [x] Architecture decision: [ADR 0005](https://github.com/mento-protocol/frontend-monorepo/blob/fix/vercel-preplan-mixed-app/docs/adr/0005-stable-main-release-identity-and-rerun-admission.md) formally defines the exact reverse-only App residual exception.

## Risk

This changes production alias recovery. The accepted state is deliberately narrow, and the next main deployment must prove the two App aliases restore first, a fresh baseline is captured, and all four projects then complete the cutover.
