### PR TITLE
fix(app): refine Sentry CSP origins

### DIFF
--- a/apps/app.mento.org/app-report-only-csp.d.mts
+++ b/apps/app.mento.org/app-report-only-csp.d.mts
@@ -1,0 +1,5 @@
+export function buildAppReportOnlyCsp(options: {
+  reportUri?: string;
+  rpcOverrideOrigins?: string[];
+  storageHostname: string;
+}): string;

--- a/apps/app.mento.org/app-report-only-csp.mjs
+++ b/apps/app.mento.org/app-report-only-csp.mjs
@@ -1,0 +1,73 @@
+const BRIDGE_CONNECT_ORIGINS = [
+  "https://li.quest",
+  "https://explorer-api.mayan.finance",
+  "https://executor.labsapis.com",
+];
+
+const METAMASK_SDK_ORIGINS = [
+  "https://metamask-sdk.api.cx.metamask.io",
+  "wss://metamask-sdk.api.cx.metamask.io",
+];
+
+function unique(values) {
+  return [...new Set(values.filter(Boolean))];
+}
+
+/**
+ * Build the app's report-only CSP from reviewed product and environment
+ * origins. Keep this app-local: the other Mento surfaces do not ship the
+ * bridge, MetaMask SDK, or remote token imagery.
+ *
+ * @param {{
+ *   reportUri?: string;
+ *   rpcOverrideOrigins?: string[];
+ *   storageHostname: string;
+ * }} options
+ * @returns {string}
+ */
+export function buildAppReportOnlyCsp({
+  reportUri = "",
+  rpcOverrideOrigins = [],
+  storageHostname,
+}) {
+  const connectSrc = unique([
+    "'self'",
+    "https://forno.celo.org",
+    "https://forno.celo-sepolia.celo-testnet.org",
+    "https://rpc.monad.xyz",
+    "https://testnet-rpc.monad.xyz",
+    "https://rpc3.monad.xyz",
+    "https://polygon.drpc.org",
+    "https://polygon-amoy.drpc.org",
+    "https://sepolia.base.org",
+    "https://api.studio.thegraph.com",
+    "https://api.coingecko.com",
+    "https://api.wormholescan.io",
+    "https://api.web3modal.org",
+    ...BRIDGE_CONNECT_ORIGINS,
+    ...METAMASK_SDK_ORIGINS,
+    "https://*.walletconnect.com",
+    "wss://*.walletconnect.com",
+    "https://*.walletconnect.org",
+    "wss://*.walletconnect.org",
+    `https://${storageHostname}`,
+    ...rpcOverrideOrigins,
+  ]);
+
+  return [
+    "default-src 'self'",
+    // 'unsafe-inline' 'unsafe-eval' are required by Next 15 + wagmi today.
+    // Tightening target: replace with per-request nonces/hashes in production.
+    "script-src 'self' 'unsafe-inline' 'unsafe-eval'",
+    "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
+    `img-src 'self' data: blob: https://${storageHostname} https://coin-images.coingecko.com`,
+    "font-src 'self' data: https://fonts.gstatic.com",
+    `connect-src ${connectSrc.join(" ")}`,
+    "frame-src 'self' https://verify.walletconnect.com https://verify.walletconnect.org",
+    "worker-src 'self' blob:",
+    "object-src 'none'",
+    "base-uri 'self'",
+    "form-action 'self'",
+    ...(reportUri ? [`report-uri ${reportUri}`] : []),
+  ].join("; ");
+}

