### PR TITLE
fix(ci): resolve rewritten post-merge receipts

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -71,8 +71,7 @@ jobs:
         uses: anthropics/claude-code-action@be7b93b1907a4abad570368f3c74b6fe3807510b # v1.0.183
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          plugin_marketplaces: ./.claude-code-plugin-marketplace
-          plugins: code-review@claude-code-plugins
+          claude_args: --plugin-dir ./.claude-code-plugin-marketplace/plugins/code-review
           prompt: "/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}"
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options

--- a/docs/adr/0006-dependabot-processing-controller.md
+++ b/docs/adr/0006-dependabot-processing-controller.md
@@ -416,6 +416,31 @@ keeps subsequent automated dependency merges blocked and routes through the
 existing recovery and managed-failure process. It is never repaired by pushing
 more commits to the already-merged Dependabot branch.
 
+The Vercel result publisher binds the proof to its Actions run URL and strict
+`dependabot-post-merge:<run-id>:<run-attempt>` external ID. GitHub's Checks API
+can return the check's generated `/runs/<check-id>` self URL even though the
+publisher submitted the Actions URL. That self URL identifies only the exact
+check; it does not identify a trusted workflow run. The controller may resolve
+this exact post-merge check only through the external-ID run and attempt, then
+must re-query and validate the exact `Vercel Main Deployment` `workflow_run`:
+source repository, `.github/workflows/vercel-main-deployment.yml` path,
+`workflow_run` event, `main` head branch, exact current-main head SHA, run ID,
+run attempt, completed status, and successful conclusion. The independently
+queried workflow `head_sha` must be present and exact; the check head is never a
+fallback. Every malformed or mismatched URL, envelope, or workflow-run field,
+including a pending or failed run, fails closed.
+
+For duplicate raw exact-name, exact-head receipts, the controller chooses the
+newest immutable GitHub check-run publication ID before workflow provenance
+resolution and enriches only that check. An unavailable obsolete run reference
+therefore cannot block a newer receipt, while failure to resolve the selected
+newest receipt remains fail closed. A newer malformed or unsuccessful receipt
+blocks an older success. Each authority-bearing check collection or
+recollection re-fetches the mutable workflow-run attempt, status, and
+conclusion. Workflow-run caching and deduplication are scoped to one collection,
+and distinct run resolutions use bounded concurrency to prevent GitHub
+secondary-rate-limit bursts. The cache never crosses a recollection boundary.
+
 ## Alternatives considered
 
 ### Extend the former auto-merge workflow in place

--- a/docs/dependabot-automation.md
+++ b/docs/dependabot-automation.md
@@ -646,6 +646,33 @@ including one left by an earlier controller or operator.
 Because the Vercel controller admits only an exact successful `CI/CD` main run,
 missing or failed main CI cannot produce this receipt.
 
+The publisher submits the exact Actions run URL as `details_url` and the stable
+`dependabot-post-merge:<run-id>:<run-attempt>` envelope as `external_id`.
+GitHub's Checks API can later return the check's generated
+`/runs/<check-id>` self URL in `details_url` instead of that submitted Actions
+URL. Treat that value only as a GitHub representation of the exact check. For
+this one check name and exact check ID, resolve the workflow run and attempt
+only from the strict `external_id` envelope, then re-query the Actions run.
+Require the returned run ID and attempt to match the envelope and validate the
+expected repository, `.github/workflows/vercel-main-deployment.yml` path,
+`workflow_run` event, `main` head branch, independently returned `head_sha`
+against the exact current-main SHA, completed status, and successful
+conclusion. The workflow `head_sha` must be present; never substitute the
+check's head SHA. No other self URL, malformed envelope, pending or failed run,
+or mismatched run supplies release proof.
+
+When several raw exact-name, exact-head post-merge checks exist, select the
+newest one by its immutable GitHub check-run publication ID before resolving
+workflow provenance. Resolve and enrich only that selected check, so an
+unavailable obsolete run reference cannot block a newer receipt. Never fall
+back to an older success: failure to resolve the selected check, or a newer
+malformed, pending, failed, or untrusted receipt, blocks the lane. Every
+authority-bearing check collection or recollection must re-fetch the underlying
+workflow run because its attempt, status, and conclusion can change. A run
+lookup may be cached and deduplicated only within that single collection, and
+distinct run resolutions use bounded concurrency to prevent GitHub
+secondary-rate-limit bursts. No later collection may reuse the cache.
+
 If main CI or release proof fails, stop the dependency queue. Use the managed
 failure issue and deployment recovery runbook. Do not push to the merged
 Dependabot branch or merge the next update to test whether it masks the issue.

--- a/scripts/dependabot-processor.mjs
+++ b/scripts/dependabot-processor.mjs
@@ -47,6 +47,7 @@ const REVIEW_THREAD_COMMENT_LIMIT = 100;
 const REVIEW_ENVELOPE_BODY_LIMIT = 50_000;
 const REPAIR_LINEAGE_COMMIT_LIMIT = 100;
 const REPAIR_LINEAGE_CHECK_CONCURRENCY = 4;
+const CHECK_SOURCE_RESOLUTION_CONCURRENCY = 8;
 const PROCESSOR_APPROVAL_PULL_LIMIT = 100;
 const PROCESSOR_APPROVAL_REVIEW_LIMIT = 2_000;
 const PROCESSOR_APPROVAL_RESULT_LIMIT = 1_000;
@@ -59,8 +60,11 @@ const PULL_REQUEST_REVIEW_STATES = new Set([
   "PENDING",
 ]);
 const PROCESSOR_CHECK_NAME = "Dependabot Processor";
+const POST_MERGE_CHECK_NAME = "Dependabot Post-Merge Verification";
 const PROCESSOR_REPAIR_RECEIPT_PATTERN =
   /^dependabot-processor:v1:pr=([1-9][0-9]{0,9}):head=([0-9a-f]{40}):mode=(observe|assist|merge):repair=([1-9][0-9]*):packet=(true|false)$/;
