### PR TITLE
fix(ci): canonicalize final deployment state targets

### DIFF
--- a/scripts/vercel-main-deployment.mjs
+++ b/scripts/vercel-main-deployment.mjs
@@ -1906,6 +1906,24 @@ function currentStateProject({ current, barrier, target, candidate }) {
   ];
 }
 
+function currentStateProjection(current) {
+  // Release execution is canonical in activation order (Governance, Reserve,
+  // UI, App). Active deployment-state artifacts use the public-state order
+  // (App, Governance, Reserve, UI), so project the already-validated
+  // execution partitions into that contract order at this boundary.
+  return {
+    stagedTargets: STAGE_BARRIER_TARGETS.filter((target) =>
+      current.execution.projection.stagedTargets.includes(target),
+    ),
+    activeTargets: STAGE_BARRIER_TARGETS.filter((target) =>
+      current.execution.projection.activeTargets.includes(target),
+    ),
+    shadowTargets: STAGE_BARRIER_TARGETS.filter((target) =>
+      current.execution.projection.shadowTargets.includes(target),
+    ),
+  };
+}
+
 export function createMainCurrentActiveDeploymentStateSpec({
   execution,
   barrier,
@@ -1924,16 +1942,17 @@ export function createMainCurrentActiveDeploymentStateSpec({
     runId,
     runAttempt,
   });
-  const active = current.execution.projection.activeTargets;
-  const shadow = current.execution.projection.shadowTargets;
-  const staged = current.execution.projection.stagedTargets;
+  const { stagedTargets, activeTargets, shadowTargets } =
+    currentStateProjection(current);
   const projects = Object.fromEntries(
     STAGE_BARRIER_TARGETS.map((target) =>
       currentStateProject({
         current,
         barrier: canonicalBarrier,
         target,
-        candidate: active.includes(target) ? highest.candidates[target] : null,
+        candidate: activeTargets.includes(target)
+          ? highest.candidates[target]
+          : null,
       }),
     ),
   );
@@ -1946,9 +1965,9 @@ export function createMainCurrentActiveDeploymentStateSpec({
     transactionId: highest.transactionId,
     releaseManifest: current.execution.manifest,
     mainOwnershipMode: current.execution.manifest.mainOwnershipMode,
-    stagedTargets: staged,
-    activeTargets: active,
-    shadowTargets: shadow,
+    stagedTargets,
+    activeTargets,
+    shadowTargets,
     projects,
     legacyAppV2: {
       alias: legacy.alias,
@@ -1976,6 +1995,8 @@ export function createMainCurrentReleaseVerifiedDeploymentStateSpec({
     runId,
     runAttempt,
   });
+  const { stagedTargets, activeTargets, shadowTargets } =
+    currentStateProjection(current);
   const legacy = current.execution.legacyAppV2;
   return assertActiveDeploymentStateSpec({
     schema: ACTIVE_DEPLOYMENT_STATE_SPEC_SCHEMA,
@@ -1985,16 +2006,16 @@ export function createMainCurrentReleaseVerifiedDeploymentStateSpec({
     transactionId: createMainTransactionId(current.identity),
     releaseManifest: current.execution.manifest,
     mainOwnershipMode: current.execution.manifest.mainOwnershipMode,
-    stagedTargets: current.execution.projection.stagedTargets,
-    activeTargets: current.execution.projection.activeTargets,
-    shadowTargets: current.execution.projection.shadowTargets,
+    stagedTargets,
+    activeTargets,
+    shadowTargets,
     projects: Object.fromEntries(
       STAGE_BARRIER_TARGETS.map((target) =>
         currentStateProject({
           current,
           barrier: canonicalBarrier,
           target,
-          candidate: current.execution.projection.activeTargets.includes(target)
+          candidate: activeTargets.includes(target)
             ? canonicalBarrier.stages[target].receipt.candidate
             : null,
         }),

--- a/scripts/vercel-main-deployment.test.mjs
+++ b/scripts/vercel-main-deployment.test.mjs
@@ -66,6 +66,7 @@ import {
   createMainActivePublicSmokes,
   createMainActiveTransactionInputs,
   createMainCurrentCandidateIntent,
+  createMainCurrentActiveDeploymentStateSpec,
   createMainCurrentReleaseVerifiedAliasMappingSet,
   createMainCurrentReleaseVerifiedDeploymentStateSpec,
   createMainCurrentActivePublicSmokes,
@@ -6306,6 +6307,142 @@ test("active recovery public-smoke materializer accepts only exact runtime resul
   } finally {
     rmSync(directory, { recursive: true, force: true });
   }
+});
+
+test("current state specs normalize a full release into active-state target order", () => {
+  const deploymentPlan = activePlan();
+  const execution = releaseExecutionForPlan(deploymentPlan);
+  assert.deepEqual(execution.projection.stagedTargets, [
+    "governance",
+    "reserve",
+    "ui",
+    "app",
+  ]);
+  const candidateReceipts = Object.fromEntries(
+    ["app", "governance", "reserve", "ui"].map((target) => [
+      target,
+      currentCandidateReceipt(execution, target),
+    ]),
+  );
+  const barrier = createMainStageBarrier({
+    execution,
+    candidateReceipts,
+    appPreparation: null,
+    runId: "800",
+    runAttempt: "3",
+  });
+  const prepared = createMainCurrentActiveInputs({
+    execution,
+    barrier,
+    currentMappings: currentCanonicalMappings(deploymentPlan),
+    runId: "800",
+    runAttempt: "3",
+  }).journal;
+  const activeSpec = createMainCurrentActiveDeploymentStateSpec({
+    execution,
+    barrier,
+    journalHistory: [prepared],
+    runId: "800",
+    runAttempt: "3",
+  });
+  assert.deepEqual(activeSpec.stagedTargets, [
+    "app",
+    "governance",
+    "reserve",
+    "ui",
+  ]);
+  assert.deepEqual(activeSpec.activeTargets, activeSpec.stagedTargets);
+  assert.deepEqual(activeSpec.shadowTargets, []);
+
+  const verifiedExecution = createMainReleaseExecution({
+    ...execution,
+    decision: "verify-existing-release",
+    reason: "current-main-release-already-complete",
+  });
+  const verifiedBarrier = createMainStageBarrier({
+    execution: verifiedExecution,
+    candidateReceipts: Object.fromEntries(
+      ["app", "governance", "reserve", "ui"].map((target) => [
+        target,
+        currentCandidateReceipt(verifiedExecution, target),
+      ]),
+    ),
+    appPreparation: null,
+    runId: "800",
+    runAttempt: "3",
+  });
+  const verifiedSpec = createMainCurrentReleaseVerifiedDeploymentStateSpec({
+    execution: verifiedExecution,
+    barrier: verifiedBarrier,
+    runId: "800",
+    runAttempt: "3",
+  });
+  assert.deepEqual(verifiedSpec.stagedTargets, activeSpec.stagedTargets);
+  assert.deepEqual(verifiedSpec.activeTargets, activeSpec.activeTargets);
+  assert.deepEqual(verifiedSpec.shadowTargets, activeSpec.shadowTargets);
+});
+
+test("current state specs normalize a mixed App and ordinary release", () => {
+  const deploymentPlan = activePlan({ deployments: ["app", "governance"] });
+  const execution = releaseExecutionForPlan(deploymentPlan);
+  assert.deepEqual(execution.projection.stagedTargets, ["governance", "app"]);
+  const candidateReceipts = {
+    app: currentCandidateReceipt(execution, "app"),
+    governance: currentCandidateReceipt(execution, "governance"),
+    reserve: null,
+    ui: null,
+  };
+  const barrier = createMainStageBarrier({
+    execution,
+    candidateReceipts,
+    appPreparation: null,
+    runId: "800",
+    runAttempt: "3",
+  });
+  const activeSpec = createMainCurrentActiveDeploymentStateSpec({
+    execution,
+    barrier,
+    journalHistory: [
+      createMainCurrentActiveInputs({
+        execution,
+        barrier,
+        currentMappings: currentCanonicalMappings(deploymentPlan),
+        runId: "800",
+        runAttempt: "3",
+      }).journal,
+    ],
+    runId: "800",
+    runAttempt: "3",
+  });
+  assert.deepEqual(activeSpec.stagedTargets, ["app", "governance"]);
+  assert.deepEqual(activeSpec.activeTargets, ["app", "governance"]);
+  assert.deepEqual(activeSpec.shadowTargets, []);
+
+  const verifiedExecution = createMainReleaseExecution({
+    ...execution,
+    decision: "verify-existing-release",
+    reason: "current-main-release-already-complete",
+  });
+  const verifiedSpec = createMainCurrentReleaseVerifiedDeploymentStateSpec({
+    execution: verifiedExecution,
+    barrier: createMainStageBarrier({
+      execution: verifiedExecution,
+      candidateReceipts: {
+        app: currentCandidateReceipt(verifiedExecution, "app"),
+        governance: currentCandidateReceipt(verifiedExecution, "governance"),
+        reserve: null,
+        ui: null,
+      },
+      appPreparation: null,
+      runId: "800",
+      runAttempt: "3",
+    }),
+    runId: "800",
+    runAttempt: "3",
+  });
+  assert.deepEqual(verifiedSpec.stagedTargets, activeSpec.stagedTargets);
+  assert.deepEqual(verifiedSpec.activeTargets, activeSpec.activeTargets);
+  assert.deepEqual(verifiedSpec.shadowTargets, activeSpec.shadowTargets);
 });
 
 test("current release verification is journal-free and binds its barrier candidates", () => {


### PR DESCRIPTION
## The Problem

The GitHub-driven production deployment built and activated all four targets and passed every public runtime smoke, but failed before committing its journal because the final state-proof builder passed release activation order (`governance`, `reserve`, `ui`, `app`) into a schema that requires public-state order (`app`, `governance`, `reserve`, `ui`). The workflow then correctly restored and certified the prior release.

## The Solution

Project already-validated release partitions into canonical public-state order at the two current-state proof boundaries. Keep release activation order, recovery logic, and strict state validators unchanged. Add full-release and mixed App-plus-Governance regressions for both active-journal and verification-only paths.

Part of #522.

## Validation

- `pnpm vercel:workflow:test` — 574/574
- `pnpm vercel:deployment-state:test` — 56/56
- `pnpm quality:budgets:test` — 34/34
- `pnpm adr:check`
- targeted Prettier check
- push hooks: Trunk, type checks, and Knip
- two independent current-diff reviews: clean

## Risk

Low and constrained to state-proof representation. Invalid, duplicate, unknown, overlapping, or reordered execution partitions still fail before projection, and the active-state validator still requires exact canonical order afterward.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to state-proof target list projection after existing validation; strict ordering checks still apply on the projected output.
> 
> **Overview**
> Fixes a production deploy failure where **successful activations** still aborted journal commit because **staged/active/shadow target lists** were emitted in **release execution order** (`governance`, `reserve`, `ui`, `app`) while the active deployment state schema expects **public-state order** (`app`, `governance`, `reserve`, `ui`).
> 
> Adds **`currentStateProjection`**, which filters already-validated execution partitions through `STAGE_BARRIER_TARGETS` at the two **current-state spec** boundaries (`createMainCurrentActiveDeploymentStateSpec` and `createMainCurrentReleaseVerifiedDeploymentStateSpec`). **Activation order, barriers, and validators are unchanged**—only the representation at those boundaries is normalized.
> 
> New tests cover a **full four-target release** and a **mixed App + Governance** release for both **active-journal** and **verification-only** paths, asserting canonical target ordering matches between the two spec builders.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7affb51f7184679b954a7f39975e7a09c69aa0fe. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->