### PR TITLE
chore(vercel): remove retired runtime trust

### DIFF
--- a/.github/actions/vercel-protected-runtime/action.yml
+++ b/.github/actions/vercel-protected-runtime/action.yml
@@ -395,10 +395,6 @@ runs:
           "$TOOLS_PATH/vercel-cli-runtime/package.json"
           "$TOOLS_PATH/vercel-cli-runtime/pnpm-lock.yaml"
         )
-        runtime_patch="$TOOLS_PATH/vercel-cli-runtime/patches/brace-expansion@2.1.2.patch"
-        if [ -e "$runtime_patch" ] || [ -L "$runtime_patch" ]; then
-          immutable_files+=("$runtime_patch")
-        fi
         for immutable_file in "${immutable_files[@]}"; do
           if [ ! -f "$immutable_file" ] || [ -L "$immutable_file" ] ||
             [ "$(/usr/bin/realpath "$immutable_file")" != "$immutable_file" ] ||

--- a/docs/dependency-overrides.md
+++ b/docs/dependency-overrides.md
@@ -26,10 +26,9 @@ peer as a direct dependency, so protected frozen installs never fetch builders
 outside the reviewed lockfile.
 
 The workspace and standalone runtime resolve legacy v2 consumers to upstream
-`brace-expansion@2.1.4`. The August 2026 rotation retired the former local
-2.1.2 patch. During a three-PR runtime rotation, the trusted controller can still
-recognize the exact previous patched state until the payload lands; it stages
-that patch only for the legacy lockfile/override pair.
+`brace-expansion@2.1.4`. The August 2026 rotation retired the former local 2.1.2
+patch. The trusted controller now accepts only the current patchless
+lockfile/override pair.
 
 After changing the root Vercel pin or any root override, update this protected
 runtime in the same PR:
