### PR TITLE
fix(ci): raise bounded preplan handoff capacity

### DIFF
--- a/scripts/vercel-main-provider-cli.mjs
+++ b/scripts/vercel-main-provider-cli.mjs
@@ -62,7 +62,8 @@ import {
 import { generateVercelMainReleaseId } from "./vercel-prebuilt.mjs";
 
 export const MAIN_PROVIDER_CLI_MAX_JSON_BYTES = 256 * 1024;
-export const MAIN_PREPLAN_HANDOFF_MAX_ENCODED_BYTES = 64 * 1024;
+export const MAIN_PREPLAN_HANDOFF_MAX_JSON_BYTES = 96 * 1024;
+export const MAIN_PREPLAN_HANDOFF_MAX_ENCODED_BYTES = 128 * 1024;
 export const MAIN_PROVIDER_CLI_RETRY_EXIT_CODE = 75;
 export const MAIN_CANONICAL_MAPPINGS_SCHEMA =
   "vercel-main-canonical-mappings:v1";
@@ -908,9 +909,13 @@ export function encodeMainPreplanHandoff(
     nextDeploySha,
     nextUpstreamRunId,
   });
-  const encoded = Buffer.from(JSON.stringify(canonical), "utf8").toString(
-    "base64url",
-  );
+  const serialized = JSON.stringify(canonical);
+  if (
+    Buffer.byteLength(serialized, "utf8") > MAIN_PREPLAN_HANDOFF_MAX_JSON_BYTES
+  ) {
+    throw new Error("Main pre-plan handoff exceeds its JSON size bound");
+  }
+  const encoded = Buffer.from(serialized, "utf8").toString("base64url");
   if (
     Buffer.byteLength(encoded, "utf8") > MAIN_PREPLAN_HANDOFF_MAX_ENCODED_BYTES
   ) {
@@ -937,6 +942,12 @@ export function decodeMainPreplanHandoff(
       throw new Error("noncanonical base64url");
     }
     const serialized = decoded.toString("utf8");
+    if (
+      Buffer.byteLength(serialized, "utf8") >
+      MAIN_PREPLAN_HANDOFF_MAX_JSON_BYTES
+    ) {
+      throw new Error("oversized JSON");
+    }
     parsed = JSON.parse(serialized);
     if (JSON.stringify(parsed) !== serialized) {
       throw new Error("noncanonical JSON");

--- a/scripts/vercel-main-provider-cli.mjs
+++ b/scripts/vercel-main-provider-cli.mjs
@@ -62,8 +62,9 @@ import {
 import { generateVercelMainReleaseId } from "./vercel-prebuilt.mjs";
 
 export const MAIN_PROVIDER_CLI_MAX_JSON_BYTES = 256 * 1024;
-export const MAIN_PREPLAN_HANDOFF_MAX_JSON_BYTES = 96 * 1024;
-export const MAIN_PREPLAN_HANDOFF_MAX_ENCODED_BYTES = 128 * 1024;
+export const MAIN_PREPLAN_HANDOFF_MAX_JSON_BYTES = 95 * 1024;
+// Leave room for MAIN_PREPLAN_HANDOFF= and NUL below Linux MAX_ARG_STRLEN.
+export const MAIN_PREPLAN_HANDOFF_MAX_ENCODED_BYTES = 127 * 1024;
 export const MAIN_PROVIDER_CLI_RETRY_EXIT_CODE = 75;
 export const MAIN_CANONICAL_MAPPINGS_SCHEMA =
   "vercel-main-canonical-mappings:v1";

--- a/scripts/vercel-main-provider-cli.test.mjs
+++ b/scripts/vercel-main-provider-cli.test.mjs
@@ -57,6 +57,11 @@ const fixtureUrl = new URL(
 );
 const SHA = "d".repeat(40);
 const PRIOR_SHA = "a".repeat(40);
+const LINUX_MAX_ARG_STRING_BYTES = 128 * 1024;
+const MAIN_PREPLAN_HANDOFF_ENV_OVERHEAD_BYTES = Buffer.byteLength(
+  "MAIN_PREPLAN_HANDOFF=\0",
+  "utf8",
+);
 
 function fixtureInput() {
   const input = JSON.parse(readFileSync(fixtureUrl, "utf8"));
@@ -943,6 +948,17 @@ test("preplan materialization accepts only inherited restore and exposes ordered
   assert.ok(
     Buffer.byteLength(productionShapeHandoff, "utf8") <=
       MAIN_PREPLAN_HANDOFF_MAX_ENCODED_BYTES,
+  );
+  assert.ok(
+    Math.ceil((MAIN_PREPLAN_HANDOFF_MAX_JSON_BYTES * 4) / 3) <=
+      MAIN_PREPLAN_HANDOFF_MAX_ENCODED_BYTES,
+    "every accepted JSON payload must fit the encoded handoff bound",
+  );
+  assert.ok(
+    MAIN_PREPLAN_HANDOFF_ENV_OVERHEAD_BYTES +
+      MAIN_PREPLAN_HANDOFF_MAX_ENCODED_BYTES <
+      LINUX_MAX_ARG_STRING_BYTES,
+    "the largest handoff must fit one Linux environment entry",
   );
   assert.deepEqual(
     decodeMainPreplanHandoff(productionShapeHandoff, {

--- a/scripts/vercel-main-provider-cli.test.mjs
+++ b/scripts/vercel-main-provider-cli.test.mjs
@@ -42,6 +42,7 @@ import {
   MAIN_PROVIDER_CLI_MAX_JSON_BYTES,
   MAIN_PROVIDER_CLI_RETRY_EXIT_CODE,
   MAIN_PREPLAN_HANDOFF_MAX_ENCODED_BYTES,
+  MAIN_PREPLAN_HANDOFF_MAX_JSON_BYTES,
   readPrivateJson,
   renderMainProviderCliFailure,
   reviewedRunnerTemp,
@@ -71,6 +72,7 @@ function releaseManifest({
   deploySha = SHA,
   upstreamRunId = "700",
   active = false,
+  productionIdPaddingBytes = 0,
 } = {}) {
   const input = fixtureInput();
   input.deploySha = deploySha;
@@ -82,6 +84,21 @@ function releaseManifest({
       reserve: "github",
       ui: "github",
     };
+  }
+  if (productionIdPaddingBytes > 0) {
+    for (const [target, prior] of Object.entries(input.priorStates)) {
+      for (const state of prior.states) {
+        state.deploymentId = `dpl_${target}${"A".repeat(productionIdPaddingBytes)}`;
+        state.deploymentUrl = `https://${target}mento-${"b".repeat(9)}-mentolabs.vercel.app`;
+        state.projectId = `prj_${target}${"C".repeat(productionIdPaddingBytes)}`;
+      }
+    }
+    input.projectIds = Object.fromEntries(
+      Object.entries(input.priorStates).map(([target, prior]) => [
+        target,
+        prior.states[0].projectId,
+      ]),
+    );
   }
   const plan = planMainDeployments({
     mode: input.mode,
@@ -135,6 +152,45 @@ function releaseManifest({
     }),
   );
   return createMainReleaseManifest({ upstreamRunId, plan, originalPriors });
+}
+
+function productionShapedDecision({ productionIdPaddingBytes = 26 } = {}) {
+  const manifest = releaseManifest({
+    active: true,
+    productionIdPaddingBytes,
+  });
+  const candidates = Object.fromEntries(
+    ["governance", "reserve", "ui", "app"].map((target) => [
+      target,
+      {
+        deploymentId: `dpl_${target}${"D".repeat(productionIdPaddingBytes)}`,
+        deploymentUrl: `https://${target}mento-${"e".repeat(9)}-mentolabs.vercel.app`,
+        manifest,
+      },
+    ]),
+  );
+  return decideMainPreplanReconciliation({
+    nextDeploySha: "e".repeat(40),
+    nextUpstreamRunId: "701",
+    candidateReleases: [{ manifest, candidates }],
+    currentMappings: Object.fromEntries(
+      ["governance", "reserve", "ui", "app"].map((target) => {
+        const current =
+          target === "app"
+            ? candidates[target]
+            : manifest.originalPriors[target];
+        return [
+          target,
+          manifest.originalPriors[target].aliases.map((alias) => ({
+            alias,
+            deploymentId: current.deploymentId,
+            deploymentUrl: current.deploymentUrl,
+          })),
+        ];
+      }),
+    ),
+    rollbackOnlyTargets: [],
+  });
 }
 
 function candidateIntent(target = "ui") {
@@ -860,6 +916,51 @@ test("preplan materialization accepts only inherited restore and exposes ordered
       nextUpstreamRunId: "700",
     }),
     maximumShapeDecision,
+  );
+  const productionShapeDecision = productionShapedDecision();
+  const productionShapeSerialized = JSON.stringify(productionShapeDecision);
+  assert.equal(productionShapeDecision.decision, "restore-before-planning");
+  assert.equal(
+    productionShapeDecision.reason,
+    "older-main-release-is-an-app-recovery-residual",
+  );
+  const productionShapeHandoff = encodeMainPreplanHandoff(
+    productionShapeDecision,
+    {
+      nextDeploySha: "e".repeat(40),
+      nextUpstreamRunId: "701",
+    },
+  );
+  assert.ok(
+    Buffer.byteLength(productionShapeSerialized, "utf8") > 49_152,
+    "production-shaped pre-plan must exceed the legacy 64 KiB base64url limit",
+  );
+  assert.ok(
+    Buffer.byteLength(productionShapeSerialized, "utf8") <=
+      MAIN_PREPLAN_HANDOFF_MAX_JSON_BYTES,
+  );
+  assert.ok(Buffer.byteLength(productionShapeHandoff, "utf8") > 64 * 1024);
+  assert.ok(
+    Buffer.byteLength(productionShapeHandoff, "utf8") <=
+      MAIN_PREPLAN_HANDOFF_MAX_ENCODED_BYTES,
+  );
+  assert.deepEqual(
+    decodeMainPreplanHandoff(productionShapeHandoff, {
+      nextDeploySha: "e".repeat(40),
+      nextUpstreamRunId: "701",
+    }),
+    productionShapeDecision,
+  );
+  assert.throws(
+    () =>
+      encodeMainPreplanHandoff(
+        productionShapedDecision({ productionIdPaddingBytes: 2_500 }),
+        {
+          nextDeploySha: "e".repeat(40),
+          nextUpstreamRunId: "701",
+        },
+      ),
+    /JSON size bound/,
   );
   const output = join(context.directory, "restore-before-planning.json");
   await runMainProviderCli({


### PR DESCRIPTION
## The Problem

The first active GitHub-driven production deployment failed before any Vercel mutation because its canonical pre-plan recovery handoff was 70,838 bytes, above the repository's 65,536-byte encoded limit. The payload represented a valid App-only recovery residual and remained well below GitHub Actions' job-output capacity.

## The Solution

Raise the bounded pre-plan transport to 95 KiB of canonical JSON and 127 KiB after base64url encoding. Encode and decode now enforce both limits while retaining the existing canonical, SHA-bound wire format. The encoded cap leaves explicit room for the environment variable name and terminator below Linux's 128 KiB per-string execution limit.

Add a synthetic production-shaped regression with all four embedded candidates and only App left on the candidate deployment. It reproduces the recovery decision, exceeds the former 64 KiB encoded limit, remains inside the new bounds, and round-trips canonically. Oversized canonical JSON still fails closed.

Relates to #522.

## Validation

- `node --test scripts/vercel-main-provider-cli.test.mjs` — 15/15 passed
- `pnpm vercel:workflow:test` — 566/566 passed
- `pnpm vercel:deployment-state:test` — 56/56 passed
- `pnpm quality:budgets:test` — 34/34 passed
- `pnpm adr:check` — passed
- `trunk check scripts/vercel-main-provider-cli.mjs scripts/vercel-main-provider-cli.test.mjs` — passed
- `pnpm exec prettier --check scripts/vercel-main-provider-cli.mjs scripts/vercel-main-provider-cli.test.mjs` — passed
- Two fresh-context code reviews — clean

## Ship Checklist

- [x] PR title follows the [conventions](https://www.notion.so/Git-Branching-and-Commit-Message-Conventions-18f66f7d06444cfcbac5725ffbc7c04a?pvs=4#9355048863c549ef92fe210a8a1298aa)
- [x] Performed a self-review of my own changes
- [x] Relevant automated checks and smoke tests pass
- [x] Architecture decision? Not applicable — this is a bounded capacity correction within the existing canonical pre-plan transport.
