### PR TITLE
fix(ci): bind terminal deployment mappings

### DIFF
--- a/.github/workflows/vercel-main-deployment.yml
+++ b/.github/workflows/vercel-main-deployment.yml
@@ -2028,7 +2028,8 @@ jobs:
               exit 1
               ;;
           esac
-          node scripts/vercel-deployment-state.mjs alias-mappings --spec "$RUNNER_TEMP/final-mapping-spec.json" --output "$RUNNER_TEMP/final-mappings.json"
+          node scripts/vercel-deployment-state.mjs alias-mappings --spec "$RUNNER_TEMP/final-mapping-spec.json" --output "$RUNNER_TEMP/final-mappings-raw.json"
+          node scripts/vercel-main-deployment.mjs active-canonical-mappings --mapping-spec "$RUNNER_TEMP/final-mapping-spec.json" --mappings "$RUNNER_TEMP/final-mappings-raw.json" --output "$RUNNER_TEMP/final-mappings.json"
           node scripts/vercel-deployment-state.mjs active-proof --spec "$RUNNER_TEMP/final-state-spec.json" --output "$RUNNER_TEMP/final-state-proof.json"
           node scripts/vercel-main-deployment.mjs active-terminal-state-proof --execution "$RUNNER_TEMP/execution.json" --stage-barrier "$RUNNER_TEMP/stage-barrier.json" --state-proof "$RUNNER_TEMP/final-state-proof.json" --output "$RUNNER_TEMP/terminal-state-proof.json"
           node scripts/vercel-deployment-state.mjs snapshot --spec "$RUNNER_TEMP/legacy-spec.json" --output "$RUNNER_TEMP/final-legacy.json"
@@ -2039,7 +2040,7 @@ jobs:
           needs.prepare-release.outputs.decision != 'verify-existing-release'
         id: finalize
         run: |
-          node scripts/vercel-main-deployment.mjs active-event-finalize --receipt "$RUNNER_TEMP/active-journals/current-receipt.json" --freshness "$RUNNER_TEMP/final-freshness.json" --current-mappings "$RUNNER_TEMP/final-mappings.json" --public-smokes "$RUNNER_TEMP/public-smokes.json" --state-proof "$RUNNER_TEMP/final-state-proof.json" --output "$RUNNER_TEMP/finalize-event.json"
+          node scripts/vercel-main-deployment.mjs active-event-finalize --receipt "$RUNNER_TEMP/active-journals/current-receipt.json" --freshness "$RUNNER_TEMP/final-freshness.json" --current-mappings "$RUNNER_TEMP/final-mappings-raw.json" --public-smokes "$RUNNER_TEMP/public-smokes.json" --state-proof "$RUNNER_TEMP/final-state-proof.json" --output "$RUNNER_TEMP/finalize-event.json"
           node scripts/vercel-main-deployment.mjs run-active --execution "$RUNNER_TEMP/execution.json" --stage-barrier "$RUNNER_TEMP/stage-barrier.json" --prepared-journal "$RUNNER_TEMP/prepared-journal.json" --event "$RUNNER_TEMP/finalize-event.json" --journal-history "$RUNNER_TEMP/active-journals/current-history.json" --journal-output "$RUNNER_TEMP/committed-journal.json" --output "$RUNNER_TEMP/finalize-transition.json"
       - name: Require a committed terminal journal transition
         if: >-
@@ -2668,7 +2669,9 @@ jobs:
         id: recovery-failed-terminal
         if: ${{ always() && !cancelled() && steps.recovery-failed.outputs.outcome == 'recovery-failed' }}
         run: |
-          node scripts/vercel-main-release-cli.mjs terminal-artifacts --active-evidence-output "$RUNNER_TEMP/recovery-evidence.json" --execution "$RUNNER_TEMP/execution.json" --final-census "$RUNNER_TEMP/null.json" --final-mappings "$RUNNER_TEMP/null.json" --freshness "$RUNNER_TEMP/null.json" --journal-history "$RUNNER_TEMP/current-attempt-journals/current-history.json" --legacy-v2 "$RUNNER_TEMP/recovery-final-legacy.json" --outcome recovery-failed --proofs-output "$RUNNER_TEMP/recovery-proofs.json" --public-smokes "$RUNNER_TEMP/null.json" --stage-results "$RUNNER_TEMP/null.json" --state-proof "$RUNNER_TEMP/null.json"
+          set -euo pipefail
+          install -m 0600 "$RUNNER_TEMP/current-attempt-journals/current-history.json" "$RUNNER_TEMP/recovery-current-history.json"
+          node scripts/vercel-main-release-cli.mjs terminal-artifacts --active-evidence-output "$RUNNER_TEMP/recovery-evidence.json" --execution "$RUNNER_TEMP/execution.json" --final-census "$RUNNER_TEMP/null.json" --final-mappings "$RUNNER_TEMP/null.json" --freshness "$RUNNER_TEMP/null.json" --journal-history "$RUNNER_TEMP/recovery-current-history.json" --legacy-v2 "$RUNNER_TEMP/recovery-final-legacy.json" --outcome recovery-failed --proofs-output "$RUNNER_TEMP/recovery-proofs.json" --public-smokes "$RUNNER_TEMP/null.json" --stage-results "$RUNNER_TEMP/null.json" --state-proof "$RUNNER_TEMP/null.json"
           echo 'outcome=recovery-failed' >> "$GITHUB_OUTPUT"
       - name: Materialize preparation failure terminal artifacts without a journal
         id: preparation-failure-terminal