@@ -68,8 +67,9 @@ runtime in the same PR:
    shasum -a 256 scripts/vercel-cli-runtime/pnpm-lock.yaml
    ```
 
-   Rotate the manifest and lockfile state in a three-PR sequence. First, land a trusted
-   default-branch controller change that maps each reviewed current/next
+   For a future rotation, change the manifest and lockfile state in a three-PR
+   sequence. First, land a trusted default-branch controller change that maps
+   each reviewed current/next
    lockfile digest to the SHA-256 of its matching canonical, sorted root
    override object. The standalone manifest must remain an exact mirror of
    that root state, and cross-paired old-lock/new-manifest or
@@ -102,10 +102,9 @@ manifest declares a local patch. The lockfile lint rejects patched-dependency
 metadata and every affected release, including pnpm aliases, so a broad OSV
 correction cannot hide a future direct or aliased vulnerable entry.
 
-The controller's temporary two-pair map may retain the exact former patched
-state only while the reviewed payload PR is open. Remove that legacy pair in
-the cleanup PR after the payload lands; do not restore the patch to either
-manifest.
+The controller's default contract contains only the current patchless pair.
+Retired patch metadata remains only in negative regression fixtures; do not
+restore the patch to either manifest.
 
 ## Wormhole Connect (`@wormhole-foundation/wormhole-connect`)
 

--- a/docs/vercel-deployments.md
+++ b/docs/vercel-deployments.md
@@ -1126,11 +1126,15 @@ The protected production-shadow Vercel CLI is a standalone frozen install.
 Trusted controller code first requires its manifest to contain
 `vercel@56.4.1` and every CLI builder peer as exact direct dependencies,
 requires its `pnpm.overrides` object to equal the root security overrides,
-binds every byte of `scripts/vercel-cli-runtime/pnpm-lock.yaml` to a reviewed
-SHA-256, and rejects any patch state outside the exact reviewed legacy pair
-used during a three-PR rotation. The current runtime uses upstream fixed
-`brace-expansion@2.1.4` and has no local patch. It copies the manifest and
-lockfile as independent runner-owned `0444`, single-link files under
+binds every byte of `scripts/vercel-cli-runtime/pnpm-lock.yaml` to the reviewed
+SHA-256
+`83351216a20b4f2dd2bf22732b74d6a7448624ff53af14c7573354b0d8342d5e`,
+and binds the canonical root overrides to
+`d07212824ebc4b41e13f76d8d5da2aeba0ca6cd64379b15ad3a816c80ddfe68f`.
+The controller accepts only that pair and rejects all patched-dependency
+metadata and patch artifacts. The current runtime uses upstream fixed
+`brace-expansion@2.1.4`. It copies the manifest and lockfile as independent
+runner-owned `0444`, single-link files under
 `$TOOLS_PATH/vercel-cli-runtime`; CI never generates or updates that lockfile.
 The protected pnpm runtime installs there with `--frozen-lockfile`,
 `--ignore-scripts`, `--ignore-workspace`, and `--package-import-method copy`.
@@ -1144,7 +1148,7 @@ the two reviewed package-name false positives for Vercel's unrelated `sandbox`
 CLI dependency. Root application suppressions cannot mask a standalone CLI
 vulnerability.
 
-For a three-PR manifest and lockfile rotation, the trusted
+For a future three-PR manifest and lockfile rotation, the trusted
 default-branch controller has a literal temporary mapping from each current or
 reviewed-next lockfile SHA-256 to the SHA-256 of its matching canonical, sorted
 root override object. The standalone manifest must exactly mirror that root

--- a/scripts/lockfile-lint.test.mjs
+++ b/scripts/lockfile-lint.test.mjs
@@ -24,8 +24,6 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import process from "node:process";
 
-import { BRACE_EXPANSION_PATCH_SHA256 } from "./vercel-cli-runtime-contract.mjs";
-
 // ── helpers ───────────────────────────────────────────────────────────────────
 
 let passed = 0;
@@ -61,6 +59,10 @@ const SCRIPT = new URL("./lockfile-lint.mjs", import.meta.url).pathname;
 /** A valid sha512 hash that passes the length + format check. */
 const VALID_SHA512 =
   "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==";
+// Historical digest retained only to prove that the retired patch state stays
+// rejected. It is deliberately not part of the production runtime contract.
+const RETIRED_BRACE_EXPANSION_PATCH_SHA256 =
+  "7cf518c5d9dbf4290d0f48d3fa4673d4a163d0088d2d1294e417b9909c111833";
 
 /**
  * Builds a minimal pnpm v9 lockfile string.
@@ -93,7 +95,7 @@ function makeLockfile(pkgs) {
  */
 function makeBraceExpansionLockfile({ patched = false, quote = "", versions }) {
   const patchBlock = patched
-    ? `\npatchedDependencies:\n  brace-expansion@2.1.2:\n    hash: ${BRACE_EXPANSION_PATCH_SHA256}\n    path: scripts/vercel-cli-runtime/patches/brace-expansion@2.1.2.patch\n`
+    ? `\npatchedDependencies:\n  brace-expansion@2.1.2:\n    hash: ${RETIRED_BRACE_EXPANSION_PATCH_SHA256}\n    path: scripts/vercel-cli-runtime/patches/brace-expansion@2.1.2.patch\n`
     : "";
   const packages = versions
     .map(
@@ -105,7 +107,7 @@ function makeBraceExpansionLockfile({ patched = false, quote = "", versions }) {
     .map((version) => {
       const patchSuffix =
         patched && version === "2.1.2"
-          ? `(patch_hash=${BRACE_EXPANSION_PATCH_SHA256})`
+          ? `(patch_hash=${RETIRED_BRACE_EXPANSION_PATCH_SHA256})`
           : "";
       return `\n  ${quote}brace-expansion@${version}${patchSuffix}${quote}: {}\n`;
     })
@@ -497,7 +499,7 @@ test("rejects the retired patched brace-expansion 2.1.2 state", () => {
 test("rejects a retired patch hash on an otherwise fixed snapshot", () => {
   const lockfile = makeBraceExpansionLockfile({ versions: ["2.1.4"] }).replace(
     "\n  brace-expansion@2.1.4: {}\n",
-    `\n  brace-expansion@2.1.4(patch_hash=${BRACE_EXPANSION_PATCH_SHA256}): {}\n`,
+    `\n  brace-expansion@2.1.4(patch_hash=${RETIRED_BRACE_EXPANSION_PATCH_SHA256}): {}\n`,
   );
   const { exitCode, stdout, stderr } = run(lockfile);
   assert(

--- a/scripts/vercel-cli-runtime-contract.mjs
+++ b/scripts/vercel-cli-runtime-contract.mjs
@@ -1,6 +1,5 @@
 import { createHash } from "node:crypto";
 import { readFileSync } from "node:fs";
-import { dirname, join } from "node:path";
 import { isDeepStrictEqual } from "node:util";
 
 export const PINNED_VERCEL_CLI_VERSION = "56.4.1";
@@ -26,45 +25,14 @@ const PINNED_VERCEL_CLI_RUNTIME_DEPENDENCIES = Object.freeze({
   "@vercel/static-build": "2.11.8",
   vercel: PINNED_VERCEL_CLI_VERSION,
 });
-const BRACE_EXPANSION_PATCHED_DEPENDENCY = "brace-expansion@2.1.2";
-export const BRACE_EXPANSION_RUNTIME_PATCH_PATH =
-  "patches/brace-expansion@2.1.2.patch";
-const BRACE_EXPANSION_ROOT_PATCH_PATH =
-  "scripts/vercel-cli-runtime/patches/brace-expansion@2.1.2.patch";
-
-// This reviewed pair binds the previous runtime lockfile, override object,
-// and brace-expansion patch required by the direct builder graph.
-const BRACE_EXPANSION_VERCEL_CLI_RUNTIME_LOCKFILE_SHA256 =
-  "a8341932863259f7abf6dd354911cf4b13beb15b77c98c763377fcfed13f279b";
-const BRACE_EXPANSION_VERCEL_CLI_RUNTIME_OVERRIDE_SHA256 =
-  "2a30c91c2e6d82386113535d8a0d03e3faeb2d4af0bc032b9200719e036b490a";
-export const BRACE_EXPANSION_PATCH_SHA256 =
-  "7cf518c5d9dbf4290d0f48d3fa4673d4a163d0088d2d1294e417b9909c111833";
-
-// This reviewed successor binds the August 2026 security-floor rotation. It
+// This reviewed pair binds the current August 2026 security-floor runtime. It
 // raises the brace-expansion, DOMPurify, fast-uri, Hono, ip-address, js-yaml,
 // nanoid, PostCSS, socket.io-parser, Undici, and uuid floors and retires the
 // local brace-expansion@2.1.2 patch in favor of upstream 2.1.4.
-const NEXT_VERCEL_CLI_RUNTIME_LOCKFILE_SHA256 =
+const PINNED_VERCEL_CLI_RUNTIME_LOCKFILE_SHA256 =
   "83351216a20b4f2dd2bf22732b74d6a7448624ff53af14c7573354b0d8342d5e";
-const NEXT_VERCEL_CLI_RUNTIME_OVERRIDE_SHA256 =
+const PINNED_VERCEL_CLI_RUNTIME_OVERRIDE_SHA256 =
   "d07212824ebc4b41e13f76d8d5da2aeba0ca6cd64379b15ad3a816c80ddfe68f";
-
-// This reviewed controller-owned state permits the one-way runtime rotation
-// only with its matching canonical override and, when present, patch state. It
-// must never be read from candidate source or PR input.
-const TRUSTED_VERCEL_CLI_RUNTIME_STATES = Object.freeze([
-  Object.freeze({
-    lockfileSha256: BRACE_EXPANSION_VERCEL_CLI_RUNTIME_LOCKFILE_SHA256,
-    overridesSha256: BRACE_EXPANSION_VERCEL_CLI_RUNTIME_OVERRIDE_SHA256,
-    patchSha256: BRACE_EXPANSION_PATCH_SHA256,
-    rootPatchSha256: BRACE_EXPANSION_PATCH_SHA256,
-  }),
-  Object.freeze({
-    lockfileSha256: NEXT_VERCEL_CLI_RUNTIME_LOCKFILE_SHA256,
-    overridesSha256: NEXT_VERCEL_CLI_RUNTIME_OVERRIDE_SHA256,
-  }),
-]);
 
 function hasExactObjectKeys(value, expectedKeys) {
   if (value === null || typeof value !== "object" || Array.isArray(value)) {
@@ -106,8 +74,6 @@ export function assertVercelCliRuntimeContract({
   rootPackageJsonPath,
   packageJsonPath,
   lockfilePath,
-  patchFilePath,
-  trustedRuntimeStates = TRUSTED_VERCEL_CLI_RUNTIME_STATES,
 }) {
   const rootPackageMetadata = JSON.parse(
     readFileSync(rootPackageJsonPath, "utf8"),
@@ -130,28 +96,9 @@ export function assertVercelCliRuntimeContract({
   const lockfileDigest = createHash("sha256")
     .update(lockfileContents)
     .digest("hex");
-  const trustedRuntimeState = trustedRuntimeStates.find(
-    (state) => state?.lockfileSha256 === lockfileDigest,
-  );
-  if (trustedRuntimeState === undefined) {
+  if (lockfileDigest !== PINNED_VERCEL_CLI_RUNTIME_LOCKFILE_SHA256) {
     throw new Error("Trusted Vercel CLI runtime lockfile is not exact");
   }
-  const hasRuntimePatch = trustedRuntimeState.patchSha256 !== undefined;
-  const hasRootPatch = trustedRuntimeState.rootPatchSha256 !== undefined;
-  const expectedPnpmKeys = hasRuntimePatch
-    ? ["overrides", "patchedDependencies"]
-    : ["overrides"];
-  const expectedPatchedDependencies = hasRuntimePatch
-    ? {
-        [BRACE_EXPANSION_PATCHED_DEPENDENCY]:
-          BRACE_EXPANSION_RUNTIME_PATCH_PATH,
-      }
-    : undefined;
-  const expectedRootPatchedDependencies = hasRootPatch
-    ? {
-        [BRACE_EXPANSION_PATCHED_DEPENDENCY]: BRACE_EXPANSION_ROOT_PATCH_PATH,
-      }
-    : undefined;
   if (
     !hasExactObjectKeys(packageMetadata, [
       "dependencies",
@@ -174,53 +121,17 @@ export function assertVercelCliRuntimeContract({
       packageMetadata.dependencies,
       PINNED_VERCEL_CLI_RUNTIME_DEPENDENCIES,
     ) ||
-    !hasExactObjectKeys(packageMetadata.pnpm, expectedPnpmKeys) ||
+    !hasExactObjectKeys(packageMetadata.pnpm, ["overrides"]) ||
     !isDeepStrictEqual(packageMetadata.pnpm.overrides, rootOverrides) ||
-    !isDeepStrictEqual(
-      packageMetadata.pnpm.patchedDependencies,
-      expectedPatchedDependencies,
-    ) ||
-    !isDeepStrictEqual(
-      rootPnpm.patchedDependencies,
-      expectedRootPatchedDependencies,
-    )
+    packageMetadata.pnpm.patchedDependencies !== undefined ||
+    rootPnpm.patchedDependencies !== undefined
   ) {
     throw new Error("Trusted Vercel CLI runtime manifest is not exact");
   }
-  if (rootOverridesSha256 !== trustedRuntimeState.overridesSha256) {
+  if (rootOverridesSha256 !== PINNED_VERCEL_CLI_RUNTIME_OVERRIDE_SHA256) {
     throw new Error(
       "Trusted Vercel CLI runtime lockfile and overrides are not an approved pair",
     );
-  }
-  if (hasRootPatch) {
-    let rootPatchDigest;
-    try {
-      rootPatchDigest = createHash("sha256")
-        .update(
-          readFileSync(
-            join(dirname(rootPackageJsonPath), BRACE_EXPANSION_ROOT_PATCH_PATH),
-          ),
-        )
-        .digest("hex");
-    } catch {
-      throw new Error("Trusted root brace-expansion patch is missing");
-    }
-    if (rootPatchDigest !== trustedRuntimeState.rootPatchSha256) {
-      throw new Error("Trusted root brace-expansion patch is not exact");
-    }
-  }
-  if (hasRuntimePatch) {
-    if (typeof patchFilePath !== "string") {
-      throw new Error("Trusted Vercel CLI runtime patch is missing");
-    }
-    const patchDigest = createHash("sha256")
-      .update(readFileSync(patchFilePath))
-      .digest("hex");
-    if (patchDigest !== trustedRuntimeState.patchSha256) {
-      throw new Error("Trusted Vercel CLI runtime patch is not exact");
-    }
-  } else if (patchFilePath !== undefined) {
-    throw new Error("Trusted Vercel CLI runtime patch is unexpected");
   }
   const lockfileText = lockfileContents.toString("utf8");
   if (
@@ -238,7 +149,6 @@ export function assertVercelCliRuntimeContract({
 
   return {
     lockfileSha256: lockfileDigest,
-    patchRequired: hasRuntimePatch,
     vercel: PINNED_VERCEL_CLI_RUNTIME_DEPENDENCIES.vercel,
   };
 }

--- a/scripts/vercel-prebuilt-workflow.mjs
+++ b/scripts/vercel-prebuilt-workflow.mjs
@@ -45,7 +45,6 @@ import {
 } from "./vercel-prebuilt.mjs";
 import {
   assertVercelCliRuntimeContract,
-  BRACE_EXPANSION_RUNTIME_PATCH_PATH,
   PINNED_VERCEL_CLI_VERSION,
 } from "./vercel-cli-runtime-contract.mjs";
 import {
@@ -2238,87 +2237,26 @@ function validatePinnedVercelCliRuntimeFiles({
   rootPackageJsonPath,
   packageJsonPath,
   lockfilePath,
-  patchFilePath,
-  trustedRuntimeStates,
 }) {
   return assertVercelCliRuntimeContract({
     rootPackageJsonPath,
     packageJsonPath,
     lockfilePath,
-    patchFilePath,
-    trustedRuntimeStates,
   });
 }
 
-function protectedVercelCliRuntimePatchArtifact({
-  runtimeRoot,
-  expectedUid,
-  expectedGid,
-}) {
+function assertNoVercelCliRuntimePatchArtifacts(runtimeRoot) {
   const patchesRoot = join(runtimeRoot, "patches");
-  if (optionalEntry(patchesRoot) === undefined) return undefined;
-  assertProtectedRuntimeEntry(patchesRoot, {
-    directory: true,
-    expectedUid,
-    expectedGid,
-  });
-  const protectedPatchesRoot = assertProtectedRuntimeDescendant({
-    root: runtimeRoot,
-    path: patchesRoot,
-    directory: true,
-    expectedUid,
-    expectedGid,
-  });
-  const patchFilePath = join(runtimeRoot, BRACE_EXPANSION_RUNTIME_PATCH_PATH);
-  if (optionalEntry(patchFilePath) !== undefined) {
-    assertProtectedRuntimeEntry(patchFilePath, {
-      directory: false,
-      expectedUid,
-      expectedGid,
-    });
+  if (optionalEntry(patchesRoot) !== undefined) {
+    throw new Error(
+      "Trusted Vercel CLI runtime patch artifacts are unexpected",
+    );
   }
-  return {
-    patchesRoot: protectedPatchesRoot.path,
-    patchFile:
-      optionalEntry(patchFilePath) === undefined
-        ? undefined
-        : assertProtectedRuntimeDescendant({
-            root: runtimeRoot,
-            path: patchFilePath,
-            directory: false,
-            expectedUid,
-            expectedGid,
-          }),
-  };
-}
-
-function assertExactVercelCliRuntimePatchArtifact({
-  patchArtifact,
-  patchRequired,
-}) {
-  if (!patchRequired) {
-    if (patchArtifact !== undefined) {
-      throw new Error("Trusted Vercel CLI runtime patch is unexpected");
-    }
-    return undefined;
-  }
-  if (patchArtifact?.patchFile === undefined) {
-    throw new Error("Trusted Vercel CLI runtime patch is missing");
-  }
-  const entries = readdirSync(patchArtifact.patchesRoot).toSorted();
-  if (
-    entries.length !== 1 ||
-    entries[0] !== BRACE_EXPANSION_RUNTIME_PATCH_PATH.split("/").at(-1)
-  ) {
-    throw new Error("Trusted Vercel CLI runtime patch artifacts are not exact");
-  }
-  return patchArtifact.patchFile;
 }
 
 export function stageTrustedVercelCliRuntimeManifest({
   controllerRoot,
   toolsRoot,
-  runtimeContractStates,
 }) {
   requiredText(controllerRoot, "Trusted controller path");
   requiredText(toolsRoot, "Trusted Vercel tools path");
@@ -2387,30 +2325,11 @@ export function stageTrustedVercelCliRuntimeManifest({
     expectedUid: currentUid,
     expectedGid: currentGid,
   });
-  const sourceRuntimeManifest = JSON.parse(
-    readFileSync(sourcePackageJson.path, "utf8"),
-  );
-  const runtimePatchRequired = Object.hasOwn(
-    sourceRuntimeManifest.pnpm ?? {},
-    "patchedDependencies",
-  );
-  const sourcePatchArtifact = runtimePatchRequired
-    ? protectedVercelCliRuntimePatchArtifact({
-        runtimeRoot: sourceRoot,
-        expectedUid: currentUid,
-        expectedGid: currentGid,
-      })
-    : undefined;
-  const sourceContract = validatePinnedVercelCliRuntimeFiles({
+  assertNoVercelCliRuntimePatchArtifacts(sourceRoot);
+  validatePinnedVercelCliRuntimeFiles({
     rootPackageJsonPath: rootPackageJson.path,
     packageJsonPath: sourcePackageJson.path,
     lockfilePath: sourceLockfile.path,
-    patchFilePath: sourcePatchArtifact?.patchFile?.path,
-    trustedRuntimeStates: runtimeContractStates,
-  });
-  const sourcePatchFile = assertExactVercelCliRuntimePatchArtifact({
-    patchArtifact: sourcePatchArtifact,
-    patchRequired: sourceContract.patchRequired,
   });
 
   const runtimeRoot = join(canonicalToolsRoot, VERCEL_CLI_RUNTIME_DIRECTORY);
@@ -2430,9 +2349,6 @@ export function stageTrustedVercelCliRuntimeManifest({
     for (const [name, source] of [
       ["package.json", sourcePackageJson],
       ["pnpm-lock.yaml", sourceLockfile],
-      ...(sourcePatchFile === undefined
-        ? []
-        : [[BRACE_EXPANSION_RUNTIME_PATCH_PATH, sourcePatchFile]]),
     ]) {
       const destination = join(runtimeRoot, name);
       mkdirSync(dirname(destination), { recursive: true, mode: 0o755 });
@@ -2451,21 +2367,11 @@ export function stageTrustedVercelCliRuntimeManifest({
         throw new Error("Trusted Vercel CLI runtime copy is not independent");
       }
     }
-    const runtimePatchArtifact = protectedVercelCliRuntimePatchArtifact({
-      runtimeRoot,
-      expectedUid: currentUid,
-      expectedGid: currentGid,
-    });
-    const runtimeContract = validatePinnedVercelCliRuntimeFiles({
+    assertNoVercelCliRuntimePatchArtifacts(runtimeRoot);
+    validatePinnedVercelCliRuntimeFiles({
       rootPackageJsonPath: rootPackageJson.path,
       packageJsonPath: join(runtimeRoot, "package.json"),
       lockfilePath: join(runtimeRoot, "pnpm-lock.yaml"),
-      patchFilePath: runtimePatchArtifact?.patchFile?.path,
-      trustedRuntimeStates: runtimeContractStates,
-    });
-    assertExactVercelCliRuntimePatchArtifact({
-      patchArtifact: runtimePatchArtifact,
-      patchRequired: runtimeContract.patchRequired,
     });
     return runtimeRoot;
   } catch (error) {
@@ -2544,20 +2450,11 @@ export function trustedStandaloneVercelCliPath({ controllerRoot, toolsRoot }) {
   ) {
     throw new Error("Trusted Vercel CLI runtime contract is writable");
   }
-  const runtimePatchArtifact = protectedVercelCliRuntimePatchArtifact({
-    runtimeRoot,
-    expectedUid: currentUid,
-    expectedGid: currentGid,
-  });
-  const runtimeContract = validatePinnedVercelCliRuntimeFiles({
+  assertNoVercelCliRuntimePatchArtifacts(runtimeRoot);
+  validatePinnedVercelCliRuntimeFiles({
     rootPackageJsonPath: rootPackageJson.path,
     packageJsonPath: runtimePackageJson.path,
     lockfilePath: runtimeLockfile.path,
-    patchFilePath: runtimePatchArtifact?.patchFile?.path,
-  });
-  assertExactVercelCliRuntimePatchArtifact({
-    patchArtifact: runtimePatchArtifact,
-    patchRequired: runtimeContract.patchRequired,
   });
 
   const virtualStoreRoot = join(runtimeRoot, "node_modules", ".pnpm");

--- a/scripts/vercel-prebuilt-workflow.test.mjs
+++ b/scripts/vercel-prebuilt-workflow.test.mjs
@@ -2272,7 +2272,76 @@ test("standalone Vercel CLI runtime is exact, override-aligned, and independentl
     writeFileSync(sourceLockfilePath, originalLockfile);
     chmodSync(sourceLockfilePath, 0o444);
 
-    const rootPackage = JSON.parse(readFileSync(rootPackagePath, "utf8"));
+    const patchedRuntimePackage = structuredClone(originalManifest);
+    patchedRuntimePackage.pnpm.patchedDependencies = {
+      "brace-expansion@2.1.2": "patches/brace-expansion@2.1.2.patch",
+    };
+    chmodSync(sourceManifestPath, 0o644);
+    writeFileSync(
+      sourceManifestPath,
+      `${JSON.stringify(patchedRuntimePackage, null, 2)}\n`,
+    );
+    chmodSync(sourceManifestPath, 0o444);
+    assert.throws(
+      () =>
+        stageTrustedVercelCliRuntimeManifest({
+          controllerRoot,
+          toolsRoot,
+        }),
+      /manifest is not exact/,
+    );
+    assert.equal(existsSync(runtimeRoot), false);
+    chmodSync(sourceManifestPath, 0o644);
+    writeFileSync(
+      sourceManifestPath,
+      `${JSON.stringify(originalManifest, null, 2)}\n`,
+    );
+    chmodSync(sourceManifestPath, 0o444);
+
+    const originalRootPackage = JSON.parse(
+      readFileSync(rootPackagePath, "utf8"),
+    );
+    const patchedRootPackage = structuredClone(originalRootPackage);
+    patchedRootPackage.pnpm.patchedDependencies = {
+      "brace-expansion@2.1.2":
+        "scripts/vercel-cli-runtime/patches/brace-expansion@2.1.2.patch",
+    };
+    writeFileSync(
+      rootPackagePath,
+      `${JSON.stringify(patchedRootPackage, null, 2)}\n`,
+    );
+    assert.throws(
+      () =>
+        stageTrustedVercelCliRuntimeManifest({
+          controllerRoot,
+          toolsRoot,
+        }),
+      /manifest is not exact/,
+    );
+    assert.equal(existsSync(runtimeRoot), false);
+    writeFileSync(
+      rootPackagePath,
+      `${JSON.stringify(originalRootPackage, null, 2)}\n`,
+    );
+
+    const retiredPatchDirectory = join(sourceRoot, "patches");
+    mkdirSync(retiredPatchDirectory, { mode: 0o755 });
+    writeFileSync(
+      join(retiredPatchDirectory, "brace-expansion@2.1.2.patch"),
+      "retired patch fixture\n",
+    );
+    assert.throws(
+      () =>
+        stageTrustedVercelCliRuntimeManifest({
+          controllerRoot,
+          toolsRoot,
+        }),
+      /patch artifacts are unexpected/,
+    );
+    assert.equal(existsSync(runtimeRoot), false);
+    rmSync(retiredPatchDirectory, { force: true, recursive: true });
+
+    const rootPackage = structuredClone(originalRootPackage);
     rootPackage.devDependencies.vercel = "56.2.1";
     writeFileSync(rootPackagePath, `${JSON.stringify(rootPackage, null, 2)}\n`);
     assert.throws(
@@ -2284,214 +2353,6 @@ test("standalone Vercel CLI runtime is exact, override-aligned, and independentl
       /root Vercel CLI contract is invalid/,
     );
     assert.equal(existsSync(runtimeRoot), false);
-  } finally {
-    rmSync(fixtureRoot, { force: true, recursive: true });
-  }
-});
-
-test("patched standalone Vercel CLI runtime stages one immutable reviewed patch", () => {
-  const fixtureRoot = mkdtempSync(join(tmpdir(), "vercel-cli-runtime-patch-"));
-  const controllerRoot = join(fixtureRoot, "controller");
-  const sourceRoot = join(controllerRoot, "scripts", "vercel-cli-runtime");
-  const toolsRoot = join(fixtureRoot, "trusted-tools");
-  const rootPackagePath = join(controllerRoot, "package.json");
-  const sourceManifestPath = join(sourceRoot, "package.json");
-  const sourceLockfilePath = join(sourceRoot, "pnpm-lock.yaml");
-  const patchDirectory = join(sourceRoot, "patches");
-  const patchPath = join(patchDirectory, "brace-expansion@2.1.2.patch");
-  const patchContents = "diff --git a/index.js b/index.js\n";
-  try {
-    mkdirSync(sourceRoot, { recursive: true });
-    mkdirSync(toolsRoot, { mode: 0o755 });
-    copyFileSync(join(REPOSITORY_ROOT, "package.json"), rootPackagePath);
-    for (const file of ["package.json", "pnpm-lock.yaml"]) {
-      copyFileSync(
-        join(REPOSITORY_ROOT, "scripts", "vercel-cli-runtime", file),
-        join(sourceRoot, file),
-      );
-      chmodSync(join(sourceRoot, file), 0o444);
-    }
-    mkdirSync(patchDirectory, { mode: 0o755 });
-    writeFileSync(patchPath, patchContents, { mode: 0o444 });
-    for (const path of [
-      controllerRoot,
-      join(controllerRoot, "scripts"),
-      sourceRoot,
-      patchDirectory,
-      toolsRoot,
-    ]) {
-      chmodSync(path, 0o755);
-    }
-
-    const rootPackage = JSON.parse(readFileSync(rootPackagePath, "utf8"));
-    const runtimePackage = JSON.parse(readFileSync(sourceManifestPath, "utf8"));
-    rootPackage.pnpm.patchedDependencies = {
-      "brace-expansion@2.1.2":
-        "scripts/vercel-cli-runtime/patches/brace-expansion@2.1.2.patch",
-    };
-    runtimePackage.pnpm.patchedDependencies = {
-      "brace-expansion@2.1.2": "patches/brace-expansion@2.1.2.patch",
-    };
-    const patchedLockfile = `${readFileSync(sourceLockfilePath, "utf8")}# patched fixture\n`;
-    chmodSync(sourceManifestPath, 0o644);
-    writeFileSync(sourceManifestPath, `${JSON.stringify(runtimePackage)}\n`);
-    chmodSync(sourceManifestPath, 0o444);
-    writeFileSync(rootPackagePath, `${JSON.stringify(rootPackage)}\n`);
-    chmodSync(sourceLockfilePath, 0o644);
-    writeFileSync(sourceLockfilePath, patchedLockfile);
-    chmodSync(sourceLockfilePath, 0o444);
-
-    const canonicalOverrides = JSON.stringify(
-      Object.fromEntries(
-        Object.entries(rootPackage.pnpm.overrides).toSorted(([left], [right]) =>
-          left.localeCompare(right),
-        ),
-      ),
-    );
-    const runtimeContractStates = [
-      {
-        lockfileSha256: createHash("sha256")
-          .update(patchedLockfile)
-          .digest("hex"),
-        overridesSha256: createHash("sha256")
-          .update(canonicalOverrides)
-          .digest("hex"),
-        rootPatchSha256: createHash("sha256")
-          .update(patchContents)
-          .digest("hex"),
-        patchSha256: createHash("sha256").update(patchContents).digest("hex"),
-      },
-    ];
-    const runtimeRoot = stageTrustedVercelCliRuntimeManifest({
-      controllerRoot,
-      toolsRoot,
-      runtimeContractStates,
-    });
-    const stagedPatchPath = join(
-      runtimeRoot,
-      "patches",
-      "brace-expansion@2.1.2.patch",
-    );
-    for (const [source, destination] of [
-      [sourceManifestPath, join(runtimeRoot, "package.json")],
-      [sourceLockfilePath, join(runtimeRoot, "pnpm-lock.yaml")],
-      [patchPath, stagedPatchPath],
-    ]) {
-      const sourceEntry = lstatSync(source);
-      const destinationEntry = lstatSync(destination);
-      assert.equal(destinationEntry.isFile(), true);
-      assert.equal(destinationEntry.isSymbolicLink(), false);
-      assert.equal(destinationEntry.mode & 0o777, 0o444);
-      assert.equal(destinationEntry.nlink, 1);
-      assert.notEqual(destinationEntry.ino, sourceEntry.ino);
-      assert.equal(
-        readFileSync(destination, "utf8"),
-        readFileSync(source, "utf8"),
-      );
-    }
-
-    rmSync(runtimeRoot, { force: true, recursive: true });
-    writeFileSync(join(patchDirectory, "extra.patch"), patchContents);
-    assert.throws(
-      () =>
-        stageTrustedVercelCliRuntimeManifest({
-          controllerRoot,
-          toolsRoot,
-          runtimeContractStates,
-        }),
-      /patch artifacts are not exact/,
-    );
-    rmSync(join(patchDirectory, "extra.patch"));
-
-    const externalPatch = join(fixtureRoot, "brace-expansion.patch");
-    writeFileSync(externalPatch, patchContents);
-    rmSync(patchPath);
-    symlinkSync(externalPatch, patchPath);
-    assert.throws(
-      () =>
-        stageTrustedVercelCliRuntimeManifest({
-          controllerRoot,
-          toolsRoot,
-          runtimeContractStates,
-        }),
-      /not runner-owned/,
-    );
-    rmSync(patchPath);
-    writeFileSync(patchPath, patchContents, { mode: 0o444 });
-
-    const inRootPatch = join(sourceRoot, "brace-expansion.patch-target");
-    writeFileSync(inRootPatch, patchContents, { mode: 0o444 });
-    rmSync(patchPath);
-    symlinkSync("../brace-expansion.patch-target", patchPath);
-    assert.throws(
-      () =>
-        stageTrustedVercelCliRuntimeManifest({
-          controllerRoot,
-          toolsRoot,
-          runtimeContractStates,
-        }),
-      /not runner-owned/,
-    );
-    rmSync(patchPath);
-    rmSync(inRootPatch);
-    writeFileSync(patchPath, patchContents, { mode: 0o444 });
-
-    const hardlinkSource = join(sourceRoot, "brace-expansion.patch-source");
-    writeFileSync(hardlinkSource, patchContents, { mode: 0o444 });
-    rmSync(patchPath);
-    linkSync(hardlinkSource, patchPath);
-    assert.throws(
-      () =>
-        stageTrustedVercelCliRuntimeManifest({
-          controllerRoot,
-          toolsRoot,
-          runtimeContractStates,
-        }),
-      /not runner-owned/,
-    );
-    rmSync(patchPath);
-    rmSync(hardlinkSource);
-    writeFileSync(patchPath, patchContents, { mode: 0o444 });
-
-    chmodSync(patchPath, 0o644);
-    writeFileSync(patchPath, `${patchContents}# drifted\n`);
-    chmodSync(patchPath, 0o444);
-    assert.throws(
-      () =>
-        stageTrustedVercelCliRuntimeManifest({
-          controllerRoot,
-          toolsRoot,
-          runtimeContractStates,
-        }),
-      /root brace-expansion patch is not exact/,
-    );
-    chmodSync(patchPath, 0o644);
-    writeFileSync(patchPath, patchContents);
-    chmodSync(patchPath, 0o444);
-
-    rmSync(patchPath);
-    assert.throws(
-      () =>
-        stageTrustedVercelCliRuntimeManifest({
-          controllerRoot,
-          toolsRoot,
-          runtimeContractStates,
-        }),
-      /root brace-expansion patch is missing/,
-    );
-    writeFileSync(patchPath, patchContents, { mode: 0o444 });
-
-    chmodSync(patchPath, 0o666);
-    assert.throws(
-      () =>
-        stageTrustedVercelCliRuntimeManifest({
-          controllerRoot,
-          toolsRoot,
-          runtimeContractStates,
-        }),
-      /not runner-owned/,
-    );
-    chmodSync(patchPath, 0o444);
   } finally {
     rmSync(fixtureRoot, { force: true, recursive: true });
   }

