### PR TITLE
fix(ci): retain preview observation receipts

### DIFF
--- a/.github/workflows/vercel-preview-controller.yml
+++ b/.github/workflows/vercel-preview-controller.yml
@@ -66,6 +66,7 @@ jobs:
       change_base_sha: ${{ steps.snapshot.outputs.change_base_sha }}
       head_sha: ${{ steps.snapshot.outputs.head_sha }}
       trust: ${{ steps.snapshot.outputs.trust }}
+      observation_receipt_required: ${{ steps.snapshot.outputs.observation_receipt_required }}
       plan_required: ${{ steps.snapshot.outputs.plan_required }}
     steps:
       - name: Check out trusted controller
@@ -257,6 +258,120 @@ jobs:
               prNumber: process.env.PR_NUMBER,
               workflowSha: process.env.WORKFLOW_SHA,
             });
+
+  publish-observation-receipt:
+    name: Retain immutable preview observation receipt
+    needs: [snapshot-event, receipt-event, reconcile-event]
+    if: >-
+      always() &&
+      needs.snapshot-event.result == 'success' &&
+      needs.receipt-event.result == 'success' &&
+      needs.reconcile-event.result == 'success' &&
+      needs.snapshot-event.outputs.observation_receipt_required == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 50
+    permissions:
+      actions: read
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Check out trusted controller
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 1
+          path: controller
+          persist-credentials: false
+          ref: ${{ github.workflow_sha }}
+
+      - name: Materialize the settled event receipt graph
+        id: materialize
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          EVENT_RUN_ID: ${{ github.run_id }}
+          PR_NUMBER: ${{ needs.receipt-event.outputs.pr_number }}
+        with:
+          script: |
+            const { writeFile } = require("node:fs/promises");
+            const { pathToFileURL } = require("node:url");
+            const moduleUrl = pathToFileURL(
+              `${process.env.GITHUB_WORKSPACE}/controller/scripts/vercel-preview-controller.mjs`,
+            );
+            const {
+              createPreviewObservationReceipt,
+              selectPreviewObservationArtifact,
+            } = await import(moduleUrl.href);
+            const artifacts = await github.paginate(
+              github.rest.actions.listWorkflowRunArtifacts,
+              {
+                ...context.repo,
+                run_id: Number(process.env.EVENT_RUN_ID),
+                per_page: 100,
+              },
+            );
+            if (selectPreviewObservationArtifact(artifacts, process.env.EVENT_RUN_ID)) {
+              core.setOutput("upload_required", "false");
+              return;
+            }
+            const marker = "<!-- vercel-preview-journal:v2 -->";
+            let commentId = null;
+            let receipt = null;
+            for (let attempt = 0; attempt < 180; attempt += 1) {
+              let comment;
+              if (commentId === null) {
+                const comments = await github.paginate(github.rest.issues.listComments, {
+                  ...context.repo,
+                  issue_number: Number(process.env.PR_NUMBER),
+                  per_page: 100,
+                });
+                const matches = comments.filter((candidate) =>
+                  candidate.user?.login === "github-actions[bot]" &&
+                  typeof candidate.body === "string" &&
+                  candidate.body.startsWith(marker),
+                );
+                if (matches.length !== 1) throw new Error("Canonical preview journal is missing or ambiguous");
+                comment = matches[0];
+                commentId = comment.id;
+              } else {
+                const response = await github.rest.issues.getComment({
+                  ...context.repo,
+                  comment_id: commentId,
+                });
+                comment = response.data;
+                if (
+                  comment.user?.login !== "github-actions[bot]" ||
+                  typeof comment.body !== "string" ||
+                  !comment.body.startsWith(marker)
+                ) {
+                  throw new Error("Canonical preview journal identity changed");
+                }
+              }
+              const json = comment.body.match(/```json\n([\s\S]+)\n```/);
+              if (!json) throw new Error("Canonical preview journal JSON is missing");
+              receipt = createPreviewObservationReceipt(
+                JSON.parse(json[1]),
+                process.env.EVENT_RUN_ID,
+              );
+              if (receipt !== null) break;
+              if (attempt === 179) {
+                throw new Error("Preview observation event did not settle before the retention deadline");
+              }
+              await new Promise((resolve) => setTimeout(resolve, 15_000));
+            }
+            await writeFile(
+              `${process.env.RUNNER_TEMP}/preview-observation-receipt.json`,
+              `${JSON.stringify(receipt, null, 2)}\n`,
+              { mode: 0o600 },
+            );
+            core.setOutput("upload_required", "true");
+
+      - name: Upload the immutable event receipt graph
+        if: steps.materialize.outputs.upload_required == 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: vercel-preview-observation-receipt-v1-${{ github.run_id }}
+          path: ${{ runner.temp }}/preview-observation-receipt.json
+          if-no-files-found: error
+          retention-days: 14
 
   snapshot-bootstrap:
     name: Snapshot requested bootstrap

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,7 @@ pnpm adr:check                       # Advisory reminder for new architecture-si
 pnpm adr:check:test                  # Test the offline ADR trigger and repository wiring
 pnpm vercel:cost:test                # Test private GitHub evidence capture plus redacted cost normalization and closeout gates
 pnpm vercel:cost:observe -- init --start <UTC> --end <UTC>  # Initialize, or append a later pre-audit end to, the private #523 GitHub interval
-pnpm vercel:cost:observe -- capture-preview --pr <number> --event-run-id <id>  # Freeze one preview event before journal compaction
+pnpm vercel:cost:observe -- capture-preview --pr <number> --event-run-id <id>  # Freeze one preview event from the live journal or its 14-day receipt artifact
 pnpm vercel:cost:observe -- capture-main --run-id <id>  # Freeze every attempt, log, and available journal for one main release
 pnpm vercel:cost:observe -- sample-github  # Snapshot visibility, runs, runner labels, caches, and artifacts
 pnpm vercel:cost:observe -- audit --end <UTC>  # Preflight GitHub evidence; once clean, freeze and emit the incomplete provider-join fragment

--- a/docs/vercel-cost-validation.md
+++ b/docs/vercel-cost-validation.md
@@ -80,12 +80,13 @@ Deployment/status evidence, then seals every raw file. It publishes only after
 the event has a terminal decision and every planned target has a complete,
 selection-bound worker result. Each trusted receipt-producing controller run
 waits outside the journal-writer concurrency queue until that graph settles,
-then uploads one event-ID-bound Actions artifact for 14 days. The collector uses
-the live journal while the event remains there and downloads that immutable
-artifact only after safe journal compaction removes it. A pending event, an
-expired or missing artifact for a compacted event, or ambiguous evidence fails
-without reserving its append-only destination. Capture promptly after
-reconciliation and before the artifact expires.
+then uploads one event-ID-bound Actions artifact for 14 days. The collector
+prefers that exact validated artifact whenever it exists, including while a
+later push still leaves the event in the live journal, and falls back to the
+live journal when no artifact exists. A pending event, an expired or missing
+artifact for a compacted event, or ambiguous evidence fails without reserving
+its append-only destination. Capture promptly after reconciliation and before
+the artifact expires.
 
 `capture-main` records every run attempt, job list, combined log, artifact
 inventory, upstream CI run when a journal binds it, and every available

