### PR TITLE
fix: bind Dependabot refresh to live main

### DIFF
--- a/docs/dependabot-automation.md
+++ b/docs/dependabot-automation.md
@@ -124,9 +124,11 @@ Prepare execution has explicit phases:
 - `request` may publish only a typed old-head Refresh request. It has no App
   credential or branch-write authority.
 - `mutate` may consume only a terminal trusted request from an earlier
-  Processor run and use a short-lived Prepare App token for the bounded branch
-  refresh. It cannot publish checks, approve, reply, resolve threads, or
-  publish ALL CLEAR.
+  Processor run. Before dispatch, the old PR base must still match the
+  receipt's `previousBaseSha`, while an independent live default-branch lookup
+  must match the receipt's `baseSha`. A short-lived Prepare App token then
+  performs the bounded branch refresh. It cannot publish checks, approve,
+  reply, resolve threads, or publish ALL CLEAR.
 - `finalize` rejects `DEPENDABOT_PROCESSOR_REPAIR_TOKEN`, cannot update a
   branch, recollects the exact head, and alone may clean stale processor
   approvals, post packet-bound replies, approve, and publish ALL CLEAR.

--- a/scripts/dependabot-preparation-receipts.mjs
+++ b/scripts/dependabot-preparation-receipts.mjs
@@ -240,6 +240,9 @@ export function validateRefreshReceipt(receipt, { state } = {}) {
   sha(receipt.parentHeadSha, "parentHeadSha");
   sha(receipt.previousBaseSha, "previousBaseSha");
   sha(receipt.baseSha, "baseSha");
+  if (receipt.previousBaseSha === receipt.baseSha) {
+    fail("refresh previous and current bases must be distinct");
+  }
   if (receipt.state === "requested") {
     if (receipt.headSha !== null)
       fail("requested refresh headSha must be null");
@@ -2347,6 +2350,34 @@ async function listOpenDependabotPulls(token, repositoryName) {
   );
 }
 
+export async function readCurrentDefaultBranchSha({
+  repositoryName,
+  requestJson,
+}) {
+  repository(repositoryName);
+  const repositoryState = plainObject(
+    await requestJson(`/repos/${repositoryName}`),
+    "repository state",
+  );
+  if (
+    repositoryState.full_name !== repositoryName ||
+    repositoryState.default_branch !== "main"
+  ) {
+    fail("repository default branch is not exact");
+  }
+  const reference = plainObject(
+    await requestJson(`/repos/${repositoryName}/git/ref/heads/main`),
+    "default-branch reference",
+  );
+  if (
+    reference.ref !== "refs/heads/main" ||
+    reference.object?.type !== "commit"
+  ) {
+    fail("default-branch reference is not exact");
+  }
+  return sha(reference.object.sha, "current default-branch SHA");
+}
+
 export async function collectTerminalSourceChecks({
   pulls,
   repositoryName,
@@ -2503,7 +2534,13 @@ function validateOperationCheck({ check, pull, receipt, sourceRunId }) {
   }
 }
 
-function validateRequestedRefreshCheck({ check, pull, receipt, sourceRunId }) {
+function validateRequestedRefreshCheck({
+  check,
+  currentBaseSha,
+  pull,
+  receipt,
+  sourceRunId,
+}) {
   if (
     check.app?.id !== GITHUB_ACTIONS_APP_ID ||
     check.app?.slug !== "github-actions" ||
@@ -2520,17 +2557,30 @@ function validateRequestedRefreshCheck({ check, pull, receipt, sourceRunId }) {
   ) {
     fail("requested refresh check is not exact");
   }
-  return receipt.baseSha === pull.base.sha;
+  return (
+    receipt.previousBaseSha === pull.base?.sha &&
+    receipt.baseSha === currentBaseSha
+  );
 }
 
 export function createRequestedRefreshAction({
   check,
+  currentBaseSha,
   pull,
   receipt,
   sourceRunId,
 }) {
   validateRefreshReceipt(receipt, { state: "requested" });
-  if (!validateRequestedRefreshCheck({ check, pull, receipt, sourceRunId })) {
+  sha(currentBaseSha, "current default-branch SHA");
+  if (
+    !validateRequestedRefreshCheck({
+      check,
+      currentBaseSha,
+      pull,
+      receipt,
+      sourceRunId,
+    })
+  ) {
     return null;
   }
   return {
@@ -2977,6 +3027,7 @@ async function commandTerminalDispatchPlan(args) {
     sourceRunAttempt,
   );
   const actions = [];
+  let currentDefaultBranchSha;
   for (const { check, pull } of checks) {
     const text = check.output?.text;
     const externalId = check.external_id ?? "";
@@ -3006,8 +3057,13 @@ async function commandTerminalDispatchPlan(args) {
         fail("refresh receipt run identity changed");
       }
       if (receipt.state === "requested") {
+        currentDefaultBranchSha ??= await readCurrentDefaultBranchSha({
+          repositoryName,
+          requestJson: (path) => githubRequest(token, "GET", path),
+        });
         const action = createRequestedRefreshAction({
           check,
+          currentBaseSha: currentDefaultBranchSha,
           pull,
           receipt,
           sourceRunId,

--- a/scripts/dependabot-preparation-receipts.test.mjs
+++ b/scripts/dependabot-preparation-receipts.test.mjs
@@ -18,6 +18,7 @@ import {
   parseRepairRunTitle,
   parseCanonicalJson,
   rawDigest,
+  readCurrentDefaultBranchSha,
   repairIntentExternalId,
   sourceAttemptBinding,
   terminalActionConfiguration,
@@ -206,6 +207,13 @@ test("operation receipts bind exact identity, workflow run, and canonical digest
   assert.match(
     operationExternalId(requested),
     /^dependabot-refresh:v1:pr=731:head=[a-f0-9]{40}:state=requested:digest=[a-f0-9]{64}:run=998877:attempt=2$/,
+  );
+  assert.throws(
+    () =>
+      validateRefreshReceipt(
+        requestedRefreshReceipt({ previousBaseSha: baseSha }),
+      ),
+    /previous and current bases must be distinct/,
   );
 
   const repair = validateRepairReceipt(repairReceipt());
@@ -568,7 +576,7 @@ test("terminal retries re-authenticate a pre-ref packet and bound recovery 0 to 
   }
 });
 
-test("a terminal requested Refresh produces only the bounded next-process event", () => {
+test("a live-shaped terminal requested Refresh binds the historical PR base and current main", () => {
   const receipt = requestedRefreshReceipt();
   const check = {
     app: { id: 15368, slug: "github-actions" },
@@ -581,12 +589,13 @@ test("a terminal requested Refresh produces only the bounded next-process event"
     status: "completed",
   };
   const pull = {
-    base: { sha: baseSha },
+    base: { sha: receipt.previousBaseSha },
     head: { ref: receipt.headRef, sha: headSha },
     number: 731,
   };
   const action = createRequestedRefreshAction({
     check,
+    currentBaseSha: receipt.baseSha,
     pull,
     receipt,
     sourceRunId: 998877,
@@ -604,22 +613,110 @@ test("a terminal requested Refresh produces only the bounded next-process event"
   assert.equal(
     createRequestedRefreshAction({
       check,
-      pull: { ...pull, base: { sha: "c".repeat(40) } },
+      currentBaseSha: "c".repeat(40),
+      pull,
       receipt,
       sourceRunId: 998877,
     }),
     null,
-    "a terminal request for an obsolete base is inert",
+    "a terminal request becomes inert when current main moves",
+  );
+  assert.equal(
+    createRequestedRefreshAction({
+      check,
+      currentBaseSha: receipt.baseSha,
+      pull: { ...pull, base: { sha: "8".repeat(40) } },
+      receipt,
+      sourceRunId: 998877,
+    }),
+    null,
+    "a terminal request becomes inert when the PR historical base changes",
   );
   assert.throws(
     () =>
       createRequestedRefreshAction({
         check: { ...check, status: "in_progress" },
+        currentBaseSha: receipt.baseSha,
         pull,
         receipt,
         sourceRunId: 998877,
       }),
     /not exact/,
+  );
+  assert.throws(
+    () =>
+      createRequestedRefreshAction({
+        check: { ...check, head_sha: "7".repeat(40) },
+        currentBaseSha: receipt.baseSha,
+        pull,
+        receipt,
+        sourceRunId: 998877,
+      }),
+    /not exact/,
+    "a requested Refresh cannot move to a different head",
+  );
+  assert.throws(
+    () =>
+      createRequestedRefreshAction({
+        check,
+        currentBaseSha: "not-a-sha",
+        pull,
+        receipt,
+        sourceRunId: 998877,
+      }),
+    /current default-branch SHA is invalid/,
+  );
+});
+
+test("terminal Refresh dispatch reads the exact live default-branch ref", async () => {
+  const requestedPaths = [];
+  const currentBaseSha = await readCurrentDefaultBranchSha({
+    repositoryName: repository,
+    requestJson: async (path) => {
+      requestedPaths.push(path);
+      if (path === `/repos/${repository}`) {
+        return {
+          default_branch: "main",
+          full_name: repository,
+          id: 123,
+        };
+      }
+      assert.equal(path, `/repos/${repository}/git/ref/heads/main`);
+      return {
+        object: { sha: baseSha, type: "commit" },
+        ref: "refs/heads/main",
+        url: `https://api.github.com/repos/${repository}/git/refs/heads/main`,
+      };
+    },
+  });
+  assert.equal(currentBaseSha, baseSha);
+  assert.deepEqual(requestedPaths, [
+    `/repos/${repository}`,
+    `/repos/${repository}/git/ref/heads/main`,
+  ]);
+
+  await assert.rejects(
+    readCurrentDefaultBranchSha({
+      repositoryName: repository,
+      requestJson: async (path) =>
+        path === `/repos/${repository}`
+          ? { default_branch: "trunk", full_name: repository }
+          : assert.fail("a non-main default must not be dereferenced"),
+    }),
+    /default branch is not exact/,
+  );
+  await assert.rejects(
+    readCurrentDefaultBranchSha({
+      repositoryName: repository,
+      requestJson: async (path) =>
+        path === `/repos/${repository}`
+          ? { default_branch: "main", full_name: repository }
+          : {
+              object: { sha: baseSha, type: "tag" },
+              ref: "refs/heads/main",
+            },
+    }),
+    /reference is not exact/,
   );
 });
 

--- a/scripts/dependabot-processor.mjs
+++ b/scripts/dependabot-processor.mjs
@@ -6121,10 +6121,12 @@ async function processRequestPhase({ adapter, evaluation, workflowContext }) {
     "Request phase is missing trusted prepare bot identity",
   );
   invariant(
-    SHA_PATTERN.test(result.base.currentBaseSha ?? "") &&
+    SHA_PATTERN.test(result.baseSha ?? "") &&
+      SHA_PATTERN.test(result.base.currentBaseSha ?? "") &&
       SHA_PATTERN.test(result.base.mergeBaseSha ?? "") &&
+      result.baseSha === result.base.mergeBaseSha &&
       result.base.currentBaseSha !== result.base.mergeBaseSha,
-    "Refresh request does not bind distinct old and current bases",
+    "Refresh request does not bind the recorded old base and distinct current base",
   );
   const receipt = {
     baseSha: result.base.currentBaseSha,
@@ -6134,7 +6136,7 @@ async function processRequestPhase({ adapter, evaluation, workflowContext }) {
     prepareAppSlug: actor.appSlug,
     prepareBotId: actor.botId,
     prepareBotLogin: actor.botLogin,
-    previousBaseSha: result.base.mergeBaseSha,
+    previousBaseSha: result.baseSha,
     pullRequestNumber: result.pullRequestNumber,
     repository: evaluation.repository,
     schema: DEPENDABOT_REFRESH_SCHEMA,
@@ -6184,6 +6186,7 @@ async function processMutatePhase({ adapter, evaluation }) {
     pending &&
       pending.requestReceipt.parentHeadSha === result.headSha &&
       pending.requestReceipt.baseSha === result.base.currentBaseSha &&
+      pending.requestReceipt.previousBaseSha === result.baseSha &&
       pending.requestReceipt.previousBaseSha === result.base.mergeBaseSha,
     "Mutate phase lacks an exact trusted current-head Refresh request",
   );

--- a/scripts/dependabot-processor.mjs
+++ b/scripts/dependabot-processor.mjs
@@ -5598,23 +5598,50 @@ export function createLiveGitHubAdapter({
     requestPullRequestUpdateBranch: async ({
       expectedBaseSha,
       expectedHeadSha,
+      expectedPreviousBaseSha,
       pullRequestNumber: number,
       repository,
     }) => {
+      const currentBaseSha = exactSha(
+        expectedBaseSha,
+        "Expected current base SHA",
+      );
+      const headSha = exactSha(expectedHeadSha, "Expected head SHA");
+      const previousBaseSha = exactSha(
+        expectedPreviousBaseSha,
+        "Expected previous base SHA",
+      );
+      invariant(
+        currentBaseSha !== previousBaseSha,
+        "Refresh requires distinct previous and current bases",
+      );
       const current = await getPullRequest(
         repository,
         pullRequestNumber(number),
       );
       invariant(
         current.state === "open" &&
-          current.head?.sha === exactSha(expectedHeadSha) &&
-          current.base?.sha === exactSha(expectedBaseSha),
+          current.head?.repo?.full_name === repository &&
+          current.head?.sha === headSha &&
+          current.base?.ref === "main" &&
+          current.base?.repo?.full_name === repository &&
+          current.base?.sha === previousBaseSha,
         `PR #${number} changed before update-branch`,
+      );
+      const mainReference = await request(
+        "GET",
+        `/repos/${repository}/git/ref/heads/main`,
+      );
+      invariant(
+        mainReference.data?.ref === "refs/heads/main" &&
+          mainReference.data?.object?.type === "commit" &&
+          mainReference.data.object.sha === currentBaseSha,
+        "main changed before update-branch",
       );
       const response = await requestWithRepairCredential(
         "PUT",
         `/repos/${repository}/pulls/${number}/update-branch`,
-        { body: { expected_head_sha: expectedHeadSha } },
+        { body: { expected_head_sha: headSha } },
       );
       return { message: response.data?.message ?? null };
     },
@@ -6163,6 +6190,7 @@ async function processMutatePhase({ adapter, evaluation }) {
   await adapter.requestPullRequestUpdateBranch({
     expectedBaseSha: pending.requestReceipt.baseSha,
     expectedHeadSha: result.headSha,
+    expectedPreviousBaseSha: pending.requestReceipt.previousBaseSha,
     pullRequestNumber: result.pullRequestNumber,
     repository: evaluation.repository,
   });

--- a/scripts/dependabot-processor.test.mjs
+++ b/scripts/dependabot-processor.test.mjs
@@ -561,6 +561,7 @@ function repairPendingSnapshotForPullRequest(
 
 function staleSnapshotForPullRequest(pullRequestNumber, headSha) {
   const current = snapshotForPullRequest(pullRequestNumber, headSha);
+  current.pullRequest.base.sha = MERGE_SHA;
   current.baseAncestry = {
     aheadBy: 1,
     baseCommitSha: BASE_SHA,
@@ -585,6 +586,13 @@ function staleSnapshot() {
       headSha: HEAD_SHA,
       mergeBaseSha: MERGE_SHA,
       status: "diverged",
+    },
+    pullRequest: {
+      base: {
+        ref: "main",
+        repo: { fullName: REPOSITORY },
+        sha: MERGE_SHA,
+      },
     },
   });
 }
@@ -4069,6 +4077,34 @@ test("refresh preparation is split across request, mutate, and finalize phases",
   assert.equal(completedReceipt.headSha, OTHER_SHA);
   assert.equal(completedReceipt.requestCheckId, requestCheck.id);
   assert.equal(completedReceipt.requestDigest, digest(requestedReceipt));
+});
+
+test("refresh request rejects a recorded base that differs from the compare merge base", async () => {
+  const stale = staleSnapshot();
+  stale.pullRequest.base.sha = OTHER_SHA;
+  let published = false;
+  await assert.rejects(
+    processDependabotSweep({
+      adapter: {
+        prepareActor: PREPARE_ACTOR,
+        publishRefreshReceipt: async () => {
+          published = true;
+          return { id: 40_001 };
+        },
+      },
+      input: {
+        mode: "prepare",
+        outstandingAutoMergeRequests: [],
+        pullRequests: [stale],
+        repository: REPOSITORY,
+        workflowContext: WORKFLOW_CONTEXT,
+      },
+      phase: "request",
+      workflowContext: WORKFLOW_CONTEXT,
+    }),
+    /does not bind the recorded old base and distinct current base/,
+  );
+  assert.equal(published, false);
 });
 
 test("same-run or malformed Refresh evidence cannot reach the App update capability", async () => {

--- a/scripts/dependabot-processor.test.mjs
+++ b/scripts/dependabot-processor.test.mjs
@@ -4031,6 +4031,7 @@ test("refresh preparation is split across request, mutate, and finalize phases",
   assert.deepEqual(updateInput, {
     expectedBaseSha: BASE_SHA,
     expectedHeadSha: HEAD_SHA,
+    expectedPreviousBaseSha: MERGE_SHA,
     pullRequestNumber: 123,
     repository: REPOSITORY,
   });
@@ -4815,6 +4816,151 @@ test("live adapters expose only their phase capability and contain no merge adap
       new RegExp(`${phase} phase must not receive a Dependabot repair token`),
     );
   }
+});
+
+test("live refresh mutation binds the historical PR base and current main before update-branch", async () => {
+  const operations = [];
+  const fetchImpl = async (url, options = {}) => {
+    const path = new URL(url).pathname;
+    if (path === `/repos/${REPOSITORY}/pulls/123`) {
+      operations.push("pull");
+      assert.equal(options.method, "GET");
+      assert.equal(options.headers.Authorization, "Bearer workflow-token");
+      return new Response(
+        JSON.stringify(
+          liveApprovalPullRequest({
+            base: {
+              ref: "main",
+              repo: { full_name: REPOSITORY },
+              sha: MERGE_SHA,
+            },
+          }),
+        ),
+        { status: 200 },
+      );
+    }
+    if (path === `/repos/${REPOSITORY}/git/ref/heads/main`) {
+      operations.push("main");
+      assert.equal(options.method, "GET");
+      assert.equal(options.headers.Authorization, "Bearer workflow-token");
+      return new Response(
+        JSON.stringify({
+          object: { sha: BASE_SHA, type: "commit" },
+          ref: "refs/heads/main",
+        }),
+        { status: 200 },
+      );
+    }
+    assert.equal(path, `/repos/${REPOSITORY}/pulls/123/update-branch`);
+    operations.push("update");
+    assert.equal(options.method, "PUT");
+    assert.equal(options.headers.Authorization, "Bearer prepare-app-token");
+    assert.deepEqual(JSON.parse(options.body), {
+      expected_head_sha: HEAD_SHA,
+    });
+    return new Response(JSON.stringify({ message: "Updating pull request" }), {
+      status: 202,
+    });
+  };
+  const adapter = createLiveGitHubAdapter({
+    fetchImpl,
+    phase: "mutate",
+    prepareAppSlug: PREPARE_ACTOR.appSlug,
+    prepareBotId: PREPARE_ACTOR.botId,
+    prepareBotLogin: PREPARE_ACTOR.botLogin,
+    repairToken: "prepare-app-token",
+    token: "workflow-token",
+  });
+  assert.deepEqual(
+    await adapter.requestPullRequestUpdateBranch({
+      expectedBaseSha: BASE_SHA,
+      expectedHeadSha: HEAD_SHA,
+      expectedPreviousBaseSha: MERGE_SHA,
+      pullRequestNumber: 123,
+      repository: REPOSITORY,
+    }),
+    { message: "Updating pull request" },
+  );
+  assert.deepEqual(operations, ["pull", "main", "update"]);
+});
+
+test("live refresh mutation rejects a changed historical base, head, or current main", async () => {
+  const attempt = async ({
+    liveBaseSha = MERGE_SHA,
+    liveHeadSha = HEAD_SHA,
+    liveMainSha = BASE_SHA,
+  }) => {
+    const operations = [];
+    const adapter = createLiveGitHubAdapter({
+      fetchImpl: async (url) => {
+        const path = new URL(url).pathname;
+        if (path === `/repos/${REPOSITORY}/pulls/123`) {
+          operations.push("pull");
+          return new Response(
+            JSON.stringify(
+              liveApprovalPullRequest({
+                base: {
+                  ref: "main",
+                  repo: { full_name: REPOSITORY },
+                  sha: liveBaseSha,
+                },
+                head: {
+                  ref: "dependabot/github_actions/github-actions-routine-123",
+                  repo: { full_name: REPOSITORY },
+                  sha: liveHeadSha,
+                },
+              }),
+            ),
+            { status: 200 },
+          );
+        }
+        if (path === `/repos/${REPOSITORY}/git/ref/heads/main`) {
+          operations.push("main");
+          return new Response(
+            JSON.stringify({
+              object: { sha: liveMainSha, type: "commit" },
+              ref: "refs/heads/main",
+            }),
+            { status: 200 },
+          );
+        }
+        operations.push("update");
+        return assert.fail("invalid refresh evidence reached update-branch");
+      },
+      phase: "mutate",
+      prepareAppSlug: PREPARE_ACTOR.appSlug,
+      prepareBotId: PREPARE_ACTOR.botId,
+      prepareBotLogin: PREPARE_ACTOR.botLogin,
+      repairToken: "prepare-app-token",
+      token: "workflow-token",
+    });
+    const promise = adapter.requestPullRequestUpdateBranch({
+      expectedBaseSha: BASE_SHA,
+      expectedHeadSha: HEAD_SHA,
+      expectedPreviousBaseSha: MERGE_SHA,
+      pullRequestNumber: 123,
+      repository: REPOSITORY,
+    });
+    return { operations, promise };
+  };
+
+  const previousBaseChanged = await attempt({ liveBaseSha: OTHER_SHA });
+  await assert.rejects(
+    previousBaseChanged.promise,
+    /changed before update-branch/,
+  );
+  assert.deepEqual(previousBaseChanged.operations, ["pull"]);
+
+  const headChanged = await attempt({ liveHeadSha: OTHER_SHA });
+  await assert.rejects(headChanged.promise, /changed before update-branch/);
+  assert.deepEqual(headChanged.operations, ["pull"]);
+
+  const mainChanged = await attempt({ liveMainSha: OTHER_SHA });
+  await assert.rejects(
+    mainChanged.promise,
+    /main changed before update-branch/,
+  );
+  assert.deepEqual(mainChanged.operations, ["pull", "main"]);
 });
 
 test("live approval brackets the exact full PR identity and returns its post-review update token", async () => {


### PR DESCRIPTION
## The Problem

The first live `prepare` rollout published a trusted Refresh request for PR #734, but the terminal dispatcher did not start the next processor pass. GitHub reports a stale pull request's recorded base SHA separately from the current `main` ref. The controller compared both identities as though they were the same SHA, so the request stayed inert. The same mismatch would have blocked the App-token mutation path.

No branch mutation occurred. The repository mode was returned to `observe` before this hotfix.

## The Solution

Bind the two base identities independently throughout the Refresh path:

- `previousBaseSha` must match the PR's recorded historical base;
- `baseSha` must match a fresh exact `refs/heads/main` lookup;
- the terminal dispatcher and mutate adapter repeat those checks before progressing;
- the normal workflow token performs the PR/main reads, and only the exact `update-branch` PUT receives the Prepare App token; and
- malformed, moved, or equal previous/current base evidence fails before any write.

The runbook now documents this contract.

## Validation

- `pnpm dependabot:process:test` — 204/204 passed
- `pnpm quality:budgets:test` — 53/53 passed
- focused receipt tests — 20/20 passed
- focused processor tests — 124/124 passed
- `trunk fmt` and `trunk check` on all five changed files
- `node --check` on both changed runtime modules
- `pnpm adr:check --include-untracked`
- `git diff --check`
- push-time full TypeScript/Trunk/Knip gate passed
- fresh-context semantic autoreview: final clean pass, 0 findings, confidence 0.98
- deterministic local autoreview: clean

## Live Evidence and Risk

For PR #734, GitHub returned recorded base `f847abe8d3aed76dc1e69518c43868598333e2fe`, current `main` `d2d7cee0390970f22713d5aab6ca0d6d684d6d7f`, and merge base `f847abe8d3aed76dc1e69518c43868598333e2fe`. The new tests reproduce that exact shape.

GitHub's update-branch API exposes an exact-head precondition but no expected-base precondition. The existing completed-receipt and current-base readiness checks retain the documented fail-closed reconciliation if `main` advances during that narrow API race. Automation still cannot merge or enable auto-merge; a maintainer remains the only merge actor.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Dependabot prepare automation that can mutate PR branches with an App token, but only tightens fail-closed base binding before existing update-branch writes.
> 
> **Overview**
> Fixes Dependabot Refresh automation that treated a PR's recorded base SHA and live `main` as the same identity, leaving trusted refresh requests inert.
> 
> **Refresh now binds two bases independently:** `previousBaseSha` must match the PR's historical base, and `baseSha` must match a fresh `refs/heads/main` lookup. Receipt validation rejects equal previous/current bases. The terminal dispatcher and mutate adapter re-check both before dispatch or `update-branch`, with workflow-token reads and App-token write only on the exact PUT.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5305aef868fec45babb51bfa7adcf325177e5e70. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->