### PR TITLE
fix: restore pinned Vercel CLI 56.4.1 pending reviewed runtime rotation

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "turbo": "^2.10.8",
     "typescript": "catalog:",
     "typescript-eslint": "catalog:",
-    "vercel": "56.5.0",
+    "vercel": "56.4.1",
     "yaml": "2.9.0"
   },
   "packageManager": "pnpm@10.34.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -219,8 +219,8 @@ importers:
         specifier: 'catalog:'
         version: 8.65.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3)
       vercel:
-        specifier: 56.5.0
-        version: 56.5.0(@vercel/container@0.0.5)(@vercel/go@3.10.2)(@vercel/hydrogen@1.4.0)(@vercel/next@4.20.4(rollup@4.59.0))(@vercel/redwood@2.5.0(rollup@4.59.0))(@vercel/remix-builder@5.9.1(rollup@4.59.0))(@vercel/ruby@2.5.1)(@vercel/rust@1.4.0)(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+        specifier: 56.4.1
+        version: 56.4.1(@vercel/container@0.0.5)(@vercel/go@3.10.2)(@vercel/hydrogen@1.4.0)(@vercel/next@4.20.4(rollup@4.59.0))(@vercel/redwood@2.5.0(rollup@4.59.0))(@vercel/remix-builder@5.9.1(rollup@4.59.0))(@vercel/ruby@2.5.1)(@vercel/rust@1.4.0)(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       yaml:
         specifier: 2.9.0
         version: 2.9.0
@@ -12519,7 +12519,6 @@ packages:
 
   stream-to-promise@2.2.0:
     resolution: {integrity: sha512-HAGUASw8NT0k8JvIVutB2Y/9iBk7gpgEyAudXwNJmZERdMITGdajOa4VJfD/kNiA3TppQpTP4J+CtcHwdzKBAw==}
-    deprecated: Deprecated. Use node:stream/promises and node:stream/consumers instead.
 
   streamx@2.28.0:
     resolution: {integrity: sha512-1Yowhzjf0ivGMrTIkY9hav5TxobO9qIVqUE41fiCGMGgc3CLlf4MY+9AHmZqBWgDTue0fY9zWjYFVyf6Diuobw==}
@@ -13276,8 +13275,8 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
       react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
 
-  vercel@56.5.0:
-    resolution: {integrity: sha512-wAKpT8DFSbnwlgbS711fbvxGjOfQeb1n+NcaBaSC4onq9eJAjbPfERrjrKE4GDsV8dkoBo0627lp0QxbLCGFiw==}
+  vercel@56.4.1:
+    resolution: {integrity: sha512-+CIEa0qcKm1RNBRhOvpo2l/yz28LMKSDuGeAYGx4/EkYyR5VOrXJZYV52WvqVARcxBAbH3Un2RRin8YGXMlcNg==}
     engines: {node: '>= 18'}
     hasBin: true
     peerDependencies:
@@ -13294,7 +13293,7 @@ packages:
       '@vercel/nestjs': 0.2.106
       '@vercel/next': 4.20.4
       '@vercel/node': 5.8.26
-      '@vercel/python': 6.51.1
+      '@vercel/python': 6.51.0
       '@vercel/redwood': 2.5.0
       '@vercel/remix-builder': 5.9.1
       '@vercel/ruby': 2.5.1
@@ -30849,7 +30848,7 @@ snapshots:
       - '@types/react'
       - '@types/react-dom'
 
-  vercel@56.5.0(@vercel/container@0.0.5)(@vercel/go@3.10.2)(@vercel/hydrogen@1.4.0)(@vercel/next@4.20.4(rollup@4.59.0))(@vercel/redwood@2.5.0(rollup@4.59.0))(@vercel/remix-builder@5.9.1(rollup@4.59.0))(@vercel/ruby@2.5.1)(@vercel/rust@1.4.0)(bufferutil@4.1.0)(utf-8-validate@5.0.10):
+  vercel@56.4.1(@vercel/container@0.0.5)(@vercel/go@3.10.2)(@vercel/hydrogen@1.4.0)(@vercel/next@4.20.4(rollup@4.59.0))(@vercel/redwood@2.5.0(rollup@4.59.0))(@vercel/remix-builder@5.9.1(rollup@4.59.0))(@vercel/ruby@2.5.1)(@vercel/rust@1.4.0)(bufferutil@4.1.0)(utf-8-validate@5.0.10):
     dependencies:
       '@vercel/blob': 2.4.0
       '@vercel/build-utils': 13.34.0


### PR DESCRIPTION
## The Problem

#716 was merged with the `vercel` 56.4.1 → 56.5.0 bump included, but the trusted Vercel CLI runtime contract (`scripts/vercel-cli-runtime-contract.mjs`) still pins `PINNED_VERCEL_CLI_VERSION = "56.4.1"`. Since that merge:

- the three contract unit tests fail on **main** and on every PR's merge ref (see #705's unrelated failures)
- `assertDeploymentIdPrerequisites` throws, blocking the protected Vercel deploy workflows

## The Solution

Restore `vercel` to the reviewed **56.4.1** pin (root `package.json` + lockfile). The other seven tooling bumps from #716 are kept.

Upgrading to 56.5.0 for real requires the full reviewed runtime rotation — contract version + `@vercel/*` dependency map, runtime mirror manifest and lockfile, digest pins — and should land as its own deliberate PR (related: #720).

## Verification

- `node --test scripts/vercel-prebuilt.test.mjs` — 16/16 pass
- `pnpm install --frozen-lockfile`, `version-skew-check`, `lockfile-lint` — all pass

## Follow-up

Exclude `vercel` from the `tooling` dependabot group (`exclude-patterns`) so this cannot recur — the pinned CLI can only move via the rotation procedure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)