--- a/scripts/vercel-main-deployment-workflow.test.mjs
+++ b/scripts/vercel-main-deployment-workflow.test.mjs
@@ -1263,9 +1263,14 @@ test("recovery is a bounded exact-current-attempt transaction with no cross-atte
     /steps\.recovery-failed\.outputs\.outcome == 'recovery-failed'/,
   );
   assert.doesNotMatch(recoveryFailedTerminal.if, /terminal-bypass/);
+  assert.match(recoveryFailedTerminal.run, /set -euo pipefail/);
   assert.match(
     recoveryFailedTerminal.run,
-    /terminal-artifacts[\s\S]*--journal-history[\s\S]*current-history[\s\S]*--legacy-v2[\s\S]*recovery-final-legacy[\s\S]*--outcome recovery-failed/,
+    /install -m 0600 "\$RUNNER_TEMP\/current-attempt-journals\/current-history\.json" "\$RUNNER_TEMP\/recovery-current-history\.json"[\s\S]*terminal-artifacts[\s\S]*--journal-history "\$RUNNER_TEMP\/recovery-current-history\.json"[\s\S]*--legacy-v2[\s\S]*recovery-final-legacy[\s\S]*--outcome recovery-failed/,
+  );
+  assert.doesNotMatch(
+    recoveryFailedTerminal.run,
+    /--journal-history "\$RUNNER_TEMP\/current-attempt-journals\/current-history\.json"/,
   );
   assert.match(
     recoveryFailedTerminal.run,
@@ -1964,7 +1969,18 @@ test("coordinator checkpoints the forward journal before six bounded mutations a
   assert.match(finalProof.run, /active-freshness/);
   assert.match(finalProof.run, /active-mapping-spec/);
   assert.match(finalProof.run, /current-release-mapping-spec/);
-  assert.match(finalProof.run, /alias-mappings/);
+  assert.match(
+    finalProof.run,
+    /alias-mappings[\s\S]*--output "\$RUNNER_TEMP\/final-mappings-raw\.json"/,
+  );
+  const canonicalFinalMappings = command(
+    coordinator,
+    "active-canonical-mappings",
+  );
+  assert.match(
+    canonicalFinalMappings.run,
+    /--mapping-spec "\$RUNNER_TEMP\/final-mapping-spec\.json"[\s\S]*--mappings "\$RUNNER_TEMP\/final-mappings-raw\.json"[\s\S]*--output "\$RUNNER_TEMP\/final-mappings\.json"/,
+  );
   assert.match(finalProof.run, /active-state-spec/);
   assert.match(finalProof.run, /current-release-state-spec/);
   assert.match(finalProof.run, /active-proof/);
@@ -1973,6 +1989,14 @@ test("coordinator checkpoints the forward journal before six bounded mutations a
   assert.match(
     finalize.run,
     /active-event-finalize[\s\S]*run-active[\s\S]*committed-journal/,
+  );
+  assert.match(
+    finalize.run,
+    /active-event-finalize[\s\S]*--current-mappings "\$RUNNER_TEMP\/final-mappings-raw\.json"/,
+  );
+  assert.doesNotMatch(
+    finalize.run,
+    /--current-mappings "\$RUNNER_TEMP\/final-mappings\.json"/,
   );
   assert.ok(jobSteps.indexOf(finalProof) < jobSteps.indexOf(finalize));
   assert.ok(jobSteps.indexOf(finalize) < jobSteps.indexOf(committedUpload));
@@ -1989,6 +2013,10 @@ test("coordinator checkpoints the forward journal before six bounded mutations a
   assert.match(
     terminalArtifacts.run,
     /--state-proof "\$RUNNER_TEMP\/terminal-state-proof\.json"/,
+  );
+  assert.match(
+    terminalArtifacts.run,
+    /--final-mappings "\$RUNNER_TEMP\/final-mappings\.json"/,
   );
   for (const input of [
     "--final-census",
@@ -2050,6 +2078,10 @@ test("a complete same-release re-verifies current state without a journal or pub
   assert.match(
     current.run,
     /--final-census "\$RUNNER_TEMP\/terminal-state-proof\.json"/,
+  );
+  assert.match(
+    current.run,
+    /--final-mappings "\$RUNNER_TEMP\/final-mappings\.json"/,
   );
   assert.match(
     current.run,

--- a/scripts/vercel-main-deployment.mjs
+++ b/scripts/vercel-main-deployment.mjs
@@ -73,10 +73,8 @@ import {
 } from "./vercel-main-active-controller.mjs";
 import {
   ACTIVE_ALIAS_MAPPING_SPEC_SCHEMA,
-  ACTIVE_ALIAS_MAPPING_SET_SCHEMA,
   ACTIVE_DEPLOYMENT_STATE_SPEC_SCHEMA,
   assertActiveAliasMappingSpec,
-  assertActiveAliasMappingSet,
   assertActiveDeploymentStateProof,
   assertActiveDeploymentStateSpec,
   assertCanonicalOutput,
@@ -84,7 +82,6 @@ import {
   assertSnapshotSpec,
   canonicalizeDeploymentUrl,
   canonicalizeHostname,
-  writeActiveAliasMappingSet,
 } from "./vercel-deployment-state.mjs";
 import {
   assertOnlyExpectedVercelGeneratedAliases,
@@ -117,6 +114,8 @@ export const MAIN_ACTIVE_PREPARATION_FAILURE_EVIDENCE_SCHEMA =
   "vercel-main-active-preparation-failure-evidence:v1";
 export const MAIN_ACTIVE_TERMINAL_PROOFS_SCHEMA =
   "vercel-main-active-terminal-proofs:v3";
+export const MAIN_CANONICAL_MAPPINGS_SCHEMA =
+  "vercel-main-canonical-mappings:v1";
 export const MAIN_STAGE_BARRIER_SCHEMA = "vercel-main-stage-barrier:v1";
 export const MAIN_TERMINAL_STATE_PROOF_SCHEMA =
   "vercel-main-terminal-state-proof:v1";
@@ -212,6 +211,13 @@ const MAX_JSON_BYTES = 256 * 1024;
 export const MAIN_ACTIVE_JOURNAL_HISTORY_MAX_JSON_BYTES = 1024 * 1024;
 export const MAIN_ACTIVE_TERMINAL_PROOFS_MAX_JSON_BYTES = 1024 * 1024;
 const APP_BUILD_PROOF_SCHEMA = "vercel-main-app-build:v2";
+const CANONICAL_MAPPING_TARGETS = Object.freeze([
+  "governance",
+  "reserve",
+  "ui",
+  "app",
+  "legacy-app",
+]);
 const CLI_COMMAND_OPTIONS = Object.freeze({
   "active-event-authorize": Object.freeze([
     "current-mappings",
@@ -307,6 +313,11 @@ const CLI_COMMAND_OPTIONS = Object.freeze({
   "active-recovery-mapping-spec": Object.freeze(["journal-history", "output"]),
   "active-recovery-canonical-mappings": Object.freeze([
     "journal-history",
+    "mappings",
+    "output",
+  ]),
+  "active-canonical-mappings": Object.freeze([
+    "mapping-spec",
     "mappings",
     "output",
   ]),
@@ -2035,32 +2046,64 @@ export function createMainCurrentReleaseVerifiedDeploymentStateSpec({
   });
 }
 
-export function createMainCurrentActiveAliasMappingSet({
+function createMainCanonicalAliasMappingSpec({ aliasesByTarget, projectIds }) {
+  assertExactKeys(
+    aliasesByTarget,
+    CANONICAL_MAPPING_TARGETS,
+    "Active canonical mapping aliases",
+  );
+  assertExactKeys(
+    projectIds,
+    CANONICAL_MAPPING_TARGETS,
+    "Active canonical mapping project IDs",
+  );
+  return assertActiveAliasMappingSpec({
+    schema: ACTIVE_ALIAS_MAPPING_SPEC_SCHEMA,
+    bindings: CANONICAL_MAPPING_TARGETS.flatMap((target) => {
+      const aliases = aliasesByTarget[target];
+      if (!Array.isArray(aliases) || aliases.length === 0) {
+        throw new Error(
+          `Active canonical ${target} mapping aliases are invalid`,
+        );
+      }
+      const projectId = requireString(
+        projectIds[target],
+        `Active canonical ${target} mapping project ID`,
+      );
+      return aliases.map((alias) => ({ alias, projectId, target }));
+    }).toSorted((left, right) => left.alias.localeCompare(right.alias)),
+  });
+}
+
+export function createMainCurrentActiveAliasMappingSpec({
   execution,
   barrier,
   journalHistory,
   runId,
   runAttempt,
 }) {
-  const { highest } = currentActiveHistory({
+  const { current, highest } = currentActiveHistory({
     execution,
     barrier,
     journalHistory,
     runId,
     runAttempt,
   });
-  return assertActiveAliasMappingSet({
-    schema: ACTIVE_ALIAS_MAPPING_SET_SCHEMA,
-    aliases: [
-      ...STAGE_BARRIER_TARGETS.flatMap(
-        (target) => highest.prior[target].aliases,
-      ),
-      ...highest.prior["legacy-app"].aliases,
-    ].toSorted(),
+  return createMainCanonicalAliasMappingSpec({
+    aliasesByTarget: Object.fromEntries(
+      CANONICAL_MAPPING_TARGETS.map((target) => [
+        target,
+        highest.prior[target].aliases,
+      ]),
+    ),
+    projectIds: {
+      ...current.execution.projection.projectIds,
+      "legacy-app": current.execution.legacyAppV2.projectId,
+    },
   });
 }
 
-export function createMainCurrentReleaseVerifiedAliasMappingSet({
+export function createMainCurrentReleaseVerifiedAliasMappingSpec({
   execution,
   barrier,
   runId,
@@ -2072,14 +2115,18 @@ export function createMainCurrentReleaseVerifiedAliasMappingSet({
     runId,
     runAttempt,
   });
-  return assertActiveAliasMappingSet({
-    schema: ACTIVE_ALIAS_MAPPING_SET_SCHEMA,
-    aliases: [
-      ...STAGE_BARRIER_TARGETS.flatMap(
-        (target) => current.execution.manifest.originalPriors[target].aliases,
-      ),
-      ...current.execution.legacyAppV2.aliases,
-    ].toSorted(),
+  return createMainCanonicalAliasMappingSpec({
+    aliasesByTarget: {
+      governance: current.execution.manifest.originalPriors.governance.aliases,
+      reserve: current.execution.manifest.originalPriors.reserve.aliases,
+      ui: current.execution.manifest.originalPriors.ui.aliases,
+      app: current.execution.manifest.originalPriors.app.aliases,
+      "legacy-app": current.execution.legacyAppV2.aliases,
+    },
+    projectIds: {
+      ...current.execution.projection.projectIds,
+      "legacy-app": current.execution.legacyAppV2.projectId,
+    },
   });
 }
 
@@ -2151,24 +2198,24 @@ export function createMainActiveRecoveryMappingSpec({
   });
 }
 
-// The provider captures bound mappings as a flat alias list. Re-derive the
-// allowed bindings from the current-attempt journal before grouping that list
-// into the transaction's canonical target shape. This deliberately keeps
-// project IDs while validating the capture and removes them only from the
-// post-binding handoff consumed by terminal artifacts.
-export function createMainActiveRecoveryCanonicalMappings({
-  journalHistory,
-  mappings,
-  runId,
-  runAttempt,
-}) {
-  const spec = createMainActiveRecoveryMappingSpec({
-    journalHistory,
-    runId,
-    runAttempt,
-  });
+// The provider captures bound mappings as a flat alias list. Validate that
+// capture against an exact canonical binding specification before grouping it
+// into the transaction's canonical target shape. Project IDs remain only long
+// enough to bind legacy App mappings, then never enter terminal artifacts.
+export function createMainActiveCanonicalMappings({ mappingSpec, mappings }) {
+  const spec = assertActiveAliasMappingSpec(mappingSpec);
+  assertSameJson(mappingSpec, spec, "Active canonical mapping specification");
+  const targets = new Set(spec.bindings.map(({ target }) => target));
+  if (
+    targets.size !== CANONICAL_MAPPING_TARGETS.length ||
+    CANONICAL_MAPPING_TARGETS.some((target) => !targets.has(target))
+  ) {
+    throw new Error(
+      "Active canonical mapping specification target coverage is incomplete",
+    );
+  }
   if (!Array.isArray(mappings) || mappings.length !== spec.bindings.length) {
-    throw new Error("Active recovery bound mappings are incomplete");
+    throw new Error("Active canonical bound mappings are incomplete");
   }
   const bound = mappings.map((value, index) => {
     const binding = spec.bindings[index];
@@ -2178,12 +2225,12 @@ export function createMainActiveRecoveryCanonicalMappings({
       hasProjectId
         ? ["alias", "deploymentId", "deploymentUrl", "projectId"]
         : ["alias", "deploymentId", "deploymentUrl"],
-      `Active recovery bound mapping ${index + 1}`,
+      `Active canonical bound mapping ${index + 1}`,
     );
     const alias = canonicalizeHostname(value.alias);
     const deploymentId = requireString(
       value.deploymentId,
-      `Active recovery bound mapping ${index + 1} deployment ID`,
+      `Active canonical bound mapping ${index + 1} deployment ID`,
       DEPLOYMENT_ID_PATTERN,
     );
     const deploymentUrl = canonicalizeDeploymentUrl(value.deploymentUrl);
@@ -2195,11 +2242,11 @@ export function createMainActiveRecoveryCanonicalMappings({
         ? !hasProjectId ||
           requireString(
             value.projectId,
-            `Active recovery bound mapping ${index + 1} project ID`,
+            `Active canonical bound mapping ${index + 1} project ID`,
           ) !== binding.projectId
         : hasProjectId)
     ) {
-      throw new Error("Active recovery bound mapping conflicts with its spec");
+      throw new Error("Active canonical bound mapping conflicts with its spec");
     }
     return {
       alias,
@@ -2210,11 +2257,11 @@ export function createMainActiveRecoveryCanonicalMappings({
         : {}),
     };
   });
-  assertSameJson(mappings, bound, "Active recovery bound mappings");
+  assertSameJson(mappings, bound, "Active canonical bound mappings");
   return {
-    schema: "vercel-main-canonical-mappings:v1",
+    schema: MAIN_CANONICAL_MAPPINGS_SCHEMA,
     mappings: Object.fromEntries(
-      ["governance", "reserve", "ui", "app", "legacy-app"].map((target) => [
+      CANONICAL_MAPPING_TARGETS.map((target) => [
         target,
         spec.bindings
           .map((binding, index) => ({ binding, mapping: bound[index] }))
@@ -2227,6 +2274,24 @@ export function createMainActiveRecoveryCanonicalMappings({
       ]),
     ),
   };
+}
+
+// Recovery derives its canonical specification from the current-attempt
+// journal, then uses the same materializer as all other active paths.
+export function createMainActiveRecoveryCanonicalMappings({
+  journalHistory,
+  mappings,
+  runId,
+  runAttempt,
+}) {
+  return createMainActiveCanonicalMappings({
+    mappingSpec: createMainActiveRecoveryMappingSpec({
+      journalHistory,
+      runId,
+      runAttempt,
+    }),
+    mappings,
+  });
 }
 
 // Recovery has no stage barrier to trust. The exact execution supplies the
@@ -2828,7 +2893,7 @@ export function createMainActiveDeploymentStateSpec({
   });
 }
 
-export function createMainActiveAliasMappingSet({
+export function createMainActiveAliasMappingSpec({
   plan,
   journalHistory,
   runId,
@@ -2847,14 +2912,17 @@ export function createMainActiveAliasMappingSet({
   });
   const highest = history.at(-1);
   assertJournalMatchesActivePlanning(highest, planning);
-  return assertActiveAliasMappingSet({
-    schema: ACTIVE_ALIAS_MAPPING_SET_SCHEMA,
-    aliases: [
-      ...MAIN_DEPLOYMENT_TARGETS.flatMap(
-        (target) => highest.prior[target].aliases,
-      ),
-      ...highest.prior["legacy-app"].aliases,
-    ].toSorted(),
+  return createMainCanonicalAliasMappingSpec({
+    aliasesByTarget: Object.fromEntries(
+      CANONICAL_MAPPING_TARGETS.map((target) => [
+        target,
+        highest.prior[target].aliases,
+      ]),
+    ),
+    projectIds: {
+      ...handoff.projectIds,
+      "legacy-app": handoff.projectIds.app,
+    },
   });
 }
 
@@ -3919,24 +3987,43 @@ function canonicalFinalMappings(journal, value, { exact = true } = {}) {
   }
   const expectedByAlias = new Map();
   for (const target of ["app", "governance", "reserve", "ui", "legacy-app"]) {
-    const expected =
+    const mapping =
       target === "legacy-app" || journal.candidates[target] === null
         ? journal.prior[target]
         : journal.candidates[target];
     for (const alias of journal.prior[target].aliases) {
-      expectedByAlias.set(alias, expected);
+      expectedByAlias.set(alias, {
+        mapping,
+        projectId: journal.prior[target].projectId,
+        target,
+      });
     }
   }
   const seen = new Set();
   const canonical = value.map((entry, index) => {
+    const alias = canonicalizeHostname(entry?.alias);
+    const expected = expectedByAlias.get(alias);
+    if (expected === undefined || seen.has(alias)) {
+      throw new Error("Active final mappings contain an unknown alias");
+    }
+    const hasProjectId = Object.hasOwn(entry ?? {}, "projectId");
     assertExactKeys(
       entry,
-      ["alias", "deploymentId", "deploymentUrl"],
+      hasProjectId
+        ? ["alias", "deploymentId", "deploymentUrl", "projectId"]
+        : ["alias", "deploymentId", "deploymentUrl"],
       `Active final mapping ${index + 1}`,
     );
-    const alias = canonicalizeHostname(entry.alias);
-    if (!expectedByAlias.has(alias) || seen.has(alias)) {
-      throw new Error("Active final mappings contain an unknown alias");
+    if (
+      (expected.target === "legacy-app" &&
+        hasProjectId &&
+        requireString(
+          entry.projectId,
+          `Active final mapping ${alias} project ID`,
+        ) !== expected.projectId) ||
+      (expected.target !== "legacy-app" && hasProjectId)
+    ) {
+      throw new Error("Active final mapping project binding is invalid");
     }
     seen.add(alias);
     const mapping = {
@@ -3949,10 +4036,9 @@ function canonicalFinalMappings(journal, value, { exact = true } = {}) {
       deploymentUrl: canonicalizeDeploymentUrl(entry.deploymentUrl),
     };
     if (exact) {
-      const expected = expectedByAlias.get(alias);
       if (
-        mapping.deploymentId !== expected.deploymentId ||
-        mapping.deploymentUrl !== expected.deploymentUrl
+        mapping.deploymentId !== expected.mapping.deploymentId ||
+        mapping.deploymentUrl !== expected.mapping.deploymentUrl
       ) {
         throw new Error("Active final mapping differs from the transaction");
       }
@@ -8979,6 +9065,20 @@ export async function runMainDeploymentCli({
     writeCanonicalJson(options.output, mappings);
     return mappings;
   }
+  if (command === "active-canonical-mappings") {
+    const mappings = createMainActiveCanonicalMappings({
+      mappingSpec: readJson(
+        options["mapping-spec"],
+        "Active canonical mapping specification",
+      ),
+      mappings: readJson(
+        options.mappings,
+        "Active canonical bound provider mappings",
+      ),
+    });
+    writeCanonicalJson(options.output, mappings);
+    return mappings;
+  }
   if (command === "active-recovery-state-spec") {
     const spec = createMainActiveRecoveryDeploymentStateSpec({
       journalHistory: readActiveJournalHistory(
@@ -9007,7 +9107,7 @@ export async function runMainDeploymentCli({
     return smokes;
   }
   if (command === "active-mapping-spec") {
-    const spec = createMainCurrentActiveAliasMappingSet({
+    const spec = createMainCurrentActiveAliasMappingSpec({
       execution: readJson(options.execution, "Main release execution"),
       barrier: readJson(options["stage-barrier"], "Current main stage barrier"),
       journalHistory: readActiveJournalHistory(
@@ -9017,17 +9117,17 @@ export async function runMainDeploymentCli({
       runId: values.GITHUB_RUN_ID,
       runAttempt: values.GITHUB_RUN_ATTEMPT,
     });
-    writeActiveAliasMappingSet(options.output, spec);
+    writeCanonicalJson(options.output, spec);
     return spec;
   }
   if (command === "current-release-mapping-spec") {
-    const spec = createMainCurrentReleaseVerifiedAliasMappingSet({
+    const spec = createMainCurrentReleaseVerifiedAliasMappingSpec({
       execution: readJson(options.execution, "Main release execution"),
       barrier: readJson(options["stage-barrier"], "Current main stage barrier"),
       runId: values.GITHUB_RUN_ID,
       runAttempt: values.GITHUB_RUN_ATTEMPT,
     });
-    writeActiveAliasMappingSet(options.output, spec);
+    writeCanonicalJson(options.output, spec);
     return spec;
   }
   if (command === "active-public-smokes") {

--- a/scripts/vercel-main-deployment.test.mjs
+++ b/scripts/vercel-main-deployment.test.mjs
@@ -16,7 +16,10 @@ import process from "node:process";
 import { test } from "node:test";
 import { fileURLToPath } from "node:url";
 
-import { createActiveDeploymentStateProof } from "./vercel-deployment-state.mjs";
+import {
+  ACTIVE_ALIAS_MAPPING_SPEC_SCHEMA,
+  createActiveDeploymentStateProof,
+} from "./vercel-deployment-state.mjs";
 import {
   MAIN_ACTIVE_EVENT_SCHEMA,
   reduceMainActiveTransition,
@@ -49,7 +52,8 @@ import {
   createMainAppCandidateExpectation,
   createMainActiveDeploymentEvidence,
   createMainActiveFreshness,
-  createMainActiveAliasMappingSet,
+  createMainActiveCanonicalMappings,
+  createMainActiveAliasMappingSpec,
   createMainActiveRecoveryCanonicalMappings,
   createMainActiveRecoveryMappingSpec,
   createMainActiveRecoveryDeploymentStateSpec,
@@ -66,8 +70,9 @@ import {
   createMainActivePublicSmokes,
   createMainActiveTransactionInputs,
   createMainCurrentCandidateIntent,
+  createMainCurrentActiveAliasMappingSpec,
   createMainCurrentActiveDeploymentStateSpec,
-  createMainCurrentReleaseVerifiedAliasMappingSet,
+  createMainCurrentReleaseVerifiedAliasMappingSpec,
   createMainCurrentReleaseVerifiedDeploymentStateSpec,
   createMainCurrentActivePublicSmokes,
   createMainCurrentActiveInputs,
@@ -1094,6 +1099,15 @@ test("controller CLI accepts only each command's exact non-duplicated options", 
       "/tmp/mapping-spec.json",
       "--stage-barrier",
       "/tmp/stage-barrier.json",
+    ],
+    [
+      "active-canonical-mappings",
+      "--mapping-spec",
+      "/tmp/mapping-spec.json",
+      "--mappings",
+      "/tmp/mappings.json",
+      "--output",
+      "/tmp/canonical-mappings.json",
     ],
     [
       "active-public-smokes",
@@ -3186,12 +3200,12 @@ test("active state spec binds the highest journal and exact stage handoffs", asy
       deploymentPlan.legacySnapshot[0].deploymentId,
     );
     assert.deepEqual(
-      createMainActiveAliasMappingSet({
+      createMainActiveAliasMappingSpec({
         plan: deploymentPlan,
         journalHistory: [prepared, highest],
         runId: "800",
         runAttempt: "3",
-      }).aliases,
+      }).bindings.map(({ alias }) => alias),
       [
         "app.mento.org",
         "appmentoorg-env-v3-mentolabs.vercel.app",
@@ -3307,6 +3321,14 @@ test("governance-only smoke materialization pipes through finalization and evide
     runId: "800",
     runAttempt: "3",
   });
+  const boundFinalMappings = activeFinalMappings(harness).map((entry) =>
+    harness.inputs.prior["legacy-app"].aliases.includes(entry.alias)
+      ? {
+          ...entry,
+          projectId: harness.inputs.release.originalPriors.app.projectId,
+        }
+      : entry,
+  );
   const finalized = reduceMainActiveTransition({
     preparedJournal: history[0],
     activeTargets: ["governance"],
@@ -3326,7 +3348,7 @@ test("governance-only smoke materialization pipes through finalization and evide
         sequence: highest.sequence,
       },
       freshSha: SHA,
-      currentMappings: activeFinalMappings(harness),
+      currentMappings: boundFinalMappings,
       publicSmokes,
       stateProof,
     },
@@ -5893,6 +5915,341 @@ test("active journal CLI accepts an inherited release SHA only through its dedic
   }
 });
 
+test("active canonical mappings bind canonical active and current captures", async () => {
+  const activeSpec = {
+    schema: ACTIVE_ALIAS_MAPPING_SPEC_SCHEMA,
+    bindings: [
+      { alias: "app.mento.org", projectId: "prj_app123", target: "app" },
+      {
+        alias: "governance.mento.org",
+        projectId: "prj_governance123",
+        target: "governance",
+      },
+      {
+        alias: "reserve.mento.org",
+        projectId: "prj_reserve123",
+        target: "reserve",
+      },
+      { alias: "ui.mento.org", projectId: "prj_ui123", target: "ui" },
+      {
+        alias: "v2-app.mento.org",
+        projectId: "prj_app123",
+        target: "legacy-app",
+      },
+    ],
+  };
+  const currentSpec = {
+    schema: ACTIVE_ALIAS_MAPPING_SPEC_SCHEMA,
+    bindings: [
+      {
+        alias: "app.mento.org",
+        projectId: "prj_app456",
+        target: "app",
+      },
+      {
+        alias: "governance.mento.org",
+        projectId: "prj_governance456",
+        target: "governance",
+      },
+      {
+        alias: "reserve.mento.org",
+        projectId: "prj_reserve456",
+        target: "reserve",
+      },
+      { alias: "ui.mento.org", projectId: "prj_ui456", target: "ui" },
+      {
+        alias: "v2-app.mento.org",
+        projectId: "prj_app456",
+        target: "legacy-app",
+      },
+    ],
+  };
+  const mappingsFor = (spec, deploymentSuffix) =>
+    spec.bindings.map((binding, index) => ({
+      alias: binding.alias,
+      deploymentId: `dpl_${deploymentSuffix}${index + 1}`,
+      deploymentUrl: `https://deployment-${deploymentSuffix}-${index + 1}.vercel.app`,
+      ...(binding.target === "legacy-app"
+        ? { projectId: binding.projectId }
+        : {}),
+    }));
+  const activeMappings = mappingsFor(activeSpec, "active");
+  const currentMappings = mappingsFor(currentSpec, "current");
+  const expectedActive = {
+    schema: "vercel-main-canonical-mappings:v1",
+    mappings: {
+      governance: [activeMappings[1]],
+      reserve: [activeMappings[2]],
+      ui: [activeMappings[3]],
+      app: [activeMappings[0]],
+      "legacy-app": [
+        {
+          alias: activeMappings[4].alias,
+          deploymentId: activeMappings[4].deploymentId,
+          deploymentUrl: activeMappings[4].deploymentUrl,
+        },
+      ],
+    },
+  };
+  assert.deepEqual(
+    createMainActiveCanonicalMappings({
+      mappingSpec: activeSpec,
+      mappings: activeMappings,
+    }),
+    expectedActive,
+  );
+  assert.deepEqual(
+    createMainActiveCanonicalMappings({
+      mappingSpec: currentSpec,
+      mappings: currentMappings,
+    }),
+    {
+      schema: "vercel-main-canonical-mappings:v1",
+      mappings: {
+        governance: [currentMappings[1]],
+        reserve: [currentMappings[2]],
+        ui: [currentMappings[3]],
+        app: [currentMappings[0]],
+        "legacy-app": [
+          {
+            alias: currentMappings[4].alias,
+            deploymentId: currentMappings[4].deploymentId,
+            deploymentUrl: currentMappings[4].deploymentUrl,
+          },
+        ],
+      },
+    },
+  );
+
+  for (const [name, mappingSpec, mappings, pattern] of [
+    [
+      "malformed specification",
+      { schema: ACTIVE_ALIAS_MAPPING_SPEC_SCHEMA, bindings: [] },
+      activeMappings,
+      /specification is malformed/,
+    ],
+    [
+      "missing capture",
+      activeSpec,
+      activeMappings.slice(1),
+      /bound mappings are incomplete/,
+    ],
+    [
+      "missing target",
+      {
+        ...activeSpec,
+        bindings: activeSpec.bindings.filter(
+          ({ target }) => target !== "legacy-app",
+        ),
+      },
+      activeMappings.filter(({ alias }) => alias !== "v2-app.mento.org"),
+      /target coverage is incomplete/,
+    ],
+    [
+      "duplicate capture",
+      activeSpec,
+      [...activeMappings.slice(0, -1), structuredClone(activeMappings[0])],
+      /conflicts with its spec/,
+    ],
+    [
+      "noncanonical capture order",
+      activeSpec,
+      [activeMappings[1], activeMappings[0], ...activeMappings.slice(2)],
+      /conflicts with its spec/,
+    ],
+    [
+      "legacy project mismatch",
+      activeSpec,
+      activeMappings.map((mapping) =>
+        mapping.alias === "v2-app.mento.org"
+          ? { ...mapping, projectId: "prj_wrong123" }
+          : mapping,
+      ),
+      /conflicts with its spec/,
+    ],
+    [
+      "ordinary project field",
+      activeSpec,
+      activeMappings.map((mapping) =>
+        mapping.alias === "app.mento.org"
+          ? { ...mapping, projectId: "prj_app123" }
+          : mapping,
+      ),
+      /conflicts with its spec/,
+    ],
+    [
+      "duplicate specification binding",
+      {
+        ...activeSpec,
+        bindings: [
+          activeSpec.bindings[0],
+          { ...activeSpec.bindings[0], target: "legacy-app" },
+          ...activeSpec.bindings.slice(2),
+        ],
+      },
+      activeMappings,
+      /bindings are ambiguous/,
+    ],
+  ]) {
+    assert.throws(
+      () => createMainActiveCanonicalMappings({ mappingSpec, mappings }),
+      pattern,
+      name,
+    );
+  }
+
+  const directory = mkdtempSync(
+    join(tmpdir(), "vercel-main-canonical-mappings-"),
+  );
+  try {
+    const specPath = join(directory, "current-mapping-spec.json");
+    const mappingsPath = join(directory, "current-mappings.json");
+    const outputPath = join(directory, "canonical-mappings.json");
+    writeFileSync(specPath, JSON.stringify(currentSpec));
+    writeFileSync(mappingsPath, JSON.stringify(currentMappings));
+    const materialized = await runMainDeploymentCli({
+      argv: [
+        "active-canonical-mappings",
+        "--mapping-spec",
+        specPath,
+        "--mappings",
+        mappingsPath,
+        "--output",
+        outputPath,
+      ],
+    });
+    assert.deepEqual(
+      JSON.parse(readFileSync(outputPath, "utf8")),
+      materialized,
+    );
+    assert.equal(
+      readFileSync(outputPath, "utf8"),
+      `${JSON.stringify(materialized)}\n`,
+    );
+    assert.deepEqual(
+      materialized,
+      createMainActiveCanonicalMappings({
+        mappingSpec: currentSpec,
+        mappings: currentMappings,
+      }),
+    );
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("active and current-release mapping-spec producers bind terminal captures", () => {
+  const deploymentPlan = activePlan({ deployments: ["governance"] });
+  const activeExecution = releaseExecutionForPlan(deploymentPlan);
+  const activeBarrier = createMainStageBarrier({
+    execution: activeExecution,
+    candidateReceipts: {
+      app: null,
+      governance: currentCandidateReceipt(activeExecution, "governance"),
+      reserve: null,
+      ui: null,
+    },
+    appPreparation: null,
+    runId: "800",
+    runAttempt: "3",
+  });
+  const activeJournal = createPreparedMainActiveJournal({
+    plan: deploymentPlan,
+    stageJobs: stageJobs(deploymentPlan),
+    appBuildProof: null,
+    runId: "800",
+    runAttempt: "3",
+  });
+  const currentExecution = createMainReleaseExecution({
+    decision: "verify-existing-release",
+    reason: "current-main-release-already-complete",
+    manifest: activeExecution.manifest,
+    upstream: activeExecution.upstream,
+    legacyAppV2: activeExecution.legacyAppV2,
+    selection: activeExecution.selection,
+  });
+  const currentBarrier = createMainStageBarrier({
+    execution: currentExecution,
+    candidateReceipts: {
+      app: null,
+      governance: currentCandidateReceipt(currentExecution, "governance"),
+      reserve: null,
+      ui: null,
+    },
+    appPreparation: null,
+    runId: "800",
+    runAttempt: "3",
+  });
+  const producers = [
+    [
+      "active",
+      createMainCurrentActiveAliasMappingSpec({
+        execution: activeExecution,
+        barrier: activeBarrier,
+        journalHistory: [activeJournal],
+        runId: "800",
+        runAttempt: "3",
+      }),
+    ],
+    [
+      "current release",
+      createMainCurrentReleaseVerifiedAliasMappingSpec({
+        execution: currentExecution,
+        barrier: currentBarrier,
+        runId: "800",
+        runAttempt: "3",
+      }),
+    ],
+  ];
+  for (const [name, spec] of producers) {
+    assert.equal(spec.schema, ACTIVE_ALIAS_MAPPING_SPEC_SCHEMA, name);
+    assert.deepEqual(
+      new Set(spec.bindings.map(({ target }) => target)),
+      new Set(["governance", "reserve", "ui", "app", "legacy-app"]),
+      name,
+    );
+    const rawMappings = spec.bindings.map((binding, index) => ({
+      alias: binding.alias,
+      deploymentId: `dpl_mapping${index + 1}`,
+      deploymentUrl: `https://${name.replaceAll(" ", "-")}-${index + 1}.vercel.app`,
+      ...(binding.target === "legacy-app"
+        ? { projectId: binding.projectId }
+        : {}),
+    }));
+    const canonical = createMainActiveCanonicalMappings({
+      mappingSpec: spec,
+      mappings: rawMappings,
+    });
+    assert.deepEqual(canonical, {
+      schema: "vercel-main-canonical-mappings:v1",
+      mappings: Object.fromEntries(
+        ["governance", "reserve", "ui", "app", "legacy-app"].map((target) => [
+          target,
+          spec.bindings
+            .map((binding, index) => ({ binding, mapping: rawMappings[index] }))
+            .filter(({ binding }) => binding.target === target)
+            .map(({ mapping }) => ({
+              alias: mapping.alias,
+              deploymentId: mapping.deploymentId,
+              deploymentUrl: mapping.deploymentUrl,
+            })),
+        ]),
+      ),
+    });
+    const malformed = structuredClone(spec);
+    malformed.bindings[0].alias = "0.invalid.example";
+    assert.throws(
+      () =>
+        createMainActiveCanonicalMappings({
+          mappingSpec: malformed,
+          mappings: rawMappings,
+        }),
+      /conflicts with its spec/,
+      `${name} rejects a capture that no longer matches its binding`,
+    );
+  }
+});
+
 test("active recovery planning and execution hand off exact reverse mutations and stay release-failing", async () => {
   const deploymentPlan = activePlan({ deployments: ["governance"] });
   const prepared = createPreparedMainActiveJournal({
@@ -6899,13 +7256,16 @@ test("current release verification is journal-free and binds its barrier candida
     runId: "800",
     runAttempt: "3",
   });
-  const aliases = createMainCurrentReleaseVerifiedAliasMappingSet({
+  const aliases = createMainCurrentReleaseVerifiedAliasMappingSpec({
     execution,
     barrier,
     runId: "800",
     runAttempt: "3",
   });
-  assert.equal(aliases.aliases.includes("governance.mento.org"), true);
+  assert.equal(
+    aliases.bindings.some(({ alias }) => alias === "governance.mento.org"),
+    true,
+  );
   const mappings = Object.values(execution.manifest.originalPriors).flatMap(
     (prior) =>
       prior.aliases.map((alias) =>


### PR DESCRIPTION
## The Problem

[Vercel Main Deployment run 30342273704](https://github.com/mento-protocol/frontend-monorepo/actions/runs/30342273704) activated and verified the release, then failed while materializing its terminal evidence:

- the provider emitted a flat alias-mapping capture while the terminal artifact builder requires mappings grouped by logical target; and
- the recovery-failed path passed a nested temporary journal path to a private-input reader that intentionally accepts only direct `RUNNER_TEMP` children.

The public sites stayed healthy, but the workflow finished red and produced no canonical terminal receipt/evidence.

## The Solution

- Emit exact, target-bound mapping specifications for active and already-current releases.
- Keep the flat provider capture for transaction finalization, then materialize a strictly validated five-target envelope for committed/current terminal artifacts.
- Reuse the same canonical materializer for recovery and strip project IDs after binding the legacy App mapping.
- Copy recovery journal history to a direct mode-`0600` private input before terminal artifact creation.
- Test the real active/current producer-to-capture-to-terminal contract plus malformed, missing, duplicate, reordered, and project-mismatched inputs.

This is a focused correction for #522. It does not expand into the post-checkpoint recovery finalizer tracked by #685.

## Validation

- `pnpm vercel:workflow:test` — 582 passed
- `node --test scripts/vercel-main-deployment.test.mjs` — 68 passed
- `pnpm quality:budgets:test` — 34 passed
- `pnpm check-types`
- `trunk check .github/workflows/vercel-main-deployment.yml scripts/vercel-main-deployment.mjs scripts/vercel-main-deployment.test.mjs scripts/vercel-main-deployment-workflow.test.mjs`
- `pnpm adr:check`
- `pnpm exec prettier --check .github/workflows/vercel-main-deployment.yml scripts/vercel-main-deployment.mjs scripts/vercel-main-deployment.test.mjs scripts/vercel-main-deployment-workflow.test.mjs`
- `git diff --check`

## Risk

The change touches only terminal proof materialization and the recovery-failed evidence input path. It does not add a provider mutation or change release planning, candidate deployment, activation order, public aliases, or legacy `v2` ownership.