--- a/docs/vercel-cost-validation.md
+++ b/docs/vercel-cost-validation.md
@@ -57,8 +57,8 @@ interval extension binds the preceding interval-chain digest.
 Capture each authoritative GitHub milestone promptly:
 
 ```bash
-# Run after an opened/synchronize controller event settles, while its v2
-# journal receipts still exist.
+# Run after an opened/synchronize controller event settles. The controller
+# retains its settled receipt graph for 14 days if the live v2 journal compacts.
 pnpm vercel:cost:observe -- capture-preview \
   --pr <number> \
   --event-run-id <pull_request_target-controller-run-id>
@@ -78,9 +78,14 @@ the immutable event receipt, controller run title, selections, referenced
 worker attempts, bot-owned final sentinel, commit statuses, and exact GitHub
 Deployment/status evidence, then seals every raw file. It publishes only after
 the event has a terminal decision and every planned target has a complete,
-selection-bound worker result. A pending, compacted-away, or ambiguous event
-fails without reserving its append-only destination; retry after reconciliation
-while the live event receipt still exists.
+selection-bound worker result. Each trusted receipt-producing controller run
+waits outside the journal-writer concurrency queue until that graph settles,
+then uploads one event-ID-bound Actions artifact for 14 days. The collector uses
+the live journal while the event remains there and downloads that immutable
+artifact only after safe journal compaction removes it. A pending event, an
+expired or missing artifact for a compacted event, or ambiguous evidence fails
+without reserving its append-only destination. Capture promptly after
+reconciliation and before the artifact expires.
 
 `capture-main` records every run attempt, job list, combined log, artifact
 inventory, upstream CI run when a journal binds it, and every available

--- a/docs/vercel-deployments.md
+++ b/docs/vercel-deployments.md
@@ -2159,6 +2159,19 @@ run ID and workflow-monotonic run number to the PR, action, head SHA,
 synchronize `before` SHA, and whether a receipt is required. Dependabot
 author/ref events and edited events without a base change are strict
 non-receipt admissions; every other eligible event requires a receipt.
+After a trusted `opened` or `synchronize` event enters the journal, a read-only
+job waits outside the per-PR writer queue for that event's terminal status
+decision and complete selection/result graph. It then uploads one artifact named
+`vercel-preview-observation-receipt-v1-<event-run-id>` with 14-day retention.
+The artifact binds the original event run ID, source journal digest, and a
+canonical event-scoped graph digest. It exists only to preserve
+cost-observation evidence after safe
+terminal compaction; it is never state, reconciliation, status, dispatch, or
+deployment authority. The private collector prefers the live journal and uses
+this artifact only when that exact event no longer remains live. Journal
+compaction keeps each marked event live until GitHub reports that exact,
+unexpired artifact. A workflow rerun reuses the existing immutable artifact
+instead of uploading another copy under the same event-run name.
 
 The journal's top-level `admission` cursor stores the active controller's
 numeric workflow ID plus the exact run ID and run number proven through. One

--- a/docs/vercel-deployments.md
+++ b/docs/vercel-deployments.md
@@ -2167,11 +2167,13 @@ The artifact binds the original event run ID, source journal digest, and a
 canonical event-scoped graph digest. It exists only to preserve
 cost-observation evidence after safe
 terminal compaction; it is never state, reconciliation, status, dispatch, or
-deployment authority. The private collector prefers the live journal and uses
-this artifact only when that exact event no longer remains live. Journal
-compaction keeps each marked event live until GitHub reports that exact,
-unexpired artifact. A workflow rerun reuses the existing immutable artifact
-instead of uploading another copy under the same event-run name.
+deployment authority. The private collector prefers this exact validated
+artifact whenever it exists and falls back to the live journal when it does
+not. This keeps a later push from making the retained live graph authoritative
+for an older settled event. Journal compaction keeps each marked event live
+until GitHub reports that exact, unexpired artifact. A workflow rerun reuses
+the existing immutable artifact instead of uploading another copy under the
+same event-run name.
 
 The journal's top-level `admission` cursor stores the active controller's
 numeric workflow ID plus the exact run ID and run number proven through. One

--- a/scripts/vercel-cost-observation.mjs
+++ b/scripts/vercel-cost-observation.mjs
@@ -33,12 +33,17 @@ import {
 import {
   PREVIEW_JOURNAL_MARKER,
   PREVIEW_JOURNAL_SCHEMA,
+  PREVIEW_OBSERVATION_RECEIPT_SCHEMA,
   PREVIEW_REPOSITORY,
   controllerEventRunName,
   createPreviewJournal,
   parseWorkerRunName,
   renderPreviewJournalBody,
   validateEventReceipt,
+  validatePreviewObservationReceipt,
+  previewObservationArtifactName,
+  selectPreviewObservationArtifact,
+  isSupportedControllerSyntheticPreviewResult,
 } from "./vercel-preview-controller.mjs";
 
 export const OBSERVATION_REPOSITORY = PREVIEW_REPOSITORY;
@@ -1032,15 +1037,83 @@ function parsePreviewJournalComment(comment, pr) {
   return canonical;
 }
 
-function eventReceiptFromJournal(journal, eventRunId) {
+function eventReceiptFromJournal(
+  journal,
+  eventRunId,
+  { allowMissing = false } = {},
+) {
   const candidates = journal.receipts.events.filter(
     (event) => String(event.event_run_id) === String(eventRunId),
   );
-  invariant(
-    candidates.length === 1,
-    "Preview event must remain in the live journal receipts",
-  );
+  invariant(candidates.length <= 1, "Preview event receipt is ambiguous");
+  if (candidates.length === 0) {
+    invariant(
+      allowMissing,
+      "Preview event must remain in the live journal receipts",
+    );
+    return null;
+  }
   return validateEventReceipt(candidates[0]);
+}
+
+function previewObservationArtifact(dependencies, controllerRunId, root) {
+  const artifactName = previewObservationArtifactName(controllerRunId);
+  const artifacts = paginatedCollection(
+    apiJson(
+      dependencies,
+      `repos/${OBSERVATION_REPOSITORY}/actions/runs/${controllerRunId}/artifacts?per_page=100`,
+      "Preview observation artifacts",
+      { paginate: true },
+    ),
+    "artifacts",
+    "Preview observation artifacts",
+  );
+  const artifact = selectPreviewObservationArtifact(artifacts, controllerRunId);
+  invariant(
+    artifact !== null,
+    "Preview observation receipt artifact is missing or ambiguous",
+  );
+  const directory = join(
+    root,
+    `.stage-observation-receipt-${controllerRunId}-${process.pid}-${randomBytes(6).toString("hex")}`,
+  );
+  invariant(!existsSync(directory), "Preview observation receipt stage exists");
+  try {
+    downloadArtifact(dependencies, controllerRunId, artifactName, directory);
+    assertPrivateDirectory(
+      directory,
+      root,
+      "Preview observation artifact directory",
+    );
+    const entries = readdirSync(directory);
+    invariant(
+      entries.length === 1 && entries[0] === "preview-observation-receipt.json",
+      "Preview observation artifact contents are invalid",
+    );
+    const path = join(directory, entries[0]);
+    const stats = lstatSync(path);
+    invariant(
+      stats.isFile() && !stats.isSymbolicLink() && stats.nlink === 1,
+      "Preview observation receipt must be a regular file",
+    );
+    chmodSync(path, 0o600);
+    let parsed;
+    try {
+      parsed = JSON.parse(readFileSync(path, "utf8"));
+    } catch {
+      throw new Error("Preview observation receipt is not valid JSON");
+    }
+    invariant(
+      parsed.schema === PREVIEW_OBSERVATION_RECEIPT_SCHEMA,
+      "Preview observation receipt schema mismatch",
+    );
+    return {
+      artifact,
+      receipt: validatePreviewObservationReceipt(parsed),
+    };
+  } finally {
+    if (existsSync(directory)) removeCaptureStage(directory, root);
+  }
 }
 
 function eventSelections(journal, eventRunId) {
@@ -1175,13 +1248,6 @@ function preBoundaryEligiblePushEvidence(journal, boundaryHeadSha) {
   );
   return hasCompleteAnchor && representsBoundaryHead ? "none" : "unknown";
 }
-
-const CONTROLLER_SYNTHETIC_PREVIEW_RESULTS = new Map([
-  ["selection-removed-from-pr", "failure"],
-  ["controller-workflow-upgraded-before-dispatch", "error"],
-  ["dispatch-disabled-intent-without-worker", "error"],
-  ["native-owned-selection-without-github-worker", "error"],
-]);
 
 function receiptMatchesSelection(receipt, selection) {
   return (
@@ -1378,9 +1444,7 @@ function validateTerminalPreviewReceipts({
         syntheticResults.length === 1 &&
           results.length === 1 &&
           evidence.length === 0 &&
-          CONTROLLER_SYNTHETIC_PREVIEW_RESULTS.get(
-            syntheticResults[0].terminal_reason,
-          ) === syntheticResults[0].state,
+          isSupportedControllerSyntheticPreviewResult(syntheticResults[0]),
         "Preview controller synthetic result is unsupported",
       );
       references.push({
@@ -1958,8 +2022,42 @@ function capturePreview({ root, pr, eventRunId, dependencies }) {
       "Expected exactly one bot-owned preview journal",
     );
     const journalComment = journalComments[0];
-    const journal = parsePreviewJournalComment(journalComment, prNumber);
+    const liveJournal = parsePreviewJournalComment(journalComment, prNumber);
+    const liveEvent = eventReceiptFromJournal(liveJournal, controllerRunId, {
+      allowMissing: true,
+    });
+    const immutable =
+      liveEvent === null
+        ? previewObservationArtifact(
+            { ...dependencies, root },
+            controllerRunId,
+            root,
+          )
+        : null;
+    const journal =
+      immutable === null
+        ? liveJournal
+        : createPreviewJournal({
+            pr: immutable.receipt.pr,
+            revision: immutable.receipt.journal_revision,
+            checkpoint: immutable.receipt.checkpoint,
+            events: immutable.receipt.receipts.events,
+            selections: immutable.receipt.receipts.selections,
+            workerEvidence: immutable.receipt.receipts.worker_evidence,
+            results: immutable.receipt.receipts.results,
+            state: immutable.receipt.state,
+            ...(Object.hasOwn(immutable.receipt, "admission")
+              ? { admission: immutable.receipt.admission }
+              : {}),
+          });
     const event = eventReceiptFromJournal(journal, controllerRunId);
+    if (immutable !== null) {
+      invariant(
+        immutable.receipt.pr === Number(prNumber) &&
+          String(immutable.receipt.event_run_id) === controllerRunId,
+        "Immutable preview observation receipt identity does not match",
+      );
+    }
     invariant(
       event.pr === Number(prNumber),
       "Preview event receipt PR does not match",
@@ -2144,6 +2242,20 @@ function capturePreview({ root, pr, eventRunId, dependencies }) {
 
     writeRawJson(stage, "raw/pull.json", pull, root);
     writeRawJson(stage, "raw/journal-comment.json", journalComment, root);
+    if (immutable !== null) {
+      writeRawJson(
+        stage,
+        "raw/observation-receipt-artifact.json",
+        immutable.artifact,
+        root,
+      );
+      writeRawJson(
+        stage,
+        "raw/observation-receipt.json",
+        immutable.receipt,
+        root,
+      );
+    }
     writeRawJson(stage, "raw/statuses.json", statuses, root);
     writeRawJson(
       stage,
@@ -2178,6 +2290,8 @@ function capturePreview({ root, pr, eventRunId, dependencies }) {
       plan: event.plan,
       canonicalDerivedFacts: {
         eligibleTrustedDeployedCodePush,
+        observationReceiptSource:
+          immutable === null ? "live-journal" : "actions-artifact",
         journalSchema: journal.schema,
         journalRevision: journal.revision,
         journalCommentId: positiveId(

--- a/scripts/vercel-cost-observation.mjs
+++ b/scripts/vercel-cost-observation.mjs
@@ -1056,7 +1056,12 @@ function eventReceiptFromJournal(
   return validateEventReceipt(candidates[0]);
 }
 
-function previewObservationArtifact(dependencies, controllerRunId, root) {
+function previewObservationArtifact(
+  dependencies,
+  controllerRunId,
+  root,
+  { required = true } = {},
+) {
   const artifactName = previewObservationArtifactName(controllerRunId);
   const artifacts = paginatedCollection(
     apiJson(
@@ -1069,10 +1074,13 @@ function previewObservationArtifact(dependencies, controllerRunId, root) {
     "Preview observation artifacts",
   );
   const artifact = selectPreviewObservationArtifact(artifacts, controllerRunId);
-  invariant(
-    artifact !== null,
-    "Preview observation receipt artifact is missing or ambiguous",
-  );
+  if (artifact === null) {
+    invariant(
+      !required,
+      "Preview observation receipt artifact is missing or ambiguous",
+    );
+    return null;
+  }
   const directory = join(
     root,
     `.stage-observation-receipt-${controllerRunId}-${process.pid}-${randomBytes(6).toString("hex")}`,
@@ -2026,14 +2034,12 @@ function capturePreview({ root, pr, eventRunId, dependencies }) {
     const liveEvent = eventReceiptFromJournal(liveJournal, controllerRunId, {
       allowMissing: true,
     });
-    const immutable =
-      liveEvent === null
-        ? previewObservationArtifact(
-            { ...dependencies, root },
-            controllerRunId,
-            root,
-          )
-        : null;
+    const immutable = previewObservationArtifact(
+      { ...dependencies, root },
+      controllerRunId,
+      root,
+      { required: liveEvent === null },
+    );
     const journal =
       immutable === null
         ? liveJournal

--- a/scripts/vercel-cost-observation.test.mjs
+++ b/scripts/vercel-cost-observation.test.mjs
@@ -110,23 +110,31 @@ function fakeGh(routes, calls = []) {
   };
 }
 
-function addPreviewObservationArtifactRoute(routes, event, journal) {
+function addPreviewObservationArtifactRoute(
+  routes,
+  event,
+  journal,
+  { available = true } = {},
+) {
   const artifactName = `vercel-preview-observation-receipt-v1-${event.event_run_id}`;
   routes.set(
     `api --method GET --paginate --slurp repos/mento-protocol/frontend-monorepo/actions/runs/${event.event_run_id}/artifacts?per_page=100`,
     [
       {
-        artifacts: [
-          {
-            id: 90_001,
-            name: artifactName,
-            expired: false,
-            size_in_bytes: 1_024,
-          },
-        ],
+        artifacts: available
+          ? [
+              {
+                id: 90_001,
+                name: artifactName,
+                expired: false,
+                size_in_bytes: 1_024,
+              },
+            ]
+          : [],
       },
     ],
   );
+  if (!available) return;
   routes.set(
     `run download ${event.event_run_id} --repo mento-protocol/frontend-monorepo --name ${artifactName} --dir`,
     (args) => {
@@ -693,7 +701,7 @@ function reselectedPreviewJournalFixture(event) {
 
 function previewRoutes(
   event = fixture("preview-event.json"),
-  { mode = "complete", events = [event] } = {},
+  { mode = "complete", events = [event], observationArtifact = false } = {},
 ) {
   const fixtureState = previewJournalFixture(event, mode, events);
   const { journal } = fixtureState;
@@ -837,7 +845,9 @@ function previewRoutes(
       Buffer.from("fixture preview worker log\n"),
     );
   }
-  addPreviewObservationArtifactRoute(routes, event, journal);
+  addPreviewObservationArtifactRoute(routes, event, journal, {
+    available: observationArtifact,
+  });
   return routes;
 }
 
@@ -1466,7 +1476,7 @@ test("capture-preview freezes the canonical v2 journal and raw GitHub facts", ()
         args[0] === "api" &&
         args.some((value) => String(value).includes("/artifacts?per_page=100")),
     ),
-    false,
+    true,
   );
   assertPrivateTree(directory);
   assert.ok(calls.some((args) => args[0] === "auth"));
@@ -1815,7 +1825,7 @@ test("capture-preview recovers a compacted event from its immutable Actions arti
   const cwd = workspace();
   runInit(cwd);
   const event = fixture("preview-event.json");
-  const routes = previewRoutes(event);
+  const routes = previewRoutes(event, { observationArtifact: true });
   const compacted = compactPreviewJournal(
     previewJournalFixture(event, "complete").journal,
   );
@@ -1839,6 +1849,104 @@ test("capture-preview recovers a compacted event from its immutable Actions arti
     gh: fakeGh(routes),
     stdout: output().stream,
   });
+  assert.equal(result.exitCode, 0);
+  const directory = join(observationRoot(cwd), "preview", "9001");
+  const capture = JSON.parse(
+    readFileSync(join(directory, "capture.json"), "utf8"),
+  );
+  assert.equal(
+    capture.canonicalDerivedFacts.observationReceiptSource,
+    "actions-artifact",
+  );
+  assert.ok(
+    capture.files.some(
+      (file) => file.path === "raw/observation-receipt-artifact.json",
+    ),
+  );
+  assert.ok(
+    capture.files.some((file) => file.path === "raw/observation-receipt.json"),
+  );
+});
+
+test("capture-preview prefers an immutable artifact when a later push leaves the event live", () => {
+  const cwd = workspace();
+  runInit(cwd);
+  const event = {
+    ...fixture("preview-event.json"),
+    plan: {
+      targets: ["ui"],
+      reason: "affected-packages",
+      base: "a".repeat(40),
+      head: "b".repeat(40),
+      planner_source_sha: "a".repeat(40),
+    },
+  };
+  const settled = previewJournalFixture(event, "complete");
+  const laterEvent = {
+    ...event,
+    event_run_id: 9_003,
+    event_run_number: 503,
+    event_action: "synchronize",
+    pr_updated_at: "2026-07-29T02:00:00.000Z",
+    before_sha: event.head_sha,
+    change_base_sha: event.head_sha,
+    head_sha: "c".repeat(40),
+    plan: {
+      ...event.plan,
+      base: event.head_sha,
+      head: "c".repeat(40),
+    },
+  };
+  const advanced = reconcileState({
+    events: [event, laterEvent],
+    results: settled.journal.receipts.results,
+    selections: settled.journal.receipts.selections,
+    pullRequest: pullFromEvent(laterEvent),
+    existingState: settled.journal.state,
+    controllerUrl:
+      "https://github.com/mento-protocol/frontend-monorepo/actions/runs/9003",
+    expectedWorkflowSha: laterEvent.trusted_base_sha,
+  });
+  assert.equal(advanced.nextDispatches.length, 1);
+  assert.equal(
+    advanced.state.targets.ui.latest_desired_sha,
+    laterEvent.head_sha,
+  );
+  const retainedLiveJournal = createPreviewJournal({
+    pr: event.pr,
+    events: [event, laterEvent],
+    selections: settled.journal.receipts.selections,
+    workerEvidence: settled.journal.receipts.worker_evidence,
+    results: settled.journal.receipts.results,
+    state: advanced.state,
+  });
+  assert.ok(
+    retainedLiveJournal.receipts.events.some(
+      (candidate) => candidate.event_run_id === event.event_run_id,
+    ),
+  );
+
+  const routes = previewRoutes(event, { observationArtifact: true });
+  routes.set(
+    "api --method GET --paginate --slurp repos/mento-protocol/frontend-monorepo/issues/700/comments?per_page=100",
+    [
+      [
+        {
+          id: 301,
+          user: { type: "Bot", login: "github-actions[bot]" },
+          body: renderPreviewJournalBody(retainedLiveJournal),
+        },
+      ],
+    ],
+  );
+  const result = runVercelCostObservation({
+    argv: ["capture-preview", "--pr", "700", "--event-run-id", "9001"],
+    cwd,
+    now: () => new Date(CAPTURED_AT),
+    gh: fakeGh(routes),
+    stdout: output().stream,
+  });
+
   assert.equal(result.exitCode, 0);
   const directory = join(observationRoot(cwd), "preview", "9001");
   const capture = JSON.parse(

--- a/scripts/vercel-cost-observation.test.mjs
+++ b/scripts/vercel-cost-observation.test.mjs
@@ -92,7 +92,14 @@ function fakeGh(routes, calls = []) {
     calls.push([...args]);
     if (args[0] === "auth" && args[1] === "status") return Buffer.from("");
     const key = commandKey(args);
-    const response = routes.get(key);
+    let response = routes.get(key);
+    if (response === undefined) {
+      const prefix = [...routes.keys()].find(
+        (candidate) =>
+          candidate.endsWith(" --dir") && key.startsWith(`${candidate} `),
+      );
+      if (prefix) response = routes.get(prefix);
+    }
     if (response === undefined) {
       throw new Error(`Unexpected fake gh command: ${key}`);
     }
@@ -101,6 +108,58 @@ function fakeGh(routes, calls = []) {
       ? response
       : Buffer.from(JSON.stringify(response));
   };
+}
+
+function addPreviewObservationArtifactRoute(routes, event, journal) {
+  const artifactName = `vercel-preview-observation-receipt-v1-${event.event_run_id}`;
+  routes.set(
+    `api --method GET --paginate --slurp repos/mento-protocol/frontend-monorepo/actions/runs/${event.event_run_id}/artifacts?per_page=100`,
+    [
+      {
+        artifacts: [
+          {
+            id: 90_001,
+            name: artifactName,
+            expired: false,
+            size_in_bytes: 1_024,
+          },
+        ],
+      },
+    ],
+  );
+  routes.set(
+    `run download ${event.event_run_id} --repo mento-protocol/frontend-monorepo --name ${artifactName} --dir`,
+    (args) => {
+      const directory = args.at(-1);
+      mkdirSync(directory, { recursive: true, mode: 0o700 });
+      chmodSync(directory, 0o700);
+      writeFileSync(
+        join(directory, "preview-observation-receipt.json"),
+        `${JSON.stringify(
+          {
+            schema: "vercel-preview-observation-receipt:v1",
+            repository: "mento-protocol/frontend-monorepo",
+            pr: journal.pr,
+            event_run_id: event.event_run_id,
+            journal_revision: journal.revision,
+            source_journal_digest: journal.journal_digest,
+            journal_digest: journal.journal_digest,
+            ...(Object.hasOwn(journal, "admission")
+              ? { admission: journal.admission }
+              : {}),
+            checkpoint: journal.checkpoint,
+            receipts: journal.receipts,
+            state: journal.state,
+          },
+          null,
+          2,
+        )}\n`,
+        { mode: 0o600 },
+      );
+      chmodSync(join(directory, "preview-observation-receipt.json"), 0o600);
+      return Buffer.from("");
+    },
+  );
 }
 
 function githubWholeSecondTimestamps(value) {
@@ -778,6 +837,7 @@ function previewRoutes(
       Buffer.from("fixture preview worker log\n"),
     );
   }
+  addPreviewObservationArtifactRoute(routes, event, journal);
   return routes;
 }
 
@@ -925,6 +985,7 @@ function reselectedPreviewRoutes(
     "run view 9005 --repo mento-protocol/frontend-monorepo --attempt 1 --log",
     Buffer.from("fixture replacement worker log\n"),
   );
+  addPreviewObservationArtifactRoute(routes, event, fixtureState.journal);
   return { routes, fixtureState };
 }
 
@@ -1386,8 +1447,26 @@ test("capture-preview freezes the canonical v2 journal and raw GitHub facts", ()
     false,
   );
   assert.equal(capture.canonicalDerivedFacts.evidenceComplete, true);
+  assert.equal(
+    capture.canonicalDerivedFacts.observationReceiptSource,
+    "live-journal",
+  );
   assert.ok(
     capture.files.some((file) => file.path === "raw/journal-comment.json"),
+  );
+  assert.equal(
+    capture.files.some((file) =>
+      file.path.startsWith("raw/observation-receipt"),
+    ),
+    false,
+  );
+  assert.equal(
+    calls.some(
+      (args) =>
+        args[0] === "api" &&
+        args.some((value) => String(value).includes("/artifacts?per_page=100")),
+    ),
+    false,
   );
   assertPrivateTree(directory);
   assert.ok(calls.some((args) => args[0] === "auth"));
@@ -1732,7 +1811,7 @@ test("capture-preview leaves no append-only capture while reconciliation is pend
   );
 });
 
-test("capture-preview rejects an event retained only by a checkpoint", () => {
+test("capture-preview recovers a compacted event from its immutable Actions artifact", () => {
   const cwd = workspace();
   runInit(cwd);
   const event = fixture("preview-event.json");
@@ -1753,6 +1832,60 @@ test("capture-preview rejects an event retained only by a checkpoint", () => {
       ],
     ],
   );
+  const result = runVercelCostObservation({
+    argv: ["capture-preview", "--pr", "700", "--event-run-id", "9001"],
+    cwd,
+    now: () => new Date(CAPTURED_AT),
+    gh: fakeGh(routes),
+    stdout: output().stream,
+  });
+  assert.equal(result.exitCode, 0);
+  const directory = join(observationRoot(cwd), "preview", "9001");
+  const capture = JSON.parse(
+    readFileSync(join(directory, "capture.json"), "utf8"),
+  );
+  assert.equal(
+    capture.canonicalDerivedFacts.observationReceiptSource,
+    "actions-artifact",
+  );
+  assert.ok(
+    capture.files.some(
+      (file) => file.path === "raw/observation-receipt-artifact.json",
+    ),
+  );
+  assert.ok(
+    capture.files.some((file) => file.path === "raw/observation-receipt.json"),
+  );
+});
+
+test("capture-preview fails closed when a compacted event has no retained artifact", () => {
+  const cwd = workspace();
+  runInit(cwd);
+  const event = fixture("preview-event.json");
+  const routes = previewRoutes(event);
+  const compacted = compactPreviewJournal(
+    previewJournalFixture(event, "complete").journal,
+  );
+  routes.set(
+    "api --method GET --paginate --slurp repos/mento-protocol/frontend-monorepo/issues/700/comments?per_page=100",
+    [
+      [
+        {
+          id: 301,
+          user: { type: "Bot", login: "github-actions[bot]" },
+          body: renderPreviewJournalBody(compacted),
+        },
+      ],
+    ],
+  );
+  const artifactName = "vercel-preview-observation-receipt-v1-9001";
+  routes.set(
+    "api --method GET --paginate --slurp repos/mento-protocol/frontend-monorepo/actions/runs/9001/artifacts?per_page=100",
+    [{ artifacts: [] }],
+  );
+  routes.delete(
+    `run download 9001 --repo mento-protocol/frontend-monorepo --name ${artifactName} --dir`,
+  );
   assert.throws(
     () =>
       runVercelCostObservation({
@@ -1762,7 +1895,11 @@ test("capture-preview rejects an event retained only by a checkpoint", () => {
         gh: fakeGh(routes),
         stdout: output().stream,
       }),
-    /must remain in the live journal receipts/,
+    /receipt artifact is missing or ambiguous/,
+  );
+  assert.equal(
+    existsSync(join(observationRoot(cwd), "preview", "9001")),
+    false,
   );
 });
 

--- a/scripts/vercel-preview-controller.mjs
+++ b/scripts/vercel-preview-controller.mjs
@@ -26,6 +26,10 @@ export const SELECTION_RECEIPT_SCHEMA = "vercel-preview-selection:v2";
 export const CONTROLLER_SCHEMA = "vercel-preview-controller:v2";
 export const PREVIEW_JOURNAL_SCHEMA = "vercel-preview-journal:v2";
 export const PREVIEW_JOURNAL_MARKER = "<!-- vercel-preview-journal:v2 -->";
+export const PREVIEW_OBSERVATION_RECEIPT_SCHEMA =
+  "vercel-preview-observation-receipt:v1";
+export const PREVIEW_OBSERVATION_ARTIFACT_PREFIX =
+  "vercel-preview-observation-receipt-v1";
 const PREVIEW_CHECKPOINT_SCHEMA = "vercel-preview-checkpoint:v2";
 const CONTROLLER_ADMISSION_SCHEMA = "vercel-preview-controller-admission:v1";
 const WORKER_WORKFLOW = "vercel-preview-worker.yml";
@@ -157,6 +161,20 @@ const SELECTION_SCOPED_CONTROLLER_RESULT_REASONS = new Set([
   NO_DISPATCH_ORPHAN_REASON,
   NATIVE_OWNED_SELECTION_REASON,
 ]);
+const CONTROLLER_SYNTHETIC_RESULT_STATES = new Map([
+  ["selection-removed-from-pr", "failure"],
+  ["controller-workflow-upgraded-before-dispatch", "error"],
+  [NO_DISPATCH_ORPHAN_REASON, "error"],
+  [NATIVE_OWNED_SELECTION_REASON, "error"],
+]);
+
+export function isSupportedControllerSyntheticPreviewResult(result) {
+  return (
+    result?.github_deployment_id === null &&
+    CONTROLLER_SYNTHETIC_RESULT_STATES.get(result.terminal_reason) ===
+      result.state
+  );
+}
 const COMMENT_EXPLANATION = [
   "**No reviewer action is required.**",
   "This repository builds pull request previews in GitHub Actions and deploys them to Vercel.",
@@ -532,7 +550,12 @@ function representedPullRequest(events, checkpoint = null) {
   return [...snapshots.values()][0];
 }
 
-export function snapshotPullRequestEvent(payload, runId, runNumber = null) {
+export function snapshotPullRequestEvent(
+  payload,
+  runId,
+  runNumber = null,
+  { retainObservationReceipt = false } = {},
+) {
   plainObject(payload, "GitHub event payload");
   const action = boundedText(payload.action, "Event action", 32);
   invariant(
@@ -548,6 +571,10 @@ export function snapshotPullRequestEvent(payload, runId, runNumber = null) {
   const before =
     action === "synchronize" ? exactSha(payload.before, "Before SHA") : null;
   const changeBaseSha = action === "synchronize" ? before : pull.baseSha;
+  const observationReceiptRequired =
+    retainObservationReceipt &&
+    pull.trust === "trusted" &&
+    ["opened", "synchronize"].includes(action);
   return {
     schema: EVENT_RECEIPT_SCHEMA,
     repository,
@@ -556,6 +583,9 @@ export function snapshotPullRequestEvent(payload, runId, runNumber = null) {
     ...(runNumber === null
       ? {}
       : { event_run_number: exactRunId(runNumber, "Event run number") }),
+    ...(observationReceiptRequired
+      ? { observation_receipt_required: true }
+      : {}),
     event_action: action,
     pr_state: pull.state,
     pr_updated_at: pull.updatedAt,
@@ -741,6 +771,14 @@ export function validateEventReceipt(value, { requirePlan = true } = {}) {
   exactRunId(event.event_run_id, "Event run ID");
   if (event.event_run_number !== undefined) {
     exactRunId(event.event_run_number, "Event run number");
+  }
+  if (event.observation_receipt_required !== undefined) {
+    invariant(
+      event.observation_receipt_required === true &&
+        event.trust === "trusted" &&
+        ["opened", "synchronize"].includes(event.event_action),
+      "Event observation receipt retention marker is invalid",
+    );
   }
   invariant(
     ALLOWED_EVENT_ACTIONS.has(event.event_action),
@@ -4330,6 +4368,278 @@ export function createPreviewJournal({
   );
 }
 
+export function previewObservationArtifactName(eventRunId) {
+  return `${PREVIEW_OBSERVATION_ARTIFACT_PREFIX}-${exactRunId(
+    eventRunId,
+    "Observation event run ID",
+  )}`;
+}
+
+export function selectPreviewObservationArtifact(values, eventRunId) {
+  invariant(
+    Array.isArray(values),
+    "Preview observation artifacts must be an array",
+  );
+  const name = previewObservationArtifactName(eventRunId);
+  const matches = values.filter(
+    (artifact) => artifact?.name === name && artifact.expired === false,
+  );
+  invariant(matches.length <= 1, "Preview observation artifact is ambiguous");
+  return matches[0] ?? null;
+}
+
+function observationSelectionsForEvent(journal, eventRunId) {
+  return journal.receipts.selections.filter(
+    (selection) =>
+      selection.selection_receipt_run_id === eventRunId ||
+      selection.coalesced_receipt_run_ids.includes(eventRunId),
+  );
+}
+
+function previewObservationJournalForEvent(journal, event) {
+  const decisions = (journal.state?.status_decisions ?? []).filter(
+    (decision) => decision.sha === event.head_sha,
+  );
+  invariant(
+    decisions.length <= 1,
+    "Preview observation event status decision is ambiguous",
+  );
+  if (!TERMINAL_STATES.has(decisions[0]?.state)) return null;
+
+  const selections = observationSelectionsForEvent(journal, event.event_run_id);
+  const selectedTargets = [
+    ...new Set(selections.map((selection) => selection.target)),
+  ].sort();
+  const plannedTargets = [...event.plan.targets].sort();
+  if (canonicalJson(selectedTargets) !== canonicalJson(plannedTargets)) {
+    return null;
+  }
+
+  if (plannedTargets.length > 0 && journal.state === null) return null;
+  const projectedState =
+    journal.state === null ? null : structuredClone(journal.state);
+  for (const selection of selections) {
+    const evidence = journal.receipts.worker_evidence.filter(
+      (entry) => entry.key_digest === selection.key_digest,
+    );
+    const results = journal.receipts.results.filter(
+      (result) => result.key_digest === selection.key_digest,
+    );
+    if (results.length === 0) return null;
+    const synthetic = results.filter(
+      (result) => result.github_deployment_id === null,
+    );
+    if (synthetic.length > 0) {
+      if (
+        synthetic.length !== 1 ||
+        results.length !== 1 ||
+        evidence.length !== 0 ||
+        !isSupportedControllerSyntheticPreviewResult(synthetic[0])
+      ) {
+        return null;
+      }
+      continue;
+    }
+    const evidenceAttempts = new Set(
+      evidence.map(
+        (entry) => `${entry.worker_run_id}:${entry.worker_run_attempt}`,
+      ),
+    );
+    const resultAttempts = new Set(
+      results.map(
+        (entry) => `${entry.worker_run_id}:${entry.worker_run_attempt}`,
+      ),
+    );
+    if (
+      evidenceAttempts.size !== evidence.length ||
+      resultAttempts.size !== results.length ||
+      evidenceAttempts.size !== resultAttempts.size ||
+      [...evidenceAttempts].some((attempt) => !resultAttempts.has(attempt)) ||
+      results.some((result) => !TERMINAL_STATES.has(result.state))
+    ) {
+      return null;
+    }
+  }
+
+  for (const target of plannedTargets) {
+    const targetSelections = selections.filter(
+      (selection) => selection.target === target,
+    );
+    const targetState = journal.state.targets[target];
+    const selectionByKey = new Map(
+      targetSelections.map((selection) => [selection.key_digest, selection]),
+    );
+    const relevantResults = journal.receipts.results.filter((result) =>
+      selectionByKey.has(result.key_digest),
+    );
+    const relevantTerminals = relevantResults
+      .toSorted(
+        (left, right) =>
+          left.worker_run_id - right.worker_run_id ||
+          left.worker_run_attempt - right.worker_run_attempt,
+      )
+      .map((result) => ({
+        target,
+        sha: result.sha,
+        key: result.controller_key,
+        key_digest: result.key_digest,
+        epoch_anchor_run_id: result.epoch_anchor_run_id,
+        reconciliation_basis_digest: result.reconciliation_basis_digest,
+        selection_receipt_run_id: result.selection_receipt_run_id,
+        expected_workflow_sha: result.expected_workflow_sha,
+        state: result.state,
+        worker_run_id: result.worker_run_id,
+        github_deployment_id: result.github_deployment_id,
+        vercel_deployment_url: result.vercel_deployment_url,
+        terminal_reason: result.terminal_reason,
+      }));
+    if (
+      relevantTerminals.length !== relevantResults.length ||
+      relevantResults.some(
+        (result) =>
+          !relevantTerminals.some(
+            (terminal) =>
+              terminal.key_digest === result.key_digest &&
+              terminal.worker_run_id === result.worker_run_id &&
+              terminal.state === result.state &&
+              terminal.github_deployment_id === result.github_deployment_id &&
+              terminal.vercel_deployment_url === result.vercel_deployment_url &&
+              terminal.terminal_reason === result.terminal_reason,
+          ),
+      )
+    ) {
+      return null;
+    }
+    const terminal = relevantTerminals.at(-1);
+    const currentSelection = terminal
+      ? selectionByKey.get(terminal.key_digest)
+      : null;
+    if (
+      !terminal ||
+      !currentSelection ||
+      (currentSelection.selection_receipt_run_id !== event.event_run_id &&
+        !currentSelection.coalesced_receipt_run_ids.includes(
+          event.event_run_id,
+        ))
+    ) {
+      return null;
+    }
+    projectedState.targets[target] = {
+      ...structuredClone(targetState),
+      latest_desired_sha: terminal.sha,
+      latest_desired_receipt_run_id: currentSelection.selection_receipt_run_id,
+      idle_cursor_receipt_run_id: currentSelection.selection_receipt_run_id,
+      active: null,
+      retired_active: [],
+      terminal_result_key_digests: [
+        ...new Set(relevantResults.map((result) => result.key_digest)),
+      ],
+      terminal_history: relevantTerminals,
+    };
+  }
+  return createPreviewJournal({
+    pr: journal.pr,
+    revision: journal.revision,
+    checkpoint: journal.checkpoint,
+    events: journal.receipts.events,
+    selections: journal.receipts.selections,
+    workerEvidence: journal.receipts.worker_evidence,
+    results: journal.receipts.results,
+    state: projectedState,
+    ...(Object.hasOwn(journal, "admission")
+      ? { admission: journal.admission }
+      : {}),
+  });
+}
+
+export function createPreviewObservationReceipt(value, rawEventRunId) {
+  const source = validatePreviewJournal(value, value.pr);
+  const eventRunId = exactRunId(rawEventRunId, "Observation event run ID");
+  const events = source.receipts.events.filter(
+    (event) => event.event_run_id === eventRunId,
+  );
+  invariant(
+    events.length === 1,
+    "Preview observation event is missing or ambiguous",
+  );
+  const projected = previewObservationJournalForEvent(source, events[0]);
+  if (projected === null) return null;
+  const receipt = {
+    schema: PREVIEW_OBSERVATION_RECEIPT_SCHEMA,
+    repository: PREVIEW_REPOSITORY,
+    pr: source.pr,
+    event_run_id: eventRunId,
+    journal_revision: projected.revision,
+    source_journal_digest: source.journal_digest,
+    journal_digest: projected.journal_digest,
+    ...(Object.hasOwn(projected, "admission")
+      ? { admission: structuredClone(projected.admission) }
+      : {}),
+    checkpoint:
+      projected.checkpoint === null
+        ? null
+        : structuredClone(projected.checkpoint),
+    receipts: structuredClone(projected.receipts),
+    state: projected.state === null ? null : structuredClone(projected.state),
+  };
+  return validatePreviewObservationReceipt(receipt);
+}
+
+export function validatePreviewObservationReceipt(value) {
+  const receipt = plainObject(value, "Preview observation receipt");
+  const fields = Object.keys(receipt).sort().join(",");
+  invariant(
+    fields ===
+      "checkpoint,event_run_id,journal_digest,journal_revision,pr,receipts,repository,schema,source_journal_digest,state" ||
+      fields ===
+        "admission,checkpoint,event_run_id,journal_digest,journal_revision,pr,receipts,repository,schema,source_journal_digest,state",
+    "Preview observation receipt fields are invalid",
+  );
+  invariant(
+    receipt.schema === PREVIEW_OBSERVATION_RECEIPT_SCHEMA &&
+      receipt.repository === PREVIEW_REPOSITORY,
+    "Preview observation receipt identity is invalid",
+  );
+  invariant(
+    typeof receipt.source_journal_digest === "string" &&
+      /^[0-9a-f]{64}$/.test(receipt.source_journal_digest),
+    "Preview observation receipt source journal digest is invalid",
+  );
+  const journal = createPreviewJournal({
+    pr: receipt.pr,
+    revision: receipt.journal_revision,
+    checkpoint: receipt.checkpoint,
+    events: receipt.receipts?.events,
+    selections: receipt.receipts?.selections,
+    workerEvidence: receipt.receipts?.worker_evidence,
+    results: receipt.receipts?.results,
+    state: receipt.state,
+    ...(Object.hasOwn(receipt, "admission")
+      ? { admission: receipt.admission }
+      : {}),
+  });
+  invariant(
+    journal.journal_digest === receipt.journal_digest,
+    "Preview observation receipt journal digest conflicts",
+  );
+  const eventRunId = exactRunId(
+    receipt.event_run_id,
+    "Preview observation receipt event run ID",
+  );
+  const events = journal.receipts.events.filter(
+    (event) => event.event_run_id === eventRunId,
+  );
+  const projected =
+    events.length === 1
+      ? previewObservationJournalForEvent(journal, events[0])
+      : null;
+  invariant(
+    projected !== null && canonicalJson(projected) === canonicalJson(journal),
+    "Preview observation receipt event is not settled or canonical",
+  );
+  return receipt;
+}
+
 function emptyReceiptCounts() {
   return { events: 0, selections: 0, worker_evidence: 0, results: 0 };
 }
@@ -4856,7 +5166,7 @@ async function mutatePreviewJournal({
   if (!loaded && assertCanCreate) await assertCanCreate();
   const current = loaded?.journal ?? createPreviewJournal({ pr, revision: 1 });
   const candidate = structuredClone(current);
-  mutate(candidate);
+  await mutate(candidate);
   if (pendingClosedBootstrapRecovery) {
     assertClosedBootstrapTerminalRecoveryWriteResult({
       current,
@@ -5277,6 +5587,32 @@ function foldCheckpointSemanticEvent(journal, event) {
   };
 }
 
+async function priorObservationReceiptsAreRetained({
+  github,
+  context,
+  events,
+}) {
+  const required = events.filter(
+    (event) =>
+      validateEventReceipt(event).observation_receipt_required === true,
+  );
+  for (const event of required) {
+    const artifacts = await github.paginate(
+      github.rest.actions.listWorkflowRunArtifacts,
+      {
+        ...ownerRepo(context),
+        run_id: event.event_run_id,
+        per_page: 100,
+      },
+    );
+    if (
+      selectPreviewObservationArtifact(artifacts, event.event_run_id) === null
+    )
+      return false;
+  }
+  return true;
+}
+
 async function appendJournalReceipt({
   github,
   context,
@@ -5316,7 +5652,7 @@ async function appendJournalReceipt({
             receipt: value,
           }
         : null,
-    mutate(journal) {
+    async mutate(journal) {
       const priorAdmissionRunNumber =
         journal.admission?.through_run_number ?? null;
       const nextAdmission =
@@ -5439,12 +5775,26 @@ async function appendJournalReceipt({
       const entries = journal.receipts[definition.name];
       const eventsBeforeAppend =
         kind === "event" ? structuredClone(journal.receipts.events) : null;
+      const priorObservationReceiptsRetained =
+        kind !== "event" ||
+        (await priorObservationReceiptsAreRetained({
+          github,
+          context,
+          events: eventsBeforeAppend,
+        }));
       entries.push(structuredClone(value));
       persistAdmission();
       if (deferCompaction) {
         // This one authenticated legacy drain must preserve the old active
         // owner lineage until the same run reconciles the persisted results.
         // Rendering here enforces the 60 KB comment headroom before any write.
+        renderPreviewJournalBody(journal);
+        return;
+      }
+      if (kind === "event" && !priorObservationReceiptsRetained) {
+        // A later controller run must not checkpoint an event before that
+        // event's immutable Actions artifact exists. The serialized comment
+        // write keeps the full graph available to its artifact publisher.
         renderPreviewJournalBody(journal);
         return;
       }
@@ -5484,7 +5834,28 @@ async function appendJournalReceipt({
               journal.pr,
               journal.checkpoint,
             );
-        if (
+        if (value.observation_receipt_required === true) {
+          if (beforeWasRepresented) {
+            journal.receipts.events = eventsBeforeAppend;
+            journal.journal_digest = previewJournalDigest(
+              journal.receipts,
+              journal.state,
+              journal.checkpoint,
+              journal.admission,
+            );
+            compactPreviewJournal(journal, {
+              expectedPullNumber,
+            });
+            // This event's publisher can only bind an exact live receipt. Even
+            // when it is semantically equal to the compacted checkpoint tail,
+            // preserve this distinct run ID until its artifact exists.
+            journal.receipts.events.push(structuredClone(value));
+          } else {
+            // The new event itself cannot be compacted until its artifact
+            // publisher has consumed this live graph.
+            renderPreviewJournalBody(journal);
+          }
+        } else if (
           semanticCheckpointReplay &&
           eventAdmissionProof.frontierRunNumber !== null
         ) {
@@ -5542,20 +5913,30 @@ async function writeControllerState({
     closedBootstrapRecoveryCapability: compactClosedBootstrapRecovery
       ? { type: CLOSED_BOOTSTRAP_RECOVERY_TERMINAL_STATE }
       : null,
-    mutate(journal) {
+    async mutate(journal) {
       journal.state = structuredClone(state);
       if (compactClosedBootstrapRecovery) {
         invariant(
           state.closed,
           "Closed bootstrap recovery compaction requires terminal state",
         );
-        journal.journal_digest = previewJournalDigest(
-          journal.receipts,
-          journal.state,
-          journal.checkpoint,
-          journal.admission,
-        );
-        compactPreviewJournal(journal, { expectedPullNumber: pr });
+        if (
+          await priorObservationReceiptsAreRetained({
+            github,
+            context,
+            events: journal.receipts.events,
+          })
+        ) {
+          journal.journal_digest = previewJournalDigest(
+            journal.receipts,
+            journal.state,
+            journal.checkpoint,
+            journal.admission,
+          );
+          compactPreviewJournal(journal, { expectedPullNumber: pr });
+        } else {
+          renderPreviewJournalBody(journal);
+        }
       }
     },
   });
@@ -5848,7 +6229,9 @@ export async function prepareBootstrap({
 }
 
 export function writeEventSnapshotOutputs({ payload, runId, runNumber, core }) {
-  const snapshot = snapshotPullRequestEvent(payload, runId, runNumber);
+  const snapshot = snapshotPullRequestEvent(payload, runId, runNumber, {
+    retainObservationReceipt: true,
+  });
   core.setOutput("snapshot", JSON.stringify(snapshot));
   for (const [name, value] of Object.entries({
     pr_number: snapshot.pr,
@@ -5856,6 +6239,8 @@ export function writeEventSnapshotOutputs({ payload, runId, runNumber, core }) {
     change_base_sha: snapshot.change_base_sha,
     head_sha: snapshot.head_sha,
     trust: snapshot.trust,
+    observation_receipt_required:
+      snapshot.observation_receipt_required === true,
     plan_required:
       snapshot.trust === "trusted" && snapshot.event_action !== "closed",
   }))

--- a/scripts/vercel-preview-controller.mjs
+++ b/scripts/vercel-preview-controller.mjs
@@ -28,7 +28,7 @@ export const PREVIEW_JOURNAL_SCHEMA = "vercel-preview-journal:v2";
 export const PREVIEW_JOURNAL_MARKER = "<!-- vercel-preview-journal:v2 -->";
 export const PREVIEW_OBSERVATION_RECEIPT_SCHEMA =
   "vercel-preview-observation-receipt:v1";
-export const PREVIEW_OBSERVATION_ARTIFACT_PREFIX =
+const PREVIEW_OBSERVATION_ARTIFACT_PREFIX =
   "vercel-preview-observation-receipt-v1";
 const PREVIEW_CHECKPOINT_SCHEMA = "vercel-preview-checkpoint:v2";
 const CONTROLLER_ADMISSION_SCHEMA = "vercel-preview-controller-admission:v1";

--- a/scripts/vercel-preview-controller.test.mjs
+++ b/scripts/vercel-preview-controller.test.mjs
@@ -16,9 +16,11 @@ import {
   controllerEventRunName,
   controllerKey,
   createPreviewJournal,
+  createPreviewObservationReceipt,
   dependabotIntakeRunName,
   normalizePlannerResult,
   parseWorkerRunName,
+  previewObservationArtifactName,
   previewOwnerForVercelConfiguration,
   publishDependabotUnsupported,
   postWorkerRecoveryError,
@@ -30,8 +32,10 @@ import {
   reconcileState,
   recoverWorkerResult,
   selectionReceiptFromDispatch,
+  selectPreviewObservationArtifact,
   snapshotPullRequestEvent,
   validateEventReceipt,
+  validatePreviewObservationReceipt,
   validateDependabotIntakeWorkflowRun,
   validateControllerEventWorkflowRun,
   validateRepositoryDispatch,
@@ -159,6 +163,7 @@ function event({
   ref = "feature/preview-controller",
   base = SHA.E,
   baseRef = "main",
+  retainObservationReceipt = false,
 } = {}) {
   const pr = pull({
     head,
@@ -180,6 +185,7 @@ function event({
     },
     run,
     runNumber,
+    { retainObservationReceipt },
   );
   const rawPlan =
     targets.length > 0
@@ -392,6 +398,30 @@ function result(
   });
 }
 
+function workerEvidence(dispatch, { runId = 8_000 } = {}) {
+  return {
+    schema: "vercel-preview-worker-evidence:v2",
+    repository: PREVIEW_REPOSITORY,
+    pr: dispatch.pr,
+    target: dispatch.target,
+    sha: dispatch.sha,
+    controller_key: dispatch.key,
+    key_digest: dispatch.key_digest,
+    epoch_anchor_run_id: dispatch.epoch_anchor_run_id,
+    reconciliation_basis_digest: dispatch.reconciliation_basis_digest,
+    selection_receipt_run_id: dispatch.selection_receipt_run_id,
+    expected_workflow_sha: dispatch.expected_workflow_sha,
+    worker_run_id: runId,
+    worker_run_attempt: 1,
+    github_deployment_id: 9_000 + runId,
+    execution_mode: "build",
+    build_completed: true,
+    vercel_deployment_id: `dpl_${runId}`,
+    next_deployment_id: `m-${dispatch.target}-${runId}`,
+    verified_upload_url: `https://${dispatch.target}-${runId}.vercel.app`,
+  };
+}
+
 function controllerResult(
   dispatch,
   {
@@ -469,9 +499,11 @@ test("trusted snapshot entrypoints emit bounded event and bootstrap outputs", as
   });
   assert.equal(eventSnapshot.event_action, "opened");
   assert.equal(eventSnapshot.event_run_number, 10);
+  assert.equal(eventSnapshot.observation_receipt_required, true);
   assert.equal(outputs.get("pr_number"), "519");
   assert.equal(outputs.get("head_sha"), SHA.A);
   assert.equal(outputs.get("plan_required"), "true");
+  assert.equal(outputs.get("observation_receipt_required"), "true");
   assert.deepEqual(JSON.parse(outputs.get("snapshot")), eventSnapshot);
 
   outputs.clear();
@@ -579,6 +611,177 @@ test("trusted snapshot entrypoints emit bounded event and bootstrap outputs", as
       head: SHA.A,
       planner_source_sha: SHA.E,
     },
+  );
+});
+
+test("preview observation receipts bind one settled event and reject pending graphs", () => {
+  const settledEvent = event({
+    run: 9_001,
+    runNumber: 501,
+    action: "opened",
+    head: SHA.A,
+    runtime: false,
+    updated: timestamp(1),
+  });
+  const settled = reconcile({
+    events: [settledEvent],
+    pullRequest: pull({ head: SHA.A, updated: timestamp(1) }),
+  });
+  const journal = createPreviewJournal({
+    pr: settledEvent.pr,
+    events: [settledEvent],
+    state: settled.state,
+  });
+  const receipt = createPreviewObservationReceipt(journal, 9_001);
+  assert.ok(receipt);
+  assert.equal(receipt.event_run_id, 9_001);
+  assert.equal(receipt.source_journal_digest, journal.journal_digest);
+  assert.equal(receipt.journal_digest, journal.journal_digest);
+  assert.deepEqual(validatePreviewObservationReceipt(receipt), receipt);
+  assert.equal(
+    previewObservationArtifactName(9_001),
+    "vercel-preview-observation-receipt-v1-9001",
+  );
+
+  const pendingEvent = event({
+    run: 9_002,
+    runNumber: 502,
+    action: "opened",
+    head: SHA.B,
+    updated: timestamp(2),
+  });
+  const pending = reconcile({
+    events: [pendingEvent],
+    pullRequest: pull({ head: SHA.B, updated: timestamp(2) }),
+  });
+  assert.equal(
+    createPreviewObservationReceipt(
+      createPreviewJournal({
+        pr: pendingEvent.pr,
+        events: [pendingEvent],
+        state: pending.state,
+      }),
+      9_002,
+    ),
+    null,
+  );
+  assert.throws(
+    () => createPreviewObservationReceipt(journal, 9_999),
+    /event is missing or ambiguous/,
+  );
+});
+
+test("preview observation artifacts are exact, unexpired, and rerun-idempotent", () => {
+  const name = previewObservationArtifactName(9_001);
+  const retained = {
+    id: 100,
+    name,
+    expired: false,
+  };
+  assert.equal(
+    selectPreviewObservationArtifact(
+      [{ id: 99, name, expired: true }, retained],
+      9_001,
+    ),
+    retained,
+  );
+  assert.equal(
+    selectPreviewObservationArtifact([{ id: 99, name, expired: true }], 9_001),
+    null,
+  );
+  assert.throws(
+    () =>
+      selectPreviewObservationArtifact(
+        [retained, { id: 101, name, expired: false }],
+        9_001,
+      ),
+    /artifact is ambiguous/,
+  );
+});
+
+test("preview observation receipts project a settled target away from a newer active push", () => {
+  const opened = event({
+    run: 9_101,
+    runNumber: 601,
+    action: "opened",
+    head: SHA.A,
+    updated: timestamp(1),
+  });
+  const selectedOpened = reconcile({
+    events: [opened],
+    pullRequest: pull({ head: SHA.A, updated: timestamp(1) }),
+  });
+  const openedActive = persistDispatch(selectedOpened, 91_001);
+  const openedSelection = selectionReceiptFromDispatch(
+    openedActive.targets.ui.active,
+  );
+  const openedResult = result(selectedOpened.nextDispatch, { runId: 91_001 });
+  const openedEvidence = workerEvidence(selectedOpened.nextDispatch, {
+    runId: 91_001,
+  });
+  const openedTerminal = reconcile({
+    events: [opened],
+    selections: [openedSelection],
+    results: [openedResult],
+    pullRequest: pull({ head: SHA.A, updated: timestamp(1) }),
+    existingState: openedActive,
+  }).state;
+
+  const synchronize = event({
+    run: 9_102,
+    runNumber: 602,
+    action: "synchronize",
+    before: SHA.A,
+    head: SHA.B,
+    updated: timestamp(2),
+  });
+  const selectedSynchronize = reconcile({
+    events: [opened, synchronize],
+    selections: [openedSelection],
+    results: [openedResult],
+    pullRequest: pull({ head: SHA.B, updated: timestamp(2) }),
+    existingState: openedTerminal,
+  });
+  const overlapping = persistDispatch(selectedSynchronize, 91_002);
+  const synchronizeSelection = selectionReceiptFromDispatch(
+    overlapping.targets.ui.active,
+  );
+  const journal = createPreviewJournal({
+    pr: opened.pr,
+    events: [opened, synchronize],
+    selections: [openedSelection, synchronizeSelection],
+    workerEvidence: [openedEvidence],
+    results: [openedResult],
+    state: overlapping,
+  });
+
+  const receipt = createPreviewObservationReceipt(journal, opened.event_run_id);
+  assert.ok(receipt);
+  assert.equal(receipt.source_journal_digest, journal.journal_digest);
+  assert.notEqual(receipt.journal_digest, journal.journal_digest);
+  assert.equal(receipt.state.targets.ui.active, null);
+  assert.equal(receipt.state.targets.ui.latest_desired_sha, opened.head_sha);
+  assert.deepEqual(receipt.state.targets.ui.terminal_history, [
+    {
+      target: "ui",
+      sha: openedResult.sha,
+      key: openedResult.controller_key,
+      key_digest: openedResult.key_digest,
+      epoch_anchor_run_id: openedResult.epoch_anchor_run_id,
+      reconciliation_basis_digest: openedResult.reconciliation_basis_digest,
+      selection_receipt_run_id: openedResult.selection_receipt_run_id,
+      expected_workflow_sha: openedResult.expected_workflow_sha,
+      state: openedResult.state,
+      worker_run_id: openedResult.worker_run_id,
+      github_deployment_id: openedResult.github_deployment_id,
+      vercel_deployment_url: openedResult.vercel_deployment_url,
+      terminal_reason: openedResult.terminal_reason,
+    },
+  ]);
+  assert.deepEqual(validatePreviewObservationReceipt(receipt), receipt);
+  assert.equal(
+    createPreviewObservationReceipt(journal, synchronize.event_run_id),
+    null,
   );
 });
 