--- a/scripts/vercel-prebuilt.mjs
+++ b/scripts/vercel-prebuilt.mjs
@@ -194,10 +194,7 @@ export function readResolvedNextVersion(lockfile) {
   return match[1];
 }
 
-export function assertDeploymentIdPrerequisites(
-  repoRoot,
-  { runtimeContractStates } = {},
-) {
+export function assertDeploymentIdPrerequisites(repoRoot) {
   const packageJson = JSON.parse(
     readFileSync(join(repoRoot, "package.json"), "utf8"),
   );
@@ -225,9 +222,6 @@ export function assertDeploymentIdPrerequisites(
     "vercel-cli-runtime",
     "package.json",
   );
-  const runtimePackage = JSON.parse(
-    readFileSync(runtimePackageJsonPath, "utf8"),
-  );
   const vercelCliRuntime = assertVercelCliRuntimeContract({
     rootPackageJsonPath: join(repoRoot, "package.json"),
     packageJsonPath: runtimePackageJsonPath,
@@ -237,19 +231,6 @@ export function assertDeploymentIdPrerequisites(
       "vercel-cli-runtime",
       "pnpm-lock.yaml",
     ),
-    patchFilePath: Object.hasOwn(
-      runtimePackage.pnpm ?? {},
-      "patchedDependencies",
-    )
-      ? join(
-          repoRoot,
-          "scripts",
-          "vercel-cli-runtime",
-          "patches",
-          "brace-expansion@2.1.2.patch",
-        )
-      : undefined,
-    trustedRuntimeStates: runtimeContractStates,
   });
 
   return { next: nextVersion, vercel: vercelVersion, vercelCliRuntime };

--- a/scripts/vercel-prebuilt.test.mjs
+++ b/scripts/vercel-prebuilt.test.mjs
@@ -1,6 +1,5 @@
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { createHash } from "node:crypto";
 import {
   copyFileSync,
   mkdirSync,
@@ -42,17 +41,8 @@ const scriptPath = fileURLToPath(
   new URL("./vercel-prebuilt.mjs", import.meta.url),
 );
 const COMMIT_SHA = "0123456789abcdef0123456789abcdef01234567";
-// CURRENT is a reviewed synthetic predecessor derived from the repository
-// lockfile by the hono floor swap below; NEXT is the repository's actual
-// August 2026 security-floor lockfile bound by the runtime contract.
-const CURRENT_VERCEL_CLI_RUNTIME_LOCKFILE_SHA256 =
-  "a38d9adafd7f6323130269637147bb6520c22466236b779cf01ddbf82072f20b";
-const NEXT_VERCEL_CLI_RUNTIME_LOCKFILE_SHA256 =
+const PINNED_VERCEL_CLI_RUNTIME_LOCKFILE_SHA256 =
   "83351216a20b4f2dd2bf22732b74d6a7448624ff53af14c7573354b0d8342d5e";
-const REVIEWED_VERCEL_CLI_RUNTIME_LOCKFILE_SHA256 = new Set([
-  CURRENT_VERCEL_CLI_RUNTIME_LOCKFILE_SHA256,
-  NEXT_VERCEL_CLI_RUNTIME_LOCKFILE_SHA256,
-]);
 
 function deploymentId(overrides = {}) {
   return generateVercelDeploymentId({
@@ -76,69 +66,6 @@ function createVersionContractFixture() {
     );
   }
   return fixtureRoot;
-}
-
-// The reviewed current/next pair differs by exactly the hono security-floor
-// bump, giving the rotation tests two distinct approved states derived from
-// the real repository lockfile without replaying historical content.
-function toNextVercelCliRuntimeLockfile(lockfile) {
-  return lockfile.replace(
-    "  hono@<4.12.27: 4.12.27",
-    "  hono@<4.12.34: 4.12.34",
-  );
-}
-
-function toCurrentVercelCliRuntimeLockfile(lockfile) {
-  return lockfile.replace(
-    "  hono@<4.12.34: 4.12.34",
-    "  hono@<4.12.27: 4.12.27",
-  );
-}
-
-function toCurrentVercelCliRuntimeOverrides(overrides) {
-  const current = {
-    ...overrides,
-    "hono@<4.12.27": "4.12.27",
-  };
-  delete current["hono@<4.12.34"];
-  return current;
-}
-
-function writeVercelCliRuntimeOverrides({
-  rootPackageJsonPath,
-  packageJsonPath,
-  overrides,
-}) {
-  const rootPackageMetadata = JSON.parse(
-    readFileSync(rootPackageJsonPath, "utf8"),
-  );
-  const packageMetadata = JSON.parse(readFileSync(packageJsonPath, "utf8"));
-  rootPackageMetadata.pnpm.overrides = overrides;
-  packageMetadata.pnpm.overrides = overrides;
-  writeFileSync(
-    rootPackageJsonPath,
-    `${JSON.stringify(rootPackageMetadata, null, 2)}\n`,
-  );
-  writeFileSync(
-    packageJsonPath,
-    `${JSON.stringify(packageMetadata, null, 2)}\n`,
-  );
-}
-
-function sha256(value) {
-  return createHash("sha256").update(value).digest("hex");
-}
-
-function canonicalOverrideSha256(overrides) {
-  return sha256(
-    JSON.stringify(
-      Object.fromEntries(
-        Object.entries(overrides).toSorted(([left], [right]) =>
-          left.localeCompare(right),
-        ),
-      ),
-    ),
-  );
 }
 
 test("generated IDs satisfy every Vercel constraint for every target", () => {
@@ -280,14 +207,12 @@ test("resolved Next.js and exact Vercel CLI satisfy custom-ID prerequisites", ()
     vercel: "56.4.1",
     vercelCliRuntime: {
       lockfileSha256: prerequisites.vercelCliRuntime.lockfileSha256,
-      patchRequired: false,
       vercel: "56.4.1",
     },
   };
-  assert.ok(
-    REVIEWED_VERCEL_CLI_RUNTIME_LOCKFILE_SHA256.has(
-      prerequisites.vercelCliRuntime.lockfileSha256,
-    ),
+  assert.equal(
+    prerequisites.vercelCliRuntime.lockfileSha256,
+    PINNED_VERCEL_CLI_RUNTIME_LOCKFILE_SHA256,
   );
   assert.deepEqual(prerequisites, expected);
   assert.deepEqual(
@@ -304,218 +229,42 @@ test("resolved Next.js and exact Vercel CLI satisfy custom-ID prerequisites", ()
   assert.equal(isVersionGreaterThan("56.4.1", "50.3.3"), true);
 });
 
-test("trusted controller accepts only the reviewed Vercel CLI runtime lockfile rotation", () => {
+test("trusted controller accepts only the pinned Vercel CLI runtime pair", () => {
   const fixtureRoot = createVersionContractFixture();
-  const packageJsonPath = join(
-    fixtureRoot,
-    "scripts",
-    "vercel-cli-runtime",
-    "package.json",
-  );
-  const lockfilePath = join(
-    fixtureRoot,
-    "scripts",
-    "vercel-cli-runtime",
-    "pnpm-lock.yaml",
-  );
   const contractPaths = {
     rootPackageJsonPath: join(fixtureRoot, "package.json"),
-    packageJsonPath,
-    lockfilePath,
+    packageJsonPath: join(
+      fixtureRoot,
+      "scripts",
+      "vercel-cli-runtime",
+      "package.json",
+    ),
+    lockfilePath: join(
+      fixtureRoot,
+      "scripts",
+      "vercel-cli-runtime",
+      "pnpm-lock.yaml",
+    ),
   };
   try {
-    const repositoryLockfile = readFileSync(lockfilePath, "utf8");
-    const repositoryRootOverrides = JSON.parse(
-      readFileSync(contractPaths.rootPackageJsonPath, "utf8"),
-    ).pnpm.overrides;
     const repositoryDigest =
       assertVercelCliRuntimeContract(contractPaths).lockfileSha256;
-    assert.equal(repositoryDigest, NEXT_VERCEL_CLI_RUNTIME_LOCKFILE_SHA256);
-    const reviewedNextLockfile = repositoryLockfile;
-    const reviewedCurrentLockfile =
-      toCurrentVercelCliRuntimeLockfile(reviewedNextLockfile);
-
-    assert.equal(
-      toCurrentVercelCliRuntimeLockfile(reviewedNextLockfile),
-      reviewedCurrentLockfile,
-    );
-    assert.equal(
-      toNextVercelCliRuntimeLockfile(reviewedCurrentLockfile),
-      reviewedNextLockfile,
-    );
-
-    const reviewedNextOverrides = repositoryRootOverrides;
-    const reviewedCurrentOverrides = toCurrentVercelCliRuntimeOverrides(
-      reviewedNextOverrides,
-    );
-    assert.equal(
-      sha256(reviewedCurrentLockfile),
-      CURRENT_VERCEL_CLI_RUNTIME_LOCKFILE_SHA256,
-    );
-    assert.equal(
-      sha256(reviewedNextLockfile),
-      NEXT_VERCEL_CLI_RUNTIME_LOCKFILE_SHA256,
-    );
-    const prePatchStates = [
-      {
-        lockfileSha256: CURRENT_VERCEL_CLI_RUNTIME_LOCKFILE_SHA256,
-        overridesSha256: canonicalOverrideSha256(reviewedCurrentOverrides),
-      },
-      {
-        lockfileSha256: NEXT_VERCEL_CLI_RUNTIME_LOCKFILE_SHA256,
-        overridesSha256: canonicalOverrideSha256(reviewedNextOverrides),
-      },
-    ];
-
-    writeVercelCliRuntimeOverrides({
-      ...contractPaths,
-      overrides: reviewedCurrentOverrides,
-    });
-    writeFileSync(lockfilePath, reviewedCurrentLockfile);
-    assert.equal(
-      assertVercelCliRuntimeContract({
-        ...contractPaths,
-        trustedRuntimeStates: prePatchStates,
-      }).lockfileSha256,
-      CURRENT_VERCEL_CLI_RUNTIME_LOCKFILE_SHA256,
-    );
-
-    writeVercelCliRuntimeOverrides({
-      ...contractPaths,
-      overrides: reviewedNextOverrides,
-    });
-    writeFileSync(lockfilePath, reviewedNextLockfile);
-    assert.equal(
-      assertVercelCliRuntimeContract({
-        ...contractPaths,
-        trustedRuntimeStates: prePatchStates,
-      }).lockfileSha256,
-      NEXT_VERCEL_CLI_RUNTIME_LOCKFILE_SHA256,
-    );
-
-    for (const [overrides, lockfile] of [
-      [reviewedCurrentOverrides, reviewedNextLockfile],
-      [reviewedNextOverrides, reviewedCurrentLockfile],
-    ]) {
-      writeVercelCliRuntimeOverrides({ ...contractPaths, overrides });
-      writeFileSync(lockfilePath, lockfile);
-      assert.throws(
-        () =>
-          assertVercelCliRuntimeContract({
-            ...contractPaths,
-            trustedRuntimeStates: prePatchStates,
-          }),
-        /lockfile and overrides are not an approved pair/,
-      );
-    }
-
-    writeVercelCliRuntimeOverrides({
-      ...contractPaths,
-      overrides: reviewedNextOverrides,
-    });
+    assert.equal(repositoryDigest, PINNED_VERCEL_CLI_RUNTIME_LOCKFILE_SHA256);
+    const repositoryLockfile = readFileSync(contractPaths.lockfilePath, "utf8");
     writeFileSync(
-      lockfilePath,
-      `${reviewedNextLockfile}\n# unreviewed digest\n`,
+      contractPaths.lockfilePath,
+      `${repositoryLockfile}\n# unreviewed digest\n`,
     );
     assert.throws(
       () => assertVercelCliRuntimeContract(contractPaths),
       /runtime lockfile is not exact/,
-    );
-
-    const fixturePatchPath = join(
-      fixtureRoot,
-      "scripts",
-      "vercel-cli-runtime",
-      "patches",
-      "brace-expansion@2.1.2.patch",
-    );
-    mkdirSync(join(fixtureRoot, "scripts", "vercel-cli-runtime", "patches"), {
-      recursive: true,
-    });
-    const patchContents = "diff --git a/index.js b/index.js\n";
-    writeFileSync(fixturePatchPath, patchContents);
-    const patchedRootPackage = JSON.parse(
-      readFileSync(contractPaths.rootPackageJsonPath, "utf8"),
-    );
-    const patchedRuntimePackage = JSON.parse(
-      readFileSync(packageJsonPath, "utf8"),
-    );
-    const rootPatchPath =
-      "scripts/vercel-cli-runtime/patches/brace-expansion@2.1.2.patch";
-    const runtimePatchPath = "patches/brace-expansion@2.1.2.patch";
-    patchedRootPackage.pnpm.patchedDependencies = {
-      "brace-expansion@2.1.2": rootPatchPath,
-    };
-    patchedRuntimePackage.pnpm.patchedDependencies = {
-      "brace-expansion@2.1.2": runtimePatchPath,
-    };
-    const patchedLockfile = `${reviewedNextLockfile}# patched fixture\n`;
-    writeFileSync(
-      contractPaths.rootPackageJsonPath,
-      `${JSON.stringify(patchedRootPackage, null, 2)}\n`,
-    );
-    writeFileSync(
-      packageJsonPath,
-      `${JSON.stringify(patchedRuntimePackage, null, 2)}\n`,
-    );
-    writeFileSync(lockfilePath, patchedLockfile);
-    const patchedStates = [
-      {
-        lockfileSha256: CURRENT_VERCEL_CLI_RUNTIME_LOCKFILE_SHA256,
-        overridesSha256: canonicalOverrideSha256(reviewedCurrentOverrides),
-      },
-      {
-        lockfileSha256: NEXT_VERCEL_CLI_RUNTIME_LOCKFILE_SHA256,
-        overridesSha256: canonicalOverrideSha256(reviewedNextOverrides),
-      },
-      {
-        lockfileSha256: sha256(patchedLockfile),
-        overridesSha256: canonicalOverrideSha256(reviewedNextOverrides),
-        rootPatchSha256: sha256(patchContents),
-        patchSha256: sha256(patchContents),
-      },
-    ];
-    assert.deepEqual(
-      assertVercelCliRuntimeContract({
-        ...contractPaths,
-        patchFilePath: fixturePatchPath,
-        trustedRuntimeStates: patchedStates,
-      }),
-      {
-        lockfileSha256: sha256(patchedLockfile),
-        patchRequired: true,
-        vercel: "56.4.1",
-      },
-    );
-    assert.equal(
-      assertDeploymentIdPrerequisites(fixtureRoot, {
-        runtimeContractStates: patchedStates,
-      }).vercelCliRuntime.patchRequired,
-      true,
-    );
-
-    patchedRuntimePackage.pnpm.patchedDependencies = {
-      "brace-expansion@2.1.2": rootPatchPath,
-    };
-    writeFileSync(
-      packageJsonPath,
-      `${JSON.stringify(patchedRuntimePackage, null, 2)}\n`,
-    );
-    assert.throws(
-      () =>
-        assertVercelCliRuntimeContract({
-          ...contractPaths,
-          patchFilePath: fixturePatchPath,
-          trustedRuntimeStates: patchedStates,
-        }),
-      /runtime manifest is not exact/,
     );
   } finally {
     rmSync(fixtureRoot, { force: true, recursive: true });
   }
 });
 
-test("version check rejects standalone pin, override, and lockfile drift", () => {
+test("version check rejects standalone pin, override, patch, and lockfile drift", () => {
   const cases = [
     {
       expected: /runtime manifest is not exact/,
@@ -528,6 +277,47 @@ test("version check rejects standalone pin, override, and lockfile drift", () =>
         );
         const packageMetadata = JSON.parse(readFileSync(path, "utf8"));
         packageMetadata.dependencies.vercel = "56.2.1";
+        writeFileSync(path, `${JSON.stringify(packageMetadata, null, 2)}\n`);
+      },
+    },
+    {
+      expected: /lockfile and overrides are not an approved pair/,
+      mutate(fixtureRoot) {
+        for (const path of [
+          join(fixtureRoot, "package.json"),
+          join(fixtureRoot, "scripts", "vercel-cli-runtime", "package.json"),
+        ]) {
+          const packageMetadata = JSON.parse(readFileSync(path, "utf8"));
+          packageMetadata.pnpm.overrides["axios@<1.18.0"] = ">=1.18.1";
+          writeFileSync(path, `${JSON.stringify(packageMetadata, null, 2)}\n`);
+        }
+      },
+    },
+    {
+      expected: /runtime manifest is not exact/,
+      mutate(fixtureRoot) {
+        const path = join(
+          fixtureRoot,
+          "scripts",
+          "vercel-cli-runtime",
+          "package.json",
+        );
+        const packageMetadata = JSON.parse(readFileSync(path, "utf8"));
+        packageMetadata.pnpm.patchedDependencies = {
+          "brace-expansion@2.1.2": "patches/brace-expansion@2.1.2.patch",
+        };
+        writeFileSync(path, `${JSON.stringify(packageMetadata, null, 2)}\n`);
+      },
+    },
+    {
+      expected: /runtime manifest is not exact/,
+      mutate(fixtureRoot) {
+        const path = join(fixtureRoot, "package.json");
+        const packageMetadata = JSON.parse(readFileSync(path, "utf8"));
+        packageMetadata.pnpm.patchedDependencies = {
+          "brace-expansion@2.1.2":
+            "scripts/vercel-cli-runtime/patches/brace-expansion@2.1.2.patch",
+        };
         writeFileSync(path, `${JSON.stringify(packageMetadata, null, 2)}\n`);
       },
     },

--- a/scripts/vercel-production-shadow-workflow.test.mjs
+++ b/scripts/vercel-production-shadow-workflow.test.mjs
@@ -415,14 +415,7 @@ test("protected build runtime installs the exact standalone Vercel CLI without w
     runtimeBlock,
     /\$TOOLS_PATH\/vercel-cli-runtime\/pnpm-lock\.yaml/,
   );
-  assert.match(
-    runtimeBlock,
-    /runtime_patch="\$TOOLS_PATH\/vercel-cli-runtime\/patches\/brace-expansion@2\.1\.2\.patch"/,
-  );
-  assert.match(
-    runtimeBlock,
-    /if \[ -e "\$runtime_patch" \] \|\| \[ -L "\$runtime_patch" \]; then\n\s+immutable_files\+=\("\$runtime_patch"\)/,
-  );
+  assert.doesNotMatch(runtimeBlock, /brace-expansion@2\.1\.2\.patch/);
   assert.match(
     runtimeBlock,
     /for immutable_file in "\$\{immutable_files\[@\]\}"/,


### PR DESCRIPTION
## The Problem

The Vercel CLI runtime rotation completed in #709, but its trusted precursor intentionally left the former patched lockfile/override pair and positive patch-staging path available until the payload landed. Keeping that transition state would authorize a retired runtime and leave the runbooks describing an active migration that is already complete.

## The Solution

- Bind the protected Vercel CLI runtime to the single current patchless lockfile and override digest pair.
- Remove the retired pair, patch artifact staging, custom trust-state injection, and transition-only positive fixtures.
- Reject root or standalone `patchedDependencies` and any runtime `patches/` artifact.
- Keep the retired patch as negative lockfile-lint coverage, retain the future three-PR rotation procedure, and leave all deployment rollback contracts unchanged.

## Validation

- `pnpm vercel:versions:check`
- `pnpm vercel:primitives:test` (63 passed)
- `pnpm vercel:workflow:test` (583 passed)
- `pnpm vercel:production-shadow:test` (147 passed)
- `pnpm supply-chain:lockfile-lint`
- `pnpm supply-chain:lockfile-lint:test` (61 fixture checks and 6 Node tests passed)
- `pnpm check-types` (8 tasks passed)
- `pnpm knip`
- `trunk check <10 changed files>`
- `pnpm adr:check`

Fresh-context autoreview inspected the complete 10-file diff in one cycle and reported zero findings with 0.94 confidence. The deterministic local review also reported zero findings. Browser verification is not applicable because this changes only protected deployment tooling, tests, and documentation.

## Risk

This is the required cleanup step of the documented three-PR trust rotation. A stale checkout that still carries the retired runtime now fails closed instead of staging it. The current `56.4.1` runtime remains bound to lockfile SHA-256 `83351216a20b4f2dd2bf22732b74d6a7448624ff53af14c7573354b0d8342d5e` and canonical override SHA-256 `d07212824ebc4b41e13f76d8d5da2aeba0ca6cd64379b15ad3a816c80ddfe68f`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes protected deployment supply-chain enforcement (fail-closed for stale or patched runtimes); current `56.4.1` binding is unchanged for compliant main.
> 
> **Overview**
> Completes the three-PR Vercel CLI runtime rotation by collapsing trust to **one** reviewed patchless lockfile/override pair and dropping all transition machinery for the retired `brace-expansion@2.1.2` patch.
> 
> **Contract and staging:** `assertVercelCliRuntimeContract` now pins only the current lockfile SHA-256 `83351216…` and override SHA-256 `d0721282…`, rejects any `patchedDependencies` on root or standalone manifests, and no longer accepts injectable `trustedRuntimeStates` or patch file validation. Protected workflow staging copies only `package.json` and `pnpm-lock.yaml`, fails if a `patches/` tree exists, and drops `patchRequired` from deployment prerequisites.
> 
> **CI and docs:** The protected runtime action no longer treats the brace-expansion patch as an immutable file. Runbooks describe a single-pair default and frame the three-PR sequence as **future** rotations only.
> 
> **Tests:** Rotation and positive patch-staging fixtures are removed or narrowed; lockfile-lint keeps retired patch digests only for negative cases; drift tests cover patch metadata rejection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit acc816e12d610c78281aa344c69d35824c4468f5. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->