### PR TITLE
Fix Vercel candidate reuse after recovery

### DIFF
--- a/.github/workflows/vercel-main-deployment.yml
+++ b/.github/workflows/vercel-main-deployment.yml
@@ -950,7 +950,7 @@ jobs:
           }
         run: |
           node scripts/vercel-main-provider-cli.mjs candidate-smoke --intent "$RUNNER_TEMP/intent.json" --output "$RUNNER_TEMP/smoke.json"
-          node scripts/vercel-main-provider-cli.mjs candidate-finalize --intent "$RUNNER_TEMP/intent.json" --smoke "$RUNNER_TEMP/smoke.json" --output "$RUNNER_TEMP/receipt.json"
+          node scripts/vercel-main-provider-cli.mjs candidate-finalize --intent "$RUNNER_TEMP/intent.json" --smoke "$RUNNER_TEMP/smoke.json" --preflight "$RUNNER_TEMP/preflight.json" --output "$RUNNER_TEMP/receipt.json"
       - name: Publish governance terminal outputs
         id: terminal
         if: ${{ always() }}
@@ -1153,7 +1153,7 @@ jobs:
           }
         run: |
           node scripts/vercel-main-provider-cli.mjs candidate-smoke --intent "$RUNNER_TEMP/intent.json" --output "$RUNNER_TEMP/smoke.json"
-          node scripts/vercel-main-provider-cli.mjs candidate-finalize --intent "$RUNNER_TEMP/intent.json" --smoke "$RUNNER_TEMP/smoke.json" --output "$RUNNER_TEMP/receipt.json"
+          node scripts/vercel-main-provider-cli.mjs candidate-finalize --intent "$RUNNER_TEMP/intent.json" --smoke "$RUNNER_TEMP/smoke.json" --preflight "$RUNNER_TEMP/preflight.json" --output "$RUNNER_TEMP/receipt.json"
       - name: Publish reserve terminal outputs
         id: terminal
         if: ${{ always() }}
@@ -1355,7 +1355,7 @@ jobs:
           }
         run: |
           node scripts/vercel-main-provider-cli.mjs candidate-smoke --intent "$RUNNER_TEMP/intent.json" --output "$RUNNER_TEMP/smoke.json"
-          node scripts/vercel-main-provider-cli.mjs candidate-finalize --intent "$RUNNER_TEMP/intent.json" --smoke "$RUNNER_TEMP/smoke.json" --output "$RUNNER_TEMP/receipt.json"
+          node scripts/vercel-main-provider-cli.mjs candidate-finalize --intent "$RUNNER_TEMP/intent.json" --smoke "$RUNNER_TEMP/smoke.json" --preflight "$RUNNER_TEMP/preflight.json" --output "$RUNNER_TEMP/receipt.json"
       - name: Publish UI terminal outputs
         id: terminal
         if: ${{ always() }}

--- a/docs/adr/0005-stable-main-release-identity-and-rerun-admission.md
+++ b/docs/adr/0005-stable-main-release-identity-and-rerun-admission.md
@@ -3,7 +3,7 @@ title: Stable active-main release identity and provider-side rerun reconciliatio
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-07-28
+last_verified: 2026-08-13
 scope: ci/deployment/main-reruns
 date: 2026-07
 ---
@@ -118,6 +118,18 @@ response SHA remains mandatory and must equal the manifest-bound served SHA.
 Candidate admission still requires canonical
 `mento-protocol/frontend-monorepo@main` Git identity.
 
+An ordinary candidate already present at the trusted preflight may have
+lost its generated project and creator aliases when recovery promoted the exact
+prior deployment. That detached state is admissible only after the same exact
+manifest-bound candidate census, inspection, and immutable smoke. The
+preflight is captured before the job can build a candidate, and a
+`create-if-zero` result does not authorize the relaxed topology. Any aliases
+that remain must be a canonical subset of the candidate's reviewed
+project/scope and creator aliases; protected/custom domains, Git/default
+aliases, wrong-target aliases, and unknown aliases remain blockers. A candidate
+absent from the trusted preflight still requires its reviewed generated project
+alias, and any candidate change after that preflight fails closed.
+
 When App belongs to `shadowTargets`, its protected custom-`v3` preparation is
 build-only terminal evidence. It never creates a provider deployment or gains
 public-mutation authority.