--- a/apps/app.mento.org/app-report-only-csp.test.mjs
+++ b/apps/app.mento.org/app-report-only-csp.test.mjs
@@ -1,0 +1,69 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { buildAppReportOnlyCsp } from "./app-report-only-csp.mjs";
+
+function directiveSources(csp, directiveName) {
+  const directive = csp
+    .split(";")
+    .map((value) => value.trim())
+    .find((value) => value.startsWith(`${directiveName} `));
+
+  assert.ok(directive, `missing ${directiveName}`);
+  return directive.split(/\s+/).slice(1);
+}
+
+test("allows the reviewed app and bridge origins in their required directives", () => {
+  const csp = buildAppReportOnlyCsp({
+    reportUri: "https://sentry.example/security",
+    rpcOverrideOrigins: ["https://rpc.example", "https://rpc.example"],
+    storageHostname: "storage.example",
+  });
+
+  const connectSrc = directiveSources(csp, "connect-src");
+  const styleSrc = directiveSources(csp, "style-src");
+  const fontSrc = directiveSources(csp, "font-src");
+  const imgSrc = directiveSources(csp, "img-src");
+
+  for (const origin of [
+    "https://li.quest",
+    "https://explorer-api.mayan.finance",
+    "https://executor.labsapis.com",
+    "https://metamask-sdk.api.cx.metamask.io",
+    "wss://metamask-sdk.api.cx.metamask.io",
+    "https://rpc.example",
+  ]) {
+    assert.ok(connectSrc.includes(origin), `${origin} must be in connect-src`);
+  }
+
+  assert.equal(
+    connectSrc.filter((source) => source === "https://rpc.example").length,
+    1,
+  );
+  assert.ok(styleSrc.includes("https://fonts.googleapis.com"));
+  assert.ok(fontSrc.includes("https://fonts.gstatic.com"));
+  assert.ok(imgSrc.includes("https://coin-images.coingecko.com"));
+  assert.ok(csp.endsWith("report-uri https://sentry.example/security"));
+});
+
+test("keeps unsupported chains and injected browser origins denied", () => {
+  const csp = buildAppReportOnlyCsp({
+    storageHostname: "storage.example",
+  });
+
+  for (const deniedOrigin of [
+    "ethereum-rpc.publicnode.com",
+    "arbitrum-one-rpc.publicnode.com",
+    "scroll-rpc.publicnode.com",
+    "rpc-http.mezo.org",
+    "wallet.binance.com",
+    "api.trongrid.io",
+    "frontend-cdn.perplexity.ai",
+    "translate.google.com",
+  ]) {
+    assert.doesNotMatch(csp, new RegExp(deniedOrigin.replaceAll(".", "\\.")));
+  }
+
+  assert.doesNotMatch(csp, /https:\/\/\*\.publicnode\.com/);
+  assert.doesNotMatch(csp, /https:\/\/\*\.metamask\.io/);
+  assert.doesNotMatch(csp, /report-uri/);
+});

--- a/apps/app.mento.org/app-report-only-csp.test.mjs
+++ b/apps/app.mento.org/app-report-only-csp.test.mjs
@@ -19,10 +19,10 @@ test("allows the reviewed app and bridge origins in their required directives", 
     storageHostname: "storage.example",
   });
 
-  const connectSrc = directiveSources(csp, "connect-src");
-  const styleSrc = directiveSources(csp, "style-src");
-  const fontSrc = directiveSources(csp, "font-src");
-  const imgSrc = directiveSources(csp, "img-src");
+  const connectSrc = new Set(directiveSources(csp, "connect-src"));
+  const styleSrc = new Set(directiveSources(csp, "style-src"));
+  const fontSrc = new Set(directiveSources(csp, "font-src"));
+  const imgSrc = new Set(directiveSources(csp, "img-src"));
 
   for (const origin of [
     "https://li.quest",
@@ -32,16 +32,25 @@ test("allows the reviewed app and bridge origins in their required directives", 
     "wss://metamask-sdk.api.cx.metamask.io",
     "https://rpc.example",
   ]) {
-    assert.ok(connectSrc.includes(origin), `${origin} must be in connect-src`);
+    assert.equal(
+      connectSrc.has(origin),
+      true,
+      `${origin} must be in connect-src`,
+    );
   }
 
   assert.equal(
-    connectSrc.filter((source) => source === "https://rpc.example").length,
+    directiveSources(csp, "connect-src").filter(
+      (source) => source === "https://rpc.example",
+    ).length,
     1,
   );
-  assert.ok(styleSrc.includes("https://fonts.googleapis.com"));
-  assert.ok(fontSrc.includes("https://fonts.gstatic.com"));
-  assert.ok(imgSrc.includes("https://coin-images.coingecko.com"));
+  assert.equal(styleSrc.has("https://fonts.googleapis.com"), true);
+  assert.equal(fontSrc.has("https://fonts.gstatic.com"), true);
+  assert.equal(imgSrc.has("https://coin-images.coingecko.com"), true);
+  assert.equal(connectSrc.has("https://coin-images.coingecko.com"), false);
+  assert.equal(styleSrc.has("https://coin-images.coingecko.com"), false);
+  assert.equal(fontSrc.has("https://coin-images.coingecko.com"), false);
   assert.ok(csp.endsWith("report-uri https://sentry.example/security"));
 });
 
