### PR TITLE
fix(ci): recover superseded Vercel releases

### DIFF
--- a/.github/workflows/vercel-main-deployment.yml
+++ b/.github/workflows/vercel-main-deployment.yml
@@ -210,7 +210,7 @@ jobs:
           { GITHUB_WORKFLOW_SHA: "${{ needs.wait-for-ci.outputs.deploy_sha }}" }
         run: |
           git -C "$SOURCE_PATH" fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
-          node scripts/vercel-main-deployment.mjs validate-source
+          node scripts/vercel-main-deployment.mjs validate-recovery-source
       - name: Install exact inherited recovery source without lifecycle scripts
         uses: ./.github/actions/pnpm-install
         with: { working-directory: source, ignore-scripts: "true" }
@@ -2220,7 +2220,7 @@ jobs:
           { GITHUB_WORKFLOW_SHA: "${{ needs.wait-for-ci.outputs.deploy_sha }}" }
         run: |
           git -C "$SOURCE_PATH" fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
-          node scripts/vercel-main-deployment.mjs validate-source
+          node scripts/vercel-main-deployment.mjs validate-recovery-source
       - name: Install exact recovery source without lifecycle scripts
         uses: ./.github/actions/pnpm-install
         with: { working-directory: source, ignore-scripts: "true" }

--- a/docs/vercel-deployments.md
+++ b/docs/vercel-deployments.md
@@ -72,9 +72,9 @@ API record with `scripts/vercel-main-ci-attempt.mjs`. The accepted run must:
 The job then requires `github.workflow_ref` to identify
 `.github/workflows/vercel-main-deployment.yml` on `refs/heads/main`,
 `github.workflow_sha == DEPLOY_SHA`, checked-out `HEAD == DEPLOY_SHA`, and
-`DEPLOY_SHA` reachable from freshly fetched `refs/heads/main`. A mismatched
-workflow definition or superseded definition exits before any Vercel
-environment or credential is available. The gate records only the
+`DEPLOY_SHA` to be the freshly fetched `origin/main` tip after first proving
+ancestry. A mismatched workflow definition or superseded source exits before
+any Vercel environment or credential is available. The gate records only the
 attempt-qualified upstream run URL, exact `Build and Test` job URL, and
 `DEPLOY_SHA`; release execution validates the attempt suffix against the
 separately admitted run attempt.
@@ -405,6 +405,16 @@ returned an unknown
 result and the captured mappings show possible movement,
 recovery uses the bounded exact transaction-metadata census; zero, multiple,
 or mismatched candidates leave App untouched and require manual intervention.
+
+Every current-attempt or inherited recovery source proof still requires the
+admitted `DEPLOY_SHA` to exist, equal both the checked-out `HEAD` and
+`GITHUB_WORKFLOW_SHA`, and remain an ancestor of freshly fetched `origin/main`.
+Unlike forward admission, recovery deliberately permits `origin/main` to be a
+newer descendant. A later main push can therefore stop forward work without
+blocking compensation for an already-admitted transaction. An unrelated main
+history, workflow-SHA mismatch, or checked-out-HEAD mismatch still fails closed
+before any recovery step references provider credentials.
+
 A started App deploy with no durable candidate identity also remains manual
 when every App and legacy mapping still resolves to its captured prior; prior
 mappings alone cannot prove that the provider created no detached candidate.

--- a/scripts/vercel-main-deployment-workflow.test.mjs
+++ b/scripts/vercel-main-deployment-workflow.test.mjs
@@ -290,6 +290,8 @@ test("inherited restoration proves and validates reuse before a durable bounded 
     proof.env.GITHUB_WORKFLOW_SHA,
     "${{ needs.wait-for-ci.outputs.deploy_sha }}",
   );