@@ -173,6 +185,8 @@ every other non-prefix state still require manual intervention.
 - The provider-side release manifest, not GitHub artifact history, is the
   durable cross-attempt source of truth.
 - Every attempt has an independently auditable journal and recovery boundary.
+- A recovered ordinary candidate remains reusable across attempts even when
+  recovery moved its reviewed generated aliases back to the prior deployment.
 - An inherited partial release is restored before a new baseline can be planned.
 - The exact terminal App recovery residual may restore only App before a new
   baseline; it never authorizes forward resumption.

--- a/docs/vercel-deployments.md
+++ b/docs/vercel-deployments.md
@@ -293,6 +293,18 @@ provider candidate from that manifest after fresh inspection and smoke. Provider
 metadata that lacks the canonical manifest, a matching URL, a matching custom
 identifier, or zero/multiple provider candidates is insufficient.
 
+When a failed active attempt promotes an ordinary prior during recovery,
+Vercel also moves the target's generated project and optional creator aliases
+back to that prior. The stable candidate then remains exact and healthy on its
+immutable URL but can have no generated aliases. A later attempt may admit that
+detached Governance, Reserve, or UI candidate only when the trusted preflight
+census captured it before the job could build a candidate, the stable manifest
+and candidate identity still match, the fresh immutable smoke passes, and every
+remaining alias is in the candidate's reviewed finite generated-alias set. A
+candidate absent from that preflight still requires the generated project
+alias. A changed candidate, protected/custom alias, Git/default alias,
+wrong-target alias, or unknown alias fails closed.
+
 The candidate HTTP smoke reads the immutable deployment root directly for App,
 Governance, and Reserve. UI reads `/basic-components` on that same immutable
 host because its root intentionally redirects there. Each request uses manual
@@ -1283,13 +1295,20 @@ hostname in the alias list, or malformed canonical evidence fails closed. The
 read-only state inspector normalizes and deduplicates raw provider aliases;
 persisted canonical evidence must remain deduplicated and sorted.
 
-That base-required topology applies to a newly staged or automatically reused
-ordinary candidate. Served-prior planning uses a separate finite contract
-because generated aliases can move independently of the protected custom
-domain. For Governance, Reserve, and UI, a served deployment may retain any
-canonical subset of its reviewed base project/scope alias, exact
-project-default alias, exact canonical creator alias when that name is safe,
-and literal native-Git `main` alias:
+That base-required topology applies to an ordinary candidate absent from the
+trusted preflight. A candidate captured there before the job could build one
+may use a canonical subset of only the reviewed project/scope and creator
+aliases, including the empty subset, because recovery promotion can move both
+aliases back to the prior deployment. A `create-if-zero` preflight does not
+receive this relaxed topology. The
+immutable hostname, protected/custom domains, project-default alias, Git alias,
+wrong-target alias, and every other alias remain forbidden.
+
+Served-prior planning uses a separate finite contract because generated aliases
+can move independently of the protected custom domain. For Governance, Reserve,
+and UI, a served deployment may retain any canonical subset of its reviewed
+base project/scope alias, exact project-default alias, exact canonical creator
+alias when that name is safe, and literal native-Git `main` alias:
 
 - Governance: `governancementoorg-mentolabs.vercel.app`,
   `governancementoorg.vercel.app`, and
@@ -1308,8 +1327,10 @@ alias, or duplicate or unsorted canonical evidence fails closed.
 For `restore-before-planning`, the workflow calls
 `candidate-finalize-inherited`, which is fixed to this served-prior mode only
 for inherited Governance, Reserve, and UI recovery. Ordinary
-`candidate-finalize` remains base-required, and inherited App remains on its
-custom `v3` path. The inherited finalizer requires the target's exact protected
+`candidate-finalize` requires the base alias for a candidate absent from its
+trusted preflight and allows the reviewed detached subset only for the exact
+candidate already captured there. Inherited App remains on its custom `v3`
+path. The inherited finalizer requires the target's exact protected
 public alias in the deployment's full alias list, removes that reviewed alias,
 then validates the remaining generated aliases against the finite served-prior
 set.