@@ -49,21 +58,34 @@ test("keeps unsupported chains and injected browser origins denied", () => {
   const csp = buildAppReportOnlyCsp({
     storageHostname: "storage.example",
   });
+  const allSources = new Set(
+    csp
+      .split(";")
+      .flatMap((directive) => directive.trim().split(/\s+/).slice(1)),
+  );
+  const directiveNames = new Set(
+    csp.split(";").map((directive) => directive.trim().split(/\s+/, 1)[0]),
+  );
 
   for (const deniedOrigin of [
-    "ethereum-rpc.publicnode.com",
-    "arbitrum-one-rpc.publicnode.com",
-    "scroll-rpc.publicnode.com",
-    "rpc-http.mezo.org",
-    "wallet.binance.com",
-    "api.trongrid.io",
-    "frontend-cdn.perplexity.ai",
-    "translate.google.com",
+    "https://ethereum-rpc.publicnode.com",
+    "https://arbitrum-one-rpc.publicnode.com",
+    "https://scroll-rpc.publicnode.com",
+    "https://jsonrpc-mezo.boar.network",
+    "https://rpc-http.mezo.org",
+    "https://wallet.binance.com",
+    "https://api.trongrid.io",
+    "https://frontend-cdn.perplexity.ai",
+    "https://translate.google.com",
+    "https://*.publicnode.com",
+    "https://*.metamask.io",
   ]) {
-    assert.doesNotMatch(csp, new RegExp(deniedOrigin.replaceAll(".", "\\.")));
+    assert.equal(
+      allSources.has(deniedOrigin),
+      false,
+      `${deniedOrigin} must stay out of the policy`,
+    );
   }
 
-  assert.doesNotMatch(csp, /https:\/\/\*\.publicnode\.com/);
-  assert.doesNotMatch(csp, /https:\/\/\*\.metamask\.io/);
-  assert.doesNotMatch(csp, /report-uri/);
+  assert.equal(directiveNames.has("report-uri"), false);
 });

--- a/apps/app.mento.org/next.config.ts
+++ b/apps/app.mento.org/next.config.ts
@@ -1,6 +1,7 @@
 import { withSentryConfig } from "@sentry/nextjs";
 import type { NextConfig } from "next";
 import { env } from "@/env.mjs";
