### PR TITLE
fix(ci): wait for UI route hydration in production smoke

### DIFF
--- a/scripts/vercel-main-runtime.mjs
+++ b/scripts/vercel-main-runtime.mjs
@@ -5,6 +5,7 @@ import process from "node:process";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { createBrowserDeploymentIdentityMonitor } from "../apps/ui.mento.org/e2e/vercel-preview-browser-smoke.mjs";
 import { loadTrustedChromium } from "./vercel-preview-browser-smoke.mjs";
 
 const SHA_PATTERN = /^[0-9a-f]{40}$/;
@@ -389,7 +390,12 @@ async function interactWithReserve(page, origin) {
   );
 }
 
-async function interactWithUi(page, origin) {
+async function interactWithUi(
+  page,
+  origin,
+  deploymentIdentityMonitor,
+  timeoutMs,
+) {
   await page
     .getByRole("heading", { name: "Basic Components", exact: true })
     .waitFor({ state: "visible" });
@@ -408,6 +414,7 @@ async function interactWithUi(page, origin) {
     exact: true,
   });
   await checkbox.waitFor({ state: "visible" });
+  await deploymentIdentityMonitor.waitForIdle(timeoutMs);
   await checkbox.click();
   await page.waitForFunction(uiCheckboxStateMatches);
   invariant(
@@ -416,11 +423,17 @@ async function interactWithUi(page, origin) {
   );
 }
 
-async function runTargetInteraction(page, target, origin) {
+async function runTargetInteraction(
+  page,
+  target,
+  origin,
+  deploymentIdentityMonitor,
+  timeoutMs,
+) {
   if (target === "app") return interactWithApp(page);
   if (target === "governance") return interactWithGovernance(page, origin);
   if (target === "reserve") return interactWithReserve(page, origin);
-  return interactWithUi(page, origin);
+  return interactWithUi(page, origin, deploymentIdentityMonitor, timeoutMs);
 }
 
 function assertExactPageLocation(page, expectedUrl, label) {
@@ -464,6 +477,10 @@ export async function runMainRuntimeSmoke({
     page.setDefaultTimeout(timeoutMs);
     page.setDefaultNavigationTimeout(timeoutMs);
     const monitor = createMainRuntimeMonitor(page, publicUrl.origin);
+    const deploymentIdentityMonitor =
+      input.logicalTarget === "ui"
+        ? createBrowserDeploymentIdentityMonitor(page, publicUrl.origin)
+        : undefined;
     const response = await page.goto(publicUrl.toString(), {
       waitUntil: "domcontentloaded",
     });
@@ -481,7 +498,13 @@ export async function runMainRuntimeSmoke({
     assertMainRuntimeSecurityHeaders(response.headers(), input.deploySha);
 
     await page.waitForLoadState("load");
-    await runTargetInteraction(page, input.logicalTarget, publicUrl.origin);
+    await runTargetInteraction(
+      page,
+      input.logicalTarget,
+      publicUrl.origin,
+      deploymentIdentityMonitor,
+      timeoutMs,
+    );
     await page.waitForTimeout(500);
     const expectedFinalUrl = new URL(config.finalPath, publicUrl);
     if (input.logicalTarget === "reserve") {

--- a/scripts/vercel-main-runtime.test.mjs
+++ b/scripts/vercel-main-runtime.test.mjs
@@ -94,7 +94,7 @@ class FakeLocator {
       return;
     }
     if (this.kind === "checkbox" && this.name === "Checkbox option") {
-      this.page.checkboxChecked = true;
+      this.page.checkboxChecked = this.page.uiRouteAssetFinished;
       return;
     }
     throw new Error(`Unexpected click: ${this.kind}/${this.name}`);
@@ -143,6 +143,7 @@ class FakePage extends EventEmitter {
       mockWalletVisible = false,
       omitResource,
       initialLanding,
+      delayedUiRouteAsset = false,
       waitForUrlNavigation,
       walletFlagsAbsent = true,
       wrongLanding,
@@ -156,6 +157,8 @@ class FakePage extends EventEmitter {
     this.mockWalletVisible = mockWalletVisible;
     this.omitResource = omitResource;
     this.initialLanding = initialLanding;
+    this.delayedUiRouteAsset = delayedUiRouteAsset;
+    this.uiRouteAssetFinished = !delayedUiRouteAsset;
     this.waitForUrlNavigation = waitForUrlNavigation;
     this.walletFlagsAbsent = walletFlagsAbsent;
     this.wrongLanding = wrongLanding;
@@ -200,6 +203,23 @@ class FakePage extends EventEmitter {
     this.currentUrl = new URL(path, this.config.publicUrl).toString();
     this.emit("framenavigated", this.frame);
     this.emit("response", this.response(`${path}?_rsc=fixture`, "fetch"));
+    if (
+      this.delayedUiRouteAsset &&
+      this.target === "ui" &&
+      path === "/form-components"
+    ) {
+      const request = {
+        redirectedFrom: () => null,
+        resourceType: () => "script",
+        url: () => `${this.config.publicUrl}_next/static/form-components.js`,
+      };
+      this.emit("request", request);
+      setTimeout(() => {
+        this.uiRouteAssetFinished = true;
+        this.calls.push(["route-asset-finished"]);
+        this.emit("requestfinished", request);
+      }, 0);
+    }
   }
 
   async goto(url, options) {
@@ -394,6 +414,26 @@ test("runs the literal interaction contract for all four public targets", async 
     assert.deepEqual(fake.state.contextOptions, { colorScheme: "dark" });
     assert.equal(fake.state.closed, true);
   }
+});
+
+test("UI waits for delayed same-origin route assets before its checkbox interaction", async () => {
+  const page = new FakePage("ui", { delayedUiRouteAsset: true });
+  await runMainRuntimeSmoke({
+    chromium: fakeChromium(page).chromium,
+    values: inputFor("ui"),
+  });
+  const routeAssetFinished = page.calls.findIndex(
+    ([operation]) => operation === "route-asset-finished",
+  );
+  const checkboxClick = page.calls.findIndex(
+    ([operation, kind, name]) =>
+      operation === "click" &&
+      kind === "checkbox" &&
+      name === "Checkbox option",
+  );
+  assert.ok(routeAssetFinished >= 0);
+  assert.ok(checkboxClick > routeAssetFinished);
+  assert.equal(page.checkboxChecked, true);
 });
 
 test("App proves real production wallets without enabling preview flags", async () => {


### PR DESCRIPTION
## The Problem

Production cutover run [30333317090](https://github.com/mento-protocol/frontend-monorepo/actions/runs/30333317090) reached all four deployments, but the UI public smoke clicked the Form Components checkbox before the client-side route finished hydrating. The lost click timed out the strict checked-state assertion. Automatic recovery restored the prior release and then passed fresh App, Governance, Reserve, and UI runtime smokes.

## The Solution

Reuse the existing bounded Next.js static-asset idle monitor after the UI client route navigation and before the checkbox interaction. Keep the semantic `aria-checked` and `data-state` assertion unchanged.

Add a production-shaped regression where a delayed route script keeps the fake checkbox inert until the script request finishes. The test proves that the hydration barrier completes before the click.

Validation:

- `pnpm vercel:workflow:test` — 575 passed
- `pnpm quality:budgets:test` — 34 passed
- `pnpm adr:check`
- `pnpm exec prettier --check scripts/vercel-main-runtime.mjs scripts/vercel-main-runtime.test.mjs`
- `git diff --check`
- Two independent fresh-context reviews — clean
- Patched runtime smoke against restored `https://ui.mento.org/` at SHA `4f2d124bba346ca13249226c2601a133968ade33` — passed through `/form-components`, including the checkbox interaction

Risk is limited to waiting up to the existing bounded browser timeout for UI route assets to settle. No deployment, alias, credential, or application code changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change to UI smoke timing in `scripts/vercel-main-runtime.mjs`; no app, auth, or deployment logic changes.
> 
> **Overview**
> Fixes a flaky **UI public production smoke** where the Form Components checkbox was clicked before the client route finished hydrating, causing lost clicks and strict checked-state timeouts.
> 
> For the **ui** target only, the main runtime smoke now wires in the existing **`createBrowserDeploymentIdentityMonitor`** and calls **`waitForIdle`** after navigating to `/form-components` and before the checkbox interaction—matching the preview browser smoke pattern. App, Governance, and Reserve flows are unchanged; the checkbox assertion semantics stay the same.
> 
> A regression test simulates a delayed same-origin route script and asserts route assets finish loading before the checkbox click.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3711e8fa595b420d6bc47b1c638756207f9d9962. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->