+  assert.match(proof.run, /validate-recovery-source/);
+  assert.doesNotMatch(proof.run, /\bvalidate-source\b/);
   const install = named(jobName, "without lifecycle scripts");
   assert.deepEqual(install.with, {
     "working-directory": "source",
@@ -1008,7 +1010,14 @@ test("recovery is a bounded exact-current-attempt transaction with no cross-atte
   );
   assert.equal(controller.with.ref, "${{ github.workflow_sha }}");
   assert.equal(source.with.ref, "${{ needs.wait-for-ci.outputs.deploy_sha }}");
-  assert.match(sourceProof("recover-main-deployment").run, /validate-source/);
+  assert.match(
+    sourceProof("recover-main-deployment").run,
+    /validate-recovery-source/,
+  );
+  assert.doesNotMatch(
+    sourceProof("recover-main-deployment").run,
+    /\bvalidate-source\b/,
+  );
   assert.deepEqual(
     steps("recover-main-deployment").find(
       (step) => step.uses === "./.github/actions/pnpm-install",

--- a/scripts/vercel-main-deployment.mjs
+++ b/scripts/vercel-main-deployment.mjs
@@ -85,6 +85,7 @@ import {
 } from "./vercel-deployment-state.mjs";
 import {
   assertOnlyExpectedVercelGeneratedAliases,
+  validateImmutableMainRecoverySource,
   validateImmutableMainSource,
 } from "./vercel-production-shadow.mjs";
 import {
@@ -450,6 +451,7 @@ const CLI_COMMAND_OPTIONS = Object.freeze({
   "run-shadow": Object.freeze(["journal"]),
   "stage-result": Object.freeze(["output", "state"]),
   "validate-context": Object.freeze([]),
+  "validate-recovery-source": Object.freeze([]),
   "validate-source": Object.freeze([]),
   "validate-stages": Object.freeze([]),
 });
@@ -957,6 +959,20 @@ export function validateMainDeploymentSource({
   execute,
 }) {
   return validateImmutableMainSource({
+    sourcePath: repoRoot,
+    deploySha,
+    workflowSha,
+    ...(execute ? { execute } : {}),
+  });
+}
+
+export function validateMainDeploymentRecoverySource({
+  repoRoot,
+  deploySha,
+  workflowSha,
+  execute,
+}) {
+  return validateImmutableMainRecoverySource({
     sourcePath: repoRoot,
     deploySha,
     workflowSha,
@@ -9396,6 +9412,14 @@ export async function runMainDeploymentCli({
   }
   if (command === "validate-source") {
     validateMainDeploymentSource({
+      repoRoot: values.SOURCE_PATH,
+      deploySha: values.DEPLOY_SHA,
+      workflowSha: values.GITHUB_WORKFLOW_SHA,
+    });
+    return;
+  }
+  if (command === "validate-recovery-source") {
+    validateMainDeploymentRecoverySource({
       repoRoot: values.SOURCE_PATH,
       deploySha: values.DEPLOY_SHA,
       workflowSha: values.GITHUB_WORKFLOW_SHA,

--- a/scripts/vercel-main-deployment.test.mjs
+++ b/scripts/vercel-main-deployment.test.mjs
@@ -103,6 +103,7 @@ import {
   runMainActiveTransaction,
   runMainDeploymentCli,
   runMainShadowTransaction,
+  validateMainDeploymentRecoverySource,
   validateMainDeploymentSource,
   validateMainStageJobs,
   validateMainWorkflowContext,
@@ -1236,6 +1237,7 @@ test("controller CLI accepts only each command's exact non-duplicated options", 
       "cmVjZWlwdA",
     ],
     ["validate-context"],
+    ["validate-recovery-source"],
     ["validate-source"],
     ["create-spec", "--scope", "main", "--output", "/tmp/spec.json"],
     ["evidence", "--output", "/tmp/evidence.json"],
@@ -2539,6 +2541,96 @@ test("workflow context and source proof bind the default-branch definition to DE
         execute: () => assert.fail("git must stay inert"),
       }),
     /GITHUB_WORKFLOW_SHA/,
+  );
+});
+
+test("recovery source proof permits only a newer main descendant of the admitted SHA", () => {
+  const descendantCalls = [];
+  const descendantMain = (_command, args) => {
+    descendantCalls.push(args);
+    const gitArgs = args.slice(2);
+    if (
+      gitArgs[0] === "rev-parse" &&
+      gitArgs[1] === "refs/remotes/origin/main"
+    ) {
+      return `${OTHER_SHA}\n`;
+    }
+    if (gitArgs[0] === "rev-parse" && gitArgs[1] === "HEAD") {
+      return `${SHA}\n`;
+    }
+    return "";
+  };
+
+  assert.equal(
+    validateMainDeploymentRecoverySource({
+      repoRoot: "/trusted/source",
+      deploySha: SHA,
+      workflowSha: SHA,
+      execute: descendantMain,
+    }),
+    SHA,
+  );
+  assert.deepEqual(descendantCalls, [
+    ["-C", "/trusted/source", "cat-file", "-e", `${SHA}^{commit}`],
+    [
+      "-C",
+      "/trusted/source",
+      "merge-base",
+      "--is-ancestor",
+      SHA,
+      "refs/remotes/origin/main",
+    ],
+    ["-C", "/trusted/source", "rev-parse", "refs/remotes/origin/main"],
+    ["-C", "/trusted/source", "rev-parse", "HEAD"],
+  ]);
+  assert.throws(
+    () =>
+      validateMainDeploymentSource({
+        repoRoot: "/trusted/source",
+        deploySha: SHA,
+        workflowSha: SHA,
+        execute: descendantMain,
+      }),
+    /does not match fetched origin\/main/,
+  );
+  assert.throws(
+    () =>
+      validateMainDeploymentRecoverySource({
+        repoRoot: "/trusted/source",
+        deploySha: SHA,
+        workflowSha: OTHER_SHA,
+        execute: () => assert.fail("git must stay inert"),
+      }),
+    /GITHUB_WORKFLOW_SHA/,
+  );
+  assert.throws(
+    () =>
+      validateMainDeploymentRecoverySource({
+        repoRoot: "/trusted/source",
+        deploySha: SHA,
+        workflowSha: SHA,
+        execute(_command, args) {
+          if (args[2] === "merge-base") {
+            throw new Error("admitted SHA is unrelated to origin/main");
+          }
+          return "";
+        },
+      }),
+    /unrelated to origin\/main/,
+  );
+  assert.throws(
+    () =>
+      validateMainDeploymentRecoverySource({
+        repoRoot: "/trusted/source",
+        deploySha: SHA,
+        workflowSha: SHA,
+        execute(_command, args) {
+          const gitArgs = args.slice(2);
+          if (gitArgs[0] === "rev-parse") return `${OTHER_SHA}\n`;
+          return "";
+        },
+      }),
+    /Checked-out HEAD does not match DEPLOY_SHA/,
   );
 });
 

--- a/scripts/vercel-production-shadow.mjs
+++ b/scripts/vercel-production-shadow.mjs
@@ -840,11 +840,12 @@ export function validateDispatchContext({
   return requireString(deploySha, "deploy_sha", SHA_PATTERN).toLowerCase();
 }
 
-export function validateImmutableMainSource({
+function validateImmutableMainSourceWithPolicy({
   deploySha,
   workflowSha,
   sourcePath = process.cwd(),
   execute = execFileSync,
+  requireExactFetchedMain,
 }) {
   const normalizedSha = requireString(
     deploySha,
@@ -874,7 +875,7 @@ export function validateImmutableMainSource({
     "refs/remotes/origin/main",
   ]);
   const fetchedMain = run(["rev-parse", "refs/remotes/origin/main"]);
-  if (fetchedMain !== normalizedSha) {
+  if (requireExactFetchedMain && fetchedMain !== normalizedSha) {
     throw new Error("DEPLOY_SHA does not match fetched origin/main");
   }
   const head = run(["rev-parse", "HEAD"]);
@@ -882,6 +883,20 @@ export function validateImmutableMainSource({
     throw new Error("Checked-out HEAD does not match DEPLOY_SHA");
   }
   return normalizedSha;
+}
+
+export function validateImmutableMainSource(options) {
+  return validateImmutableMainSourceWithPolicy({
+    ...options,
+    requireExactFetchedMain: true,
+  });
+}
+
+export function validateImmutableMainRecoverySource(options) {
+  return validateImmutableMainSourceWithPolicy({
+    ...options,
+    requireExactFetchedMain: false,
+  });
 }
 
 export function parseTurboCacheSummary(log) {


### PR DESCRIPTION
## The Problem

[Vercel Main Deployment run 30361698382](https://github.com/mento-protocol/frontend-monorepo/actions/runs/30361698382) correctly stopped when `main` advanced after it had persisted a first-operation intent but before it executed the provider command. No public mapping changed.

The compensation job then reused forward admission's exact-tip source validator. Because the admitted deployment SHA was now an older `main` ancestor, recovery failed before reading the durable journal and could not certify the no-mutation state. The final graph failed closed, but it reported a recovery failure for an expected supersession.

## The Solution

Add a recovery-only source validator and use it for current-attempt and inherited compensation:

- require the admitted commit to exist;
- require it to remain an ancestor of freshly fetched `origin/main`;
- require checked-out `HEAD` and `GITHUB_WORKFLOW_SHA` to equal the admitted `DEPLOY_SHA`;
- allow only `origin/main` itself to be a newer descendant.

All seven forward admission, planning, staging, and activation paths keep the existing exact-current-tip validator. Structural and unit tests enforce that separation, and the deployment runbook now documents the recovery contract.

## Validation

- `pnpm vercel:workflow:test` — 583/583 passed
- focused validator/workflow tests — 149/149 passed
- `pnpm quality:budgets:test` — 34/34 passed
- `pnpm ci:action-pins` — all 29 workflow/composite files valid
- `trunk check` — clean
- `pnpm adr:check`
- `git diff --check`
- repository pre-push typecheck, Trunk, and Knip gates
- fresh-context security/correctness review — no findings

## Risk

The relaxed rule is available only to the two compensation paths for an already-admitted transaction. It does not let an unrelated commit, mismatched workflow definition, mismatched checkout, or non-ancestor source reach recovery credentials or provider actions.

Refs #523.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Relaxes source proof only on two compensation paths before Vercel credentials; forward paths unchanged, but any bug in the policy split could widen what reaches recovery.
> 
> **Overview**
> When **main** moves ahead after a release is admitted but before compensation runs, recovery used the same **exact `origin/main` tip** check as forward deploys, so the job failed before it could read the journal.
> 
> This PR adds **`validate-recovery-source`** / `validateImmutableMainRecoverySource`, which still requires the admitted `DEPLOY_SHA` to exist, match `HEAD` and `GITHUB_WORKFLOW_SHA`, and be an **ancestor** of fetched `origin/main`, but **does not** require `DEPLOY_SHA === origin/main`. Only **`restore-inherited-release`** and **`recover-main-deployment`** call it; all forward admission, planning, staging, and activation steps keep **`validate-source`**.
> 
> The runbook documents the recovery contract; workflow and unit tests assert recovery jobs never invoke `validate-source`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e255c443edfec4268c8f359d7696a59da244d155. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->