+import { buildAppReportOnlyCsp } from "./app-report-only-csp.mjs";
 import {
   buildSecurityHeaders,
   originOf,
@@ -44,46 +45,13 @@ const rpcOverrideOrigins = [
   .map(originOf)
   .filter(Boolean);
 
-const connectSrc = [
-  "'self'",
-  "https://forno.celo.org",
-  "https://forno.celo-sepolia.celo-testnet.org",
-  "https://rpc.monad.xyz",
-  "https://testnet-rpc.monad.xyz",
-  "https://rpc3.monad.xyz",
-  "https://polygon.drpc.org",
-  "https://polygon-amoy.drpc.org",
-  "https://sepolia.base.org",
-  "https://api.studio.thegraph.com",
-  "https://api.coingecko.com",
-  "https://api.wormholescan.io",
-  "https://api.web3modal.org",
-  "https://*.walletconnect.com",
-  "wss://*.walletconnect.com",
-  "https://*.walletconnect.org",
-  "wss://*.walletconnect.org",
-  `https://${storageHostname}`,
-  ...rpcOverrideOrigins,
-];
-
 const reportUri = sentryCspReportUri(env.NEXT_PUBLIC_SENTRY_DSN_SWAP);
 
-const reportOnlyCsp = [
-  "default-src 'self'",
-  // 'unsafe-inline' 'unsafe-eval' are required by Next 15 + wagmi today.
-  // Tightening target: replace with per-request nonces/hashes in production.
-  "script-src 'self' 'unsafe-inline' 'unsafe-eval'",
-  "style-src 'self' 'unsafe-inline'",
-  `img-src 'self' data: blob: https://${storageHostname}`,
-  "font-src 'self' data:",
-  `connect-src ${connectSrc.join(" ")}`,
-  "frame-src 'self' https://verify.walletconnect.com https://verify.walletconnect.org",
-  "worker-src 'self' blob:",
-  "object-src 'none'",
-  "base-uri 'self'",
-  "form-action 'self'",
-  ...(reportUri ? [`report-uri ${reportUri}`] : []),
-].join("; ");
+const reportOnlyCsp = buildAppReportOnlyCsp({
+  reportUri,
+  rpcOverrideOrigins,
+  storageHostname,
+});
 
 const nextConfig: NextConfig = {
   ...sharpOutputFileTracingConfig(import.meta.url),

--- a/apps/app.mento.org/turbo.json
+++ b/apps/app.mento.org/turbo.json
@@ -7,6 +7,7 @@
         "$TURBO_EXTENDS$",
         "MENTO_NEXT_DEPLOYMENT_ID",
         "VERCEL_ENV",
+        "VERCEL_TARGET_ENV",
         "VERCEL_GIT_COMMIT_SHA"
       ],
       "inputs": ["$TURBO_EXTENDS$", "$TURBO_ROOT$/scripts/security-headers.mjs"]

--- a/apps/governance.mento.org/turbo.json
+++ b/apps/governance.mento.org/turbo.json
@@ -7,6 +7,7 @@
         "$TURBO_EXTENDS$",
         "MENTO_NEXT_DEPLOYMENT_ID",
         "VERCEL_ENV",
+        "VERCEL_TARGET_ENV",
         "VERCEL_GIT_COMMIT_SHA"
       ],
       "inputs": ["$TURBO_EXTENDS$", "$TURBO_ROOT$/scripts/security-headers.mjs"]

--- a/apps/reserve.mento.org/turbo.json
+++ b/apps/reserve.mento.org/turbo.json
@@ -7,6 +7,7 @@
         "$TURBO_EXTENDS$",
         "MENTO_NEXT_DEPLOYMENT_ID",
         "VERCEL_ENV",
+        "VERCEL_TARGET_ENV",
         "VERCEL_GIT_COMMIT_SHA"
       ],
       "inputs": ["$TURBO_EXTENDS$", "$TURBO_ROOT$/scripts/security-headers.mjs"]

--- a/apps/ui.mento.org/turbo.json
+++ b/apps/ui.mento.org/turbo.json
@@ -7,6 +7,7 @@
         "$TURBO_EXTENDS$",
         "MENTO_NEXT_DEPLOYMENT_ID",
         "VERCEL_ENV",
+        "VERCEL_TARGET_ENV",
         "VERCEL_GIT_COMMIT_SHA"
       ],
       "inputs": ["$TURBO_EXTENDS$", "$TURBO_ROOT$/scripts/security-headers.mjs"]

--- a/docs/dependency-overrides.md
+++ b/docs/dependency-overrides.md
@@ -140,6 +140,13 @@ shared application bundle. The route config in
 `@wormhole-foundation/wormhole-connect/ntt` subpath; that value import belongs
 to the bridge route chunk.
 
