### PR TITLE
fix: raise preview journal capacity

### DIFF
--- a/docs/adr/0002-single-comment-preview-controller-journal.md
+++ b/docs/adr/0002-single-comment-preview-controller-journal.md
@@ -109,7 +109,7 @@ latest runtime event for dispatch. Thus queued receipt jobs cannot disappear,
 and a docs-only tail cannot remain pending after its runtime dependency ends.
 
 The complete rendered comment body remains subject to the controller's
-60,000-byte UTF-8 hard limit. A mutation that cannot use either terminal or
+64,000-byte UTF-8 hard limit. A mutation that cannot use either terminal or
 capacity checkpointing safely and would exceed that bound fails closed before
 it changes the journal, publishes a success status, or dispatches a worker.
 Unfinished evidence and active or retired ownership are never truncated to
@@ -423,7 +423,7 @@ cost, retention policy, and operator dependency for preview deployment.
   operational signal alongside preview latency.
 - Deterministic terminal and capacity checkpoints keep sequential previews and
   overlapping bursts bounded without adding an archive, rollover comment, or
-  compatibility path. The 60,000-byte UTF-8 bound remains a fail-closed
+  compatibility path. The 64,000-byte UTF-8 bound remains a fail-closed
   constraint when unfinished ownership cannot be summarized safely.
 - Terminal results remove their retired owners once the result is durable.
   More than 40 genuinely unfinished retired owners fails closed; ownership is

--- a/docs/vercel-deployments.md
+++ b/docs/vercel-deployments.md
@@ -2321,7 +2321,7 @@ retired owners are then removed. More than 40 genuinely unfinished retired
 owners fails closed instead of silently discarding ownership. No unfinished
 worker evidence is truncated.
 
-The complete rendered journal body has a 60,000-byte hard limit measured as
+The complete rendered journal body has a 64,000-byte hard limit measured as
 UTF-8. A transition that cannot safely use either terminal or capacity
 checkpointing and would cross it fails closed before changing the journal,
 reporting success, or dispatching work; active, retired, or unmatched evidence

--- a/scripts/vercel-preview-controller.mjs
+++ b/scripts/vercel-preview-controller.mjs
@@ -81,7 +81,8 @@ const MAX_HISTORY = 40;
 // terminal receipts need a small fixed number of rereads before publication.
 const MAX_RECONCILIATION_PROGRESS_PASSES = MAX_HISTORY + 4;
 const MAX_SERIALIZED_UPDATE_ATTEMPTS = 3;
-const MAX_JOURNAL_BYTES = 60_000;
+// GitHub issue comments cap at 65,536 bytes; 64,000 retains 1,536 bytes of headroom.
+const MAX_JOURNAL_BYTES = 64_000;
 const ACTIVE_CHECKPOINT_BYTES = 40_000;
 const WORKER_RUN_PAGE_SIZE = 100;
 const MAX_WORKER_RUN_PAGES = 3;

--- a/scripts/vercel-preview-controller.test.mjs
+++ b/scripts/vercel-preview-controller.test.mjs
@@ -2529,6 +2529,149 @@ test("capacity checkpoints keep a long overlapping push burst recoverable", () =
   );
 });
 
