### PR TITLE
fix: bound Dependabot review API usage

### DIFF
--- a/.github/workflows/dependabot-claude-review.yml
+++ b/.github/workflows/dependabot-claude-review.yml
@@ -464,9 +464,52 @@ jobs:
             security, compatibility, and test findings. A clean verdict means
             the exact diff has no actionable findings.
           allowed_bots: ${{ needs.preflight.outputs.review_actor_login }}
+          settings: |
+            {
+              "env": {
+                "BASH_MAX_OUTPUT_LENGTH": "150000",
+                "DEPENDABOT_REVIEW_PR_NUMBER": "${{ needs.preflight.outputs.pr_number }}",
+                "DEPENDABOT_REVIEW_REPOSITORY": "mento-protocol/frontend-monorepo"
+              },
+              "hooks": {
+                "PreToolUse": [{
+                  "matcher": "Bash",
+                  "hooks": [{
+                    "type": "command",
+                    "command": "node \"${{ github.workspace }}/scripts/dependabot-claude-review-tool-guard.mjs\" || exit 2",
+                    "timeout": 5
+                  }]
+                }],
+                "PostToolUse": [{
+                  "matcher": "Bash",
+                  "hooks": [{
+                    "type": "command",
+                    "command": "node \"${{ github.workspace }}/scripts/dependabot-claude-review-tool-guard.mjs\" || exit 2",
+                    "timeout": 5
+                  }]
+                }]
+              }
+            }
+          # allowedTools only auto-approves calls. Restrict availability with
+          # --tools; trusted hooks approve and receipt one exact diff read.
           claude_args: >-
-            --allowedTools "Bash(gh pr diff ${{ needs.preflight.outputs.pr_number }} --repo ${{ github.repository }})"
+            --tools "Bash"
+            --disallowedTools "mcp__*"
+            --permission-mode dontAsk
+            --setting-sources user
+            --strict-mcp-config
             --json-schema '{"type":"object","additionalProperties":false,"required":["schema","repository","pullRequestNumber","headSha","reviewCompleted","verdict","findings"],"properties":{"schema":{"const":"dependabot-claude-review-result:v1"},"repository":{"const":"mento-protocol/frontend-monorepo"},"pullRequestNumber":{"type":"integer","minimum":1},"headSha":{"type":"string","pattern":"^[0-9a-f]{40}$"},"reviewCompleted":{"type":"boolean"},"verdict":{"enum":["clean","findings"]},"findings":{"type":"array","maxItems":20,"items":{"type":"object","additionalProperties":false,"required":["title","path","line","summary"],"properties":{"title":{"type":"string","minLength":1,"maxLength":160},"path":{"type":"string","minLength":1,"maxLength":300},"line":{"type":"integer","minimum":1},"summary":{"type":"string","minLength":1,"maxLength":1000}}}}}}'
+
+      - name: Require a completed exact diff read
+        if: ${{ always() }}
+        shell: bash
+        env:
+          DEPENDABOT_REVIEW_PR_NUMBER: ${{ needs.preflight.outputs.pr_number }}
+          DEPENDABOT_REVIEW_REPOSITORY: mento-protocol/frontend-monorepo
+        run: |
+          set -euo pipefail
+          node "$GITHUB_WORKSPACE/scripts/dependabot-claude-review-tool-guard.mjs" \
+            --verify-completion
 
   publish:
     name: dependabot-claude-review-publisher

