### PR TITLE
fix: reconcile late Dependabot refreshes

### DIFF
--- a/.github/workflows/dependabot-intake.yml
+++ b/.github/workflows/dependabot-intake.yml
@@ -3,7 +3,7 @@ name: Dependabot Intake
 # This title is the only handoff to the trusted follow-up workflow. It contains
 # immutable event metadata, not an artifact or data produced by candidate code.
 run-name: >-
-  ${{ format('dependabot-intake:v1 | repository={0} | pr={1} | sha={2} | action={3} | receipt={4}', github.repository, github.event.pull_request.number, github.event.pull_request.head.sha, github.event.action, github.event.pull_request.user.login == 'dependabot[bot]' && startsWith(github.event.pull_request.head.ref, 'dependabot/') && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.base.ref == 'main') }}
+  ${{ format('dependabot-intake:v1 | repository={0} | pr={1} | sha={2} | action={3} | receipt={4}', github.repository, github.event.pull_request.number, github.event.pull_request.head.sha, github.event.action, github.event.sender.login == 'dependabot[bot]' && github.event.sender.id == 49699333 && github.event.sender.type == 'Bot' && github.event.pull_request.user.login == 'dependabot[bot]' && startsWith(github.event.pull_request.head.ref, 'dependabot/') && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.base.ref == 'main') }}
 
 on:
   pull_request_target:
@@ -17,6 +17,9 @@ jobs:
   validate-receipt:
     name: Validate immutable Dependabot event metadata
     if: >-
+      github.event.sender.login == 'dependabot[bot]' &&
+      github.event.sender.id == 49699333 &&
+      github.event.sender.type == 'Bot' &&
       github.event.pull_request.user.login == 'dependabot[bot]' &&
       startsWith(github.event.pull_request.head.ref, 'dependabot/')
     runs-on: ubuntu-latest
@@ -34,9 +37,15 @@ jobs:
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REPOSITORY: ${{ github.repository }}
+          SENDER_ID: ${{ github.event.sender.id }}
+          SENDER_LOGIN: ${{ github.event.sender.login }}
+          SENDER_TYPE: ${{ github.event.sender.type }}
         run: |
           set -euo pipefail
           test "$REPOSITORY" = "mento-protocol/frontend-monorepo"
+          test "$SENDER_ID" = "49699333"
+          test "$SENDER_LOGIN" = "dependabot[bot]"
+          test "$SENDER_TYPE" = "Bot"
           test "$AUTHOR" = "dependabot[bot]"
           test "$HEAD_REPOSITORY" = "$REPOSITORY"
           test "$DEFAULT_BRANCH" = "main"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ merges or enables native auto-merge. A maintainer performs the final squash
 merge only after the exact head has a successful `Dependabot ALL CLEAR` check.
 
 `.github/workflows/dependabot-intake.yml` remains the credentialless v1 boundary
-for Dependabot-authored heads. Prepared heads use the distinct credentialless
+for exact Dependabot-bot-sent native events. Prepared heads use the distinct credentialless
 `.github/workflows/dependabot-prepared-head-intake.yml` repository-dispatch
 boundary. That intake accepts only the exact Prepare App bot ID/login, exact App
 slug, nine-key bounded payload, and a digest-bound completed Refresh or Repair

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,8 +168,8 @@ case, and whitespace variants become `observe`. No processor path merges or
 enables auto-merge. A maintainer clicks Merge only while the exact head carries
 a successful `Dependabot ALL CLEAR` receipt.
 
-`.github/workflows/dependabot-intake.yml` remains the credentialless
-Dependabot-authored v1 event boundary. A Refresh or Repair successor uses
+`.github/workflows/dependabot-intake.yml` remains the credentialless v1 event
+boundary for exact Dependabot-bot senders. A Refresh or Repair successor uses
 `.github/workflows/dependabot-prepared-head-intake.yml`, whose strict
 `dependabot-prepared-head` repository dispatch accepts only the configured
 Prepare App bot ID/login, exact App slug, nine-key payload, and a completed

