### PR TITLE
fix(vercel): authorize PR 709 runtime rotation

### DIFF
--- a/docs/dependency-overrides.md
+++ b/docs/dependency-overrides.md
@@ -70,7 +70,7 @@ runtime in the same PR:
    shasum -a 256 scripts/vercel-cli-runtime/pnpm-lock.yaml
    ```
 
-   Rotate the manifest and lockfile state in two PRs. First, land a trusted
+   Rotate the manifest and lockfile state in a three-PR sequence. First, land a trusted
    default-branch controller change that maps each reviewed current/next
    lockfile digest to the SHA-256 of its matching canonical, sorted root
    override object. The standalone manifest must remain an exact mirror of

--- a/docs/dependency-overrides.md
+++ b/docs/dependency-overrides.md
@@ -77,10 +77,10 @@ runtime in the same PR:
    that root state, and cross-paired old-lock/new-manifest or
    new-lock/old-manifest hybrids must reject. Candidate or PR-authored source
    must never supply or extend this mapping. Then land the matching manifest
-   and lockfile state in #645, keeping the manifest's exact `vercel@56.4.1`
-   pin and all registry-only checks intact. Immediately after #645 merges,
-   remove the former digest/override pair from the controller mapping and
-   restore the single-pair contract.
+   and lockfile state in a second PR, keeping the manifest's exact Vercel pin
+   and all registry-only checks intact. Immediately after that PR merges, use
+   a third cleanup PR to remove the former digest/override pair and restore the
+   single-pair contract.
 
 4. Verify the root/standalone pins, exact manifest, override mirror, reviewed
    lockfile digest, and registry-only lockfile policy:

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -1,3 +1,105 @@
+## Short-lived bridge for the two-PR Vercel runtime trust rotation.
+##
+## PR #709 contains the reviewed fixed root and standalone runtime lockfiles,
+## but those bytes cannot deploy until this trusted-controller precursor lands.
+## Keep these ignores only long enough to merge this precursor; #709 removes
+## every fixable entry immediately when it lands.
+
+[[IgnoredVulns]]
+id = "GHSA-rgw5-rvv9-x895"
+ignoreUntil = 2026-08-17T00:00:00Z
+reason = "Temporary #709 trust-rotation bridge; the reviewed fixed brace-expansion lockfile cannot deploy until the exact successor pair is trusted on main."
+
+[[IgnoredVulns]]
+id = "GHSA-55q2-fjhq-7xh7"
+ignoreUntil = 2026-08-17T00:00:00Z
+reason = "Temporary #709 trust-rotation bridge; the reviewed fixed DOMPurify lockfile follows this precursor immediately."
+
+[[IgnoredVulns]]
+id = "GHSA-7p8r-x3mc-p8w7"
+ignoreUntil = 2026-08-17T00:00:00Z
+reason = "Temporary #709 trust-rotation bridge; the reviewed fixed fast-uri lockfile cannot deploy until the exact successor pair is trusted on main."
+
+[[IgnoredVulns]]
+id = "GHSA-54fx-42gc-7vw4"
+ignoreUntil = 2026-08-17T00:00:00Z
+reason = "Temporary #709 trust-rotation bridge; the reviewed fixed Hono lockfile cannot deploy until the exact successor pair is trusted on main."
+
+[[IgnoredVulns]]
+id = "GHSA-79qm-7rj5-m7r9"
+ignoreUntil = 2026-08-17T00:00:00Z
+reason = "Temporary #709 trust-rotation bridge; the reviewed fixed Hono lockfile cannot deploy until the exact successor pair is trusted on main."
+
+[[IgnoredVulns]]
+id = "GHSA-8j4g-w8fx-2239"
+ignoreUntil = 2026-08-17T00:00:00Z
+reason = "Temporary #709 trust-rotation bridge; the reviewed fixed Hono lockfile cannot deploy until the exact successor pair is trusted on main."
+
+[[IgnoredVulns]]
+id = "GHSA-f23p-vx2j-j53r"
+ignoreUntil = 2026-08-17T00:00:00Z
+reason = "Temporary #709 trust-rotation bridge; the reviewed fixed Hono lockfile cannot deploy until the exact successor pair is trusted on main."
+
+[[IgnoredVulns]]
+id = "GHSA-5p2g-fcmc-qvqq"
+ignoreUntil = 2026-08-17T00:00:00Z
+reason = "Temporary #709 trust-rotation bridge; image-size has no fixed release and #709 will replace this bridge with the reviewed disposition."
+
+[[IgnoredVulns]]
+id = "GHSA-w3rx-r6r6-pgpr"
+ignoreUntil = 2026-08-17T00:00:00Z
+reason = "Temporary #709 trust-rotation bridge; image-size has no fixed release and #709 will replace this bridge with the reviewed disposition."
+
+[[IgnoredVulns]]
+id = "GHSA-mwp4-54f8-5fhr"
+ignoreUntil = 2026-08-17T00:00:00Z
+reason = "Temporary #709 trust-rotation bridge; the reviewed fixed ip-address lockfile follows this precursor immediately."
+
+[[IgnoredVulns]]
+id = "GHSA-5p4m-2wfm-xmqj"
+ignoreUntil = 2026-08-17T00:00:00Z
+reason = "Temporary #709 trust-rotation bridge; the reviewed fixed js-yaml lockfile follows this precursor immediately."
+
+[[IgnoredVulns]]
+id = "GHSA-2v37-7h3g-55p8"
+ignoreUntil = 2026-08-17T00:00:00Z
+reason = "Temporary #709 trust-rotation bridge; the reviewed fixed nanoid lockfile follows this precursor immediately."
+
+[[IgnoredVulns]]
+id = "GHSA-fxqj-rqcc-2cmp"
+ignoreUntil = 2026-08-17T00:00:00Z
+reason = "Temporary #709 trust-rotation bridge; the reviewed fixed PostCSS lockfile cannot deploy until the exact successor pair is trusted on main."
+
+[[IgnoredVulns]]
+id = "GHSA-2m8v-j782-fhvr"
+ignoreUntil = 2026-08-17T00:00:00Z
+reason = "Temporary #709 trust-rotation bridge; the reviewed fixed socket.io-parser lockfile follows this precursor immediately."
+
+[[IgnoredVulns]]
+id = "GHSA-8xcm-r25x-g524"
+ignoreUntil = 2026-08-17T00:00:00Z
+reason = "Temporary #709 trust-rotation bridge; the reviewed fixed Undici lockfile cannot deploy until the exact successor pair is trusted on main."
+
+[[IgnoredVulns]]
+id = "GHSA-m8rv-5g2x-5cg5"
+ignoreUntil = 2026-08-17T00:00:00Z
+reason = "Temporary #709 trust-rotation bridge; the reviewed fixed Undici lockfile cannot deploy until the exact successor pair is trusted on main."
+
+[[IgnoredVulns]]
+id = "GHSA-v3r7-h72x-cjcm"
+ignoreUntil = 2026-08-17T00:00:00Z
+reason = "Temporary #709 trust-rotation bridge; the reviewed fixed Undici lockfile cannot deploy until the exact successor pair is trusted on main."
+
+[[IgnoredVulns]]
+id = "GHSA-4cwx-7wf7-3272"
+ignoreUntil = 2026-08-17T00:00:00Z
+reason = "Temporary #709 trust-rotation bridge; the reviewed fixed Undici lockfile cannot deploy until the exact successor pair is trusted on main."
+
+[[IgnoredVulns]]
+id = "GHSA-jr45-8vmc-qm54"
+ignoreUntil = 2026-08-17T00:00:00Z
+reason = "Temporary #709 trust-rotation bridge; the reviewed fixed Undici lockfile cannot deploy until the exact successor pair is trusted on main."
+
 [[IgnoredVulns]]
 id = "GHSA-3gc7-fjrx-p6mg"
 reason = "bigint-buffer vulnerability is in transitive deps; no direct fix available"
@@ -101,8 +203,8 @@ id = "GHSA-w5hq-g745-h8pq"
 # TODO: Re-evaluate at ignoreUntil — re-run the audit after any major
 # lockfile churn (e.g. new wallet SDK, upstream ESM migrations) to confirm
 # no new pre-14 uuid consumer has entered the tree on a vulnerable path.
-ignoreUntil = 2026-08-01T00:00:00Z
-reason = "uuid v3/v5/v6+buf advisory — unreachable (all 16 pre-14 consumers audited; none call v3, v6, or v5 with a buf argument); upgrade blocked by ESM-only uuid@14 vs CJS consumers."
+ignoreUntil = 2026-08-17T00:00:00Z
+reason = "Temporary #709 trust-rotation bridge; #709 replaces the expired unreachable-path exception with a reviewed fixed uuid lockfile."
 
 # ---------------------------------------------------------------------------
 # Batch added 2026-05-15 alongside the Trove Activity panel PR.

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -1,4 +1,4 @@
-## Short-lived bridge for the two-PR Vercel runtime trust rotation.
+## Short-lived bridge for the three-PR Vercel runtime trust rotation.
 ##
 ## PR #709 contains the reviewed fixed root and standalone runtime lockfiles,
 ## but those bytes cannot deploy until this trusted-controller precursor lands.

--- a/scripts/vercel-cli-runtime-contract.mjs
+++ b/scripts/vercel-cli-runtime-contract.mjs
@@ -32,36 +32,37 @@ export const BRACE_EXPANSION_RUNTIME_PATCH_PATH =
 const BRACE_EXPANSION_ROOT_PATCH_PATH =
   "scripts/vercel-cli-runtime/patches/brace-expansion@2.1.2.patch";
 
-// This reviewed successor binds the regenerated runtime lockfile, override
-// object, and brace-expansion patch required by the direct builder graph.
-const NEXT_VERCEL_CLI_RUNTIME_LOCKFILE_SHA256 =
+// This reviewed pair binds the current runtime lockfile, override object, and
+// brace-expansion patch required by the direct builder graph.
+const BRACE_EXPANSION_VERCEL_CLI_RUNTIME_LOCKFILE_SHA256 =
   "a8341932863259f7abf6dd354911cf4b13beb15b77c98c763377fcfed13f279b";
-const NEXT_VERCEL_CLI_RUNTIME_OVERRIDE_SHA256 =
+const BRACE_EXPANSION_VERCEL_CLI_RUNTIME_OVERRIDE_SHA256 =
   "2a30c91c2e6d82386113535d8a0d03e3faeb2d4af0bc032b9200719e036b490a";
 export const BRACE_EXPANSION_PATCH_SHA256 =
   "7cf518c5d9dbf4290d0f48d3fa4673d4a163d0088d2d1294e417b9909c111833";
+
+// This reviewed successor binds the 2026-08 security-floor rotation: it
+// raises the brace-expansion (GHSA-rgw5-rvv9-x895), fast-uri, hono,
+// ip-address, postcss, socket.io-parser, undici, and uuid override floors and
+// retires the local brace-expansion@2.1.2 patch in favor of upstream 2.1.4.
+const NEXT_VERCEL_CLI_RUNTIME_LOCKFILE_SHA256 =
+  "5c70b093926a8ed722b9a912ea9b4f2a3996e373bde2118be9975baf93c8fa9e";
+const NEXT_VERCEL_CLI_RUNTIME_OVERRIDE_SHA256 =
+  "d97b2eead9f597f82f99ba4d2a4b8e0a883dad129190f17838838d0209693867";
 
 // This reviewed controller-owned state permits the one-way runtime rotation
 // only with its matching canonical override and, when present, patch state. It
 // must never be read from candidate source or PR input.
 const TRUSTED_VERCEL_CLI_RUNTIME_STATES = Object.freeze([
   Object.freeze({
-    lockfileSha256:
-      "505674eac656c26fce2fe912a2b14228f8f4f3edd4b3d6d7b0f2c9f08c276d76",
-    overridesSha256:
-      "1470e9d2fb8aefb32cd1cfa0f8e6b626663b8ac0de27b52f2e646240c1ece08e",
-  }),
-  Object.freeze({
-    lockfileSha256:
-      "884e3c4186c9d5faee0e6cf710b112e7e60cdae5d46be13da1b2b0ae9cf11eb0",
-    overridesSha256:
-      "0941482390a44f7e16c1f7182469e01162434f9e274059d53d6ebbef2ebed695",
+    lockfileSha256: BRACE_EXPANSION_VERCEL_CLI_RUNTIME_LOCKFILE_SHA256,
+    overridesSha256: BRACE_EXPANSION_VERCEL_CLI_RUNTIME_OVERRIDE_SHA256,
+    patchSha256: BRACE_EXPANSION_PATCH_SHA256,
+    rootPatchSha256: BRACE_EXPANSION_PATCH_SHA256,
   }),
   Object.freeze({
     lockfileSha256: NEXT_VERCEL_CLI_RUNTIME_LOCKFILE_SHA256,
     overridesSha256: NEXT_VERCEL_CLI_RUNTIME_OVERRIDE_SHA256,
-    patchSha256: BRACE_EXPANSION_PATCH_SHA256,
-    rootPatchSha256: BRACE_EXPANSION_PATCH_SHA256,
   }),
 ]);
 

--- a/scripts/vercel-cli-runtime-contract.mjs
+++ b/scripts/vercel-cli-runtime-contract.mjs
@@ -41,14 +41,14 @@ const BRACE_EXPANSION_VERCEL_CLI_RUNTIME_OVERRIDE_SHA256 =
 export const BRACE_EXPANSION_PATCH_SHA256 =
   "7cf518c5d9dbf4290d0f48d3fa4673d4a163d0088d2d1294e417b9909c111833";
 
-// This reviewed successor binds the 2026-08 security-floor rotation: it
-// raises the brace-expansion (GHSA-rgw5-rvv9-x895), fast-uri, hono,
-// ip-address, postcss, socket.io-parser, undici, and uuid override floors and
-// retires the local brace-expansion@2.1.2 patch in favor of upstream 2.1.4.
+// This reviewed successor binds the August 2026 security-floor rotation. It
+// raises the brace-expansion, DOMPurify, fast-uri, Hono, ip-address, js-yaml,
+// nanoid, PostCSS, socket.io-parser, Undici, and uuid floors and retires the
+// local brace-expansion@2.1.2 patch in favor of upstream 2.1.4.
 const NEXT_VERCEL_CLI_RUNTIME_LOCKFILE_SHA256 =
-  "5c70b093926a8ed722b9a912ea9b4f2a3996e373bde2118be9975baf93c8fa9e";
+  "83351216a20b4f2dd2bf22732b74d6a7448624ff53af14c7573354b0d8342d5e";
 const NEXT_VERCEL_CLI_RUNTIME_OVERRIDE_SHA256 =
-  "d97b2eead9f597f82f99ba4d2a4b8e0a883dad129190f17838838d0209693867";
+  "d07212824ebc4b41e13f76d8d5da2aeba0ca6cd64379b15ad3a816c80ddfe68f";
 
 // This reviewed controller-owned state permits the one-way runtime rotation
 // only with its matching canonical override and, when present, patch state. It

--- a/scripts/vercel-cli-runtime/osv-scanner.toml
+++ b/scripts/vercel-cli-runtime/osv-scanner.toml
@@ -4,7 +4,7 @@
 # Keep these package-name false positives scoped to this standalone CLI lock so
 # root application suppressions cannot mask a CLI vulnerability.
 
-# Short-lived bridge for the two-PR Vercel runtime trust rotation. PR #709
+# Short-lived bridge for the three-PR Vercel runtime trust rotation. PR #709
 # contains the exact fixed runtime bytes authorized by this precursor and
 # removes these entries immediately when it lands.
 

--- a/scripts/vercel-cli-runtime/osv-scanner.toml
+++ b/scripts/vercel-cli-runtime/osv-scanner.toml
@@ -4,6 +4,40 @@
 # Keep these package-name false positives scoped to this standalone CLI lock so
 # root application suppressions cannot mask a CLI vulnerability.
 
+# Short-lived bridge for the two-PR Vercel runtime trust rotation. PR #709
+# contains the exact fixed runtime bytes authorized by this precursor and
+# removes these entries immediately when it lands.
+
+[[IgnoredVulns]]
+id = "GHSA-rgw5-rvv9-x895"
+ignoreUntil = 2026-08-17T00:00:00Z
+reason = "Temporary #709 trust-rotation bridge; the reviewed fixed brace-expansion runtime cannot deploy until its exact pair is trusted on main."
+
+[[IgnoredVulns]]
+id = "GHSA-7p8r-x3mc-p8w7"
+ignoreUntil = 2026-08-17T00:00:00Z
+reason = "Temporary #709 trust-rotation bridge; the reviewed fixed fast-uri runtime cannot deploy until its exact pair is trusted on main."
+
+[[IgnoredVulns]]
+id = "GHSA-5p4m-2wfm-xmqj"
+ignoreUntil = 2026-08-17T00:00:00Z
+reason = "Temporary #709 trust-rotation bridge; the reviewed fixed js-yaml runtime follows this precursor immediately."
+
+[[IgnoredVulns]]
+id = "GHSA-8xcm-r25x-g524"
+ignoreUntil = 2026-08-17T00:00:00Z
+reason = "Temporary #709 trust-rotation bridge; the reviewed fixed Undici runtime cannot deploy until its exact pair is trusted on main."
+
+[[IgnoredVulns]]
+id = "GHSA-m8rv-5g2x-5cg5"
+ignoreUntil = 2026-08-17T00:00:00Z
+reason = "Temporary #709 trust-rotation bridge; the reviewed fixed Undici runtime cannot deploy until its exact pair is trusted on main."
+
+[[IgnoredVulns]]
+id = "GHSA-v3r7-h72x-cjcm"
+ignoreUntil = 2026-08-17T00:00:00Z
+reason = "Temporary #709 trust-rotation bridge; the reviewed fixed Undici runtime cannot deploy until its exact pair is trusted on main."
+
 [[IgnoredVulns]]
 id = "GHSA-fm4j-4xhm-xpwx"
 ignoreUntil = 2026-10-14T00:00:00Z

--- a/scripts/vercel-prebuilt-workflows.test.mjs
+++ b/scripts/vercel-prebuilt-workflows.test.mjs
@@ -438,15 +438,25 @@ test("prebuilt authenticates a locked Linux pnpm binary before cache or candidat
     [...vercelCliRuntimeOsvConfig.matchAll(/^id = "([^"]+)"$/gm)].map(
       ([, id]) => id,
     ),
-    ["GHSA-fm4j-4xhm-xpwx", "GHSA-gc25-3vc5-2jf9", "GHSA-mh99-v99m-4gvg"],
+    [
+      "GHSA-rgw5-rvv9-x895",
+      "GHSA-7p8r-x3mc-p8w7",
+      "GHSA-5p4m-2wfm-xmqj",
+      "GHSA-8xcm-r25x-g524",
+      "GHSA-m8rv-5g2x-5cg5",
+      "GHSA-v3r7-h72x-cjcm",
+      "GHSA-fm4j-4xhm-xpwx",
+      "GHSA-gc25-3vc5-2jf9",
+      "GHSA-mh99-v99m-4gvg",
+    ],
   );
   assert.equal(
     (vercelCliRuntimeOsvConfig.match(/^\[\[IgnoredVulns\]\]$/gm) ?? []).length,
-    3,
+    9,
   );
   assert.doesNotMatch(
     vercelCliRuntimeOsvConfig,
-    /GHSA-(?!fm4j-4xhm-xpwx|gc25-3vc5-2jf9|mh99-v99m-4gvg)/,
+    /GHSA-(?!rgw5-rvv9-x895|7p8r-x3mc-p8w7|5p4m-2wfm-xmqj|8xcm-r25x-g524|m8rv-5g2x-5cg5|v3r7-h72x-cjcm|fm4j-4xhm-xpwx|gc25-3vc5-2jf9|mh99-v99m-4gvg)/,
   );
   assert.equal(
     supplyChain.jobs["osv-pnpm-bootstrap"].with["scan-args"].trim(),


### PR DESCRIPTION
## The Problem

PR #709 updates the repository's security floors and rotates the standalone Vercel CLI runtime lockfile. Preview workers execute the trusted controller from `main`, so they correctly reject that new pair before PR-authored code can influence the trust decision. All four #709 preview workers therefore stop at `Verify pinned Vercel prerequisites`.

The protected runtime cannot safely authorize its own replacement. The exact next lockfile and override pair must first be reviewed and landed in the trusted default-branch controller.

OSV published additional findings after #709 last passed on August 6. This precursor still carries the old lockfiles by design, so the supply-chain workflow cannot pass until #709's fixed payload becomes authorized.

## The Solution

- Authorize exactly the current patched runtime pair and #709's reviewed patchless successor pair in controller-owned code.
- Bind each lockfile digest to its matching canonical override digest. The current pair still requires the exact brace-expansion patch; the successor explicitly forbids it.
- Remove two stale pre-patch transition pairs that are no longer present on `main`.
- Add one-week, advisory-specific OSV exceptions for the old lockfiles. #709 removes every fixable exception and replaces the two unfixed `image-size` findings with a reviewed Metro-only disposition.
- Generalize the rotation runbook so future changes follow the same precursor, payload, and cleanup sequence.

After this precursor merges, #709 can be refreshed and its preview workers can accept the new exact pair. A cleanup PR must remove the former pair after #709 lands.

## Validation

- `pnpm vercel:versions:check`
- `pnpm vercel:primitives:test` — 63/63 pass
- `pnpm vercel:production-shadow:test` — 147/147 pass
- `pnpm supply-chain:lockfile-lint`
- `node --test scripts/vercel-prebuilt-workflows.test.mjs` — 17/17 pass
- `trunk check scripts/vercel-prebuilt-workflows.test.mjs docs/dependency-overrides.md osv-scanner.toml scripts/vercel-cli-runtime/osv-scanner.toml`
- Pre-push gate: Trunk, TypeScript checks across all workspaces, and Knip pass
- Structured local autoreview: clean; no accepted findings
- `pnpm vercel:workflow:test`: 583/584 pass locally. The sole `fd loader runs the pinned Vercel ESM entrypoint` spawn failure is unchanged by this diff and reproduces in the local baseline environment.

## Risk

The controller temporarily accepts two exact, review-bound states. Candidate and PR-authored code still cannot supply or extend the mapping, cross-paired manifests and lockfiles still fail, and the old pair is scheduled for immediate removal after #709 merges. The transition-only OSV exceptions expire on August 17 and must disappear with the payload rather than become permanent policy.

## Ship Checklist

- [x] PR title follows the repository convention
- [x] Performed a self-review
- [x] Ran focused deployment-contract tests
- [x] Updated the canonical rotation runbook
- [x] Architecture decision not required; this follows the documented three-PR precursor, payload, and cleanup sequence