--- a/.github/workflows/dependabot-claude-review.yml
+++ b/.github/workflows/dependabot-claude-review.yml
@@ -457,9 +457,11 @@ jobs:
             ${{ github.repository }}/pull/${{ needs.preflight.outputs.pr_number }}
             at head ${{ needs.preflight.outputs.head_sha }}. Read the diff with
             exactly `gh pr diff ${{ needs.preflight.outputs.pr_number }} --repo
-            ${{ github.repository }}`. Complete the review even when the update
-            is automated, small, or appears trivial. Do not make any repository,
-            pull-request, issue, review, comment, check, or workflow mutation.
+            ${{ github.repository }}`. The trusted PostToolUse guard delivers
+            the validated diff as one plain-text document tool result; review
+            every byte in that document. Complete the review even when the
+            update is automated, small, or appears trivial. Do not make any
+            repository, pull-request, issue, review, comment, check, or workflow mutation.
             Return the requested structured result with concrete correctness,
             security, compatibility, and test findings. A clean verdict means
             the exact diff has no actionable findings.

--- a/.github/workflows/dependabot-claude-review.yml
+++ b/.github/workflows/dependabot-claude-review.yml
@@ -455,15 +455,17 @@ jobs:
           prompt: >-
             Review the exact Dependabot pull request
             ${{ github.repository }}/pull/${{ needs.preflight.outputs.pr_number }}
-            at head ${{ needs.preflight.outputs.head_sha }}. Read the diff only
-            through GitHub APIs. Complete the review even when the update is
-            automated, small, or appears trivial. Do not make any repository,
+            at head ${{ needs.preflight.outputs.head_sha }}. Read the diff with
+            exactly `gh pr diff ${{ needs.preflight.outputs.pr_number }} --repo
+            ${{ github.repository }}`. Complete the review even when the update
+            is automated, small, or appears trivial. Do not make any repository,
             pull-request, issue, review, comment, check, or workflow mutation.
             Return the requested structured result with concrete correctness,
             security, compatibility, and test findings. A clean verdict means
             the exact diff has no actionable findings.
           allowed_bots: ${{ needs.preflight.outputs.review_actor_login }}
           claude_args: >-
+            --allowedTools "Bash(gh pr diff ${{ needs.preflight.outputs.pr_number }} --repo ${{ github.repository }})"
             --json-schema '{"type":"object","additionalProperties":false,"required":["schema","repository","pullRequestNumber","headSha","reviewCompleted","verdict","findings"],"properties":{"schema":{"const":"dependabot-claude-review-result:v1"},"repository":{"const":"mento-protocol/frontend-monorepo"},"pullRequestNumber":{"type":"integer","minimum":1},"headSha":{"type":"string","pattern":"^[0-9a-f]{40}$"},"reviewCompleted":{"type":"boolean"},"verdict":{"enum":["clean","findings"]},"findings":{"type":"array","maxItems":20,"items":{"type":"object","additionalProperties":false,"required":["title","path","line","summary"],"properties":{"title":{"type":"string","minLength":1,"maxLength":160},"path":{"type":"string","minLength":1,"maxLength":300},"line":{"type":"integer","minimum":1},"summary":{"type":"string","minLength":1,"maxLength":1000}}}}}}'
 
   publish:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,14 +44,18 @@ read-only Claude job checks out only `github.workflow_sha`. It restricts
 built-in tools to Bash, denies every MCP tool, and runs in `dontAsk` mode. A
 trusted `PreToolUse` guard authorizes one exact bound repository-scoped
 `gh pr diff` command per workflow run attempt and blocks every other Bash call.
-A paired `PostToolUse` guard seals the same successful, complete foreground
-diff result, and a later no-token step requires that receipt before the review
-job can succeed. Missing, failed, interrupted, empty, or persisted/truncated
-diff output is retry-first. The job emits bounded canonical JSON and never
-checks out, caches, downloads, installs, or executes candidate-controlled input. A valid
-`findings` result is deterministic repair input; an infrastructure or malformed
-result is retry-first. The isolated publisher owns the exact-head
-`claude-review` check. Human PRs keep the separate `claude-review-human` check.
+A paired `PostToolUse` guard validates the same successful, complete foreground
+diff result, seals its original bytes in a
+`dependabot-claude-review-tool-completed:v2` receipt, and delivers those exact
+bytes as one `text/plain` document tool result. The document bypasses Claude
+Code 2.1.220's 30,000-character Bash text-result persistence. A later no-token
+step requires the receipt before the review job can succeed. Missing, failed,
+interrupted, empty, or persisted/truncated diff output is retry-first. The job
+emits bounded canonical JSON and never checks out, caches, downloads, installs,
+or executes candidate-controlled input. A valid `findings` result is
+deterministic repair input; an infrastructure or malformed result is
+retry-first. The isolated publisher owns the exact-head `claude-review` check.
+Human PRs keep the separate `claude-review-human` check.
 
 `observe` classifies only. `assist` publishes non-authorizing evidence for
 human handling but cannot issue an automatic repair packet. `prepare` may

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,9 +40,10 @@ Dependabot AI review runs through
 `.github/workflows/dependabot-claude-review.yml`. Its first credentialless step
 authenticates either intake. For a prepared head, it also proves the exact
 append-only Refresh/Repair chain back to a verified Dependabot seed. The
-read-only Claude job checks out only `github.workflow_sha`, reads the diff
-through GitHub APIs, and emits bounded canonical JSON. It never checks out,
-caches, downloads, installs, or executes candidate-controlled input. A valid
+read-only Claude job checks out only `github.workflow_sha` and pre-authorizes
+only the exact bound repository-scoped `gh pr diff` command. It emits
+bounded canonical JSON and never checks out, caches, downloads, installs, or
+executes candidate-controlled input. A valid
 `findings` result is deterministic repair input; an infrastructure or malformed
 result is retry-first. The isolated publisher owns the exact-head
 `claude-review` check. Human PRs keep the separate `claude-review-human` check.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,10 +40,15 @@ Dependabot AI review runs through
 `.github/workflows/dependabot-claude-review.yml`. Its first credentialless step
 authenticates either intake. For a prepared head, it also proves the exact
 append-only Refresh/Repair chain back to a verified Dependabot seed. The
-read-only Claude job checks out only `github.workflow_sha` and pre-authorizes
-only the exact bound repository-scoped `gh pr diff` command. It emits
-bounded canonical JSON and never checks out, caches, downloads, installs, or
-executes candidate-controlled input. A valid
+read-only Claude job checks out only `github.workflow_sha`. It restricts
+built-in tools to Bash, denies every MCP tool, and runs in `dontAsk` mode. A
+trusted `PreToolUse` guard authorizes one exact bound repository-scoped
+`gh pr diff` command per workflow run attempt and blocks every other Bash call.
+A paired `PostToolUse` guard seals the same successful, complete foreground
+diff result, and a later no-token step requires that receipt before the review
+job can succeed. Missing, failed, interrupted, empty, or persisted/truncated
+diff output is retry-first. The job emits bounded canonical JSON and never
+checks out, caches, downloads, installs, or executes candidate-controlled input. A valid
 `findings` result is deterministic repair input; an infrastructure or malformed
 result is retry-first. The isolated publisher owns the exact-head
 `claude-review` check. Human PRs keep the separate `claude-review-human` check.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -186,9 +186,10 @@ the exact-workflow-SHA `scripts/dependabot-prepared-review.mjs` helper fetches
 and validates canonical Refresh/Repair checks, terminal Actions run provenance,
 append-only parents, exact Prepare App bot repair commits, and the verified
 Dependabot seed. The read-only Claude job checks out only
-`github.workflow_sha`, reads candidate data through GitHub APIs, and never
-checks out, caches, installs, downloads, or executes candidate input. The
-publisher is isolated from the Claude secret. It writes canonical structured
+`github.workflow_sha`; its quoted tool allowlist admits only the exact bound
+repository-scoped `gh pr diff` command. It never checks
+out, caches, installs, downloads, or executes candidate input. The publisher is
+isolated from the Claude secret. It writes canonical structured
 JSON to the exact-head `claude-review` check: validated `findings` are
 deterministic repair input, while an infrastructure or invalid-schema failure is
 retry-first. Human PRs continue to report `claude-review-human`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -191,9 +191,12 @@ tool, and uses a trusted fail-closed `PreToolUse` guard to authorize one exact
 bound repository-scoped `gh pr diff` command per run attempt. `dontAsk` mode
 and the guard block every other Bash call. A paired `PostToolUse` guard and a
 later no-token assertion require the same successful, complete foreground diff
-result; missing, failed, interrupted, empty, or persisted/truncated output is
-retry-first. The job never checks out, caches, installs, downloads, or executes
-candidate input. The publisher is isolated
+result. The post-hook seals the original bytes in a
+`dependabot-claude-review-tool-completed:v2` receipt, then delivers those exact
+bytes as one `text/plain` document tool result, bypassing Claude Code 2.1.220's
+30,000-character Bash text-result persistence. Missing, failed, interrupted,
+empty, or persisted/truncated output is retry-first. The job never checks out,
+caches, installs, downloads, or executes candidate input. The publisher is isolated
 from the Claude secret. It writes canonical structured
 JSON to the exact-head `claude-review` check: validated `findings` are
 deterministic repair input, while an infrastructure or invalid-schema failure is

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -186,10 +186,15 @@ the exact-workflow-SHA `scripts/dependabot-prepared-review.mjs` helper fetches
 and validates canonical Refresh/Repair checks, terminal Actions run provenance,
 append-only parents, exact Prepare App bot repair commits, and the verified
 Dependabot seed. The read-only Claude job checks out only
-`github.workflow_sha`; its quoted tool allowlist admits only the exact bound
-repository-scoped `gh pr diff` command. It never checks
-out, caches, installs, downloads, or executes candidate input. The publisher is
-isolated from the Claude secret. It writes canonical structured
+`github.workflow_sha`. It restricts built-in tools to Bash, denies every MCP
+tool, and uses a trusted fail-closed `PreToolUse` guard to authorize one exact
+bound repository-scoped `gh pr diff` command per run attempt. `dontAsk` mode
+and the guard block every other Bash call. A paired `PostToolUse` guard and a
+later no-token assertion require the same successful, complete foreground diff
+result; missing, failed, interrupted, empty, or persisted/truncated output is
+retry-first. The job never checks out, caches, installs, downloads, or executes
+candidate input. The publisher is isolated
+from the Claude secret. It writes canonical structured
 JSON to the exact-head `claude-review` check: validated `findings` are
 deterministic repair input, while an infrastructure or invalid-schema failure is
 retry-first. Human PRs continue to report `claude-review-human`.

--- a/README.md
+++ b/README.md
@@ -384,9 +384,13 @@ restricts built-in tools to Bash, denies every MCP tool, and uses a trusted
 fail-closed `PreToolUse` guard to authorize one exact bound repository-scoped
 `gh pr diff` command per run attempt. A paired `PostToolUse` guard and a later
 no-token assertion require the same successful, complete foreground diff
-result. It emits canonical exact-head results; validated findings can feed a
-bounded repair, while a missing, failed, interrupted, empty, persisted/truncated,
-or otherwise invalid diff remains retry-first.
+result. The post-hook seals the original bytes in a
+`dependabot-claude-review-tool-completed:v2` receipt, then delivers those exact
+bytes as one `text/plain` document tool result, bypassing Claude Code 2.1.220's
+30,000-character Bash text-result persistence. It emits canonical exact-head
+results; validated findings can feed a bounded repair, while a missing, failed,
+interrupted, empty, persisted/truncated, or otherwise invalid diff remains
+retry-first.
 
 The preparable tier includes verified npm updates, including grouped and major
 updates. Verified non-sensitive GitHub Actions updates may be refreshed and,

--- a/README.md
+++ b/README.md
@@ -379,9 +379,10 @@ through the distinct credentialless
 `.github/workflows/dependabot-prepared-head-intake.yml`, which authenticates
 the exact Prepare App bot, a bounded nine-key dispatch, and the completed
 operation receipt. `.github/workflows/dependabot-claude-review.yml` handles
-both sources without candidate checkout or execution. It reads the diff through
-GitHub APIs and emits canonical exact-head results; validated findings can feed
-a bounded repair, while reviewer infrastructure failure remains retry-first.
+both sources without candidate checkout or execution. Its read-only job allows
+only the exact bound repository-scoped `gh pr diff` command
+and emits canonical exact-head results; validated findings can feed a bounded
+repair, while reviewer infrastructure failure remains retry-first.
 
 The preparable tier includes verified npm updates, including grouped and major
 updates. Verified non-sensitive GitHub Actions updates may be refreshed and,

--- a/README.md
+++ b/README.md
@@ -379,10 +379,14 @@ through the distinct credentialless
 `.github/workflows/dependabot-prepared-head-intake.yml`, which authenticates
 the exact Prepare App bot, a bounded nine-key dispatch, and the completed
 operation receipt. `.github/workflows/dependabot-claude-review.yml` handles
-both sources without candidate checkout or execution. Its read-only job allows
-only the exact bound repository-scoped `gh pr diff` command
-and emits canonical exact-head results; validated findings can feed a bounded
-repair, while reviewer infrastructure failure remains retry-first.
+both sources without candidate checkout or execution. Its read-only job
+restricts built-in tools to Bash, denies every MCP tool, and uses a trusted
+fail-closed `PreToolUse` guard to authorize one exact bound repository-scoped
+`gh pr diff` command per run attempt. A paired `PostToolUse` guard and a later
+no-token assertion require the same successful, complete foreground diff
+result. It emits canonical exact-head results; validated findings can feed a
+bounded repair, while a missing, failed, interrupted, empty, persisted/truncated,
+or otherwise invalid diff remains retry-first.
 
 The preparable tier includes verified npm updates, including grouped and major
 updates. Verified non-sensitive GitHub Actions updates may be refreshed and,

--- a/docs/adr/0006-dependabot-processing-controller.md
+++ b/docs/adr/0006-dependabot-processing-controller.md
@@ -107,8 +107,9 @@ For prepared heads, the workflow materializes
   committer match the live configured App bot ID/login; and
 - a bounded operation chain rooted in a verified Dependabot seed.
 
-The Claude job checks out only the trusted workflow source, reads the candidate
-through GitHub APIs, and never restores candidate artifacts/caches, installs
+The Claude job checks out only the trusted workflow source. Its quoted tool
+allowlist admits only the exact bound repository-scoped `gh pr diff` command;
+it never restores candidate artifacts/caches, installs
 candidate dependencies, or executes candidate code. Its bot allowlist is the
 exact Dependabot login plus exact Prepare App bot login. The no-secret publisher
 writes canonical `dependabot-claude-review-result:v1` JSON for both clean and
@@ -236,6 +237,12 @@ force-push, rebase, missing receipt, reordered history, ambiguous receipt, or
 third repair fails closed rather than resetting the budget.
 
 ### Receipts are canonical, typed, and run-bound
+
+The collector resolves Actions workflow provenance only for exact configured
+gate and receipt names. Unrelated checks and statuses remain non-authorizing raw
+evidence. It caches each exact repository/run/attempt lookup within one
+processor job to bound installation API use, while the selected post-merge gate
+always gets a fresh run read.
 
 Authority-bearing checks use exact recursively key-sorted compact JSON and
 SHA-256 of those bytes. External IDs are indexes, not independent authority.

--- a/docs/adr/0006-dependabot-processing-controller.md
+++ b/docs/adr/0006-dependabot-processing-controller.md
@@ -3,14 +3,14 @@ title: A trusted controller prepares exact-head Dependabot pull requests for hum
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-08-11
+last_verified: 2026-08-12
 scope: ci/dependabot-processing
 date: 2026-08-10
 ---
 
 # ADR 0006 — A trusted controller prepares exact-head Dependabot pull requests for human merge
 
-**Status:** Accepted, amended Aug 11 2026
+**Status:** Accepted, amended Aug 12 2026
 **Scope:** ci/dependabot-processing
 
 ## Context
@@ -111,12 +111,17 @@ The Claude job checks out only the trusted workflow source. It restricts
 built-in tools to Bash, denies every MCP tool, and runs in `dontAsk` mode. A
 trusted `PreToolUse` guard authorizes one exact bound repository-scoped
 `gh pr diff` command per workflow run attempt and blocks every other Bash call.
-A paired `PostToolUse` guard seals the same successful, complete foreground
-diff result, and a later no-token step requires that receipt. Missing, failed,
-interrupted, empty, or persisted/truncated output is retry-first. The job never
-restores candidate artifacts/caches, installs candidate dependencies, or
-executes candidate code. Its bot allowlist is the exact Dependabot login
-plus exact Prepare App bot login. The no-secret publisher writes canonical
+A paired `PostToolUse` guard validates the same successful, complete foreground
+diff result, seals the original bytes in a
+`dependabot-claude-review-tool-completed:v2` receipt, and replaces the
+model-visible Bash result with one `text/plain` document containing those exact
+bytes. This document path bypasses Claude Code 2.1.220's 30,000-character
+text-result persistence, which would otherwise leave the restricted reviewer a
+short persisted preview it cannot reopen. A later no-token step requires the v2
+receipt. Missing, failed, interrupted, empty, or persisted/truncated output is
+retry-first. The job never restores candidate artifacts/caches, installs
+candidate dependencies, or executes candidate code. Its bot allowlist is the
+exact Dependabot login plus exact Prepare App bot login. The no-secret publisher writes canonical
 `dependabot-claude-review-result:v1` JSON for both clean and findings verdicts.
 A valid findings result is deterministic repair input; an Action, provider,
 schema, or infrastructure failure is retry-first.

--- a/docs/adr/0006-dependabot-processing-controller.md
+++ b/docs/adr/0006-dependabot-processing-controller.md
@@ -107,14 +107,19 @@ For prepared heads, the workflow materializes
   committer match the live configured App bot ID/login; and
 - a bounded operation chain rooted in a verified Dependabot seed.
 
-The Claude job checks out only the trusted workflow source. Its quoted tool
-allowlist admits only the exact bound repository-scoped `gh pr diff` command;
-it never restores candidate artifacts/caches, installs
-candidate dependencies, or executes candidate code. Its bot allowlist is the
-exact Dependabot login plus exact Prepare App bot login. The no-secret publisher
-writes canonical `dependabot-claude-review-result:v1` JSON for both clean and
-findings verdicts. A valid findings result is deterministic repair input; an
-Action, provider, schema, or infrastructure failure is retry-first.
+The Claude job checks out only the trusted workflow source. It restricts
+built-in tools to Bash, denies every MCP tool, and runs in `dontAsk` mode. A
+trusted `PreToolUse` guard authorizes one exact bound repository-scoped
+`gh pr diff` command per workflow run attempt and blocks every other Bash call.
+A paired `PostToolUse` guard seals the same successful, complete foreground
+diff result, and a later no-token step requires that receipt. Missing, failed,
+interrupted, empty, or persisted/truncated output is retry-first. The job never
+restores candidate artifacts/caches, installs candidate dependencies, or
+executes candidate code. Its bot allowlist is the exact Dependabot login
+plus exact Prepare App bot login. The no-secret publisher writes canonical
+`dependabot-claude-review-result:v1` JSON for both clean and findings verdicts.
+A valid findings result is deterministic repair input; an Action, provider,
+schema, or infrastructure failure is retry-first.
 
 ### Preparation eligibility is broader than automatic eligibility
 

--- a/docs/dependabot-automation.md
+++ b/docs/dependabot-automation.md
@@ -3,7 +3,7 @@ title: Dependabot Processing
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-08-11
+last_verified: 2026-08-12
 scope: ci/dependabot-processing
 ---
 
@@ -182,8 +182,14 @@ a candidate artifact, restores a candidate cache, installs candidate
 dependencies, or executes candidate code. A paired trusted `PostToolUse` guard
 binds the same command and tool-use ID, rejects interrupted, background,
 timed-out, empty, or persisted/truncated output, and seals a digest-bound
-completion receipt. A later no-token step requires that receipt, so a missing
-or failed diff cannot be upgraded by schema-valid model output. Its exact bot allowlist contains only
+`dependabot-claude-review-tool-completed:v2` receipt over the original diff.
+After sealing, the hook replaces the model-visible Bash result with one
+`text/plain` document whose data is the exact validated stdout. This document
+path bypasses Claude Code 2.1.220's 30,000-character text-result persistence,
+which would otherwise replace a large successful result with a short persisted
+preview that the restricted reviewer cannot reopen. A later no-token step
+requires the v2 receipt, so a missing or failed diff cannot be upgraded by
+schema-valid model output. Its exact bot allowlist contains only
 `dependabot[bot]` and the configured Prepare App bot login.
 
 The isolated publisher has no Claude secret or checkout. For both clean and

--- a/docs/dependabot-automation.md
+++ b/docs/dependabot-automation.md
@@ -172,12 +172,19 @@ the canonical receipt. A generic github-actions check, external ID alone,
 candidate comment, or configured actor assertion cannot establish lineage.
 
 The Claude job has only read permissions and checks out only the trusted
-workflow SHA. Its quoted tool allowlist admits only the exact bound
-repository-scoped `gh pr diff` command; it does not
-grant generic Bash, `gh api`, Git, curl, web, or GitHub MCP access. The job never
-downloads a candidate artifact, restores a candidate cache, installs candidate
-dependencies, or executes candidate code. Its exact bot allowlist contains
-only `dependabot[bot]` and the configured Prepare App bot login.
+workflow SHA. It restricts built-in tools to Bash, denies every MCP tool, and
+runs in `dontAsk` mode. A trusted `PreToolUse` guard authorizes one exact bound
+repository-scoped `gh pr diff` command per workflow run attempt and exits with a
+blocking result for every other Bash input, including suffixes, compound shell
+syntax, background execution, and malformed calls. The job therefore grants no
+generic Bash, `gh api`, Git, curl, web, or GitHub MCP access. It never downloads
+a candidate artifact, restores a candidate cache, installs candidate
+dependencies, or executes candidate code. A paired trusted `PostToolUse` guard
+binds the same command and tool-use ID, rejects interrupted, background,
+timed-out, empty, or persisted/truncated output, and seals a digest-bound
+completion receipt. A later no-token step requires that receipt, so a missing
+or failed diff cannot be upgraded by schema-valid model output. Its exact bot allowlist contains only
+`dependabot[bot]` and the configured Prepare App bot login.
 
 The isolated publisher has no Claude secret or checkout. For both clean and
 findings outcomes, `claude-review` check `output.text` is the exact canonical

--- a/docs/dependabot-automation.md
+++ b/docs/dependabot-automation.md
@@ -171,11 +171,13 @@ The validator accepts the submitted Actions URL or GitHub's exact
 the canonical receipt. A generic github-actions check, external ID alone,
 candidate comment, or configured actor assertion cannot establish lineage.
 
-The Claude job has only read permissions, checks out only the trusted workflow
-SHA, and reads the PR diff/blobs through GitHub APIs. It never downloads a
-candidate artifact, restores a candidate cache, installs candidate dependencies,
-or executes candidate code. Its exact bot allowlist contains only
-`dependabot[bot]` and the configured Prepare App bot login.
+The Claude job has only read permissions and checks out only the trusted
+workflow SHA. Its quoted tool allowlist admits only the exact bound
+repository-scoped `gh pr diff` command; it does not
+grant generic Bash, `gh api`, Git, curl, web, or GitHub MCP access. The job never
+downloads a candidate artifact, restores a candidate cache, installs candidate
+dependencies, or executes candidate code. Its exact bot allowlist contains
+only `dependabot[bot]` and the configured Prepare App bot login.
 
 The isolated publisher has no Claude secret or checkout. For both clean and
 findings outcomes, `claude-review` check `output.text` is the exact canonical
@@ -269,6 +271,12 @@ collects every bounded thread/reply, review, issue comment, close/reopen event,
 force-push event, and native `AutoMergeRequest`. Any collection cap,
 pagination ambiguity, malformed SHA/envelope, unknown authority-bearing bot, or
 identity drift fails closed.
+
+Only exact configured gate and receipt names trigger an Actions workflow-run
+provenance lookup. Unrelated checks and statuses remain raw non-authorizing
+evidence and consume no run lookup. One processor job caches each exact
+repository/run/attempt provenance read across its collections; the selected
+post-merge gate is always re-fetched for its current snapshot.
 
 Every required gate must report for the exact head. Attribute each failure
 against the corresponding current-`main` baseline:

--- a/scripts/dependabot-claude-review-tool-guard.mjs
+++ b/scripts/dependabot-claude-review-tool-guard.mjs
@@ -15,7 +15,7 @@ import process from "node:process";
 
 const EXPECTED_REPOSITORY = "mento-protocol/frontend-monorepo";
 const ISSUED_SCHEMA = "dependabot-claude-review-tool-issued:v1";
-const COMPLETED_SCHEMA = "dependabot-claude-review-tool-completed:v1";
+const COMPLETED_SCHEMA = "dependabot-claude-review-tool-completed:v2";
 const MAX_BASH_OUTPUT_LENGTH = 150_000;
 const MAX_BASH_OUTPUT_BYTES = MAX_BASH_OUTPUT_LENGTH * 4;
 const MAX_DESCRIPTION_LENGTH = 500;
@@ -378,4 +378,28 @@ writeMarker(
     toolUseId: hookInput.tool_use_id,
   },
   "the diff-read completion was already sealed or could not be recorded",
+);
+
+process.stdout.write(
+  `${JSON.stringify({
+    hookSpecificOutput: {
+      hookEventName: "PostToolUse",
+      updatedToolOutput: {
+        interrupted: false,
+        isImage: false,
+        stderr: "",
+        stdout: "",
+        structuredContent: [
+          {
+            source: {
+              data: response.stdout,
+              media_type: "text/plain",
+              type: "text",
+            },
+            type: "document",
+          },
+        ],
+      },
+    },
+  })}\n`,
 );

--- a/scripts/dependabot-claude-review-tool-guard.mjs
+++ b/scripts/dependabot-claude-review-tool-guard.mjs
@@ -1,0 +1,381 @@
+/* eslint-disable turbo/no-undeclared-env-vars -- The trusted review hook validates exact workflow-only environment identities. */
+import { Buffer } from "node:buffer";
+import { createHash } from "node:crypto";
+import {
+  closeSync,
+  constants,
+  fstatSync,
+  fsyncSync,
+  openSync,
+  readFileSync,
+  writeSync,
+} from "node:fs";
+import { join } from "node:path";
+import process from "node:process";
+
+const EXPECTED_REPOSITORY = "mento-protocol/frontend-monorepo";
+const ISSUED_SCHEMA = "dependabot-claude-review-tool-issued:v1";
+const COMPLETED_SCHEMA = "dependabot-claude-review-tool-completed:v1";
+const MAX_BASH_OUTPUT_LENGTH = 150_000;
+const MAX_BASH_OUTPUT_BYTES = MAX_BASH_OUTPUT_LENGTH * 4;
+const MAX_DESCRIPTION_LENGTH = 500;
+const MAX_HOOK_INPUT_BYTES = 2_097_152;
+const MAX_MARKER_BYTES = 4_096;
+const MAX_TIMEOUT_MS = 120_000;
+const ALLOWED_INPUT_KEYS = new Set([
+  "command",
+  "description",
+  "run_in_background",
+  "timeout",
+]);
+
+function block(reason) {
+  console.error(`Blocked Dependabot review tool call: ${reason}`);
+  process.exit(2);
+}
+
+function isCanonicalPositiveSafeInteger(value) {
+  if (!/^[1-9]\d*$/.test(value)) {
+    return false;
+  }
+  const number = Number(value);
+  return Number.isSafeInteger(number) && String(number) === value;
+}
+
+function isToolUseId(value) {
+  return (
+    typeof value === "string" && /^toolu_[A-Za-z0-9_-]{1,200}$/.test(value)
+  );
+}
+
+function sha256(value) {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function hasExactKeys(value, keys) {
+  return (
+    value &&
+    typeof value === "object" &&
+    !Array.isArray(value) &&
+    JSON.stringify(Object.keys(value).sort()) ===
+      JSON.stringify([...keys].sort())
+  );
+}
+
+function requiredEnvironment() {
+  const repository = process.env.DEPENDABOT_REVIEW_REPOSITORY ?? "";
+  const pullRequestNumber = process.env.DEPENDABOT_REVIEW_PR_NUMBER ?? "";
+  const runnerTemp = process.env.RUNNER_TEMP ?? "";
+  const runAttempt = process.env.GITHUB_RUN_ATTEMPT ?? "";
+  const runId = process.env.GITHUB_RUN_ID ?? "";
+
+  if (repository !== EXPECTED_REPOSITORY) {
+    block("repository identity is missing or invalid");
+  }
+  if (!isCanonicalPositiveSafeInteger(pullRequestNumber)) {
+    block("pull-request identity is missing or invalid");
+  }
+  if (!runnerTemp.startsWith("/") || !isCanonicalPositiveSafeInteger(runId)) {
+    block("workflow run identity is missing or invalid");
+  }
+  if (!isCanonicalPositiveSafeInteger(runAttempt)) {
+    block("workflow run attempt is missing or invalid");
+  }
+
+  return { pullRequestNumber, repository, runAttempt, runId, runnerTemp };
+}
+
+async function parseHookInput() {
+  let value;
+  try {
+    value = JSON.parse(await readStdin());
+  } catch {
+    block("hook input is not valid JSON");
+  }
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    block("hook input is not an object");
+  }
+  return value;
+}
+
+async function readStdin() {
+  const chunks = [];
+  let size = 0;
+  for await (const chunk of process.stdin) {
+    size += chunk.length;
+    if (size > MAX_HOOK_INPUT_BYTES) {
+      block("hook input exceeds the bounded size");
+    }
+    chunks.push(chunk);
+  }
+  return Buffer.concat(chunks).toString("utf8");
+}
+
+function markerPaths({ runAttempt, runId, runnerTemp }) {
+  const prefix = join(
+    runnerTemp,
+    `dependabot-review-tool-${runId}-${runAttempt}`,
+  );
+  return {
+    completed: `${prefix}.completed.json`,
+    issued: `${prefix}.issued.json`,
+  };
+}
+
+function writeMarker(path, value, duplicateReason) {
+  let file;
+  try {
+    file = openSync(path, "wx", 0o600);
+    writeSync(file, `${JSON.stringify(value)}\n`);
+    fsyncSync(file);
+    closeSync(file);
+  } catch {
+    if (file !== undefined) {
+      try {
+        closeSync(file);
+      } catch {
+        // The marker remains consumed when it cannot be closed.
+      }
+    }
+    block(duplicateReason);
+  }
+}
+
+function readMarker(path, description) {
+  let file;
+  try {
+    file = openSync(path, constants.O_RDONLY | constants.O_NOFOLLOW);
+    const stats = fstatSync(file);
+    if (
+      !stats.isFile() ||
+      stats.nlink !== 1 ||
+      (stats.mode & 0o777) !== 0o600 ||
+      stats.size < 2 ||
+      stats.size > MAX_MARKER_BYTES
+    ) {
+      throw new Error("invalid marker metadata");
+    }
+    const value = JSON.parse(readFileSync(file, "utf8"));
+    closeSync(file);
+    return value;
+  } catch {
+    if (file !== undefined) {
+      try {
+        closeSync(file);
+      } catch {
+        // The marker is invalid when it cannot be closed.
+      }
+    }
+    block(`${description} is missing or invalid`);
+  }
+}
+
+function validateToolInput(toolInput, expectedCommand) {
+  if (!toolInput || typeof toolInput !== "object" || Array.isArray(toolInput)) {
+    block("Bash input is missing or invalid");
+  }
+  for (const key of Object.keys(toolInput)) {
+    if (!ALLOWED_INPUT_KEYS.has(key)) {
+      block(`unexpected Bash input field: ${key}`);
+    }
+  }
+  if (toolInput.command !== expectedCommand) {
+    block("command does not exactly match the receipt-bound PR diff");
+  }
+  if (
+    toolInput.description !== undefined &&
+    (typeof toolInput.description !== "string" ||
+      toolInput.description.length > MAX_DESCRIPTION_LENGTH)
+  ) {
+    block("command description is invalid");
+  }
+  if (
+    toolInput.timeout !== undefined &&
+    (!Number.isInteger(toolInput.timeout) ||
+      toolInput.timeout < 1 ||
+      toolInput.timeout > MAX_TIMEOUT_MS)
+  ) {
+    block("command timeout is invalid");
+  }
+  if (
+    toolInput.run_in_background !== undefined &&
+    toolInput.run_in_background !== false
+  ) {
+    block("background execution is forbidden");
+  }
+  return {
+    command: toolInput.command,
+    ...(toolInput.description === undefined
+      ? {}
+      : { description: toolInput.description }),
+    ...(toolInput.run_in_background === undefined
+      ? {}
+      : { run_in_background: toolInput.run_in_background }),
+    ...(toolInput.timeout === undefined ? {} : { timeout: toolInput.timeout }),
+  };
+}
+
+function validateIssuedMarker(marker, identity) {
+  if (
+    !hasExactKeys(marker, [
+      "pullRequestNumber",
+      "repository",
+      "runAttempt",
+      "runId",
+      "schema",
+      "toolInputDigest",
+      "toolUseId",
+    ]) ||
+    marker.schema !== ISSUED_SCHEMA ||
+    marker.pullRequestNumber !== identity.pullRequestNumber ||
+    marker.repository !== identity.repository ||
+    marker.runAttempt !== identity.runAttempt ||
+    marker.runId !== identity.runId ||
+    !/^[0-9a-f]{64}$/.test(marker.toolInputDigest ?? "") ||
+    !isToolUseId(marker.toolUseId)
+  ) {
+    block("issued diff-read marker is not canonically bound");
+  }
+  return marker;
+}
+
+function verifyCompletion(identity, paths) {
+  const issued = validateIssuedMarker(
+    readMarker(paths.issued, "issued diff-read marker"),
+    identity,
+  );
+  const completed = readMarker(paths.completed, "completed diff-read marker");
+  if (
+    !hasExactKeys(completed, [
+      "outputBytes",
+      "outputDigest",
+      "pullRequestNumber",
+      "repository",
+      "runAttempt",
+      "runId",
+      "schema",
+      "toolInputDigest",
+      "toolUseId",
+    ]) ||
+    completed.schema !== COMPLETED_SCHEMA ||
+    completed.pullRequestNumber !== identity.pullRequestNumber ||
+    completed.repository !== identity.repository ||
+    completed.runAttempt !== identity.runAttempt ||
+    completed.runId !== identity.runId ||
+    completed.toolInputDigest !== issued.toolInputDigest ||
+    completed.toolUseId !== issued.toolUseId ||
+    !Number.isSafeInteger(completed.outputBytes) ||
+    completed.outputBytes < 1 ||
+    completed.outputBytes > MAX_BASH_OUTPUT_BYTES ||
+    !/^[0-9a-f]{64}$/.test(completed.outputDigest ?? "")
+  ) {
+    block("completed diff-read marker is not canonically bound");
+  }
+}
+
+const identity = requiredEnvironment();
+const { pullRequestNumber, repository, runAttempt, runId } = identity;
+const paths = markerPaths(identity);
+
+if (process.argv.length === 3 && process.argv[2] === "--verify-completion") {
+  verifyCompletion(identity, paths);
+  process.exit(0);
+}
+if (process.argv.length !== 2) {
+  block("command-line arguments are invalid");
+}
+
+const hookInput = await parseHookInput();
+
+if (hookInput.tool_name !== "Bash" || !isToolUseId(hookInput.tool_use_id)) {
+  block("only a canonical Bash tool call is accepted");
+}
+
+const expectedCommand = `gh pr diff ${pullRequestNumber} --repo ${repository}`;
+const canonicalToolInput = validateToolInput(
+  hookInput.tool_input,
+  expectedCommand,
+);
+const toolInputDigest = sha256(JSON.stringify(canonicalToolInput));
+
+if (hookInput.hook_event_name === "PreToolUse") {
+  writeMarker(
+    paths.issued,
+    {
+      pullRequestNumber,
+      repository,
+      runAttempt,
+      runId,
+      schema: ISSUED_SCHEMA,
+      toolInputDigest,
+      toolUseId: hookInput.tool_use_id,
+    },
+    "the one permitted diff read was already issued or could not be sealed",
+  );
+  process.stdout.write(
+    `${JSON.stringify({
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        permissionDecision: "allow",
+        permissionDecisionReason:
+          "Exact receipt-bound Dependabot PR diff command",
+      },
+    })}\n`,
+  );
+  process.exit(0);
+}
+
+if (hookInput.hook_event_name !== "PostToolUse") {
+  block("only Bash PreToolUse and PostToolUse events are accepted");
+}
+
+const issued = validateIssuedMarker(
+  readMarker(paths.issued, "issued diff-read marker"),
+  identity,
+);
+if (
+  issued.toolUseId !== hookInput.tool_use_id ||
+  issued.toolInputDigest !== toolInputDigest
+) {
+  block("completed tool call does not match the issued diff read");
+}
+
+const response = hookInput.tool_response;
+if (
+  !response ||
+  typeof response !== "object" ||
+  Array.isArray(response) ||
+  typeof response.stdout !== "string" ||
+  response.stdout.length < 1 ||
+  response.stdout.length > MAX_BASH_OUTPUT_LENGTH ||
+  !response.stdout.startsWith("diff --git ") ||
+  typeof response.stderr !== "string" ||
+  response.interrupted !== false ||
+  (response.isImage !== undefined && response.isImage !== false) ||
+  response.noOutputExpected === true ||
+  response.persistedOutputPath !== undefined ||
+  response.persistedOutputSize !== undefined ||
+  response.rawOutputPath !== undefined ||
+  response.structuredContent !== undefined ||
+  response.backgroundTaskId !== undefined ||
+  response.backgroundedByUser !== undefined ||
+  response.timedOutAfterMs !== undefined
+) {
+  block("Bash result is not a complete foreground PR diff");
+}
+
+writeMarker(
+  paths.completed,
+  {
+    outputBytes: Buffer.byteLength(response.stdout),
+    outputDigest: sha256(response.stdout),
+    pullRequestNumber,
+    repository,
+    runAttempt,
+    runId,
+    schema: COMPLETED_SCHEMA,
+    toolInputDigest,
+    toolUseId: hookInput.tool_use_id,
+  },
+  "the diff-read completion was already sealed or could not be recorded",
+);

--- a/scripts/dependabot-prepared-review.test.mjs
+++ b/scripts/dependabot-prepared-review.test.mjs
@@ -1674,11 +1674,35 @@ test("Dependabot reviewer accepts only authenticated native or prepared intake",
   const claude = review.jobs.review.steps.find(
     ({ name }) => name === "Run Claude Code Review",
   );
+  assert.deepEqual(review.jobs.review.permissions, {
+    contents: "read",
+    issues: "read",
+    "pull-requests": "read",
+  });
   assert.equal(
     claude.with.allowed_bots,
     "${{ needs.preflight.outputs.review_actor_login }}",
   );
   assert.notEqual(claude.with.allowed_bots, "*");
+  assert.match(
+    claude.with.prompt,
+    /gh pr diff.*needs\.preflight\.outputs\.pr_number.*--repo.*github\.repository/s,
+  );
+  const allowedToolFlags = [
+    ...claude.with.claude_args.matchAll(
+      /--(?:allowedTools|allowed-tools)\s+"([^"]+)"/g,
+    ),
+  ];
+  assert.equal(allowedToolFlags.length, 1);
+  assert.equal(
+    allowedToolFlags[0][1],
+    "Bash(gh pr diff ${{ needs.preflight.outputs.pr_number }} --repo ${{ github.repository }})",
+  );
+  assert.doesNotMatch(allowedToolFlags[0][1], /:\*|\s+\*/);
+  assert.doesNotMatch(
+    claude.with.claude_args,
+    /Bash\(gh api|Bash\(curl|Bash\(git|WebFetch|WebSearch|mcp__github__|--permission-mode\s+bypassPermissions|--dangerously-skip-permissions/,
+  );
   const publish = review.jobs.publish.steps.find(
     ({ name }) => name === "Publish the exact-head Claude review check",
   );

--- a/scripts/dependabot-prepared-review.test.mjs
+++ b/scripts/dependabot-prepared-review.test.mjs
@@ -1688,21 +1688,71 @@ test("Dependabot reviewer accepts only authenticated native or prepared intake",
     claude.with.prompt,
     /gh pr diff.*needs\.preflight\.outputs\.pr_number.*--repo.*github\.repository/s,
   );
-  const allowedToolFlags = [
-    ...claude.with.claude_args.matchAll(
-      /--(?:allowedTools|allowed-tools)\s+"([^"]+)"/g,
+  const settings = JSON.parse(claude.with.settings);
+  assert.deepEqual(settings.env, {
+    BASH_MAX_OUTPUT_LENGTH: "150000",
+    DEPENDABOT_REVIEW_PR_NUMBER: "${{ needs.preflight.outputs.pr_number }}",
+    DEPENDABOT_REVIEW_REPOSITORY: "mento-protocol/frontend-monorepo",
+  });
+  assert.deepEqual(settings.hooks, {
+    PreToolUse: [
+      {
+        matcher: "Bash",
+        hooks: [
+          {
+            type: "command",
+            command:
+              'node "${{ github.workspace }}/scripts/dependabot-claude-review-tool-guard.mjs" || exit 2',
+            timeout: 5,
+          },
+        ],
+      },
+    ],
+    PostToolUse: [
+      {
+        matcher: "Bash",
+        hooks: [
+          {
+            type: "command",
+            command:
+              'node "${{ github.workspace }}/scripts/dependabot-claude-review-tool-guard.mjs" || exit 2',
+            timeout: 5,
+          },
+        ],
+      },
+    ],
+  });
+  assert.deepEqual(
+    [...claude.with.claude_args.matchAll(/--tools\s+"([^"]+)"/g)].map(
+      (match) => match[1],
     ),
-  ];
-  assert.equal(allowedToolFlags.length, 1);
-  assert.equal(
-    allowedToolFlags[0][1],
-    "Bash(gh pr diff ${{ needs.preflight.outputs.pr_number }} --repo ${{ github.repository }})",
+    ["Bash"],
   );
-  assert.doesNotMatch(allowedToolFlags[0][1], /:\*|\s+\*/);
+  assert.deepEqual(
+    [
+      ...claude.with.claude_args.matchAll(
+        /--(?:disallowedTools|disallowed-tools)\s+"([^"]+)"/g,
+      ),
+    ].map((match) => match[1]),
+    ["mcp__*"],
+  );
+  assert.match(claude.with.claude_args, /--permission-mode\s+dontAsk/);
+  assert.match(claude.with.claude_args, /--setting-sources\s+user/);
+  assert.match(claude.with.claude_args, /--strict-mcp-config\b/);
   assert.doesNotMatch(
     claude.with.claude_args,
-    /Bash\(gh api|Bash\(curl|Bash\(git|WebFetch|WebSearch|mcp__github__|--permission-mode\s+bypassPermissions|--dangerously-skip-permissions/,
+    /--(?:allowedTools|allowed-tools)\b/,
   );
+  assert.doesNotMatch(
+    claude.with.claude_args,
+    /Bash\(gh api|Bash\(curl|Bash\(git|WebFetch|WebSearch|mcp__github__|--permission-mode\s+bypassPermissions|--dangerously-skip-permissions|--tools\s+"[^"]*(?:Read|Edit|Write|Glob|Grep|Agent)/,
+  );
+  const completion = review.jobs.review.steps.find(
+    ({ name }) => name === "Require a completed exact diff read",
+  );
+  assert.ok(completion);
+  assert.equal(completion.if, "${{ always() }}");
+  assert.match(completion.run, /--verify-completion/);
   const publish = review.jobs.publish.steps.find(
     ({ name }) => name === "Publish the exact-head Claude review check",
   );

--- a/scripts/dependabot-prepared-review.test.mjs
+++ b/scripts/dependabot-prepared-review.test.mjs
@@ -1688,6 +1688,7 @@ test("Dependabot reviewer accepts only authenticated native or prepared intake",
     claude.with.prompt,
     /gh pr diff.*needs\.preflight\.outputs\.pr_number.*--repo.*github\.repository/s,
   );
+  assert.match(claude.with.prompt, /one plain-text document tool result/);
   const settings = JSON.parse(claude.with.settings);
   assert.deepEqual(settings.env, {
     BASH_MAX_OUTPUT_LENGTH: "150000",
@@ -1747,6 +1748,14 @@ test("Dependabot reviewer accepts only authenticated native or prepared intake",
     claude.with.claude_args,
     /Bash\(gh api|Bash\(curl|Bash\(git|WebFetch|WebSearch|mcp__github__|--permission-mode\s+bypassPermissions|--dangerously-skip-permissions|--tools\s+"[^"]*(?:Read|Edit|Write|Glob|Grep|Agent)/,
   );
+  const guard = read("scripts/dependabot-claude-review-tool-guard.mjs");
+  assert.match(guard, /dependabot-claude-review-tool-completed:v2/);
+  assert.match(guard, /hookEventName: "PostToolUse"/);
+  assert.match(guard, /updatedToolOutput:/);
+  assert.match(guard, /structuredContent:/);
+  assert.match(guard, /type: "document"/);
+  assert.match(guard, /media_type: "text\/plain"/);
+  assert.match(guard, /data: response\.stdout/);
   const completion = review.jobs.review.steps.find(
     ({ name }) => name === "Require a completed exact diff read",
   );

--- a/scripts/dependabot-processor.mjs
+++ b/scripts/dependabot-processor.mjs
@@ -369,6 +369,22 @@ const RECEIPT_SOURCE_POLICY = Object.freeze({
   },
 });
 
+function checkNameRequiresWorkflowSource(name, kind) {
+  if (typeof name !== "string") return false;
+  if (
+    kind === "check" &&
+    (Object.hasOwn(RECEIPT_SOURCE_POLICY, name) ||
+      name === POST_MERGE_CHECK_NAME)
+  ) {
+    return true;
+  }
+  return CHECK_POLICY_DEFINITIONS.some(
+    (definition) =>
+      (CHECK_SOURCE_POLICY[definition.id]?.kind ?? "check") === kind &&
+      definition.names.some((pattern) => pattern.test(name)),
+  );
+}
+
 export const DEPENDABOT_PROCESSOR_HELP = `Usage:
   dependabot-processor.mjs evaluate --live --repo owner/name --pr-numbers all|1,2 [--mode observe|assist|prepare]
   dependabot-processor.mjs process --live --repo owner/name --pr-numbers all|1,2 [--mode observe|assist|prepare] [--phase request|mutate|finalize] [--publish-checks]
