### PR TITLE
fix(ci): read dispatch event from runner path

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -36,6 +36,15 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Reject candidate marketplace path collision
+        shell: bash
+        run: |
+          marketplace_path="$GITHUB_WORKSPACE/.claude-code-plugin-marketplace"
+          if [[ -e "$marketplace_path" || -L "$marketplace_path" ]]; then
+            echo "::error::Candidate content occupies the trusted marketplace path"
+            exit 1
+          fi
+
       - name: Checkout pinned Claude plugin marketplace
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -46,6 +55,16 @@ jobs:
             .claude-plugin
             plugins/code-review
           persist-credentials: false
+
+      - name: Verify pinned Claude plugin marketplace
+        shell: bash
+        env:
+          EXPECTED_MARKETPLACE_SHA: 2bb60696142b493eafaeacfe00eac51d16c50c4f
+        run: |
+          marketplace_path="$GITHUB_WORKSPACE/.claude-code-plugin-marketplace"
+          [[ -d "$marketplace_path" && ! -L "$marketplace_path" ]]
+          actual_sha="$(git -C "$marketplace_path" rev-parse HEAD)"
+          [[ "$actual_sha" == "$EXPECTED_MARKETPLACE_SHA" ]]
 
       - name: Run Claude Code Review
         id: claude-review-human

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -36,12 +36,23 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Checkout pinned Claude plugin marketplace
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: anthropics/claude-code
+          ref: 2bb60696142b493eafaeacfe00eac51d16c50c4f
+          path: .claude-code-plugin-marketplace
+          sparse-checkout: |
+            .claude-plugin
+            plugins/code-review
+          persist-credentials: false
+
       - name: Run Claude Code Review
         id: claude-review-human
         uses: anthropics/claude-code-action@be7b93b1907a4abad570368f3c74b6fe3807510b # v1.0.183
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          plugin_marketplaces: https://github.com/anthropics/claude-code.git#2bb60696142b493eafaeacfe00eac51d16c50c4f
+          plugin_marketplaces: ./.claude-code-plugin-marketplace
           plugins: code-review@claude-code-plugins
           prompt: "/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}"
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md

--- a/.github/workflows/dependabot-process.yml
+++ b/.github/workflows/dependabot-process.yml
@@ -67,7 +67,6 @@ jobs:
         env:
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
           EVENT_NAME: ${{ github.event_name }}
-          EVENT_PATH: ${{ github.event_path }}
           INTAKE_ACTOR_LOGIN: ${{ github.event.workflow_run.actor.login }}
           INTAKE_ACTOR_TYPE: ${{ github.event.workflow_run.actor.type }}
           INTAKE_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