--- a/scripts/vercel-main-candidate-controller.mjs
+++ b/scripts/vercel-main-candidate-controller.mjs
@@ -38,12 +38,52 @@ const EMPTY_REUSE_METRICS = Object.freeze({
 
 function assertAliasTopologyTarget(intent, aliasTopologyMode) {
   if (
-    aliasTopologyMode ===
-      PRODUCTION_GENERATED_ALIAS_TOPOLOGY_MODES.SERVED_PRIOR &&
-    intent.target === "app"
+    intent.target === "app" &&
+    aliasTopologyMode !== PRODUCTION_GENERATED_ALIAS_TOPOLOGY_MODES.CANDIDATE
   ) {
-    throw new Error("Served-prior candidate finalization excludes App");
+    throw new Error("Alternate candidate alias topology excludes App");
   }
+}
+
+function canonicalAdmissionPreflight(value, intent, candidate) {
+  if (value === null) return null;
+  const preflight = assertMainCandidatePreflight(value);
+  if (JSON.stringify(preflight.intent) !== JSON.stringify(intent)) {
+    throw new Error("Main candidate admission preflight conflicts with intent");
+  }
+  if (
+    preflight.outcome === "reuse-existing" &&
+    JSON.stringify(preflight.candidate) !== JSON.stringify(candidate)
+  ) {
+    throw new Error("Main candidate changed after its admission preflight");
+  }
+  return preflight;
+}
+
+function resolvedAliasTopologyMode(
+  intent,
+  candidate,
+  aliasTopologyMode,
+  admissionPreflight,
+) {
+  if (
+    aliasTopologyMode !== PRODUCTION_GENERATED_ALIAS_TOPOLOGY_MODES.CANDIDATE ||
+    intent.target === "app" ||
+    admissionPreflight === null
+  ) {
+    return aliasTopologyMode;
+  }
+  const preflight = canonicalAdmissionPreflight(
+    admissionPreflight,
+    intent,
+    candidate,
+  );
+  // Recovery can move Vercel's generated aliases away from an exact candidate.
+  // Only the trusted census captured before this job could build a candidate
+  // may authorize the detached topology.
+  return preflight.outcome === "reuse-existing"
+    ? PRODUCTION_GENERATED_ALIAS_TOPOLOGY_MODES.REUSED_CANDIDATE
+    : aliasTopologyMode;
 }
 
 function exactKeys(value, keys, label) {
@@ -301,7 +341,7 @@ export function assertMainCandidatePreflight(value) {
 }
 
 async function resolveMainCandidateHandoffForAliasTopology(
-  { intent, provider, smokeCandidate },
+  { intent, provider, smokeCandidate, admissionPreflight = null },
   aliasTopologyMode,
 ) {
   const canonicalIntent = assertMainCandidateIntent(intent);
@@ -333,13 +373,19 @@ async function resolveMainCandidateHandoffForAliasTopology(
     candidate: canonicalResolution.candidate,
     immutableSmoke: canonicalResolution.immutableSmoke,
   });
+  const resolvedTopologyMode = resolvedAliasTopologyMode(
+    canonicalIntent,
+    receipt.candidate,
+    aliasTopologyMode,
+    admissionPreflight,
+  );
   if (typeof provider.inspectCandidateState !== "function")
     throw new Error("Main candidate canonical-state provider is required");
   const canonicalState = assertMainCandidateCanonicalState(
     await provider.inspectCandidateState(receipt.candidate.deploymentId),
     canonicalIntent,
     receipt.candidate,
-    aliasTopologyMode,
+    resolvedTopologyMode,
   );
   return {
     schema: MAIN_CANDIDATE_HANDOFF_SCHEMA,
@@ -441,7 +487,11 @@ function assertMainCandidateCanonicalState(
   return canonicalState;
 }
 
-function assertMainCandidateHandoffForAliasTopology(value, aliasTopologyMode) {
+function assertMainCandidateHandoffForAliasTopology(
+  value,
+  aliasTopologyMode,
+  admissionPreflight,
+) {
   exactKeys(
     value,
     [
@@ -488,7 +538,12 @@ function assertMainCandidateHandoffForAliasTopology(value, aliasTopologyMode) {
     value.canonicalState,
     intent,
     receipt.candidate,
-    aliasTopologyMode,
+    resolvedAliasTopologyMode(
+      intent,
+      receipt.candidate,
+      aliasTopologyMode,
+      admissionPreflight,
+    ),
   );
   return {
     ...value,
@@ -501,16 +556,21 @@ function assertMainCandidateHandoffForAliasTopology(value, aliasTopologyMode) {
   };
 }
 
-export function assertMainCandidateHandoff(value) {
+export function assertMainCandidateHandoff(value, admissionPreflight = null) {
   return assertMainCandidateHandoffForAliasTopology(
     value,
     PRODUCTION_GENERATED_ALIAS_TOPOLOGY_MODES.CANDIDATE,
+    admissionPreflight,
   );
 }
 
-export function assertMainServedPriorCandidateHandoff(value) {
+export function assertMainServedPriorCandidateHandoff(
+  value,
+  admissionPreflight = null,
+) {
   return assertMainCandidateHandoffForAliasTopology(
     value,
     PRODUCTION_GENERATED_ALIAS_TOPOLOGY_MODES.SERVED_PRIOR,
+    admissionPreflight,
   );
 }

--- a/scripts/vercel-main-candidate-provider.test.mjs
+++ b/scripts/vercel-main-candidate-provider.test.mjs
@@ -10,6 +10,7 @@ import {
 import {
   assertMainCandidateHandoff,
   assertMainServedPriorCandidateHandoff,
+  preflightMainCandidateProvider,
   resolveMainCandidateHandoff,
   resolveMainServedPriorCandidateHandoff,
 } from "./vercel-main-candidate-controller.mjs";
@@ -91,18 +92,34 @@ function releaseManifest() {
   });
 }
 
-function intent(target = "ui") {
+function intent(
+  target = "ui",
+  {
+    originAttempt = "1",
+    originTransactionId = "main-0123456789abcdef0123456789abcdef",
+  } = {},
+) {
   const manifest = releaseManifest();
   return createMainCandidateIntent({
     target,
     deploySha: "dddddddddddddddddddddddddddddddddddddddd",
     upstreamRunId: "700",
     originRunId: "800",
-    originAttempt: "1",
-    originTransactionId: "main-0123456789abcdef0123456789abcdef",
+    originAttempt,
+    originTransactionId,
     projectId: manifest.originalPriors[target].projectId,
     releaseManifest: manifest,
   });
+}
+
+function originForAttempt(originAttempt) {
+  return {
+    originAttempt,
+    originTransactionId:
+      originAttempt === "1"
+        ? "main-0123456789abcdef0123456789abcdef"
+        : "main-fedcba9876543210fedcba9876543210",
+  };
 }
 
 function deploymentResponse(
@@ -156,10 +173,20 @@ function subsets(values) {
 async function resolveHandoff(
   target,
   aliases,
-  { deploymentUrl, servedPrior = false } = {},
+  {
+    candidateAttempt,
+    currentAttempt = "1",
+    deploymentUrl,
+    admittedBeforeJob = false,
+    servedPrior = false,
+  } = {},
 ) {
-  const currentIntent = intent(target);
-  const response = deploymentResponse(currentIntent, {
+  const currentIntent = intent(target, originForAttempt(currentAttempt));
+  const candidateIntent = intent(
+    target,
+    originForAttempt(candidateAttempt ?? currentAttempt),
+  );
+  const response = deploymentResponse(candidateIntent, {
     ...(deploymentUrl === undefined ? {} : { url: deploymentUrl }),
   });
   const provider = createMainCandidateVercelProvider({
@@ -176,15 +203,20 @@ async function resolveHandoff(
   const resolve = servedPrior
     ? resolveMainServedPriorCandidateHandoff
     : resolveMainCandidateHandoff;
-  return resolve({
+  const admissionPreflight = admittedBeforeJob
+    ? await preflightMainCandidateProvider({ intent: currentIntent, provider })
+    : null;
+  const handoff = await resolve({
     intent: currentIntent,
     provider,
+    admissionPreflight,
     smokeCandidate: async (candidate) => ({
       immutableUrl: candidate.deploymentUrl,
       servedSha: currentIntent.deploySha,
       status: "passed",
     }),
   });
+  return admittedBeforeJob ? { handoff, admissionPreflight } : handoff;
 }
 
 test("provider lists a complete bounded project and stable-identity census", async () => {
@@ -311,6 +343,73 @@ test("automatic ordinary candidate finalization requires the base and permits th
       assert.deepEqual(assertMainCandidateHandoff(handoff), handoff);
     }
   }
+});
+
+test("a later attempt reuses a detached ordinary candidate after recovery moved its generated aliases", async () => {
+  for (const target of ["governance", "reserve", "ui"]) {
+    const contract = PRODUCTION_GENERATED_ALIAS_CONTRACTS[target];
+    for (const aliases of subsets([
+      contract.generatedProjectAlias,
+      generatedCreatorAlias(target),
+    ])) {
+      const { handoff, admissionPreflight } = await resolveHandoff(
+        target,
+        aliases,
+        {
+          candidateAttempt: "1",
+          currentAttempt: "2",
+          admittedBeforeJob: true,
+        },
+      );
+      assert.equal(handoff.action, "reuse");
+      assert.deepEqual(handoff.canonicalState.aliases, aliases);
+      assert.deepEqual(
+        assertMainCandidateHandoff(handoff, admissionPreflight),
+        handoff,
+      );
+      assert.deepEqual(
+        assertMainCandidateHandoff(
+          JSON.parse(JSON.stringify(handoff)),
+          admissionPreflight,
+        ),
+        handoff,
+      );
+    }
+  }
+});
+
+test("a later attempt still rejects unreviewed aliases on a detached ordinary candidate", async () => {
+  for (const target of ["governance", "reserve", "ui"]) {
+    const contract = PRODUCTION_GENERATED_ALIAS_CONTRACTS[target];
+    for (const [name, aliases] of [
+      ["git-main", [contract.generatedGitMainAlias]],
+      ["project-default", [contract.generatedProjectDefaultAlias]],
+      ["protected", MAIN_TARGET_CONTRACTS[target].aliases],
+      ["unknown", [`${target}-preview.mento.org`]],
+    ]) {
+      await assert.rejects(
+        () =>
+          resolveHandoff(target, aliases, {
+            candidateAttempt: "1",
+            currentAttempt: "2",
+            admittedBeforeJob: true,
+          }),
+        /reused-candidate generated-alias topology mismatch/,
+        `${target}: ${name}`,
+      );
+    }
+  }
+});
+
+test("detached ordinary candidates require a trusted reuse preflight regardless of audit labels", async () => {
+  await assert.rejects(
+    () =>
+      resolveHandoff("governance", [], {
+        candidateAttempt: "1",
+        currentAttempt: "2",
+      }),
+    /candidate generated-alias topology mismatch/,
+  );
 });
 
 test("automatic ordinary candidate finalization rejects non-candidate alias topologies", async () => {

--- a/scripts/vercel-main-deployment-workflow.test.mjs
+++ b/scripts/vercel-main-deployment-workflow.test.mjs
@@ -1648,7 +1648,10 @@ test("ordinary candidates emit a current-attempt intent before create and a rece
       finalize,
       `${target} smoke and finalization stay one fail-closed step`,
     );
-    assert.match(smoke.run, /candidate-smoke[\s\S]*candidate-finalize/);
+    assert.match(
+      smoke.run,
+      /candidate-smoke[\s\S]*candidate-finalize[\s\S]*--preflight "\$RUNNER_TEMP\/preflight\.json"/,
+    );
     assert.ok(workflow.jobs[job].outputs.receipt, `${target} receipt output`);
   }
 });

--- a/scripts/vercel-main-provider-cli.mjs
+++ b/scripts/vercel-main-provider-cli.mjs
@@ -107,6 +107,7 @@ const CLI_OPTIONS = Object.freeze({
 });
 const OPTIONAL_OPTIONS = Object.freeze({
   "canonical-mappings": new Set(["legacy-snapshot"]),
+  "candidate-finalize": new Set(["preflight"]),
 });
 const DISCOVERY_SCHEMA = "vercel-main-preplan-candidate-discovery:v2";
 const DIGEST_PATTERN = /^[a-f0-9]{64}$/;
@@ -1396,6 +1397,13 @@ export async function runMainProviderCli({
     "Main candidate immutable smoke",
     runnerTemp,
   );
+  const admissionPreflight = options.preflight
+    ? readPrivateJson(
+        options.preflight,
+        "Main candidate admission preflight",
+        runnerTemp,
+      )
+    : null;
   const inherited = command === "candidate-finalize-inherited";
   const resolveHandoff = inherited
     ? resolveMainServedPriorCandidateHandoff
@@ -1408,7 +1416,9 @@ export async function runMainProviderCli({
       intent,
       provider,
       smokeCandidate: async () => smoke,
+      admissionPreflight,
     }),
+    admissionPreflight,
   );
   if (result.action !== "reuse") {
     throw new Error("Candidate finalization requires one reusable candidate");

--- a/scripts/vercel-main-provider-cli.test.mjs
+++ b/scripts/vercel-main-provider-cli.test.mjs
@@ -1461,6 +1461,28 @@ test("candidate finalization reuses one fresh candidate and rejects smoke mismat
     intent.deploySha,
   );
 
+  const creationPreflightPath = join(
+    context.directory,
+    "creation-preflight.json",
+  );
+  const creationPreflight = await runMainProviderCli({
+    argv: [
+      "candidate-preflight",
+      "--intent",
+      intentPath,
+      "--output",
+      creationPreflightPath,
+    ],
+    env: context.env,
+    stdout: context.stdout,
+    stateClientFactory: () => ({
+      requestWithRetry: async () => ({
+        deployments: [],
+        pagination: { next: null },
+      }),
+    }),
+  });
+  assert.equal(creationPreflight.outcome, "create-if-zero");
   await assert.rejects(
     () =>
       runMainProviderCli({
@@ -1470,6 +1492,8 @@ test("candidate finalization reuses one fresh candidate and rejects smoke mismat
           intentPath,
           "--smoke",
           smokePath,
+          "--preflight",
+          creationPreflightPath,
           "--output",
           join(context.directory, "missing-base-handoff.json"),
         ],
@@ -1486,6 +1510,42 @@ test("candidate finalization reuses one fresh candidate and rejects smoke mismat
       }),
     /candidate generated-alias topology mismatch/,
   );
+
+  const admissionPreflightPath = join(
+    context.directory,
+    "admission-preflight.json",
+  );
+  const admissionPreflight = await runMainProviderCli({
+    argv: [
+      "candidate-preflight",
+      "--intent",
+      intentPath,
+      "--output",
+      admissionPreflightPath,
+    ],
+    env: context.env,
+    stdout: context.stdout,
+    stateClientFactory: candidateSmokeStateClient(response),
+  });
+  assert.equal(admissionPreflight.outcome, "reuse-existing");
+  const rerunResult = await runMainProviderCli({
+    argv: [
+      "candidate-finalize",
+      "--intent",
+      intentPath,
+      "--smoke",
+      smokePath,
+      "--preflight",
+      admissionPreflightPath,
+      "--output",
+      join(context.directory, "detached-rerun-handoff.json"),
+    ],
+    env: context.env,
+    stdout: context.stdout,
+    stateClientFactory: candidateSmokeStateClient(response),
+  });
+  assert.equal(rerunResult.action, "reuse");
+  assert.deepEqual(rerunResult.canonicalState.aliases, []);
 
   const badSmokePath = writeJson(context.directory, "bad-smoke.json", {
     immutableUrl: response.url,

--- a/scripts/vercel-production-generated-aliases.mjs
+++ b/scripts/vercel-production-generated-aliases.mjs
@@ -30,6 +30,7 @@ export const PRODUCTION_GENERATED_ALIAS_CONTRACTS = Object.freeze({
 
 export const PRODUCTION_GENERATED_ALIAS_TOPOLOGY_MODES = Object.freeze({
   CANDIDATE: "candidate",
+  REUSED_CANDIDATE: "reused-candidate",
   SERVED_PRIOR: "served-prior",
 });
 
@@ -133,10 +134,10 @@ export function assertOnlyExpectedProductionGeneratedAliases({
         ])
       : new Set([generatedProjectAlias, ...allowedCreatorAliases]);
   const topologyMatches =
-    mode === PRODUCTION_GENERATED_ALIAS_TOPOLOGY_MODES.SERVED_PRIOR
-      ? canonicalAliases.every((alias) => allowedAliases.has(alias))
-      : canonicalAliases.includes(generatedProjectAlias) &&
-        canonicalAliases.every((alias) => allowedAliases.has(alias));
+    mode === PRODUCTION_GENERATED_ALIAS_TOPOLOGY_MODES.CANDIDATE
+      ? canonicalAliases.includes(generatedProjectAlias) &&
+        canonicalAliases.every((alias) => allowedAliases.has(alias))
+      : canonicalAliases.every((alias) => allowedAliases.has(alias));
   if (!topologyMatches) {
     throw new Error(
       `Production ${logicalTarget} ${mode} generated-alias topology mismatch: allowed ${JSON.stringify([...allowedAliases].toSorted())}; actual ${JSON.stringify(canonicalAliases)}`,

--- a/scripts/vercel-production-generated-aliases.test.mjs
+++ b/scripts/vercel-production-generated-aliases.test.mjs
@@ -71,6 +71,28 @@ test("candidate mode requires the project alias and permits only the exact creat
   }
 });
 
+test("reused-candidate mode permits only the surviving candidate alias subset", () => {
+  for (const logicalTarget of ORDINARY_TARGETS) {
+    const contract = PRODUCTION_GENERATED_ALIAS_CONTRACTS[logicalTarget];
+    for (const aliases of subsets([
+      contract.generatedProjectAlias,
+      creatorAlias(logicalTarget),
+    ])) {
+      const canonicalAliases = aliases.toSorted();
+      assert.deepEqual(
+        assertOnlyExpectedProductionGeneratedAliases({
+          aliases: canonicalAliases,
+          creatorUsername: CREATOR_USERNAME,
+          logicalTarget,
+          mode: PRODUCTION_GENERATED_ALIAS_TOPOLOGY_MODES.REUSED_CANDIDATE,
+        }),
+        canonicalAliases,
+        `${logicalTarget}: ${JSON.stringify(canonicalAliases)}`,
+      );
+    }
+  }
+});
+
 test("served-prior mode rejects aliases outside the finite reviewed set", () => {
   const contract = PRODUCTION_GENERATED_ALIAS_CONTRACTS.governance;
   for (const [name, aliases] of [
@@ -168,6 +190,38 @@ test("candidate mode rejects missing-base and non-candidate generated aliases", 
           mode: PRODUCTION_GENERATED_ALIAS_TOPOLOGY_MODES.CANDIDATE,
         }),
       /generated-alias topology mismatch/,
+      name,
+    );
+  }
+});
+
+test("reused-candidate mode rejects aliases outside the finite candidate set", () => {
+  const contract = PRODUCTION_GENERATED_ALIAS_CONTRACTS.governance;
+  for (const [name, aliases] of [
+    ["git-main", [contract.generatedGitMainAlias]],
+    ["project-default", [contract.generatedProjectDefaultAlias]],
+    ["protected", ["governance.mento.org"]],
+    ["unknown", ["governance-preview.mento.org"]],
+    [
+      "wrong target",
+      [PRODUCTION_GENERATED_ALIAS_CONTRACTS.reserve.generatedProjectAlias],
+    ],
+    [
+      "creator near miss",
+      [
+        `${contract.generatedProjectSlug}-fixture-author2-${contract.generatedScopeSlug}.vercel.app`,
+      ],
+    ],
+  ]) {
+    assert.throws(
+      () =>
+        assertOnlyExpectedProductionGeneratedAliases({
+          aliases,
+          creatorUsername: CREATOR_USERNAME,
+          logicalTarget: "governance",
+          mode: PRODUCTION_GENERATED_ALIAS_TOPOLOGY_MODES.REUSED_CANDIDATE,
+        }),
+      /reused-candidate generated-alias topology mismatch/,
       name,
     );
   }


### PR DESCRIPTION
## The Problem

The production deployment for the merged wallet-rejection filtering change recovered safely after its final provider census failed, but recovery moved Governance and Reserve generated aliases back to their prior deployments. The exact manifest-bound candidates stayed healthy on their immutable URLs. Later attempts found those candidates and passed immutable smoke, then failed `candidate-finalize` because the existing topology required the generated project alias.

This left production on the prior SHA and opened managed incident #636. Re-running the unchanged workflow could not recover because every attempt reached the same detached-candidate state.

## The Solution

Allow Governance, Reserve, and UI to reuse an exact detached candidate only when the trusted preflight captured that candidate before the job could build one. Finalization binds the preflight to the exact intent and candidate, repeats the provider census and inspection, requires a fresh immutable SHA smoke, and permits only a canonical subset of the reviewed project and creator aliases. Protected/custom domains, Git/default aliases, wrong-target aliases, unknown aliases, and a candidate changed after preflight still fail closed.

A `create-if-zero` preflight keeps the existing generated-project-alias requirement. App and served-prior recovery keep their existing contracts. The workflow now passes the runner-owned preflight into all three ordinary finalizers, and the runbook plus ADR describe the admission rule.

## Validation

- `pnpm vercel:workflow:test` — 591 passed
- focused candidate/provider/alias tests — 54 passed
- workflow structure test — 33 passed after adding the preflight assertion
- `pnpm quality:budgets:test` — 53 passed
- `pnpm check-types`
- `pnpm adr:check`
- scoped and pre-push Trunk checks
- pre-push Knip completed with only existing configuration hints
- nine-lens review plus independent Codex signal; accepted security, docs, test, and cleanup findings fixed
- security re-review: approve
- fresh-context Codex autoreview: clean, 0.97 confidence
- deterministic autoreview: clean

## Risk

This changes a production deployment trust boundary. The relaxed topology is unavailable without an exact `reuse-existing` preflight captured before candidate creation could run, and all later candidate identity, provider census, immutable smoke, and alias allowlist checks remain mandatory. The external Claude security scan was skipped because no source-code-egress approval was returned.

Operational context: #636 is managed by the CI failure notifier and should close only after the workflow succeeds for this partition.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes production deployment admission and alias topology for main Vercel candidates; safeguards are explicit preflight binding and unchanged smoke/census, but mistaken relaxation could admit wrong alias state.
> 
> **Overview**
> Fixes **rerun deadlocks** where recovery moved generated project/creator aliases off an still-valid manifest-bound candidate, so `candidate-finalize` kept failing on missing base alias even after smoke passed.
> 
> **`candidate-finalize`** now accepts optional **`--preflight`** (Governance, Reserve, UI workflow steps pass `preflight.json`). Finalization binds that snapshot to intent and candidate; a **`reuse-existing`** preflight captured before any build can switch alias checks to **`reused-candidate`** mode, which allows only a canonical subset of reviewed project/scope and creator aliases (including **none**). **`create-if-zero`** preflights and candidates not seen at preflight still require the full generated project alias; Git/default, protected, wrong-target, and unknown aliases still fail closed.
> 
> Controller logic adds **`resolvedAliasTopologyMode`** / **`canonicalAdmissionPreflight`**; **`vercel-production-generated-aliases.mjs`** gains **`REUSED_CANDIDATE`** with subset-only validation. ADR 0005 and **`docs/vercel-deployments.md`** document detached admission; tests cover detached reuse, rejections, and CLI/workflow wiring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71d5e53c7bca303235e827acf4ad5d88147dbbf4. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->