### PR TITLE
fix(ci): preserve terminal evidence after committed release failure

### DIFF
--- a/.github/workflows/vercel-main-deployment.yml
+++ b/.github/workflows/vercel-main-deployment.yml
@@ -2303,6 +2303,7 @@ jobs:
           node scripts/vercel-main-deployment.mjs active-journal-receipt --journal "$RUNNER_TEMP/current-attempt-journals/$ARTIFACT_NAME/main-journal.json" --artifact-name "$ARTIFACT_NAME" --artifact-id "$ARTIFACT_ID" --output "$RUNNER_TEMP/current-attempt-journals/current-receipt.json"
           install -m 0600 "$RUNNER_TEMP/current-attempt-journals/$ARTIFACT_NAME/main-journal.json" "$RUNNER_TEMP/current-attempt-journals/current-journal.json"
       - name: Derive and capture full recovery mappings from journal history
+        id: recovery-mappings
         if: steps.journal-presence.outputs.has_journal == 'true'
         env:
           VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
@@ -2324,8 +2325,44 @@ jobs:
         run: |
           node scripts/vercel-main-deployment.mjs active-recovery-event-initialize --receipt "$RUNNER_TEMP/current-attempt-journals/current-receipt.json" --output "$RUNNER_TEMP/recovery-initialize-event.json"
           node scripts/vercel-main-deployment.mjs run-active-recovery --plan "$RUNNER_TEMP/recovery-plan.json" --event "$RUNNER_TEMP/recovery-initialize-event.json" --journal-history "$RUNNER_TEMP/current-attempt-journals/current-history.json" --journal-output "$RUNNER_TEMP/recovery-initialized-journal.json" --output "$RUNNER_TEMP/recovery-initialize-transition.json"
+      - name: Classify recovery preparation failure or non-journal result
+        id: recovery-failed
+        if: >-
+          always() && !cancelled() &&
+          steps.journal-presence.outputs.has_journal == 'true' &&
+          (steps.recovery-mappings.outcome == 'failure' ||
+          steps.recovery-plan.outcome == 'failure' ||
+          steps.initialize.outcome == 'failure' ||
+          (steps.initialize.outcome == 'success' &&
+          (steps.initialize.outputs.transition_kind == 'recovery-not-required' ||
+          steps.initialize.outputs.transition_kind == 'recovery-ready')))
+        env:
+          AFTER_UPLOAD_ACTION: ${{ steps.initialize.outputs.after_upload_action }}
+          ARTIFACT_NAME: ${{ steps.initialize.outputs.journal_artifact_name }}
+          INITIALIZE_OUTCOME: ${{ steps.initialize.outcome }}
+          NEXT_ACTION: ${{ steps.initialize.outputs.next_action }}
+          RECOVERY_MAPPINGS_OUTCOME: ${{ steps.recovery-mappings.outcome }}
+          RECOVERY_PLAN_OUTCOME: ${{ steps.recovery-plan.outcome }}
+          TRANSITION_KIND: ${{ steps.initialize.outputs.transition_kind }}
+        run: |
+          set -euo pipefail
+          if [ "$RECOVERY_MAPPINGS_OUTCOME" = failure ] || [ "$RECOVERY_PLAN_OUTCOME" = failure ] || [ "$INITIALIZE_OUTCOME" = failure ]; then
+            echo 'outcome=recovery-failed' >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          test "$INITIALIZE_OUTCOME" = success
+          case "$TRANSITION_KIND" in
+            recovery-not-required) test "$NEXT_ACTION" = fail-after-evidence ;;
+            recovery-ready) test "$NEXT_ACTION" = dispatch ;;
+            *) exit 1 ;;
+          esac
+          test "$AFTER_UPLOAD_ACTION" = none
+          test "$ARTIFACT_NAME" = none
+          echo 'outcome=recovery-failed' >> "$GITHUB_OUTPUT"
       - name: Require initialized recovery journal checkpoint
-        if: steps.journal-presence.outputs.has_journal == 'true'
+        if: >-
+          steps.journal-presence.outputs.has_journal == 'true' &&
+          steps.initialize.outputs.transition_kind == 'journal'
         env:
           AFTER_UPLOAD_ACTION: ${{ steps.initialize.outputs.after_upload_action }}
           ARTIFACT_NAME: ${{ steps.initialize.outputs.journal_artifact_name }}
@@ -2338,14 +2375,18 @@ jobs:
           test "$AFTER_UPLOAD_ACTION" = dispatch
           test "$ARTIFACT_NAME" != none
       - name: Stage initialized recovery journal under its canonical artifact basename
-        if: steps.journal-presence.outputs.has_journal == 'true'
+        if: >-
+          steps.journal-presence.outputs.has_journal == 'true' &&
+          steps.initialize.outputs.transition_kind == 'journal'
         run: |
           set -euo pipefail
           install -d -m 0700 "$RUNNER_TEMP/recovery-initialized-artifact"
           install -m 0600 "$RUNNER_TEMP/recovery-initialized-journal.json" "$RUNNER_TEMP/recovery-initialized-artifact/main-journal.json"
       - name: Upload initialized recovery journal
         id: upload-initialized
-        if: steps.journal-presence.outputs.has_journal == 'true'
+        if: >-
+          steps.journal-presence.outputs.has_journal == 'true' &&
+          steps.initialize.outputs.transition_kind == 'journal'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ steps.initialize.outputs.journal_artifact_name }}
@@ -2353,7 +2394,9 @@ jobs:
           if-no-files-found: error
           retention-days: 7
       - name: Checkpoint initialized recovery journal
-        if: steps.journal-presence.outputs.has_journal == 'true'
+        if: >-
+          steps.journal-presence.outputs.has_journal == 'true' &&
+          steps.initialize.outputs.transition_kind == 'journal'
         env:
           ARTIFACT_ID: ${{ steps.upload-initialized.outputs.artifact-id }}
           ARTIFACT_NAME: ${{ steps.initialize.outputs.journal_artifact_name }}
@@ -2367,7 +2410,9 @@ jobs:
           install -m 0600 "$RUNNER_TEMP/recovery-initialized-journal.json" "$RUNNER_TEMP/current-attempt-journals/current-journal.json"
           install -m 0600 "$RUNNER_TEMP/recovery-initialized-receipt.json" "$RUNNER_TEMP/current-attempt-journals/current-receipt.json"
       - name: Restore bounded recovery transition 1
-        if: steps.journal-presence.outputs.has_journal == 'true'
+        if: >-
+          steps.journal-presence.outputs.has_journal == 'true' &&
+          steps.initialize.outputs.transition_kind == 'journal'
         uses: ./.github/actions/vercel-main-active-recovery-transition
         env:
           {
@@ -2385,10 +2430,10 @@ jobs:
           }
       - name: Inspect recovery head 1
         id: recovery-head-1
-        if: ${{ always() && steps.journal-presence.outputs.has_journal == 'true' && !failure() && !cancelled() }}
+        if: ${{ always() && steps.journal-presence.outputs.has_journal == 'true' && steps.initialize.outputs.transition_kind == 'journal' && !failure() && !cancelled() }}
         run: node scripts/vercel-main-deployment.mjs active-journal-history --artifacts "$RUNNER_TEMP/current-attempt-journals" --output "$RUNNER_TEMP/recovery-head-1.json"
       - name: Restore bounded recovery transition 2
-        if: ${{ steps.journal-presence.outputs.has_journal == 'true' && steps.recovery-head-1.outputs.highest_status != 'recovered' && steps.recovery-head-1.outputs.highest_status != 'manual_intervention' }}
+        if: ${{ steps.journal-presence.outputs.has_journal == 'true' && steps.initialize.outputs.transition_kind == 'journal' && steps.recovery-head-1.outputs.highest_status != 'recovered' && steps.recovery-head-1.outputs.highest_status != 'manual_intervention' }}
         uses: ./.github/actions/vercel-main-active-recovery-transition
         env:
           {
@@ -2406,10 +2451,10 @@ jobs:
           }
       - name: Inspect recovery head 2
         id: recovery-head-2
-        if: ${{ always() && steps.journal-presence.outputs.has_journal == 'true' && !failure() && !cancelled() }}
+        if: ${{ always() && steps.journal-presence.outputs.has_journal == 'true' && steps.initialize.outputs.transition_kind == 'journal' && !failure() && !cancelled() }}
         run: node scripts/vercel-main-deployment.mjs active-journal-history --artifacts "$RUNNER_TEMP/current-attempt-journals" --output "$RUNNER_TEMP/recovery-head-2.json"
       - name: Restore bounded recovery transition 3
-        if: ${{ steps.journal-presence.outputs.has_journal == 'true' && steps.recovery-head-2.outputs.highest_status != 'recovered' && steps.recovery-head-2.outputs.highest_status != 'manual_intervention' }}
+        if: ${{ steps.journal-presence.outputs.has_journal == 'true' && steps.initialize.outputs.transition_kind == 'journal' && steps.recovery-head-2.outputs.highest_status != 'recovered' && steps.recovery-head-2.outputs.highest_status != 'manual_intervention' }}
         uses: ./.github/actions/vercel-main-active-recovery-transition
         env:
           {
@@ -2427,10 +2472,10 @@ jobs:
           }
       - name: Inspect recovery head 3
         id: recovery-head-3
-        if: ${{ always() && steps.journal-presence.outputs.has_journal == 'true' && !failure() && !cancelled() }}
+        if: ${{ always() && steps.journal-presence.outputs.has_journal == 'true' && steps.initialize.outputs.transition_kind == 'journal' && !failure() && !cancelled() }}
         run: node scripts/vercel-main-deployment.mjs active-journal-history --artifacts "$RUNNER_TEMP/current-attempt-journals" --output "$RUNNER_TEMP/recovery-head-3.json"
       - name: Restore bounded recovery transition 4
-        if: ${{ steps.journal-presence.outputs.has_journal == 'true' && steps.recovery-head-3.outputs.highest_status != 'recovered' && steps.recovery-head-3.outputs.highest_status != 'manual_intervention' }}
+        if: ${{ steps.journal-presence.outputs.has_journal == 'true' && steps.initialize.outputs.transition_kind == 'journal' && steps.recovery-head-3.outputs.highest_status != 'recovered' && steps.recovery-head-3.outputs.highest_status != 'manual_intervention' }}
         uses: ./.github/actions/vercel-main-active-recovery-transition
         env:
           {
@@ -2448,10 +2493,10 @@ jobs:
           }
       - name: Inspect recovery head 4
         id: recovery-head-4
