### PR TITLE
fix(ci): preserve recovered evidence when census is unproven

### DIFF
--- a/.github/workflows/vercel-main-deployment.yml
+++ b/.github/workflows/vercel-main-deployment.yml
@@ -2700,18 +2700,33 @@ jobs:
       - name: Capture fresh final provider state and census
         id: recovery-final-state
         if: steps.recovery-terminal.outcome == 'success'
-        continue-on-error: true
         env:
           VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN_PRODUCTION }}
-        run: >-
-          node scripts/vercel-deployment-state.mjs active-proof
-          --spec "$RUNNER_TEMP/recovery-final-state-spec.json"
-          --output "$RUNNER_TEMP/recovery-final-state-proof.json"
-      - name: Require a proven recovered provider state
-        if: steps.recovery-terminal.outputs.outcome == 'recovered'
+        run: |
+          set -euo pipefail
+          if node scripts/vercel-deployment-state.mjs active-proof --spec "$RUNNER_TEMP/recovery-final-state-spec.json" --output "$RUNNER_TEMP/recovery-final-state-proof.json" 2>"$RUNNER_TEMP/recovery-final-state.stderr"; then
+            echo 'census_outcome=proven' >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          failure_line="$(<"$RUNNER_TEMP/recovery-final-state.stderr")"
+          case "$failure_line" in
+            'Vercel deployment state failed category=active-census-unproven') category=active-census-unproven ;;
+            'Vercel deployment state failed category=provider-read-timeout') category=provider-read-timeout ;;
+            'Vercel deployment state failed category=provider-read-transport') category=provider-read-transport ;;
+            'Vercel deployment state failed category=provider-read-rate-limited') category=provider-read-rate-limited ;;
+            'Vercel deployment state failed category=provider-read-http') category=provider-read-http ;;
+            'Vercel deployment state failed category=provider-read-malformed') category=provider-read-malformed ;;
+            'Vercel deployment state failed category=state-validation-failed') category=state-validation-failed ;;
+            *) exit 1 ;;
+          esac
+          node scripts/vercel-main-deployment.mjs active-census-failure --category "$category" --output "$RUNNER_TEMP/recovery-final-census-failure.json"
+          echo 'census_outcome=unproven' >> "$GITHUB_OUTPUT"
+      - name: Require a proven provider state unless recovered proof is preserved separately
+        if: steps.recovery-terminal.outputs.outcome == 'manual-intervention'
         run: |
           test "${{ steps.recovery-final-state.outcome }}" = success
+          test "${{ steps.recovery-final-state.outputs.census_outcome }}" = proven
           test -s "$RUNNER_TEMP/recovery-final-state-proof.json"
       - name: Capture fresh final recovery mappings
         if: steps.recovery-terminal.outcome == 'success'
@@ -2767,13 +2782,40 @@ jobs:
         id: recovered-terminal
         if: steps.recovery-terminal.outcome == 'success'
         env:
-          { TERMINAL_OUTCOME: "${{ steps.recovery-terminal.outputs.outcome }}" }
+          {
+            TERMINAL_OUTCOME: "${{ steps.recovery-terminal.outputs.outcome }}",
+            CENSUS_OUTCOME: "${{ steps.recovery-final-state.outputs.census_outcome }}",
+          }
         run: |
           set -euo pipefail
-          if [ "$TERMINAL_OUTCOME" = recovered ]; then public_smokes="$RUNNER_TEMP/recovery-public-smokes.json"; else public_smokes="$RUNNER_TEMP/null.json"; fi
-          test -s "$RUNNER_TEMP/recovery-final-state-proof.json"
-          node scripts/vercel-main-release-cli.mjs terminal-artifacts --active-evidence-output "$RUNNER_TEMP/recovery-evidence.json" --execution "$RUNNER_TEMP/execution.json" --final-census "$RUNNER_TEMP/recovery-final-state-proof.json" --final-mappings "$RUNNER_TEMP/recovery-final-mappings.json" --freshness "$RUNNER_TEMP/null.json" --journal-history "$RUNNER_TEMP/recovered-history.json" --legacy-v2 "$RUNNER_TEMP/recovery-final-legacy.json" --outcome "$TERMINAL_OUTCOME" --proofs-output "$RUNNER_TEMP/recovery-proofs.json" --public-smokes "$public_smokes" --stage-results "$RUNNER_TEMP/null.json" --state-proof "$RUNNER_TEMP/recovery-final-state-proof.json"
-          echo "outcome=$TERMINAL_OUTCOME" >> "$GITHUB_OUTPUT"
+          if [ "$TERMINAL_OUTCOME" = recovered ]; then
+            test -s "$RUNNER_TEMP/recovery-public-smokes.json"
+            test -s "$RUNNER_TEMP/recovery-final-mappings.json"
+            case "$CENSUS_OUTCOME" in
+              proven)
+                terminal_outcome=recovered
+                final_census="$RUNNER_TEMP/recovery-final-state-proof.json"
+                state_proof="$RUNNER_TEMP/recovery-final-state-proof.json"
+                test -s "$final_census"
+                ;;
+              unproven)
+                terminal_outcome=recovered-census-unproven
+                final_census="$RUNNER_TEMP/recovery-final-census-failure.json"
+                state_proof="$RUNNER_TEMP/null.json"
+                test -s "$final_census"
+                ;;
+              *) exit 1 ;;
+            esac
+            public_smokes="$RUNNER_TEMP/recovery-public-smokes.json"
+          else
+            terminal_outcome="$TERMINAL_OUTCOME"
+            final_census="$RUNNER_TEMP/recovery-final-state-proof.json"
+            state_proof="$RUNNER_TEMP/recovery-final-state-proof.json"
+            public_smokes="$RUNNER_TEMP/null.json"
+            test -s "$final_census"
+          fi
+          node scripts/vercel-main-release-cli.mjs terminal-artifacts --active-evidence-output "$RUNNER_TEMP/recovery-evidence.json" --execution "$RUNNER_TEMP/execution.json" --final-census "$final_census" --final-mappings "$RUNNER_TEMP/recovery-final-mappings.json" --freshness "$RUNNER_TEMP/null.json" --journal-history "$RUNNER_TEMP/recovered-history.json" --legacy-v2 "$RUNNER_TEMP/recovery-final-legacy.json" --outcome "$terminal_outcome" --proofs-output "$RUNNER_TEMP/recovery-proofs.json" --public-smokes "$public_smokes" --stage-results "$RUNNER_TEMP/null.json" --state-proof "$state_proof"
+          echo "outcome=$terminal_outcome" >> "$GITHUB_OUTPUT"
       - name: Publish recovery terminal producer outputs
         id: terminal
         if: ${{ always() && !cancelled() && (steps.preparation-failure-terminal.outcome == 'success' || steps.recovery-failed-terminal.outcome == 'success' || steps.recovered-terminal.outcome == 'success') }}
