### PR TITLE
fix(vercel): bind preview captures to candidate runs

### DIFF
--- a/scripts/vercel-cost-observation.mjs
+++ b/scripts/vercel-cost-observation.mjs
@@ -1224,6 +1224,21 @@ function latestSentinelStatus(statuses) {
   );
 }
 
+function canonicalHttpsTargetUrl(value, label) {
+  invariant(typeof value === "string", `${label} must be an HTTPS URL`);
+  let parsed;
+  try {
+    parsed = new URL(value);
+  } catch {
+    throw new Error(`${label} must be an HTTPS URL`);
+  }
+  invariant(
+    parsed.protocol === "https:" && !parsed.username && !parsed.password,
+    `${label} must be an HTTPS URL without credentials`,
+  );
+  return parsed.toString();
+}
+
 function deploymentCapture(deployments) {
   return deployments.map(({ deployment, statuses }) => ({
     deployment,
@@ -1329,7 +1344,14 @@ function validatePreviewDeployment({
         Number(runIdMatch[2]) === Number(result.worker_run_attempt)) &&
       status.state === result.state &&
       (result.state !== "success" ||
-        status.environment_url === result.vercel_deployment_url) &&
+        canonicalHttpsTargetUrl(
+          status.environment_url,
+          "GitHub Deployment status environment URL",
+        ) ===
+          canonicalHttpsTargetUrl(
+            result.vercel_deployment_url,
+            "Preview worker result deployment URL",
+          )) &&
       status.creator?.type === "Bot" &&
       status.creator?.login === "github-actions[bot]"
     );
@@ -1358,9 +1380,16 @@ function validateTerminalPreviewReceipts({
   );
   invariant(
     sentinel !== null &&
-      sentinel.sha === event.head_sha &&
+      (!Object.hasOwn(sentinel, "sha") || sentinel.sha === event.head_sha) &&
       sentinel.state === decision.state &&
-      sentinel.target_url === decision.target_url &&
+      canonicalHttpsTargetUrl(
+        sentinel.target_url,
+        "Preview terminal status target URL",
+      ) ===
+        canonicalHttpsTargetUrl(
+          decision.target_url,
+          "Preview controller decision target URL",
+        ) &&
       sentinel.creator?.type === "Bot" &&
       sentinel.creator?.login === "github-actions[bot]",
     "Preview terminal status does not match the bot-owned controller decision",

--- a/scripts/vercel-cost-observation.mjs
+++ b/scripts/vercel-cost-observation.mjs
@@ -35,10 +35,10 @@ import {
   PREVIEW_JOURNAL_SCHEMA,
   PREVIEW_OBSERVATION_RECEIPT_SCHEMA,
   PREVIEW_REPOSITORY,
-  controllerEventRunName,
   createPreviewJournal,
   parseWorkerRunName,
   renderPreviewJournalBody,
+  validateControllerEventWorkflowRun,
   validateEventReceipt,
   validatePreviewObservationReceipt,
   previewObservationArtifactName,
@@ -1629,6 +1629,24 @@ function journalTargetStateForValidation(
   return currentSelections[0];
 }
 
+function assertControllerEventRunBinding(rawRun, event) {
+  const identity = validateControllerEventWorkflowRun(rawRun, event.head_sha);
+  invariant(
+    String(identity.runId) === String(event.event_run_id) &&
+      (event.event_run_number === undefined ||
+        identity.runNumber === event.event_run_number) &&
+      identity.pr === event.pr &&
+      identity.sha === event.head_sha &&
+      identity.before === event.before_sha &&
+      identity.action === event.event_action &&
+      identity.receiptRequired === true &&
+      identity.headRef === event.head_ref &&
+      identity.headRepository === event.head_repository,
+    "Preview controller run conflicts with its event receipt",
+  );
+  return identity;
+}
+
 export function assertControllerSyntheticRunBinding({
   rawRun,
   bindings,
@@ -1644,22 +1662,7 @@ export function assertControllerSyntheticRunBinding({
   );
   if (matchingEvents.length === 1) {
     const event = matchingEvents[0];
-    invariant(
-      rawRun.event === "pull_request_target" &&
-        rawRun.head_branch === event.base_ref &&
-        rawRun.head_sha === event.trusted_base_sha &&
-        rawRun.display_title ===
-          controllerEventRunName({
-            runId: event.event_run_id,
-            runNumber: event.event_run_number,
-            pr: event.pr,
-            sha: event.head_sha,
-            before: event.before_sha,
-            action: event.event_action,
-            receiptRequired: true,
-          }),
-      "Preview controller synthetic run conflicts with its event receipt",
-    );
+    assertControllerEventRunBinding(rawRun, event);
     return true;
   }
   invariant(
@@ -2081,25 +2084,10 @@ function capturePreview({ root, pr, eventRunId, dependencies }) {
       "Preview controller run",
     );
     invariant(
-      controllerRun.event === "pull_request_target" &&
-        String(controllerRun.id) === controllerRunId &&
-        controllerRun.head_branch === event.base_ref &&
-        controllerRun.head_sha === event.trusted_base_sha,
-      "Preview controller run is not the immutable PR event run",
+      String(controllerRun.id) === controllerRunId,
+      "Preview controller run ID does not match the requested event run",
     );
-    const expectedTitle = controllerEventRunName({
-      runId: controllerRunId,
-      runNumber: event.event_run_number ?? controllerRun.run_number,
-      pr: event.pr,
-      sha: event.head_sha,
-      before: event.before_sha,
-      action: event.event_action,
-      receiptRequired: true,
-    });
-    invariant(
-      controllerRun.display_title === expectedTitle,
-      "Preview controller run title does not match the event receipt",
-    );
+    assertControllerEventRunBinding(controllerRun, event);
     invariant(
       withinInterval(controllerRun.created_at, interval),
       "Preview event is outside the observation interval",

--- a/scripts/vercel-cost-observation.test.mjs
+++ b/scripts/vercel-cost-observation.test.mjs
@@ -1506,6 +1506,69 @@ test("capture-preview freezes the canonical v2 journal and raw GitHub facts", ()
   );
 });
 
+test("capture-preview rejects a conflicting optional commit-status SHA", () => {
+  const cwd = workspace();
+  runInit(cwd);
+  const event = fixture("preview-event.json");
+  const routes = previewRoutes(event);
+  const statusPages = routes.get(
+    `api --method GET --paginate --slurp repos/mento-protocol/frontend-monorepo/commits/${event.head_sha}/statuses?per_page=100`,
+  );
+  statusPages[0][0].sha = "c".repeat(40);
+
+  assert.throws(
+    () =>
+      runVercelCostObservation({
+        argv: ["capture-preview", "--pr", "700", "--event-run-id", "9001"],
+        cwd,
+        now: () => new Date(CAPTURED_AT),
+        gh: fakeGh(routes),
+        stdout: output().stream,
+      }),
+    /Preview terminal status does not match the bot-owned controller decision/,
+  );
+  assert.equal(
+    existsSync(join(observationRoot(cwd), "preview", "9001")),
+    false,
+  );
+});
+
+test("capture-preview rejects a deployment URL path mismatch", () => {
+  const cwd = workspace();
+  runInit(cwd);
+  const sourceEvent = fixture("preview-event.json");
+  const event = {
+    ...sourceEvent,
+    plan: {
+      ...sourceEvent.plan,
+      targets: ["ui"],
+      reason: "affected-packages",
+    },
+  };
+  const routes = previewRoutes(event);
+  const statusPages = routes.get(
+    "api --method GET --paginate --slurp repos/mento-protocol/frontend-monorepo/deployments/7001/statuses?per_page=100",
+  );
+  statusPages[0][0].environment_url =
+    "https://ui-observation-fixture.vercel.app/another-path";
+
+  assert.throws(
+    () =>
+      runVercelCostObservation({
+        argv: ["capture-preview", "--pr", "700", "--event-run-id", "9001"],
+        cwd,
+        now: () => new Date(CAPTURED_AT),
+        gh: fakeGh(routes),
+        stdout: output().stream,
+      }),
+    /GitHub Deployment terminal status is missing or ambiguous/,
+  );
+  assert.equal(
+    existsSync(join(observationRoot(cwd), "preview", "9001")),
+    false,
+  );
+});
+
 test("capture-preview normalizes whole-second GitHub REST timestamps", () => {
   const cwd = workspace();
   runInit(cwd);

--- a/scripts/vercel-cost-observation.test.mjs
+++ b/scripts/vercel-cost-observation.test.mjs
@@ -744,13 +744,13 @@ function previewRoutes(
   };
   const status = {
     id: 401,
-    sha: event.head_sha,
     context: "Vercel Preview",
     state: "success",
-    target_url:
+    target_url: new URL(
       journal.state?.status_decisions.find(
         (decision) => decision.sha === event.head_sha,
       )?.target_url ?? run.html_url,
+    ).toString(),
     created_at: "2026-07-29T01:04:00.000Z",
     updated_at: "2026-07-29T01:04:00.000Z",
     creator: { type: "Bot", login: "github-actions[bot]" },
@@ -811,7 +811,7 @@ function previewRoutes(
             state: "success",
             log_url:
               "https://github.com/mento-protocol/frontend-monorepo/actions/runs/8001",
-            environment_url: "https://ui-observation-fixture.vercel.app",
+            environment_url: "https://ui-observation-fixture.vercel.app/",
             created_at: "2026-07-29T01:03:00.000Z",
             creator: { type: "Bot", login: "github-actions[bot]" },
           },
@@ -894,10 +894,9 @@ function reselectedPreviewRoutes(
       [
         {
           id: 402,
-          sha: event.head_sha,
           context: "Vercel Preview",
           state: decision.state,
-          target_url: decision.target_url,
+          target_url: new URL(decision.target_url).toString(),
           created_at: "2026-07-29T01:04:00.000Z",
           updated_at: "2026-07-29T01:04:00.000Z",
           creator: { type: "Bot", login: "github-actions[bot]" },

--- a/scripts/vercel-cost-observation.test.mjs
+++ b/scripts/vercel-cost-observation.test.mjs
@@ -723,8 +723,14 @@ function previewRoutes(
     conclusion: "success",
     created_at: "2026-07-29T01:00:01.000Z",
     updated_at: "2026-07-29T01:04:00.000Z",
-    head_branch: event.base_ref,
-    head_sha: event.trusted_base_sha,
+    head_branch: event.head_ref,
+    head_sha: event.head_sha,
+    head_repository: {
+      full_name: event.head_repository,
+      url: `https://api.github.com/repos/${event.head_repository}`,
+    },
+    repository: { full_name: "mento-protocol/frontend-monorepo" },
+    pull_requests: [],
     html_url: `https://github.com/mento-protocol/frontend-monorepo/actions/runs/${event.event_run_id}`,
     display_title: controllerEventRunName({
       runId: event.event_run_id,
@@ -1700,9 +1706,21 @@ test("a later controller event can remove a selection after the trusted base adv
     assertControllerSyntheticRunBinding({
       rawRun: {
         id: 9_006,
+        run_number: event.event_run_number,
+        name: "Vercel Preview Controller",
+        path: ".github/workflows/vercel-preview-controller.yml",
         event: "pull_request_target",
-        head_branch: "main",
-        head_sha: "d".repeat(40),
+        head_branch: event.head_ref,
+        head_sha: event.head_sha,
+        head_repository: {
+          full_name: event.head_repository,
+          url: `https://api.github.com/repos/${event.head_repository}`,
+        },
+        repository: { full_name: "mento-protocol/frontend-monorepo" },
+        pull_requests: [],
+        status: "completed",
+        conclusion: "success",
+        created_at: "2026-07-29T01:00:01.000Z",
         display_title: controllerEventRunName({
           runId: event.event_run_id,
           runNumber: event.event_run_number,
@@ -1751,7 +1769,7 @@ test("a real worker run cannot be reused across preview selection keys", () => {
   );
 });
 
-test("capture-preview rejects a controller run on another trusted base SHA", () => {
+test("capture-preview rejects a controller run on another candidate SHA", () => {
   const cwd = workspace();
   runInit(cwd);
   const routes = previewRoutes();
@@ -1768,7 +1786,28 @@ test("capture-preview rejects a controller run on another trusted base SHA", () 
         gh: fakeGh(routes),
         stdout: output().stream,
       }),
-    /not the immutable PR event run/,
+    /Controller event head SHA mismatch/,
+  );
+});
+
+test("capture-preview rejects a controller run on another candidate ref", () => {
+  const cwd = workspace();
+  runInit(cwd);
+  const routes = previewRoutes();
+  const controllerRun = routes.get(
+    "api --method GET repos/mento-protocol/frontend-monorepo/actions/runs/9001",
+  );
+  controllerRun.head_branch = "feature/another-candidate";
+  assert.throws(
+    () =>
+      runVercelCostObservation({
+        argv: ["capture-preview", "--pr", "700", "--event-run-id", "9001"],
+        cwd,
+        now: () => new Date(CAPTURED_AT),
+        gh: fakeGh(routes),
+        stdout: output().stream,
+      }),
+    /conflicts with its event receipt/,
   );
 });
 


### PR DESCRIPTION
## The Problem

The cost-observation collector compared `pull_request_target` controller runs
with the trusted base branch and SHA. GitHub reports these runs against the PR
candidate ref and SHA, so every real `capture-preview` call failed before
sealing the event. The live #758 receipt also exposed two GitHub REST response
normalizations absent from the fixtures: individual commit-status rows omit
`sha`, and GitHub serializes bare HTTPS origins with a trailing slash.

## The Solution

Use the controller's canonical workflow-run validator in both preview-capture
paths, then bind its parsed run ID, run number, PR, candidate SHA, prior SHA,
action, receipt flag, candidate ref, and head repository to the immutable event
receipt. Keep the trusted base fields as planner provenance.

The collector now treats a commit-status row's SHA as optional because the
request is already scoped to the exact event SHA; any supplied SHA must still
match. It compares the bot-owned terminal and GitHub Deployment HTTPS URLs
after standard URL serialization, preserving protocol and credential checks.

Tests model GitHub's real candidate-head and status envelopes, reject
mismatched candidate SHAs and refs, reject conflicting optional status SHAs and
deployment URL paths, and preserve non-main-base capture support.

## Validation

- Reviewed head: `9b83e5bbdeacc7d4b1fd1f596cb26a9f190b7aab`
- `node --test scripts/vercel-cost-observation.test.mjs` (53/53)
- `pnpm vercel:cost:test` (203/203)
- `pnpm vercel:workflow:test` (591/591)
- `pnpm check-types` (8/8)
- isolated real capture of PR #758 event run `31707415887`: sealed successfully
  with all four workers, then passed an idempotent replay
- `trunk check scripts/vercel-cost-observation.mjs scripts/vercel-cost-observation.test.mjs`
- `pnpm adr:check` and `git diff --check`
- full pre-push Trunk (1,225 files), typecheck (8/8), and Knip hooks
- fresh-context full-branch semantic review: clean, confidence 0.95
- deterministic autoreview: clean

## Operational evidence

GitHub's resolved August 13 incident interrupted the prior head before provider
upload for three targets and before UI dispatch. One authorized reconcile after
the incident produced verified App, Governance, and UI previews and settled the
durable journal at revision 68 with no active workers. Reserve retained its
pre-provider incident failure. This new head creates a fresh four-target
lifecycle and supersedes those old checks.

## Risk

The change is limited to offline observation identity and representation
validation plus fixtures. It does not change preview dispatch, provider
credentials, deployment behavior, or public runtime state.
