### PR TITLE
fix(vercel): accept pnpm observation separator

### DIFF
--- a/scripts/vercel-cost-observation.mjs
+++ b/scripts/vercel-cost-observation.mjs
@@ -3867,11 +3867,10 @@ function auditObservation({ root, end, now }) {
 }
 
 function parseArguments(argv) {
-  invariant(
-    Array.isArray(argv) && argv.length > 0,
-    "Observation command is required",
-  );
-  const [command, ...rest] = argv;
+  invariant(Array.isArray(argv), "Observation command is required");
+  const normalizedArgv = argv[0] === "--" ? argv.slice(1) : argv;
+  invariant(normalizedArgv.length > 0, "Observation command is required");
+  const [command, ...rest] = normalizedArgv;
   invariant(
     [
       "init",

--- a/scripts/vercel-cost-observation.test.mjs
+++ b/scripts/vercel-cost-observation.test.mjs
@@ -935,6 +935,38 @@ test("init creates an idempotent private interval and rejects conflicts", () => 
   );
 });
 
+test("init accepts exactly one leading pnpm script separator", () => {
+  const cwd = workspace();
+  const sink = output();
+  const result = runVercelCostObservation({
+    argv: ["--", "init", "--start", START, "--end", END],
+    cwd,
+    now: () => new Date(INITIALIZED_AT),
+    gh: fakeGh(boundaryRoutes()),
+    stdout: sink.stream,
+  });
+
+  assert.equal(result.exitCode, 0);
+  assert.equal(JSON.parse(sink.read()).command, "init");
+  assert.equal(
+    JSON.parse(
+      readFileSync(join(observationRoot(cwd), "interval.json"), "utf8"),
+    ).startUtc,
+    START,
+  );
+  assert.throws(
+    () =>
+      runVercelCostObservation({
+        argv: ["--", "--", "init", "--start", START, "--end", END],
+        cwd: workspace(),
+        now: () => new Date(INITIALIZED_AT),
+        gh: fakeGh(boundaryRoutes()),
+        stdout: output().stream,
+      }),
+    /Observation command is unsupported/,
+  );
+});
+
 test("init leaves no boundary evidence when capture finishes after start", () => {
   const cwd = workspace();
   let nowCalls = 0;


### PR DESCRIPTION
## The Problem

The checked-in #523 runbook invokes the observation collector as `pnpm vercel:cost:observe -- <command>`. pnpm forwards that separator to the script, so the real interval launch failed with `Observation command is unsupported`.

The private interval was then initialized successfully with the equivalent no-separator form; no observation evidence was lost.

## The Solution

Normalize exactly one optional leading script separator before the existing command and option validation. Direct invocation remains valid, while an empty command or a second separator still fails closed.

Add regression coverage for the real pnpm-forwarded argv shape and the doubled-separator rejection.

## Validation

- `pnpm vercel:cost:test` — 86/86 passed
- Exact documented `pnpm vercel:cost:observe -- init ...` invocation — passed idempotently
- Targeted Trunk check — passed
- `pnpm adr:check` — passed
- Pre-push Trunk, workspace type checks, and Knip — passed
- Fresh-context semantic autoreview — no findings, 0.99 confidence
- Deterministic autoreview — no actionable findings

## Risk

The change only normalizes the first argv token. Existing command and option allowlists remain unchanged, and the private evidence tree is not part of the diff.

## Ship Checklist

- [x] ship skill used
- [x] local review run
- [x] validation run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Argv normalization only at the CLI entry; command allowlists and observation logic are unchanged.
> 
> **Overview**
> Fixes the Vercel cost observation CLI when invoked as `pnpm vercel:cost:observe -- <command>`, where pnpm forwards a leading `--` and the collector previously treated it as the command name.
> 
> **`parseArguments`** in `vercel-cost-observation.mjs` now strips exactly one optional leading `--` before command and option validation. Direct invocation without the separator is unchanged; an empty argv after normalization or a doubled `--` still fails with the existing unsupported-command path.
> 
> Regression tests cover the pnpm-forwarded argv shape for `init` and rejection when `--` appears twice.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c3054d2e65f26b10582a872d56c101de4ffa261. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->