+test("two-event four-target recovery fits the result-only write before terminal folding", () => {
+  const firstEvent = event({
+    run: 317_000_000,
+    action: "opened",
+    head: SHA.A,
+    targets: PREVIEW_TARGETS,
+    updated: timestamp(1),
+  });
+  const firstPull = pull({ head: SHA.A, updated: timestamp(1) });
+  const selections = [];
+  const workerEvidenceReceipts = [];
+  const results = [];
+  const persistWave = (reconciled, runBase) => {
+    const runIds = Object.fromEntries(
+      PREVIEW_TARGETS.map((target, index) => [target, runBase + index]),
+    );
+    const state = persistTargetDispatches(reconciled, runIds);
+    for (const target of PREVIEW_TARGETS) {
+      const active = state.targets[target].active;
+      selections.push(selectionReceiptFromDispatch(active));
+      workerEvidenceReceipts.push(
+        workerEvidence(active, { runId: runIds[target] }),
+      );
+    }
+    return { runIds, state };
+  };
+  const failWave = (state, runIds) => {
+    for (const target of PREVIEW_TARGETS) {
+      results.push(
+        result(state.targets[target].active, {
+          runId: runIds[target],
+          state: "failure",
+          reason: "build-failed-retriable",
+        }),
+      );
+    }
+  };
+
+  let selected = reconcile({ events: [firstEvent], pullRequest: firstPull });
+  let activeWave = persistWave(selected, 317_100_000);
+  failWave(activeWave.state, activeWave.runIds);
+  selected = reconcile({
+    events: [firstEvent],
+    selections,
+    results,
+    pullRequest: firstPull,
+    existingState: activeWave.state,
+  });
+  activeWave = persistWave(selected, 317_110_000);
+  failWave(activeWave.state, activeWave.runIds);
+  const firstTerminal = reconcile({
+    events: [firstEvent],
+    selections,
+    results,
+    pullRequest: firstPull,
+    existingState: activeWave.state,
+  });
+
+  const secondEvent = event({
+    run: 317_000_001,
+    action: "synchronize",
+    before: SHA.A,
+    head: SHA.B,
+    targets: PREVIEW_TARGETS,
+    updated: timestamp(2),
+  });
+  const events = [firstEvent, secondEvent];
+  const secondPull = pull({ head: SHA.B, updated: timestamp(2) });
+  selected = reconcile({
+    events,
+    selections,
+    results,
+    pullRequest: secondPull,
+    existingState: firstTerminal.state,
+  });
+  activeWave = persistWave(selected, 317_200_000);
+  failWave(activeWave.state, activeWave.runIds);
+  selected = reconcile({
+    events,
+    selections,
+    results,
+    pullRequest: secondPull,
+    existingState: activeWave.state,
+  });
+  activeWave = persistWave(selected, 317_210_000);
+  // Two failed attempts ended before they could publish pre-completion evidence.
+  workerEvidenceReceipts.splice(0, 2);
+
+  let state = activeWave.state;
+  let maximumResultOnlyBytes = 0;
+  for (const target of PREVIEW_TARGETS) {
+    const terminalResult = result(state.targets[target].active, {
+      runId: activeWave.runIds[target],
+    });
+    const resultOnlyJournal = createPreviewJournal({
+      pr: 519,
+      events,
+      selections,
+      workerEvidence: workerEvidenceReceipts,
+      results: [...results, terminalResult],
+      state,
+    });
+    maximumResultOnlyBytes = Math.max(
+      maximumResultOnlyBytes,
+      Buffer.byteLength(previewJournalBody(resultOnlyJournal), "utf8"),
+    );
+    results.push(terminalResult);
+    state = reconcile({
+      events,
+      selections,
+      results,
+      pullRequest: secondPull,
+      existingState: state,
+    }).state;
+  }
+
+  assert.ok(
+    maximumResultOnlyBytes >= 62_500 && maximumResultOnlyBytes <= 63_500,
+    `expected a result-only journal near 63,073 bytes, got ${maximumResultOnlyBytes}`,
+  );
+  assert.ok(
+    maximumResultOnlyBytes < 64_000,
+    `journal was ${maximumResultOnlyBytes} bytes`,
+  );
+  const terminal = compactPreviewJournal(
+    createPreviewJournal({
+      pr: 519,
+      events,
+      selections,
+      workerEvidence: workerEvidenceReceipts,
+      results,
+      state,
+    }),
+  );
+  assert.deepEqual(terminal.receipts, {
+    events: [],
+    selections: [],
+    worker_evidence: [],
+    results: [],
+  });
+  assert.ok(Buffer.byteLength(previewJournalBody(terminal), "utf8") < 64_000);
+});
+
 test("capacity checkpoints preserve the newest queued runtime before reconciliation", () => {
   const openedHead = (200).toString(16).padStart(40, "0");
   const opened = event({


### PR DESCRIPTION
## The Problem

The preview controller's 60,000-byte journal limit rejects a valid result-only recovery transition before terminal compaction can fold it. The generated two-event, four-target recovery fixture reaches 62,777 UTF-8 bytes, reproducing the deterministic deadlock that blocked PR #758.

## The Solution

Raise the hard journal limit to 64,000 bytes. GitHub issue comments allow 65,536 bytes, so the controller retains 1,536 bytes of headroom. Keep the 40,000-byte active checkpoint threshold and every compaction, authority, dispatch, provider, and credential boundary unchanged.

Add a generated multi-wave recovery regression that proves the result-only intermediate fits and the terminal fold removes all receipts. Update the deployment runbook and journal ADR with the new hard limit.

The current head `c504755b80ccdd579f22ba42b89ef7216da2bd31` also contains a normal, conflict-free merge of secured `main` at `7a8a0969f1934ab844c235b97c0c80e8dea1aa5d`, which carries the nanoid 3.3.18 lockfile fix from #765.

## Validation

- `node --test scripts/vercel-preview-controller.test.mjs` — 203/203 passed
- `pnpm vercel:workflow:test` — 591/591 passed
- `pnpm check-types` — 8/8 tasks passed
- root OSV Scanner 2.3.3 against `pnpm-lock.yaml` with `osv-scanner.toml` — no issues found after the configured 24 filters
- `trunk check docs/adr/0002-single-comment-preview-controller-journal.md docs/vercel-deployments.md scripts/vercel-preview-controller.mjs scripts/vercel-preview-controller.test.mjs` — clean
- `pnpm adr:check` — clean
- `git diff --check origin/main...HEAD` — clean
- PR description validator — clean
- Autoreview deterministic guard and current-session semantic/security review of the functional change — no actionable findings

Claude security egress was skipped pending explicit approval. No provider credentials, mutations, reruns, or reconcile requests were used.

## Risk

The hard limit is 4,000 bytes higher and leaves 1,536 bytes below GitHub's issue-comment cap. The existing 70,000-byte fail-closed regression remains in place.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single constant and documentation change with a targeted regression test; no auth, dispatch, or compaction logic changes beyond allowing slightly larger journal comments still below GitHub’s limit.
> 
> **Overview**
> Fixes a **fail-closed deadlock** where a legitimate **result-only recovery** journal could exceed the old **60,000-byte** cap (~63k in the two-event, four-target case) and be rejected **before** terminal compaction could shrink it.
> 
> **`MAX_JOURNAL_BYTES`** moves to **64,000** with a short note that GitHub issue comments max at **65,536** bytes, leaving **1,536** bytes of headroom. The **40,000-byte** active checkpoint threshold and compaction/authority behavior are unchanged.
> 
> The deployment runbook documents the new hard limit. A new controller test simulates **two events**, **four preview targets**, repeated failed waves, and a **result-only** write path: it asserts the intermediate body lands near **63k**, stays **under 64k**, and that **terminal folding** clears receipt arrays while the final comment remains under the cap.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bfa595cb01bba8465ebae63390275db2820cdf7a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
