### PR TITLE
fix(ci): normalize GitHub cost evidence inputs

### DIFF
--- a/scripts/vercel-cost-observation.mjs
+++ b/scripts/vercel-cost-observation.mjs
@@ -147,6 +147,22 @@ function exactUtc(value, label) {
   return canonical;
 }
 
+function githubUtc(value, label) {
+  invariant(typeof value === "string", `${label} must be an ISO UTC timestamp`);
+  invariant(
+    /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3})?Z$/.test(value),
+    `${label} must be a canonical GitHub ISO UTC timestamp`,
+  );
+  const milliseconds = Date.parse(value);
+  invariant(Number.isFinite(milliseconds), `${label} is not a timestamp`);
+  const canonical = new Date(milliseconds).toISOString();
+  invariant(
+    canonical === value || canonical.replace(/\.000Z$/, "Z") === value,
+    `${label} must be a canonical GitHub ISO UTC timestamp`,
+  );
+  return canonical;
+}
+
 function utcBoundary(value, label) {
   const canonical = exactUtc(value, label);
   invariant(
@@ -828,10 +844,14 @@ function terminalRun(run, expectedPath, label) {
     TERMINAL_RUN_CONCLUSIONS.has(run.conclusion),
     `${label} conclusion is not terminal`,
   );
-  exactUtc(run.created_at, `${label} creation time`);
-  exactUtc(run.updated_at, `${label} update time`);
+  const createdAtUtc = githubUtc(run.created_at, `${label} creation time`);
+  const updatedAtUtc = githubUtc(run.updated_at, `${label} update time`);
   positiveId(run.run_attempt, `${label} attempt`);
-  return run;
+  return {
+    ...run,
+    created_at: createdAtUtc,
+    updated_at: updatedAtUtc,
+  };
 }
 
 function withinInterval(timestamp, interval) {
@@ -996,9 +1016,17 @@ function parsePreviewJournalComment(comment, pr) {
       ? { admission: parsed.admission }
       : {}),
   });
+  const canonicalCandidates = [canonical];
+  if (Object.hasOwn(canonical, "admission")) {
+    const { admission, ...withoutAdmission } = canonical;
+    canonicalCandidates.push({ ...withoutAdmission, admission });
+  }
   invariant(
-    JSON.stringify(parsed) === JSON.stringify(canonical) &&
-      comment.body === renderPreviewJournalBody(canonical),
+    canonicalCandidates.some(
+      (candidate) =>
+        JSON.stringify(parsed) === JSON.stringify(candidate) &&
+        comment.body === renderPreviewJournalBody(candidate),
+    ),
     "Preview journal is not canonical",
   );
   return canonical;