+The report-only CSP records the bridge's reviewed runtime egress in
+`apps/app.mento.org/app-report-only-csp.mjs`. Wormhole Connect and its route
+SDKs use `li.quest` for transfer analytics, `explorer-api.mayan.finance` for
+Mayan swap status, and `executor.labsapis.com` for NTT transaction status.
+Keep those entries exact and app-local. Do not authorize dependency-default RPC
+origins for chains outside the configured Celo, Monad, and Polygon routes.
+
 The app declares `@mui/icons-material`, `@mui/material`,
 `@mui/styled-engine`, `@mui/system`, `@emotion/react`, and `@emotion/styled`
 only to satisfy Wormhole Connect peer ranges. There are no direct TypeScript,

--- a/docs/vercel-deployments.md
+++ b/docs/vercel-deployments.md
@@ -899,17 +899,17 @@ is outside the custom-CI migration.
 The repository's Vercel-system-variable reads are deliberately limited:
 
 - `VERCEL_ENV` controls Sentry source-map upload in the app, governance, and
-  reserve Next.js configurations; labels server/edge Sentry events in those
-  apps; and selects preview CSP behavior in `scripts/security-headers.mjs`.
+  reserve Next.js configurations and labels server/edge Sentry events in those
+  apps.
 - `NEXT_PUBLIC_VERCEL_ENV` labels browser Sentry events in app, governance, and
   reserve; selects production network behavior in `packages/web3`; and is a
   required governance client variable used by proposal rendering.
-- `VERCEL_TARGET_ENV` is not read directly by application source. The Vercel
-  CLI's `--target v3` option selects the custom target; setting
-  `VERCEL_TARGET_ENV` does not select it. The workflow restores this variable
-  only to reproduce the system semantics Vercel's builder would inject and to
-  prevent `v3` from being mistaken for standard preview or production
-  semantics.
+- `VERCEL_TARGET_ENV` selects preview-only CSP allowances in
+  `scripts/security-headers.mjs`. Only the literal `preview` target permits the
+  Vercel toolbar origin; App's production-serving `v3` target remains strict
+  even though it builds with `VERCEL_ENV=preview`. The Vercel CLI's
+  `--target v3` option selects the custom target; setting `VERCEL_TARGET_ENV`
+  does not select it.
 - No other Vercel system variable is a required build-time input in the current
   application source. A future read must be added to this contract and its
   fixture tests before the workflows may rely on it.

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "pr:description:check": "node scripts/check-pr-description.mjs",
     "pr:description:test": "node scripts/check-pr-description.test.mjs",
     "quality:budgets": "pnpm quality:budgets:test && pnpm quality:coverage && pnpm build && pnpm quality:bundle:check",
-    "quality:budgets:test": "node --test scripts/check-bundle-size.test.mjs scripts/ci-failure-issue.test.mjs scripts/quality-workflows.test.mjs",
+    "quality:budgets:test": "node --test scripts/check-bundle-size.test.mjs scripts/ci-failure-issue.test.mjs scripts/quality-workflows.test.mjs scripts/security-headers.test.mjs apps/app.mento.org/app-report-only-csp.test.mjs",
     "quality:bundle:check": "node scripts/check-bundle-size.mjs",
     "quality:coverage": "turbo run test:coverage --filter=app.mento.org --filter=governance.mento.org --filter=@mento-protocol/ui --filter=@repo/web3",
     "rebuild": "pnpm run clean && turbo run build",

