### PR TITLE
fix(ci): follow App runtime redirect in production smoke

### DIFF
--- a/scripts/vercel-main-active-controller.mjs
+++ b/scripts/vercel-main-active-controller.mjs
@@ -99,7 +99,7 @@ const ACTIVE_RUNTIME_RESULT_KEYS = Object.freeze([
   "successful_stylesheets",
 ]);
 const ACTIVE_RUNTIME_FINAL_PATHS = Object.freeze({
-  app: "/",
+  app: "/swap/celo",
   governance: "/voting-power",
   reserve: "/?tab=stablecoins",
   ui: "/form-components",

--- a/scripts/vercel-main-active-controller.test.mjs
+++ b/scripts/vercel-main-active-controller.test.mjs
@@ -615,7 +615,7 @@ function activeStateProof(
 
 function runtimeSmoke(target, deploySha = SHA) {
   const finalUrls = {
-    app: "https://app.mento.org/",
+    app: "https://app.mento.org/swap/celo",
     governance: "https://governance.mento.org/voting-power",
     reserve: "https://reserve.mento.org/?tab=stablecoins",
     ui: "https://ui.mento.org/form-components",

--- a/scripts/vercel-main-deployment.mjs
+++ b/scripts/vercel-main-deployment.mjs
@@ -2372,7 +2372,7 @@ const ACTIVE_RUNTIME_RESULT_KEYS = Object.freeze([
 ]);
 
 const ACTIVE_RECOVERY_RUNTIME_FINAL_PATHS = Object.freeze({
-  app: "/",
+  app: "/swap/celo",
   governance: "/voting-power",
   reserve: "/?tab=stablecoins",
   ui: "/form-components",

--- a/scripts/vercel-main-deployment.test.mjs
+++ b/scripts/vercel-main-deployment.test.mjs
@@ -639,7 +639,7 @@ function activeFinalMappings(harness) {
 
 function runtimeSmoke(target, deploySha = SHA) {
   const finalPaths = {
-    app: "https://app.mento.org/",
+    app: "https://app.mento.org/swap/celo",
     governance: "https://governance.mento.org/voting-power",
     reserve: "https://reserve.mento.org/?tab=stablecoins",
     ui: "https://ui.mento.org/form-components",
@@ -6203,7 +6203,7 @@ test("active recovery public-smoke materializer accepts only exact runtime resul
   const deploymentPlan = activePlan({ deployments: ["governance"] });
   const execution = releaseExecutionForPlan(deploymentPlan);
   const finalPaths = {
-    app: "https://app.mento.org/",
+    app: "https://app.mento.org/swap/celo",
     governance: "https://governance.mento.org/voting-power",
     reserve: "https://reserve.mento.org/?tab=stablecoins",
     ui: "https://ui.mento.org/form-components",

--- a/scripts/vercel-main-release-cli.test.mjs
+++ b/scripts/vercel-main-release-cli.test.mjs
@@ -448,7 +448,7 @@ function verifiedReleaseExecution(releaseManifest) {
 
 function currentReleaseRuntimeSmoke(target) {
   const finalUrls = {
-    app: "https://app.mento.org/",
+    app: "https://app.mento.org/swap/celo",
     governance: "https://governance.mento.org/voting-power",
     reserve: "https://reserve.mento.org/?tab=stablecoins",
     ui: "https://ui.mento.org/form-components",

--- a/scripts/vercel-main-runtime.mjs
+++ b/scripts/vercel-main-runtime.mjs
@@ -23,8 +23,8 @@ const REQUIRED_RESOURCE_TYPES = ["document", "font", "script", "stylesheet"];
 export const MAIN_RUNTIME_TARGETS = Object.freeze({
   app: Object.freeze({
     publicUrl: "https://app.mento.org/",
-    landingPath: "/",
-    finalPath: "/",
+    landingPath: "/swap/celo",
+    finalPath: "/swap/celo",
     interaction: "real-production-wallet-list",
   }),
   governance: Object.freeze({
@@ -471,9 +471,11 @@ export async function runMainRuntimeSmoke({
       response && response.ok(),
       `Main runtime navigation failed with HTTP ${response?.status() ?? "unknown"}`,
     );
+    const expectedLandingUrl = new URL(config.landingPath, publicUrl);
+    await page.waitForURL(expectedLandingUrl.toString());
     assertExactPageLocation(
       page,
-      new URL(config.landingPath, publicUrl),
+      expectedLandingUrl,
       `${input.logicalTarget} public landing URL`,
     );
     assertMainRuntimeSecurityHeaders(response.headers(), input.deploySha);

--- a/scripts/vercel-main-runtime.test.mjs
+++ b/scripts/vercel-main-runtime.test.mjs
@@ -19,6 +19,12 @@ import {
 } from "./vercel-main-runtime.mjs";
 
 const SHA = "0123456789abcdef0123456789abcdef01234567";
+const ACTUAL_LANDING_PATHS = Object.freeze({
+  app: "/swap/celo",
+  governance: "/",
+  reserve: "/",
+  ui: "/basic-components",
+});
 
 function securityHeaders(sha = SHA) {
   return {
@@ -136,6 +142,8 @@ class FakePage extends EventEmitter {
       headers = securityHeaders(),
       mockWalletVisible = false,
       omitResource,
+      initialLanding,
+      waitForUrlNavigation,
       walletFlagsAbsent = true,
       wrongLanding,
     } = {},
@@ -147,6 +155,8 @@ class FakePage extends EventEmitter {
     this.responseHeaders = headers;
     this.mockWalletVisible = mockWalletVisible;
     this.omitResource = omitResource;
+    this.initialLanding = initialLanding;
+    this.waitForUrlNavigation = waitForUrlNavigation;
     this.walletFlagsAbsent = walletFlagsAbsent;
     this.wrongLanding = wrongLanding;
     this.currentUrl = this.config.publicUrl;
@@ -195,7 +205,10 @@ class FakePage extends EventEmitter {
   async goto(url, options) {
     assert.equal(url, this.config.publicUrl);
     assert.deepEqual(options, { waitUntil: "domcontentloaded" });
-    const landingPath = this.wrongLanding ?? this.config.landingPath;
+    const landingPath =
+      this.wrongLanding ??
+      this.initialLanding ??
+      ACTUAL_LANDING_PATHS[this.target];
     this.currentUrl = new URL(landingPath, url).toString();
     this.emit("framenavigated", this.frame);
     const documentResponse = this.response(landingPath, "document");
@@ -245,7 +258,10 @@ class FakePage extends EventEmitter {
   async waitForURL(expected) {
     const expectedUrl =
       typeof expected === "string" ? expected : expected.toString();
-    assert.equal(this.currentUrl, expectedUrl);
+    if (this.waitForUrlNavigation !== undefined) {
+      this.navigate(this.waitForUrlNavigation);
+      this.waitForUrlNavigation = undefined;
+    }
     this.calls.push(["wait-url", expectedUrl]);
   }
 
@@ -319,6 +335,27 @@ test("hard-binds each logical target to its literal public URL and SHA", () => {
       /target|public URL mismatch|immutable lowercase/,
     );
   }
+});
+
+test("App public runtime verification follows the production root redirect", () => {
+  assert.equal(MAIN_RUNTIME_TARGETS.app.landingPath, "/swap/celo");
+  assert.equal(MAIN_RUNTIME_TARGETS.app.finalPath, "/swap/celo");
+});
+
+test("App waits for the client-side production root redirect", async () => {
+  const page = new FakePage("app", {
+    initialLanding: "/",
+    waitForUrlNavigation: "/swap/celo",
+  });
+  const result = await runMainRuntimeSmoke({
+    chromium: fakeChromium(page).chromium,
+    values: inputFor("app"),
+  });
+  assert.equal(result.final_url, "https://app.mento.org/swap/celo");
+  assert.deepEqual(
+    page.calls.find(([operation]) => operation === "wait-url"),
+    ["wait-url", "https://app.mento.org/swap/celo"],
+  );
 });
 
 test("requires the exact deployment SHA and complete security-header contract", () => {


### PR DESCRIPTION
## The Problem

The first GitHub-driven production cutover reached all six public mapping transitions, then failed its App runtime smoke because the smoke required `https://app.mento.org/` after interaction. The App intentionally performs a client-side redirect from `/` to `/swap/celo`. The same stale expectation also prevented the recovery job from certifying a rollback that had already restored every public mapping.

## The Solution

Wait for the exact `/swap/celo` client navigation before asserting the App landing route, and use that route consistently in active, recovery, current-release, and final-evidence contracts. Decouple the fake browser route from the production configuration and cover the delayed client redirect explicitly.

Part of #522.

## Validation

- `pnpm vercel:workflow:test` — 572/572
- focused App runtime/active/recovery/release suite — 135/135
- `pnpm quality:budgets:test` — 34/34
- `pnpm adr:check`
- targeted Prettier check
- push hooks: Trunk, type checks, and Knip
- two independent current-diff reviews: clean

## Risk

Low and fail-closed. The smoke still requires the exact origin and path, the exact deployment SHA/security headers, the real production wallet list, and the final location after interaction. Route drift or a missing redirect still fails the deployment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only runtime smoke and test fixture changes; checks remain strict on SHA, headers, wallet list, and exact final URLs.
> 
> **Overview**
> **Fixes production App runtime smoke** that failed cutover and blocked recovery certification because smoke expected `https://app.mento.org/` while the live App **client-redirects** `/` → `/swap/celo`.
> 
> `MAIN_RUNTIME_TARGETS` and all **active / recovery / release** final-path contracts now use **`/swap/celo`** for App. Runtime verification **`waitForURL`** on the expected landing URL before asserting location, so an initial `/` load can settle on `/swap/celo` before wallet-list interaction and final URL checks.
> 
> Tests mirror the new URL everywhere and add coverage for **delayed client redirect** (fake page starts at `/`, navigates to `/swap/celo` on `waitForURL`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8aad8aa35a55811b9ff406ab720c8753de4a9d87. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->