-        if: ${{ always() && steps.journal-presence.outputs.has_journal == 'true' && !failure() && !cancelled() }}
+        if: ${{ always() && steps.journal-presence.outputs.has_journal == 'true' && steps.initialize.outputs.transition_kind == 'journal' && !failure() && !cancelled() }}
         run: node scripts/vercel-main-deployment.mjs active-journal-history --artifacts "$RUNNER_TEMP/current-attempt-journals" --output "$RUNNER_TEMP/recovery-head-4.json"
       - name: Restore bounded recovery transition 5
-        if: ${{ steps.journal-presence.outputs.has_journal == 'true' && steps.recovery-head-4.outputs.highest_status != 'recovered' && steps.recovery-head-4.outputs.highest_status != 'manual_intervention' }}
+        if: ${{ steps.journal-presence.outputs.has_journal == 'true' && steps.initialize.outputs.transition_kind == 'journal' && steps.recovery-head-4.outputs.highest_status != 'recovered' && steps.recovery-head-4.outputs.highest_status != 'manual_intervention' }}
         uses: ./.github/actions/vercel-main-active-recovery-transition
         env:
           {
@@ -2469,10 +2514,10 @@ jobs:
           }
       - name: Inspect recovery head 5
         id: recovery-head-5
-        if: ${{ always() && steps.journal-presence.outputs.has_journal == 'true' && !failure() && !cancelled() }}
+        if: ${{ always() && steps.journal-presence.outputs.has_journal == 'true' && steps.initialize.outputs.transition_kind == 'journal' && !failure() && !cancelled() }}
         run: node scripts/vercel-main-deployment.mjs active-journal-history --artifacts "$RUNNER_TEMP/current-attempt-journals" --output "$RUNNER_TEMP/recovery-head-5.json"
       - name: Restore bounded recovery transition 6
-        if: ${{ steps.journal-presence.outputs.has_journal == 'true' && steps.recovery-head-5.outputs.highest_status != 'recovered' && steps.recovery-head-5.outputs.highest_status != 'manual_intervention' }}
+        if: ${{ steps.journal-presence.outputs.has_journal == 'true' && steps.initialize.outputs.transition_kind == 'journal' && steps.recovery-head-5.outputs.highest_status != 'recovered' && steps.recovery-head-5.outputs.highest_status != 'manual_intervention' }}
         uses: ./.github/actions/vercel-main-active-recovery-transition
         env:
           {
@@ -2490,10 +2535,10 @@ jobs:
           }
       - name: Inspect recovery head 6
         id: recovery-head-6
-        if: ${{ always() && steps.journal-presence.outputs.has_journal == 'true' && !failure() && !cancelled() }}
+        if: ${{ always() && steps.journal-presence.outputs.has_journal == 'true' && steps.initialize.outputs.transition_kind == 'journal' && !failure() && !cancelled() }}
         run: node scripts/vercel-main-deployment.mjs active-journal-history --artifacts "$RUNNER_TEMP/current-attempt-journals" --output "$RUNNER_TEMP/recovery-head-6.json"
       - name: Restore bounded recovery transition 7
-        if: ${{ steps.journal-presence.outputs.has_journal == 'true' && steps.recovery-head-6.outputs.highest_status != 'recovered' && steps.recovery-head-6.outputs.highest_status != 'manual_intervention' }}
+        if: ${{ steps.journal-presence.outputs.has_journal == 'true' && steps.initialize.outputs.transition_kind == 'journal' && steps.recovery-head-6.outputs.highest_status != 'recovered' && steps.recovery-head-6.outputs.highest_status != 'manual_intervention' }}
         uses: ./.github/actions/vercel-main-active-recovery-transition
         env:
           {
@@ -2511,10 +2556,10 @@ jobs:
           }
       - name: Inspect recovery head 7
         id: recovery-head-7
-        if: ${{ always() && steps.journal-presence.outputs.has_journal == 'true' && !failure() && !cancelled() }}
+        if: ${{ always() && steps.journal-presence.outputs.has_journal == 'true' && steps.initialize.outputs.transition_kind == 'journal' && !failure() && !cancelled() }}
         run: node scripts/vercel-main-deployment.mjs active-journal-history --artifacts "$RUNNER_TEMP/current-attempt-journals" --output "$RUNNER_TEMP/recovery-head-7.json"
       - name: Restore bounded recovery transition 8
-        if: ${{ steps.journal-presence.outputs.has_journal == 'true' && steps.recovery-head-7.outputs.highest_status != 'recovered' && steps.recovery-head-7.outputs.highest_status != 'manual_intervention' }}
+        if: ${{ steps.journal-presence.outputs.has_journal == 'true' && steps.initialize.outputs.transition_kind == 'journal' && steps.recovery-head-7.outputs.highest_status != 'recovered' && steps.recovery-head-7.outputs.highest_status != 'manual_intervention' }}
         uses: ./.github/actions/vercel-main-active-recovery-transition
         env:
           {
@@ -2532,10 +2577,10 @@ jobs:
           }
       - name: Inspect recovery head 8
         id: recovery-head-8
-        if: ${{ always() && steps.journal-presence.outputs.has_journal == 'true' && !failure() && !cancelled() }}
+        if: ${{ always() && steps.journal-presence.outputs.has_journal == 'true' && steps.initialize.outputs.transition_kind == 'journal' && !failure() && !cancelled() }}
         run: node scripts/vercel-main-deployment.mjs active-journal-history --artifacts "$RUNNER_TEMP/current-attempt-journals" --output "$RUNNER_TEMP/recovery-head-8.json"
       - name: Restore bounded recovery transition 9
-        if: ${{ steps.journal-presence.outputs.has_journal == 'true' && steps.recovery-head-8.outputs.highest_status != 'recovered' && steps.recovery-head-8.outputs.highest_status != 'manual_intervention' }}
+        if: ${{ steps.journal-presence.outputs.has_journal == 'true' && steps.initialize.outputs.transition_kind == 'journal' && steps.recovery-head-8.outputs.highest_status != 'recovered' && steps.recovery-head-8.outputs.highest_status != 'manual_intervention' }}
         uses: ./.github/actions/vercel-main-active-recovery-transition
         env:
           {
@@ -2553,10 +2598,10 @@ jobs:
           }
       - name: Inspect recovery head 9
         id: recovery-head-9
-        if: ${{ always() && steps.journal-presence.outputs.has_journal == 'true' && !failure() && !cancelled() }}
+        if: ${{ always() && steps.journal-presence.outputs.has_journal == 'true' && steps.initialize.outputs.transition_kind == 'journal' && !failure() && !cancelled() }}
         run: node scripts/vercel-main-deployment.mjs active-journal-history --artifacts "$RUNNER_TEMP/current-attempt-journals" --output "$RUNNER_TEMP/recovery-head-9.json"
       - name: Restore terminal recovery transition 10
-        if: ${{ steps.journal-presence.outputs.has_journal == 'true' && steps.recovery-head-9.outputs.highest_status != 'recovered' && steps.recovery-head-9.outputs.highest_status != 'manual_intervention' }}
+        if: ${{ steps.journal-presence.outputs.has_journal == 'true' && steps.initialize.outputs.transition_kind == 'journal' && steps.recovery-head-9.outputs.highest_status != 'recovered' && steps.recovery-head-9.outputs.highest_status != 'manual_intervention' }}
         uses: ./.github/actions/vercel-main-active-recovery-transition
         env:
           {
@@ -2574,11 +2619,13 @@ jobs:
           }
       - name: Read final current-attempt recovery head
         id: recovered-head
-        if: ${{ always() && steps.journal-presence.outputs.has_journal == 'true' && !failure() && !cancelled() }}
+        if: ${{ always() && steps.journal-presence.outputs.has_journal == 'true' && steps.initialize.outputs.transition_kind == 'journal' && !failure() && !cancelled() }}
         run: node scripts/vercel-main-deployment.mjs active-journal-history --artifacts "$RUNNER_TEMP/current-attempt-journals" --output "$RUNNER_TEMP/recovered-history.json"
       - name: Require a recovered or manual terminal recovery journal
         id: recovery-terminal
-        if: steps.journal-presence.outputs.has_journal == 'true'
+        if: >-
+          steps.journal-presence.outputs.has_journal == 'true' &&
+          steps.initialize.outputs.transition_kind == 'journal'
         env:
           {
             RECOVERY_STATUS: "${{ steps.recovered-head.outputs.highest_status }}",
@@ -2591,6 +2638,12 @@ jobs:
             *) exit 1 ;;
           esac
       - name: Capture fresh full legacy proof
+        if: >-
+          always() && !cancelled() &&
+          steps.journal-presence.outcome == 'success' &&
+          (steps.journal-presence.outputs.has_journal != 'true' ||
+          steps.recovery-failed.outputs.outcome == 'recovery-failed' ||
+          (steps.initialize.outputs.transition_kind == 'journal' && !failure()))
         env:
           VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN_PRODUCTION }}
@@ -2598,6 +2651,12 @@ jobs:
           node scripts/vercel-deployment-state.mjs snapshot
           --spec "$RUNNER_TEMP/legacy-spec.json"
           --output "$RUNNER_TEMP/recovery-final-legacy.json"
+      - name: Materialize recovery-failed terminal artifacts without a recovery journal
+        id: recovery-failed-terminal
+        if: ${{ always() && !cancelled() && steps.recovery-failed.outputs.outcome == 'recovery-failed' }}
+        run: |
+          node scripts/vercel-main-release-cli.mjs terminal-artifacts --active-evidence-output "$RUNNER_TEMP/recovery-evidence.json" --execution "$RUNNER_TEMP/execution.json" --final-census "$RUNNER_TEMP/null.json" --final-mappings "$RUNNER_TEMP/null.json" --freshness "$RUNNER_TEMP/null.json" --journal-history "$RUNNER_TEMP/current-attempt-journals/current-history.json" --legacy-v2 "$RUNNER_TEMP/recovery-final-legacy.json" --outcome recovery-failed --proofs-output "$RUNNER_TEMP/recovery-proofs.json" --public-smokes "$RUNNER_TEMP/null.json" --stage-results "$RUNNER_TEMP/null.json" --state-proof "$RUNNER_TEMP/null.json"
+          echo 'outcome=recovery-failed' >> "$GITHUB_OUTPUT"
       - name: Materialize preparation failure terminal artifacts without a journal
         id: preparation-failure-terminal
         if: steps.journal-presence.outputs.has_journal != 'true'
@@ -2701,7 +2760,7 @@ jobs:
           echo "outcome=$TERMINAL_OUTCOME" >> "$GITHUB_OUTPUT"
       - name: Publish recovery terminal producer outputs
         id: terminal
-        if: ${{ always() && !cancelled() && (steps.preparation-failure-terminal.outcome == 'success' || steps.recovered-terminal.outcome == 'success') }}
+        if: ${{ always() && !cancelled() && (steps.preparation-failure-terminal.outcome == 'success' || steps.recovery-failed-terminal.outcome == 'success' || steps.recovered-terminal.outcome == 'success') }}
         run: >-
           node scripts/vercel-main-deployment.mjs terminal-evidence-create
           --manifest "$RUNNER_TEMP/manifest.json" --execution "$RUNNER_TEMP/execution.json"