@@ -4302,9 +4318,51 @@ export function createLiveGitHubAdapter({
     return payload.data;
   };
 
+  const workflowRunCache = new Map();
+  const normalizeWorkflowRunSource = (data) => ({
+    runDisplayTitle: data.display_title,
+    runHeadBranch: data.head_branch,
+    runConclusion:
+      typeof data.conclusion === "string"
+        ? data.conclusion.toLowerCase()
+        : null,
+    sourceRepository: data.repository?.full_name,
+    runAttempt: data.run_attempt,
+    runHeadSha: data.head_sha ?? null,
+    runId: data.id,
+    runStatus:
+      typeof data.status === "string" ? data.status.toLowerCase() : null,
+    workflowEvent: data.event,
+    workflowPath: String(data.path ?? "").replace(/@.*$/, ""),
+  });
+  const readWorkflowRunSource = (repository, runId, runAttempt = null) => {
+    const path =
+      runAttempt === null
+        ? `/repos/${repository}/actions/runs/${runId}`
+        : `/repos/${repository}/actions/runs/${runId}/attempts/${runAttempt}`;
+    return request("GET", path).then(({ data }) =>
+      normalizeWorkflowRunSource(data),
+    );
+  };
+  const cachedWorkflowRunSource = (
+    repository,
+    runId,
+    runAttempt = null,
+    { fresh = false } = {},
+  ) => {
+    if (fresh) return readWorkflowRunSource(repository, runId, runAttempt);
+    const cacheKey = `${repository}:${runId}:${runAttempt ?? "latest"}`;
+    if (!workflowRunCache.has(cacheKey)) {
+      workflowRunCache.set(
+        cacheKey,
+        readWorkflowRunSource(repository, runId, runAttempt),
+      );
+    }
+    return workflowRunCache.get(cacheKey);
+  };
+
   const getChecks = async (repository, sha) => {
     exactSha(sha);
-    const workflowRunCache = new Map();
     const receiptRunIdentity = (check) => {
       const pattern =
         check.name === PROCESSOR_CHECK_NAME
@@ -4328,39 +4386,11 @@ export function createLiveGitHubAdapter({
         runId: Number(external.at(-2)),
       };
     };
-    const normalizeWorkflowRunSource = (data) => ({
-      runDisplayTitle: data.display_title,
-      runHeadBranch: data.head_branch,
-      runConclusion:
-        typeof data.conclusion === "string"
-          ? data.conclusion.toLowerCase()
-          : null,
-      sourceRepository: data.repository?.full_name,
-      runAttempt: data.run_attempt,
-      runHeadSha: data.head_sha ?? null,
-      runId: data.id,
-      runStatus:
-        typeof data.status === "string" ? data.status.toLowerCase() : null,
-      workflowEvent: data.event,
-      workflowPath: String(data.path ?? "").replace(/@.*$/, ""),
-    });
-    const cachedWorkflowRunSource = (repository, runId, runAttempt = null) => {
-      const cacheKey = `${runId}:${runAttempt ?? "latest"}`;
-      if (!workflowRunCache.has(cacheKey)) {
-        const path =
-          runAttempt === null
-            ? `/repos/${repository}/actions/runs/${runId}`
-            : `/repos/${repository}/actions/runs/${runId}/attempts/${runAttempt}`;
-        workflowRunCache.set(
-          cacheKey,
-          request("GET", path).then(({ data }) =>
-            normalizeWorkflowRunSource(data),
-          ),
-        );
-      }
-      return workflowRunCache.get(cacheKey);
-    };
-    const workflowRunSource = async (url, check = {}) => {
+    const workflowRunSource = async (
+      url,
+      check = {},
+      { fresh = false } = {},
+    ) => {
       const match = /\/actions\/runs\/([1-9][0-9]*)/.exec(String(url ?? ""));
       const externalReceipt = receiptRunIdentity(check);
       const exactReceiptSelfUrl =
@@ -4371,7 +4401,9 @@ export function createLiveGitHubAdapter({
       if (!match && !exactReceiptSelfUrl) return null;
       const runId = Number(match?.[1] ?? externalReceipt?.runId);
       if (!Number.isSafeInteger(runId) || runId < 1) return null;
-      const latest = await cachedWorkflowRunSource(repository, runId);
+      const latest = await cachedWorkflowRunSource(repository, runId, null, {
+        fresh,
+      });
       const recordedAttempt =
         externalReceipt?.runId === runId &&
         Number.isSafeInteger(externalReceipt.runAttempt) &&
@@ -4417,13 +4449,24 @@ export function createLiveGitHubAdapter({
         isPostMergeCheck &&
         run.head_sha === sha &&
         Number(run.id) === newestPostMergeCheck?.id;
+      const requiresWorkflowSource = checkNameRequiresWorkflowSource(
+        run.name,
+        "check",
+      );
       const source =
-        !isPostMergeCheck || isSelectedPostMergeCheck
-          ? await workflowRunSource(run.details_url, {
-              externalId: run.external_id,
-              id: Number(run.id),
-              name: run.name,
-            })
+        requiresWorkflowSource &&
+        (!isPostMergeCheck || isSelectedPostMergeCheck)
+          ? await workflowRunSource(
+              run.details_url,
+              {
+                externalId: run.external_id,
+                id: Number(run.id),
+                name: run.name,
+              },
+              {
+                fresh: isSelectedPostMergeCheck,
+              },
+            )
           : null;
       return {
         ...source,
@@ -4469,7 +4512,9 @@ export function createLiveGitHubAdapter({
     return [
       ...checkRuns,
       ...(await mapWithSourceResolutionLimit(statuses, async (status) => ({
-        ...(await workflowRunSource(status.target_url)),
+        ...(checkNameRequiresWorkflowSource(status.context, "status")
+          ? await workflowRunSource(status.target_url)
+          : null),
         creatorLogin: status.creator?.login,
         conclusion: status.state,
         description: status.description,

--- a/scripts/dependabot-processor.test.mjs
+++ b/scripts/dependabot-processor.test.mjs
@@ -5459,6 +5459,7 @@ test("live approval dismissal is idempotent when GitHub already dismissed the re
 });
 
 test("live check collection binds a check to its queried workflow repository", async () => {
+  let workflowRunReads = 0;
   const fetchImpl = async (url) => {
     if (url.includes(`/repos/${REPOSITORY}/commits/${HEAD_SHA}/check-runs`)) {
       return new Response(
@@ -5481,6 +5482,7 @@ test("live check collection binds a check to its queried workflow repository", a
       );
     }
     if (url.endsWith(`/repos/${REPOSITORY}/actions/runs/99`)) {
+      workflowRunReads += 1;
       return new Response(
         JSON.stringify({
           event: "pull_request",
@@ -5508,11 +5510,151 @@ test("live check collection binds a check to its queried workflow repository", a
     repository: REPOSITORY,
   });
   assert.equal(result.policy.find(({ id }) => id === "ci").state, "passing");
+  assert.equal(workflowRunReads, 1);
+});
+
+test("live check collection skips workflow-run reads for irrelevant checks and statuses", async () => {
+  const fetchImpl = async (url) => {
+    if (url.includes(`/repos/${REPOSITORY}/commits/${HEAD_SHA}/check-runs`)) {
+      return new Response(
+        JSON.stringify({
+          check_runs: [
+            {
+              app: { id: 15_368 },
+              completed_at: "2026-08-10T00:01:00Z",
+              conclusion: "success",
+              details_url: `https://github.com/${REPOSITORY}/actions/runs/101`,
+              head_sha: HEAD_SHA,
+              id: 102,
+              name: "Trunk Check",
+              started_at: "2026-08-10T00:00:00Z",
+              status: "completed",
+            },
+          ],
+        }),
+        { status: 200 },
+      );
+    }
+    if (url.includes(`/repos/${REPOSITORY}/commits/${HEAD_SHA}/statuses`)) {
+      return new Response(
+        JSON.stringify([
+          {
+            context: "argos/summary",
+            creator: { login: "github-actions[bot]" },
+            id: 103,
+            state: "success",
+            target_url: `https://github.com/${REPOSITORY}/actions/runs/104`,
+            updated_at: "2026-08-10T00:01:00Z",
+          },
+        ]),
+        { status: 200 },
+      );
+    }
+    assert.fail(`Irrelevant evidence must not fetch its workflow run: ${url}`);
+  };
+  const adapter = createLiveGitHubAdapter({ fetchImpl, token: "test-token" });
+  const checks = await adapter.getChecks(REPOSITORY, HEAD_SHA);
+
+  assert.deepEqual(
+    checks.map(({ name, runId, sourceRepository, workflowPath }) => ({
+      name,
+      runId,
+      sourceRepository,
+      workflowPath,
+    })),
+    [
+      {
+        name: "Trunk Check",
+        runId: undefined,
+        sourceRepository: undefined,
+        workflowPath: undefined,
+      },
+      {
+        name: "argos/summary",
+        runId: undefined,
+        sourceRepository: undefined,
+        workflowPath: undefined,
+      },
+    ],
+  );
+});
+
+test("live check collection caches relevant workflow provenance across repeated collections", async () => {
+  let checkReads = 0;
+  let workflowRunReads = 0;
+  const fetchImpl = async (url) => {
+    if (url.includes(`/repos/${REPOSITORY}/commits/${HEAD_SHA}/check-runs`)) {
+      checkReads += 1;
+      return new Response(
+        JSON.stringify({
+          check_runs: [
+            {
+              app: { id: 15_368 },
+              completed_at: "2026-08-10T00:01:00Z",
+              conclusion: "success",
+              details_url: `https://github.com/${REPOSITORY}/actions/runs/105`,
+              head_sha: HEAD_SHA,
+              id: 106,
+              name: "Build and Test",
+              started_at: "2026-08-10T00:00:00Z",
+              status: "completed",
+            },
+          ],
+        }),
+        { status: 200 },
+      );
+    }
+    if (url.endsWith(`/repos/${REPOSITORY}/actions/runs/105`)) {
+      workflowRunReads += 1;
+      return new Response(
+        JSON.stringify({
+          conclusion: "success",
+          event: "pull_request",
+          head_branch: "dependabot/test",
+          head_sha: HEAD_SHA,
+          id: 105,
+          path: ".github/workflows/ci.yml",
+          repository: { full_name: REPOSITORY },
+          run_attempt: 1,
+          status: "completed",
+        }),
+        { status: 200 },
+      );
+    }
+    if (url.includes(`/repos/${REPOSITORY}/commits/${HEAD_SHA}/statuses`)) {
+      return new Response(JSON.stringify([]), { status: 200 });
+    }
+    assert.fail(`Unexpected request: ${url}`);
+  };
+  const adapter = createLiveGitHubAdapter({ fetchImpl, token: "test-token" });
+
+  for (let collection = 0; collection < 2; collection += 1) {
+    const [check] = await adapter.getChecks(REPOSITORY, HEAD_SHA);
+    assert.equal(check.runId, 105);
+    assert.equal(check.sourceRepository, REPOSITORY);
+    assert.equal(check.workflowPath, ".github/workflows/ci.yml");
+  }
+  assert.equal(checkReads, 2);
+  assert.equal(workflowRunReads, 1);
 });
 
 test("live check collection bounds concurrent workflow-run enrichment for checks and statuses", async () => {
   const checkCount = 12;
   const statusCount = 12;
+  const relevantCheckNames = [
+    "Build and Test",
+    "Action Pin Policy",
+    "Action Pin Policy Source",
+    "dependency-review",
+    "osv-scanner / osv-scan",
+    "osv-scanner (trusted pnpm runtime) / osv-scan",
+    "osv-scanner (standalone Vercel CLI runtime) / osv-scan",
+    "osv-scanner (trusted pnpm bootstrap) / osv-scan",
+    "lockfile integrity + registry",
+    "catalog version-skew",
+    "coverage and production bundles",
+    "E2E Plan",
+  ];
   const firstWorkflowRunId = 31_471_141_700;
   const firstStatusWorkflowRunId = firstWorkflowRunId + checkCount;
   let activeWorkflowRunGets = 0;
@@ -5544,7 +5686,7 @@ test("live check collection bounds concurrent workflow-run enrichment for checks
               details_url: `https://github.com/${REPOSITORY}/actions/runs/${workflowRunId}`,
               head_sha: HEAD_SHA,
               id: 93_713_691_500 + index,
-              name: `Workflow-backed check ${index}`,
+              name: relevantCheckNames[index],
               started_at: "2026-08-11T08:23:59Z",
               status: "completed",
             };
@@ -5585,7 +5727,7 @@ test("live check collection bounds concurrent workflow-run enrichment for checks
           Array.from({ length: statusCount }, (_, index) => {
             const workflowRunId = firstStatusWorkflowRunId + index;
             return {
-              context: `Workflow-backed status ${index}`,
+              context: "Vercel Preview",
               creator: { login: "github-actions[bot]" },
               id: 93_713_691_600 + index,
               state: "success",
@@ -5677,7 +5819,7 @@ test("live typed receipt enrichment preserves historical attempts without cache 
               details_url: `https://github.com/${REPOSITORY}/actions/runs/${workflowRunId}`,
               head_sha: HEAD_SHA,
               id: 93_713_691_752,
-              name: "Current workflow-backed check",
+              name: "Build and Test",
               started_at: "2026-08-11T08:25:59Z",
               status: "completed",
             },
@@ -5749,8 +5891,6 @@ test("live typed receipt enrichment preserves historical attempts without cache 
     );
   }
   assert.deepEqual(requestedRunPaths, [
-    `/repos/${REPOSITORY}/actions/runs/${workflowRunId}`,
-    `/repos/${REPOSITORY}/actions/runs/${workflowRunId}/attempts/1`,
     `/repos/${REPOSITORY}/actions/runs/${workflowRunId}`,
     `/repos/${REPOSITORY}/actions/runs/${workflowRunId}/attempts/1`,
   ]);

--- a/scripts/dependabot-workflows.test.mjs
+++ b/scripts/dependabot-workflows.test.mjs
@@ -1,5 +1,6 @@
 /* eslint-disable turbo/no-undeclared-env-vars -- The Bash-validator harness preserves the host executable search path. */
 import assert from "node:assert/strict";
+import { Buffer } from "node:buffer";
 import { spawn, spawnSync } from "node:child_process";
 import {
   chmodSync,
@@ -1622,6 +1623,7 @@ test("Dependabot Claude review follows only authenticated intake runs", () => {
     review.with.prompt,
     /gh pr diff.*needs\.preflight\.outputs\.pr_number.*--repo.*github\.repository/s,
   );
+  assert.match(review.with.prompt, /one plain-text document tool result/);
   assert.match(review.with.prompt, /Do not make any.*mutation/s);
   assert.match(review.with.claude_code_oauth_token, /secrets\./);
   const settings = JSON.parse(review.with.settings);
@@ -1773,6 +1775,15 @@ test("Dependabot Claude review follows only authenticated intake runs", () => {
   const raw = read(dependabotReviewPath);
   assert.doesNotMatch(raw, forbiddenCandidateSurfaces);
   assert.doesNotMatch(raw, /github\.event\.pull_request/);
+
+  const guard = read("scripts/dependabot-claude-review-tool-guard.mjs");
+  assert.match(guard, /dependabot-claude-review-tool-completed:v2/);
+  assert.match(guard, /hookEventName: "PostToolUse"/);
+  assert.match(guard, /updatedToolOutput:/);
+  assert.match(guard, /structuredContent:/);
+  assert.match(guard, /type: "document"/);
+  assert.match(guard, /media_type: "text\/plain"/);
+  assert.match(guard, /data: response\.stdout/);
 });
 
 test("Dependabot Claude review tool guard permits only the exact bound diff", async () => {
@@ -1821,6 +1832,16 @@ test("Dependabot Claude review tool guard permits only the exact bound diff", as
   assert.equal(duplicate.status, 2);
   assert.match(duplicate.stderr, /one permitted diff read/);
 
+  const exactDiff = [
+    "diff --git a/package.json b/package.json",
+    "--- a/package.json",
+    "+++ b/package.json",
+    "@@ -1 +1 @@",
+    `-${"a".repeat(16_000)}`,
+    `+${"b".repeat(16_000)}`,
+    "",
+  ].join("\n");
+  assert.ok(Buffer.byteLength(exactDiff) > 30_000);
   const postInput = {
     ...exactInput,
     hook_event_name: "PostToolUse",
@@ -1829,8 +1850,28 @@ test("Dependabot Claude review tool guard permits only the exact bound diff", as
       isImage: false,
       noOutputExpected: false,
       stderr: "",
-      stdout:
-        "diff --git a/package.json b/package.json\n--- a/package.json\n+++ b/package.json\n",
+      stdout: exactDiff,
+    },
+  };
+  const expectedPostHookOutput = {
+    hookSpecificOutput: {
+      hookEventName: "PostToolUse",
+      updatedToolOutput: {
+        interrupted: false,
+        isImage: false,
+        stderr: "",
+        stdout: "",
+        structuredContent: [
+          {
+            source: {
+              data: exactDiff,
+              media_type: "text/plain",
+              type: "text",
+            },
+            type: "document",
+          },
+        ],
+      },
     },
   };
   const completed = spawnSync(
@@ -1843,7 +1884,24 @@ test("Dependabot Claude review tool guard permits only the exact bound diff", as
     },
   );
   assert.equal(completed.status, 0, completed.stderr);
-  assert.equal(completed.stdout, "");
+  assert.equal(completed.stdout, `${JSON.stringify(expectedPostHookOutput)}\n`);
+  const deliveredDiff = JSON.parse(completed.stdout).hookSpecificOutput
+    .updatedToolOutput.structuredContent[0].source.data;
+  assert.deepEqual(Buffer.from(deliveredDiff), Buffer.from(exactDiff));
+  const completedReceipt = JSON.parse(
+    readFileSync(
+      join(
+        environment.RUNNER_TEMP,
+        "dependabot-review-tool-123456-1.completed.json",
+      ),
+      "utf8",
+    ),
+  );
+  assert.equal(
+    completedReceipt.schema,
+    "dependabot-claude-review-tool-completed:v2",
+  );
+  assert.equal(completedReceipt.outputBytes, Buffer.byteLength(exactDiff));
   const verified = spawnSync(
     process.execPath,
     [dependabotReviewToolGuardPath, "--verify-completion"],
@@ -1908,11 +1966,16 @@ test("Dependabot Claude review tool guard permits only the exact bound diff", as
         stdio: ["pipe", "pipe", "pipe"],
       });
       let stderr = "";
+      let stdout = "";
       child.stderr.setEncoding("utf8");
+      child.stdout.setEncoding("utf8");
       child.stderr.on("data", (chunk) => {
         stderr += chunk;
       });
-      child.on("close", (status) => resolve({ status, stderr }));
+      child.stdout.on("data", (chunk) => {
+        stdout += chunk;
+      });
+      child.on("close", (status) => resolve({ status, stderr, stdout }));
       child.stdin.end(JSON.stringify(postInput));
     });
   const parallelCompletionResults = await Promise.all([
@@ -1922,6 +1985,12 @@ test("Dependabot Claude review tool guard permits only the exact bound diff", as
   assert.deepEqual(
     parallelCompletionResults.map(({ status }) => status).sort(),
     [0, 2],
+  );
+  assert.equal(
+    parallelCompletionResults.filter(
+      ({ stdout }) => stdout === `${JSON.stringify(expectedPostHookOutput)}\n`,
+    ).length,
+    1,
   );
   const parallelVerified = spawnSync(
     process.execPath,
@@ -2047,10 +2116,32 @@ test("Dependabot Claude review tool guard permits only the exact bound diff", as
     },
     {
       ...postInput,
+      tool_response: { ...postInput.tool_response, isImage: true },
+    },
+    {
+      ...postInput,
+      tool_response: { ...postInput.tool_response, noOutputExpected: true },
+    },
+    {
+      ...postInput,
       tool_response: {
         ...postInput.tool_response,
         persistedOutputPath: "/tmp/full-diff",
         persistedOutputSize: 150_001,
+      },
+    },
+    {
+      ...postInput,
+      tool_response: {
+        ...postInput.tool_response,
+        rawOutputPath: "/tmp/raw-diff",
+      },
+    },
+    {
+      ...postInput,
+      tool_response: {
+        ...postInput.tool_response,
+        structuredContent: [{ type: "text", text: exactDiff }],
       },
     },
     {
@@ -2064,22 +2155,54 @@ test("Dependabot Claude review tool guard permits only the exact bound diff", as
       ...postInput,
       tool_response: {
         ...postInput.tool_response,
+        backgroundedByUser: true,
+      },
+    },
+    {
+      ...postInput,
+      tool_response: {
+        ...postInput.tool_response,
         timedOutAfterMs: 120_000,
       },
     },
   ];
-  for (const input of blockedInputs) {
-    const blocked = spawnSync(
-      process.execPath,
-      [dependabotReviewToolGuardPath],
-      {
-        encoding: "utf8",
-        env: environment,
-        input: JSON.stringify(input),
-      },
-    );
-    assert.equal(blocked.status, 2, JSON.stringify(input));
-    assert.match(blocked.stderr, /Blocked Dependabot review tool call/);
+  for (const [index, input] of blockedInputs.entries()) {
+    const blockedEnvironment = {
+      ...environment,
+      RUNNER_TEMP: mkdtempSync(
+        join(tmpdir(), `dependabot-review-tool-blocked-${index}-`),
+      ),
+    };
+    try {
+      if (input.hook_event_name === "PostToolUse") {
+        const issued = spawnSync(
+          process.execPath,
+          [dependabotReviewToolGuardPath],
+          {
+            encoding: "utf8",
+            env: blockedEnvironment,
+            input: JSON.stringify(exactInput),
+          },
+        );
+        assert.equal(issued.status, 0, issued.stderr);
+      }
+      const blocked = spawnSync(
+        process.execPath,
+        [dependabotReviewToolGuardPath],
+        {
+          encoding: "utf8",
+          env: blockedEnvironment,
+          input: JSON.stringify(input),
+        },
+      );
+      assert.equal(blocked.status, 2, JSON.stringify(input));
+      assert.match(blocked.stderr, /Blocked Dependabot review tool call/);
+    } finally {
+      rmSync(blockedEnvironment.RUNNER_TEMP, {
+        force: true,
+        recursive: true,
+      });
+    }
   }
 
   for (const [input, env] of [

--- a/scripts/dependabot-workflows.test.mjs
+++ b/scripts/dependabot-workflows.test.mjs
@@ -1,6 +1,6 @@
 /* eslint-disable turbo/no-undeclared-env-vars -- The Bash-validator harness preserves the host executable search path. */
 import assert from "node:assert/strict";
-import { spawnSync } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import {
   chmodSync,
   existsSync,
@@ -49,6 +49,9 @@ const preparedDispatchPath =
   ".github/workflows/dependabot-prepared-head-dispatch.yml";
 const dependabotReviewPath = ".github/workflows/dependabot-claude-review.yml";
 const humanReviewPath = ".github/workflows/claude-code-review.yml";
+const dependabotReviewToolGuardPath = fileURLToPath(
+  new URL("./dependabot-claude-review-tool-guard.mjs", import.meta.url),
+);
 const intake = workflow(intakePath);
 const processor = workflow(processorPath);
 const repair = workflow(repairPath);
@@ -1577,7 +1580,7 @@ test("Dependabot Claude review follows only authenticated intake runs", () => {
     "${{ steps.claude-review.outputs.structured_output }}",
   );
 
-  const [immediate, checkout, review] = reviewJob.steps;
+  const [immediate, checkout, review, verifyDiffRead] = reviewJob.steps;
   assert.equal(Object.hasOwn(immediate, "uses"), false);
   assert.equal(immediate.env.GH_TOKEN, "${{ github.token }}");
   assert.equal(
@@ -1621,25 +1624,86 @@ test("Dependabot Claude review follows only authenticated intake runs", () => {
   );
   assert.match(review.with.prompt, /Do not make any.*mutation/s);
   assert.match(review.with.claude_code_oauth_token, /secrets\./);
-  const allowedToolFlags = [
+  const settings = JSON.parse(review.with.settings);
+  assert.deepEqual(settings.env, {
+    BASH_MAX_OUTPUT_LENGTH: "150000",
+    DEPENDABOT_REVIEW_PR_NUMBER: "${{ needs.preflight.outputs.pr_number }}",
+    DEPENDABOT_REVIEW_REPOSITORY: "mento-protocol/frontend-monorepo",
+  });
+  assert.deepEqual(settings.hooks, {
+    PreToolUse: [
+      {
+        matcher: "Bash",
+        hooks: [
+          {
+            type: "command",
+            command:
+              'node "${{ github.workspace }}/scripts/dependabot-claude-review-tool-guard.mjs" || exit 2',
+            timeout: 5,
+          },
+        ],
+      },
+    ],
+    PostToolUse: [
+      {
+        matcher: "Bash",
+        hooks: [
+          {
+            type: "command",
+            command:
+              'node "${{ github.workspace }}/scripts/dependabot-claude-review-tool-guard.mjs" || exit 2',
+            timeout: 5,
+          },
+        ],
+      },
+    ],
+  });
+  const toolFlags = [
+    ...review.with.claude_args.matchAll(/--tools\s+"([^"]+)"/g),
+  ];
+  assert.deepEqual(
+    toolFlags.map((match) => match[1]),
+    ["Bash"],
+  );
+  const disallowedToolFlags = [
     ...review.with.claude_args.matchAll(
-      /--(?:allowedTools|allowed-tools)\s+"([^"]+)"/g,
+      /--(?:disallowedTools|disallowed-tools)\s+"([^"]+)"/g,
     ),
   ];
-  assert.equal(allowedToolFlags.length, 1);
-  assert.equal(
-    allowedToolFlags[0][1],
-    "Bash(gh pr diff ${{ needs.preflight.outputs.pr_number }} --repo ${{ github.repository }})",
+  assert.deepEqual(
+    disallowedToolFlags.map((match) => match[1]),
+    ["mcp__*"],
   );
-  assert.doesNotMatch(allowedToolFlags[0][1], /:\*|\s+\*/);
+  assert.match(review.with.claude_args, /--permission-mode\s+dontAsk/);
+  assert.match(review.with.claude_args, /--setting-sources\s+user/);
+  assert.match(review.with.claude_args, /--strict-mcp-config\b/);
   assert.doesNotMatch(
     review.with.claude_args,
-    /Bash\(gh api|Bash\(curl|Bash\(git|WebFetch|WebSearch|mcp__github__|--permission-mode\s+bypassPermissions|--dangerously-skip-permissions/,
+    /--(?:allowedTools|allowed-tools)\b/,
+  );
+  assert.doesNotMatch(
+    review.with.claude_args,
+    /Bash\(gh api|Bash\(curl|Bash\(git|WebFetch|WebSearch|mcp__github__|--permission-mode\s+bypassPermissions|--dangerously-skip-permissions|--tools\s+"[^"]*(?:Read|Edit|Write|Glob|Grep|Agent)/,
   );
   assert.match(review.with.claude_args, /--json-schema/);
   assert.match(review.with.claude_args, /dependabot-claude-review-result:v1/);
   assert.match(review.with.claude_args, /"maxItems":20/);
   assert.match(review.with.claude_args, /"additionalProperties":false/);
+
+  assert.equal(verifyDiffRead.name, "Require a completed exact diff read");
+  assert.equal(verifyDiffRead.if, "${{ always() }}");
+  assert.equal(
+    verifyDiffRead.env.DEPENDABOT_REVIEW_PR_NUMBER,
+    "${{ needs.preflight.outputs.pr_number }}",
+  );
+  assert.equal(
+    verifyDiffRead.env.DEPENDABOT_REVIEW_REPOSITORY,
+    "mento-protocol/frontend-monorepo",
+  );
+  assert.match(
+    verifyDiffRead.run,
+    /dependabot-claude-review-tool-guard\.mjs[\s\S]*--verify-completion/,
+  );
 
   assert.equal(publishJob.name, "dependabot-claude-review-publisher");
   assert.deepEqual(publishJob.needs, ["preflight", "review"]);
@@ -1709,6 +1773,345 @@ test("Dependabot Claude review follows only authenticated intake runs", () => {
   const raw = read(dependabotReviewPath);
   assert.doesNotMatch(raw, forbiddenCandidateSurfaces);
   assert.doesNotMatch(raw, /github\.event\.pull_request/);
+});
+
+test("Dependabot Claude review tool guard permits only the exact bound diff", async () => {
+  const environment = {
+    ...process.env,
+    DEPENDABOT_REVIEW_PR_NUMBER: "731",
+    DEPENDABOT_REVIEW_REPOSITORY: "mento-protocol/frontend-monorepo",
+    GITHUB_RUN_ATTEMPT: "1",
+    GITHUB_RUN_ID: "123456",
+    RUNNER_TEMP: mkdtempSync(join(tmpdir(), "dependabot-review-tool-")),
+  };
+  const exactInput = {
+    hook_event_name: "PreToolUse",
+    tool_name: "Bash",
+    tool_use_id: "toolu_01DependabotDiffRead",
+    tool_input: {
+      command: "gh pr diff 731 --repo mento-protocol/frontend-monorepo",
+      description: "Read the authenticated pull-request diff",
+      run_in_background: false,
+      timeout: 120_000,
+    },
+  };
+  const allowed = spawnSync(process.execPath, [dependabotReviewToolGuardPath], {
+    encoding: "utf8",
+    env: environment,
+    input: JSON.stringify(exactInput),
+  });
+  assert.equal(allowed.status, 0, allowed.stderr);
+  assert.deepEqual(JSON.parse(allowed.stdout), {
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      permissionDecision: "allow",
+      permissionDecisionReason:
+        "Exact receipt-bound Dependabot PR diff command",
+    },
+  });
+  const duplicate = spawnSync(
+    process.execPath,
+    [dependabotReviewToolGuardPath],
+    {
+      encoding: "utf8",
+      env: environment,
+      input: JSON.stringify(exactInput),
+    },
+  );
+  assert.equal(duplicate.status, 2);
+  assert.match(duplicate.stderr, /one permitted diff read/);
+
+  const postInput = {
+    ...exactInput,
+    hook_event_name: "PostToolUse",
+    tool_response: {
+      interrupted: false,
+      isImage: false,
+      noOutputExpected: false,
+      stderr: "",
+      stdout:
+        "diff --git a/package.json b/package.json\n--- a/package.json\n+++ b/package.json\n",
+    },
+  };
+  const completed = spawnSync(
+    process.execPath,
+    [dependabotReviewToolGuardPath],
+    {
+      encoding: "utf8",
+      env: environment,
+      input: JSON.stringify(postInput),
+    },
+  );
+  assert.equal(completed.status, 0, completed.stderr);
+  assert.equal(completed.stdout, "");
+  const verified = spawnSync(
+    process.execPath,
+    [dependabotReviewToolGuardPath, "--verify-completion"],
+    { encoding: "utf8", env: environment },
+  );
+  assert.equal(verified.status, 0, verified.stderr);
+  const duplicateCompletion = spawnSync(
+    process.execPath,
+    [dependabotReviewToolGuardPath],
+    {
+      encoding: "utf8",
+      env: environment,
+      input: JSON.stringify(postInput),
+    },
+  );
+  assert.equal(duplicateCompletion.status, 2);
+  assert.match(duplicateCompletion.stderr, /completion was already sealed/);
+
+  const parallelEnvironment = {
+    ...environment,
+    RUNNER_TEMP: mkdtempSync(join(tmpdir(), "dependabot-review-tool-race-")),
+  };
+  const runGuard = () =>
+    new Promise((resolve) => {
+      const child = spawn(process.execPath, [dependabotReviewToolGuardPath], {
+        env: parallelEnvironment,
+        stdio: ["pipe", "pipe", "pipe"],
+      });
+      let stderr = "";
+      let stdout = "";
+      child.stderr.setEncoding("utf8");
+      child.stdout.setEncoding("utf8");
+      child.stderr.on("data", (chunk) => {
+        stderr += chunk;
+      });
+      child.stdout.on("data", (chunk) => {
+        stdout += chunk;
+      });
+      child.on("close", (status) => resolve({ status, stderr, stdout }));
+      child.stdin.end(JSON.stringify(exactInput));
+    });
+  const parallelResults = await Promise.all([runGuard(), runGuard()]);
+  assert.deepEqual(parallelResults.map(({ status }) => status).sort(), [0, 2]);
+  assert.equal(
+    parallelResults.filter(({ stdout }) =>
+      stdout.includes('"permissionDecision":"allow"'),
+    ).length,
+    1,
+  );
+  const verifyBeforeCompletion = spawnSync(
+    process.execPath,
+    [dependabotReviewToolGuardPath, "--verify-completion"],
+    { encoding: "utf8", env: parallelEnvironment },
+  );
+  assert.equal(verifyBeforeCompletion.status, 2);
+  assert.match(verifyBeforeCompletion.stderr, /completed diff-read marker/);
+
+  const runCompletionGuard = () =>
+    new Promise((resolve) => {
+      const child = spawn(process.execPath, [dependabotReviewToolGuardPath], {
+        env: parallelEnvironment,
+        stdio: ["pipe", "pipe", "pipe"],
+      });
+      let stderr = "";
+      child.stderr.setEncoding("utf8");
+      child.stderr.on("data", (chunk) => {
+        stderr += chunk;
+      });
+      child.on("close", (status) => resolve({ status, stderr }));
+      child.stdin.end(JSON.stringify(postInput));
+    });
+  const parallelCompletionResults = await Promise.all([
+    runCompletionGuard(),
+    runCompletionGuard(),
+  ]);
+  assert.deepEqual(
+    parallelCompletionResults.map(({ status }) => status).sort(),
+    [0, 2],
+  );
+  const parallelVerified = spawnSync(
+    process.execPath,
+    [dependabotReviewToolGuardPath, "--verify-completion"],
+    { encoding: "utf8", env: parallelEnvironment },
+  );
+  assert.equal(parallelVerified.status, 0, parallelVerified.stderr);
+
+  const blockedInputs = [
+    {
+      ...exactInput,
+      tool_input: { command: ` ${exactInput.tool_input.command}` },
+    },
+    {
+      ...exactInput,
+      tool_input: { command: `${exactInput.tool_input.command} ` },
+    },
+    {
+      ...exactInput,
+      tool_input: { command: `${exactInput.tool_input.command} --patch` },
+    },
+    {
+      ...exactInput,
+      tool_input: { command: `${exactInput.tool_input.command}; env` },
+    },
+    {
+      ...exactInput,
+      tool_input: { command: `${exactInput.tool_input.command} && env` },
+    },
+    {
+      ...exactInput,
+      tool_input: { command: `${exactInput.tool_input.command} || env` },
+    },
+    {
+      ...exactInput,
+      tool_input: { command: `${exactInput.tool_input.command} | cat` },
+    },
+    {
+      ...exactInput,
+      tool_input: { command: `${exactInput.tool_input.command} > /tmp/diff` },
+    },
+    {
+      ...exactInput,
+      tool_input: { command: `${exactInput.tool_input.command} $(env)` },
+    },
+    {
+      ...exactInput,
+      tool_input: { command: `${exactInput.tool_input.command} \`env\`` },
+    },
+    {
+      ...exactInput,
+      tool_input: { command: `${exactInput.tool_input.command}\ncat .env` },
+    },
+    {
+      ...exactInput,
+      tool_input: {
+        command: "gh pr diff 732 --repo mento-protocol/frontend-monorepo",
+      },
+    },
+    {
+      ...exactInput,
+      tool_input: {
+        command: "gh pr diff 731 --repo attacker/example",
+      },
+    },
+    {
+      ...exactInput,
+      tool_input: { command: `command ${exactInput.tool_input.command}` },
+    },
+    {
+      ...exactInput,
+      tool_input: { command: `GH_TOKEN=x ${exactInput.tool_input.command}` },
+    },
+    {
+      ...exactInput,
+      tool_input: {
+        command: exactInput.tool_input.command,
+        run_in_background: true,
+      },
+    },
+    {
+      ...exactInput,
+      tool_input: {
+        command: exactInput.tool_input.command,
+        timeout: 120_001,
+      },
+    },
+    {
+      ...exactInput,
+      tool_input: {
+        command: exactInput.tool_input.command,
+        description: "x".repeat(501),
+      },
+    },
+    {
+      ...exactInput,
+      tool_input: {
+        command: exactInput.tool_input.command,
+        dangerouslyDisableSandbox: true,
+      },
+    },
+    { ...exactInput, tool_name: "Read" },
+    { ...exactInput, hook_event_name: "PermissionRequest" },
+    { ...exactInput, hook_event_name: "PostToolUseFailure" },
+    {
+      ...postInput,
+      tool_use_id: "toolu_01DifferentDiffRead",
+    },
+    {
+      ...postInput,
+      tool_response: { ...postInput.tool_response, stdout: "" },
+    },
+    {
+      ...postInput,
+      tool_response: {
+        ...postInput.tool_response,
+        stdout: "not a unified diff",
+      },
+    },
+    {
+      ...postInput,
+      tool_response: { ...postInput.tool_response, interrupted: true },
+    },
+    {
+      ...postInput,
+      tool_response: {
+        ...postInput.tool_response,
+        persistedOutputPath: "/tmp/full-diff",
+        persistedOutputSize: 150_001,
+      },
+    },
+    {
+      ...postInput,
+      tool_response: {
+        ...postInput.tool_response,
+        backgroundTaskId: "task-1",
+      },
+    },
+    {
+      ...postInput,
+      tool_response: {
+        ...postInput.tool_response,
+        timedOutAfterMs: 120_000,
+      },
+    },
+  ];
+  for (const input of blockedInputs) {
+    const blocked = spawnSync(
+      process.execPath,
+      [dependabotReviewToolGuardPath],
+      {
+        encoding: "utf8",
+        env: environment,
+        input: JSON.stringify(input),
+      },
+    );
+    assert.equal(blocked.status, 2, JSON.stringify(input));
+    assert.match(blocked.stderr, /Blocked Dependabot review tool call/);
+  }
+
+  for (const [input, env] of [
+    ["not-json", environment],
+    [
+      JSON.stringify({
+        ...exactInput,
+        padding: "x".repeat(2_097_152),
+      }),
+      environment,
+    ],
+    [
+      JSON.stringify(exactInput),
+      { ...environment, DEPENDABOT_REVIEW_PR_NUMBER: "0731" },
+    ],
+    [
+      JSON.stringify(exactInput),
+      { ...environment, DEPENDABOT_REVIEW_REPOSITORY: "attacker/example" },
+    ],
+    [JSON.stringify(exactInput), { ...environment, GITHUB_RUN_ID: "0" }],
+    [JSON.stringify(exactInput), { ...environment, RUNNER_TEMP: "relative" }],
+  ]) {
+    const blocked = spawnSync(
+      process.execPath,
+      [dependabotReviewToolGuardPath],
+      { encoding: "utf8", env, input },
+    );
+    assert.equal(blocked.status, 2);
+    assert.match(blocked.stderr, /Blocked Dependabot review tool call/);
+  }
+  rmSync(environment.RUNNER_TEMP, { force: true, recursive: true });
+  rmSync(parallelEnvironment.RUNNER_TEMP, { force: true, recursive: true });
 });
 
 test("Dependabot Claude review authenticates live upstream head metadata", () => {

--- a/scripts/dependabot-workflows.test.mjs
+++ b/scripts/dependabot-workflows.test.mjs
@@ -1615,8 +1615,27 @@ test("Dependabot Claude review follows only authenticated intake runs", () => {
     review.with.prompt,
     /head.*needs\.preflight\.outputs\.head_sha/s,
   );
+  assert.match(
+    review.with.prompt,
+    /gh pr diff.*needs\.preflight\.outputs\.pr_number.*--repo.*github\.repository/s,
+  );
   assert.match(review.with.prompt, /Do not make any.*mutation/s);
   assert.match(review.with.claude_code_oauth_token, /secrets\./);
+  const allowedToolFlags = [
+    ...review.with.claude_args.matchAll(
+      /--(?:allowedTools|allowed-tools)\s+"([^"]+)"/g,
+    ),
+  ];
+  assert.equal(allowedToolFlags.length, 1);
+  assert.equal(
+    allowedToolFlags[0][1],
+    "Bash(gh pr diff ${{ needs.preflight.outputs.pr_number }} --repo ${{ github.repository }})",
+  );
+  assert.doesNotMatch(allowedToolFlags[0][1], /:\*|\s+\*/);
+  assert.doesNotMatch(
+    review.with.claude_args,
+    /Bash\(gh api|Bash\(curl|Bash\(git|WebFetch|WebSearch|mcp__github__|--permission-mode\s+bypassPermissions|--dangerously-skip-permissions/,
+  );
   assert.match(review.with.claude_args, /--json-schema/);
   assert.match(review.with.claude_args, /dependabot-claude-review-result:v1/);
   assert.match(review.with.claude_args, /"maxItems":20/);


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## The Problem

- The first live prepared-head review reached Claude with a read-only token, but Claude could not run the GitHub command needed to read the PR diff. It returned an infrastructure result after 15 permission denials.
- Broad prepare sweeps also enriched every check and status with an Actions run lookup. Repeated collections exhausted the workflow installation's API quota before the pending refresh could mutate.

## The Solution

- Restrict the reviewer to Bash alone and install a trusted fail-closed hook that permits exactly one receipt-bound `gh pr diff` command under the existing read-only token. A matching success-only `PostToolUse` receipt seals the validated raw bytes, then replaces the ordinary Bash result with one exact `text/plain` document carrying those bytes so Claude Code's large-text preview cannot truncate model input. An independent post-action verifier requires that completed receipt before the workflow can accept review evidence. Failed, interrupted, backgrounded, empty, truncated, persisted, mismatched, repeated, or missing reads become retry-first infrastructure failures.
- Keep generic API, Git, curl, web, agent, MCP, wildcard, and permission-bypass access unavailable. Bind the hook state to the validated PR, fixed repository, workflow run, attempt, command, and tool-use ID.
- Resolve workflow-run provenance only for configured gate and receipt names, and cache each repository/run/attempt lookup across a processor job. The selected post-merge gate still gets a fresh read.
- Update the workflow contract, runbook, ADR, repository guidance, and structural regressions.

## Validation

- `pnpm dependabot:process:test` — 209 passed
- `pnpm quality:budgets:test` — 53 passed
- `pnpm ci:action-pins:test` — 59 passed
- Focused workflow and prepared-review tests — 61 passed
- `trunk fmt` and `trunk check` — clean across the affected files
- `pnpm adr:check`, Node syntax checks, and `git diff --check` — clean
- Fresh-context local Codex autoreview — accepted tool-boundary, completion-proof, and complete large-diff delivery findings fixed; the final document-delivery batch passed a clean semantic review at 0.93 confidence and a clean deterministic review; no accepted actionable finding remains
- Live rollout remains contained in exact `observe` mode; this PR authorizes no Dependabot branch mutation, approval, ALL CLEAR, auto-merge, or merge

## Ship Checklist

- [x] PR title follows the conventions
- [x] Performed a self-review of my own changes
- [x] Relevant automated checks and smoke tests pass
- [x] Architecture decision: updated `docs/adr/0006-dependabot-processing-controller.md`

Claude Security scan: skipped because this is a Codex runtime. Fresh-context reviews explicitly covered the reviewer tool boundary, completion receipt, workflow permissions, and provenance cache.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes tighten a security-sensitive Dependabot review tool boundary and CI evidence collection; behavior is fail-closed with heavy regression coverage, but mistakes could block reviews or mis-attribute gate provenance.
> 
> **Overview**
> **Dependabot Claude review** no longer relies on broad GitHub API diff access. The read-only Claude job is limited to **Bash only** (`dontAsk`, MCP denied). A new **`dependabot-claude-review-tool-guard.mjs`** hook pair allows exactly one receipt-bound `gh pr diff` per run attempt, seals stdout in a **`dependabot-claude-review-tool-completed:v2`** marker, and rewrites the model-visible result as a **`text/plain` document** so large diffs are not truncated by Claude Code’s Bash output persistence. A final **`--verify-completion`** step fails the job if that read did not complete cleanly.
> 
> **Dependabot processor** collection now resolves Actions workflow provenance **only for configured gate/receipt check names** (and matching policy statuses), skips unrelated checks, **caches** each `repository/run/attempt` lookup within a job, and still **re-fetches** the selected post-merge gate fresh.
> 
> Workflow contract, ADR/runbook/README/AGENTS guidance, and structural/integration tests are updated to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f14414134e08142b811a17e39288c1cba74daadf. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->