### PR TITLE
fix(ci): retry immutable candidate readiness

### DIFF
--- a/scripts/vercel-main-provider-cli.mjs
+++ b/scripts/vercel-main-provider-cli.mjs
@@ -74,6 +74,8 @@ const PROJECT_TARGETS = Object.freeze(["app", "governance", "reserve", "ui"]);
 const MAIN_CANDIDATE_SMOKE_PATHS = Object.freeze({
   ui: "/basic-components",
 });
+const MAIN_CANDIDATE_SMOKE_MAX_ATTEMPTS = 4;
+const MAIN_CANDIDATE_SMOKE_RETRY_DELAY_MS = 1_000;
 const LEGACY_ALIAS = "v2-app.mento.org";
 const LEGACY_ALIASES = Object.freeze(
   [
@@ -124,6 +126,10 @@ const PREPLAN_POST_CENSUS_FAILURE_CODES = new Set([
   "preplan-handoff-encode-failed",
   "preplan-github-output-append-failed",
 ]);
+const CANDIDATE_SMOKE_FAILURE_CODES = new Set([
+  "candidate-smoke-edge-transport-exhausted",
+  "candidate-smoke-edge-transient-exhausted",
+]);
 const SAFE_MAIN_PROVIDER_FAILURE_CODES = new Set([
   ...["planning-census", "legacy-census"].flatMap((stage) => [
     `${stage}-read-timeout`,
@@ -137,6 +143,7 @@ const SAFE_MAIN_PROVIDER_FAILURE_CODES = new Set([
   ]),
   "preplan-reconciliation-failed",
   ...PREPLAN_POST_CENSUS_FAILURE_CODES,
+  ...CANDIDATE_SMOKE_FAILURE_CODES,
 ]);
 const RETRYABLE_MAIN_PROVIDER_FAILURE_CODES = new Set([
   "planning-census-unstable",
@@ -1002,6 +1009,8 @@ async function smokeMainCandidateUrl({
   intent,
   candidate,
   fetchImpl = globalThis.fetch,
+  sleepImpl = (milliseconds) =>
+    new Promise((resolveSleep) => setTimeout(resolveSleep, milliseconds)),
 }) {
   const canonicalIntent = assertMainCandidateIntent(intent);
   const canonicalCandidate = assertMainCandidateProviderCandidate(
@@ -1010,6 +1019,11 @@ async function smokeMainCandidateUrl({
   );
   if (typeof fetchImpl !== "function") {
     throw new Error("Main candidate HTTP smoke implementation is required");
+  }
+  if (typeof sleepImpl !== "function") {
+    throw new Error(
+      "Main candidate HTTP smoke retry implementation is required",
+    );
   }
   const url = new URL(canonicalCandidate.deploymentUrl);
   if (
@@ -1028,47 +1042,94 @@ async function smokeMainCandidateUrl({
     MAIN_CANDIDATE_SMOKE_PATHS[canonicalIntent.target] ?? "/",
     url,
   );
-  let response;
-  try {
-    response = await fetchImpl(smokeUrl.toString(), {
-      method: "GET",
-      redirect: "manual",
-      signal: AbortSignal.timeout(15_000),
-      headers: {
-        "user-agent": "mento-vercel-main-candidate-smoke/1",
-      },
-    });
-  } catch {
-    throw new Error("Main candidate immutable HTTP smoke failed");
-  }
-  let responseUrl = null;
-  try {
-    responseUrl =
-      typeof response?.url === "string"
-        ? new URL(response.url).toString()
-        : null;
-  } catch {
-    responseUrl = null;
-  }
-  const servedSha = response?.headers?.get?.("x-mento-deployment-sha");
-  if (
-    !Number.isSafeInteger(response?.status) ||
-    response.status < 200 ||
-    response.status >= 300 ||
-    response.redirected !== false ||
-    responseUrl !== smokeUrl.toString() ||
-    servedSha !== canonicalIntent.deploySha
-  ) {
-    throw new Error("Main candidate immutable HTTP smoke is inconsistent");
-  }
-  if (typeof response.body?.cancel === "function") {
-    await response.body.cancel();
-  }
-  return {
-    immutableUrl: canonicalCandidate.deploymentUrl,
-    servedSha: canonicalIntent.deploySha,
-    status: "passed",
+  const exhaustedEdgeReadiness = (failureCode) => {
+    if (!CANDIDATE_SMOKE_FAILURE_CODES.has(failureCode)) {
+      throw new Error(
+        "Main candidate immutable HTTP smoke failure code is malformed",
+      );
+    }
+    const error = new Error("Main candidate immutable HTTP smoke failed");
+    error.mainProviderFailureCode = failureCode;
+    return error;
   };
+  for (
+    let attempt = 1;
+    attempt <= MAIN_CANDIDATE_SMOKE_MAX_ATTEMPTS;
+    attempt += 1
+  ) {
+    let response;
+    try {
+      response = await fetchImpl(smokeUrl.toString(), {
+        method: "GET",
+        redirect: "manual",
+        signal: AbortSignal.timeout(15_000),
+        headers: {
+          "user-agent": "mento-vercel-main-candidate-smoke/1",
+        },
+      });
+    } catch {
+      if (attempt === MAIN_CANDIDATE_SMOKE_MAX_ATTEMPTS) {
+        throw exhaustedEdgeReadiness(
+          "candidate-smoke-edge-transport-exhausted",
+        );
+      }
+      await sleepImpl(MAIN_CANDIDATE_SMOKE_RETRY_DELAY_MS);
+      continue;
+    }
+
+    let retryableStatus = false;
+    try {
+      let responseUrl = null;
+      try {
+        responseUrl =
+          typeof response?.url === "string"
+            ? new URL(response.url).toString()
+            : null;
+      } catch {
+        responseUrl = null;
+      }
+      if (
+        !Number.isSafeInteger(response?.status) ||
+        response.redirected !== false ||
+        responseUrl !== smokeUrl.toString()
+      ) {
+        throw new Error("Main candidate immutable HTTP smoke is inconsistent");
+      }
+      retryableStatus =
+        response.status === 404 ||
+        (response.status >= 500 && response.status < 600);
+      if (!retryableStatus) {
+        const servedSha = response.headers?.get?.("x-mento-deployment-sha");
+        if (
+          response.status < 200 ||
+          response.status >= 300 ||
+          servedSha !== canonicalIntent.deploySha
+        ) {
+          throw new Error(
+            "Main candidate immutable HTTP smoke is inconsistent",
+          );
+        }
+      }
+    } finally {
+      if (typeof response.body?.cancel === "function") {
+        await response.body.cancel();
+      }
+    }
+
+    if (!retryableStatus) {
+      return {
+        immutableUrl: canonicalCandidate.deploymentUrl,
+        servedSha: canonicalIntent.deploySha,
+        status: "passed",
+      };
+    }
+    if (attempt === MAIN_CANDIDATE_SMOKE_MAX_ATTEMPTS) {
+      throw exhaustedEdgeReadiness("candidate-smoke-edge-transient-exhausted");
+    }
+    await sleepImpl(MAIN_CANDIDATE_SMOKE_RETRY_DELAY_MS);
+  }
+
+  throw new Error("Main candidate immutable HTTP smoke failed");
 }
 
 export async function runMainProviderCli({
@@ -1081,6 +1142,7 @@ export async function runMainProviderCli({
       intent === undefined ? { client } : { client, intent },
     ),
   fetchImpl = globalThis.fetch,
+  sleepImpl,
 } = {}) {
   const { command, options } = parseArguments(argv);
   const runnerTemp = reviewedRunnerTemp(env.RUNNER_TEMP);
@@ -1319,6 +1381,7 @@ export async function runMainProviderCli({
       intent,
       candidate: preflight.candidate,
       fetchImpl,
+      sleepImpl,
     });
     writePrivateJson(options.output, result, runnerTemp);
     appendGithubOutputs(env, {

--- a/scripts/vercel-main-provider-cli.test.mjs
+++ b/scripts/vercel-main-provider-cli.test.mjs
@@ -364,6 +364,38 @@ function deploymentResponse(intent, id = "dpl_candidate0123456789") {
   };
 }
 
+function candidateSmokeStateClient(response) {
+  return () => ({
+    requestWithRetry: async () => ({
+      deployments: [{ uid: response.id }],
+      pagination: { next: null },
+    }),
+    inspectDeployment: async () => response,
+    listDeploymentAliases: async () => ({ aliases: [] }),
+  });
+}
+
+function candidateSmokeHttpResponse({
+  url,
+  intent,
+  status = 200,
+  redirected = false,
+  servedSha = intent.deploySha,
+  onCancel = () => {},
+}) {
+  return {
+    status,
+    redirected,
+    url,
+    headers: {
+      get: (name) => (name === "x-mento-deployment-sha" ? servedSha : null),
+    },
+    body: {
+      cancel: async () => onCancel(),
+    },
+  };
+}
+
 function generatedCreatorAlias(target, creatorUsername = "fixture-author") {
   const { generatedProjectSlug, generatedScopeSlug } =
     PRODUCTION_GENERATED_ALIAS_CONTRACTS[target];
@@ -1649,6 +1681,186 @@ test("candidate smoke uses the target's direct immutable route and preserves the
   }
 });
 
+test("candidate smoke retries a timeout once before accepting the immutable candidate", async (t) => {
+  const context = testContext(t);
+  const intent = candidateIntent();
+  const response = deploymentResponse(intent);
+  const intentPath = writeJson(context.directory, "intent.json", intent);
+  const output = join(context.directory, "candidate-smoke.json");
+  const retryDelays = [];
+  let calls = 0;
+  let cancelled = 0;
+  const result = await runMainProviderCli({
+    argv: ["candidate-smoke", "--intent", intentPath, "--output", output],
+    env: context.env,
+    stdout: context.stdout,
+    stateClientFactory: candidateSmokeStateClient(response),
+    sleepImpl: async (milliseconds) => {
+      retryDelays.push(milliseconds);
+    },
+    fetchImpl: async (url) => {
+      calls += 1;
+      if (calls === 1) {
+        const error = new Error("candidate edge timed out");
+        error.name = "TimeoutError";
+        throw error;
+      }
+      return candidateSmokeHttpResponse({
+        url,
+        intent,
+        onCancel: () => {
+          cancelled += 1;
+        },
+      });
+    },
+  });
+
+  assert.equal(calls, 2);
+  assert.deepEqual(retryDelays, [1_000]);
+  assert.equal(cancelled, 1);
+  assert.equal(result.status, "passed");
+});
+
+test("candidate smoke retries transient edge statuses before accepting the immutable candidate", async (t) => {
+  const context = testContext(t);
+  const intent = candidateIntent();
+  const response = deploymentResponse(intent);
+  const intentPath = writeJson(context.directory, "intent.json", intent);
+
+  for (const transientStatus of [404, 503]) {
+    const retryDelays = [];
+    let calls = 0;
+    let cancelled = 0;
+    const result = await runMainProviderCli({
+      argv: [
+        "candidate-smoke",
+        "--intent",
+        intentPath,
+        "--output",
+        join(context.directory, `candidate-smoke-${transientStatus}.json`),
+      ],
+      env: context.env,
+      stdout: context.stdout,
+      stateClientFactory: candidateSmokeStateClient(response),
+      sleepImpl: async (milliseconds) => {
+        retryDelays.push(milliseconds);
+      },
+      fetchImpl: async (url) => {
+        calls += 1;
+        return candidateSmokeHttpResponse({
+          url,
+          intent,
+          status: calls === 1 ? transientStatus : 200,
+          onCancel: () => {
+            cancelled += 1;
+          },
+        });
+      },
+    });
+
+    assert.equal(calls, 2, String(transientStatus));
+    assert.deepEqual(retryDelays, [1_000], String(transientStatus));
+    assert.equal(cancelled, 2, String(transientStatus));
+    assert.equal(result.status, "passed", String(transientStatus));
+  }
+});
+
+test("candidate smoke fails after bounded transient retries and cancels every response body", async (t) => {
+  const context = testContext(t);
+  const intent = candidateIntent();
+  const response = deploymentResponse(intent);
+  const intentPath = writeJson(context.directory, "intent.json", intent);
+  const retryDelays = [];
+  let calls = 0;
+  let cancelled = 0;
+
+  const error = await captureRejection(
+    () =>
+      runMainProviderCli({
+        argv: [
+          "candidate-smoke",
+          "--intent",
+          intentPath,
+          "--output",
+          join(context.directory, "candidate-smoke.json"),
+        ],
+        env: context.env,
+        stdout: context.stdout,
+        stateClientFactory: candidateSmokeStateClient(response),
+        sleepImpl: async (milliseconds) => {
+          retryDelays.push(milliseconds);
+        },
+        fetchImpl: async (url) => {
+          calls += 1;
+          return candidateSmokeHttpResponse({
+            url,
+            intent,
+            status: 503,
+            onCancel: () => {
+              cancelled += 1;
+            },
+          });
+        },
+      }),
+    /HTTP smoke failed/,
+  );
+
+  assert.equal(calls, 4);
+  assert.deepEqual(retryDelays, [1_000, 1_000, 1_000]);
+  assert.equal(cancelled, 4);
+  assert.equal(
+    renderMainProviderCliFailure(error),
+    "Vercel main provider command failed (candidate-smoke-edge-transient-exhausted)\n",
+  );
+  assert.equal(mainProviderCliFailureExitCode(error), 1);
+});
+
+test("candidate smoke classifies exhausted transport retries without exposing transport details", async (t) => {
+  const context = testContext(t);
+  const intent = candidateIntent();
+  const response = deploymentResponse(intent);
+  const intentPath = writeJson(context.directory, "intent.json", intent);
+  const retryDelays = [];
+  let calls = 0;
+  const error = await captureRejection(
+    () =>
+      runMainProviderCli({
+        argv: [
+          "candidate-smoke",
+          "--intent",
+          intentPath,
+          "--output",
+          join(context.directory, "candidate-smoke.json"),
+        ],
+        env: context.env,
+        stdout: context.stdout,
+        stateClientFactory: candidateSmokeStateClient(response),
+        sleepImpl: async (milliseconds) => {
+          retryDelays.push(milliseconds);
+        },
+        fetchImpl: async () => {
+          calls += 1;
+          throw new Error(
+            `${context.env.VERCEL_TOKEN} private transport error`,
+          );
+        },
+      }),
+    /HTTP smoke failed/,
+  );
+
+  assert.equal(calls, 4);
+  assert.deepEqual(retryDelays, [1_000, 1_000, 1_000]);
+  assert.equal(
+    renderMainProviderCliFailure(error),
+    "Vercel main provider command failed (candidate-smoke-edge-transport-exhausted)\n",
+  );
+  assert.doesNotMatch(
+    renderMainProviderCliFailure(error),
+    /test-secret-token|private transport error/,
+  );
+  assert.equal(mainProviderCliFailureExitCode(error), 1);
+});
+
 test("candidate smoke fails closed for UI redirects, host or path changes, SHA mismatches, and non-2xx responses", async (t) => {
   const context = testContext(t);
   const intent = candidateIntent("ui");
@@ -1676,8 +1888,12 @@ test("candidate smoke fails closed for UI redirects, host or path changes, SHA m
         },
       },
     ],
-    ["bad-status", { status: 503 }],
+    ["bad-status", { status: 400 }],
+    ["rate-limited", { status: 429 }],
+    ["outside-http-status-range", { status: 600 }],
   ]) {
+    let calls = 0;
+    const retryDelays = [];
     await assert.rejects(
       () =>
         runMainProviderCli({
@@ -1691,16 +1907,24 @@ test("candidate smoke fails closed for UI redirects, host or path changes, SHA m
           env: context.env,
           stdout: context.stdout,
           stateClientFactory,
-          fetchImpl: async (url) => ({
-            status: 200,
-            redirected: false,
-            url,
-            headers: { get: () => intent.deploySha },
-            ...patch,
-          }),
+          sleepImpl: async (milliseconds) => {
+            retryDelays.push(milliseconds);
+          },
+          fetchImpl: async (url) => {
+            calls += 1;
+            return {
+              status: 200,
+              redirected: false,
+              url,
+              headers: { get: () => intent.deploySha },
+              ...patch,
+            };
+          },
         }),
       /HTTP smoke/,
     );
+    assert.equal(calls, 1, name);
+    assert.deepEqual(retryDelays, [], name);
   }
 });
 


### PR DESCRIPTION
## The Problem

Production run 30327323736 built and uploaded the Reserve candidate successfully, then started its immutable HTTP smoke 10 ms later. The single probe hit its 15-second timeout while Vercel's edge route was still becoming available, so the release failed before any public alias promotion. The same immutable candidate now returns HTTP 200 with the exact deployment SHA.

## The Solution

Retry immutable candidate readiness within a fixed bound: four 15-second probes separated by one-second delays. Retry only transport/timeouts, HTTP 404 propagation, and HTTP 5xx responses.

Keep integrity failures immediate and single-shot: redirects, response URL drift, wrong or missing deployment SHA, HTTP 429, and other non-transient statuses still fail closed. Every returned response body is cancelled, and exhausted transient failures expose only safe diagnostic codes.

Relates to #522.

## Validation

- Exact failed Reserve candidate now returns HTTP 200, no redirect, and `X-Mento-Deployment-Sha: 5722300ec39bb98f8ac2aaf0b4368aa928ce4453`
- `node --test scripts/vercel-main-provider-cli.test.mjs` — 19/19 passed
- `pnpm vercel:workflow:test` — 570/570 passed
- `pnpm vercel:deployment-state:test` — 56/56 passed
- `pnpm quality:budgets:test` — 34/34 passed
- `pnpm adr:check` — passed
- `trunk check scripts/vercel-main-provider-cli.mjs scripts/vercel-main-provider-cli.test.mjs` — passed
- Two fresh-context code reviews — clean

## Ship Checklist

- [x] PR title follows the [conventions](https://www.notion.so/Git-Branching-and-Commit-Message-Conventions-18f66f7d06444cfcbac5725ffbc7c04a?pvs=4#9355048863c549ef92fe210a8a1298aa)
- [x] Performed a self-review of my own changes
- [x] Relevant automated checks and smoke tests pass
- [x] Architecture decision? Not applicable — this is a bounded reliability correction within the existing immutable candidate smoke contract.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI reliability change in candidate smoke only; integrity checks remain fail-closed and failure output stays sanitized.
> 
> **Overview**
> **Immutable candidate HTTP smoke** now retries up to **four** probes with **1s** delays instead of failing on the first edge blip.
> 
> Retries apply only to **transport/timeouts**, **HTTP 404**, and **5xx** responses. Redirects, URL drift, wrong or missing `x-mento-deployment-sha`, **429**, and other non-transient statuses still fail on the first attempt. Every probe cancels the response body; when retries are exhausted, failures surface only as **`candidate-smoke-edge-transport-exhausted`** or **`candidate-smoke-edge-transient-exhausted`** (added to safe CLI failure codes). `sleepImpl` is injectable for tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35a07c1996cdfa0a85cb58f67419aacca28fe946. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->