@@ -1684,7 +1712,7 @@ function captureStartBoundary(
     openPullRequestJournals.push({
       pr: Number(pr),
       headSha,
-      updatedAtUtc: exactUtc(pull.updated_at, `Boundary PR ${pr} update time`),
+      updatedAtUtc: githubUtc(pull.updated_at, `Boundary PR ${pr} update time`),
       preBoundaryEligiblePushEvidence: preBoundaryEligiblePushEvidence(
         journal,
         headSha,
@@ -2025,17 +2053,20 @@ function capturePreview({ root, pr, eventRunId, dependencies }) {
     const capturedControllerSyntheticRuns = [];
 
     for (const reference of validatedReferences) {
-      const rawRun = fetchAttempt(
-        dependencies,
-        reference.runId,
-        reference.attempt,
-        "Preview referenced run",
-      );
       const expectedPath =
         reference.kind === "worker"
           ? ".github/workflows/vercel-preview-worker.yml"
           : ".github/workflows/vercel-preview-controller.yml";
-      terminalRun(rawRun, expectedPath, "Preview referenced run");
+      const rawRun = terminalRun(
+        fetchAttempt(
+          dependencies,
+          reference.runId,
+          reference.attempt,
+          "Preview referenced run",
+        ),
+        expectedPath,
+        "Preview referenced run",
+      );
       invariant(
         String(rawRun.id) === reference.runId &&
           Number(rawRun.run_attempt) === reference.attempt &&
@@ -2092,7 +2123,7 @@ function capturePreview({ root, pr, eventRunId, dependencies }) {
           sha: parsedTitle.sha,
           keyDigest: parsedTitle.keyDigest,
           conclusion: rawRun.conclusion,
-          completedAtUtc: exactUtc(
+          completedAtUtc: githubUtc(
             rawRun.updated_at,
             "Preview worker completion time",
           ),
@@ -2103,7 +2134,7 @@ function capturePreview({ root, pr, eventRunId, dependencies }) {
           attempt: reference.attempt,
           terminalReason: reference.result.terminal_reason,
           conclusion: rawRun.conclusion,
-          completedAtUtc: exactUtc(
+          completedAtUtc: githubUtc(
             rawRun.updated_at,
             "Preview controller synthetic completion time",
           ),
@@ -2136,7 +2167,7 @@ function capturePreview({ root, pr, eventRunId, dependencies }) {
         dependencies.now().toISOString(),
         "Preview capture time",
       ),
-      eventTimestampUtc: exactUtc(
+      eventTimestampUtc: githubUtc(
         controllerRun.created_at,
         "Preview event time",
       ),
@@ -2159,7 +2190,7 @@ function capturePreview({ root, pr, eventRunId, dependencies }) {
               id: positiveId(sentinel.id, "Preview status ID"),
               state: sentinel.state,
               targetUrl: sentinel.target_url ?? null,
-              updatedAtUtc: exactUtc(
+              updatedAtUtc: githubUtc(
                 sentinel.updated_at ?? sentinel.created_at,
                 "Preview status update time",
               ),
@@ -2187,7 +2218,7 @@ function capturePreview({ root, pr, eventRunId, dependencies }) {
             deploymentId,
             statusId: positiveId(status.id, "Preview deployment status ID"),
             state: status.state,
-            createdAtUtc: exactUtc(
+            createdAtUtc: githubUtc(
               status.created_at,
               "Preview deployment status time",
             ),
@@ -2472,11 +2503,13 @@ function captureMain({ root, runId, dependencies }) {
       attempt <= currentAttempt;
       attempt += 1
     ) {
-      const run =
+      const run = terminalRun(
         attempt === currentAttempt
           ? currentRun
-          : fetchAttempt(dependencies, mainRunId, attempt, "Main run");
-      terminalRun(run, MAIN_WORKFLOW_PATH, `Main run attempt ${attempt}`);
+          : fetchAttempt(dependencies, mainRunId, attempt, "Main run"),
+        MAIN_WORKFLOW_PATH,
+        `Main run attempt ${attempt}`,
+      );
       invariant(
         Number(run.run_attempt) === attempt,
         "Main attempt endpoint returned another attempt",
@@ -2718,11 +2751,11 @@ function captureMain({ root, runId, dependencies }) {
           dependencies.now().toISOString(),
           "Main capture time",
         ),
-        eventTimestampUtc: exactUtc(
+        eventTimestampUtc: githubUtc(
           attemptData.run.created_at,
           "Main run event time",
         ),
-        runCompletedAtUtc: exactUtc(
+        runCompletedAtUtc: githubUtc(
           attemptData.run.updated_at,
           "Main run completion time",
         ),
@@ -2818,8 +2851,8 @@ function compactRun(run) {
     event: run.event,
     status: run.status,
     conclusion: run.conclusion,
-    createdAtUtc: exactUtc(run.created_at, "Workflow run creation time"),
-    updatedAtUtc: exactUtc(run.updated_at, "Workflow run update time"),
+    createdAtUtc: githubUtc(run.created_at, "Workflow run creation time"),
+    updatedAtUtc: githubUtc(run.updated_at, "Workflow run update time"),
     headSha:
       typeof run.head_sha === "string" && SHA_PATTERN.test(run.head_sha)
         ? run.head_sha

--- a/scripts/vercel-cost-observation.test.mjs
+++ b/scripts/vercel-cost-observation.test.mjs
@@ -103,6 +103,30 @@ function fakeGh(routes, calls = []) {
   };
 }
 
+function githubWholeSecondTimestamps(value) {
+  if (typeof value === "string") return value.replace(/\.000Z$/, "Z");
+  if (Buffer.isBuffer(value)) return value;
+  if (Array.isArray(value)) return value.map(githubWholeSecondTimestamps);
+  if (value !== null && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, entry]) => [
+        key,
+        githubWholeSecondTimestamps(entry),
+      ]),
+    );
+  }
+  return value;
+}
+
+function githubWholeSecondRoutes(routes) {
+  return new Map(
+    [...routes].map(([key, value]) => [
+      key,
+      githubWholeSecondTimestamps(value),
+    ]),
+  );
+}
+
 function boundaryRoutes({ openPulls = [], commentsByPr = new Map() } = {}) {
   const workflows = [
     "_vercel-prebuilt.yml",
@@ -1009,6 +1033,86 @@ test("init retries when an open PR head changes during journal capture", () => {
   );
 });
 
+test("init canonicalizes GitHub REST whole-second timestamps", () => {
+  const cwd = workspace();
+  const pull = {
+    number: 700,
+    head: { sha: "a".repeat(40) },
+    updated_at: "2026-07-28T23:30:00Z",
+  };
+
+  runInit(cwd, {
+    gh: fakeGh(boundaryRoutes({ openPulls: [pull] })),
+  });
+
+  const boundary = JSON.parse(
+    readFileSync(join(observationRoot(cwd), "boundary", "start.json"), "utf8"),
+  );
+  assert.equal(
+    boundary.openPullRequestJournals[0].updatedAtUtc,
+    "2026-07-28T23:30:00.000Z",
+  );
+});
+
+test("init accepts only the controller's two canonical admission orderings", () => {
+  const pull = {
+    number: 700,
+    head: { sha: "a".repeat(40) },
+    updated_at: "2026-07-28T23:30:00Z",
+  };
+  const canonical = createPreviewJournal({
+    pr: pull.number,
+    admission: {
+      schema: "vercel-preview-controller-admission:v1",
+      workflow_id: 100,
+      through_run_id: 200,
+      through_run_number: 300,
+    },
+  });
+  const { admission, ...withoutAdmission } = canonical;
+  const admissionLast = { ...withoutAdmission, admission };
+  const comment = {
+    id: 400,
+    user: { type: "Bot", login: "github-actions[bot]" },
+    body: renderPreviewJournalBody(admissionLast),
+  };
+  const commentsByPr = new Map([[pull.number, [comment]]]);
+  const acceptedWorkspace = workspace();
+
+  runInit(acceptedWorkspace, {
+    gh: fakeGh(boundaryRoutes({ openPulls: [pull], commentsByPr })),
+  });
+
+  const boundary = JSON.parse(
+    readFileSync(
+      join(observationRoot(acceptedWorkspace), "boundary", "start.json"),
+      "utf8",
+    ),
+  );
+  assert.equal(
+    boundary.openPullRequestJournals[0].journal.digest,
+    canonical.journal_digest,
+  );
+
+  const { schema, ...withoutSchema } = admissionLast;
+  const unsupportedOrderComment = {
+    ...comment,
+    body: renderPreviewJournalBody({ ...withoutSchema, schema }),
+  };
+  assert.throws(
+    () =>
+      runInit(workspace(), {
+        gh: fakeGh(
+          boundaryRoutes({
+            openPulls: [pull],
+            commentsByPr: new Map([[pull.number, [unsupportedOrderComment]]]),
+          }),
+        ),
+      }),
+    /Preview journal is not canonical/,
+  );
+});
+
 test("init recovers when the start boundary exists without its commit marker", () => {
   const cwd = workspace();
   runInit(cwd);
@@ -1301,6 +1405,30 @@ test("capture-preview freezes the canonical v2 journal and raw GitHub facts", ()
           "github.com/mento-protocol/frontend-monorepo",
       ),
   );
+});
+
+test("capture-preview normalizes whole-second GitHub REST timestamps", () => {
+  const cwd = workspace();
+  runInit(cwd);
+  const result = runVercelCostObservation({
+    argv: ["capture-preview", "--pr", "700", "--event-run-id", "9001"],
+    cwd,
+    now: () => new Date(CAPTURED_AT),
+    gh: fakeGh(githubWholeSecondRoutes(previewRoutes())),
+    stdout: output().stream,
+  });
+
+  assert.equal(result.exitCode, 0);
+  const directory = join(observationRoot(cwd), "preview", "9001");
+  const capture = JSON.parse(
+    readFileSync(join(directory, "capture.json"), "utf8"),
+  );
+  const controllerRun = JSON.parse(
+    readFileSync(join(directory, "raw", "controller-run.json"), "utf8"),
+  );
+  assert.equal(capture.eventTimestampUtc, "2026-07-29T01:00:01.000Z");
+  assert.equal(controllerRun.created_at, "2026-07-29T01:00:01.000Z");
+  assert.equal(controllerRun.updated_at, "2026-07-29T01:04:00.000Z");
 });
 
 test("capture-preview accepts a controller event for a non-main base", () => {
@@ -2117,7 +2245,7 @@ test("a drained pre-start controller receipt excludes a carried PR first preview
   );
 });
 
-test("capture-main records every GitHub attempt and leaves provider probes unresolved", () => {
+test("capture-main normalizes whole-second GitHub timestamps and records every attempt", () => {
   const cwd = workspace();
   runInit(cwd);
   const run = {
@@ -2128,8 +2256,8 @@ test("capture-main records every GitHub attempt and leaves provider probes unres
     event: "workflow_run",
     status: "completed",
     conclusion: "success",
-    created_at: "2026-07-30T02:00:00.000Z",
-    updated_at: "2026-07-30T02:12:00.000Z",
+    created_at: "2026-07-30T02:00:00Z",
+    updated_at: "2026-07-30T02:12:00Z",
     head_branch: "main",
     head_sha: "c".repeat(40),
     html_url:
@@ -2160,8 +2288,8 @@ test("capture-main records every GitHub attempt and leaves provider probes unres
     event: "push",
     status: "completed",
     conclusion: "success",
-    created_at: "2026-07-30T01:40:00.000Z",
-    updated_at: "2026-07-30T01:59:00.000Z",
+    created_at: "2026-07-30T01:40:00Z",
+    updated_at: "2026-07-30T01:59:00Z",
     head_branch: "main",
     head_sha: "c".repeat(40),
     html_url:
@@ -2205,7 +2333,14 @@ test("capture-main records every GitHub attempt and leaves provider probes unres
   const capture = JSON.parse(
     readFileSync(join(directory, "capture.json"), "utf8"),
   );
+  const storedRun = JSON.parse(
+    readFileSync(join(directory, "raw", "run.json"), "utf8"),
+  );
   assert.equal(capture.schema, MAIN_CAPTURE_SCHEMA);
+  assert.equal(capture.eventTimestampUtc, "2026-07-30T02:00:00.000Z");
+  assert.equal(capture.runCompletedAtUtc, "2026-07-30T02:12:00.000Z");
+  assert.equal(storedRun.created_at, "2026-07-30T02:00:00.000Z");
+  assert.equal(storedRun.updated_at, "2026-07-30T02:12:00.000Z");
   assert.equal(capture.canonicalDerivedFacts.jobCount, 1);
   assert.equal(
     capture.canonicalDerivedFacts.terminalRoute.outcome,
@@ -2223,7 +2358,7 @@ test("capture-main records every GitHub attempt and leaves provider probes unres
   assertPrivateTree(directory);
 
   run.run_attempt = 2;
-  run.updated_at = "2026-07-30T02:20:00.000Z";
+  run.updated_at = "2026-07-30T02:20:00Z";
   routes.set(
     "api --method GET --paginate --slurp repos/mento-protocol/frontend-monorepo/actions/runs/9100/attempts/2/jobs?filter=all&per_page=100",
     [


### PR DESCRIPTION
## The Problem

- The private Vercel-cost collector rejected canonical GitHub REST timestamps when GitHub omitted the zero-millisecond suffix, so a clean observation interval could not initialize or capture preview and main runs.
- The preview controller can canonically add its admission cursor either when creating a journal or later during reconciliation. Those two paths place the same validated field in different JSON key positions, but the collector accepted only the creation-time ordering.

## The Solution

- Accept GitHub's canonical whole-second and millisecond timestamp forms, then normalize both to the collector's stable millisecond UTC representation before storing or deriving evidence.
- Accept exactly the two preview-journal property orderings emitted by the controller while continuing to reject every other serialization.
- Add regression coverage for observation initialization, preview capture, and multi-attempt main capture using GitHub's whole-second timestamps, plus positive and negative journal-ordering cases.

## Validation

- `pnpm vercel:cost:test` — 89/89 tests passed.
- `trunk check scripts/vercel-cost-observation.mjs scripts/vercel-cost-observation.test.mjs` — passed.
- `git diff --check origin/main...HEAD` — passed.
- `pnpm adr:check --base origin/main --head HEAD` — passed with no reminder.
- Fresh-context semantic autoreview and the deterministic local guardrail — clean with no accepted findings.
- Browser verification: not applicable; this changes a credential-free CLI collector and its unit tests, not a user interface.

## Ship Checklist

- [x] PR title follows the [conventions](https://www.notion.so/Git-Branching-and-Commit-Message-Conventions-18f66f7d06444cfcbac5725ffbc7c04a?pvs=4#9355048863c549ef92fe210a8a1298aa)
- [x] Performed a self-review of my own changes
- [x] Relevant automated checks and smoke tests pass
- [x] Architecture decision? Not applicable — this is a compatibility fix within the existing private observation contract; it does not change a system boundary, workflow, or engineering policy.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to the credential-free observation CLI and unit tests; no auth, billing, or production runtime paths.
> 
> **Overview**
> Fixes **GitHub REST compatibility** for the private Vercel-cost observation collector so init, preview capture, and main capture no longer fail when GitHub omits millisecond suffixes on timestamps.
> 
> Adds **`githubUtc`**, which validates GitHub-style ISO UTC strings (with or without `.000`), normalizes them to stable millisecond form, and wires that through workflow run handling (`terminalRun` rewrites `created_at` / `updated_at`), boundary PR metadata, preview/main capture derived times, and stored raw run JSON.
> 
> **Preview journal canonicalization** now accepts exactly the two JSON property orderings the controller can emit when `admission` is present (field grouped with other keys vs. `admission` last); other serializations still fail.
> 
> Tests cover init boundary timestamps, preview/main capture normalization, and positive/negative admission-order cases via `githubWholeSecondTimestamps` fixtures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a26bef0e3202d61ae8911c41236be8d2aa3aa491. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->