@@ -3686,6 +3889,7 @@ function fakeGitHub({
   uiVercelContentErrorStatus,
   includeDefaultControllerFloor = true,
   controllerWorkflowId = CONTROLLER_WORKFLOW_ID,
+  artifacts: initialArtifacts = [],
 } = {}) {
   const comments = structuredClone(initialComments);
   const runs = structuredClone(initialRuns);
@@ -3696,6 +3900,7 @@ function fakeGitHub({
     runs.push(controllerInertRun());
   }
   const deployments = structuredClone(initialDeployments);
+  const artifacts = structuredClone(initialArtifacts);
   const statuses = new Map(
     [...deploymentStatuses.entries()].map(([key, value]) => [
       String(key),
@@ -3743,6 +3948,7 @@ function fakeGitHub({
   const listComments = async () => {};
   const listCommits = async () => {};
   const listDeployments = async () => {};
+  const listWorkflowRunArtifacts = async () => {};
   const listCommitStatusesForRef = async ({ ref, per_page = 100 }) => {
     listCommitStatusRequests += 1;
     beforeListCommitStatuses?.({
@@ -3806,6 +4012,7 @@ function fakeGitHub({
         listCommits,
       },
       actions: {
+        listWorkflowRunArtifacts,
         getWorkflow: async ({ workflow_id }) => {
           assert.ok(
             workflow_id === "vercel-preview-controller.yml" ||
@@ -4025,6 +4232,13 @@ function fakeGitHub({
       if (method === listDeployments) {
         deploymentLookupCallCount += 1;
         return structuredClone(deployments);
+      }
+      if (method === listWorkflowRunArtifacts) {
+        return structuredClone(
+          artifacts.filter(
+            (artifact) => artifact.workflow_run_id === request.run_id,
+          ),
+        );
       }
       if (method === listCommitStatusesForRef) {
         return structuredClone(
@@ -7903,6 +8117,178 @@ test("the first receipt after a terminal checkpoint remains live for reconciliat
   });
   assert.equal(reconciled.epoch.tail_receipt_run_id, docs.event_run_id);
   assert.equal(reconciled.status_decisions.at(-1).state, "success");
+});
+
+test("event compaction waits for an unexpired immutable observation artifact", async () => {
+  const opened = event({
+    run: 25_001,
+    runNumber: 2,
+    action: "opened",
+    head: SHA.A,
+    updated: timestamp(1),
+    retainObservationReceipt: true,
+  });
+  const selected = reconcile({
+    events: [opened],
+    pullRequest: pull({ head: SHA.A, updated: timestamp(1) }),
+  });
+  const active = persistDispatch(selected, 62_001);
+  const selection = selectionReceiptFromDispatch(active.targets.ui.active);
+  const terminalResult = result(selected.nextDispatch, { runId: 62_001 });
+  const terminalState = reconcile({
+    events: [opened],
+    selections: [selection],
+    results: [terminalResult],
+    pullRequest: pull({ head: SHA.A, updated: timestamp(1) }),
+    existingState: active,
+  }).state;
+  const synchronize = event({
+    run: 25_002,
+    runNumber: 3,
+    action: "synchronize",
+    before: SHA.A,
+    head: SHA.B,
+    runtime: false,
+    updated: timestamp(2),
+    retainObservationReceipt: true,
+  });
+  const baseOptions = {
+    pullRequest: pull({ head: SHA.B, updated: timestamp(2) }),
+    comments: [
+      journalComment({
+        events: [opened],
+        selections: [selection],
+        results: [terminalResult],
+        state: terminalState,
+        admission: {
+          schema: "vercel-preview-controller-admission:v1",
+          workflow_id: CONTROLLER_WORKFLOW_ID,
+          through_run_id: opened.event_run_id,
+          through_run_number: opened.event_run_number,
+        },
+      }),
+    ],
+    runs: [
+      controllerEventRun({
+        id: opened.event_run_id,
+        runNumber: opened.event_run_number,
+        action: "opened",
+        sha: SHA.A,
+      }),
+      controllerEventRun({
+        id: synchronize.event_run_id,
+        runNumber: synchronize.event_run_number,
+        action: "synchronize",
+        before: SHA.A,
+        sha: SHA.B,
+        createdAt: timestamp(2),
+      }),
+    ],
+    includeDefaultControllerFloor: false,
+  };
+
+  const missing = fakeGitHub({
+    ...baseOptions,
+    artifacts: [
+      {
+        id: 699,
+        workflow_run_id: opened.event_run_id,
+        name: previewObservationArtifactName(opened.event_run_id),
+        expired: true,
+      },
+    ],
+  });
+  await recordEventReceipt({
+    github: missing.github,
+    context: fakeContext({
+      runId: synchronize.event_run_id,
+      runNumber: synchronize.event_run_number,
+    }),
+    core: fakeCore(),
+    ...eventRecordInputs(synchronize),
+  });
+  const retainedLive = journalFromComment(missing.comments[0]);
+  assert.equal(retainedLive.checkpoint, null);
+  assert.deepEqual(
+    retainedLive.receipts.events.map((entry) => entry.event_run_id),
+    [opened.event_run_id, synchronize.event_run_id],
+  );
+
+  const retained = fakeGitHub({
+    ...baseOptions,
+    artifacts: [
+      {
+        id: 700,
+        workflow_run_id: opened.event_run_id,
+        name: previewObservationArtifactName(opened.event_run_id),
+        expired: false,
+      },
+    ],
+  });
+  await recordEventReceipt({
+    github: retained.github,
+    context: fakeContext({
+      runId: synchronize.event_run_id,
+      runNumber: synchronize.event_run_number,
+    }),
+    core: fakeCore(),
+    ...eventRecordInputs(synchronize),
+  });
+  const compacted = journalFromComment(retained.comments[0]);
+  assert.equal(compacted.checkpoint.event.event_run_id, opened.event_run_id);
+  assert.deepEqual(
+    compacted.receipts.events.map((entry) => entry.event_run_id),
+    [synchronize.event_run_id],
+  );
+
+  const duplicate = event({
+    run: 25_003,
+    runNumber: 3,
+    action: "opened",
+    head: SHA.A,
+    updated: timestamp(1),
+    retainObservationReceipt: true,
+  });
+  const duplicateFixture = fakeGitHub({
+    pullRequest: pull({ head: SHA.A, updated: timestamp(1) }),
+    comments: baseOptions.comments,
+    runs: [
+      baseOptions.runs[0],
+      controllerEventRun({
+        id: duplicate.event_run_id,
+        runNumber: duplicate.event_run_number,
+        action: "opened",
+        sha: SHA.A,
+      }),
+    ],
+    artifacts: [
+      {
+        id: 701,
+        workflow_run_id: opened.event_run_id,
+        name: previewObservationArtifactName(opened.event_run_id),
+        expired: false,
+      },
+    ],
+    includeDefaultControllerFloor: false,
+  });
+  await recordEventReceipt({
+    github: duplicateFixture.github,
+    context: fakeContext({
+      runId: duplicate.event_run_id,
+      runNumber: duplicate.event_run_number,
+    }),
+    core: fakeCore(),
+    ...eventRecordInputs(duplicate),
+  });
+  const duplicatePersisted = journalFromComment(duplicateFixture.comments[0]);
+  assert.equal(
+    duplicatePersisted.checkpoint.event.event_run_id,
+    opened.event_run_id,
+  );
+  assert.deepEqual(
+    duplicatePersisted.receipts.events.map((entry) => entry.event_run_id),
+    [duplicate.event_run_id],
+  );
 });
 
 test("queued receipts after a terminal checkpoint preserve every transition", async () => {

--- a/scripts/vercel-preview-workflows.test.mjs
+++ b/scripts/vercel-preview-workflows.test.mjs
@@ -127,6 +127,62 @@ test("controller run title marks exactly the receipt-producing PR events", () =>
   }
 });
 
+test("trusted PR events retain one settled immutable observation artifact", () => {
+  const retention = controller.jobs["publish-observation-receipt"];
+  assert.deepEqual(retention.needs, [
+    "snapshot-event",
+    "receipt-event",
+    "reconcile-event",
+  ]);
+  assert.match(
+    retention.if,
+    /snapshot-event\.outputs\.observation_receipt_required == 'true'/,
+  );
+  assert.match(retention.if, /reconcile-event\.result == 'success'/);
+  assert.equal(Object.hasOwn(retention, "concurrency"), false);
+  assert.equal(retention["timeout-minutes"], 50);
+  assert.deepEqual(retention.permissions, {
+    actions: "read",
+    contents: "read",
+    "pull-requests": "read",
+  });
+
+  const materialize = retention.steps.find((step) =>
+    String(step.with?.script ?? "").includes("createPreviewObservationReceipt"),
+  );
+  assert.ok(materialize);
+  assert.equal(materialize.id, "materialize");
+  assert.equal(materialize.env.EVENT_RUN_ID, "${{ github.run_id }}");
+  assert.match(materialize.with.script, /listWorkflowRunArtifacts/);
+  assert.match(materialize.with.script, /selectPreviewObservationArtifact/);
+  assert.match(materialize.with.script, /upload_required", "false/);
+  assert.match(materialize.with.script, /issues\.getComment/);
+  assert.match(materialize.with.script, /setTimeout\(resolve, 15_000\)/);
+  assert.match(
+    materialize.with.script,
+    /createPreviewObservationReceipt\([\s\S]+process\.env\.EVENT_RUN_ID/,
+  );
+
+  const upload = retention.steps.find((step) =>
+    String(step.uses ?? "").startsWith("actions/upload-artifact@"),
+  );
+  assert.ok(upload);
+  assert.equal(
+    upload.if,
+    "steps.materialize.outputs.upload_required == 'true'",
+  );
+  assert.equal(
+    upload.with.name,
+    "vercel-preview-observation-receipt-v1-${{ github.run_id }}",
+  );
+  assert.equal(
+    upload.with.path,
+    "${{ runner.temp }}/preview-observation-receipt.json",
+  );
+  assert.equal(upload.with["if-no-files-found"], "error");
+  assert.equal(upload.with["retention-days"], 14);
+});
+
 test("controller mode is canonical and reaches every reconciliation call", () => {
   assert.deepEqual(Object.keys(controller.env), [
     "VERCEL_PREVIEW_CONTROLLER_MODE",


### PR DESCRIPTION
## The Problem

The private Vercel cost observation collector could only capture preview evidence while an event still existed in the compacting PR journal. Rapid pushes could checkpoint a settled `opened` or `synchronize` event before the collector ran, leaving no durable event graph for the observation window.

## The Solution

The preview controller now retains one immutable, event-run-bound Actions artifact for each trusted `opened` or `synchronize` event. Journal compaction keeps the exact event receipt live until GitHub reports its unexpired artifact, while an event-scoped projection preserves a settled event even when a newer push is already active. Workflow reruns reuse the exact existing artifact.

The observation collector continues to prefer the live journal and falls back to the artifact only after compaction. It validates the artifact identity, canonical graph, source and projected digests, selection/result/evidence pairing, and terminal state before reserving an append-only capture. The runbook and command reference document the 14-day retention window.

## Validation

- `pnpm vercel:preview:test` — 270 passed
- `pnpm vercel:cost:test` — 90 passed
- `node --test scripts/vercel-preview-controller.test.mjs scripts/vercel-preview-workflows.test.mjs` — 227 passed
- `pnpm ci:action-pins` — all 34 workflow/composite-action files pinned
- `pnpm adr:check` — passed
- `trunk check` — no issues in 9 modified files
- Local deterministic autoreview — clean
- Fresh-context autoreview — 0 findings; patch correct (0.90 confidence)

## Ship Checklist

- [x] PR title follows the [conventions](https://www.notion.so/Git-Branching-and-Commit-Message-Conventions-18f66f7d06444cfcbac5725ffbc7c04a?pvs=4#9355048863c549ef92fe210a8a1298aa)
- [x] Performed a self-review of my own changes
- [x] Relevant automated checks and smoke tests pass
- [x] Architecture decision? Not applicable — this hardens the existing GitHub-driven Vercel preview and observation contracts documented in the deployment runbook; it does not introduce a new architectural choice.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches preview-controller journal compaction and cost-observation evidence capture, which are important CI contracts. Risk is moderated by fail-closed validation and by treating the artifact as non-authoritative for deployment or reconciliation.
> 
> **Overview**
> Prevents cost-observation gaps when rapid pushes compact settled `opened`/`synchronize` events out of the live preview journal.
> 
> Trusted receipt-producing controller runs now mark those events for retention, wait outside the writer queue for a terminal settled graph, and upload one event-run-bound Actions artifact (`vercel-preview-observation-receipt-v1-<run-id>`) with **14-day** retention. Reruns reuse an existing unexpired artifact instead of uploading another copy.
> 
> **Journal compaction** now keeps a marked event live until GitHub reports that exact artifact. The private `capture-preview` collector still prefers the live journal and falls back to the artifact only after compaction, validating identity, digests, and terminal selection/result evidence before publishing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 805b965042f99d43c7b2a5203649068439c30449. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->