--- a/scripts/security-headers.mjs
+++ b/scripts/security-headers.mjs
@@ -67,15 +67,16 @@ export function buildSecurityHeaders({ reportOnlyCsp } = {}) {
 }
 
 /**
- * Vercel injects the preview feedback widget from https://vercel.live on preview
- * deployments. Keep production CSP telemetry stricter while avoiding noisy
- * report-only violations during PR review.
+ * Vercel injects the preview feedback widget from https://vercel.live on
+ * standard preview deployments. Use the target environment because App's
+ * production-serving custom `v3` target deliberately builds with
+ * `VERCEL_ENV=preview`.
  *
  * @param {string | undefined} reportOnlyCsp
  * @returns {string | undefined}
  */
 function allowVercelLiveInPreview(reportOnlyCsp) {
-  if (!reportOnlyCsp || process.env.VERCEL_ENV !== "preview") {
+  if (!reportOnlyCsp || process.env.VERCEL_TARGET_ENV !== "preview") {
     return reportOnlyCsp;
   }
 

--- a/scripts/security-headers.test.mjs
+++ b/scripts/security-headers.test.mjs
@@ -1,0 +1,131 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import process from "node:process";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import {
+  buildSecurityHeaders,
+  originOf,
+  sentryCspReportUri,
+} from "./security-headers.mjs";
+
+const repositoryRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+);
+
+function reportOnlyHeader(reportOnlyCsp) {
+  return buildSecurityHeaders({ reportOnlyCsp }).find(
+    ({ key }) => key === "Content-Security-Policy-Report-Only",
+  )?.value;
+}
+
+test("allows the Vercel toolbar only for the standard preview target", () => {
+  const originalTargetEnvironment = process.env.VERCEL_TARGET_ENV;
+  const originalVercelEnvironment = process.env.VERCEL_ENV;
+  const csp = "default-src 'self'; script-src 'self'";
+
+  try {
+    process.env.VERCEL_TARGET_ENV = "preview";
+    process.env.VERCEL_ENV = "preview";
+    const previewCsp = reportOnlyHeader(csp);
+    assert.match(previewCsp, /script-src 'self' https:\/\/vercel\.live/);
+    assert.match(previewCsp, /connect-src 'self' https:\/\/vercel\.live/);
+    assert.match(previewCsp, /frame-src 'self' https:\/\/vercel\.live/);
+
+    process.env.VERCEL_TARGET_ENV = "v3";
+    assert.equal(reportOnlyHeader(csp), csp);
+
+    process.env.VERCEL_TARGET_ENV = "production";
+    process.env.VERCEL_ENV = "production";
+    assert.equal(reportOnlyHeader(csp), csp);
+
+    delete process.env.VERCEL_TARGET_ENV;
+    process.env.VERCEL_ENV = "preview";
+    assert.equal(reportOnlyHeader(csp), csp);
+  } finally {
+    if (originalTargetEnvironment === undefined) {
+      delete process.env.VERCEL_TARGET_ENV;
+    } else {
+      process.env.VERCEL_TARGET_ENV = originalTargetEnvironment;
+    }
+    if (originalVercelEnvironment === undefined) {
+      delete process.env.VERCEL_ENV;
+    } else {
+      process.env.VERCEL_ENV = originalVercelEnvironment;
+    }
+  }
+});
+
+test("does not duplicate an existing toolbar origin", () => {
+  const originalTargetEnvironment = process.env.VERCEL_TARGET_ENV;
+  process.env.VERCEL_TARGET_ENV = "preview";
+  try {
+    const csp = reportOnlyHeader(
+      "script-src 'self' https://vercel.live; connect-src https://vercel.live; frame-src 'self'",
+    );
+    assert.equal(csp.match(/https:\/\/vercel\.live/g)?.length, 3);
+  } finally {
+    if (originalTargetEnvironment === undefined) {
+      delete process.env.VERCEL_TARGET_ENV;
+    } else {
+      process.env.VERCEL_TARGET_ENV = originalTargetEnvironment;
+    }
+  }
+});
+
+test("keeps the enforced CSP limited to anti-framing", () => {
+  const headers = buildSecurityHeaders();
+  assert.deepEqual(
+    headers.find(({ key }) => key === "Content-Security-Policy"),
+    {
+      key: "Content-Security-Policy",
+      value: "frame-ancestors 'none'",
+    },
+  );
+  assert.equal(
+    headers.some(({ key }) => key === "Content-Security-Policy-Report-Only"),
+    false,
+  );
+});
+
+test("derives Sentry report endpoints and configured origins safely", () => {
+  assert.equal(
+    sentryCspReportUri("https://public-key@o123.ingest.us.sentry.io/456789"),
+    "https://o123.ingest.us.sentry.io/api/456789/security/?sentry_key=public-key",
+  );
+  assert.equal(sentryCspReportUri("not-a-dsn"), "");
+  assert.equal(originOf("https://rpc.example/path"), "https://rpc.example");
+  assert.equal(originOf("not-a-url"), "");
+});
+
+test("declares VERCEL_TARGET_ENV as an input for every app build", async () => {
+  const rootTurboConfig = JSON.parse(
+    await readFile(path.join(repositoryRoot, "turbo.json"), "utf8"),
+  );
+  assert.ok(
+    rootTurboConfig.globalPassThroughEnv.includes("VERCEL_TARGET_ENV"),
+    "the root task graph must pass VERCEL_TARGET_ENV through",
+  );
+
+  const appNames = [
+    "app.mento.org",
+    "governance.mento.org",
+    "reserve.mento.org",
+    "ui.mento.org",
+  ];
+
+  for (const appName of appNames) {
+    const turboConfig = JSON.parse(
+      await readFile(
+        path.join(repositoryRoot, "apps", appName, "turbo.json"),
+        "utf8",
+      ),
+    );
+    assert.ok(
+      turboConfig.tasks.build.env.includes("VERCEL_TARGET_ENV"),
+      `${appName} must hash VERCEL_TARGET_ENV`,
+    );
+  }
+});

--- a/turbo.json
+++ b/turbo.json
@@ -6,7 +6,8 @@
     "NEXT_RUNTIME",
     "PREVIEW_URL",
     "SENTRY_DSN",
-    "VERCEL_ENV"
+    "VERCEL_ENV",
+    "VERCEL_TARGET_ENV"
   ],
   "tasks": {
     "build": {


### PR DESCRIPTION
## The Problem

The report-only App CSP still reports legitimate runtime origins used by Wormhole Connect, MetaMask SDK, wallet fonts, and token imagery. Those groups obscure intentional denies for unsupported-chain RPCs and browser-injected traffic.

The shared preview helper also keys on `VERCEL_ENV=preview`. App custom `v3` production builds deliberately use that value, so the production-serving artifact incorrectly authorizes `vercel.live`.

## The Solution

- Extract the App report-only policy into an app-local builder and allow only the exact reviewed vendor origins in their required directives.
- Keep unsupported-chain RPCs, injected wallet traffic, translation/extension traffic, and production Vercel Toolbar traffic denied.
- Use `VERCEL_TARGET_ENV=preview` for the toolbar allowance and hash that input in all four app builds.
- Add focused policy/header tests and document the bridge vendor-egress and Vercel build contracts.
- Keep the full policy report-only; the enforced policy remains exactly `frame-ancestors none`.

## Validation

- `pnpm quality:budgets:test` — 41 passed
- `pnpm check-types` — 8 tasks passed
- `pnpm knip`
- `pnpm adr:check`
- Trunk — 1,204 files checked, no issues in the pre-push hook
- `pnpm --filter app.mento.org build` with standard preview and App custom `v3` environments
- Chrome: `/bridge` loaded, the wallet picker opened, no CSP report request was emitted, preview included `vercel.live`, and the separately built `v3` artifact excluded it while retaining all eight approved origins
- Lighthouse: Accessibility 96, Best Practices 100, SEO 100, Agentic Browsing 100
- Fresh-context semantic autoreview and deterministic autoreview: no actionable findings
- Claude Security scan: skipped because this is a Codex runtime

## Risks

The new origins authorize third-party vendor egress in report-only telemetry only. Exact-host tests prevent unsupported RPC and injected origins from entering the policy. Standard previews now depend on the already-restored `VERCEL_TARGET_ENV=preview` build contract for the Vercel Toolbar allowance.

## Ship Checklist

- [x] ship skill used
- [x] local review run
- [x] validation run

Addresses #529
Addresses #556
Addresses #564
Addresses #565