@@ -2792,7 +2834,7 @@ jobs:
         run: |
           set -euo pipefail
           case "$TERMINAL_OUTCOME" in
-            recovered|manual-intervention|recovery-failed|preparation-failed-before-journal) ;;
+            recovered|recovered-census-unproven|manual-intervention|recovery-failed|preparation-failed-before-journal) ;;
             *) exit 1 ;;
           esac
           echo "outcome=$TERMINAL_OUTCOME" >> "$GITHUB_OUTPUT"
@@ -2801,7 +2843,7 @@ jobs:
         env: { TERMINAL_OUTCOME: "${{ steps.outcome.outputs.outcome }}" }
         run: |
           case "$TERMINAL_OUTCOME" in
-            recovered|manual-intervention|recovery-failed|preparation-failed-before-journal) exit 1 ;;
+            recovered|recovered-census-unproven|manual-intervention|recovery-failed|preparation-failed-before-journal) exit 1 ;;
             *) exit 1 ;;
           esac
       - name: Remove authenticated recovery runtime

--- a/.github/workflows/vercel-main-deployment.yml
+++ b/.github/workflows/vercel-main-deployment.yml
@@ -2818,6 +2818,9 @@ jobs:
           --manifest "$RUNNER_TEMP/manifest.json" --execution "$RUNNER_TEMP/execution.json"
           --active-evidence "$RUNNER_TEMP/recovery-evidence.json" --proofs "$RUNNER_TEMP/recovery-proofs.json"
           --receipt-output "$RUNNER_TEMP/recovery-receipt.json" --evidence-output "$RUNNER_TEMP/recovery-terminal-evidence.json"
+      - name: Mark recovered census-unproven terminal route
+        if: ${{ always() && steps.terminal.outcome == 'success' && steps.recovered-terminal.outputs.outcome == 'recovered-census-unproven' }}
+        run: "true"
       - name: Publish recovery outcome
         id: outcome
         if: ${{ always() && steps.terminal.outcome == 'success' }}

--- a/.github/workflows/vercel-main-deployment.yml
+++ b/.github/workflows/vercel-main-deployment.yml
@@ -2722,12 +2722,6 @@ jobs:
           esac
           node scripts/vercel-main-deployment.mjs active-census-failure --category "$category" --output "$RUNNER_TEMP/recovery-final-census-failure.json"
           echo 'census_outcome=unproven' >> "$GITHUB_OUTPUT"
-      - name: Require a proven provider state unless recovered proof is preserved separately
-        if: steps.recovery-terminal.outputs.outcome == 'manual-intervention'
-        run: |
-          test "${{ steps.recovery-final-state.outcome }}" = success
-          test "${{ steps.recovery-final-state.outputs.census_outcome }}" = proven
-          test -s "$RUNNER_TEMP/recovery-final-state-proof.json"
       - name: Capture fresh final recovery mappings
         if: steps.recovery-terminal.outcome == 'success'
         env:

--- a/docs/adr/0001-github-actions-vercel-deployment-orchestration.md
+++ b/docs/adr/0001-github-actions-vercel-deployment-orchestration.md
@@ -237,6 +237,13 @@ not also attempt any replaced `main` path for the exact target/SHA release.
 Legacy App `v2 -> production` activity is classified and verified separately
 instead of being mislabeled as a duplicate `main -> v3` deployment.
 
+If recovery has already restored and verified every protected prior mapping and
+credential-free runtime smoke, but the final duplicate census cannot be proven,
+the terminal evidence retains those verified facts with a bounded non-secret
+census-failure category. The release still fails as
+`recovered-census-unproven`; this outcome is not evidence that the duplicate
+census passed and never authorizes forward progress.
+
 ### Trust and credential boundary
 
 - Pull-request code is never executed by a credentialed

--- a/docs/vercel-deployments.md
+++ b/docs/vercel-deployments.md
@@ -430,6 +430,16 @@ as `recovery-failed`. It performs no recovery transition or provider mutation,
 then publishes terminal evidence bound to the unchanged canonical journal
 history and a fresh legacy App `v2` proof before failing the release.
 
+When a recovered journal, fresh protected alias mappings, and all four
+credential-free restored-prior runtime smokes are verified, a later duplicate
+census can still be unproven because a bounded provider read failed or the
+census found an unexpected deployment. The workflow records only a fixed,
+non-secret census-failure category in terminal evidence, preserves the verified
+recovery journal, mappings, and smokes, and reports
+`recovered-census-unproven`. It never treats that outcome as a proven census or
+as a successful release: the recovery job and final result fail after the
+evidence is published. A mapping or smoke failure does not use this path.
+
 If a recovered journal proves that App's `app_v3_deploy` operation never
 started and its prepared candidate still has no deployment identity, the final
 state specification records App as `recoveredPrior`. That narrow state expects

--- a/scripts/vercel-cost-observation.mjs
+++ b/scripts/vercel-cost-observation.mjs
@@ -2443,6 +2443,9 @@ const MAIN_TERMINAL_ROUTE_STEPS = new Map([
   ],
 ]);
 
