### PR TITLE
fix: bind Dependabot callbacks to workflow paths

### DIFF
--- a/.github/workflows/ci-failure-notifier.yml
+++ b/.github/workflows/ci-failure-notifier.yml
@@ -46,18 +46,21 @@ jobs:
           github.event.workflow_run.event == 'repository_dispatch' &&
           (
             (
-              github.event.workflow_run.name == 'Dependabot Processor' &&
+              (github.event.workflow_run.path == '.github/workflows/dependabot-process.yml' ||
+               github.event.workflow_run.path == '.github/workflows/dependabot-process.yml@main') &&
               github.event.workflow_run.display_title == 'Dependabot processor | event=repository_dispatch | target=scope=open'
             ) ||
             (
-              github.event.workflow_run.name == 'Dependabot Prepare Repair' &&
+              (github.event.workflow_run.path == '.github/workflows/dependabot-prepare-repair.yml' ||
+               github.event.workflow_run.path == '.github/workflows/dependabot-prepare-repair.yml@main') &&
               (
                 startsWith(github.event.workflow_run.display_title, 'dependabot-repair:v1 | pr=') ||
                 startsWith(github.event.workflow_run.display_title, 'dependabot-repair-recover:v1 | pr=')
               )
             ) ||
             (
-              github.event.workflow_run.name == 'Dependabot Prepared Head Intake' &&
+              (github.event.workflow_run.path == '.github/workflows/dependabot-prepared-head-intake.yml' ||
+               github.event.workflow_run.path == '.github/workflows/dependabot-prepared-head-intake.yml@main') &&
               startsWith(github.event.workflow_run.display_title, 'dependabot-prepared-head:v1|p=') &&
               endsWith(github.event.workflow_run.display_title, '|ok=true')
             )
@@ -70,11 +73,13 @@ jobs:
           (
             github.event.workflow_run.name == 'Vercel Main Deployment' ||
             (
-              github.event.workflow_run.name == 'Dependabot Prepared Head Dispatch' &&
+              (github.event.workflow_run.path == '.github/workflows/dependabot-prepared-head-dispatch.yml' ||
+               github.event.workflow_run.path == '.github/workflows/dependabot-prepared-head-dispatch.yml@main') &&
               startsWith(github.event.workflow_run.display_title, 'dependabot-prepared-dispatch:v1 | source=')
             ) ||
             (
-              github.event.workflow_run.name == 'Dependabot Processor' &&
+              (github.event.workflow_run.path == '.github/workflows/dependabot-process.yml' ||
+               github.event.workflow_run.path == '.github/workflows/dependabot-process.yml@main') &&
               startsWith(github.event.workflow_run.display_title, 'Dependabot processor | event=workflow_run | receipt=')
             )
           ) &&

--- a/.github/workflows/dependabot-claude-review.yml
+++ b/.github/workflows/dependabot-claude-review.yml
@@ -20,12 +20,14 @@ jobs:
       github.repository == 'mento-protocol/frontend-monorepo' &&
       (
         (
-          github.event.workflow_run.name == 'Dependabot Intake' &&
+          (github.event.workflow_run.path == '.github/workflows/dependabot-intake.yml' ||
+           github.event.workflow_run.path == '.github/workflows/dependabot-intake.yml@main') &&
           startsWith(github.event.workflow_run.display_title, 'dependabot-intake:v1 | ') &&
           endsWith(github.event.workflow_run.display_title, 'receipt=true')
         ) ||
         (
-          github.event.workflow_run.name == 'Dependabot Prepared Head Intake' &&
+          (github.event.workflow_run.path == '.github/workflows/dependabot-prepared-head-intake.yml' ||
+           github.event.workflow_run.path == '.github/workflows/dependabot-prepared-head-intake.yml@main') &&
           startsWith(github.event.workflow_run.display_title, 'dependabot-prepared-head:v1|') &&
           endsWith(github.event.workflow_run.display_title, '|ok=true')
         )
@@ -73,7 +75,6 @@ jobs:
           INTAKE_TRIGGERING_ACTOR_LOGIN: ${{ github.event.workflow_run.triggering_actor.login }}
           INTAKE_TRIGGERING_ACTOR_ID: ${{ github.event.workflow_run.triggering_actor.id }}
           INTAKE_TRIGGERING_ACTOR_TYPE: ${{ github.event.workflow_run.triggering_actor.type }}
-          INTAKE_WORKFLOW: ${{ github.event.workflow_run.name }}
           REPOSITORY: ${{ github.repository }}
           RUN_ATTEMPT: ${{ github.run_attempt }}
           RUN_ID: ${{ github.run_id }}
@@ -92,8 +93,8 @@ jobs:
           review_actor_login=""
           operation=""
           operation_check_id=""
-          case "$INTAKE_WORKFLOW" in
-            "Dependabot Intake")
+          case "$INTAKE_PATH" in
+            .github/workflows/dependabot-intake.yml|.github/workflows/dependabot-intake.yml@main)
               test "$INTAKE_EVENT" = "pull_request_target"
               test "$INTAKE_ACTOR_LOGIN" = "dependabot[bot]"
               test "$INTAKE_ACTOR_TYPE" = "Bot"