@@ -141,7 +140,7 @@ jobs:
                 import { readFileSync } from "node:fs";
 
                 const payload = JSON.parse(
-                  readFileSync(process.env.EVENT_PATH, "utf8"),
+                  readFileSync(process.env.GITHUB_EVENT_PATH, "utf8"),
                 );
                 const clientPayload = payload.client_payload;
                 if (

--- a/scripts/dependabot-workflows.test.mjs
+++ b/scripts/dependabot-workflows.test.mjs
@@ -3,10 +3,12 @@ import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
 import {
   existsSync,
+  mkdirSync,
   mkdtempSync,
   readFileSync,
   readdirSync,
   rmSync,
+  symlinkSync,
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
@@ -846,9 +848,20 @@ test("human Claude review cannot shadow the Dependabot review check", () => {
   assert.match(job.if, /pull_request\.user\.type == 'User'/);
   assert.equal(humanReview.jobs["claude-review"], undefined);
 
-  const marketplaceCheckout = job.steps.find(
+  const guardIndex = job.steps.findIndex(
+    (step) => step.name === "Reject candidate marketplace path collision",
+  );
+  const marketplaceCheckoutIndex = job.steps.findIndex(
     (step) => step.name === "Checkout pinned Claude plugin marketplace",
   );
+  assert.ok(guardIndex >= 0);
+  assert.equal(marketplaceCheckoutIndex, guardIndex + 1);
+  const marketplaceGuard = job.steps[guardIndex];
+  assert.match(marketplaceGuard.run, /GITHUB_WORKSPACE/);
+  assert.match(marketplaceGuard.run, /-e "\$marketplace_path"/);
+  assert.match(marketplaceGuard.run, /-L "\$marketplace_path"/);
+
+  const marketplaceCheckout = job.steps[marketplaceCheckoutIndex];
   assert.ok(marketplaceCheckout);
   assert.equal(
     marketplaceCheckout.uses,
@@ -863,10 +876,52 @@ test("human Claude review cannot shadow the Dependabot review check", () => {
     [".claude-plugin", "plugins/code-review"],
   );
 
+  const marketplaceVerification = job.steps[marketplaceCheckoutIndex + 1];
+  assert.equal(
+    marketplaceVerification.name,
+    "Verify pinned Claude plugin marketplace",
+  );
+  assert.equal(
+    marketplaceVerification.env.EXPECTED_MARKETPLACE_SHA,
+    claudePluginMarketplaceRef,
+  );
+  assert.match(marketplaceVerification.run, /! -L "\$marketplace_path"/);
+  assert.match(
+    marketplaceVerification.run,
+    /git -C "\$marketplace_path" rev-parse HEAD/,
+  );
+
   const review = job.steps.find((step) => step.uses === claudeAction);
   assert.ok(review);
   assert.equal(review.with.plugin_marketplaces, claudePluginMarketplace);
   assert.equal(Object.hasOwn(review.with, "allowed_bots"), false);
+});
+
+test("human Claude review rejects a candidate marketplace symlink", () => {
+  const guard = humanReview.jobs["claude-review-human"].steps.find(
+    (step) => step.name === "Reject candidate marketplace path collision",
+  );
+  assert.ok(guard);
+
+  const workspace = mkdtempSync(join(tmpdir(), "claude-review-workspace-"));
+  try {
+    const redirect = join(workspace, "redirect");
+    mkdirSync(redirect);
+    symlinkSync(
+      redirect,
+      join(workspace, claudePluginMarketplace.slice(2)),
+      "dir",
+    );
+    const result = spawnSync("bash", ["-c", guard.run], {
+      encoding: "utf8",
+      env: { PATH: process.env.PATH, GITHUB_WORKSPACE: workspace },
+    });
+    assert.notEqual(result.status, 0);
+    assert.match(result.stdout, /Candidate content occupies/);
+    assert.deepEqual(readdirSync(redirect), []);
+  } finally {
+    rmSync(workspace, { force: true, recursive: true });
+  }
 });
 
 test("the processor is the sole Dependabot merge authority", () => {

--- a/scripts/dependabot-workflows.test.mjs
+++ b/scripts/dependabot-workflows.test.mjs
@@ -154,7 +154,7 @@ function runBashStep(step, env, eventPayload) {
         PATH: process.env.PATH,
         GITHUB_OUTPUT: githubOutput,
         ...env,
-        ...(eventPayload === undefined ? {} : { EVENT_PATH: eventPath }),
+        ...(eventPayload === undefined ? {} : { GITHUB_EVENT_PATH: eventPath }),
       },
     });
     return {
@@ -335,6 +335,10 @@ test("read-only evaluation authenticates every trigger before live collection", 
   );
   assert.ok(target);
   assert.match(target.run, /Object\.keys\(clientPayload\)\.sort\(\)/);
+  assert.match(target.run, /process\.env\.GITHUB_EVENT_PATH/);
+  assert.equal(Object.hasOwn(target.env, "EVENT_PATH"), false);
+  assert.equal(Object.hasOwn(target.env, "GITHUB_EVENT_PATH"), false);
+  assert.doesNotMatch(JSON.stringify(target.env), /github\.event_path/);
   assert.match(target.run, /\["scope"\]/);
   assert.doesNotMatch(target.run, /clientPayload\.(?:repository|schema)/);
   assert.match(target.run, /dependabot-intake:v1/);
@@ -401,6 +405,16 @@ test("processor accepts a live-shaped repository dispatch envelope", () => {
 
   assert.equal(result.status, 0, result.stderr);
   assert.equal(result.githubOutput, "pr_numbers=all\nexpected_head_sha=\n");
+});
+
+test("processor fails closed without the runner event path", () => {
+  const target = processor.jobs.evaluate.steps.find(
+    (step) => step.name === "Validate trigger and select a bounded target",
+  );
+  const result = runBashStep(target, liveRepositoryDispatchEnvironment());
+
+  assert.notEqual(result.status, 0);
+  assert.equal(result.githubOutput, "");
 });
 
 test("processor rejects malformed repository dispatch envelopes", () => {

--- a/scripts/dependabot-workflows.test.mjs
+++ b/scripts/dependabot-workflows.test.mjs
@@ -48,8 +48,8 @@ const humanReview = workflow(humanReviewPath);
 
 const claudeAction =
   "anthropics/claude-code-action@be7b93b1907a4abad570368f3c74b6fe3807510b";
-const claudePluginMarketplace =
-  "https://github.com/anthropics/claude-code.git#2bb60696142b493eafaeacfe00eac51d16c50c4f";
+const claudePluginMarketplace = "./.claude-code-plugin-marketplace";
+const claudePluginMarketplaceRef = "2bb60696142b493eafaeacfe00eac51d16c50c4f";
 
 const forbiddenCandidateSurfaces =
   /actions\/(?:download-artifact|upload-artifact|cache)@|cache-dependency-path|gh pr checkout|git (?:checkout|switch|fetch)|node_modules|pnpm install|npm (?:ci|install)|yarn install/;
@@ -845,6 +845,23 @@ test("human Claude review cannot shadow the Dependabot review check", () => {
   assert.match(job.if, /head\.repo\.full_name == github\.repository/);
   assert.match(job.if, /pull_request\.user\.type == 'User'/);
   assert.equal(humanReview.jobs["claude-review"], undefined);
+
+  const marketplaceCheckout = job.steps.find(
+    (step) => step.name === "Checkout pinned Claude plugin marketplace",
+  );
+  assert.ok(marketplaceCheckout);
+  assert.equal(
+    marketplaceCheckout.uses,
+    "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1",
+  );
+  assert.equal(marketplaceCheckout.with.repository, "anthropics/claude-code");
+  assert.equal(marketplaceCheckout.with.ref, claudePluginMarketplaceRef);
+  assert.equal(marketplaceCheckout.with.path, claudePluginMarketplace.slice(2));
+  assert.equal(marketplaceCheckout.with["persist-credentials"], false);
+  assert.deepEqual(
+    marketplaceCheckout.with["sparse-checkout"].trim().split("\n"),
+    [".claude-plugin", "plugins/code-review"],
+  );
 
   const review = job.steps.find((step) => step.uses === claudeAction);
   assert.ok(review);


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## The Problem

The first live all-open Dependabot sweep failed before policy evaluation. In [run 31437040953](https://github.com/mento-protocol/frontend-monorepo/actions/runs/31437040953), `${{ github.event_path }}` produced an empty `EVENT_PATH`, so the validator tried to read an empty path and exited with `ENOENT`.

The first CI run on this hotfix then exposed a second production defect in [run 31437614548](https://github.com/mento-protocol/frontend-monorepo/actions/runs/31437614548): the pinned Claude action rejects marketplace Git URLs containing `#<commit>` before invoking Claude Code, so the human review job could never start.

## The Solution

Read the runner-provided `GITHUB_EVENT_PATH` directly. The executable workflow harness now uses the same default environment variable, rejects a missing path, and prevents a custom workflow mapping from shadowing it.

Check out the Claude plugin marketplace at the existing immutable commit with the pinned checkout action, limit it to the manifest and `code-review` plugin, disable persisted credentials, and give the Claude action the supported local marketplace path. Reject any candidate file, directory, or symlink at that path before checkout, then verify the resulting directory and exact commit before Claude runs. This preserves the exact marketplace pin without falling back to its moving default branch or following a candidate-controlled redirect.

## Validation

- `pnpm dependabot:process:test` — 124/124 pass
- `node --test scripts/dependabot-workflows.test.mjs` — 21/21 pass, including an executable symlink-redirect regression
- `pnpm ci:action-pins` and `pnpm ci:action-pins:test` — pass (48 action-pin tests and 11 source tests)
- `trunk check .github/workflows/dependabot-process.yml .github/workflows/claude-code-review.yml scripts/dependabot-workflows.test.mjs` — pass
- `pnpm adr:check --include-untracked` — pass
- Pre-push Trunk, workspace type checks, builds, and Knip — pass
- Fresh-context semantic autoreview cycle 1 found one path-boundary issue; cycle 2 verified the accepted fix with no remaining findings
- Deterministic autoreview — no findings

The dispatch API contract and reviewer policy are unchanged. Both failed runs are pinned to older workflow revisions; end-to-end verification requires new runs after this fix reaches `main`.

## Ship Checklist

- [x] PR title follows the [conventions](https://www.notion.so/Git-Branching-and-Commit-Message-Conventions-18f66f7d06444cfcbac5725ffbc7c04a?pvs=4#9355048863c549ef92fe210a8a1298aa)
- [x] Performed a self-review of my own changes
- [x] Relevant automated checks and smoke tests pass
- [x] Architecture decision? Not applicable — this restores the already-approved repository-dispatch contract without changing architecture.