@@ -2712,12 +2771,12 @@ jobs:
         if: ${{ always() && steps.terminal.outcome == 'success' }}
         env:
           {
-            TERMINAL_OUTCOME: "${{ steps.preparation-failure-terminal.outputs.outcome || steps.recovered-terminal.outputs.outcome }}",
+            TERMINAL_OUTCOME: "${{ steps.preparation-failure-terminal.outputs.outcome || steps.recovery-failed-terminal.outputs.outcome || steps.recovered-terminal.outputs.outcome }}",
           }
         run: |
           set -euo pipefail
           case "$TERMINAL_OUTCOME" in
-            recovered|manual-intervention|preparation-failed-before-journal) ;;
+            recovered|manual-intervention|recovery-failed|preparation-failed-before-journal) ;;
             *) exit 1 ;;
           esac
           echo "outcome=$TERMINAL_OUTCOME" >> "$GITHUB_OUTPUT"
@@ -2726,7 +2785,7 @@ jobs:
         env: { TERMINAL_OUTCOME: "${{ steps.outcome.outputs.outcome }}" }
         run: |
           case "$TERMINAL_OUTCOME" in
-            recovered|manual-intervention|preparation-failed-before-journal) exit 1 ;;
+            recovered|manual-intervention|recovery-failed|preparation-failed-before-journal) exit 1 ;;
             *) exit 1 ;;
           esac
       - name: Remove authenticated recovery runtime

--- a/.github/workflows/vercel-main-deployment.yml
+++ b/.github/workflows/vercel-main-deployment.yml
@@ -2339,6 +2339,7 @@ jobs:
         env:
           AFTER_UPLOAD_ACTION: ${{ steps.initialize.outputs.after_upload_action }}
           ARTIFACT_NAME: ${{ steps.initialize.outputs.journal_artifact_name }}
+          HIGHEST_STATUS: ${{ steps.journal-history.outputs.highest_status }}
           INITIALIZE_OUTCOME: ${{ steps.initialize.outcome }}
           NEXT_ACTION: ${{ steps.initialize.outputs.next_action }}
           RECOVERY_MAPPINGS_OUTCOME: ${{ steps.recovery-mappings.outcome }}
@@ -2351,13 +2352,23 @@ jobs:
             exit 0
           fi
           test "$INITIALIZE_OUTCOME" = success
+          test "$AFTER_UPLOAD_ACTION" = none
+          test "$ARTIFACT_NAME" = none
           case "$TRANSITION_KIND" in
-            recovery-not-required) test "$NEXT_ACTION" = fail-after-evidence ;;
+            recovery-not-required)
+              test "$NEXT_ACTION" = fail-after-evidence
+              case "$HIGHEST_STATUS" in
+                recovered|manual_intervention)
+                  install -m 0600 "$RUNNER_TEMP/current-attempt-journals/current-history.json" "$RUNNER_TEMP/recovered-history.json"
+                  echo 'outcome=terminal-bypass' >> "$GITHUB_OUTPUT"
+                  echo "terminal_status=$HIGHEST_STATUS" >> "$GITHUB_OUTPUT"
+                  exit 0
+                  ;;
+              esac
+              ;;
             recovery-ready) test "$NEXT_ACTION" = dispatch ;;
             *) exit 1 ;;
           esac
-          test "$AFTER_UPLOAD_ACTION" = none
-          test "$ARTIFACT_NAME" = none
           echo 'outcome=recovery-failed' >> "$GITHUB_OUTPUT"
       - name: Require initialized recovery journal checkpoint
         if: >-
@@ -2625,10 +2636,11 @@ jobs:
         id: recovery-terminal
         if: >-
           steps.journal-presence.outputs.has_journal == 'true' &&
-          steps.initialize.outputs.transition_kind == 'journal'
+          (steps.initialize.outputs.transition_kind == 'journal' ||
+          steps.recovery-failed.outputs.outcome == 'terminal-bypass')
         env:
           {
-            RECOVERY_STATUS: "${{ steps.recovered-head.outputs.highest_status }}",
+            RECOVERY_STATUS: "${{ steps.recovery-failed.outputs.terminal_status || steps.recovered-head.outputs.highest_status }}",
           }
         run: |
           set -euo pipefail
@@ -2643,6 +2655,7 @@ jobs:
           steps.journal-presence.outcome == 'success' &&
           (steps.journal-presence.outputs.has_journal != 'true' ||
           steps.recovery-failed.outputs.outcome == 'recovery-failed' ||
+          steps.recovery-failed.outputs.outcome == 'terminal-bypass' ||
           (steps.initialize.outputs.transition_kind == 'journal' && !failure()))
         env:
           VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}

--- a/docs/vercel-deployments.md
+++ b/docs/vercel-deployments.md
@@ -414,6 +414,12 @@ activation order before it terminalizes manual intervention. Recovery, manual
 intervention, a missing journal after a possible mutation, and recovery failure
 all fail the release after publishing redacted evidence.
 
+If an exact current-attempt journal exists but recovery initialization cannot
+produce the next durable recovery snapshot, the workflow classifies the outcome
+as `recovery-failed`. It performs no recovery transition or provider mutation,
+then publishes terminal evidence bound to the unchanged canonical journal
+history and a fresh legacy App `v2` proof before failing the release.
+
 If a recovered journal proves that App's `app_v3_deploy` operation never
 started and its prepared candidate still has no deployment identity, the final
 state specification records App as `recoveredPrior`. That narrow state expects

--- a/scripts/vercel-main-deployment-workflow.test.mjs
+++ b/scripts/vercel-main-deployment-workflow.test.mjs
@@ -1085,6 +1085,15 @@ test("recovery is a bounded exact-current-attempt transaction with no cross-atte
     command("recover-main-deployment", "plan-active-recovery").run,
     /current-history[\s\S]*recovery-start-mappings/,
   );
