### PR TITLE
fix(ui): stabilize calendar hydration

### DIFF
--- a/apps/ui.mento.org/app/form-components/page.tsx
+++ b/apps/ui.mento.org/app/form-components/page.tsx
@@ -38,7 +38,7 @@ export default function FormComponentsPage() {
   const [checkboxChecked, setCheckboxChecked] = useState(false);
   const [radioValue, setRadioValue] = useState("option1");
   const [selectValue, setSelectValue] = useState("");
-  const [date, setDate] = useState<Date | undefined>(new Date());
+  const [date, setDate] = useState<Date | undefined>(DATEPICKER_DEFAULT_DATE);
   const [coin, setCoin] = useState("CELO");
 
   return (
@@ -143,6 +143,7 @@ export default function FormComponentsPage() {
             <Calendar
               mode="single"
               selected={date}
+              defaultMonth={DATEPICKER_DEFAULT_DATE}
               onSelect={setDate}
               className="rounded-md border"
             />

--- a/apps/ui.mento.org/e2e/showcase.visual.spec.ts
+++ b/apps/ui.mento.org/e2e/showcase.visual.spec.ts
@@ -1,3 +1,5 @@
+import { expect } from "@playwright/test";
+
 import { snapshotPage, test, type Theme } from "./fixtures";
 
 // These 6 data-free showcase pages mount the @mento-protocol/ui components in their
@@ -29,3 +31,20 @@ for (const { url, name } of PAGES) {
     });
   }
 }
+
+test("form components hydrates with a clock different from its build", async ({
+  page,
+}) => {
+  const pageErrors: string[] = [];
+  page.on("pageerror", (error) => pageErrors.push(error.message));
+
+  await page.clock.setFixedTime(new Date("2040-02-15T12:00:00.000Z"));
+  await page.goto("/form-components", { waitUntil: "domcontentloaded" });
+  await page.waitForLoadState("networkidle");
+
+  await expect(
+    page.getByRole("heading", { name: "Form Components", exact: true }),
+  ).toBeVisible();
+  await expect(page.getByText("January 2026", { exact: true })).toBeVisible();
+  expect(pageErrors).toEqual([]);
+});


### PR DESCRIPTION
## The Problem

The UI showcase initialized its calendar with `new Date()` during both static rendering and browser hydration. If those renders happened in different months, React received different calendar markup and reported a hydration error.

## The Solution

Use the showcase's existing fixed January 15, 2026 date for both the selected day and initial calendar month. Add a Playwright regression that moves the browser clock to February 2040 and confirms the prerendered January 2026 calendar hydrates without a page error.

## Validation

- `NEXT_PUBLIC_STORAGE_URL=https://storage.mento.org pnpm exec turbo run build --filter ui.mento.org`
- `pnpm --filter ui.mento.org check-types`
- `trunk check apps/ui.mento.org/app/form-components/page.tsx apps/ui.mento.org/e2e/showcase.visual.spec.ts`
- Focused cross-clock Playwright regression: 2/2 desktop and mobile tests passed
- Full showcase Playwright suite: 26/26 desktop and mobile tests passed
- Chrome DevTools: January 15 rendered selected, next-month navigation reached February, and the console contained no errors
- Structured autoreview: deterministic pass clean; fresh-context semantic pass clean

## Ship Checklist

- [x] PR title follows the conventions
- [x] Performed a self-review of my own changes
- [x] Relevant automated checks and smoke tests pass
- [x] Architecture decision? Not applicable — this is a focused showcase hydration bug fix and does not change an architectural boundary or policy.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Showcase-only date initialization and an e2e regression; no auth, data, or production app behavior changes.
> 
> **Overview**
> Fixes React hydration mismatches on the **Form Components** showcase when server and client renders fall in different months.
> 
> The calendar demo no longer seeds state with `new Date()`; it uses the existing fixed **`DATEPICKER_DEFAULT_DATE`** (January 15, 2026) for the selected day and passes the same value as **`defaultMonth`** so the visible month stays deterministic across SSR and hydration.
> 
> A new Playwright test pins the browser clock to February 2040, loads `/form-components`, asserts **January 2026** is still shown, and checks that no client-side page errors were recorded.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d7e8b6a6ecc1e0cc355d0a3bf1c7e121157c53a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->