### PR TITLE
fix: bind Claude check self URLs

### DIFF
--- a/scripts/dependabot-processor.mjs
+++ b/scripts/dependabot-processor.mjs
@@ -1884,6 +1884,12 @@ function trustedCheckSource(
       return { reason: "post-merge-run-url-mismatch", trusted: false };
     }
   } else if (definition.id === "claude-review") {
+    if (check.name !== "claude-review") {
+      return {
+        reason: "unexpected-claude-review-check-name",
+        trusted: false,
+      };
+    }
     const displayTitle = String(check.runDisplayTitle ?? "");
     const nativeDisplayReceipt =
       CLAUDE_REVIEW_RECEIPT_PATTERN.exec(displayTitle);

--- a/scripts/dependabot-processor.mjs
+++ b/scripts/dependabot-processor.mjs
@@ -1927,10 +1927,14 @@ function trustedCheckSource(
     ) {
       return { reason: "claude-review-run-identity-mismatch", trusted: false };
     }
-    if (
-      check.detailsUrl !==
-      `https://github.com/${repository}/actions/runs/${check.runId}`
-    ) {
+    if (!Number.isSafeInteger(check.id) || check.id < 1) {
+      return { reason: "invalid-claude-review-check-id", trusted: false };
+    }
+    const allowedDetailsUrls = new Set([
+      `https://github.com/${repository}/actions/runs/${check.runId}`,
+      `https://github.com/${repository}/runs/${check.id}`,
+    ]);
+    if (!allowedDetailsUrls.has(check.detailsUrl)) {
       return { reason: "claude-review-run-url-mismatch", trusted: false };
     }
   } else if (check.runHeadSha !== headSha) {
@@ -1943,7 +1947,7 @@ function trustedCheckSource(
     return { reason: "invalid-workflow-run-id", trusted: false };
   }
   if (
-    definition.id !== "post-merge-verification" &&
+    !["claude-review", "post-merge-verification"].includes(definition.id) &&
     check.detailsUrl &&
     !check.detailsUrl.includes(`/actions/runs/${check.runId}`)
   ) {
@@ -4375,11 +4379,16 @@ export function createLiveGitHubAdapter({
                 ? ALL_CLEAR_RECEIPT_PATTERN
                 : check.name === POST_MERGE_CHECK_NAME
                   ? POST_MERGE_EXTERNAL_ID_PATTERN
-                  : null;
+                  : check.name === "claude-review"
+                    ? CLAUDE_REVIEW_EXTERNAL_ID_PATTERN
+                    : null;
       const external = pattern?.exec(String(check.externalId ?? ""));
       if (!external) return null;
       if (check.name === POST_MERGE_CHECK_NAME) {
         return { runAttempt: Number(external[2]), runId: Number(external[1]) };
+      }
+      if (check.name === "claude-review") {
+        return { runAttempt: Number(external[4]), runId: Number(external[3]) };
       }
       return {
         runAttempt: Number(external.at(-1)),

--- a/scripts/dependabot-processor.test.mjs
+++ b/scripts/dependabot-processor.test.mjs
@@ -1568,6 +1568,25 @@ test("Claude review requires the workflow-run receipt, main source ref, and exac
     "passing",
   );
 
+  const rewrittenChecks = completeChecks();
+  const rewrittenIndex = rewrittenChecks.findIndex(
+    ({ name }) => name === "claude-review",
+  );
+  rewrittenChecks[rewrittenIndex] = {
+    ...rewrittenChecks[rewrittenIndex],
+    detailsUrl: `https://github.com/${REPOSITORY}/runs/${rewrittenChecks[rewrittenIndex].id}`,
+  };
+  const rewritten = evaluateDependabotChecks({
+    checks: rewrittenChecks,
+    headSha: HEAD_SHA,
+    pullRequestNumber: 123,
+    repository: REPOSITORY,
+  });
+  assert.equal(
+    rewritten.policy.find(({ id }) => id === "claude-review").state,
+    "passing",
+  );
+
   for (const mutation of [
     { runHeadBranch: "dependabot-branch" },
     { runHeadSha: HEAD_SHA },
@@ -1577,7 +1596,17 @@ test("Claude review requires the workflow-run receipt, main source ref, and exac
     {
       externalId: `dependabot-claude-review:v1:pr=123:sha=${HEAD_SHA}:run=1:attempt=2`,
     },
+    {
+      externalId: `dependabot-claude-review:v1:pr=123:sha=${HEAD_SHA}:run=2:attempt=1`,
+    },
+    { externalId: "dependabot-claude-review:v1:malformed" },
+    { detailsUrl: `https://github.com/${REPOSITORY}/runs/2` },
+    {
+      detailsUrl: `https://github.com/${REPOSITORY}/runs/1`,
+      id: 0,
+    },
     { detailsUrl: `https://github.com/${REPOSITORY}/actions/runs/1/job/2` },
+    { sourceRepository: "attacker/fork" },
     { workflowEvent: "pull_request_target" },
   ]) {
     const checks = completeChecks();
@@ -5511,6 +5540,181 @@ test("live check collection binds a check to its queried workflow repository", a
   });
   assert.equal(result.policy.find(({ id }) => id === "ci").state, "passing");
   assert.equal(workflowRunReads, 1);
+});
+
+test("live Claude review collection follows its exact receipt when GitHub rewrites the check URL", async () => {
+  const checkRunId = 93_713_691_800;
+  const workflowRunId = 31_471_141_800;
+  const requestedWorkflowRuns = [];
+  const fetchImpl = async (url) => {
+    const path = new URL(url).pathname;
+    if (path.endsWith(`/commits/${HEAD_SHA}/check-runs`)) {
+      return new Response(
+        JSON.stringify({
+          check_runs: [
+            {
+              app: { id: 15_368 },
+              completed_at: "2026-08-12T10:01:00Z",
+              conclusion: "success",
+              details_url: `https://github.com/${REPOSITORY}/runs/${checkRunId}`,
+              external_id: `dependabot-claude-review:v1:pr=123:sha=${HEAD_SHA}:run=${workflowRunId}:attempt=1`,
+              head_sha: HEAD_SHA,
+              id: checkRunId,
+              name: "claude-review",
+              output: {
+                text: stableJson({
+                  findings: [],
+                  headSha: HEAD_SHA,
+                  pullRequestNumber: 123,
+                  repository: REPOSITORY,
+                  reviewCompleted: true,
+                  schema: "dependabot-claude-review-result:v1",
+                  verdict: "clean",
+                }),
+              },
+              started_at: "2026-08-12T10:00:00Z",
+              status: "completed",
+            },
+          ],
+        }),
+        { status: 200 },
+      );
+    }
+    if (path === `/repos/${REPOSITORY}/actions/runs/${workflowRunId}`) {
+      requestedWorkflowRuns.push(workflowRunId);
+      return new Response(
+        JSON.stringify({
+          conclusion: "success",
+          display_title: `dependabot-claude-review:v1 | source=dependabot-intake:v1 | repository=${REPOSITORY} | pr=123 | sha=${HEAD_SHA} | action=synchronize | receipt=true`,
+          event: "workflow_run",
+          head_branch: "main",
+          head_sha: MERGE_SHA,
+          id: workflowRunId,
+          path: ".github/workflows/dependabot-claude-review.yml",
+          repository: { full_name: REPOSITORY },
+          run_attempt: 1,
+          status: "completed",
+        }),
+        { status: 200 },
+      );
+    }
+    if (path.endsWith(`/commits/${HEAD_SHA}/statuses`)) {
+      return new Response(JSON.stringify([]), { status: 200 });
+    }
+    assert.fail(`Unexpected request: ${url}`);
+  };
+  const adapter = createLiveGitHubAdapter({ fetchImpl, token: "test-token" });
+  const [review] = await adapter.getChecks(REPOSITORY, HEAD_SHA);
+
+  assert.deepEqual(requestedWorkflowRuns, [workflowRunId]);
+  assert.equal(review.id, checkRunId);
+  assert.equal(
+    review.detailsUrl,
+    `https://github.com/${REPOSITORY}/runs/${checkRunId}`,
+  );
+  assert.equal(review.runId, workflowRunId);
+  assert.equal(review.runAttempt, 1);
+  assert.equal(review.sourceRepository, REPOSITORY);
+  assert.equal(
+    review.workflowPath,
+    ".github/workflows/dependabot-claude-review.yml",
+  );
+
+  const result = evaluateDependabotChecks({
+    checks: [review],
+    headSha: HEAD_SHA,
+    pullRequestNumber: 123,
+    repository: REPOSITORY,
+  });
+  assert.deepEqual(
+    result.policy
+      .filter(({ id }) => id === "claude-review")
+      .map(({ findings, reason, source, state }) => ({
+        findings,
+        reason,
+        source,
+        state,
+      })),
+    [
+      {
+        findings: [],
+        reason: "passing",
+        source: "trusted-source",
+        state: "passing",
+      },
+    ],
+  );
+});
+
+test("live Claude review self URLs fail closed without the exact receipt and check identity", async () => {
+  const checkRunId = 93_713_691_810;
+  const workflowRunId = 31_471_141_810;
+  const cases = [
+    {
+      detailsUrl: `https://github.com/${REPOSITORY}/runs/${checkRunId}`,
+      externalId: "dependabot-claude-review:v1:malformed",
+      label: "malformed external receipt",
+    },
+    {
+      detailsUrl: `https://github.com/${REPOSITORY}/runs/${checkRunId + 1}`,
+      externalId: `dependabot-claude-review:v1:pr=123:sha=${HEAD_SHA}:run=${workflowRunId}:attempt=1`,
+      label: "wrong self check ID",
+    },
+  ];
+
+  for (const testCase of cases) {
+    let workflowRunReads = 0;
+    const fetchImpl = async (url) => {
+      const path = new URL(url).pathname;
+      if (path.endsWith(`/commits/${HEAD_SHA}/check-runs`)) {
+        return new Response(
+          JSON.stringify({
+            check_runs: [
+              {
+                app: { id: 15_368 },
+                completed_at: "2026-08-12T10:01:00Z",
+                conclusion: "success",
+                details_url: testCase.detailsUrl,
+                external_id: testCase.externalId,
+                head_sha: HEAD_SHA,
+                id: checkRunId,
+                name: "claude-review",
+                started_at: "2026-08-12T10:00:00Z",
+                status: "completed",
+              },
+            ],
+          }),
+          { status: 200 },
+        );
+      }
+      if (path.includes(`/repos/${REPOSITORY}/actions/runs/`)) {
+        workflowRunReads += 1;
+        return new Response(JSON.stringify({ message: "unexpected" }), {
+          status: 500,
+        });
+      }
+      if (path.endsWith(`/commits/${HEAD_SHA}/statuses`)) {
+        return new Response(JSON.stringify([]), { status: 200 });
+      }
+      assert.fail(`Unexpected request: ${url}`);
+    };
+    const adapter = createLiveGitHubAdapter({
+      fetchImpl,
+      token: "test-token",
+    });
+    const [review] = await adapter.getChecks(REPOSITORY, HEAD_SHA);
+    const result = evaluateDependabotChecks({
+      checks: [review],
+      headSha: HEAD_SHA,
+      pullRequestNumber: 123,
+      repository: REPOSITORY,
+    });
+    const policy = result.policy.find(({ id }) => id === "claude-review");
+
+    assert.equal(workflowRunReads, 0, testCase.label);
+    assert.equal(policy.state, "failing", testCase.label);
+    assert.equal(policy.reason, "unexpected-source-repository", testCase.label);
+  }
 });
 
 test("live check collection skips workflow-run reads for irrelevant checks and statuses", async () => {

--- a/scripts/dependabot-processor.test.mjs
+++ b/scripts/dependabot-processor.test.mjs
@@ -1587,6 +1587,42 @@ test("Claude review requires the workflow-run receipt, main source ref, and exac
     "passing",
   );
 
+  for (const variant of [
+    {
+      detailsUrl: `https://github.com/${REPOSITORY}/actions/runs/2`,
+      name: "Claude-Review",
+    },
+    {
+      detailsUrl: `https://github.com/${REPOSITORY}/runs/2`,
+      name: "CLAUDE-REVIEW",
+    },
+  ]) {
+    const checks = completeChecks();
+    const index = checks.findIndex(({ name }) => name === "claude-review");
+    checks.push({
+      ...checks[index],
+      detailsUrl: variant.detailsUrl,
+      externalId: `dependabot-claude-review:v1:pr=123:sha=${HEAD_SHA}:run=2:attempt=1`,
+      id: 2,
+      name: variant.name,
+      runId: 2,
+    });
+    const result = evaluateDependabotChecks({
+      checks,
+      headSha: HEAD_SHA,
+      pullRequestNumber: 123,
+      repository: REPOSITORY,
+    });
+    const policy = result.policy.find(({ id }) => id === "claude-review");
+    assert.equal(policy.check.name, variant.name, JSON.stringify(variant));
+    assert.equal(policy.state, "failing", JSON.stringify(variant));
+    assert.equal(
+      policy.reason,
+      "unexpected-claude-review-check-name",
+      JSON.stringify(variant),
+    );
+  }
+
   for (const mutation of [
     { runHeadBranch: "dependabot-branch" },
     { runHeadSha: HEAD_SHA },


### PR DESCRIPTION
## The Problem

GitHub rewrites the Dependabot `claude-review` check `details_url` from its submitted Actions-run URL to the check-run self URL. The live processor therefore failed to recover the review workflow provenance, rejected a successful exact-head review as `unexpected-source-repository`, and suppressed the bounded repair packet for PR #734. Prepare mode was returned to `observe`; no Repair Intent, Repair, ALL CLEAR, approval, or auto-merge was issued.

## The Solution

Recover Claude workflow run and attempt identity only from its strict external receipt, then accept the exact check-run self URL bound to the safe positive check ID alongside the exact Actions-run URL. Keep malformed receipts, wrong self IDs, wrong run or attempt identity, wrong source provenance, and URL suffixes fail-closed.

Validation:

- `pnpm dependabot:process:test` — 211/211
- `pnpm quality:budgets:test` — 53/53
- scoped Trunk, Node syntax, and `git diff --check`
- fresh-context autoreview — 0 findings, 0.96 confidence
- live canary evidence: clean Claude check `94210524996` requested the Actions URL but GitHub stored `/runs/94210524996`

Risk: this changes only provenance recovery for the exact lowercase `claude-review` check. The self URL is accepted only when its check ID, external run/attempt receipt, repository, workflow path/event, source ref, and display receipt all match.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes trust rules for the security-sensitive `claude-review` gate; scope is narrow (provenance/URL binding only) with expanded fail-closed checks and test coverage.
> 
> **Overview**
> **Claude review provenance** now tolerates GitHub rewriting `details_url` from the Actions run link to the check-run self URL (`/runs/{checkId}`), matching the pattern already used for post-merge verification.
> 
> Trust for `claude-review` requires the exact lowercase check name, a valid check ID, and `details_url` in a small allowlist tied to the receipt’s workflow run and the check’s own ID. Live check collection resolves workflow run/attempt from the Claude **external_id** receipt (not only from the URL). Malformed receipts, wrong self IDs, run/attempt mismatches, and spoofed names still fail closed.
> 
> Tests cover rewritten URLs, case-variant check names, additional mutation cases, and live adapter behavior with/without valid receipts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58817d91f4438caaf99a4f9f0fd17ad61b60d342. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->