--- a/README.md
+++ b/README.md
@@ -373,7 +373,7 @@ repairs, re-review, satisfy receipt-bound feedback, create the ruleset-required
 processor approval, and publish `Dependabot ALL CLEAR`. It never merges or
 enables native auto-merge. A maintainer performs the final squash merge.
 
-Native Dependabot heads enter through the credentialless
+Native events from the exact Dependabot bot sender enter through the credentialless
 `.github/workflows/dependabot-intake.yml`. Refresh/Repair successors enter
 through the distinct credentialless
 `.github/workflows/dependabot-prepared-head-intake.yml`, which authenticates

--- a/docs/adr/0006-dependabot-processing-controller.md
+++ b/docs/adr/0006-dependabot-processing-controller.md
@@ -66,8 +66,9 @@ CLEAR head.
 
 `.github/workflows/dependabot-intake.yml` remains the credentialless
 `dependabot-intake:v1` `pull_request_target` boundary. It accepts only the
-strict repository-owned Dependabot branch/head/base event and gains no token,
-secret, checkout, API, artifact, or dispatch capability.
+strict repository-owned Dependabot branch/head/base event from the exact
+Dependabot bot sender and gains no token, secret, checkout, API, artifact, or
+dispatch capability.
 
 `.github/workflows/dependabot-prepared-head-intake.yml` is a second
 credentialless boundary. It accepts only a

--- a/docs/dependabot-automation.md
+++ b/docs/dependabot-automation.md
@@ -53,11 +53,13 @@ Keep these properties true in code, workflows, rulesets, and operation:
 `reopened`. Its existing `dependabot-intake:v1` title stays strict. The
 workflow has `permissions: {}`, one local shell step, no API call, no secret,
 no checkout, and no artifact. It binds repository, PR, Dependabot-owned
-`dependabot/*` ref, exact head, base `main`, and action.
+`dependabot/*` ref, exact head, base `main`, action, and the exact Dependabot
+bot event sender login, user ID, and type.
 
 Do not relax this receipt to admit an App-authored head. The strict native
 receipt is useful because a normal Dependabot synchronize and a prepared
-successor have different actors and lineage requirements.
+successor have different actors and lineage requirements. App-authored
+synchronize events are inert here and enter only through prepared-head intake.
 
 ### Prepared-head intake
 
@@ -301,6 +303,13 @@ The completed head is accepted only when:
 
 A refresh never increments the repair count. Do not use Dependabot rebase,
 force-push, or a history rewrite.
+
+GitHub may retarget existing review-comment commit metadata while update-branch
+creates the append-only successor. The bounded old-head wait and typed
+snapshot-race retry use separate counters so a late successor still gets a
+stable read. The accepted read still requires a fully stable snapshot plus the
+exact parent, base, App identity, and signature evidence above. Persistent drift
+or any other collection error fails closed.
 
 ### 3. Produce and publish one bounded repair
 
@@ -561,7 +570,8 @@ or failed. Follow the managed failure issue and deployment recovery runbook.
 | Evidence/outcome                                     | Action                                                            |
 | ---------------------------------------------------- | ----------------------------------------------------------------- |
 | Malformed/false intake or dispatch                   | Fail; inspect actor and exact envelope.                           |
-| Head/base/feedback changed                           | Make no mutation; start a fresh exact-head cycle.                 |
+| Head/base/feedback changed before mutation           | Make no mutation; start a fresh exact-head cycle.                 |
+| Snapshot race after one authorized refresh request   | Retry read-only collection within the bounded successor poll.     |
 | Missing/pending gate                                 | Wait for trusted evidence; recollect.                             |
 | Base failure                                         | Repair `main`, prove recovery, then refresh affected PRs.         |
 | Provider/Claude infrastructure failure               | Retry through the trusted provider path; never patch around it.   |

--- a/scripts/dependabot-processor.mjs
+++ b/scripts/dependabot-processor.mjs
@@ -53,6 +53,7 @@ const REPAIR_LINEAGE_COMMIT_LIMIT = 100;
 const REPAIR_LINEAGE_CHECK_CONCURRENCY = 4;
 const CHECK_SOURCE_RESOLUTION_CONCURRENCY = 8;
 const REFRESH_SUCCESSOR_POLL_ATTEMPTS = 5;
