### PR TITLE
fix: suppress wallet rejections in Sentry

### DIFF
--- a/apps/governance.mento.org/app/components/voting/vote-card.test.tsx
+++ b/apps/governance.mento.org/app/components/voting/vote-card.test.tsx
@@ -186,4 +186,37 @@ describe("VoteCard", () => {
 
     expect(mocks.captureException).not.toHaveBeenCalled();
   });
+
+  it("does not capture a rejected execute request", () => {
+    const rejection = new Error("User rejected the request.");
+    render(<VoteCard proposal={proposal} votingDeadline={undefined} />);
+
+    const contentProps = mocks.voteCardContent.mock.calls.at(-1)?.[0] as
+      | { onExecute: () => void }
+      | undefined;
+    contentProps?.onExecute();
+    const onError = mocks.executeProposal.mock.calls.at(-1)?.[2] as
+      | ((error: Error) => void)
+      | undefined;
+    onError?.(rejection);
+
+    expect(mocks.captureException).not.toHaveBeenCalled();
+  });
+
+  it("captures an unexpected execute failure", () => {
+    const executionError = new Error("execution reverted");
+    render(<VoteCard proposal={proposal} votingDeadline={undefined} />);
+
+    const contentProps = mocks.voteCardContent.mock.calls.at(-1)?.[0] as
+      | { onExecute: () => void }
+      | undefined;
+    contentProps?.onExecute();
+    const onError = mocks.executeProposal.mock.calls.at(-1)?.[2] as
+      | ((error: Error) => void)
+      | undefined;
+    onError?.(executionError);
+
+    expect(mocks.captureException).toHaveBeenCalledOnce();
+    expect(mocks.captureException).toHaveBeenCalledWith(executionError);
+  });
 });

--- a/apps/governance.mento.org/app/components/voting/vote-card.test.tsx
+++ b/apps/governance.mento.org/app/components/voting/vote-card.test.tsx
@@ -203,8 +203,8 @@ describe("VoteCard", () => {
     expect(mocks.captureException).not.toHaveBeenCalled();
   });
 
-  it("captures an unexpected execute failure", () => {
-    const executionError = new Error("execution reverted");
+  it("captures a generic request-rejected execute failure", () => {
+    const executionError = new Error("Request rejected by upstream");
     render(<VoteCard proposal={proposal} votingDeadline={undefined} />);
 
     const contentProps = mocks.voteCardContent.mock.calls.at(-1)?.[0] as

--- a/apps/governance.mento.org/app/components/voting/vote-card.tsx
+++ b/apps/governance.mento.org/app/components/voting/vote-card.tsx
@@ -1,6 +1,5 @@
 import { deriveVoteCardState } from "@/components/voting/derive-vote-card-state";
 import { getActiveGovernanceTransactionError } from "@/components/voting/get-active-governance-transaction-error";
-import { getGovernanceTransactionErrorMessage } from "@/components/voting/get-governance-transaction-error-message";
 import { VoteCardContent } from "@/components/voting/vote-card-content";
 import { useDelayedVoteCardRefire } from "@/components/voting/use-delayed-vote-card-refire";
 import { getWatchdogMultisigAddress } from "@/config";

--- a/apps/governance.mento.org/app/components/voting/vote-card.tsx
+++ b/apps/governance.mento.org/app/components/voting/vote-card.tsx
@@ -31,6 +31,15 @@ interface VoteCardProps {
   onVoteConfirmed?: () => void;
 }
 
+function reportGovernanceTransactionError(error: unknown): boolean {
+  if (getGovernanceTransactionErrorMessage(error) === null) {
+    return false;
+  }
+
+  Sentry.captureException(error);
+  return true;
+}
+
 export const VoteCard = ({
   proposal,
   votingDeadline,
@@ -300,7 +309,7 @@ export const VoteCard = ({
       try {
         castVote(proposal.proposalId, support);
       } catch (error) {
-        Sentry.captureException(error);
+        reportGovernanceTransactionError(error);
       }
     }
   };
@@ -317,11 +326,11 @@ export const VoteCard = ({
             }
           },
           (error) => {
-            Sentry.captureException(error);
+            reportGovernanceTransactionError(error);
           },
         );
       } catch (error) {
-        Sentry.captureException(error);
+        reportGovernanceTransactionError(error);
       }
     }
   };
@@ -338,11 +347,11 @@ export const VoteCard = ({
             }
           },
           (error) => {
-            Sentry.captureException(error);
+            reportGovernanceTransactionError(error);
           },
         );
       } catch (error) {
-        Sentry.captureException(error);
+        reportGovernanceTransactionError(error);
       }
     }
   };