+const POST_MERGE_EXTERNAL_ID_PATTERN =
+  /^dependabot-post-merge:([1-9][0-9]*):([1-9][0-9]*)$/;
 const CLAUDE_REVIEW_RECEIPT_PATTERN =
   /^dependabot-claude-review:v1 \| source=dependabot-intake:v1 \| repository=([A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+) \| pr=([1-9][0-9]{0,9}) \| sha=([0-9a-f]{40}) \| action=(opened|synchronize|reopened) \| receipt=true$/;
 const CLAUDE_REVIEW_EXTERNAL_ID_PATTERN =
@@ -302,7 +306,7 @@ const CHECK_SOURCE_POLICY = Object.freeze({
 const POST_MERGE_CHECK_DEFINITION = Object.freeze({
   id: "post-merge-verification",
   label: "Dependabot post-merge verification",
-  names: [/^Dependabot Post-Merge Verification$/],
+  names: [new RegExp(`^${POST_MERGE_CHECK_NAME}$`)],
 });
 
 export const DEPENDABOT_PROCESSOR_HELP = `Usage:
@@ -1020,6 +1024,11 @@ function normalizeCheck(check, assumedHeadSha) {
     check?.createdAt ??
     check?.created_at ??
     "";
+  const runHeadSha = Object.hasOwn(check ?? {}, "runHeadSha")
+    ? (check.runHeadSha ?? null)
+    : Object.hasOwn(check?.source ?? {}, "runHeadSha")
+      ? (check.source.runHeadSha ?? null)
+      : null;
   return {
     appId: Number(check?.appId ?? check?.app?.id ?? check?.source?.appId ?? 0),
     conclusion,
@@ -1043,12 +1052,13 @@ function normalizeCheck(check, assumedHeadSha) {
     runAttempt: Number(
       check?.runAttempt ?? check?.run_attempt ?? check?.source?.runAttempt ?? 0,
     ),
-    runHeadSha:
-      check?.runHeadSha ?? check?.source?.runHeadSha ?? check?.headSha ?? null,
+    runHeadSha,
     runHeadBranch: check?.runHeadBranch ?? check?.source?.runHeadBranch ?? null,
     runDisplayTitle:
       check?.runDisplayTitle ?? check?.source?.runDisplayTitle ?? null,
+    runConclusion: check?.runConclusion ?? check?.source?.runConclusion ?? null,
     runId: Number(check?.runId ?? check?.source?.runId ?? 0),
+    runStatus: check?.runStatus ?? check?.source?.runStatus ?? null,
     sourceRepository:
       check?.sourceRepository ?? check?.source?.repository ?? null,
     status,
@@ -1077,6 +1087,15 @@ function compareChecks(left, right) {
     String(right.timestamp),
   );
   return timestampComparison || left.id - right.id;
+}
+
+function comparePostMergeChecks(left, right) {
+  const leftIdValid = Number.isSafeInteger(left.id) && left.id > 0;
+  const rightIdValid = Number.isSafeInteger(right.id) && right.id > 0;
+  if (leftIdValid !== rightIdValid) return leftIdValid ? -1 : 1;
+  const idComparison = left.id - right.id;
+  if (idComparison !== 0) return idComparison;
+  return String(left.timestamp).localeCompare(String(right.timestamp));
 }
 
 function trustedCheckSource(
@@ -1132,6 +1151,47 @@ function trustedCheckSource(
     ) {
       return { reason: "vercel-preview-run-url-mismatch", trusted: false };
     }
+  } else if (definition.id === "post-merge-verification") {
+    const externalReceipt = POST_MERGE_EXTERNAL_ID_PATTERN.exec(
+      String(check.externalId ?? ""),
+    );
+    if (!externalReceipt) {
+      return { reason: "invalid-post-merge-receipt", trusted: false };
+    }
+    const externalRunId = Number(externalReceipt[1]);
+    const externalRunAttempt = Number(externalReceipt[2]);
+    if (
+      !Number.isSafeInteger(externalRunId) ||
+      externalRunId < 1 ||
+      !Number.isSafeInteger(externalRunAttempt) ||
+      externalRunAttempt < 1 ||
+      externalRunId !== check.runId ||
+      externalRunAttempt !== check.runAttempt
+    ) {
+      return {
+        reason: "post-merge-run-identity-mismatch",
+        trusted: false,
+      };
+    }
+    if (check.runHeadBranch !== "main" || check.runHeadSha !== headSha) {
+      return { reason: "untrusted-post-merge-source-ref", trusted: false };
+    }
+    if (check.runStatus !== "completed" || check.runConclusion !== "success") {
+      return {
+        reason: "post-merge-workflow-not-successful",
+        trusted: false,
+      };
+    }
+    if (!Number.isSafeInteger(check.id) || check.id < 1) {
+      return { reason: "invalid-post-merge-check-id", trusted: false };
+    }
+    const allowedDetailsUrls = new Set([
+      `https://github.com/${repository}/actions/runs/${check.runId}`,
+      `https://github.com/${repository}/runs/${check.id}`,
+    ]);
+    if (!allowedDetailsUrls.has(check.detailsUrl)) {
+      return { reason: "post-merge-run-url-mismatch", trusted: false };
+    }
   } else if (definition.id === "claude-review") {
     const displayReceipt = CLAUDE_REVIEW_RECEIPT_PATTERN.exec(
       String(check.runDisplayTitle ?? ""),
@@ -1183,6 +1243,7 @@ function trustedCheckSource(
     return { reason: "invalid-workflow-run-id", trusted: false };
   }
   if (
+    definition.id !== "post-merge-verification" &&
     check.detailsUrl &&
     !check.detailsUrl.includes(`/actions/runs/${check.runId}`)
   ) {
@@ -1193,6 +1254,10 @@ function trustedCheckSource(
 
 export function selectLatestExactHeadCheck(checks, headSha, definition) {
   exactSha(headSha, "Expected check head SHA");
+  const compare =
+    definition.id === "post-merge-verification"
+      ? comparePostMergeChecks
+      : compareChecks;
   const candidates = checks
     .map((check) => normalizeCheck(check))
     .filter(
@@ -1200,7 +1265,7 @@ export function selectLatestExactHeadCheck(checks, headSha, definition) {
         check.headSha === headSha &&
         definition.names.some((pattern) => pattern.test(check.name)),
     )
-    .sort(compareChecks);
+    .sort(compare);
   return candidates.at(-1) ?? null;
 }
 
@@ -2759,35 +2824,44 @@ export function createLiveGitHubAdapter({
     return payload.data;
   };
 
-  const workflowRunCache = new Map();
-  const workflowRunSource = async (repository, url) => {
-    const match = /\/actions\/runs\/([1-9][0-9]*)/.exec(String(url ?? ""));
-    if (!match) return null;
-    const runId = Number(match[1]);
-    const key = `${repository}:${runId}`;
-    if (!workflowRunCache.has(key)) {
-      workflowRunCache.set(
-        key,
-        request("GET", `/repos/${repository}/actions/runs/${runId}`).then(
-          ({ data }) => ({
-            runDisplayTitle: data.display_title,
-            runHeadBranch: data.head_branch,
-            sourceRepository: data.repository?.full_name,
-            runAttempt: data.run_attempt,
-            runHeadSha: data.head_sha,
-            runId: data.id,
-            workflowEvent: data.event,
-            workflowPath: String(data.path ?? "").replace(/@.*$/, ""),
-          }),
-        ),
-      );
-    }
-    return workflowRunCache.get(key);
-  };
-
   const getChecks = async (repository, sha) => {
     exactSha(sha);
-    const checkRuns = [];
+    const workflowRunCache = new Map();
+    const workflowRunSource = async (url, check = {}) => {
+      const match = /\/actions\/runs\/([1-9][0-9]*)/.exec(String(url ?? ""));
+      const externalReceipt = POST_MERGE_EXTERNAL_ID_PATTERN.exec(
+        String(check.externalId ?? ""),
+      );
+      const exactPostMergeSelfUrl =
+        check.name === POST_MERGE_CHECK_NAME &&
+        Number.isSafeInteger(check.id) &&
+        check.id > 0 &&
+        url === `https://github.com/${repository}/runs/${check.id}`;
+      if (!match && (!exactPostMergeSelfUrl || !externalReceipt)) return null;
+      const runId = Number(match?.[1] ?? externalReceipt[1]);
+      if (!Number.isSafeInteger(runId) || runId < 1) return null;
+      if (!workflowRunCache.has(runId)) {
+        workflowRunCache.set(
+          runId,
+          request("GET", `/repos/${repository}/actions/runs/${runId}`).then(
+            ({ data }) => ({
+              runDisplayTitle: data.display_title,
+              runHeadBranch: data.head_branch,
+              runConclusion: data.conclusion,
+              sourceRepository: data.repository?.full_name,
+              runAttempt: data.run_attempt,
+              runHeadSha: data.head_sha ?? null,
+              runId: data.id,
+              runStatus: data.status,
+              workflowEvent: data.event,
+              workflowPath: String(data.path ?? "").replace(/@.*$/, ""),
+            }),
+          ),
+        );
+      }
+      return workflowRunCache.get(runId);
+    };
+    const rawCheckRuns = [];
     let page = 1;
     while (page <= 20) {
       const response = await request(
@@ -2796,50 +2870,84 @@ export function createLiveGitHubAdapter({
       );
       const runs = response.data?.check_runs;
       invariant(Array.isArray(runs), "GitHub check-runs response is invalid");
-      checkRuns.push(
-        ...(await Promise.all(
-          runs.map(async (run) => ({
-            ...(await workflowRunSource(repository, run.details_url)),
-            appId: run.app?.id,
-            completedAt: run.completed_at,
-            conclusion: run.conclusion,
-            detailsUrl: run.details_url,
-            externalId: run.external_id,
-            headSha: run.head_sha,
-            id: run.id,
-            name: run.name,
-            startedAt: run.started_at,
-            status: run.status,
-            kind: "check",
-          })),
-        )),
-      );
+      rawCheckRuns.push(...runs);
       if (runs.length < 100) break;
       page += 1;
     }
     invariant(page <= 20, "GitHub check-run pagination limit exceeded");
+    const newestPostMergeCheck = selectLatestExactHeadCheck(
+      rawCheckRuns,
+      sha,
+      POST_MERGE_CHECK_DEFINITION,
+    );
+    const enrichCheckRun = async (run) => {
+      const isPostMergeCheck = run.name === POST_MERGE_CHECK_NAME;
+      const isSelectedPostMergeCheck =
+        isPostMergeCheck &&
+        run.head_sha === sha &&
+        Number(run.id) === newestPostMergeCheck?.id;
+      const source =
+        !isPostMergeCheck || isSelectedPostMergeCheck
+          ? await workflowRunSource(run.details_url, {
+              externalId: run.external_id,
+              id: Number(run.id),
+              name: run.name,
+            })
+          : null;
+      return {
+        ...source,
+        appId: run.app?.id,
+        completedAt: run.completed_at,
+        conclusion: run.conclusion,
+        detailsUrl: run.details_url,
+        externalId: run.external_id,
+        headSha: run.head_sha,
+        id: run.id,
+        name: run.name,
+        startedAt: run.started_at,
+        status: run.status,
+        kind: "check",
+      };
+    };
+    const mapWithSourceResolutionLimit = async (items, mapper) => {
+      const resolved = [];
+      for (
+        let index = 0;
+        index < items.length;
+        index += CHECK_SOURCE_RESOLUTION_CONCURRENCY
+      ) {
+        resolved.push(
+          ...(await Promise.all(
+            items
+              .slice(index, index + CHECK_SOURCE_RESOLUTION_CONCURRENCY)
+              .map(mapper),
+          )),
+        );
+      }
+      return resolved;
+    };
+    const checkRuns = await mapWithSourceResolutionLimit(
+      rawCheckRuns,
+      enrichCheckRun,
+    );
     const statuses = await paginate(
       `/repos/${repository}/commits/${sha}/statuses`,
     );
     return [
       ...checkRuns,
-      ...(await Promise.all(
-        statuses.map(async (status) => ({
-          ...(await workflowRunSource(repository, status.target_url)),
-          creatorLogin: status.creator?.login,
-          conclusion: status.state,
-          description: status.description,
-          detailsUrl: status.target_url,
-          headSha: sha,
-          id: status.id,
-          name: status.context,
-          kind: "status",
-          status: PENDING_STATUSES.has(status.state)
-            ? status.state
-            : "completed",
-          updatedAt: status.updated_at,
-        })),
-      )),
+      ...(await mapWithSourceResolutionLimit(statuses, async (status) => ({
+        ...(await workflowRunSource(status.target_url)),
+        creatorLogin: status.creator?.login,
+        conclusion: status.state,
+        description: status.description,
+        detailsUrl: status.target_url,
+        headSha: sha,
+        id: status.id,
+        name: status.context,
+        kind: "status",
+        status: PENDING_STATUSES.has(status.state) ? status.state : "completed",
+        updatedAt: status.updated_at,
+      }))),
     ];
   };
 

--- a/scripts/dependabot-processor.mjs
+++ b/scripts/dependabot-processor.mjs
@@ -1092,6 +1092,8 @@ function compareChecks(left, right) {
 function comparePostMergeChecks(left, right) {
   const leftIdValid = Number.isSafeInteger(left.id) && left.id > 0;
   const rightIdValid = Number.isSafeInteger(right.id) && right.id > 0;
+  // Select unorderable exact-name/head evidence so it fails closed instead of
+  // letting an older valid publication authorize the merge lane.
   if (leftIdValid !== rightIdValid) return leftIdValid ? -1 : 1;
   const idComparison = left.id - right.id;
   if (idComparison !== 0) return idComparison;

--- a/scripts/dependabot-processor.test.mjs
+++ b/scripts/dependabot-processor.test.mjs
@@ -153,13 +153,17 @@ function postMergeReceipt(headSha = BASE_SHA) {
     completedAt: "2026-08-10T10:00:00Z",
     conclusion: "success",
     detailsUrl: `https://github.com/${REPOSITORY}/actions/runs/99`,
+    externalId: "dependabot-post-merge:99:1",
     headSha,
-    id: 99,
+    id: 100,
     kind: "check",
     name: "Dependabot Post-Merge Verification",
     runAttempt: 1,
+    runConclusion: "success",
+    runHeadBranch: "main",
     runHeadSha: headSha,
     runId: 99,
+    runStatus: "completed",
     sourceRepository: REPOSITORY,
     status: "completed",
     workflowEvent: "workflow_run",
@@ -297,6 +301,21 @@ function snapshot(overrides = {}) {
     ...overrides,
     feedback,
   };
+}
+
+function evaluateMergeSerializationReceipt(receipt) {
+  const current = snapshot();
+  current.baseline.checks = [
+    ...current.baseline.checks.filter(
+      ({ name }) => name !== "Dependabot Post-Merge Verification",
+    ),
+    receipt,
+  ];
+  return evaluateDependabotSweep({
+    mode: "merge",
+    pullRequests: [current],
+    repository: REPOSITORY,
+  });
 }
 
 function withCurrentProcessorApproval(current, approvalId = 7001) {
@@ -2627,6 +2646,121 @@ test("blocks merge serialization without an exact trusted main receipt", () => {
   );
 });
 
+test("post-merge serialization binds an exact Actions receipt to its trusted workflow run", () => {
+  const actionsReceipt = evaluateMergeSerializationReceipt(
+    postMergeReceipt(BASE_SHA),
+  );
+  assert.equal(actionsReceipt.serialization.ready, true);
+  assert.equal(
+    actionsReceipt.serialization.reason,
+    "exact-main-post-merge-receipt-passed",
+  );
+  assert.deepEqual(actionsReceipt.mergeCandidate, {
+    headSha: HEAD_SHA,
+    pullRequestNumber: 123,
+  });
+
+  const validReceipt = postMergeReceipt(BASE_SHA);
+  const cases = [
+    ["malformed external ID", { externalId: "dependabot-post-merge:invalid" }],
+    [
+      "mismatched external run ID",
+      { externalId: "dependabot-post-merge:100:1" },
+    ],
+    [
+      "mismatched external attempt",
+      { externalId: "dependabot-post-merge:99:2" },
+    ],
+    [
+      "wrong Actions run URL",
+      { detailsUrl: `https://github.com/${REPOSITORY}/actions/runs/100` },
+    ],
+    [
+      "wrong self check URL",
+      {
+        detailsUrl: `https://github.com/${REPOSITORY}/runs/101`,
+        id: 100,
+      },
+    ],
+    ["wrong source repository", { sourceRepository: "attacker/repository" }],
+    ["wrong workflow path", { workflowPath: ".github/workflows/ci.yml" }],
+    ["wrong workflow event", { workflowEvent: "push" }],
+    ["wrong workflow branch", { runHeadBranch: "release" }],
+    ["wrong workflow head", { runHeadSha: OTHER_SHA }],
+    ["wrong workflow attempt", { runAttempt: 2 }],
+    ["failed workflow run", { runConclusion: "failure" }],
+    [
+      "in-progress workflow run",
+      { runConclusion: null, runStatus: "in_progress" },
+    ],
+  ];
+  for (const [label, override] of cases) {
+    const result = evaluateMergeSerializationReceipt({
+      ...validReceipt,
+      ...override,
+    });
+    assert.equal(result.serialization.ready, false, label);
+    assert.equal(result.mergeCandidate, null, label);
+    assert.equal(
+      result.evaluations[0].disposition,
+      "waiting-post-merge-verification",
+      label,
+    );
+  }
+
+  const { runHeadSha: omittedRunHeadSha, ...withoutWorkflowHead } =
+    validReceipt;
+  assert.equal(omittedRunHeadSha, BASE_SHA);
+  const persistedWithoutWorkflowHead = JSON.parse(
+    stableJson(withoutWorkflowHead),
+  );
+  assert.equal(
+    Object.hasOwn(persistedWithoutWorkflowHead, "runHeadSha"),
+    false,
+  );
+  const omittedWorkflowHead = evaluateMergeSerializationReceipt(
+    persistedWithoutWorkflowHead,
+  );
+  assert.equal(omittedWorkflowHead.serialization.ready, false);
+  assert.equal(
+    omittedWorkflowHead.serialization.reason,
+    "untrusted-post-merge-source-ref",
+  );
+  assert.equal(omittedWorkflowHead.mergeCandidate, null);
+});
+
+test("a newer malformed post-merge check supersedes an older valid receipt and closes the lane", () => {
+  const current = snapshot();
+  current.baseline.checks.push({
+    appId: 15_368,
+    completedAt: "2026-08-10T10:01:00Z",
+    conclusion: "failure",
+    detailsUrl: `https://github.com/${REPOSITORY}/runs/101`,
+    externalId: "malformed",
+    headSha: BASE_SHA,
+    id: 101,
+    kind: "check",
+    name: "Dependabot Post-Merge Verification",
+    status: "completed",
+  });
+
+  const result = evaluateDependabotSweep({
+    mode: "merge",
+    pullRequests: [current],
+    repository: REPOSITORY,
+  });
+
+  assert.equal(result.serialization.ready, false);
+  assert.equal(result.serialization.reason, "unexpected-source-repository");
+  assert.equal(result.serialization.check.conclusion, "failure");
+  assert.equal(result.serialization.check.runId, 0);
+  assert.equal(result.mergeCandidate, null);
+  assert.equal(
+    result.evaluations[0].disposition,
+    "waiting-post-merge-verification",
+  );
+});
+
 test("an exact current auto-merge request re-enters the full gate", () => {
   const outstanding = snapshot({
     feedback: {
@@ -4024,6 +4158,463 @@ test("live check collection binds a check to its queried workflow repository", a
     repository: REPOSITORY,
   });
   assert.equal(result.policy.find(({ id }) => id === "ci").state, "passing");
+});
+
+test("live check collection bounds concurrent workflow-run enrichment for checks and statuses", async () => {
+  const checkCount = 12;
+  const statusCount = 12;
+  const firstWorkflowRunId = 31_471_141_700;
+  const firstStatusWorkflowRunId = firstWorkflowRunId + checkCount;
+  let activeWorkflowRunGets = 0;
+  let maxConcurrentWorkflowRunGets = 0;
+  let releaseScheduled = false;
+  let workflowRunGets = 0;
+  const pendingReleases = [];
+  const waitForCurrentWave = () =>
+    new Promise((resolve) => {
+      pendingReleases.push(resolve);
+      if (releaseScheduled) return;
+      releaseScheduled = true;
+      queueMicrotask(() => {
+        releaseScheduled = false;
+        const currentWave = pendingReleases.splice(0);
+        for (const release of currentWave) release();
+      });
+    });
+  const fetchImpl = async (url) => {
+    if (url.includes(`/repos/${REPOSITORY}/commits/${HEAD_SHA}/check-runs`)) {
+      return new Response(
+        JSON.stringify({
+          check_runs: Array.from({ length: checkCount }, (_, index) => {
+            const workflowRunId = firstWorkflowRunId + index;
+            return {
+              app: { id: 15_368 },
+              completed_at: "2026-08-11T08:24:00Z",
+              conclusion: "success",
+              details_url: `https://github.com/${REPOSITORY}/actions/runs/${workflowRunId}`,
+              head_sha: HEAD_SHA,
+              id: 93_713_691_500 + index,
+              name: `Workflow-backed check ${index}`,
+              started_at: "2026-08-11T08:23:59Z",
+              status: "completed",
+            };
+          }),
+        }),
+        { status: 200 },
+      );
+    }
+    const workflowRunMatch = /\/actions\/runs\/([1-9][0-9]*)$/.exec(url);
+    if (workflowRunMatch) {
+      const workflowRunId = Number(workflowRunMatch[1]);
+      workflowRunGets += 1;
+      activeWorkflowRunGets += 1;
+      maxConcurrentWorkflowRunGets = Math.max(
+        maxConcurrentWorkflowRunGets,
+        activeWorkflowRunGets,
+      );
+      await waitForCurrentWave();
+      activeWorkflowRunGets -= 1;
+      return new Response(
+        JSON.stringify({
+          conclusion: "success",
+          event: "pull_request",
+          head_branch: "dependabot/test",
+          head_sha: HEAD_SHA,
+          id: workflowRunId,
+          path: ".github/workflows/ci.yml",
+          repository: { full_name: REPOSITORY },
+          run_attempt: 1,
+          status: "completed",
+        }),
+        { status: 200 },
+      );
+    }
+    if (url.includes(`/repos/${REPOSITORY}/commits/${HEAD_SHA}/statuses`)) {
+      return new Response(
+        JSON.stringify(
+          Array.from({ length: statusCount }, (_, index) => {
+            const workflowRunId = firstStatusWorkflowRunId + index;
+            return {
+              context: `Workflow-backed status ${index}`,
+              creator: { login: "github-actions[bot]" },
+              id: 93_713_691_600 + index,
+              state: "success",
+              target_url: `https://github.com/${REPOSITORY}/actions/runs/${workflowRunId}`,
+              updated_at: "2026-08-11T08:24:00Z",
+            };
+          }),
+        ),
+        { status: 200 },
+      );
+    }
+    assert.fail(`Unexpected request: ${url}`);
+  };
+  const adapter = createLiveGitHubAdapter({ fetchImpl, token: "test-token" });
+  const checks = await adapter.getChecks(REPOSITORY, HEAD_SHA);
+
+  assert.equal(checks.length, checkCount + statusCount);
+  assert.equal(workflowRunGets, checkCount + statusCount);
+  assert.equal(activeWorkflowRunGets, 0);
+  assert.ok(maxConcurrentWorkflowRunGets > 0);
+  assert.ok(maxConcurrentWorkflowRunGets <= 8);
+  assert.deepEqual(
+    checks.map(({ runId }) => runId),
+    [
+      ...Array.from(
+        { length: checkCount },
+        (_, index) => firstWorkflowRunId + index,
+      ),
+      ...Array.from(
+        { length: statusCount },
+        (_, index) => firstStatusWorkflowRunId + index,
+      ),
+    ],
+  );
+});
+
+test("live post-merge collection follows the durable external receipt when GitHub rewrites the check URL", async () => {
+  const checkRunId = 93_713_691_394;
+  const workflowRunId = 31_471_141_674;
+  const requestedWorkflowRuns = [];
+  const fetchImpl = async (url) => {
+    if (url.includes(`/repos/${REPOSITORY}/commits/${BASE_SHA}/check-runs`)) {
+      return new Response(
+        JSON.stringify({
+          check_runs: [
+            {
+              app: { id: 15_368 },
+              completed_at: "2026-08-11T08:20:00Z",
+              conclusion: "success",
+              details_url: `https://github.com/${REPOSITORY}/runs/${checkRunId}`,
+              external_id: `dependabot-post-merge:${workflowRunId}:1`,
+              head_sha: BASE_SHA,
+              id: checkRunId,
+              name: "Dependabot Post-Merge Verification",
+              started_at: "2026-08-11T08:19:59Z",
+              status: "completed",
+            },
+          ],
+        }),
+        { status: 200 },
+      );
+    }
+    if (url.endsWith(`/repos/${REPOSITORY}/actions/runs/${workflowRunId}`)) {
+      requestedWorkflowRuns.push(workflowRunId);
+      return new Response(
+        JSON.stringify({
+          conclusion: "success",
+          event: "workflow_run",
+          head_branch: "main",
+          head_sha: BASE_SHA,
+          id: workflowRunId,
+          path: ".github/workflows/vercel-main-deployment.yml",
+          repository: { full_name: REPOSITORY },
+          run_attempt: 1,
+          status: "completed",
+        }),
+        { status: 200 },
+      );
+    }
+    if (url.includes(`/repos/${REPOSITORY}/commits/${BASE_SHA}/statuses`)) {
+      return new Response(JSON.stringify([]), { status: 200 });
+    }
+    assert.fail(`Unexpected request: ${url}`);
+  };
+  const adapter = createLiveGitHubAdapter({ fetchImpl, token: "test-token" });
+  const [receipt] = await adapter.getChecks(REPOSITORY, BASE_SHA);
+
+  assert.deepEqual(requestedWorkflowRuns, [workflowRunId]);
+  assert.equal(receipt.id, checkRunId);
+  assert.equal(
+    receipt.detailsUrl,
+    `https://github.com/${REPOSITORY}/runs/${checkRunId}`,
+  );
+  assert.equal(receipt.externalId, `dependabot-post-merge:${workflowRunId}:1`);
+  assert.equal(receipt.runId, workflowRunId);
+  assert.equal(receipt.runAttempt, 1);
+  assert.equal(receipt.runConclusion, "success");
+  assert.equal(receipt.runHeadBranch, "main");
+  assert.equal(receipt.runHeadSha, BASE_SHA);
+  assert.equal(receipt.sourceRepository, REPOSITORY);
+  assert.equal(receipt.runStatus, "completed");
+  assert.equal(receipt.workflowEvent, "workflow_run");
+  assert.equal(
+    receipt.workflowPath,
+    ".github/workflows/vercel-main-deployment.yml",
+  );
+
+  const result = evaluateMergeSerializationReceipt(receipt);
+  assert.equal(result.serialization.ready, true);
+  assert.deepEqual(result.serialization.check, {
+    conclusion: "success",
+    headSha: BASE_SHA,
+    name: "Dependabot Post-Merge Verification",
+    runAttempt: 1,
+    runId: workflowRunId,
+  });
+});
+
+test("live post-merge collection refetches mutable workflow-run state for every gate snapshot", async () => {
+  const checkRunId = 93_713_691_395;
+  const workflowRunId = 31_471_141_675;
+  let checkReads = 0;
+  let workflowRunReads = 0;
+  const fetchImpl = async (url) => {
+    if (url.includes(`/repos/${REPOSITORY}/commits/${BASE_SHA}/check-runs`)) {
+      checkReads += 1;
+      return new Response(
+        JSON.stringify({
+          check_runs: [
+            {
+              app: { id: 15_368 },
+              completed_at: "2026-08-11T08:21:00Z",
+              conclusion: "success",
+              details_url: `https://github.com/${REPOSITORY}/runs/${checkRunId}`,
+              external_id: `dependabot-post-merge:${workflowRunId}:1`,
+              head_sha: BASE_SHA,
+              id: checkRunId,
+              name: "Dependabot Post-Merge Verification",
+              started_at: "2026-08-11T08:20:59Z",
+              status: "completed",
+            },
+          ],
+        }),
+        { status: 200 },
+      );
+    }
+    if (url.endsWith(`/repos/${REPOSITORY}/actions/runs/${workflowRunId}`)) {
+      workflowRunReads += 1;
+      const completed = workflowRunReads === 1;
+      return new Response(
+        JSON.stringify({
+          conclusion: completed ? "success" : null,
+          event: "workflow_run",
+          head_branch: "main",
+          head_sha: BASE_SHA,
+          id: workflowRunId,
+          path: ".github/workflows/vercel-main-deployment.yml",
+          repository: { full_name: REPOSITORY },
+          run_attempt: 1,
+          status: completed ? "completed" : "in_progress",
+        }),
+        { status: 200 },
+      );
+    }
+    if (url.includes(`/repos/${REPOSITORY}/commits/${BASE_SHA}/statuses`)) {
+      return new Response(JSON.stringify([]), { status: 200 });
+    }
+    assert.fail(`Unexpected request: ${url}`);
+  };
+  const adapter = createLiveGitHubAdapter({ fetchImpl, token: "test-token" });
+
+  const [firstReceipt] = await adapter.getChecks(REPOSITORY, BASE_SHA);
+  const firstResult = evaluateMergeSerializationReceipt(firstReceipt);
+  assert.equal(firstReceipt.runStatus, "completed");
+  assert.equal(firstReceipt.runConclusion, "success");
+  assert.equal(firstResult.serialization.ready, true);
+
+  const [secondReceipt] = await adapter.getChecks(REPOSITORY, BASE_SHA);
+  const secondResult = evaluateMergeSerializationReceipt(secondReceipt);
+  assert.equal(secondReceipt.runStatus, "in_progress");
+  assert.equal(secondReceipt.runConclusion, null);
+  assert.equal(secondResult.serialization.ready, false);
+  assert.equal(
+    secondResult.serialization.reason,
+    "post-merge-workflow-not-successful",
+  );
+  assert.equal(secondResult.mergeCandidate, null);
+  assert.equal(checkReads, 2);
+  assert.equal(workflowRunReads, 2);
+});
+
+test("live post-merge collection preserves an absent workflow head as null across stable JSON", async () => {
+  const cases = [
+    { explicitNull: false, label: "omitted" },
+    { explicitNull: true, label: "null" },
+  ];
+  let omittedReceipt = null;
+  for (const [index, testCase] of cases.entries()) {
+    const checkRunId = 93_713_691_400 + index;
+    const workflowRunId = 31_471_141_680 + index;
+    const fetchImpl = async (url) => {
+      if (url.includes(`/repos/${REPOSITORY}/commits/${BASE_SHA}/check-runs`)) {
+        return new Response(
+          JSON.stringify({
+            check_runs: [
+              {
+                app: { id: 15_368 },
+                completed_at: "2026-08-11T08:22:00Z",
+                conclusion: "success",
+                details_url: `https://github.com/${REPOSITORY}/runs/${checkRunId}`,
+                external_id: `dependabot-post-merge:${workflowRunId}:1`,
+                head_sha: BASE_SHA,
+                id: checkRunId,
+                name: "Dependabot Post-Merge Verification",
+                started_at: "2026-08-11T08:21:59Z",
+                status: "completed",
+              },
+            ],
+          }),
+          { status: 200 },
+        );
+      }
+      if (url.endsWith(`/repos/${REPOSITORY}/actions/runs/${workflowRunId}`)) {
+        const workflowRun = {
+          conclusion: "success",
+          event: "workflow_run",
+          head_branch: "main",
+          id: workflowRunId,
+          path: ".github/workflows/vercel-main-deployment.yml",
+          repository: { full_name: REPOSITORY },
+          run_attempt: 1,
+          status: "completed",
+        };
+        if (testCase.explicitNull) workflowRun.head_sha = null;
+        return new Response(JSON.stringify(workflowRun), { status: 200 });
+      }
+      if (url.includes(`/repos/${REPOSITORY}/commits/${BASE_SHA}/statuses`)) {
+        return new Response(JSON.stringify([]), { status: 200 });
+      }
+      assert.fail(`Unexpected request: ${url}`);
+    };
+    const adapter = createLiveGitHubAdapter({ fetchImpl, token: "test-token" });
+    const [receipt] = await adapter.getChecks(REPOSITORY, BASE_SHA);
+
+    assert.equal(receipt.runHeadSha, null, testCase.label);
+    if (!testCase.explicitNull) omittedReceipt = receipt;
+    const result = evaluateMergeSerializationReceipt(receipt);
+    assert.equal(result.serialization.ready, false, testCase.label);
+    assert.equal(
+      result.serialization.reason,
+      "untrusted-post-merge-source-ref",
+      testCase.label,
+    );
+    assert.equal(result.mergeCandidate, null, testCase.label);
+  }
+
+  assert.notEqual(omittedReceipt, null);
+  const persistedReceipt = JSON.parse(stableJson(omittedReceipt));
+  assert.equal(persistedReceipt.runHeadSha, null);
+  const persistedResult = evaluateMergeSerializationReceipt(persistedReceipt);
+  assert.equal(persistedResult.serialization.ready, false);
+  assert.equal(
+    persistedResult.serialization.reason,
+    "untrusted-post-merge-source-ref",
+  );
+  assert.equal(persistedResult.mergeCandidate, null);
+});
+
+test("live post-merge collection dereferences only the newest exact receipt", async () => {
+  const olderCheckRunId = 93_713_691_410;
+  const olderWorkflowRunId = 31_471_141_690;
+  const newerCheckRunId = olderCheckRunId + 1;
+  const newerWorkflowRunId = olderWorkflowRunId + 1;
+  const checkRunPages = [];
+  const requestedWorkflowRuns = [];
+  const fetchImpl = async (url) => {
+    if (url.includes(`/repos/${REPOSITORY}/commits/${BASE_SHA}/check-runs`)) {
+      const page = Number(new URL(url).searchParams.get("page"));
+      checkRunPages.push(page);
+      const newerReceipt = {
+        app: { id: 15_368 },
+        completed_at: "2026-08-11T08:20:00Z",
+        conclusion: "success",
+        details_url: `https://github.com/${REPOSITORY}/runs/${newerCheckRunId}`,
+        external_id: `dependabot-post-merge:${newerWorkflowRunId}:1`,
+        head_sha: BASE_SHA,
+        id: newerCheckRunId,
+        name: "Dependabot Post-Merge Verification",
+        started_at: "2026-08-11T08:19:59Z",
+        status: "completed",
+      };
+      const olderReceipt = {
+        app: { id: 15_368 },
+        completed_at: "2026-08-11T08:23:00Z",
+        conclusion: "success",
+        details_url: `https://github.com/${REPOSITORY}/runs/${olderCheckRunId}`,
+        external_id: `dependabot-post-merge:${olderWorkflowRunId}:1`,
+        head_sha: BASE_SHA,
+        id: olderCheckRunId,
+        name: "Dependabot Post-Merge Verification",
+        started_at: "2026-08-11T08:22:59Z",
+        status: "completed",
+      };
+      const unrelatedChecks = Array.from({ length: 99 }, (_, index) => ({
+        app: { id: 15_368 },
+        completed_at: "2026-08-11T08:21:00Z",
+        conclusion: "success",
+        details_url: null,
+        head_sha: BASE_SHA,
+        id: 50_000 + index,
+        name: `Unrelated check ${index}`,
+        started_at: "2026-08-11T08:20:59Z",
+        status: "completed",
+      }));
+      const checkRuns =
+        page === 1
+          ? [newerReceipt, ...unrelatedChecks]
+          : page === 2
+            ? [olderReceipt]
+            : [];
+      return new Response(JSON.stringify({ check_runs: checkRuns }), {
+        status: 200,
+      });
+    }
+    if (
+      url.endsWith(`/repos/${REPOSITORY}/actions/runs/${olderWorkflowRunId}`)
+    ) {
+      requestedWorkflowRuns.push(olderWorkflowRunId);
+      return new Response(JSON.stringify({ message: "Not Found" }), {
+        status: 404,
+      });
+    }
+    if (
+      url.endsWith(`/repos/${REPOSITORY}/actions/runs/${newerWorkflowRunId}`)
+    ) {
+      requestedWorkflowRuns.push(newerWorkflowRunId);
+      return new Response(
+        JSON.stringify({
+          conclusion: "success",
+          event: "workflow_run",
+          head_branch: "main",
+          head_sha: BASE_SHA,
+          id: newerWorkflowRunId,
+          path: ".github/workflows/vercel-main-deployment.yml",
+          repository: { full_name: REPOSITORY },
+          run_attempt: 1,
+          status: "completed",
+        }),
+        { status: 200 },
+      );
+    }
+    if (url.includes(`/repos/${REPOSITORY}/commits/${BASE_SHA}/statuses`)) {
+      return new Response(JSON.stringify([]), { status: 200 });
+    }
+    assert.fail(`Unexpected request: ${url}`);
+  };
+  const adapter = createLiveGitHubAdapter({ fetchImpl, token: "test-token" });
+  const receipts = await adapter.getChecks(REPOSITORY, BASE_SHA);
+
+  assert.deepEqual(checkRunPages, [1, 2]);
+  assert.deepEqual(requestedWorkflowRuns, [newerWorkflowRunId]);
+  const current = snapshot();
+  current.baseline.checks = [
+    ...current.baseline.checks.filter(
+      ({ name }) => name !== "Dependabot Post-Merge Verification",
+    ),
+    ...receipts,
+  ];
+  const result = evaluateDependabotSweep({
+    mode: "merge",
+    pullRequests: [current],
+    repository: REPOSITORY,
+  });
+  assert.equal(result.serialization.ready, true);
+  assert.equal(result.serialization.check.runId, newerWorkflowRunId);
+  assert.deepEqual(result.mergeCandidate, {
+    headSha: HEAD_SHA,
+    pullRequestNumber: 123,
+  });
 });
 
 test("live check collection authenticates the current Dependabot Vercel intake status envelope", async () => {

--- a/scripts/dependabot-processor.test.mjs
+++ b/scripts/dependabot-processor.test.mjs
@@ -2761,6 +2761,29 @@ test("a newer malformed post-merge check supersedes an older valid receipt and c
   );
 });
 
+test("an unordered post-merge receipt blocks fallback to an older valid publication", () => {
+  const current = snapshot();
+  current.baseline.checks.push({
+    ...postMergeReceipt(BASE_SHA),
+    completedAt: "2026-08-10T10:01:00Z",
+    id: 0,
+  });
+
+  const result = evaluateDependabotSweep({
+    mode: "merge",
+    pullRequests: [current],
+    repository: REPOSITORY,
+  });
+
+  assert.equal(result.serialization.ready, false);
+  assert.equal(result.serialization.reason, "invalid-post-merge-check-id");
+  assert.equal(result.mergeCandidate, null);
+  assert.equal(
+    result.evaluations[0].disposition,
+    "waiting-post-merge-verification",
+  );
+});
+
 test("an exact current auto-merge request re-enters the full gate", () => {
   const outstanding = snapshot({
     feedback: {

--- a/scripts/dependabot-workflows.test.mjs
+++ b/scripts/dependabot-workflows.test.mjs
@@ -51,6 +51,7 @@ const humanReview = workflow(humanReviewPath);
 const claudeAction =
   "anthropics/claude-code-action@be7b93b1907a4abad570368f3c74b6fe3807510b";
 const claudePluginMarketplace = "./.claude-code-plugin-marketplace";
+const claudeCodeReviewPlugin = `${claudePluginMarketplace}/plugins/code-review`;
 const claudePluginMarketplaceRef = "2bb60696142b493eafaeacfe00eac51d16c50c4f";
 
 const forbiddenCandidateSurfaces =
@@ -893,7 +894,12 @@ test("human Claude review cannot shadow the Dependabot review check", () => {
 
   const review = job.steps.find((step) => step.uses === claudeAction);
   assert.ok(review);
-  assert.equal(review.with.plugin_marketplaces, claudePluginMarketplace);
+  assert.equal(
+    review.with.claude_args,
+    `--plugin-dir ${claudeCodeReviewPlugin}`,
+  );
+  assert.equal(Object.hasOwn(review.with, "plugin_marketplaces"), false);
+  assert.equal(Object.hasOwn(review.with, "plugins"), false);
   assert.equal(Object.hasOwn(review.with, "allowed_bots"), false);
 });
 

--- a/scripts/vercel-main-deployment-workflow.test.mjs
+++ b/scripts/vercel-main-deployment-workflow.test.mjs
@@ -2323,6 +2323,10 @@ test("result publishes an exact-SHA Dependabot release proof before failing clos
     "${{ steps.terminal-restore.outputs.terminal_restored }}",
   );
   assert.equal(publish.env.GH_TOKEN, "${{ github.token }}");
+  assert.equal(
+    publish.env.RUN_URL,
+    "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+  );
   assert.match(publish.run, /\[0-9a-f\]\{40\}/);
   assert.match(
     publish.run,
@@ -2333,6 +2337,13 @@ test("result publishes an exact-SHA Dependabot release proof before failing clos
   assert.match(publish.run, /FAIL_AFTER_EVIDENCE.*false/s);
   assert.match(publish.run, /Dependabot Post-Merge Verification/);
   assert.match(publish.run, /head_sha: \$deploy_sha/);
+  assert.match(publish.run, /--arg details_url "\$RUN_URL"/);
+  assert.match(
+    publish.run,
+    /--arg external_id "dependabot-post-merge:\$\{\{ github\.run_id \}\}:\$\{\{ github\.run_attempt \}\}"/,
+  );
+  assert.match(publish.run, /details_url: \$details_url/);
+  assert.match(publish.run, /external_id: \$external_id/);
   assert.match(publish.run, /gh api --method POST/);
   assert.match(publish.run, /repos\/\$REPOSITORY\/check-runs/);
   assert.doesNotMatch(


### PR DESCRIPTION
## The Problem

GitHub rewrites the `Dependabot Post-Merge Verification` check's submitted Actions URL to the check-run self URL. The processor could not recover the trusted Vercel workflow run from that live shape, so merge serialization stayed closed with `unexpected-source-repository` even after exact-main CI and deployment verification succeeded.

The existing adapter also resolved every workflow-backed check concurrently and allowed a persisted receipt without an independently fetched workflow head to recover that head from the check SHA.

## The Solution

Resolve only the newest exact-name, exact-head post-merge receipt through its strict `dependabot-post-merge:<run-id>:<attempt>` external ID when GitHub returns the exact check self URL. Re-query the referenced Actions run and bind its repository, workflow path, event, branch, exact main SHA, run ID, attempt, status, and conclusion before admitting the receipt.

The collector now preserves a missing workflow head as `null`, never falls back to the check head, scopes its run cache to one collection, and limits distinct workflow-run lookups for checks and commit statuses to eight concurrent requests. Older receipts are not dereferenced, and the newest check-run ID wins even when its receipt is malformed.

The Dependabot runbook, ADR, and Vercel publisher contract tests now document and enforce the live URL/external-ID boundary.

## Validation

- `pnpm dependabot:process:test` — 131/131 passed
- `node --test scripts/vercel-main-deployment-workflow.test.mjs` — 33/33 passed
- `pnpm adr:check --include-untracked` — passed
- `trunk fmt` and `trunk check` on all five changed files — passed
- `node --check` on all changed JavaScript files — passed
- `git diff --check` — passed
- Pre-push full Trunk, workspace type checks, and Knip — passed
- Fresh-context Codex autoreview — clean after accepted fail-closed and concurrency findings
- Deterministic local autoreview — clean
- Browser verification: not applicable; this PR changes a Node controller, tests, and documentation only

## Material Risk

This changes merge-lane trust evaluation. Every fallback remains exact-name, exact-head, exact-self-URL, exact-external-ID, and trusted-workflow bound; mismatches fail closed. Provider URLs and unavailable or obsolete run references remain untrusted.

## Ship Checklist

- [x] PR title follows the conventions
- [x] Performed a self-review of my own changes
- [x] Relevant automated checks and smoke tests pass
- [x] Architecture decision: updated `docs/adr/0006-dependabot-processing-controller.md`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes fail-closed trust for the serial Dependabot merge lane; mis-validation could block merges or admit bad proof, though mismatches are designed to close the lane.
> 
> **Overview**
> Fixes merge serialization staying closed when **Dependabot Post-Merge Verification** succeeds but GitHub replaces the publisher’s Actions `details_url` with the check-run self URL (`/runs/<check-id>`).
> 
> The processor now treats that self URL as valid only for the **newest** exact-name, exact-head receipt, resolves the trusted **Vercel Main Deployment** run from `dependabot-post-merge:<run-id>:<attempt>` (not from `details_url`), and **fail-closed** validates repository, workflow path, `workflow_run` on `main`, run ID/attempt, completed success, and an **independently fetched** workflow `head_sha`—never the check head. Duplicate receipts pick the highest check-run publication ID; only that receipt is workflow-enriched so a 404 on an older run cannot block the lane, while a newer bad receipt blocks an older success.
> 
> Live collection scopes workflow-run cache to **one** `getChecks` call, caps concurrent run lookups at **8**, and enriches post-merge runs when the self URL plus external ID are present. **ADR**, **dependabot-automation**, the Vercel publisher contract test (`RUN_URL`, `external_id`), and processor tests document and enforce the boundary.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e69c02db69dfcbfba888d7fce012032c30982a21. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->