+  const recoveryMappings = named(
+    "recover-main-deployment",
+    "Derive and capture full recovery mappings from journal history",
+  );
+  assert.equal(recoveryMappings.id, "recovery-mappings");
+  assert.equal(
+    command("recover-main-deployment", "plan-active-recovery").id,
+    "recovery-plan",
+  );
   const initialize = named(
     "recover-main-deployment",
     "Initialize durable current-attempt recovery journal",
@@ -1093,6 +1102,75 @@ test("recovery is a bounded exact-current-attempt transaction with no cross-atte
     initialize.run,
     /active-recovery-event-initialize[\s\S]*run-active-recovery/,
   );
+  const classifyRecoveryFailure = named(
+    "recover-main-deployment",
+    "Classify recovery preparation failure or non-journal result",
+  );
+  assert.match(classifyRecoveryFailure.if, /always\(\)[\s\S]*!cancelled\(\)/);
+  assert.match(
+    classifyRecoveryFailure.if,
+    /steps\.journal-presence\.outputs\.has_journal == 'true'/,
+  );
+  assert.match(
+    classifyRecoveryFailure.if,
+    /steps\.recovery-mappings\.outcome == 'failure'/,
+  );
+  assert.match(
+    classifyRecoveryFailure.if,
+    /steps\.recovery-plan\.outcome == 'failure'/,
+  );
+  assert.match(
+    classifyRecoveryFailure.if,
+    /steps\.initialize\.outcome == 'failure'/,
+  );
+  assert.match(
+    classifyRecoveryFailure.if,
+    /steps\.initialize\.outcome == 'success'[\s\S]*transition_kind == 'recovery-not-required'/,
+  );
+  assert.match(
+    classifyRecoveryFailure.if,
+    /steps\.initialize\.outcome == 'success'[\s\S]*transition_kind == 'recovery-ready'/,
+  );
+  assert.match(
+    classifyRecoveryFailure.run,
+    /RECOVERY_MAPPINGS_OUTCOME[\s\S]*= failure[\s\S]*RECOVERY_PLAN_OUTCOME[\s\S]*= failure[\s\S]*INITIALIZE_OUTCOME[\s\S]*= failure[\s\S]*outcome=recovery-failed[\s\S]*exit 0/,
+  );
+  assert.match(
+    classifyRecoveryFailure.run,
+    /recovery-not-required\) test "\$NEXT_ACTION" = fail-after-evidence[\s\S]*recovery-ready\) test "\$NEXT_ACTION" = dispatch[\s\S]*AFTER_UPLOAD_ACTION[\s\S]*none[\s\S]*ARTIFACT_NAME[\s\S]*none[\s\S]*outcome=recovery-failed/,
+  );
+  assert.doesNotMatch(
+    JSON.stringify(classifyRecoveryFailure),
+    /VERCEL_(?:ORG_ID|TOKEN)|vercel-main-active-recovery-transition/,
+  );
+  const initializedJournalSteps = [
+    named(
+      "recover-main-deployment",
+      "Require initialized recovery journal checkpoint",
+    ),
+    named(
+      "recover-main-deployment",
+      "Stage initialized recovery journal under its canonical artifact basename",
+    ),
+    named("recover-main-deployment", "Upload initialized recovery journal"),
+    named("recover-main-deployment", "Checkpoint initialized recovery journal"),
+    ...steps("recover-main-deployment").filter(
+      (step) =>
+        step.name?.startsWith("Inspect recovery head") ||
+        step.name === "Read final current-attempt recovery head" ||
+        step.name ===
+          "Require a recovered or manual terminal recovery journal" ||
+        step.uses ===
+          "./.github/actions/vercel-main-active-recovery-transition",
+    ),
+  ];
+  for (const step of initializedJournalSteps) {
+    assert.match(
+      step.if,
+      /steps\.initialize\.outputs\.transition_kind == 'journal'/,
+      step.name ?? step.uses,
+    );
+  }
   assert.ok(
     steps("recover-main-deployment").some(
       (step) =>
@@ -1119,6 +1197,16 @@ test("recovery is a bounded exact-current-attempt transaction with no cross-atte
     ["1", "2", "3", "4", "5", "6", "7", "8", "9", "10"],
   );
   for (const transition of transitions) {
+    assert.match(
+      transition.if,
+      /steps\.initialize\.outputs\.transition_kind == 'journal'/,
+      transition.name ?? transition.uses,
+    );
+    assert.doesNotMatch(
+      transition.if,
+      /recovery-ready/,
+      transition.name ?? transition.uses,
+    );
     assert.equal(
       transition.with["operation-cwd"],
       "${{ github.workspace }}/source",
@@ -1144,7 +1232,42 @@ test("recovery is a bounded exact-current-attempt transaction with no cross-atte
     preparationFailure.run,
     /terminal-stage-results[\s\S]*--app-result[\s\S]*--coordinator-result[\s\S]*preparation-stage-results/,
   );
+  assert.match(
+    preparationFailure.if,
+    /steps\.journal-presence\.outputs\.has_journal != 'true'/,
+  );
   assert.doesNotMatch(preparationFailure.run, /vercel-main-stage-results:v1/);
+  const recoveryFailedTerminal = named(
+    "recover-main-deployment",
+    "recovery-failed terminal artifacts",
+  );
+  assert.match(recoveryFailedTerminal.if, /always\(\)[\s\S]*!cancelled\(\)/);
+  assert.match(
+    recoveryFailedTerminal.if,
+    /steps\.recovery-failed\.outputs\.outcome == 'recovery-failed'/,
+  );
+  assert.match(
+    recoveryFailedTerminal.run,
+    /terminal-artifacts[\s\S]*--journal-history[\s\S]*current-history[\s\S]*--legacy-v2[\s\S]*recovery-final-legacy[\s\S]*--outcome recovery-failed/,
+  );
+  assert.match(
+    recoveryFailedTerminal.run,
+    /--final-census[\s\S]*null\.json[\s\S]*--final-mappings[\s\S]*null\.json[\s\S]*--freshness[\s\S]*null\.json[\s\S]*--public-smokes[\s\S]*null\.json[\s\S]*--stage-results[\s\S]*null\.json[\s\S]*--state-proof[\s\S]*null\.json/,
+  );
+  assert.match(recoveryFailedTerminal.run, /outcome=recovery-failed/);
+  assert.doesNotMatch(
+    JSON.stringify(recoveryFailedTerminal),
+    /VERCEL_(?:ORG_ID|TOKEN)|vercel-main-active-recovery-transition/,
+  );
+  const freshLegacyProof = named(
+    "recover-main-deployment",
+    "Capture fresh full legacy proof",
+  );
+  assert.match(freshLegacyProof.if, /always\(\)[\s\S]*!cancelled\(\)/);
+  assert.match(
+    freshLegacyProof.if,
+    /steps\.recovery-failed\.outputs\.outcome == 'recovery-failed'/,
+  );
   assert.match(
     command("recover-main-deployment", "active-recovery-state-spec").run,
     /--execution[\s\S]*recovered-history/,
@@ -1180,7 +1303,26 @@ test("recovery is a bounded exact-current-attempt transaction with no cross-atte
       "recover-main-deployment",
       "Fail after recording recovery terminal evidence",
     ).run,
-    /recovered\|manual-intervention\|preparation-failed-before-journal[\s\S]*exit 1/,
+    /recovered\|manual-intervention\|recovery-failed\|preparation-failed-before-journal[\s\S]*exit 1/,
+  );
+  assert.match(
+    named("recover-main-deployment", "Publish recovery outcome").env
+      .TERMINAL_OUTCOME,
+    /steps\.recovery-failed-terminal\.outputs\.outcome/,
+  );
+  const recoveryStepNames = steps("recover-main-deployment").map(
+    (step) => step.name,
+  );
+  assert.ok(
+    recoveryStepNames.indexOf(
+      "Materialize recovery-failed terminal artifacts without a recovery journal",
+    ) < recoveryStepNames.indexOf("Publish recovery terminal producer outputs"),
+  );
+  assert.ok(
+    recoveryStepNames.indexOf("Publish recovery terminal producer outputs") <
+      recoveryStepNames.indexOf(
+        "Fail after recording recovery terminal evidence",
+      ),
   );
   const cleanup = named(
     "recover-main-deployment",

--- a/scripts/vercel-main-deployment-workflow.test.mjs
+++ b/scripts/vercel-main-deployment-workflow.test.mjs
@@ -1137,7 +1137,11 @@ test("recovery is a bounded exact-current-attempt transaction with no cross-atte
   );
   assert.match(
     classifyRecoveryFailure.run,
-    /recovery-not-required\) test "\$NEXT_ACTION" = fail-after-evidence[\s\S]*recovery-ready\) test "\$NEXT_ACTION" = dispatch[\s\S]*AFTER_UPLOAD_ACTION[\s\S]*none[\s\S]*ARTIFACT_NAME[\s\S]*none[\s\S]*outcome=recovery-failed/,
+    /AFTER_UPLOAD_ACTION[\s\S]*none[\s\S]*ARTIFACT_NAME[\s\S]*none[\s\S]*recovery-not-required\)[\s\S]*NEXT_ACTION[\s\S]*fail-after-evidence[\s\S]*HIGHEST_STATUS[\s\S]*recovered\|manual_intervention[\s\S]*current-history\.json[\s\S]*recovered-history\.json[\s\S]*outcome=terminal-bypass[\s\S]*terminal_status=[\s\S]*exit 0[\s\S]*recovery-ready\) test "\$NEXT_ACTION" = dispatch[\s\S]*outcome=recovery-failed/,
+  );
+  assert.match(
+    classifyRecoveryFailure.env.HIGHEST_STATUS,
+    /steps\.journal-history\.outputs\.highest_status/,
   );
   assert.doesNotMatch(
     JSON.stringify(classifyRecoveryFailure),
@@ -1204,7 +1208,7 @@ test("recovery is a bounded exact-current-attempt transaction with no cross-atte
     );
     assert.doesNotMatch(
       transition.if,
-      /recovery-ready/,
+      /recovery-ready|terminal-bypass/,
       transition.name ?? transition.uses,
     );
     assert.equal(
@@ -1219,6 +1223,18 @@ test("recovery is a bounded exact-current-attempt transaction with no cross-atte
   assert.match(
     named("recover-main-deployment", "recovered or manual terminal").run,
     /recovered[\s\S]*manual_intervention/,
+  );
+  const recoveryTerminal = named(
+    "recover-main-deployment",
+    "Require a recovered or manual terminal recovery journal",
+  );
+  assert.match(
+    recoveryTerminal.if,
+    /steps\.recovery-failed\.outputs\.outcome == 'terminal-bypass'/,
+  );
+  assert.match(
+    recoveryTerminal.env.RECOVERY_STATUS,
+    /steps\.recovery-failed\.outputs\.terminal_status[\s\S]*steps\.recovered-head\.outputs\.highest_status/,
   );
   const preparationFailure = named(
     "recover-main-deployment",
@@ -1246,6 +1262,7 @@ test("recovery is a bounded exact-current-attempt transaction with no cross-atte
     recoveryFailedTerminal.if,
     /steps\.recovery-failed\.outputs\.outcome == 'recovery-failed'/,
   );
+  assert.doesNotMatch(recoveryFailedTerminal.if, /terminal-bypass/);
   assert.match(
     recoveryFailedTerminal.run,
     /terminal-artifacts[\s\S]*--journal-history[\s\S]*current-history[\s\S]*--legacy-v2[\s\S]*recovery-final-legacy[\s\S]*--outcome recovery-failed/,
@@ -1267,6 +1284,10 @@ test("recovery is a bounded exact-current-attempt transaction with no cross-atte
   assert.match(
     freshLegacyProof.if,
     /steps\.recovery-failed\.outputs\.outcome == 'recovery-failed'/,
+  );
+  assert.match(
+    freshLegacyProof.if,
+    /steps\.recovery-failed\.outputs\.outcome == 'terminal-bypass'/,
   );
   assert.match(
     command("recover-main-deployment", "active-recovery-state-spec").run,

--- a/scripts/vercel-main-deployment.mjs
+++ b/scripts/vercel-main-deployment.mjs
@@ -5263,7 +5263,13 @@ function canonicalTerminalArtifact(value, label, depth = 0) {
 function canonicalTerminalProof(value, label, { journal = false } = {}) {
   assertExactKeys(value, ["status", "artifact"], label);
   const statuses = journal
-    ? ["committed", "recovered", "manual-intervention", "not-applicable"]
+    ? [
+        "committed",
+        "recovered",
+        "manual-intervention",
+        "recovery-failed",
+        "not-applicable",
+      ]
     : ["passed", "not-required", "superseded", "prepared", "unsafe"];
   if (!statuses.includes(value.status)) {
     throw new Error(`${label} status is malformed`);
@@ -5349,7 +5355,7 @@ export function assertMainActiveTerminalProofs(value) {
   const outcome = requireString(
     value.outcome,
     "Main active terminal outcome",
-    /^(?:active-committed|current-release-verified|recovered|verified-noop|no-target|superseded-before-journal|shadow-prepared|manual-intervention|preparation-failed-before-journal)$/,
+    /^(?:active-committed|current-release-verified|recovered|verified-noop|no-target|superseded-before-journal|shadow-prepared|manual-intervention|recovery-failed|preparation-failed-before-journal)$/,
   );
   const finalMapping = canonicalTerminalProof(
     value.finalMapping,
@@ -5841,6 +5847,7 @@ function terminalJobs(execution, outcome) {
     "recovered",
     "verified-noop",
     "manual-intervention",
+    "recovery-failed",
   ].includes(outcome);
   return {
     waitForCi: "success",
@@ -5855,7 +5862,9 @@ function terminalJobs(execution, outcome) {
       ? "success"
       : "skipped",
     coordinator: recoveryOutcome ? "failure" : "success",
-    recovery: outcome === "manual-intervention" ? "failure" : "success",
+    recovery: ["manual-intervention", "recovery-failed"].includes(outcome)
+      ? "failure"
+      : "success",
   };
 }
 
@@ -5902,6 +5911,7 @@ export function createMainActiveTerminalArtifacts({
       "superseded-before-journal",
       "shadow-prepared",
       "manual-intervention",
+      "recovery-failed",
       "preparation-failed-before-journal",
     ].includes(outcome)
   ) {
@@ -6297,6 +6307,67 @@ export function createMainActiveTerminalArtifacts({
         status: "not-applicable",
         artifact: null,
       }),
+    };
+  } else if (outcome === "recovery-failed") {
+    if (
+      stageResults !== null ||
+      finalMappings !== null ||
+      publicSmokes !== null ||
+      stateProof !== null ||
+      finalCensus !== null ||
+      freshness !== null
+    ) {
+      throw new Error(
+        "Terminal recovery failure cannot contain provider or stage proof",
+      );
+    }
+    if (history.length === 0) {
+      throw new Error("Terminal recovery failure requires a durable journal");
+    }
+    const highest = history.at(-1);
+    assertJournalMatchesActivePlanning(highest, planning);
+    if (
+      ![
+        "prepared",
+        "started",
+        "command_returned",
+        "verified",
+        "committed",
+        "recovering",
+      ].includes(highest.status)
+    ) {
+      throw new Error("Terminal recovery failure journal head is unsupported");
+    }
+    const counts = operationMutationCounts(highest);
+    evidence = createMainActiveDeploymentFailureEvidence({
+      eventHeadSha: manifest.deploySha,
+      verifiedDeploySha: manifest.deploySha,
+      planOutput: "execution-bound",
+      jobs: safeJobs,
+      workflowDefinitionSha: manifest.deploySha,
+      runId: canonicalRunId,
+      runAttempt: canonicalRunAttempt,
+      workflowRunUrl: terminalWorkflowRunUrl(canonicalRunId),
+      mainOwnershipMode: planning.mainOwnershipMode,
+      journalHistory: history,
+      publicServingMutationCommands: counts.started,
+      coordinatorOutcome: "active-failed",
+      recoveryOutcome: "recovery-failed",
+      errorCode: "RECOVERY_FAILED_AFTER_DURABLE_JOURNAL",
+    });
+    proofs = {
+      ...proofIdentity,
+      producerJob: "recover-main-deployment",
+      outcome,
+      finalMapping: terminalProof({ status: "unsafe", artifact: evidence }),
+      finalCensus: terminalProof({ status: "unsafe", artifact: evidence }),
+      stateProof: terminalProof({ status: "unsafe", artifact: evidence }),
+      publicSmoke: terminalProof({ status: "not-required", artifact: null }),
+      freshLegacyV2: terminalProof({ status: "passed", artifact: legacyState }),
+      mutationCount: counts.started,
+      rollbackTargets: [],
+      affectedOperations: [],
+      journal: terminalProof({ status: "recovery-failed", artifact: history }),
     };
   } else {
     if (stageResults !== null) {
@@ -6865,6 +6936,9 @@ function terminalOutcomeForActiveEvidence(evidence) {
     throw new Error("Nested active evidence schema is unsupported");
   }
   if (evidence.recoveryOutcome === "recovered") return "recovered";
+  if (evidence.recoveryOutcome === "recovery-failed") {
+    return "recovery-failed";
+  }
   if (
     evidence.recoveryOutcome === "verified-no-mutation" &&
     evidence.publicServingMutationCommands === 0
@@ -7471,6 +7545,23 @@ export function assertMainActiveTerminalEvidenceArtifact(
       "Manual-intervention evidence lacks a terminal unsafe journal",
     );
   }
+  if (
+    terminalOutcome === "recovery-failed" &&
+    (journal.historyStatus !== "valid" ||
+      ![
+        "prepared",
+        "started",
+        "command_returned",
+        "verified",
+        "committed",
+        "recovering",
+      ].includes(journal.highestStatus) ||
+      rollbackStateTargets.length !== 0 ||
+      recoveryOutcome !== "recovery-failed" ||
+      errorCode !== "RECOVERY_FAILED_AFTER_DURABLE_JOURNAL")
+  ) {
+    throw new Error("Recovery-failed evidence lacks a durable journal proof");
+  }
   return canonical;
 }
 
@@ -7867,6 +7958,28 @@ function assertMainActiveTerminalProofBindings({
       "Main terminal preparation failure proofs conflict with evidence",
     );
   }
+  if (proofs.outcome === "recovery-failed") {
+    if (
+      evidence.schema !== MAIN_ACTIVE_FAILURE_EVIDENCE_SCHEMA ||
+      evidence.recoveryOutcome !== "recovery-failed" ||
+      evidence.errorCode !== "RECOVERY_FAILED_AFTER_DURABLE_JOURNAL" ||
+      proofs.finalMapping.receipt.status !== "unsafe" ||
+      proofs.finalCensus.receipt.status !== "unsafe" ||
+      proofs.stateProof.receipt.status !== "unsafe" ||
+      !sameJson(proofs.finalMapping.artifact, evidence) ||
+      !sameJson(proofs.finalCensus.artifact, evidence) ||
+      !sameJson(proofs.stateProof.artifact, evidence) ||
+      proofs.publicSmoke.receipt.status !== "not-required" ||
+      proofs.publicSmoke.artifact !== null ||
+      proofs.journal.receipt.status !== "recovery-failed" ||
+      proofs.rollbackTargets.length !== 0 ||
+      proofs.affectedOperations.length !== 0
+    ) {
+      throw new Error(
+        "Recovery-failed terminal proofs conflict with failure evidence",
+      );
+    }
+  }
   assertFreshLegacyV2TerminalProof(proofs.freshLegacyV2.artifact, execution);
 
   if (evidence.finalMappings !== undefined && evidence.finalMappings !== null) {
@@ -8014,6 +8127,12 @@ function assertMainActiveTerminalProofBindings({
       throw new Error(
         "Main terminal affected operations conflict with the journal",
       );
+    }
+    if (
+      proofs.outcome === "recovery-failed" &&
+      operationMutationCounts(highest).started !== proofs.mutationCount
+    ) {
+      throw new Error("Recovery-failed terminal mutation count conflicts");
     }
   }
 }

--- a/scripts/vercel-main-deployment.test.mjs
+++ b/scripts/vercel-main-deployment.test.mjs
@@ -112,6 +112,7 @@ import {
   attachDiscoveredAppCandidate,
   classifyMainTransactionMapping,
   finishMainTransactionRecovery,
+  markMainTransactionCommitted,
   mainTransactionJournalArtifactName,
   recordMainTransactionCommandReturned,
   recordMainTransactionVerified,
@@ -3445,6 +3446,225 @@ test("active controller commits exact ordered mutations and emits canonical reda
   );
 });
 
+test("production-shaped all-target terminal artifacts cover the five-operation committed journal", async () => {
+  const harness = activeHarness({
+    appAliasesMovedByDeploy: ["app.mento.org"],
+  });
+  const transaction = await runMainActiveTransaction({
+    plan: harness.plan,
+    stageJobs: harness.stageJobs,
+    appBuildProof: harness.appBuildProof,
+    runId: "800",
+    runAttempt: "3",
+    journalHistory: [],
+    adapters: harness.adapters,
+  });
+  const execution = releaseExecutionForPlan(harness.plan);
+  const appCommandReturnedIndex = transaction.journalHistory.findIndex(
+    (journal) =>
+      journal.operations.at(-1)?.type === "app_v3_deploy" &&
+      journal.operations.at(-1)?.state === "command_returned",
+  );
+  const appCommandReturned = structuredClone(
+    transaction.journalHistory[appCommandReturnedIndex],
+  );
+  const discoveredAppCandidate = {
+    deploymentId: appCommandReturned.candidates.app.deploymentId,
+    deploymentUrl: appCommandReturned.candidates.app.deploymentUrl,
+    ...appCommandReturned.candidates.app.discovery,
+  };
+  appCommandReturned.candidates.app.deploymentId = null;
+  appCommandReturned.candidates.app.deploymentUrl = null;
+  appCommandReturned.operations.at(-1).candidateDeploymentId = null;
+  appCommandReturned.operations.at(-1).candidateDeploymentUrl = null;
+  const appCandidateAttached = attachDiscoveredAppCandidate(
+    appCommandReturned,
+    discoveredAppCandidate,
+  );
+  const appOperationId = appCandidateAttached.operations.at(-1).operationId;
+  const appVerified = recordMainTransactionVerified(appCandidateAttached, {
+    operationId: appOperationId,
+    mappingState: "candidate",
+  });
+  const alias = "appmentoorg-env-v3-mentolabs.vercel.app";
+  const aliasStarted = startMainTransactionOperation(appVerified, {
+    type: "app_alias_set",
+    target: "app",
+    alias,
+  });
+  const aliasOperationId = aliasStarted.operations.at(-1).operationId;
+  const aliasReturned = recordMainTransactionCommandReturned(aliasStarted, {
+    operationId: aliasOperationId,
+    outcome: "success",
+  });
+  const aliasVerified = recordMainTransactionVerified(aliasReturned, {
+    operationId: aliasOperationId,
+    mappingState: "candidate",
+  });
+  const productionJournalHistory = [
+    ...transaction.journalHistory.slice(0, appCommandReturnedIndex),
+    appCommandReturned,
+    appCandidateAttached,
+    appVerified,
+    aliasStarted,
+    aliasReturned,
+    aliasVerified,
+    markMainTransactionCommitted(aliasVerified),
+  ];
+  for (let index = 1; index <= productionJournalHistory.length; index += 1) {
+    try {
+      assertMainActiveJournalHistory({
+        journals: productionJournalHistory.slice(0, index),
+        deploySha: SHA,
+        runId: "800",
+        runAttempt: "3",
+      });
+    } catch (error) {
+      throw new Error(
+        `production-shaped journal is invalid at snapshot ${index - 1}: ${error.message}`,
+      );
+    }
+  }
+  const stateProof = activeStateProof({
+    deploymentPlan: harness.plan,
+    journalHistory: productionJournalHistory,
+    jobs: harness.stageJobs,
+    runId: "800",
+    runAttempt: "3",
+  });
+  const completeStateProof = terminalStateProof({ execution, stateProof });
+  const artifacts = createMainActiveTerminalArtifacts({
+    execution,
+    outcome: "active-committed",
+    journalHistory: activeHistoryDocument(productionJournalHistory),
+    finalMappings: providerMappings(execution, activeFinalMappings(harness)),
+    publicSmokes: activePublicSmokes(transaction),
+    stateProof: completeStateProof,
+    finalCensus: completeStateProof,
+    freshLegacyV2: harness.plan.legacySnapshot,
+    freshness: null,
+    runId: "800",
+    runAttempt: "3",
+  });
+
+  assert.equal(transaction.publicServingMutationCommands, 5);
+  assert.equal(productionJournalHistory.length, 18);
+  assert.equal(productionJournalHistory.at(-1).sequence, 17);
+  assert.deepEqual(
+    transaction.journal.operations
+      .filter((operation) => operation.state === "verified")
+      .map((operation) => [operation.type, operation.target, operation.alias]),
+    [
+      ["promote", "governance", null],
+      ["promote", "reserve", null],
+      ["promote", "ui", null],
+      ["app_v3_deploy", "app", null],
+      ["app_alias_set", "app", "appmentoorg-env-v3-mentolabs.vercel.app"],
+    ],
+  );
+  assert.deepEqual(artifacts.evidence.planning.activeTargets, [
+    "app",
+    "governance",
+    "reserve",
+    "ui",
+  ]);
+  assert.deepEqual(Object.keys(artifacts.evidence.publicSmokes).sort(), [
+    "app",
+    "governance",
+    "reserve",
+    "ui",
+  ]);
+  assert.equal(artifacts.evidence.orderedVerifiedOperations.length, 5);
+  assert.equal(artifacts.proofs.mutationCount, 5);
+  assert.equal(artifacts.proofs.journal.artifact.length, 18);
+
+  const evidenceBytes = Buffer.byteLength(
+    `${JSON.stringify(artifacts.evidence)}\n`,
+    "utf8",
+  );
+  const proofBytes = Buffer.byteLength(
+    `${JSON.stringify(artifacts.proofs)}\n`,
+    "utf8",
+  );
+  assert.ok(
+    evidenceBytes <= 256 * 1024,
+    `production-shaped terminal evidence uses ${evidenceBytes} bytes`,
+  );
+  assert.ok(
+    proofBytes <= MAIN_ACTIVE_TERMINAL_PROOFS_MAX_JSON_BYTES,
+    `production-shaped terminal proofs use ${proofBytes} bytes`,
+  );
+
+  const recoveryFailedArtifacts = createMainActiveTerminalArtifacts({
+    execution,
+    outcome: "recovery-failed",
+    journalHistory: activeHistoryDocument(productionJournalHistory),
+    finalMappings: null,
+    publicSmokes: null,
+    stateProof: null,
+    finalCensus: null,
+    freshLegacyV2: harness.plan.legacySnapshot,
+    freshness: null,
+    stageResults: null,
+    runId: "800",
+    runAttempt: "3",
+  });
+  assert.equal(
+    recoveryFailedArtifacts.evidence.recoveryOutcome,
+    "recovery-failed",
+  );
+  assert.deepEqual(recoveryFailedArtifacts.evidence.jobs, {
+    waitForCi: "success",
+    plan: "success",
+    stageGovernance: "success",
+    stageReserve: "success",
+    stageUi: "success",
+    coordinator: "failure",
+    recovery: "failure",
+  });
+  assert.equal(recoveryFailedArtifacts.proofs.mutationCount, 5);
+  assert.equal(recoveryFailedArtifacts.proofs.journal.artifact.length, 18);
+
+  const recoveryFailedTerminal = createMainActiveTerminalHandoff({
+    activeEvidence: recoveryFailedArtifacts.evidence,
+    releaseManifest: execution.manifest,
+    execution,
+    proofs: recoveryFailedArtifacts.proofs,
+    deploySha: SHA,
+    upstreamRunId: "123456",
+    upstreamRunAttempt: "2",
+    workflowRunId: "800",
+    producerRunAttempt: "3",
+    repository: "mento-protocol/frontend-monorepo",
+  });
+  assert.equal(recoveryFailedTerminal.receipt.outcome, "recovery-failed");
+  assert.deepEqual(
+    restoreMainActiveTerminalEvidence({
+      encodedReceipt: recoveryFailedTerminal.encodedReceipt,
+      encodedEvidence: recoveryFailedTerminal.encodedEvidence,
+      releaseManifest: execution.manifest,
+      execution,
+      deploySha: SHA,
+      upstreamRunId: "123456",
+      upstreamRunAttempt: "2",
+      workflowRunId: "800",
+      finalRunAttempt: "4",
+      repository: "mento-protocol/frontend-monorepo",
+    }).artifact,
+    recoveryFailedArtifacts.evidence,
+  );
+  assert.ok(
+    Buffer.byteLength(recoveryFailedTerminal.encodedReceipt, "utf8") <
+      32 * 1024,
+    "production-shaped recovery-failed receipt exceeds the workflow output bound",
+  );
+  assert.ok(
+    Buffer.byteLength(recoveryFailedTerminal.encodedEvidence, "utf8") <
+      64 * 1024,
+    "production-shaped recovery-failed evidence exceeds the workflow output bound",
+  );
+});
+
 test("execution-bound terminal artifacts derive committed and verified-noop proof from provider evidence and the current journal", async () => {
   const committedHarness = activeHarness({
     deploymentPlan: activePlan({ deployments: ["governance"] }),
@@ -4036,6 +4256,196 @@ test("manual terminal handoff binds its affected-operation set to the exact curr
         repository: "mento-protocol/frontend-monorepo",
       }),
     /affected operations conflict with the journal/,
+  );
+});
+
+test("recovery-failed terminal artifacts preserve a durable journal without recovery claims", () => {
+  const deploymentPlan = activePlan({ deployments: ["governance"] });
+  const execution = releaseExecutionForPlan(deploymentPlan);
+  const prepared = createPreparedMainActiveJournal({
+    plan: deploymentPlan,
+    stageJobs: stageJobs(deploymentPlan),
+    appBuildProof: null,
+    runId: "800",
+    runAttempt: "3",
+  });
+  const started = startMainTransactionOperation(prepared, {
+    type: "promote",
+    target: "governance",
+  });
+  const returned = recordMainTransactionCommandReturned(started, {
+    operationId: started.operations.at(-1).operationId,
+    outcome: "success",
+  });
+  const verified = recordMainTransactionVerified(returned, {
+    operationId: returned.operations.at(-1).operationId,
+    mappingState: "candidate",
+  });
+  const committed = markMainTransactionCommitted(verified);
+  const recovering = startMainTransactionRecovery(started);
+  const cases = [
+    {
+      name: "prepared journal before a public-serving mutation",
+      history: [prepared],
+      expectedStarted: 0,
+      expectedStatus: "prepared",
+    },
+    {
+      name: "committed journal",
+      history: [prepared, started, returned, verified, committed],
+      expectedStarted: 1,
+      expectedStatus: "committed",
+    },
+    {
+      name: "durable nonterminal journal",
+      history: [prepared, started],
+      expectedStarted: 1,
+      expectedStatus: "started",
+    },
+    {
+      name: "recovering journal after a durable mutation start",
+      history: [prepared, started, recovering],
+      expectedStarted: 1,
+      expectedStatus: "recovering",
+    },
+  ];
+
+  for (const scenario of cases) {
+    const artifacts = createMainActiveTerminalArtifacts({
+      execution,
+      outcome: "recovery-failed",
+      journalHistory: activeHistoryDocument(scenario.history),
+      finalMappings: null,
+      publicSmokes: null,
+      stateProof: null,
+      finalCensus: null,
+      freshLegacyV2: deploymentPlan.legacySnapshot,
+      freshness: null,
+      stageResults: null,
+      runId: "800",
+      runAttempt: "3",
+    });
+    assert.equal(
+      artifacts.evidence.schema,
+      MAIN_ACTIVE_FAILURE_EVIDENCE_SCHEMA,
+    );
+    assert.equal(artifacts.evidence.recoveryOutcome, "recovery-failed");
+    assert.deepEqual(
+      artifacts.evidence.jobs,
+      {
+        waitForCi: "success",
+        plan: "success",
+        stageGovernance: "success",
+        stageReserve: "skipped",
+        stageUi: "skipped",
+        coordinator: "failure",
+        recovery: "failure",
+      },
+      scenario.name,
+    );
+    assert.equal(
+      artifacts.evidence.errorCode,
+      "RECOVERY_FAILED_AFTER_DURABLE_JOURNAL",
+    );
+    assert.equal(
+      artifacts.evidence.journal.highestStatus,
+      scenario.expectedStatus,
+      scenario.name,
+    );
+    assert.equal(
+      artifacts.evidence.publicServingMutationCommands,
+      scenario.expectedStarted,
+      scenario.name,
+    );
+    assert.equal(artifacts.proofs.outcome, "recovery-failed", scenario.name);
+    assert.equal(
+      artifacts.proofs.journal.status,
+      "recovery-failed",
+      scenario.name,
+    );
+    assert.deepEqual(artifacts.proofs.journal.artifact, scenario.history);
+    assert.equal(artifacts.proofs.mutationCount, scenario.expectedStarted);
+    assert.deepEqual(artifacts.proofs.rollbackTargets, []);
+    assert.deepEqual(artifacts.proofs.affectedOperations, []);
+    for (const proof of [
+      artifacts.proofs.finalMapping,
+      artifacts.proofs.finalCensus,
+      artifacts.proofs.stateProof,
+    ]) {
+      assert.equal(proof.status, "unsafe", scenario.name);
+      assert.deepEqual(proof.artifact, artifacts.evidence, scenario.name);
+    }
+
+    const terminal = createMainActiveTerminalHandoff({
+      activeEvidence: artifacts.evidence,
+      releaseManifest: execution.manifest,
+      execution,
+      proofs: artifacts.proofs,
+      deploySha: SHA,
+      upstreamRunId: "123456",
+      upstreamRunAttempt: "2",
+      workflowRunId: "800",
+      producerRunAttempt: "3",
+      repository: "mento-protocol/frontend-monorepo",
+    });
+    assert.equal(terminal.receipt.outcome, "recovery-failed", scenario.name);
+    assert.deepEqual(
+      restoreMainActiveTerminalEvidence({
+        encodedReceipt: terminal.encodedReceipt,
+        encodedEvidence: terminal.encodedEvidence,
+        releaseManifest: execution.manifest,
+        execution,
+        deploySha: SHA,
+        upstreamRunId: "123456",
+        upstreamRunAttempt: "2",
+        workflowRunId: "800",
+        finalRunAttempt: "4",
+        repository: "mento-protocol/frontend-monorepo",
+      }).artifact,
+      artifacts.evidence,
+      scenario.name,
+    );
+  }
+
+  const inputs = {
+    execution,
+    outcome: "recovery-failed",
+    journalHistory: activeHistoryDocument([prepared, started]),
+    finalMappings: null,
+    publicSmokes: null,
+    stateProof: null,
+    finalCensus: null,
+    freshLegacyV2: deploymentPlan.legacySnapshot,
+    freshness: null,
+    stageResults: null,
+    runId: "800",
+    runAttempt: "3",
+  };
+  assert.throws(
+    () => createMainActiveTerminalArtifacts({ ...inputs, journalHistory: [] }),
+    /requires a durable journal/,
+  );
+  for (const field of [
+    "finalMappings",
+    "publicSmokes",
+    "stateProof",
+    "finalCensus",
+    "freshness",
+    "stageResults",
+  ]) {
+    assert.throws(
+      () =>
+        createMainActiveTerminalArtifacts({
+          ...inputs,
+          [field]: { unexpected: true },
+        }),
+      /cannot contain provider or stage proof/,
+      field,
+    );
+  }
+  assert.throws(
+    () => createMainActiveTerminalArtifacts({ ...inputs, freshLegacyV2: null }),
+    /Canonical deployment state is malformed/,
   );
 });
 
@@ -5164,7 +5574,7 @@ test("terminal failure validation preserves manual-intervention journal semantic
     rollbackStateTargets: ["governance"],
     publicServingMutationCommands: 1,
     coordinatorOutcome: "active-failed",
-    recoveryOutcome: "recovery-failed",
+    recoveryOutcome: "manual-intervention",
     errorCode: "RECOVERY_FAILED",
   });
   assert.throws(

--- a/scripts/vercel-main-release-cli.mjs
+++ b/scripts/vercel-main-release-cli.mjs
@@ -122,6 +122,24 @@ export const MAIN_RELEASE_EXECUTION_DIAGNOSTIC_CODES = Object.freeze({
     "main-release-execution-github-output",
 });
 
+const TERMINAL_ARTIFACT_DIAGNOSTIC_PHASES = Object.freeze({
+  READ_INPUTS: "read-inputs",
+  CREATE_ARTIFACTS: "create-artifacts",
+  EVIDENCE_WRITE: "evidence-write",
+  PROOFS_WRITE: "proofs-write",
+});
+
+export const MAIN_RELEASE_TERMINAL_ARTIFACT_DIAGNOSTIC_CODES = Object.freeze({
+  [TERMINAL_ARTIFACT_DIAGNOSTIC_PHASES.READ_INPUTS]:
+    "main-release-terminal-artifacts-read-inputs",
+  [TERMINAL_ARTIFACT_DIAGNOSTIC_PHASES.CREATE_ARTIFACTS]:
+    "main-release-terminal-artifacts-create-artifacts",
+  [TERMINAL_ARTIFACT_DIAGNOSTIC_PHASES.EVIDENCE_WRITE]:
+    "main-release-terminal-artifacts-evidence-write",
+  [TERMINAL_ARTIFACT_DIAGNOSTIC_PHASES.PROOFS_WRITE]:
+    "main-release-terminal-artifacts-proofs-write",
+});
+
 const BASELINE_PRIOR_PHASE_BY_TARGET = Object.freeze({
   app: EXECUTION_DIAGNOSTIC_PHASES.BASELINE_PRIOR_APP,
   governance: EXECUTION_DIAGNOSTIC_PHASES.BASELINE_PRIOR_GOVERNANCE,
@@ -211,7 +229,33 @@ function createExecutionDiagnostics() {
   });
 }
 
+function createTerminalArtifactDiagnostics() {
+  let phase = TERMINAL_ARTIFACT_DIAGNOSTIC_PHASES.READ_INPUTS;
+  return Object.freeze({
+    mark(nextPhase) {
+      if (
+        !Object.hasOwn(
+          MAIN_RELEASE_TERMINAL_ARTIFACT_DIAGNOSTIC_CODES,
+          nextPhase,
+        )
+      ) {
+        throw new Error(
+          "Main release terminal artifact diagnostic phase is unsupported",
+        );
+      }
+      phase = nextPhase;
+    },
+    current() {
+      return phase;
+    },
+  });
+}
+
 function markExecutionPhase(diagnostics, phase) {
+  diagnostics?.mark(phase);
+}
+
+function markTerminalArtifactPhase(diagnostics, phase) {
   diagnostics?.mark(phase);
 }
 
@@ -512,8 +556,13 @@ export async function runMainReleaseCli({
   env = process.env,
   baselineFactory = createMainReleaseBaseline,
   executionDiagnostics = null,
+  terminalArtifactDiagnostics = null,
 } = {}) {
   markExecutionPhase(executionDiagnostics, EXECUTION_DIAGNOSTIC_PHASES.INPUT);
+  markTerminalArtifactPhase(
+    terminalArtifactDiagnostics,
+    TERMINAL_ARTIFACT_DIAGNOSTIC_PHASES.READ_INPUTS,
+  );
   const { command, options } = parseArguments(argv);
   const identity = requireEnvironment(env);
   const runnerTemp = reviewedRunnerTemp(env.RUNNER_TEMP);
@@ -602,9 +651,7 @@ export async function runMainReleaseCli({
       ),
       identity,
     );
-    const artifacts = createMainActiveTerminalArtifacts({
-      execution,
-      outcome: options.outcome,
+    const inputs = {
       journalHistory: readPrivateJson(
         options["journal-history"],
         "Main terminal journal history",
@@ -646,12 +693,29 @@ export async function runMainReleaseCli({
         "Main terminal stage results",
         runnerTemp,
       ),
+    };
+    markTerminalArtifactPhase(
+      terminalArtifactDiagnostics,
+      TERMINAL_ARTIFACT_DIAGNOSTIC_PHASES.CREATE_ARTIFACTS,
+    );
+    const artifacts = createMainActiveTerminalArtifacts({
+      execution,
+      outcome: options.outcome,
+      ...inputs,
       ...currentAttempt(env),
     });
+    markTerminalArtifactPhase(
+      terminalArtifactDiagnostics,
+      TERMINAL_ARTIFACT_DIAGNOSTIC_PHASES.EVIDENCE_WRITE,
+    );
     writePrivateJson(
       options["active-evidence-output"],
       artifacts.evidence,
       runnerTemp,
+    );
+    markTerminalArtifactPhase(
+      terminalArtifactDiagnostics,
+      TERMINAL_ARTIFACT_DIAGNOSTIC_PHASES.PROOFS_WRITE,
     );
     writePrivateJson(
       options["proofs-output"],
@@ -947,6 +1011,16 @@ export function renderMainReleaseExecutionCliFailure(phase) {
   return `Vercel main release execution failed phase=${phase} code=${code}\n`;
 }
 
+export function renderMainReleaseTerminalArtifactCliFailure(phase) {
+  const code = MAIN_RELEASE_TERMINAL_ARTIFACT_DIAGNOSTIC_CODES[phase];
+  if (code === undefined) {
+    throw new Error(
+      "Main release terminal artifact diagnostic phase is unsupported",
+    );
+  }
+  return `Vercel main release terminal artifacts failed phase=${phase} code=${code}\n`;
+}
+
 export async function runMainReleaseCliEntrypoint({
   argv = process.argv.slice(2),
   env = process.env,
@@ -955,13 +1029,26 @@ export async function runMainReleaseCliEntrypoint({
 } = {}) {
   const diagnostics =
     argv[0] === "execution" ? createExecutionDiagnostics() : null;
+  const terminalArtifactDiagnostics =
+    argv[0] === "terminal-artifacts"
+      ? createTerminalArtifactDiagnostics()
+      : null;
   try {
-    await run({ argv, env, executionDiagnostics: diagnostics });
+    await run({
+      argv,
+      env,
+      executionDiagnostics: diagnostics,
+      terminalArtifactDiagnostics,
+    });
     return 0;
   } catch {
     writeStderr(
       diagnostics === null
-        ? renderMainReleaseCliFailure()
+        ? terminalArtifactDiagnostics === null
+          ? renderMainReleaseCliFailure()
+          : renderMainReleaseTerminalArtifactCliFailure(
+              terminalArtifactDiagnostics.current(),
+            )
         : renderMainReleaseExecutionCliFailure(diagnostics.current()),
     );
     return 1;

--- a/scripts/vercel-main-release-cli.test.mjs
+++ b/scripts/vercel-main-release-cli.test.mjs
@@ -21,8 +21,10 @@ import { fileURLToPath } from "node:url";
 
 import {
   MAIN_RELEASE_EXECUTION_DIAGNOSTIC_CODES,
+  MAIN_RELEASE_TERMINAL_ARTIFACT_DIAGNOSTIC_CODES,
   renderMainReleaseCliFailure,
   renderMainReleaseExecutionCliFailure,
+  renderMainReleaseTerminalArtifactCliFailure,
   runMainReleaseCli,
   runMainReleaseCliEntrypoint,
 } from "./vercel-main-release-cli.mjs";
@@ -689,6 +691,22 @@ test("execution diagnostics use an exhaustive fixed allowlist", () => {
   );
 });
 
+test("terminal artifact diagnostics use an exhaustive fixed allowlist", () => {
+  const expected = {
+    "read-inputs": "main-release-terminal-artifacts-read-inputs",
+    "create-artifacts": "main-release-terminal-artifacts-create-artifacts",
+    "evidence-write": "main-release-terminal-artifacts-evidence-write",
+    "proofs-write": "main-release-terminal-artifacts-proofs-write",
+  };
+  assert.deepEqual(MAIN_RELEASE_TERMINAL_ARTIFACT_DIAGNOSTIC_CODES, expected);
+  for (const [phase, code] of Object.entries(expected)) {
+    assert.equal(
+      renderMainReleaseTerminalArtifactCliFailure(phase),
+      `Vercel main release terminal artifacts failed phase=${phase} code=${code}\n`,
+    );
+  }
+});
+
 test("execution entrypoint emits one fixed secret-free line for injected failures", async () => {
   const secret = "secret-value-never-print";
   for (const phase of Object.keys(MAIN_RELEASE_EXECUTION_DIAGNOSTIC_CODES)) {
@@ -705,6 +723,32 @@ test("execution entrypoint emits one fixed secret-free line for injected failure
     });
     assert.equal(status, 1, phase);
     assert.equal(stderr, renderMainReleaseExecutionCliFailure(phase), phase);
+    assert.doesNotMatch(stderr, new RegExp(secret), phase);
+  }
+});
+
+test("terminal artifact entrypoint emits one fixed secret-free line for injected failures", async () => {
+  const secret = "secret-value-never-print";
+  for (const phase of Object.keys(
+    MAIN_RELEASE_TERMINAL_ARTIFACT_DIAGNOSTIC_CODES,
+  )) {
+    let stderr = "";
+    const status = await runMainReleaseCliEntrypoint({
+      argv: ["terminal-artifacts"],
+      writeStderr: (line) => {
+        stderr += line;
+      },
+      run: ({ terminalArtifactDiagnostics }) => {
+        terminalArtifactDiagnostics.mark(phase);
+        throw new Error(secret);
+      },
+    });
+    assert.equal(status, 1, phase);
+    assert.equal(
+      stderr,
+      renderMainReleaseTerminalArtifactCliFailure(phase),
+      phase,
+    );
     assert.doesNotMatch(stderr, new RegExp(secret), phase);
   }
 });
@@ -1761,10 +1805,12 @@ test("terminal artifact CLI writes execution-bound safe-noop evidence without pl
   const argumentsFor = ({
     legacyValue = [execution.legacyAppV2],
     legacyName = "terminal-legacy.json",
+    evidenceOutputPath = evidenceOutput,
+    proofsOutputPath = proofsOutput,
   } = {}) => [
     "terminal-artifacts",
     "--active-evidence-output",
-    evidenceOutput,
+    evidenceOutputPath,
     "--execution",
     write(directory, "terminal-execution.json", execution),
     "--final-census",
@@ -1780,7 +1826,7 @@ test("terminal artifact CLI writes execution-bound safe-noop evidence without pl
     "--outcome",
     "no-target",
     "--proofs-output",
-    proofsOutput,
+    proofsOutputPath,
     "--public-smokes",
     nullPath,
     "--stage-results",
@@ -1821,6 +1867,68 @@ test("terminal artifact CLI writes execution-bound safe-noop evidence without pl
       env: environment(directory),
     }),
     /fresh legacy v2 snapshot conflicts/,
+  );
+
+  const secret = "terminal-artifact-path-secret";
+  const assertEntrypointFailure = async (argv, phase) => {
+    let stderr = "";
+    const status = await runMainReleaseCliEntrypoint({
+      argv,
+      env: environment(directory),
+      writeStderr: (line) => {
+        stderr += line;
+      },
+    });
+    assert.equal(status, 1, phase);
+    assert.equal(stderr, renderMainReleaseTerminalArtifactCliFailure(phase));
+    assert.doesNotMatch(stderr, new RegExp(secret));
+  };
+  const malformedInput = argumentsFor({
+    evidenceOutputPath: join(directory, "malformed-input-evidence.json"),
+    proofsOutputPath: join(directory, "malformed-input-proofs.json"),
+  });
+  malformedInput[malformedInput.indexOf("--journal-history") + 1] = join(
+    directory,
+    `${secret}-missing-history.json`,
+  );
+  await assertEntrypointFailure(malformedInput, "read-inputs");
+  await assertEntrypointFailure(
+    argumentsFor({
+      evidenceOutputPath: join(directory, "create-evidence.json"),
+      proofsOutputPath: join(directory, "create-proofs.json"),
+      legacyValue: [
+        {
+          ...execution.legacyAppV2,
+          deploymentId: "dpl_wrongLegacy123",
+        },
+      ],
+      legacyName: "create-wrong-legacy.json",
+    }),
+    "create-artifacts",
+  );
+  const blockedEvidenceOutput = write(
+    directory,
+    `${secret}-blocked-evidence.json`,
+    { existing: true },
+  );
+  await assertEntrypointFailure(
+    argumentsFor({
+      evidenceOutputPath: blockedEvidenceOutput,
+      proofsOutputPath: join(directory, "evidence-write-proofs.json"),
+    }),
+    "evidence-write",
+  );
+  const blockedProofsOutput = write(
+    directory,
+    `${secret}-blocked-proofs.json`,
+    { existing: true },
+  );
+  await assertEntrypointFailure(
+    argumentsFor({
+      evidenceOutputPath: join(directory, "proofs-write-evidence.json"),
+      proofsOutputPath: blockedProofsOutput,
+    }),
+    "proofs-write",
   );
 });
 

--- a/scripts/vercel-main-terminal-receipt.mjs
+++ b/scripts/vercel-main-terminal-receipt.mjs
@@ -53,6 +53,7 @@ const PROOF_STATUSES = Object.freeze([
 const JOURNAL_STATUSES = Object.freeze([
   "committed",
   "recovered",
+  "recovery-failed",
   "manual-intervention",
   "not-applicable",
 ]);
@@ -173,6 +174,12 @@ export const MAIN_TERMINAL_RECEIPT_OUTCOMES = Object.freeze({
     minMutations: 1,
     rollback: "any",
     affectedOperations: "required",
+  }),
+  "recovery-failed": Object.freeze({
+    proofs: ["unsafe", "unsafe", "unsafe", "not-required", "passed"],
+    journal: "recovery-failed",
+    rollback: "empty",
+    affectedOperations: "empty",
   }),
   "preparation-failed-before-journal": Object.freeze({
     proofs: ["unsafe", "unsafe", "unsafe", "not-required", "passed"],
@@ -513,6 +520,14 @@ function assertOutcomeContract(receipt) {
     throw new Error("Main terminal receipt journal conflicts with outcome");
   }
   if (
+    receipt.outcome === "recovery-failed" &&
+    receipt.producerJob !== "recover-main-deployment"
+  ) {
+    throw new Error(
+      "Recovery-failed terminal receipt requires the recovery producer job",
+    );
+  }
+  if (
     contract.mutations !== undefined &&
     receipt.mutationCount !== contract.mutations
   ) {
@@ -622,7 +637,7 @@ function canonicalReceipt(value, { checkDigest = true } = {}) {
     outcome: requireString(
       value.outcome,
       "Main terminal receipt outcome",
-      /^(?:active-committed|recovered|verified-noop|current-release-verified|no-target|superseded-before-journal|shadow-prepared|manual-intervention|preparation-failed-before-journal)$/,
+      /^(?:active-committed|recovered|verified-noop|current-release-verified|no-target|superseded-before-journal|shadow-prepared|manual-intervention|recovery-failed|preparation-failed-before-journal)$/,
     ),
     finalMapping: canonicalProof(
       value.finalMapping,
@@ -797,10 +812,18 @@ function canonicalEvidence(value) {
   const outcome = requireString(
     value.outcome,
     "Main terminal evidence outcome",
-    /^(?:active-committed|recovered|verified-noop|current-release-verified|no-target|superseded-before-journal|shadow-prepared|manual-intervention|preparation-failed-before-journal)$/,
+    /^(?:active-committed|recovered|verified-noop|current-release-verified|no-target|superseded-before-journal|shadow-prepared|manual-intervention|recovery-failed|preparation-failed-before-journal)$/,
   );
   if (!MAIN_TERMINAL_RECEIPT_OUTCOMES[outcome]) {
     throw new Error("Main terminal evidence outcome is unsupported");
+  }
+  if (
+    outcome === "recovery-failed" &&
+    identity.producerJob !== "recover-main-deployment"
+  ) {
+    throw new Error(
+      "Recovery-failed terminal evidence requires the recovery producer job",
+    );
   }
   if (
     !value.artifact ||

--- a/scripts/vercel-main-terminal-receipt.test.mjs
+++ b/scripts/vercel-main-terminal-receipt.test.mjs
@@ -58,7 +58,10 @@ function receiptInput(outcome = "active-committed") {
   return {
     ...IDENTITY,
     producerRunAttempt: "2",
-    producerJob: "activate-and-verify",
+    producerJob:
+      outcome === "recovery-failed"
+        ? "recover-main-deployment"
+        : "activate-and-verify",
     evidenceDigest: DIGEST(`terminal-evidence:${outcome}`),
     outcome,
     finalMapping: proof(mapping, "mapping"),
@@ -66,7 +69,7 @@ function receiptInput(outcome = "active-committed") {
     stateProof: proof(state, "state"),
     publicSmoke: proof(smoke, "smoke"),
     freshLegacyV2: proof(legacy, "legacy"),
-    mutationCount: contract.mutations ?? contract.minMutations,
+    mutationCount: contract.mutations ?? contract.minMutations ?? 0,
     rollbackTargets: contract.rollback === "required" ? ["governance"] : [],
     affectedOperations:
       outcome === "manual-intervention" ? [affectedOperation()] : [],
@@ -117,6 +120,77 @@ test("every terminal receipt outcome has a strict proof and journal contract", (
   assert.throws(
     () => createMainTerminalReceipt(committed),
     /journal conflicts/,
+  );
+});
+
+test("recovery failure has a recovery-only, dynamic, tamper-evident terminal handoff", () => {
+  const input = receiptInput("recovery-failed");
+  input.producerJob = "recover-main-deployment";
+  input.mutationCount = 17;
+  const receipt = createMainTerminalReceipt(input);
+
+  assert.deepEqual(
+    [
+      receipt.finalMapping.status,
+      receipt.finalCensus.status,
+      receipt.stateProof.status,
+      receipt.publicSmoke.status,
+      receipt.freshLegacyV2.status,
+    ],
+    ["unsafe", "unsafe", "unsafe", "not-required", "passed"],
+  );
+  assert.deepEqual(receipt.journal, {
+    status: "recovery-failed",
+    digest: DIGEST("journal:recovery-failed"),
+  });
+  assert.equal(receipt.mutationCount, 17);
+  assert.deepEqual(receipt.rollbackTargets, []);
+  assert.deepEqual(receipt.affectedOperations, []);
+
+  assert.equal(
+    createMainTerminalReceipt({ ...input, mutationCount: 0 }).mutationCount,
+    0,
+  );
+  assert.throws(
+    () => createMainTerminalReceipt({ ...input, mutationCount: -1 }),
+    /mutation count is malformed/,
+  );
+
+  const encoded = encodeMainTerminalReceipt(receipt);
+  assert.deepEqual(decodeMainTerminalReceipt(encoded, IDENTITY), receipt);
+
+  const tampered = structuredClone(receipt);
+  tampered.mutationCount = 18;
+  const tamperedEncoded = Buffer.from(JSON.stringify(tampered)).toString(
+    "base64url",
+  );
+  assert.throws(
+    () => decodeMainTerminalReceipt(tamperedEncoded, IDENTITY),
+    /self digest does not match/,
+  );
+  assert.throws(
+    () =>
+      createMainTerminalReceipt({
+        ...input,
+        producerJob: "activate-and-verify",
+      }),
+    /requires the recovery producer job/,
+  );
+  assert.throws(
+    () =>
+      createMainTerminalReceipt({
+        ...input,
+        rollbackTargets: ["governance"],
+      }),
+    /forbids rollback targets/,
+  );
+  assert.throws(
+    () =>
+      createMainTerminalReceipt({
+        ...input,
+        affectedOperations: [affectedOperation()],
+      }),
+    /forbids affected operations/,
   );
 });
 


### PR DESCRIPTION
## The Problem

The first all-target GitHub-driven main release successfully built, activated, and smoke-tested all four applications, then failed while materializing its terminal certification artifacts. The CLI exposed only a generic error. Recovery correctly recognized that the durable journal was already committed and made no rollback mutation, but the workflow then required a new recovery journal and failed without publishing the canonical terminal receipt and evidence.

Observed run: https://github.com/mento-protocol/frontend-monorepo/actions/runs/30335725449

## The Solution

- Add fixed, secret-free diagnostic phases around terminal artifact input, construction, and private writes.
- Add a strict `recovery-failed` terminal outcome backed by the unchanged durable current-attempt journal, exact started-mutation count, and a fresh legacy App v2 proof.
- Publish a canonical receipt and evidence before deliberately failing when recovery preparation cannot produce a new journal, including read-only mapping/planning failures and an already-`recovering` journal head.
- Keep recovery transitions and provider mutations unreachable on this failure path.
- Add production-shaped coverage for the actual 18-snapshot, five-operation, four-target journal and compact handoff restoration.
- Document the evidence-first failure behavior.

The broader finalizer for failures after a new recovery journal upload is tracked in #685 because it must re-download exact current-attempt artifacts before rebuilding canonical history.

## Validation

- `pnpm vercel:workflow:test` — 580 passed
- `pnpm quality:budgets:test` — 34 passed
- `pnpm adr:check` — passed
- Prettier check for all changed files — passed
- `git diff --check` — passed
- Three fresh specialist reviews plus a final no-edit gate — no blockers

## Ship Checklist

- [x] PR title follows the conventions
- [x] Performed a self-review of my own changes
- [x] Relevant automated checks and smoke tests pass
- [x] Architecture decision? Not applicable — this repairs the existing deployment architecture and terminal evidence contract; it does not change the deployment ownership decision.

Part of #522.