+const MAIN_RECOVERED_CENSUS_UNPROVEN_MARKER =
+  "Mark recovered census-unproven terminal route";
+
 export function deriveMainTerminalRoute({ jobs, journalHistories }) {
   invariant(Array.isArray(jobs), "Main terminal route jobs are malformed");
   invariant(
@@ -2452,14 +2455,18 @@ export function deriveMainTerminalRoute({ jobs, journalHistories }) {
   const completedSteps = jobs.flatMap((job) =>
     (Array.isArray(job.steps) ? job.steps : [])
       .filter(
-        (step) =>
-          step.status === "completed" &&
-          step.conclusion === "success" &&
-          MAIN_TERMINAL_ROUTE_STEPS.has(step.name),
+        (step) => step.status === "completed" && step.conclusion === "success",
       )
       .map((step) => step.name),
   );
-  const uniqueSteps = [...new Set(completedSteps)];
+  const uniqueSteps = [
+    ...new Set(
+      completedSteps.filter((step) => MAIN_TERMINAL_ROUTE_STEPS.has(step)),
+    ),
+  ];
+  const recoveredCensusUnproven = completedSteps.includes(
+    MAIN_RECOVERED_CENSUS_UNPROVEN_MARKER,
+  );
   if (uniqueSteps.length !== 1) {
     return {
       complete: false,
@@ -2475,6 +2482,19 @@ export function deriveMainTerminalRoute({ jobs, journalHistories }) {
   }
   const terminalStep = uniqueSteps[0];
   const contract = MAIN_TERMINAL_ROUTE_STEPS.get(terminalStep);
+  if (
+    recoveredCensusUnproven &&
+    terminalStep !== "Materialize recovered or manual terminal artifacts"
+  ) {
+    return {
+      complete: false,
+      outcome: null,
+      terminalStep,
+      journalBinding: null,
+      reason: "recovered-census-unproven-marker-conflict",
+      observedTerminalSteps: uniqueSteps,
+    };
+  }
   let outcome = contract.outcome;
   let journalBinding = null;
   if (contract.journalStatus === "committed") {
@@ -2516,8 +2536,19 @@ export function deriveMainTerminalRoute({ jobs, journalHistories }) {
         observedTerminalSteps: uniqueSteps,
       };
     }
-    outcome =
-      matches[0].highestStatus === "recovered"
+    if (recoveredCensusUnproven && matches[0].highestStatus !== "recovered") {
+      return {
+        complete: false,
+        outcome: null,
+        terminalStep,
+        journalBinding: null,
+        reason: "recovered-census-unproven-marker-conflict",
+        observedTerminalSteps: uniqueSteps,
+      };
+    }
+    outcome = recoveredCensusUnproven
+      ? "recovered-census-unproven"
+      : matches[0].highestStatus === "recovered"
         ? "recovered"
         : "manual-intervention";
     journalBinding = {

--- a/scripts/vercel-cost-observation.test.mjs
+++ b/scripts/vercel-cost-observation.test.mjs
@@ -2690,6 +2690,41 @@ test("main terminal routes are mutually exclusive and bind required journal stat
   assert.equal(recovered.complete, true);
   assert.equal(recovered.outcome, "recovered");
 
+  const recoveredCensusUnproven = deriveMainTerminalRoute({
+    jobs: jobsFor(
+      "Materialize recovered or manual terminal artifacts",
+      "Mark recovered census-unproven terminal route",
+    ),
+    journalHistories: [
+      {
+        transactionId: `main-${"e".repeat(32)}`,
+        highestSequence: 8,
+        highestStatus: "recovered",
+      },
+    ],
+  });
+  assert.equal(recoveredCensusUnproven.complete, true);
+  assert.equal(recoveredCensusUnproven.outcome, "recovered-census-unproven");
+
+  const conflictingMarker = deriveMainTerminalRoute({
+    jobs: jobsFor(
+      "Materialize recovered or manual terminal artifacts",
+      "Mark recovered census-unproven terminal route",
+    ),
+    journalHistories: [
+      {
+        transactionId: `main-${"f".repeat(32)}`,
+        highestSequence: 9,
+        highestStatus: "manual_intervention",
+      },
+    ],
+  });
+  assert.equal(conflictingMarker.complete, false);
+  assert.equal(
+    conflictingMarker.reason,
+    "recovered-census-unproven-marker-conflict",
+  );
+
   const missingCommittedJournal = deriveMainTerminalRoute({
     jobs: jobsFor("Materialize committed terminal artifacts"),
     journalHistories: [],

--- a/scripts/vercel-deployment-state.mjs
+++ b/scripts/vercel-deployment-state.mjs
@@ -3412,9 +3412,18 @@ export async function runCli({
 }
 
 export function renderCliFailure(error) {
-  return error instanceof CanonicalDriftError
-    ? `${error.message}\n`
-    : "Vercel deployment state command failed\n";
+  if (error instanceof CanonicalDriftError) return `${error.message}\n`;
+  const category =
+    error?.message === "Active deployment state is unproven"
+      ? "active-census-unproven"
+      : ({
+          VERCEL_API_READ_TIMEOUT: "provider-read-timeout",
+          VERCEL_API_READ_TRANSPORT: "provider-read-transport",
+          VERCEL_API_READ_RATE_LIMITED: "provider-read-rate-limited",
+          VERCEL_API_READ_HTTP: "provider-read-http",
+          VERCEL_API_READ_MALFORMED: "provider-read-malformed",
+        }[error?.code] ?? "state-validation-failed");
+  return `Vercel deployment state failed category=${category}\n`;
 }
 
 function isCliEntrypoint() {

--- a/scripts/vercel-deployment-state.test.mjs
+++ b/scripts/vercel-deployment-state.test.mjs
@@ -1881,11 +1881,14 @@ test("CLI entrypoint redacts ordinary failures and compares without credentials"
   );
   assert.equal(failed.status, 1);
   assert.equal(failed.stdout, "");
-  assert.equal(failed.stderr, "Vercel deployment state command failed\n");
+  assert.equal(
+    failed.stderr,
+    "Vercel deployment state failed category=state-validation-failed\n",
+  );
   assert.doesNotMatch(failed.stderr, /private-test-value|\/private\//);
   assert.equal(
     renderCliFailure(new Error(`${sensitivePath}: test-token-never-printed`)),
-    "Vercel deployment state command failed\n",
+    "Vercel deployment state failed category=state-validation-failed\n",
   );
 });
 
@@ -3227,6 +3230,16 @@ test("active-proof CLI writes canonical duplicate evidence before failing unprov
     renderCliFailure(
       new Error("unproven-cli-token-never-output raw-secret-never-output"),
     ),
-    "Vercel deployment state command failed\n",
+    "Vercel deployment state failed category=state-validation-failed\n",
+  );
+  assert.equal(
+    renderCliFailure(new Error("Active deployment state is unproven")),
+    "Vercel deployment state failed category=active-census-unproven\n",
+  );
+  const transport = new Error("active-proof-token-never-output");
+  transport.code = "VERCEL_API_READ_TRANSPORT";
+  assert.equal(
+    renderCliFailure(transport),
+    "Vercel deployment state failed category=provider-read-transport\n",
   );
 });

--- a/scripts/vercel-main-deployment-workflow.test.mjs
+++ b/scripts/vercel-main-deployment-workflow.test.mjs
@@ -1355,6 +1355,19 @@ test("recovery is a bounded exact-current-attempt transaction with no cross-atte
     command("recover-main-deployment", "terminal-evidence-create").run,
     /terminal-evidence-create/,
   );
+  const recoveredCensusUnprovenMarker = named(
+    "recover-main-deployment",
+    "Mark recovered census-unproven terminal route",
+  );
+  assert.match(
+    recoveredCensusUnprovenMarker.if,
+    /steps\.terminal\.outcome == 'success'/,
+  );
+  assert.match(
+    recoveredCensusUnprovenMarker.if,
+    /steps\.recovered-terminal\.outputs\.outcome == 'recovered-census-unproven'/,
+  );
+  assert.equal(recoveredCensusUnprovenMarker.run, "true");
   assert.match(
     named(
       "recover-main-deployment",

--- a/scripts/vercel-main-deployment-workflow.test.mjs
+++ b/scripts/vercel-main-deployment-workflow.test.mjs
@@ -1316,18 +1316,32 @@ test("recovery is a bounded exact-current-attempt transaction with no cross-atte
     /--journal-history[\s\S]*recovered-history[\s\S]*--mappings[\s\S]*recovery-final-mappings-raw[\s\S]*--output[\s\S]*recovery-final-mappings/,
   );
   assert.doesNotMatch(canonicalMappings.run, /jq -n --slurpfile/);
+  const recoveryFinalState = command("recover-main-deployment", "active-proof");
+  assert.match(recoveryFinalState.run, /recovery-final-state-spec/);
   assert.match(
-    command("recover-main-deployment", "active-proof").run,
-    /recovery-final-state-spec/,
+    recoveryFinalState.run,
+    /Vercel deployment state failed category=provider-read-transport/,
   );
+  assert.match(
+    recoveryFinalState.run,
+    /active-census-failure[\s\S]*recovery-final-census-failure/,
+  );
+  assert.doesNotMatch(recoveryFinalState.run, /cat "\$RUNNER_TEMP/);
   assert.match(
     command("recover-main-deployment", "active-recovery-public-smokes").run,
     /--execution[\s\S]*recovery-app-runtime-smoke[\s\S]*recovery-ui-runtime-smoke/,
   );
+  const recoveredTerminal = named(
+    "recover-main-deployment",
+    "recovered or manual terminal artifacts",
+  );
   assert.match(
-    named("recover-main-deployment", "recovered or manual terminal artifacts")
-      .run,
+    recoveredTerminal.run,
     /terminal-artifacts[\s\S]*recovery-final-mappings[\s\S]*recovery-final-legacy/,
+  );
+  assert.match(
+    recoveredTerminal.run,
+    /recovered-census-unproven[\s\S]*recovery-final-census-failure/,
   );
   assert.match(
     command("recover-main-deployment", "terminal-evidence-create").run,
@@ -1338,7 +1352,7 @@ test("recovery is a bounded exact-current-attempt transaction with no cross-atte
       "recover-main-deployment",
       "Fail after recording recovery terminal evidence",
     ).run,
-    /recovered\|manual-intervention\|recovery-failed\|preparation-failed-before-journal[\s\S]*exit 1/,
+    /recovered\|recovered-census-unproven\|manual-intervention\|recovery-failed\|preparation-failed-before-journal[\s\S]*exit 1/,
   );
   assert.match(
     named("recover-main-deployment", "Publish recovery outcome").env

--- a/scripts/vercel-main-deployment-workflow.test.mjs
+++ b/scripts/vercel-main-deployment-workflow.test.mjs
@@ -1344,6 +1344,14 @@ test("recovery is a bounded exact-current-attempt transaction with no cross-atte
     /recovered-census-unproven[\s\S]*recovery-final-census-failure/,
   );
   assert.match(
+    recoveredTerminal.run,
+    /else[\s\S]*terminal_outcome="\$TERMINAL_OUTCOME"[\s\S]*final_census="\$RUNNER_TEMP\/recovery-final-state-proof\.json"[\s\S]*state_proof="\$RUNNER_TEMP\/recovery-final-state-proof\.json"/,
+  );
+  assert.doesNotMatch(
+    workflowSource,
+    /Require a proven provider state unless recovered proof is preserved separately/,
+  );
+  assert.match(
     command("recover-main-deployment", "terminal-evidence-create").run,
     /terminal-evidence-create/,
   );

--- a/scripts/vercel-main-deployment.mjs
+++ b/scripts/vercel-main-deployment.mjs
@@ -111,6 +111,8 @@ export const MAIN_ACTIVE_SAFE_NOOP_EVIDENCE_SCHEMA =
   "vercel-main-active-safe-noop-evidence:v1";
 export const MAIN_ACTIVE_FAILURE_EVIDENCE_SCHEMA =
   "vercel-main-active-failure-evidence:v1";
+export const MAIN_ACTIVE_CENSUS_FAILURE_SCHEMA =
+  "vercel-main-active-census-failure:v1";
 export const MAIN_ACTIVE_PREPARATION_FAILURE_EVIDENCE_SCHEMA =
   "vercel-main-active-preparation-failure-evidence:v1";
 export const MAIN_ACTIVE_TERMINAL_PROOFS_SCHEMA =
@@ -275,6 +277,7 @@ const CLI_COMMAND_OPTIONS = Object.freeze({
     "output",
     "state-proof",
   ]),
+  "active-census-failure": Object.freeze(["category", "output"]),
   "active-safe-noop-evidence": Object.freeze(["output"]),
   "terminal-evidence-create": Object.freeze([
     "active-evidence",
@@ -4573,6 +4576,7 @@ export function createMainActiveDeploymentFailureEvidence({
   coordinatorOutcome,
   recoveryOutcome,
   errorCode,
+  censusFailure = null,
 }) {
   const expectedRunId = requirePositiveId(
     runId,
@@ -4698,6 +4702,10 @@ export function createMainActiveDeploymentFailureEvidence({
       "Active failure error code",
       /^[A-Z][A-Z0-9_]*$/,
     ),
+    censusFailure:
+      censusFailure === null
+        ? null
+        : canonicalMainActiveCensusFailureEvidence(censusFailure),
     outcome: "failed",
   };
 }
@@ -4805,6 +4813,11 @@ export function renderMainActiveDeploymentFailureEvidence(evidence) {
     `- Public-serving mutation commands: \`${evidence.publicServingMutationCommands}\``,
     `- Coordinator: \`${evidence.coordinatorOutcome}\`; recovery: \`${evidence.recoveryOutcome}\``,
     `- Error code: \`${evidence.errorCode}\``,
+    ...(evidence.censusFailure === null
+      ? []
+      : [
+          `- Final provider census: unproven (\`${evidence.censusFailure.category}\`); recovery mappings and public smokes remain separately verified.`,
+        ]),
     `- Canonical deployment state proof: ${
       evidence.stateProofSummary === null
         ? "unavailable"
@@ -5055,11 +5068,6 @@ export function evaluateMainActiveFinalResults({
     jobs,
     "Active final job results",
   );
-  const coordinator = requireString(
-    coordinatorOutcome,
-    "Active coordinator outcome",
-    /^[a-z][a-z0-9-]*$/,
-  );
   const recovery = requireString(
     recoveryOutcome,
     "Active recovery outcome",
@@ -5094,7 +5102,12 @@ export function evaluateMainActiveFinalResults({
   }
 
   if (
-    ["recovered", "manual-intervention", "recovery-failed"].includes(recovery)
+    [
+      "recovered",
+      "recovered-census-unproven",
+      "manual-intervention",
+      "recovery-failed",
+    ].includes(recovery)
   ) {
     if (
       canonicalJobs.coordinator === "failure" &&
@@ -5104,6 +5117,11 @@ export function evaluateMainActiveFinalResults({
     }
     return result("failure", "unexpected-active-job-graph");
   }
+  const coordinator = requireString(
+    coordinatorOutcome,
+    "Active coordinator outcome",
+    /^[a-z][a-z0-9-]*$/,
+  );
   if (coordinator === "preparation-failed-before-journal") {
     if (
       canonicalJobs.coordinator === "failure" &&
@@ -5457,7 +5475,7 @@ export function assertMainActiveTerminalProofs(value) {
   const outcome = requireString(
     value.outcome,
     "Main active terminal outcome",
-    /^(?:active-committed|current-release-verified|recovered|verified-noop|no-target|superseded-before-journal|shadow-prepared|manual-intervention|recovery-failed|preparation-failed-before-journal)$/,
+    /^(?:active-committed|current-release-verified|recovered|recovered-census-unproven|verified-noop|no-target|superseded-before-journal|shadow-prepared|manual-intervention|recovery-failed|preparation-failed-before-journal)$/,
   );
   const finalMapping = canonicalTerminalProof(
     value.finalMapping,
@@ -5947,6 +5965,7 @@ export function createMainTerminalStageResults({
 function terminalJobs(execution, outcome) {
   const recoveryOutcome = [
     "recovered",
+    "recovered-census-unproven",
     "verified-noop",
     "manual-intervention",
     "recovery-failed",
@@ -5964,7 +5983,11 @@ function terminalJobs(execution, outcome) {
       ? "success"
       : "skipped",
     coordinator: recoveryOutcome ? "failure" : "success",
-    recovery: ["manual-intervention", "recovery-failed"].includes(outcome)
+    recovery: [
+      "recovered-census-unproven",
+      "manual-intervention",
+      "recovery-failed",
+    ].includes(outcome)
       ? "failure"
       : "success",
   };
@@ -5980,6 +6003,42 @@ function terminalWorkflowRunUrl(runId) {
 
 function terminalProof({ status, artifact }) {
   return { status, artifact };
+}
+
+const MAIN_ACTIVE_CENSUS_FAILURE_CATEGORIES = new Set([
+  "active-census-unproven",
+  "provider-read-timeout",
+  "provider-read-transport",
+  "provider-read-rate-limited",
+  "provider-read-http",
+  "provider-read-malformed",
+  "state-validation-failed",
+]);
+
+export function createMainActiveCensusFailureEvidence({ category }) {
+  if (!MAIN_ACTIVE_CENSUS_FAILURE_CATEGORIES.has(category)) {
+    throw new Error("Active census failure category is unsupported");
+  }
+  return {
+    schema: MAIN_ACTIVE_CENSUS_FAILURE_SCHEMA,
+    phase: "recovery-final-active-proof",
+    category,
+  };
+}
+
+function canonicalMainActiveCensusFailureEvidence(value) {
+  assertExactKeys(
+    value,
+    ["schema", "phase", "category"],
+    "Active census failure evidence",
+  );
+  const canonical = createMainActiveCensusFailureEvidence({
+    category: value.category,
+  });
+  if (value.schema !== canonical.schema || value.phase !== canonical.phase) {
+    throw new Error("Active census failure evidence is malformed");
+  }
+  return canonical;
 }
 
 export function createMainActiveTerminalArtifacts({
@@ -6008,6 +6067,7 @@ export function createMainActiveTerminalArtifacts({
       "active-committed",
       "current-release-verified",
       "recovered",
+      "recovered-census-unproven",
       "verified-noop",
       "no-target",
       "superseded-before-journal",
@@ -6470,6 +6530,77 @@ export function createMainActiveTerminalArtifacts({
       rollbackTargets: [],
       affectedOperations: [],
       journal: terminalProof({ status: "recovery-failed", artifact: history }),
+    };
+  } else if (outcome === "recovered-census-unproven") {
+    if (freshness !== null || stateProof !== null || stageResults !== null) {
+      throw new Error(
+        "Recovered-census-unproven terminal evidence cannot contain a state proof",
+      );
+    }
+    if (
+      history.length === 0 ||
+      finalMappings === null ||
+      publicSmokes === null
+    ) {
+      throw new Error(
+        "Recovered-census-unproven terminal evidence lacks recovery proof",
+      );
+    }
+    const highest = history.at(-1);
+    assertJournalMatchesActivePlanning(highest, planning);
+    if (highest.status !== "recovered") {
+      throw new Error(
+        "Recovered-census-unproven terminal evidence requires a recovered journal",
+      );
+    }
+    const counts = operationMutationCounts(highest);
+    const mappings = canonicalFinalMappings(
+      highest,
+      canonicalTerminalProviderMappings(finalMappings),
+      { exact: false },
+    );
+    assertTerminalMappingsArePriors(mappings, releaseExecution);
+    const smokes = canonicalTerminalPriorSmokes(publicSmokes, releaseExecution);
+    const censusFailure = canonicalMainActiveCensusFailureEvidence(finalCensus);
+    const rollbackTargets = terminalRollbackTargets(highest);
+    if (rollbackTargets.length === 0) {
+      throw new Error(
+        "Recovered-census-unproven terminal evidence lacks rollback proof",
+      );
+    }
+    evidence = createMainActiveDeploymentFailureEvidence({
+      eventHeadSha: manifest.deploySha,
+      verifiedDeploySha: manifest.deploySha,
+      planOutput: "execution-bound",
+      jobs: safeJobs,
+      workflowDefinitionSha: manifest.deploySha,
+      runId: canonicalRunId,
+      runAttempt: canonicalRunAttempt,
+      workflowRunUrl: terminalWorkflowRunUrl(canonicalRunId),
+      mainOwnershipMode: planning.mainOwnershipMode,
+      journalHistory: history,
+      finalMappings: mappings,
+      publicSmokes: smokes,
+      rollbackStateTargets: rollbackTargets,
+      publicServingMutationCommands: counts.started,
+      coordinatorOutcome: "active-failed",
+      recoveryOutcome: "recovered",
+      errorCode: "RECOVERED_CENSUS_UNPROVEN",
+      censusFailure,
+    });
+    proofs = {
+      ...proofIdentity,
+      producerJob: "recover-main-deployment",
+      outcome,
+      finalMapping: terminalProof({ status: "passed", artifact: mappings }),
+      finalCensus: terminalProof({ status: "unsafe", artifact: censusFailure }),
+      stateProof: terminalProof({ status: "unsafe", artifact: censusFailure }),
+      publicSmoke: terminalProof({ status: "passed", artifact: smokes }),
+      freshLegacyV2: terminalProof({ status: "passed", artifact: legacyState }),
+      mutationCount: counts.started,
+      rollbackTargets,
+      affectedOperations: [],
+      journal: terminalProof({ status: "recovered", artifact: history }),
     };
   } else {
     if (stageResults !== null) {
@@ -7037,7 +7168,11 @@ function terminalOutcomeForActiveEvidence(evidence) {
   if (evidence.schema !== MAIN_ACTIVE_FAILURE_EVIDENCE_SCHEMA) {
     throw new Error("Nested active evidence schema is unsupported");
   }
-  if (evidence.recoveryOutcome === "recovered") return "recovered";
+  if (evidence.recoveryOutcome === "recovered") {
+    return evidence.errorCode === "RECOVERED_CENSUS_UNPROVEN"
+      ? "recovered-census-unproven"
+      : "recovered";
+  }
   if (evidence.recoveryOutcome === "recovery-failed") {
     return "recovery-failed";
   }
@@ -7467,6 +7602,7 @@ export function assertMainActiveTerminalEvidenceArtifact(
       "coordinatorOutcome",
       "recoveryOutcome",
       "errorCode",
+      "censusFailure",
       "outcome",
     ],
     "Nested active failure evidence",
@@ -7598,6 +7734,10 @@ export function assertMainActiveTerminalEvidenceArtifact(
     "Nested active failure error code",
     /^[A-Z][A-Z0-9_]*$/,
   );
+  const censusFailure =
+    value.censusFailure === null
+      ? null
+      : canonicalMainActiveCensusFailureEvidence(value.censusFailure);
   const canonical = {
     schema: MAIN_ACTIVE_FAILURE_EVIDENCE_SCHEMA,
     mode: MAIN_ACTIVE_DEPLOYMENT_MODE,
@@ -7622,6 +7762,7 @@ export function assertMainActiveTerminalEvidenceArtifact(
     coordinatorOutcome,
     recoveryOutcome,
     errorCode,
+    censusFailure,
     outcome: "failed",
   };
   assertSameJson(value, canonical, "Nested active failure evidence");
@@ -7630,12 +7771,37 @@ export function assertMainActiveTerminalEvidenceArtifact(
     throw new Error("Nested active failure outcome conflicts");
   }
   if (
+    terminalOutcome !== "recovered-census-unproven" &&
+    censusFailure !== null
+  ) {
+    throw new Error(
+      "Only recovered-census-unproven evidence may carry a census failure",
+    );
+  }
+  if (
     terminalOutcome === "recovered" &&
     (journal.historyStatus !== "valid" ||
       journal.highestStatus !== "recovered" ||
-      rollbackStateTargets.length === 0)
+      rollbackStateTargets.length === 0 ||
+      errorCode !== "RECOVERED_TO_PRIORS" ||
+      censusFailure !== null)
   ) {
     throw new Error("Recovered active evidence lacks terminal recovery proof");
+  }
+  if (
+    terminalOutcome === "recovered-census-unproven" &&
+    (journal.historyStatus !== "valid" ||
+      journal.highestStatus !== "recovered" ||
+      rollbackStateTargets.length === 0 ||
+      errorCode !== "RECOVERED_CENSUS_UNPROVEN" ||
+      censusFailure === null ||
+      finalMappings === null ||
+      publicSmokes === null ||
+      stateProofSummary !== null)
+  ) {
+    throw new Error(
+      "Recovered-census-unproven evidence lacks bounded recovery proof",
+    );
   }
   if (
     terminalOutcome === "manual-intervention" &&
@@ -8079,6 +8245,25 @@ function assertMainActiveTerminalProofBindings({
     ) {
       throw new Error(
         "Recovery-failed terminal proofs conflict with failure evidence",
+      );
+    }
+  }
+  if (proofs.outcome === "recovered-census-unproven") {
+    if (
+      evidence.schema !== MAIN_ACTIVE_FAILURE_EVIDENCE_SCHEMA ||
+      evidence.recoveryOutcome !== "recovered" ||
+      evidence.errorCode !== "RECOVERED_CENSUS_UNPROVEN" ||
+      evidence.censusFailure === null ||
+      proofs.finalMapping.receipt.status !== "passed" ||
+      proofs.finalCensus.receipt.status !== "unsafe" ||
+      proofs.stateProof.receipt.status !== "unsafe" ||
+      !sameJson(proofs.finalCensus.artifact, evidence.censusFailure) ||
+      !sameJson(proofs.stateProof.artifact, evidence.censusFailure) ||
+      proofs.publicSmoke.receipt.status !== "passed" ||
+      proofs.journal.receipt.status !== "recovered"
+    ) {
+      throw new Error(
+        "Recovered-census-unproven terminal proofs conflict with failure evidence",
       );
     }
   }
@@ -9398,6 +9583,13 @@ export async function runMainDeploymentCli({
       values.GITHUB_STEP_SUMMARY,
       renderMainActiveDeploymentFailureEvidence(evidence),
     );
+    return evidence;
+  }
+  if (command === "active-census-failure") {
+    const evidence = createMainActiveCensusFailureEvidence({
+      category: options.category,
+    });
+    writeCanonicalJson(options.output, evidence);
     return evidence;
   }
   if (command === "validate-context") {

--- a/scripts/vercel-main-deployment.test.mjs
+++ b/scripts/vercel-main-deployment.test.mjs
@@ -29,6 +29,7 @@ import {
   MAIN_ACTIVE_CURRENT_RELEASE_EVIDENCE_SCHEMA,
   MAIN_ACTIVE_EVIDENCE_SCHEMA,
   MAIN_ACTIVE_FAILURE_EVIDENCE_SCHEMA,
+  MAIN_ACTIVE_CENSUS_FAILURE_SCHEMA,
   MAIN_ACTIVE_JOURNAL_HISTORY_MAX_JSON_BYTES,
   MAIN_ACTIVE_SAFE_NOOP_EVIDENCE_SCHEMA,
   MAIN_ACTIVE_TERMINAL_PROOFS_MAX_JSON_BYTES,
@@ -4098,6 +4099,117 @@ test("execution-bound recovered terminal artifacts prove rollback to every origi
         runAttempt: "3",
       }),
     /does not restore its prior/,
+  );
+});
+
+test("recovered terminal preserves verified rollback evidence when final provider census is unproven", async () => {
+  const deploymentPlan = activePlan({ deployments: ["governance"] });
+  const execution = releaseExecutionForPlan(deploymentPlan);
+  const prepared = createPreparedMainActiveJournal({
+    plan: deploymentPlan,
+    stageJobs: stageJobs(deploymentPlan),
+    appBuildProof: null,
+    runId: "800",
+    runAttempt: "3",
+  });
+  const started = startMainTransactionOperation(prepared, {
+    type: "promote",
+    target: "governance",
+  });
+  let mappingState = "candidate";
+  const recoveredHistory = [prepared, started];
+  const recovery = await runMainActiveRecovery({
+    recoveryPlan: planMainActiveRecovery({
+      journalHistory: recoveredHistory,
+      deploySha: SHA,
+      runId: "800",
+      runAttempt: "3",
+      currentMappings: Object.values(started.prior).flatMap((prior) =>
+        prior.aliases.map((alias) =>
+          mapping(
+            alias,
+            alias === "governance.mento.org"
+              ? started.candidates.governance
+              : prior,
+          ),
+        ),
+      ),
+      appCandidateMatches: [],
+    }),
+    adapters: {
+      uploadJournal: async ({ artifactName, journal }) => {
+        recoveredHistory.push(structuredClone(journal));
+        return {
+          acknowledged: true,
+          artifactName,
+          artifactId: String(8000 + journal.sequence),
+        };
+      },
+      inspectMapping: async () => ({ mappingState }),
+      ordinaryRollback: async () => {
+        mappingState = "prior";
+        return { outcome: "success" };
+      },
+      verifyMapping: async () => ({ mappingState }),
+    },
+  });
+  const priorMappings = Object.values(recovery.journal.prior).flatMap((prior) =>
+    prior.aliases.map((alias) => mapping(alias, prior)),
+  );
+  const censusFailure = {
+    schema: MAIN_ACTIVE_CENSUS_FAILURE_SCHEMA,
+    phase: "recovery-final-active-proof",
+    category: "provider-read-transport",
+  };
+  const artifacts = createMainActiveTerminalArtifacts({
+    execution,
+    outcome: "recovered-census-unproven",
+    journalHistory: activeHistoryDocument(recoveredHistory),
+    finalMappings: providerMappings(execution, priorMappings),
+    publicSmokes: priorPublicSmokes(execution),
+    stateProof: null,
+    finalCensus: censusFailure,
+    freshLegacyV2: deploymentPlan.legacySnapshot,
+    freshness: null,
+    runId: "800",
+    runAttempt: "3",
+  });
+  assert.equal(artifacts.proofs.outcome, "recovered-census-unproven");
+  assert.equal(artifacts.proofs.finalMapping.status, "passed");
+  assert.equal(artifacts.proofs.publicSmoke.status, "passed");
+  assert.equal(artifacts.proofs.finalCensus.status, "unsafe");
+  assert.deepEqual(artifacts.proofs.finalCensus.artifact, censusFailure);
+  assert.equal(artifacts.proofs.journal.status, "recovered");
+  assert.equal(artifacts.evidence.errorCode, "RECOVERED_CENSUS_UNPROVEN");
+  assert.deepEqual(artifacts.evidence.censusFailure, censusFailure);
+  assert.equal(
+    evaluateMainActiveFinalResults({
+      execution,
+      jobs: finalActiveJobs(deploymentPlan, {
+        coordinator: "failure",
+        recovery: "failure",
+      }),
+      coordinatorOutcome: "",
+      recoveryOutcome: "recovered-census-unproven",
+    }).failAfterEvidence,
+    true,
+  );
+  assert.throws(
+    () =>
+      createMainActiveTerminalArtifacts({
+        execution,
+        outcome: "recovered-census-unproven",
+        journalHistory: activeHistoryDocument(recoveredHistory),
+        finalMappings: providerMappings(execution, priorMappings),
+        publicSmokes: priorPublicSmokes(execution),
+        stateProof: null,
+        finalCensus: { ...censusFailure, category: "unbounded-provider-error" },
+        freshLegacyV2: deploymentPlan.legacySnapshot,
+        freshness: null,
+        runId: "800",
+        runAttempt: "3",
+      }),
+    /category is unsupported/,
   );
 });
 

--- a/scripts/vercel-main-terminal-receipt.mjs
+++ b/scripts/vercel-main-terminal-receipt.mjs
@@ -126,6 +126,12 @@ export const MAIN_TERMINAL_RECEIPT_OUTCOMES = Object.freeze({
     minMutations: 1,
     rollback: "required",
   }),
+  "recovered-census-unproven": Object.freeze({
+    proofs: ["passed", "unsafe", "unsafe", "passed", "passed"],
+    journal: "recovered",
+    minMutations: 1,
+    rollback: "required",
+  }),
   "verified-noop": Object.freeze({
     proofs: ["passed", "passed", "passed", "passed", "passed"],
     journal: "not-applicable",
@@ -520,11 +526,13 @@ function assertOutcomeContract(receipt) {
     throw new Error("Main terminal receipt journal conflicts with outcome");
   }
   if (
-    receipt.outcome === "recovery-failed" &&
+    ["recovery-failed", "recovered-census-unproven"].includes(
+      receipt.outcome,
+    ) &&
     receipt.producerJob !== "recover-main-deployment"
   ) {
     throw new Error(
-      "Recovery-failed terminal receipt requires the recovery producer job",
+      `${receipt.outcome} terminal receipt requires the recovery producer job`,
     );
   }
   if (
@@ -637,7 +645,7 @@ function canonicalReceipt(value, { checkDigest = true } = {}) {
     outcome: requireString(
       value.outcome,
       "Main terminal receipt outcome",
-      /^(?:active-committed|recovered|verified-noop|current-release-verified|no-target|superseded-before-journal|shadow-prepared|manual-intervention|recovery-failed|preparation-failed-before-journal)$/,
+      /^(?:active-committed|recovered|recovered-census-unproven|verified-noop|current-release-verified|no-target|superseded-before-journal|shadow-prepared|manual-intervention|recovery-failed|preparation-failed-before-journal)$/,
     ),
     finalMapping: canonicalProof(
       value.finalMapping,
@@ -812,17 +820,17 @@ function canonicalEvidence(value) {
   const outcome = requireString(
     value.outcome,
     "Main terminal evidence outcome",
-    /^(?:active-committed|recovered|verified-noop|current-release-verified|no-target|superseded-before-journal|shadow-prepared|manual-intervention|recovery-failed|preparation-failed-before-journal)$/,
+    /^(?:active-committed|recovered|recovered-census-unproven|verified-noop|current-release-verified|no-target|superseded-before-journal|shadow-prepared|manual-intervention|recovery-failed|preparation-failed-before-journal)$/,
   );
   if (!MAIN_TERMINAL_RECEIPT_OUTCOMES[outcome]) {
     throw new Error("Main terminal evidence outcome is unsupported");
   }
   if (
-    outcome === "recovery-failed" &&
+    ["recovery-failed", "recovered-census-unproven"].includes(outcome) &&
     identity.producerJob !== "recover-main-deployment"
   ) {
     throw new Error(
-      "Recovery-failed terminal evidence requires the recovery producer job",
+      `${outcome} terminal evidence requires the recovery producer job`,
     );
   }
   if (

--- a/scripts/vercel-main-terminal-receipt.test.mjs
+++ b/scripts/vercel-main-terminal-receipt.test.mjs
@@ -58,10 +58,11 @@ function receiptInput(outcome = "active-committed") {
   return {
     ...IDENTITY,
     producerRunAttempt: "2",
-    producerJob:
-      outcome === "recovery-failed"
-        ? "recover-main-deployment"
-        : "activate-and-verify",
+    producerJob: ["recovery-failed", "recovered-census-unproven"].includes(
+      outcome,
+    )
+      ? "recover-main-deployment"
+      : "activate-and-verify",
     evidenceDigest: DIGEST(`terminal-evidence:${outcome}`),
     outcome,
     finalMapping: proof(mapping, "mapping"),
@@ -191,6 +192,78 @@ test("recovery failure has a recovery-only, dynamic, tamper-evident terminal han
         affectedOperations: [affectedOperation()],
       }),
     /forbids affected operations/,
+  );
+});
+
+test("recovered unproven census has a recovery-only durable terminal handoff", () => {
+  const outcome = "recovered-census-unproven";
+  const evidence = createMainTerminalEvidence({
+    ...IDENTITY,
+    producerRunAttempt: "2",
+    producerJob: "recover-main-deployment",
+    outcome,
+    affectedOperations: [],
+    artifact: {
+      censusFailure: "provider-read-transport",
+      finalMapping: "prior",
+      publicSmoke: "passed",
+    },
+  });
+  const receipt = createMainTerminalReceipt({
+    ...receiptInput(outcome),
+    evidenceDigest: digestMainTerminalEvidence(evidence),
+  });
+
+  assert.deepEqual(
+    [
+      receipt.finalMapping.status,
+      receipt.finalCensus.status,
+      receipt.stateProof.status,
+      receipt.publicSmoke.status,
+      receipt.freshLegacyV2.status,
+    ],
+    ["passed", "unsafe", "unsafe", "passed", "passed"],
+  );
+  assert.equal(receipt.journal.status, "recovered");
+  assert.deepEqual(receipt.rollbackTargets, ["governance"]);
+  assert.deepEqual(
+    decodeMainTerminalReceipt(encodeMainTerminalReceipt(receipt), IDENTITY),
+    receipt,
+  );
+  assert.deepEqual(
+    decodeMainTerminalEvidence(encodeMainTerminalEvidence(evidence), {
+      receipt,
+    }),
+    evidence,
+  );
+
+  assert.throws(
+    () =>
+      createMainTerminalReceipt({
+        ...receiptInput(outcome),
+        producerJob: "activate-and-verify",
+      }),
+    /requires the recovery producer job/,
+  );
+  assert.throws(
+    () =>
+      createMainTerminalEvidence({
+        ...IDENTITY,
+        producerRunAttempt: "2",
+        producerJob: "activate-and-verify",
+        outcome,
+        affectedOperations: [],
+        artifact: { censusFailure: "provider-read-transport" },
+      }),
+    /requires the recovery producer job/,
+  );
+  assert.throws(
+    () =>
+      createMainTerminalReceipt({
+        ...receiptInput(outcome),
+        finalCensus: proof("passed", "census"),
+      }),
+    /proof statuses conflict/,
   );
 });
 


### PR DESCRIPTION
## The Problem

A provider census failure after a successful main-release rollback only reported a generic command failure. That left the recovered journal, restored mappings, and verified public smokes unavailable in terminal evidence, and the final result could fail before recording the recovery state.

## The Solution

Classify active-provider census failures with a fixed non-secret category. When recovery has independently verified the journal, protected mappings, and all restored-prior runtime smokes, publish that evidence as `recovered-census-unproven` and fail the recovery and final jobs explicitly. The path cannot claim a proven census or authorize a release.

## Validation

- `pnpm vercel:workflow:test` (585 passing)
- `pnpm ci:action-pins`
- `pnpm adr:check`
- `git diff --check`
- local deterministic autoreview clean; a fresh-context reviewer slot was unavailable because the active team thread limit was reached.

## Risk

The new outcome remains fail-closed. It exposes only an allowlisted category, not provider output, tokens, or other raw error data.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches production main-deployment recovery terminalization and provider census handling; behavior stays fail-closed but adds a new outcome path operators must interpret correctly.
> 
> **Overview**
> When main-release **recovery** has already verified the journal, protected alias mappings, and restored-prior runtime smokes, a failed final duplicate **provider census** no longer collapses into a generic CLI failure that drops that proof.
> 
> **`vercel-deployment-state.mjs`** now emits a single stderr line with a fixed, allowlisted `category=` (unproven census, provider read errors, or validation failure) instead of a generic message. The recovery workflow catches those categories, writes bounded census-failure JSON via **`active-census-failure`**, and sets `census_outcome` to **proven** or **unproven** without `continue-on-error` swallowing the step.
> 
> For **`recovered`** journals with **unproven** census, terminal artifacts use outcome **`recovered-census-unproven`**: verified mappings and public smokes stay in evidence; census/state proofs are marked unsafe with only the category (no raw provider output). **`manual-intervention`** still requires a proven census. The release and recovery jobs **fail after** publishing that evidence—same fail-closed posture, with auditable rollback facts preserved.
> 
> Docs (ADR and **`vercel-deployments.md`**) and tests cover the new outcome and CLI failure shapes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 727383a08c1c388115cb723339ee1ff539bf7ed1. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->