@@ -103,10 +104,6 @@ jobs:
                 test "$INTAKE_TRIGGERING_ACTOR_TYPE" = "Bot"
               fi
               [[ "$INTAKE_HEAD_BRANCH" == dependabot/* ]]
-              case "$INTAKE_PATH" in
-                .github/workflows/dependabot-intake.yml|.github/workflows/dependabot-intake.yml@main) ;;
-                *) exit 1 ;;
-              esac
 
               receipt_pattern='^dependabot-intake:v1 \| repository=mento-protocol/frontend-monorepo \| pr=([1-9][0-9]*) \| sha=([0-9a-f]{40}) \| action=(opened|synchronize|reopened) \| receipt=true$'
               [[ "$INTAKE_TITLE" =~ $receipt_pattern ]]
@@ -135,7 +132,7 @@ jobs:
               source_kind="dependabot"
               review_actor_login="dependabot[bot]"
               ;;
-            "Dependabot Prepared Head Intake")
+            .github/workflows/dependabot-prepared-head-intake.yml|.github/workflows/dependabot-prepared-head-intake.yml@main)
               test "$INTAKE_EVENT" = "repository_dispatch"
               [[ "$EXPECTED_PREPARE_APP_SLUG" =~ ^[a-z0-9][a-z0-9-]{0,99}$ ]]
               [[ "$EXPECTED_PREPARE_BOT_ID" =~ ^[1-9][0-9]*$ ]]
@@ -151,10 +148,6 @@ jobs:
                 test "$INTAKE_TRIGGERING_ACTOR_TYPE" = "Bot"
               fi
               test "$INTAKE_HEAD_BRANCH" = "main"
-              case "$INTAKE_PATH" in
-                .github/workflows/dependabot-prepared-head-intake.yml|.github/workflows/dependabot-prepared-head-intake.yml@main) ;;
-                *) exit 1 ;;
-              esac
 
               receipt_pattern='^dependabot-prepared-head:v1\|p=([1-9][0-9]{0,9})\|h=([0-9a-f]{40})\|o=([rp])\|c=([1-9][0-9]*)\|d=([0-9a-f]{64})\|ok=true$'
               [[ "$INTAKE_TITLE" =~ $receipt_pattern ]]

--- a/.github/workflows/dependabot-prepared-head-dispatch.yml
+++ b/.github/workflows/dependabot-prepared-head-dispatch.yml
@@ -1,7 +1,7 @@
 name: Dependabot Prepared Head Dispatch
 
 run-name: >-
-  ${{ format('dependabot-prepared-dispatch:v1 | source={0} | run={1} | attempt={2}', github.event.workflow_run.name, github.event.workflow_run.id, github.event.workflow_run.run_attempt) }}
+  ${{ format('dependabot-prepared-dispatch:v1 | source={0} | run={1} | attempt={2}', (github.event.workflow_run.path == '.github/workflows/dependabot-process.yml' || github.event.workflow_run.path == '.github/workflows/dependabot-process.yml@main') && 'Dependabot Processor' || 'Dependabot Prepare Repair', github.event.workflow_run.id, github.event.workflow_run.run_attempt) }}
 
 on:
   workflow_run:
@@ -21,9 +21,11 @@ jobs:
     if: >-
       github.repository == 'mento-protocol/frontend-monorepo' &&
       github.event.workflow_run.status == 'completed' &&
-      ((github.event.workflow_run.name == 'Dependabot Processor' &&
+      (((github.event.workflow_run.path == '.github/workflows/dependabot-process.yml' ||
+         github.event.workflow_run.path == '.github/workflows/dependabot-process.yml@main') &&
         github.event.workflow_run.conclusion == 'success') ||
-       (github.event.workflow_run.name == 'Dependabot Prepare Repair' &&
+       ((github.event.workflow_run.path == '.github/workflows/dependabot-prepare-repair.yml' ||
+         github.event.workflow_run.path == '.github/workflows/dependabot-prepare-repair.yml@main') &&
         (github.event.workflow_run.conclusion == 'success' ||
          github.event.workflow_run.conclusion == 'action_required' ||
          github.event.workflow_run.conclusion == 'failure' ||
@@ -62,7 +64,6 @@ jobs:
           SOURCE_PATH: ${{ github.event.workflow_run.path }}
           SOURCE_STATUS: ${{ github.event.workflow_run.status }}
           SOURCE_TITLE: ${{ github.event.workflow_run.display_title }}
-          SOURCE_WORKFLOW: ${{ github.event.workflow_run.name }}
         run: |
           set -euo pipefail
           test "$REPOSITORY" = "mento-protocol/frontend-monorepo"
@@ -73,24 +74,16 @@ jobs:
           [[ "$SOURCE_ID" =~ ^[1-9][0-9]*$ ]]
           [[ "$SOURCE_ATTEMPT" =~ ^[1-9][0-9]*$ ]]
 
-          case "$SOURCE_WORKFLOW" in
-            "Dependabot Processor")
+          case "$SOURCE_PATH" in
+            .github/workflows/dependabot-process.yml|.github/workflows/dependabot-process.yml@main)
               test "$SOURCE_CONCLUSION" = "success"
-              case "$SOURCE_PATH" in
-                .github/workflows/dependabot-process.yml|.github/workflows/dependabot-process.yml@main) ;;
-                *) exit 1 ;;
-              esac
               case "$SOURCE_EVENT" in
                 workflow_run|repository_dispatch|schedule) ;;
                 *) exit 1 ;;
               esac
               [[ "$SOURCE_TITLE" =~ ^Dependabot\ processor\ \|\ event= ]]
               ;;
-            "Dependabot Prepare Repair")
-              case "$SOURCE_PATH" in
-                .github/workflows/dependabot-prepare-repair.yml|.github/workflows/dependabot-prepare-repair.yml@main) ;;
-                *) exit 1 ;;
-              esac
+            .github/workflows/dependabot-prepare-repair.yml|.github/workflows/dependabot-prepare-repair.yml@main)
               test "$SOURCE_EVENT" = "repository_dispatch"
               test "$SOURCE_ACTOR_ID" = "$EXPECTED_BOT_ID"
               test "$SOURCE_ACTOR_LOGIN" = "$EXPECTED_BOT_LOGIN"
@@ -141,13 +134,22 @@ jobs:
           SOURCE_ATTEMPT: ${{ github.event.workflow_run.run_attempt }}
           SOURCE_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
           SOURCE_ID: ${{ github.event.workflow_run.id }}
-          SOURCE_WORKFLOW: ${{ github.event.workflow_run.name }}
+          SOURCE_PATH: ${{ github.event.workflow_run.path }}
           VALIDATOR_PATH: ${{ steps.validator.outputs.path }}
         run: |
           set -euo pipefail
+          case "$SOURCE_PATH" in
+            .github/workflows/dependabot-process.yml|.github/workflows/dependabot-process.yml@main)
+              source_workflow="Dependabot Processor"
+              ;;
+            .github/workflows/dependabot-prepare-repair.yml|.github/workflows/dependabot-prepare-repair.yml@main)
+              source_workflow="Dependabot Prepare Repair"
+              ;;
+            *) exit 1 ;;
+          esac
           node "$VALIDATOR_PATH" terminal-dispatch-plan \
             --repository "$REPOSITORY" \
-            --source-workflow "$SOURCE_WORKFLOW" \
+            --source-workflow "$source_workflow" \
             --source-run-id "$SOURCE_ID" \
             --source-run-attempt "$SOURCE_ATTEMPT" \
             --source-workflow-sha "$SOURCE_HEAD_SHA" \

--- a/.github/workflows/dependabot-process.yml
+++ b/.github/workflows/dependabot-process.yml
@@ -51,16 +51,19 @@ jobs:
           github.event_name == 'workflow_run' &&
           (
             (
-              github.event.workflow_run.name == 'Dependabot Intake' &&
+              (github.event.workflow_run.path == '.github/workflows/dependabot-intake.yml' ||
+               github.event.workflow_run.path == '.github/workflows/dependabot-intake.yml@main') &&
               endsWith(github.event.workflow_run.display_title, 'receipt=true')
             ) ||
             (
-              github.event.workflow_run.name == 'Dependabot Prepared Head Intake' &&
+              (github.event.workflow_run.path == '.github/workflows/dependabot-prepared-head-intake.yml' ||
+               github.event.workflow_run.path == '.github/workflows/dependabot-prepared-head-intake.yml@main') &&
               startsWith(github.event.workflow_run.display_title, 'dependabot-prepared-head:v1|') &&
               endsWith(github.event.workflow_run.display_title, '|ok=true')
             ) ||
             (
-              github.event.workflow_run.name == 'Dependabot Claude Review' &&
+              (github.event.workflow_run.path == '.github/workflows/dependabot-claude-review.yml' ||
+               github.event.workflow_run.path == '.github/workflows/dependabot-claude-review.yml@main') &&
               startsWith(github.event.workflow_run.display_title, 'dependabot-claude-review:v1 | source=')
             )
           )
@@ -100,7 +103,6 @@ jobs:
           INTAKE_TITLE: ${{ github.event.workflow_run.display_title }}
           INTAKE_TRIGGERING_ACTOR_LOGIN: ${{ github.event.workflow_run.triggering_actor.login }}
           INTAKE_TRIGGERING_ACTOR_TYPE: ${{ github.event.workflow_run.triggering_actor.type }}
-          INTAKE_WORKFLOW: ${{ github.event.workflow_run.name }}
           INTAKE_STATUS: ${{ github.event.workflow_run.status }}
           INTAKE_RUN_ATTEMPT: ${{ github.event.workflow_run.run_attempt }}
           INTAKE_RUN_ID: ${{ github.event.workflow_run.id }}
@@ -120,8 +122,8 @@ jobs:
               [[ "$INTAKE_RUN_ID" =~ ^[1-9][0-9]*$ ]]
               [[ "$INTAKE_RUN_ATTEMPT" =~ ^[1-9][0-9]*$ ]]
 
-              case "$INTAKE_WORKFLOW" in
-                "Dependabot Intake")
+              case "$INTAKE_PATH" in
+                .github/workflows/dependabot-intake.yml|.github/workflows/dependabot-intake.yml@main)
                   test "$INTAKE_CONCLUSION" = "success"
                   test "$INTAKE_EVENT" = "pull_request_target"
                   test "$INTAKE_ACTOR_LOGIN" = "dependabot[bot]"
@@ -132,10 +134,6 @@ jobs:
                     test "$INTAKE_TRIGGERING_ACTOR_TYPE" = "Bot"
                   fi
                   [[ "$INTAKE_HEAD_BRANCH" == dependabot/* ]]
-                  case "$INTAKE_PATH" in
-                    .github/workflows/dependabot-intake.yml|.github/workflows/dependabot-intake.yml@main) ;;
-                    *) exit 1 ;;
-                  esac
                   receipt_pattern='^dependabot-intake:v1 \| repository=mento-protocol/frontend-monorepo \| pr=([1-9][0-9]{0,9}) \| sha=([0-9a-f]{40}) \| action=(opened|synchronize|reopened) \| receipt=true$'
                   [[ "$INTAKE_TITLE" =~ $receipt_pattern ]]
                   receipt_pr_number="${BASH_REMATCH[1]}"
@@ -167,17 +165,13 @@ jobs:
                     '
                   followup_kind="native-intake"
                   ;;
-                "Dependabot Prepared Head Intake")
+                .github/workflows/dependabot-prepared-head-intake.yml|.github/workflows/dependabot-prepared-head-intake.yml@main)
                   test "$INTAKE_CONCLUSION" = "success"
                   test "$INTAKE_EVENT" = "repository_dispatch"
                   test "$INTAKE_HEAD_BRANCH" = "main"
                   test "$INTAKE_ACTOR_ID" = "$EXPECTED_PREPARE_BOT_ID"
                   test "$INTAKE_ACTOR_LOGIN" = "$EXPECTED_PREPARE_BOT_LOGIN"
                   test "$INTAKE_ACTOR_TYPE" = "Bot"
-                  case "$INTAKE_PATH" in
-                    .github/workflows/dependabot-prepared-head-intake.yml|.github/workflows/dependabot-prepared-head-intake.yml@main) ;;
-                    *) exit 1 ;;
-                  esac
                   prepared_pattern='^dependabot-prepared-head:v1\|p=([1-9][0-9]{0,9})\|h=([0-9a-f]{40})\|o=([rp])\|c=([1-9][0-9]*)\|d=([0-9a-f]{64})\|ok=true$'
                   [[ "$INTAKE_TITLE" =~ $prepared_pattern ]]
                   receipt_pr_number="${BASH_REMATCH[1]}"
@@ -187,17 +181,13 @@ jobs:
                   operation_digest="${BASH_REMATCH[5]}"
                   followup_kind="prepared-intake"
                   ;;
-                "Dependabot Claude Review")
+                .github/workflows/dependabot-claude-review.yml|.github/workflows/dependabot-claude-review.yml@main)
                   case "$INTAKE_CONCLUSION" in
                     success|failure) ;;
                     *) exit 1 ;;
                   esac
                   test "$INTAKE_EVENT" = "workflow_run"
                   test "$INTAKE_HEAD_BRANCH" = "main"
-                  case "$INTAKE_PATH" in
-                    .github/workflows/dependabot-claude-review.yml|.github/workflows/dependabot-claude-review.yml@main) ;;
-                    *) exit 1 ;;
-                  esac
                   native_review_pattern='^dependabot-claude-review:v1 \| source=dependabot-intake:v1 \| repository=mento-protocol/frontend-monorepo \| pr=([1-9][0-9]{0,9}) \| sha=([0-9a-f]{40}) \| action=(opened|synchronize|reopened) \| receipt=true$'
                   prepared_review_pattern='^dependabot-claude-review:v1 \| source=dependabot-prepared-head:v1\|p=([1-9][0-9]{0,9})\|h=([0-9a-f]{40})\|o=([rp])\|c=([1-9][0-9]*)\|d=([0-9a-f]{64})\|ok=true$'
                   if [[ "$INTAKE_TITLE" =~ $native_review_pattern ]]; then

--- a/docs/dependabot-automation.md
+++ b/docs/dependabot-automation.md
@@ -110,6 +110,10 @@ whose payload is exactly `{"scope":"open"}`. There is no
 
 The schedule runs at minutes `3,13,23,33,43,53` to reconcile missed events.
 Immediate intake and review completions provide the normal low-latency path.
+Every downstream `workflow_run` gate identifies its source by the exact
+allowlisted workflow path. A custom `run-name` becomes the live run's `name`
+and `display_title`, so those dynamic fields authenticate only the typed receipt
+grammar and never select the source workflow.
 Every entry point materializes `scripts/dependabot-processor.mjs` and its
 `scripts/dependabot-preparation-receipts.mjs` validator dependency through the
 GitHub Contents API at the same exact `github.workflow_sha`; it never checks out
@@ -136,7 +140,7 @@ Prepare execution has explicit phases:
 intake through `workflow_run`. Before any token, secret, or Action:
 
 1. the first shell step authenticates upstream conclusion, event, actor ID,
-   actor login/type, workflow name/path, repository, compact receipt, run ID,
+   actor login/type, exact workflow path, repository, compact receipt, run ID,
    attempt, and workflow SHA;
 2. it re-queries the live open non-draft Dependabot PR and exact head; and
 3. for prepared heads it materializes

--- a/docs/quality-budgets.md
+++ b/docs/quality-budgets.md
@@ -90,8 +90,12 @@ canonical default-branch `Dependabot Processor` sweep and exact, bounded
 `Dependabot Prepare Repair` or `Dependabot Prepared Head Intake` titles. Repair
 monitoring includes both exact bounded normal and recovery titles with their
 infrastructure retry count. The trusted script revalidates each case-sensitive
-identity; malformed repair titles and prepared-intake `ok=false` skips are
-ignored. It also monitors
+identity. It binds each Dependabot source to its exact
+`.github/workflows/*.yml` path or exact `@main` form because GitHub exposes a custom `run-name` through
+`workflow_run.name`; the separately validated `display_title` carries the
+bounded receipt grammar. Malformed repair titles, path mismatches, and
+prepared-intake `ok=false` skips are ignored. Managed issue prose uses the
+canonical workflow name derived from that trusted path. It also monitors
 repository-owned, default-branch `workflow_run` completions for `Vercel Main
 Deployment`, `Dependabot Prepared Head Dispatch`, and `Dependabot Processor`
 runs whose title exactly carries a valid native-intake, prepared-intake, or

--- a/scripts/ci-failure-issue.mjs
+++ b/scripts/ci-failure-issue.mjs
@@ -13,12 +13,25 @@ const FAILURE_CONCLUSIONS = new Set([
 ]);
 const NOTIFIER_WORKFLOW_NAME = "CI Failure Notifier";
 const TAG_PUSH_WORKFLOW_NAMES = new Set(["Publish UI Package"]);
-const DEPENDABOT_PROCESSOR_WORKFLOW_NAME = "Dependabot Processor";
-const DEPENDABOT_REPAIR_WORKFLOW_NAME = "Dependabot Prepare Repair";
-const DEPENDABOT_PREPARED_DISPATCH_WORKFLOW_NAME =
-  "Dependabot Prepared Head Dispatch";
-const DEPENDABOT_PREPARED_INTAKE_WORKFLOW_NAME =
-  "Dependabot Prepared Head Intake";
+const DEPENDABOT_PROCESSOR_WORKFLOW_PATH =
+  ".github/workflows/dependabot-process.yml";
+const DEPENDABOT_REPAIR_WORKFLOW_PATH =
+  ".github/workflows/dependabot-prepare-repair.yml";
+const DEPENDABOT_PREPARED_DISPATCH_WORKFLOW_PATH =
+  ".github/workflows/dependabot-prepared-head-dispatch.yml";
+const DEPENDABOT_PREPARED_INTAKE_WORKFLOW_PATH =
+  ".github/workflows/dependabot-prepared-head-intake.yml";
+// GitHub exposes `run-name` through run.name for these workflows. The exact
+// repository path is the stable source identity; display_title carries data.
+const DEPENDABOT_WORKFLOW_NAMES_BY_PATH = new Map([
+  [DEPENDABOT_PROCESSOR_WORKFLOW_PATH, "Dependabot Processor"],
+  [DEPENDABOT_REPAIR_WORKFLOW_PATH, "Dependabot Prepare Repair"],
+  [
+    DEPENDABOT_PREPARED_DISPATCH_WORKFLOW_PATH,
+    "Dependabot Prepared Head Dispatch",
+  ],
+  [DEPENDABOT_PREPARED_INTAKE_WORKFLOW_PATH, "Dependabot Prepared Head Intake"],
+]);
 const DEPENDABOT_PROCESSOR_SWEEP_TITLE =
   "Dependabot processor | event=repository_dispatch | target=scope=open";
 const VERCEL_MAIN_WORKFLOW_NAME = "Vercel Main Deployment";
@@ -58,11 +71,15 @@ function runIdentity(run) {
   return `${runId}:${run.run_attempt ?? 1}`;
 }
 
+function workflowPathMatches(run, expectedPath) {
+  return run.path === expectedPath || run.path === `${expectedPath}@main`;
+}
+
 function dependabotAutomationPrTarget(run) {
   const title = String(run.display_title ?? "");
   let patterns = [];
   if (
-    run.name === DEPENDABOT_PROCESSOR_WORKFLOW_NAME &&
+    workflowPathMatches(run, DEPENDABOT_PROCESSOR_WORKFLOW_PATH) &&
     run.event === "workflow_run"
   ) {
     patterns = [
@@ -72,12 +89,12 @@ function dependabotAutomationPrTarget(run) {
       DEPENDABOT_PROCESSOR_PREPARED_REVIEW_TITLE,
     ];
   } else if (
-    run.name === DEPENDABOT_REPAIR_WORKFLOW_NAME &&
+    workflowPathMatches(run, DEPENDABOT_REPAIR_WORKFLOW_PATH) &&
     run.event === "repository_dispatch"
   ) {
     patterns = [DEPENDABOT_REPAIR_TITLE];
   } else if (
-    run.name === DEPENDABOT_PREPARED_INTAKE_WORKFLOW_NAME &&
+    workflowPathMatches(run, DEPENDABOT_PREPARED_INTAKE_WORKFLOW_PATH) &&
     run.event === "repository_dispatch"
   ) {
     patterns = [DEPENDABOT_PREPARED_INTAKE_TITLE];
@@ -88,7 +105,7 @@ function dependabotAutomationPrTarget(run) {
 
 function isDependabotProcessorSweep(run, defaultBranch, repositoryFullName) {
   return (
-    run.name === DEPENDABOT_PROCESSOR_WORKFLOW_NAME &&
+    workflowPathMatches(run, DEPENDABOT_PROCESSOR_WORKFLOW_PATH) &&
     run.event === "repository_dispatch" &&
     run.display_title === DEPENDABOT_PROCESSOR_SWEEP_TITLE &&
     run.head_branch === defaultBranch &&
@@ -118,16 +135,24 @@ function runLink(run) {
   return `[run #${run.run_number}, attempt ${run.run_attempt ?? 1}](${run.html_url})`;
 }
 
+function workflowNameFor(run) {
+  const path = String(run.path ?? "");
+  const canonicalPath = path.endsWith("@main") ? path.slice(0, -5) : path;
+  return DEPENDABOT_WORKFLOW_NAMES_BY_PATH.get(canonicalPath) ?? run.name;
+}
+
 function issueTitle(run, targetRef) {
-  return `CI: ${run.name} is failing (${targetRef}; ${run.event})`.slice(
+  const workflowName = workflowNameFor(run);
+  return `CI: ${workflowName} is failing (${targetRef}; ${run.event})`.slice(
     0,
     255,
   );
 }
 
 function failureBody(run, targetRef, marker) {
+  const workflowName = workflowNameFor(run);
   return [
-    `The **${run.name}** workflow failed for \`${targetRef}\`.`,
+    `The **${workflowName}** workflow failed for \`${targetRef}\`.`,
     "",
     `- Conclusion: \`${run.conclusion}\``,
     `- Trigger: \`${run.event}\``,
@@ -140,12 +165,13 @@ function failureBody(run, targetRef, marker) {
 }
 
 function recoveryBody(existingBody, run, targetRef) {
+  const workflowName = workflowNameFor(run);
   return [
     existingBody.trim(),
     "",
     "## Recovery",
     "",
-    `**${run.name}** recovered for \`${targetRef}\` in ${runLink(run)}.`,
+    `**${workflowName}** recovered for \`${targetRef}\` in ${runLink(run)}.`,
   ].join("\n");
 }
 
@@ -167,7 +193,7 @@ function isRelevantRun(run, defaultBranch, repositoryFullName) {
     (run.event === "workflow_run" &&
       (run.name === VERCEL_MAIN_WORKFLOW_NAME ||
         dependabotTarget !== null ||
-        (run.name === DEPENDABOT_PREPARED_DISPATCH_WORKFLOW_NAME &&
+        (workflowPathMatches(run, DEPENDABOT_PREPARED_DISPATCH_WORKFLOW_PATH) &&
           DEPENDABOT_PREPARED_DISPATCH_TITLE.test(
             String(run.display_title ?? ""),
           ))) &&

--- a/scripts/ci-failure-issue.test.mjs
+++ b/scripts/ci-failure-issue.test.mjs
@@ -3,6 +3,15 @@ import { test } from "node:test";
 
 import { reconcileCiFailureIssue } from "./ci-failure-issue.mjs";
 
+const DEPENDABOT_PROCESSOR_WORKFLOW_PATH =
+  ".github/workflows/dependabot-process.yml";
+const DEPENDABOT_REPAIR_WORKFLOW_PATH =
+  ".github/workflows/dependabot-prepare-repair.yml";
+const DEPENDABOT_PREPARED_DISPATCH_WORKFLOW_PATH =
+  ".github/workflows/dependabot-prepared-head-dispatch.yml";
+const DEPENDABOT_PREPARED_INTAKE_WORKFLOW_PATH =
+  ".github/workflows/dependabot-prepared-head-intake.yml";
+
 function managedMarker(event = "push", targetRef = "main") {
   return `<!-- managed-ci-failure:77:${event}:${encodeURIComponent(targetRef)} -->`;
 }
@@ -13,6 +22,7 @@ function workflowRun(overrides = {}) {
     id: 1_000 + runNumber,
     workflow_id: 77,
     name: "Quality Budgets",
+    path: ".github/workflows/quality-budgets.yml",
     run_number: runNumber,
     run_attempt: 1,
     html_url:
@@ -31,20 +41,28 @@ function workflowRun(overrides = {}) {
 function mainDeploymentRun(overrides = {}) {
   return workflowRun({
     name: "Vercel Main Deployment",
+    path: ".github/workflows/vercel-main-deployment.yml",
     event: "workflow_run",
     ...overrides,
   });
 }
 
 function dependabotProcessorRun(overrides = {}) {
-  const { target = "pr=711", ...runOverrides } = overrides;
+  const {
+    target = "pr=711",
+    display_title: explicitDisplayTitle,
+    name: explicitName,
+    ...runOverrides
+  } = overrides;
   const targetValue = String(target).replace(/^pr=/, "");
   const displayTitle =
-    target === "ignored"
+    explicitDisplayTitle ??
+    (target === "ignored"
       ? "Dependabot processor | event=workflow_run | target=ignored"
-      : `Dependabot processor | event=workflow_run | receipt=dependabot-intake:v1 | repository=mento-protocol/frontend-monorepo | pr=${targetValue} | sha=${"a".repeat(40)} | action=synchronize | receipt=true`;
+      : `Dependabot processor | event=workflow_run | receipt=dependabot-intake:v1 | repository=mento-protocol/frontend-monorepo | pr=${targetValue} | sha=${"a".repeat(40)} | action=synchronize | receipt=true`);
   return workflowRun({
-    name: "Dependabot Processor",
+    name: explicitName ?? displayTitle,
+    path: DEPENDABOT_PROCESSOR_WORKFLOW_PATH,
     event: "workflow_run",
     display_title: displayTitle,
     ...runOverrides,
@@ -52,42 +70,78 @@ function dependabotProcessorRun(overrides = {}) {
 }
 
 function dependabotProcessorSweepRun(overrides = {}) {
+  const {
+    display_title: explicitDisplayTitle,
+    name: explicitName,
+    ...runOverrides
+  } = overrides;
+  const displayTitle =
+    explicitDisplayTitle ??
+    "Dependabot processor | event=repository_dispatch | target=scope=open";
   return workflowRun({
-    name: "Dependabot Processor",
+    name: explicitName ?? displayTitle,
+    path: DEPENDABOT_PROCESSOR_WORKFLOW_PATH,
     event: "repository_dispatch",
-    display_title:
-      "Dependabot processor | event=repository_dispatch | target=scope=open",
-    ...overrides,
+    display_title: displayTitle,
+    ...runOverrides,
   });
 }
 
 function dependabotRepairRun(overrides = {}) {
-  const { pr = 711, recovery = false, retry = 0, ...runOverrides } = overrides;
+  const {
+    pr = 711,
+    recovery = false,
+    retry = 0,
+    display_title: explicitDisplayTitle,
+    name: explicitName,
+    ...runOverrides
+  } = overrides;
+  const displayTitle =
+    explicitDisplayTitle ??
+    `dependabot-repair${recovery ? "-recover" : ""}:v1 | pr=${pr} | head=${"a".repeat(40)} | check=123 | digest=${"b".repeat(64)} | retry=${retry}`;
   return workflowRun({
-    name: "Dependabot Prepare Repair",
+    name: explicitName ?? displayTitle,
+    path: DEPENDABOT_REPAIR_WORKFLOW_PATH,
     event: "repository_dispatch",
-    display_title: `dependabot-repair${recovery ? "-recover" : ""}:v1 | pr=${pr} | head=${"a".repeat(40)} | check=123 | digest=${"b".repeat(64)} | retry=${retry}`,
+    display_title: displayTitle,
     ...runOverrides,
   });
 }
 
 function dependabotPreparedIntakeRun(overrides = {}) {
-  const { pr = 711, ...runOverrides } = overrides;
+  const {
+    pr = 711,
+    display_title: explicitDisplayTitle,
+    name: explicitName,
+    ...runOverrides
+  } = overrides;
+  const displayTitle =
+    explicitDisplayTitle ??
+    `dependabot-prepared-head:v1|p=${pr}|h=${"a".repeat(40)}|o=p|c=123|d=${"b".repeat(64)}|ok=true`;
   return workflowRun({
-    name: "Dependabot Prepared Head Intake",
+    name: explicitName ?? displayTitle,
+    path: DEPENDABOT_PREPARED_INTAKE_WORKFLOW_PATH,
     event: "repository_dispatch",
-    display_title: `dependabot-prepared-head:v1|p=${pr}|h=${"a".repeat(40)}|o=p|c=123|d=${"b".repeat(64)}|ok=true`,
+    display_title: displayTitle,
     ...runOverrides,
   });
 }
 
 function dependabotPreparedDispatchRun(overrides = {}) {
+  const {
+    display_title: explicitDisplayTitle,
+    name: explicitName,
+    ...runOverrides
+  } = overrides;
+  const displayTitle =
+    explicitDisplayTitle ??
+    "dependabot-prepared-dispatch:v1 | source=Dependabot Prepare Repair | run=123 | attempt=1";
   return workflowRun({
-    name: "Dependabot Prepared Head Dispatch",
+    name: explicitName ?? displayTitle,
+    path: DEPENDABOT_PREPARED_DISPATCH_WORKFLOW_PATH,
     event: "workflow_run",
-    display_title:
-      "dependabot-prepared-dispatch:v1 | source=Dependabot Prepare Repair | run=123 | attempt=1",
-    ...overrides,
+    display_title: displayTitle,
+    ...runOverrides,
   });
 }
 
@@ -376,6 +430,8 @@ test("exposes the manual trigger in the incident title", async () => {
 
 test("tracks repository-dispatch processor sweeps on the default branch", async () => {
   const run = dependabotProcessorSweepRun();
+  assert.equal(run.name, run.display_title);
+  assert.notEqual(run.name, "Dependabot Processor");
   const { github, context, calls } = harness({ run });
   const result = await reconcileCiFailureIssue({ github, context });
 
@@ -384,6 +440,90 @@ test("tracks repository-dispatch processor sweeps on the default branch", async 
     calls.create[0].title,
     "CI: Dependabot Processor is failing (main; repository_dispatch)",
   );
+});
+
+test("uses the exact path instead of a custom run name for Dependabot identity", async () => {
+  const run = dependabotProcessorRun({
+    name: "a custom title that is not an identity",
+  });
+  const { github, context, calls } = harness({ run });
+  const result = await reconcileCiFailureIssue({ github, context });
+
+  assert.deepEqual(result, { action: "opened", issueNumber: 91 });
+  assert.equal(
+    calls.create[0].title,
+    "CI: Dependabot Processor is failing (pr=711; workflow_run)",
+  );
+  assert.match(
+    calls.create[0].body,
+    /The \*\*Dependabot Processor\*\* workflow/,
+  );
+  assert.doesNotMatch(calls.create[0].body, /a custom title/);
+});
+
+test("accepts only GitHub's exact main-qualified Dependabot path form", async () => {
+  for (const run of [
+    dependabotProcessorSweepRun({
+      path: `${DEPENDABOT_PROCESSOR_WORKFLOW_PATH}@main`,
+    }),
+    dependabotProcessorRun({
+      path: `${DEPENDABOT_PROCESSOR_WORKFLOW_PATH}@main`,
+    }),
+    dependabotRepairRun({
+      path: `${DEPENDABOT_REPAIR_WORKFLOW_PATH}@main`,
+    }),
+    dependabotPreparedIntakeRun({
+      path: `${DEPENDABOT_PREPARED_INTAKE_WORKFLOW_PATH}@main`,
+    }),
+    dependabotPreparedDispatchRun({
+      path: `${DEPENDABOT_PREPARED_DISPATCH_WORKFLOW_PATH}@main`,
+    }),
+  ]) {
+    const { github, context } = harness({ run });
+    const result = await reconcileCiFailureIssue({ github, context });
+    assert.deepEqual(result, { action: "opened", issueNumber: 91 });
+  }
+});
+
+test("does not accept a Dependabot name and title without the exact workflow path", async () => {
+  const wrongPath = ".github/workflows/quality-budgets.yml";
+  for (const run of [
+    dependabotProcessorSweepRun({
+      name: "Dependabot Processor",
+      path: wrongPath,
+    }),
+    dependabotProcessorRun({
+      name: "Dependabot Processor",
+      path: wrongPath,
+    }),
+    dependabotRepairRun({
+      name: "Dependabot Prepare Repair",
+      path: wrongPath,
+    }),
+    dependabotPreparedIntakeRun({
+      name: "Dependabot Prepared Head Intake",
+      path: wrongPath,
+    }),
+    dependabotPreparedDispatchRun({
+      name: "Dependabot Prepared Head Dispatch",
+      path: wrongPath,
+    }),
+  ]) {
+    const { github, context, calls } = harness({ run });
+    const result = await reconcileCiFailureIssue({ github, context });
+    assert.deepEqual(result, { action: "ignored", reason: "untracked-run" });
+    assert.equal(calls.listRuns, 0);
+    assert.equal(calls.listIssues, 0);
+  }
+
+  const spoofedMainPath = dependabotProcessorRun({
+    path: `${DEPENDABOT_PROCESSOR_WORKFLOW_PATH}@main@main`,
+  });
+  const { github, context } = harness({ run: spoofedMainPath });
+  assert.deepEqual(await reconcileCiFailureIssue({ github, context }), {
+    action: "ignored",
+    reason: "untracked-run",
+  });
 });
 
 test("partitions repair, recovery, and prepared-intake incidents by exact pull request", async () => {

--- a/scripts/dependabot-prepared-review.test.mjs
+++ b/scripts/dependabot-prepared-review.test.mjs
@@ -1633,7 +1633,8 @@ test("Dependabot reviewer accepts only authenticated native or prepared intake",
   });
   assert.deepEqual(review.permissions, {});
   const preflight = review.jobs.preflight;
-  assert.match(preflight.if, /Dependabot Prepared Head Intake/);
+  assert.match(preflight.if, /dependabot-prepared-head-intake\.yml/);
+  assert.doesNotMatch(preflight.if, /workflow_run\.name/);
   assert.match(preflight.if, /\|ok=true/);
   assert.deepEqual(preflight.permissions, {
     actions: "read",
@@ -1642,8 +1643,13 @@ test("Dependabot reviewer accepts only authenticated native or prepared intake",
     "pull-requests": "read",
   });
   const authentication = preflight.steps[0];
-  assert.match(authentication.run, /Dependabot Intake/);
-  assert.match(authentication.run, /Dependabot Prepared Head Intake/);
+  assert.match(authentication.run, /dependabot-intake\.yml/);
+  assert.match(authentication.run, /dependabot-prepared-head-intake\.yml/);
+  assert.equal(
+    authentication.env.INTAKE_PATH,
+    "${{ github.event.workflow_run.path }}",
+  );
+  assert.equal(Object.hasOwn(authentication.env, "INTAKE_WORKFLOW"), false);
   assert.match(authentication.run, /INTAKE_ACTOR_ID.*EXPECTED_PREPARE_BOT_ID/s);
   assert.match(authentication.run, /dependabot-prepared-head:v1/);
   assert.match(authentication.run, /operation_digest/);
@@ -1718,7 +1724,6 @@ test("prepared reviewer preflight authenticates and emits the actual compact rec
         INTAKE_TRIGGERING_ACTOR_ID: String(prepareBotId),
         INTAKE_TRIGGERING_ACTOR_LOGIN: prepareBotLogin,
         INTAKE_TRIGGERING_ACTOR_TYPE: "Bot",
-        INTAKE_WORKFLOW: "Dependabot Prepared Head Intake",
         PATH: process.env.PATH,
         REPOSITORY: repository,
         RUN_ATTEMPT: "1",

--- a/scripts/dependabot-workflows.test.mjs
+++ b/scripts/dependabot-workflows.test.mjs
@@ -210,7 +210,6 @@ function liveIntakeEnvironment(overrides = {}) {
     INTAKE_STATUS: "completed",
     INTAKE_RUN_ATTEMPT: "1",
     INTAKE_RUN_ID: "123456789",
-    INTAKE_WORKFLOW: "Dependabot Intake",
     EXPECTED_PREPARE_BOT_ID: "123456",
     EXPECTED_PREPARE_BOT_LOGIN: "mento-dependabot-prepare[bot]",
     REPOSITORY: "mento-protocol/frontend-monorepo",
@@ -348,19 +347,24 @@ test("read-only evaluation authenticates every trigger before live collection", 
     evaluate.if,
     /endsWith\(github\.event\.workflow_run\.display_title, 'receipt=true'\)/,
   );
-  assert.match(evaluate.if, /Dependabot Prepared Head Intake/);
-  assert.match(evaluate.if, /Dependabot Claude Review/);
+  assert.match(evaluate.if, /dependabot-prepared-head-intake\.yml/);
+  assert.match(evaluate.if, /dependabot-claude-review\.yml/);
   assert.match(evaluate.if, /github\.event\.action == 'dependabot-process'/);
   assert.doesNotMatch(evaluate.if, /client_payload/);
+  assert.doesNotMatch(evaluate.if, /workflow_run\.name/);
   assert.doesNotMatch(
     evaluate.if,
-    /workflow_run\.(?:path|event|conclusion|head_repository|head_branch)/,
+    /workflow_run\.(?:event|conclusion|head_repository|head_branch)/,
   );
+  assert.match(evaluate.if, /workflow_run\.path/);
 
   const target = evaluate.steps.find(
     (step) => step.name === "Validate trigger and select a bounded target",
   );
   assert.ok(target);
+  assert.equal(target.env.INTAKE_PATH, "${{ github.event.workflow_run.path }}");
+  assert.equal(Object.hasOwn(target.env, "INTAKE_WORKFLOW"), false);
+  assert.match(target.run, /case "\$INTAKE_PATH" in/);
   assert.match(target.run, /Object\.keys\(clientPayload\)\.sort\(\)/);
   assert.match(target.run, /process\.env\.GITHUB_EVENT_PATH/);
   assert.equal(Object.hasOwn(target.env, "EVENT_PATH"), false);
@@ -441,7 +445,6 @@ test("processor accepts an exact prepared-head intake completion", () => {
     INTAKE_PATH: ".github/workflows/dependabot-prepared-head-intake.yml",
     INTAKE_PULL_REQUESTS_JSON: "[]",
     INTAKE_TITLE: `dependabot-prepared-head:v1|p=701|h=${headSha}|o=p|c=321|d=${digest}|ok=true`,
-    INTAKE_WORKFLOW: "Dependabot Prepared Head Intake",
   });
 
   assert.equal(result.status, 0, result.stderr);
@@ -465,7 +468,6 @@ test("processor wakes on a failed exact Claude reviewer completion", () => {
     INTAKE_HEAD_SHA: "c".repeat(40),
     INTAKE_PATH: ".github/workflows/dependabot-claude-review.yml",
     INTAKE_TITLE: `dependabot-claude-review:v1 | source=dependabot-intake:v1 | repository=mento-protocol/frontend-monorepo | pr=701 | sha=${headSha} | action=synchronize | receipt=true`,
-    INTAKE_WORKFLOW: "Dependabot Claude Review",
   });
 
   assert.equal(result.status, 0, result.stderr);
@@ -1367,7 +1369,12 @@ test("terminal dispatch accepts successful Processor and exact terminal Repair o
   assert.deepEqual(preparedDispatch.permissions, {});
   const plan = preparedDispatch.jobs.plan;
   const dispatch = preparedDispatch.jobs.dispatch;
+  assert.doesNotMatch(read(preparedDispatchPath), /workflow_run\.name/);
+  assert.match(preparedDispatch["run-name"], /workflow_run\.path/);
   assert.match(plan.if, /workflow_run\.status == 'completed'/);
+  assert.match(plan.if, /dependabot-process\.yml/);
+  assert.match(plan.if, /dependabot-prepare-repair\.yml/);
+  assert.doesNotMatch(plan.if, /workflow_run\.name/);
   assert.match(plan.if, /workflow_run\.conclusion == 'success'/);
   assert.match(plan.if, /workflow_run\.conclusion == 'failure'/);
   assert.match(plan.if, /workflow_run\.conclusion == 'cancelled'/);
@@ -1398,7 +1405,22 @@ test("terminal dispatch accepts successful Processor and exact terminal Repair o
   );
   assert.match(plan.steps[0].run, /dependabot-repair-recover:v1/);
   assert.match(plan.steps[0].run, /retry=\[0-2\]/);
+  assert.equal(
+    plan.steps[0].env.SOURCE_PATH,
+    "${{ github.event.workflow_run.path }}",
+  );
+  assert.equal(Object.hasOwn(plan.steps[0].env, "SOURCE_WORKFLOW"), false);
+  assert.equal(
+    plan.steps.at(-1).env.SOURCE_PATH,
+    "${{ github.event.workflow_run.path }}",
+  );
+  assert.match(plan.steps.at(-1).run, /source_workflow="Dependabot Processor"/);
+  assert.match(
+    plan.steps.at(-1).run,
+    /source_workflow="Dependabot Prepare Repair"/,
+  );
   assert.match(plan.steps.at(-1).run, /terminal-dispatch-plan/);
+  assert.match(plan.steps.at(-1).run, /--source-workflow "\$source_workflow"/);
 
   const token = dispatch.steps[0];
   assert.equal(
@@ -1441,6 +1463,9 @@ test("Dependabot Claude review follows only authenticated intake runs", () => {
   assert.equal(preflightJob.name, "dependabot-claude-review-preflight");
   assert.match(preflightJob.if, /mento-protocol\/frontend-monorepo/);
   assert.match(preflightJob.if, /receipt=true/);
+  assert.match(preflightJob.if, /dependabot-intake\.yml/);
+  assert.match(preflightJob.if, /dependabot-prepared-head-intake\.yml/);
+  assert.doesNotMatch(preflightJob.if, /workflow_run\.name/);
   assert.deepEqual(preflightJob.permissions, {
     actions: "read",
     checks: "read",
@@ -1463,6 +1488,8 @@ test("Dependabot Claude review follows only authenticated intake runs", () => {
   assert.equal(intake.id, "intake");
   assert.equal(Object.hasOwn(intake, "uses"), false);
   assert.equal(Object.hasOwn(intake.env, "GH_TOKEN"), false);
+  assert.equal(Object.hasOwn(intake.env, "INTAKE_WORKFLOW"), false);
+  assert.equal(intake.env.INTAKE_PATH, "${{ github.event.workflow_run.path }}");
   assert.doesNotMatch(JSON.stringify(intake), /secrets\.|github\.token/);
   assert.match(intake.run, /INTAKE_CONCLUSION.*success/);
   assert.match(intake.run, /INTAKE_EVENT.*pull_request_target/);
@@ -1477,7 +1504,7 @@ test("Dependabot Claude review follows only authenticated intake runs", () => {
   assert.match(intake.run, /pullRequest\?\.head\?\.sha/);
   assert.match(intake.run, /dependabot-intake:v1/);
   assert.match(intake.run, /dependabot-intake\.yml@main/);
-  assert.match(intake.run, /Dependabot Prepared Head Intake/);
+  assert.match(intake.run, /dependabot-prepared-head-intake\.yml/);
   assert.match(intake.run, /dependabot-prepared-head:v1/);
   assert.match(intake.run, /EXPECTED_PREPARE_BOT_ID/);
 
@@ -1656,7 +1683,6 @@ test("Dependabot Claude review authenticates live upstream head metadata", () =>
   const intake = dependabotReview.jobs.preflight.steps[0];
   const result = runBashStep(intake, {
     ...liveIntakeEnvironment(),
-    INTAKE_WORKFLOW: "Dependabot Intake",
     RUN_ATTEMPT: "1",
     RUN_ID: "123456789",
     WORKFLOW_SHA: "c".repeat(40),
@@ -1677,7 +1703,6 @@ test("native Dependabot review needs no Prepare App configuration", () => {
       EXPECTED_PREPARE_BOT_ID: "",
       EXPECTED_PREPARE_BOT_LOGIN: "",
     }),
-    INTAKE_WORKFLOW: "Dependabot Intake",
     RUN_ATTEMPT: "1",
     RUN_ID: "123456789",
     WORKFLOW_SHA: "c".repeat(40),
@@ -1691,7 +1716,6 @@ test("Dependabot Claude review allows an omitted linked PR after receipt authent
   const intake = dependabotReview.jobs.preflight.steps[0];
   const result = runBashStep(intake, {
     ...liveIntakeEnvironment({ INTAKE_PULL_REQUESTS_JSON: "[]" }),
-    INTAKE_WORKFLOW: "Dependabot Intake",
     RUN_ATTEMPT: "1",
     RUN_ID: "123456789",
     WORKFLOW_SHA: "c".repeat(40),
@@ -1704,7 +1728,6 @@ test("Dependabot Claude review rejects an upstream head and receipt mismatch", (
   const intake = dependabotReview.jobs.preflight.steps[0];
   const result = runBashStep(intake, {
     ...liveIntakeEnvironment({ INTAKE_HEAD_SHA: "b".repeat(40) }),
-    INTAKE_WORKFLOW: "Dependabot Intake",
     RUN_ATTEMPT: "1",
     RUN_ID: "123456789",
     WORKFLOW_SHA: "c".repeat(40),

--- a/scripts/quality-workflows.test.mjs
+++ b/scripts/quality-workflows.test.mjs
@@ -226,16 +226,39 @@ test("the notifier is loop-safe, secretless, and least privilege", () => {
   assert.match(workflow, /^ {6}issues: write$/m);
   assert.match(workflow, /workflow_run\.name == 'Publish UI Package'/);
   assert.match(workflow, /workflow_run\.name == 'Vercel Main Deployment'/);
-  assert.match(workflow, /workflow_run\.name == 'Dependabot Processor'/);
-  assert.match(workflow, /workflow_run\.name == 'Dependabot Prepare Repair'/);
   assert.match(
     workflow,
-    /workflow_run\.name == 'Dependabot Prepared Head Dispatch'/,
+    /workflow_run\.path == '\.github\/workflows\/dependabot-process\.yml'/,
   );
   assert.match(
     workflow,
-    /workflow_run\.name == 'Dependabot Prepared Head Intake'/,
+    /workflow_run\.path == '\.github\/workflows\/dependabot-process\.yml@main'/,
   );
+  assert.match(
+    workflow,
+    /workflow_run\.path == '\.github\/workflows\/dependabot-prepare-repair\.yml'/,
+  );
+  assert.match(
+    workflow,
+    /workflow_run\.path == '\.github\/workflows\/dependabot-prepare-repair\.yml@main'/,
+  );
+  assert.match(
+    workflow,
+    /workflow_run\.path == '\.github\/workflows\/dependabot-prepared-head-dispatch\.yml'/,
+  );
+  assert.match(
+    workflow,
+    /workflow_run\.path == '\.github\/workflows\/dependabot-prepared-head-dispatch\.yml@main'/,
+  );
+  assert.match(
+    workflow,
+    /workflow_run\.path == '\.github\/workflows\/dependabot-prepared-head-intake\.yml'/,
+  );
+  assert.match(
+    workflow,
+    /workflow_run\.path == '\.github\/workflows\/dependabot-prepared-head-intake\.yml@main'/,
+  );
+  assert.doesNotMatch(workflow, /workflow_run\.name == 'Dependabot /);
   assert.match(
     workflow,
     /startsWith\(github\.event\.workflow_run\.display_title, 'Dependabot processor \| event=workflow_run \| receipt='\)/,


### PR DESCRIPTION
## The Problem

- GitHub exposes a workflow's custom `run-name` through `workflow_run.name`. The new Dependabot callbacks compared that dynamic value with static workflow names, so valid Intake, Claude Review, Processor, Repair, and Prepared Head completions could skip their downstream jobs. The failure notifier used the same assumption and could miss or strand managed incidents.

## The Solution

- Bind every Dependabot `workflow_run` source to its exact allowlisted workflow path, including GitHub's exact `@main` representation.
- Keep `display_title` limited to the existing typed receipt grammar and derive canonical notifier names only after path authentication.
- Add live-shaped callback and incident regressions where `name === display_title`, plus wrong-path and malformed-path rejection coverage.

## Validation

- `pnpm dependabot:process:test` — 201/201 passed.
- `pnpm quality:budgets:test` — 53/53 passed.
- `pnpm ci:action-pins:test` — 48 pin tests and 11 materializer tests passed.
- `pnpm adr:check --include-untracked` — passed.
- `trunk fmt` and `trunk check` on all 11 changed files — passed.
- `git diff --check` — passed.
- Pre-push type checks, Trunk, and Knip — passed; Knip reported only existing configuration hints.
- Live run `31525040810` confirmed the custom `run-name` appears in `name` while `path` remains `.github/workflows/dependabot-process.yml`.
- Autoreview cycle 1 found the missing `@main` notifier case; it was fixed. Cycle 2 was clean at 0.96 confidence.
- Claude Security scan: skipped because that plugin is unavailable in the Codex runtime. The fresh-context semantic review explicitly covered the workflow trust boundary.

## Risk

- No permission, token, mutation, or merge authority changed. The path and title allowlists remain fail-closed. Post-merge validation will require a live Dependabot callback to start substantive downstream jobs.

## Ship Checklist

- [x] PR title follows the conventions.
- [x] Performed a self-review of my own changes.
- [x] Relevant automated checks and smoke tests pass.
- [x] Architecture decision: Not applicable — this corrects the deployed workflow identity contract without changing the accepted architecture.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches fail-closed trust boundaries for Dependabot automation and default-branch CI alerting; behavior change is intentional but wrong path allowlists could skip or mis-attribute incidents until a live callback validates.
> 
> **Overview**
> Fixes Dependabot automation and CI failure notification when workflows use custom **`run-name`**, because GitHub surfaces that value as **`workflow_run.name`** instead of the static workflow title.
> 
> **Dependabot chain** (`dependabot-process`, `dependabot-claude-review`, `dependabot-prepared-head-dispatch`, and **`ci-failure-notifier`**) now gates on the allowlisted **`.github/workflows/*.yml`** path (and the **`@main`** form). Shell authentication branches on **`INTAKE_PATH` / `SOURCE_PATH`** instead of workflow name; **`display_title`** still carries only the typed receipt grammar.
> 
> **`scripts/ci-failure-issue.mjs`** matches Dependabot runs by path, maps path → canonical workflow name for issue titles/bodies, and ignores name/title spoofing without the exact path. Docs and workflow tests cover live-shaped runs where **`name === display_title`**, **`@main`** paths, and wrong-path rejection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 64a9303833e1871ca9c8e852d6ccd7c7721d1136. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->