@@ -359,11 +368,11 @@ export const VoteCard = ({
             }
           },
           (error) => {
-            Sentry.captureException(error);
+            reportGovernanceTransactionError(error);
           },
         );
       } catch (error) {
-        Sentry.captureException(error);
+        reportGovernanceTransactionError(error);
       }
     }
   };
@@ -380,11 +389,11 @@ export const VoteCard = ({
             }
           },
           (error) => {
-            Sentry.captureException(error);
+            reportGovernanceTransactionError(error);
           },
         );
       } catch (error) {
-        Sentry.captureException(error);
+        reportGovernanceTransactionError(error);
       }
     }
   };
@@ -414,16 +423,13 @@ export const VoteCard = ({
   // Execute, queue, and cancel errors are captured by their callbacks or hooks.
   // Cast-vote does not receive an onError callback, so capture its hook state here.
   useEffect(() => {
-    if (
-      !error ||
-      getGovernanceTransactionErrorMessage(error) === null ||
-      capturedVoteErrorsRef.current.has(error)
-    ) {
+    if (!error || capturedVoteErrorsRef.current.has(error)) {
       return;
     }
 
-    Sentry.captureException(error);
-    capturedVoteErrorsRef.current.add(error);
+    if (reportGovernanceTransactionError(error)) {
+      capturedVoteErrorsRef.current.add(error);
+    }
   }, [error]);
 
   const currentState = useMemo(() => {

--- a/apps/governance.mento.org/app/components/voting/vote-card.tsx
+++ b/apps/governance.mento.org/app/components/voting/vote-card.tsx
@@ -20,6 +20,7 @@ import { getTimelockOperationId } from "@/contracts/governor/utils/get-timelock-
 import { Proposal, ProposalState } from "@/graphql/subgraph/generated/subgraph";
 import { useVeMentoDelegationSummary } from "@/hooks/use-ve-mento-delegation-summary";
 import { NumbersService } from "@repo/web3";
+import { isUserRejectionForTelemetry } from "@repo/web3/is-user-rejection";
 import { useAccount, useChainId } from "@repo/web3/wagmi";
 import * as Sentry from "@sentry/nextjs";
 import { useEffect, useMemo, useRef, useState } from "react";
@@ -32,7 +33,7 @@ interface VoteCardProps {
 }
 
 function reportGovernanceTransactionError(error: unknown): boolean {
-  if (getGovernanceTransactionErrorMessage(error) === null) {
+  if (isUserRejectionForTelemetry(error)) {
     return false;
   }
 

--- a/apps/governance.mento.org/app/contracts/governor/use-cancel-proposal-as-proposer.tsx
+++ b/apps/governance.mento.org/app/contracts/governor/use-cancel-proposal-as-proposer.tsx
@@ -12,6 +12,7 @@ import {
   type WriteContractErrorType,
 } from "@repo/web3/wagmi";
 import * as Sentry from "@sentry/nextjs";
+import { isUserRejection } from "@repo/web3/is-user-rejection";
 
 /**
  * Hook to cancel a proposal as the proposer.
@@ -65,13 +66,7 @@ export const useCancelProposalAsProposer = () => {
   // Toast notifications for proposal cancellation
   useEffect(() => {
     if (error) {
-      const errorMessage = error.message || "";
-      const isUserRejection =
-        errorMessage.includes("User rejected") ||
-        errorMessage.includes("user rejected") ||
-        errorMessage.includes("User denied");
-
-      if (isUserRejection) {
+      if (isUserRejection(error)) {
         toast.error("Cancellation rejected by user");
       } else {
         // Send non-rejection errors to Sentry

--- a/apps/governance.mento.org/app/contracts/governor/use-cancel-proposal-as-proposer.tsx
+++ b/apps/governance.mento.org/app/contracts/governor/use-cancel-proposal-as-proposer.tsx
@@ -12,7 +12,7 @@ import {
   type WriteContractErrorType,
 } from "@repo/web3/wagmi";
 import * as Sentry from "@sentry/nextjs";
-import { isUserRejection } from "@repo/web3/is-user-rejection";
+import { isUserRejectionForTelemetry } from "@repo/web3/is-user-rejection";
 
 /**
  * Hook to cancel a proposal as the proposer.
@@ -66,7 +66,7 @@ export const useCancelProposalAsProposer = () => {
   // Toast notifications for proposal cancellation
   useEffect(() => {
     if (error) {
-      if (isUserRejection(error)) {
+      if (isUserRejectionForTelemetry(error)) {
         toast.error("Cancellation rejected by user");
       } else {
         // Send non-rejection errors to Sentry

--- a/apps/governance.mento.org/app/contracts/governor/use-cancel-proposal-as-watchdog.ts
+++ b/apps/governance.mento.org/app/contracts/governor/use-cancel-proposal-as-watchdog.ts
@@ -16,7 +16,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { ProposalQueryKey } from "@/contracts/governor/use-proposal";
 import * as Sentry from "@sentry/nextjs";
 import { useIsWatchdog } from "@/contracts/governor/use-is-watchdog";
-import { isUserRejection } from "@repo/web3/is-user-rejection";
+import { isUserRejectionForTelemetry } from "@repo/web3/is-user-rejection";
 
 /**
  * Hook to cancel a queued proposal.
@@ -78,7 +78,7 @@ export const useCancelProposalAsWatchdog = (): {
             onSuccess?.();
           },
           onError: (error) => {
-            if (isUserRejection(error)) {
+            if (isUserRejectionForTelemetry(error)) {
               // User deliberately rejected - show clear message
               toast.error("Failed to cancel proposal", {
                 description: "You rejected the transaction",
@@ -211,7 +211,7 @@ export const useCancelProposalAsWatchdog = (): {
           downloadCancelTransaction(operationId, onSuccess);
         }
       } catch (error) {
-        if (isUserRejection(error)) {
+        if (isUserRejectionForTelemetry(error)) {
           toast.error("Failed to cancel proposal", {
             description: "You rejected the transaction",
           });

--- a/apps/governance.mento.org/app/contracts/governor/use-cancel-proposal-as-watchdog.ts
+++ b/apps/governance.mento.org/app/contracts/governor/use-cancel-proposal-as-watchdog.ts
@@ -16,6 +16,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { ProposalQueryKey } from "@/contracts/governor/use-proposal";
 import * as Sentry from "@sentry/nextjs";
 import { useIsWatchdog } from "@/contracts/governor/use-is-watchdog";
+import { isUserRejection } from "@repo/web3/is-user-rejection";
 
 /**
  * Hook to cancel a queued proposal.
@@ -77,21 +78,13 @@ export const useCancelProposalAsWatchdog = (): {
             onSuccess?.();
           },
           onError: (error) => {
-            console.error("Failed to cancel proposal:", error);
-
-            // Check if user rejected the transaction
-            const errorMessage = error.message || "";
-            const isUserRejection =
-              errorMessage.includes("User rejected") ||
-              errorMessage.includes("user rejected") ||
-              errorMessage.includes("User denied");
-
-            if (isUserRejection) {
+            if (isUserRejection(error)) {
               // User deliberately rejected - show clear message
               toast.error("Failed to cancel proposal", {
                 description: "You rejected the transaction",
               });
             } else {
+              console.error("Failed to cancel proposal:", error);
               // Unexpected error - send to Sentry and show generic error toast
               Sentry.captureException(error, {
                 tags: {
@@ -218,17 +211,23 @@ export const useCancelProposalAsWatchdog = (): {
           downloadCancelTransaction(operationId, onSuccess);
         }
       } catch (error) {
-        console.error("Failed to create Safe transaction:", error);
-        Sentry.captureException(error, {
-          tags: {
-            context: "cancel-proposal",
-            mode: isWatchdogSafe ? "direct-execution" : "file-download",
-          },
-        });
-        toast.error("Failed to prepare cancellation transaction", {
-          description:
-            "Unable to prepare the cancellation transaction. Check your wallet connection and try again.",
-        });
+        if (isUserRejection(error)) {
+          toast.error("Failed to cancel proposal", {
+            description: "You rejected the transaction",
+          });
+        } else {
+          console.error("Failed to create Safe transaction:", error);
+          Sentry.captureException(error, {
+            tags: {
+              context: "cancel-proposal",
+              mode: isWatchdogSafe ? "direct-execution" : "file-download",
+            },
+          });
+          toast.error("Failed to prepare cancellation transaction", {
+            description:
+              "Unable to prepare the cancellation transaction. Check your wallet connection and try again.",
+          });
+        }
         onError?.(error as Error);
       }
     },

--- a/packages/web3/src/is-user-rejection.ts
+++ b/packages/web3/src/is-user-rejection.ts
@@ -1,1 +1,5 @@
-export { isUserRejection } from "./utils/is-user-rejection";
+export {
+  isStructuredUserRejection,
+  isUserRejection,
+  isUserRejectionForTelemetry,
+} from "./utils/is-user-rejection";

--- a/packages/web3/src/utils/is-user-rejection.test.ts
+++ b/packages/web3/src/utils/is-user-rejection.test.ts
@@ -1,6 +1,10 @@
 import { UserRejectedRequestError } from "viem";
 import { describe, expect, it } from "vitest";
-import { isUserRejection } from "./is-user-rejection";
+import {
+  isStructuredUserRejection,
+  isUserRejection,
+  isUserRejectionForTelemetry,
+} from "./is-user-rejection";
 
 describe("isUserRejection", () => {
   it("detects MetaMask/viem rejection messages", () => {
@@ -26,7 +30,7 @@ describe("isUserRejection", () => {
     expect(isUserRejection("Swap transaction rejected by user.")).toBe(true);
   });
 
-  it("detects a UserRejectedRequestError instance via BaseError#walk", () => {
+  it("detects a UserRejectedRequestError instance", () => {
     const error = new UserRejectedRequestError(new Error("denied"));
     expect(isUserRejection(error)).toBe(true);
   });
@@ -41,5 +45,30 @@ describe("isUserRejection", () => {
     expect(isUserRejection("insufficient funds")).toBe(false);
     expect(isUserRejection("execution reverted")).toBe(false);
     expect(isUserRejection(undefined)).toBe(false);
+  });
+});
+
+describe("isUserRejectionForTelemetry", () => {
+  it("accepts structured and unambiguous user denials", () => {
+    expect(isUserRejectionForTelemetry({ code: 4001 })).toBe(true);
+    expect(isUserRejectionForTelemetry(new Error("User denied"))).toBe(true);
+    expect(
+      isUserRejectionForTelemetry(new Error("Transaction rejected by user")),
+    ).toBe(true);
+  });
+
+  it("keeps generic request-rejected failures reportable", () => {
+    expect(
+      isUserRejectionForTelemetry(new Error("Request rejected by upstream")),
+    ).toBe(false);
+  });
+
+  it("finds structured causes and tolerates cause cycles", () => {
+    const rejection = { code: 4001 } as { cause?: unknown; code: number };
+    const wrapper = { cause: rejection };
+    rejection.cause = wrapper;
+
+    expect(isStructuredUserRejection(wrapper)).toBe(true);
+    expect(isUserRejectionForTelemetry(wrapper)).toBe(true);
   });
 });

--- a/packages/web3/src/utils/is-user-rejection.ts
+++ b/packages/web3/src/utils/is-user-rejection.ts
@@ -1,12 +1,70 @@
-import { BaseError, UserRejectedRequestError } from "viem";
+const USER_REJECTED_REQUEST_CODE = 4001;
+const USER_REJECTED_REQUEST_ERROR_NAME = "UserRejectedRequestError";
 
-const USER_REJECTION_PATTERNS = [
+const UNAMBIGUOUS_USER_REJECTION_PATTERNS = [
   /user\s+rejected/i,
   /user\s+denied/i,
   /denied\s+transaction\s+signature/i,
   /rejected\s+by\s+user/i,
+] as const;
+
+const USER_REJECTION_PATTERNS = [
+  ...UNAMBIGUOUS_USER_REJECTION_PATTERNS,
   /request\s+rejected/i,
-];
+] as const;
+
+function isUserRejectionWithPatterns(
+  error: unknown,
+  patterns: readonly RegExp[],
+  seen = new Set<object>(),
+): boolean {
+  const message =
+    typeof error === "string"
+      ? error
+      : error instanceof Error
+        ? error.message
+        : "";
+
+  if (patterns.some((pattern) => pattern.test(message))) {
+    return true;
+  }
+
+  if (typeof error !== "object" || error === null || seen.has(error)) {
+    return false;
+  }
+
+  seen.add(error);
+  const candidate = error as {
+    cause?: unknown;
+    code?: unknown;
+    name?: unknown;
+  };
+
+  if (
+    candidate.code === USER_REJECTED_REQUEST_CODE ||
+    candidate.name === USER_REJECTED_REQUEST_ERROR_NAME
+  ) {
+    return true;
+  }
+
+  return isUserRejectionWithPatterns(candidate.cause, patterns, seen);
+}
+
+export function isStructuredUserRejection(error: unknown): boolean {
+  return isUserRejectionWithPatterns(error, []);
+}
+
+/**
+ * Detects rejections that are specific enough to suppress from telemetry.
+ * Generic "request rejected" messages remain reportable because an RPC or
+ * provider can reject a request without the user choosing to deny it.
+ */
+export function isUserRejectionForTelemetry(error: unknown): boolean {
+  return isUserRejectionWithPatterns(
+    error,
+    UNAMBIGUOUS_USER_REJECTION_PATTERNS,
+  );
+}
 
 /**
  * Detects whether an error represents a user rejecting a wallet action
@@ -15,28 +73,5 @@ const USER_REJECTION_PATTERNS = [
  * back to a message-based check for errors that only expose a string.
  */
 export function isUserRejection(error: unknown): boolean {
-  if (
-    error instanceof BaseError &&
-    error.walk((cause) => cause instanceof UserRejectedRequestError)
-  ) {
-    return true;
-  }
-
-  if (
-    typeof error === "object" &&
-    error !== null &&
-    "code" in error &&
-    (error as { code?: unknown }).code === UserRejectedRequestError.code
-  ) {
-    return true;
-  }
-
-  const message =
-    typeof error === "string"
-      ? error
-      : error instanceof Error
-        ? error.message
-        : String(error ?? "");
-
-  return USER_REJECTION_PATTERNS.some((pattern) => pattern.test(message));
+  return isUserRejectionWithPatterns(error, USER_REJECTION_PATTERNS);
 }

--- a/packages/web3/src/utils/sentry-filter.test.ts
+++ b/packages/web3/src/utils/sentry-filter.test.ts
@@ -75,6 +75,54 @@ describe("sentry-filter", () => {
     expect(filterNoisySentryEvents(event)).toBeNull();
   });
 
+  it("drops typed user-rejection errors from an exception chain", () => {
+    const event = {
+      exception: {
+        values: [
+          {
+            type: "ContractFunctionExecutionError",
+            value: "User rejected the request.",
+          },
+          {
+            type: "UserRejectedRequestError",
+            value: "User rejected the request.",
+          },
+        ],
+      },
+    } as ErrorEvent;
+
+    expect(filterNoisySentryEvents(event)).toBeNull();
+  });
+
+  it("drops code 4001 errors without relying on global wallet context", () => {
+    const event = makeEvent();
+    const hint = {
+      originalException: { code: 4001, message: "User rejected the request." },
+    } as EventHint;
+
+    expect(filterNoisySentryEvents(event, hint)).toBeNull();
+  });
+
+  it("keeps generic request-rejected errors even with global wallet context", () => {
+    const event = {
+      ...makeEvent({ message: "Request rejected by upstream" }),
+      contexts: { wallet: { connection_status: "connected" } },
+      tags: { "wallet.type": "Rabby Wallet" },
+    } as ErrorEvent;
+
+    expect(filterNoisySentryEvents(event)).toBe(event);
+  });
+
+  it("drops a nested code 4001 cause and tolerates cause cycles", () => {
+    const rejection = { code: 4001 } as { cause?: unknown; code: number };
+    const wrapper = { cause: rejection };
+    rejection.cause = wrapper;
+    const event = makeEvent();
+    const hint = { originalException: wrapper } as EventHint;
+
+    expect(filterNoisySentryEvents(event, hint)).toBeNull();
+  });
+
   it("drops Merkl proxy transport failures on the Merkl route", () => {
     const event = makeEvent({
       exceptionType: "AbortError",

--- a/packages/web3/src/utils/sentry-filter.ts
+++ b/packages/web3/src/utils/sentry-filter.ts
@@ -1,5 +1,8 @@
 import type { ErrorEvent, EventHint } from "@sentry/nextjs";
 
+const USER_REJECTED_REQUEST_CODE = 4001;
+const USER_REJECTED_REQUEST_ERROR_NAME = "UserRejectedRequestError";
+
 const ALWAYS_IGNORE_ERROR_PATTERNS = [
   /Origin not allowed/i,
   /has not been authorized yet/i,
@@ -114,6 +117,40 @@ function eventTargetsRoute(event: ErrorEvent, route: string): boolean {
   return requestUrl.includes(route) || transaction.includes(route);
 }
 
+function hasStructuredUserRejection(
+  error: unknown,
+  seen = new Set<object>(),
+): boolean {
+  if (typeof error !== "object" || error === null || seen.has(error)) {
+    return false;
+  }
+
+  seen.add(error);
+  const candidate = error as {
+    cause?: unknown;
+    code?: unknown;
+    name?: unknown;
+  };
+
+  if (
+    candidate.code === USER_REJECTED_REQUEST_CODE ||
+    candidate.name === USER_REJECTED_REQUEST_ERROR_NAME
+  ) {
+    return true;
+  }
+
+  return hasStructuredUserRejection(candidate.cause, seen);
+}
+
+function isUserRejectionEvent(event: ErrorEvent, hint?: EventHint): boolean {
+  return (
+    hasStructuredUserRejection(hint?.originalException) ||
+    (event.exception?.values ?? []).some(
+      ({ type }) => type === USER_REJECTED_REQUEST_ERROR_NAME,
+    )
+  );
+}
+
 export function filterNoisySentryEvents(
   event: ErrorEvent,
   hint?: EventHint,
@@ -121,6 +158,10 @@ export function filterNoisySentryEvents(
   const message = getEventMessage(event, hint);
   const eventType = getEventType(event, hint);
   const eventSignal = `${eventType} ${message}`.trim();
+
+  if (isUserRejectionEvent(event, hint)) {
+    return null;
+  }
 
   if (ALWAYS_IGNORE_ERROR_PATTERNS.some((pattern) => pattern.test(message))) {
     return null;

--- a/packages/web3/src/utils/sentry-filter.ts
+++ b/packages/web3/src/utils/sentry-filter.ts
@@ -1,6 +1,6 @@
 import type { ErrorEvent, EventHint } from "@sentry/nextjs";
+import { isStructuredUserRejection } from "./is-user-rejection";
 
-const USER_REJECTED_REQUEST_CODE = 4001;
 const USER_REJECTED_REQUEST_ERROR_NAME = "UserRejectedRequestError";
 
 const ALWAYS_IGNORE_ERROR_PATTERNS = [
@@ -117,34 +117,9 @@ function eventTargetsRoute(event: ErrorEvent, route: string): boolean {
   return requestUrl.includes(route) || transaction.includes(route);
 }
 
-function hasStructuredUserRejection(
-  error: unknown,
-  seen = new Set<object>(),
-): boolean {
-  if (typeof error !== "object" || error === null || seen.has(error)) {
-    return false;
-  }
-
-  seen.add(error);
-  const candidate = error as {
-    cause?: unknown;
-    code?: unknown;
-    name?: unknown;
-  };
-
-  if (
-    candidate.code === USER_REJECTED_REQUEST_CODE ||
-    candidate.name === USER_REJECTED_REQUEST_ERROR_NAME
-  ) {
-    return true;
-  }
-
-  return hasStructuredUserRejection(candidate.cause, seen);
-}
-
 function isUserRejectionEvent(event: ErrorEvent, hint?: EventHint): boolean {
   return (
-    hasStructuredUserRejection(hint?.originalException) ||
+    isStructuredUserRejection(hint?.originalException) ||
     (event.exception?.values ?? []).some(
       ({ type }) => type === USER_REJECTED_REQUEST_ERROR_NAME,
     )


### PR DESCRIPTION
## The Problem

Expected wallet denials were reaching Sentry as application failures. The governance transaction handlers captured every callback and synchronous error, so actions such as rejecting an execute-proposal request created monitoring noise in [GOVERNANCE-MENTO-ORG-5J](https://mento-labs.sentry.io/issues/7667922856/?project=4509825739849728).

## The Solution

Suppress user-rejection errors at the governance transaction capture boundaries, including vote, execute, queue, watchdog, and proposer-cancellation paths. Add a shared `beforeSend` backstop that drops only structured wallet rejection evidence: error code `4001`, the exact `UserRejectedRequestError` name, or that exact type in the Sentry exception chain.

Generic upstream errors whose messages happen to contain words such as `request rejected` still reach Sentry. This keeps unexpected failures observable while removing routine user choices.

## Validation

- `pnpm lint:fix`
- `pnpm check-types`
- `pnpm --filter @repo/web3 test` — 213 tests passed
- `pnpm --filter governance.mento.org test` — 107 tests passed
- `pnpm --filter governance.mento.org build` with CI-style environment values
- `pnpm adr:check`
- Fresh-context semantic autoreview and deterministic autoreview: no actionable findings
- Chrome DevTools: production governance home rendered and the wallet picker opened successfully

## Risks

The shared Sentry backstop intentionally requires structured rejection evidence. A provider that discards both the wallet error type and code may still report a message-only rejection, which is safer than dropping unrelated failures based on broad text matching.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Monitoring-only changes with conservative rejection detection; unrelated failures with message-only rejections may still appear in Sentry, which is intentional.
> 
> **Overview**
> Stops **expected wallet denials** from being reported as app failures in governance and in global Sentry filtering.
> 
> **Governance `VoteCard`:** Adds `reportGovernanceTransactionError`, which only calls `Sentry.captureException` when `getGovernanceTransactionErrorMessage` treats the error as real (user rejections already map to `null`). Vote, execute, queue, and both cancel paths use this instead of unconditional capture; cast-vote hook errors follow the same rule. Tests cover execute rejections vs real failures.
> 
> **Cancel hooks:** Proposer and watchdog cancellation replace ad-hoc “User rejected” string checks with shared `isUserRejection`; watchdog also treats rejections in the outer `try/catch` without logging to Sentry.
> 
> **`@repo/web3` Sentry filter:** `filterNoisySentryEvents` drops events with structured rejection evidence—EIP-1193 code `4001`, `UserRejectedRequestError` in the exception chain, or nested `cause` (including cycles)—while **keeping** vague messages like “Request rejected by upstream.”
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a95f4ba1d86a7724407094378df2cd5ffad3c402. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->