+const REFRESH_SNAPSHOT_RACE_ATTEMPTS = 5;
 const REFRESH_SUCCESSOR_POLL_INTERVAL_MS = 2_000;
 const GITHUB_WEB_FLOW_BOT_ID = 19_864_447;
 const PROCESSOR_APPROVAL_PULL_LIMIT = 100;
@@ -395,6 +396,12 @@ export const DEPENDABOT_CHECK_POLICY = Object.freeze(
 
 function invariant(condition, message) {
   if (!condition) throw new Error(message);
+}
+
+class PullRequestSnapshotChangedError extends Error {}
+
+function snapshotInvariant(condition, message) {
+  if (!condition) throw new PullRequestSnapshotChangedError(message);
 }
 
 function exactSha(value, label = "Commit SHA") {
@@ -4106,7 +4113,7 @@ export function requireStablePullRequestSnapshot(initial, final, number) {
     SHA_PATTERN.test(initialIdentity.headSha ?? "");
   const stable =
     complete && stableJson(initialIdentity) === stableJson(finalIdentity);
-  invariant(
+  snapshotInvariant(
     stable,
     `PR #${number} changed while its exact-head snapshot was collected`,
   );
@@ -4138,7 +4145,7 @@ export function requireStableFeedbackSnapshot(initial, final, number) {
     typeof initial?.updatedAt === "string" &&
     initial.updatedAt === final?.updatedAt &&
     initial.headSha === final?.headSha;
-  invariant(
+  snapshotInvariant(
     stable,
     `PR #${number} feedback changed while its exact-head snapshot was collected`,
   );
@@ -4548,7 +4555,7 @@ export function createLiveGitHubAdapter({
         threadQueryHead = pullRequest.headRefOid;
         threadQueryUpdatedAt = pullRequest.updatedAt;
       } else {
-        invariant(
+        snapshotInvariant(
           pullRequest.headRefOid === threadQueryHead &&
             pullRequest.updatedAt === threadQueryUpdatedAt,
           `PR #${number} feedback changed during thread pagination`,
@@ -5017,7 +5024,7 @@ export function createLiveGitHubAdapter({
       getFeedback(repository, number),
     ]);
     const headSha = exactSha(raw.head.sha, "PR head SHA");
-    invariant(
+    snapshotInvariant(
       initialFeedback.headSha === headSha,
       `PR #${number} changed while feedback was collected`,
     );
@@ -6203,20 +6210,31 @@ async function processMutatePhase({ adapter, evaluation }) {
     repository: evaluation.repository,
     requestReceipt: pending.requestReceipt,
   };
-  for (
-    let attempt = 1;
-    attempt <= REFRESH_SUCCESSOR_POLL_ATTEMPTS;
-    attempt += 1
-  ) {
-    const snapshot = await adapter.collectPullRequestSnapshot(
-      evaluation.repository,
-      result.pullRequestNumber,
-    );
+  let snapshotRaceAttempts = 0;
+  for (let stablePolls = 0; stablePolls < REFRESH_SUCCESSOR_POLL_ATTEMPTS; ) {
+    let snapshot;
+    try {
+      snapshot = await adapter.collectPullRequestSnapshot(
+        evaluation.repository,
+        result.pullRequestNumber,
+      );
+    } catch (error) {
+      if (!(error instanceof PullRequestSnapshotChangedError)) {
+        throw error;
+      }
+      snapshotRaceAttempts += 1;
+      if (snapshotRaceAttempts === REFRESH_SNAPSHOT_RACE_ATTEMPTS) throw error;
+      if (typeof adapter.waitForRefreshSuccessor === "function") {
+        await adapter.waitForRefreshSuccessor();
+      }
+      continue;
+    }
+    stablePolls += 1;
     const successor = exactRefreshSuccessor(snapshot, expected);
     successorHeadSha = successor?.headSha ?? null;
     if (successor !== null) break;
     if (
-      attempt < REFRESH_SUCCESSOR_POLL_ATTEMPTS &&
+      stablePolls < REFRESH_SUCCESSOR_POLL_ATTEMPTS &&
       typeof adapter.waitForRefreshSuccessor === "function"
     ) {
       await adapter.waitForRefreshSuccessor();

--- a/scripts/dependabot-processor.test.mjs
+++ b/scripts/dependabot-processor.test.mjs
@@ -4079,6 +4079,190 @@ test("refresh preparation is split across request, mutate, and finalize phases",
   assert.equal(completedReceipt.requestDigest, digest(requestedReceipt));
 });
 
+test("refresh successor polling retries only bounded snapshot races after the ref moves", async () => {
+  const requestCheck = refreshReceiptCheck("requested");
+  const pending = staleSnapshot();
+  pending.repairHistoryChecks = [requestCheck];
+  const stableFeedback = {
+    digest: "a".repeat(64),
+    headSha: OTHER_SHA,
+    updatedAt: "2026-08-12T09:58:00Z",
+  };
+  let reads = 0;
+  let waits = 0;
+  const result = await processDependabotSweep({
+    adapter: {
+      collectPullRequestSnapshot: async () => {
+        reads += 1;
+        if (reads === 1) {
+          requireStableFeedbackSnapshot(
+            stableFeedback,
+            { ...stableFeedback, digest: "b".repeat(64) },
+            123,
+          );
+        }
+        return refreshedSnapshot({ repairHistoryChecks: [requestCheck] });
+      },
+      requestPullRequestUpdateBranch: async () => {},
+      waitForRefreshSuccessor: async () => {
+        waits += 1;
+      },
+    },
+    input: {
+      mode: "prepare",
+      outstandingAutoMergeRequests: [],
+      pullRequests: [pending],
+      repository: REPOSITORY,
+      workflowContext: WORKFLOW_CONTEXT,
+    },
+    phase: "mutate",
+    workflowContext: WORKFLOW_CONTEXT,
+  });
+  assert.equal(reads, 2);
+  assert.equal(waits, 1);
+  assert.deepEqual(result.mutations, [
+    {
+      headSha: HEAD_SHA,
+      kind: "refresh-update-requested",
+      pullRequestNumber: 123,
+      requestCheckId: requestCheck.id,
+      requestDigest: digest(JSON.parse(requestCheck.outputText)),
+      successorHeadSha: OTHER_SHA,
+    },
+  ]);
+
+  reads = 0;
+  waits = 0;
+  const slowSuccessor = await processDependabotSweep({
+    adapter: {
+      collectPullRequestSnapshot: async () => {
+        reads += 1;
+        if (reads <= 4) return pending;
+        if (reads === 5) {
+          requireStableFeedbackSnapshot(
+            stableFeedback,
+            { ...stableFeedback, digest: "b".repeat(64) },
+            123,
+          );
+        }
+        return refreshedSnapshot({ repairHistoryChecks: [requestCheck] });
+      },
+      requestPullRequestUpdateBranch: async () => {},
+      waitForRefreshSuccessor: async () => {
+        waits += 1;
+      },
+    },
+    input: {
+      mode: "prepare",
+      outstandingAutoMergeRequests: [],
+      pullRequests: [pending],
+      repository: REPOSITORY,
+      workflowContext: WORKFLOW_CONTEXT,
+    },
+    phase: "mutate",
+    workflowContext: WORKFLOW_CONTEXT,
+  });
+  assert.equal(reads, 6);
+  assert.equal(waits, 5);
+  assert.equal(
+    slowSuccessor.mutations[0].successorHeadSha,
+    OTHER_SHA,
+    "old-head polls must not consume the separate snapshot-race budget",
+  );
+
+  reads = 0;
+  waits = 0;
+  await assert.rejects(
+    processDependabotSweep({
+      adapter: {
+        collectPullRequestSnapshot: async () => {
+          reads += 1;
+          requireStableFeedbackSnapshot(
+            stableFeedback,
+            { ...stableFeedback, updatedAt: `2026-08-12T09:58:0${reads}Z` },
+            123,
+          );
+        },
+        requestPullRequestUpdateBranch: async () => {},
+        waitForRefreshSuccessor: async () => {
+          waits += 1;
+        },
+      },
+      input: {
+        mode: "prepare",
+        outstandingAutoMergeRequests: [],
+        pullRequests: [pending],
+        repository: REPOSITORY,
+        workflowContext: WORKFLOW_CONTEXT,
+      },
+      phase: "mutate",
+      workflowContext: WORKFLOW_CONTEXT,
+    }),
+    /feedback changed while its exact-head snapshot was collected/,
+  );
+  assert.equal(reads, 5);
+  assert.equal(waits, 4);
+
+  await assert.rejects(
+    processDependabotSweep({
+      adapter: {
+        collectPullRequestSnapshot: async () => {
+          throw new Error("GitHub API unavailable");
+        },
+        requestPullRequestUpdateBranch: async () => {},
+        waitForRefreshSuccessor: async () =>
+          assert.fail("arbitrary failures must not be retried"),
+      },
+      input: {
+        mode: "prepare",
+        outstandingAutoMergeRequests: [],
+        pullRequests: [pending],
+        repository: REPOSITORY,
+        workflowContext: WORKFLOW_CONTEXT,
+      },
+      phase: "mutate",
+      workflowContext: WORKFLOW_CONTEXT,
+    }),
+    /GitHub API unavailable/,
+  );
+
+  const badSuccessor = refreshedSnapshot({
+    repairHistoryChecks: [requestCheck],
+  });
+  badSuccessor.commits.at(-1).parents = [HEAD_SHA];
+  reads = 0;
+  await assert.rejects(
+    processDependabotSweep({
+      adapter: {
+        collectPullRequestSnapshot: async () => {
+          reads += 1;
+          if (reads === 1) {
+            requireStableFeedbackSnapshot(
+              stableFeedback,
+              { ...stableFeedback, digest: "b".repeat(64) },
+              123,
+            );
+          }
+          return badSuccessor;
+        },
+        requestPullRequestUpdateBranch: async () => {},
+        waitForRefreshSuccessor: async () => {},
+      },
+      input: {
+        mode: "prepare",
+        outstandingAutoMergeRequests: [],
+        pullRequests: [pending],
+        repository: REPOSITORY,
+        workflowContext: WORKFLOW_CONTEXT,
+      },
+      phase: "mutate",
+      workflowContext: WORKFLOW_CONTEXT,
+    }),
+    /refresh commit parents are invalid/,
+  );
+  assert.equal(reads, 2);
+});
+
 test("refresh request rejects a recorded base that differs from the compare merge base", async () => {
   const stale = staleSnapshot();
   stale.pullRequest.base.sha = OTHER_SHA;

--- a/scripts/dependabot-workflows.test.mjs
+++ b/scripts/dependabot-workflows.test.mjs
@@ -259,6 +259,9 @@ test("intake is an exact credentialless metadata receipt", () => {
   assert.equal(job.steps.length, 1);
   assert.equal(Object.hasOwn(job.steps[0], "uses"), false);
   assert.match(job.if, /dependabot\[bot\].*dependabot\//s);
+  assert.match(job.if, /github\.event\.sender\.login.*dependabot\[bot\]/s);
+  assert.match(job.if, /github\.event\.sender\.id.*49699333/s);
+  assert.match(job.if, /github\.event\.sender\.type.*Bot/s);
   assert.deepEqual(Object.keys(job.steps[0].env).sort(), [
     "ACTION",
     "AUTHOR",
@@ -269,15 +272,25 @@ test("intake is an exact credentialless metadata receipt", () => {
     "HEAD_SHA",
     "PR_NUMBER",
     "REPOSITORY",
+    "SENDER_ID",
+    "SENDER_LOGIN",
+    "SENDER_TYPE",
   ]);
   assert.match(job.steps[0].run, /mento-protocol\/frontend-monorepo/);
   assert.match(job.steps[0].run, /dependabot\[bot\]/);
+  assert.match(job.steps[0].run, /SENDER_ID.*49699333/);
+  assert.match(job.steps[0].run, /SENDER_LOGIN.*dependabot\[bot\]/);
+  assert.match(job.steps[0].run, /SENDER_TYPE.*Bot/);
   assert.match(job.steps[0].run, /HEAD_REPOSITORY.*REPOSITORY/);
   assert.match(job.steps[0].run, /DEFAULT_BRANCH.*main/);
   assert.match(job.steps[0].run, /BASE_REF.*main/);
   assert.match(job.steps[0].run, /HEAD_REF.*dependabot\/\*/);
   assert.match(job.steps[0].run, /\[0-9a-f\]\{40\}/);
   assert.match(job.steps[0].run, /opened\|synchronize\|reopened/);
+  assert.match(
+    intake["run-name"],
+    /github\.event\.sender\.login.*github\.event\.sender\.id.*github\.event\.sender\.type/s,
+  );
 
   const raw = JSON.stringify(intake);
   assert.doesNotMatch(


### PR DESCRIPTION
## The Problem

- The first live `prepare` refresh moved Dependabot PR #734 to the exact current base, then failed before publishing its completed Refresh receipt. GitHub created the successor late enough that four stable old-head polls consumed the shared budget; the final poll crossed GitHub's review-comment metadata retargeting and failed the strict feedback snapshot check.
- The App-authored synchronize event also entered native Dependabot Intake because that boundary checked the PR author but not the event sender. Stricter downstream jobs rejected it, creating safe but noisy failures.

## The Solution

- Give stable old-head successor polls and typed snapshot-race retries separate bounded counters. Retrying remains read-only, update-branch is issued once, and every lineage, parent, App identity, signature, repository, ref, base, and force-push check remains unchanged.
- Require native intake's event sender to match the exact Dependabot bot login, user ID, and type in the receipt, job gate, and shell validation. App-authored successors now enter only through prepared-head intake.
- Document both trust-boundary behaviors and failure handling.

## Validation

- `pnpm dependabot:process:test` — 206/206 passed
- `pnpm quality:budgets:test` — 53/53 passed
- `trunk check` on all 9 changed files — passed
- `pnpm adr:check` — passed
- Node syntax checks and `git diff --check` — passed
- Fresh-context semantic autoreview — clean, 0 findings, confidence 0.96
- Deterministic autoreview — clean
- Live evidence: Processor run `31585115305` made the exact verified two-parent refresh commit, then reproduced the bounded post-move feedback race; observe-mode containment run `31586395161` completed with every authority job skipped.

## Ship Checklist

- [x] PR title follows the [conventions](https://www.notion.so/Git-Branching-and-Commit-Message-Conventions-18f66f7d06444cfbac5725ffbc7c04a?pvs=4#9355048863c549ef92fe210a8a1298aa)
- [x] Performed a self-review of my own changes
- [x] Relevant automated checks and smoke tests pass
- [x] Architecture decision: updated ADR 0006 to keep the native/prepared intake boundary current.

<!-- ship-checklist:v1 -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the Dependabot intake trust boundary and prepare-mode refresh mutation path. Changes tighten sender checks and add bounded read-only retries without broadening authority or altering lineage requirements.
> 
> **Overview**
> Fixes two Dependabot preparation races: late refresh successors no longer burn the shared poll budget, and App-authored synchronize events no longer enter native intake.
> 
> **Refresh polling** now keeps separate bounded counters for old-head successor waits and typed snapshot-race retries. Update-branch still runs once; lineage, parent, App identity, and signature checks are unchanged. Transient feedback/snapshot drift after the ref moves is retried read-only; other collection errors still fail closed.
> 
> **Native intake** now requires the exact Dependabot bot sender (`login`, ID `49699333`, type `Bot`) in the receipt, job gate, and shell validation—not just PR authorship. App-authored successors stay on prepared-head intake only.
> 
> Docs/ADR and workflow tests cover both trust-boundary behaviors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92644506e6e8edb3d62237941a98f8f47505911c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->