### PR TITLE
fix(deps): resolve nanoid 3.3.18

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11030,8 +11030,8 @@ packages:
   nan@2.26.1:
     resolution: {integrity: sha512-vodKprLlmaKmraa9E/TxHQwpH4eKYTJbLdeQE49pb9GOmrLs68zESjJu0LQOz1W6JwJmftOWD5Ls4dpd/elQtQ==}
 
-  nanoid@3.3.17:
-    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -28244,7 +28244,7 @@ snapshots:
 
   nan@2.26.1: {}
 
-  nanoid@3.3.17: {}
+  nanoid@3.3.18: {}
 
   natural-compare@1.4.0: {}
 
@@ -28885,13 +28885,13 @@ snapshots:
 
   postcss@8.5.23:
     dependencies:
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
   postcss@8.5.26:
     dependencies:
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## The Problem

- GitHub revised [GHSA-2v37-7h3g-55p8](https://github.com/advisories/GHSA-2v37-7h3g-55p8) on August 13, 2026, moving the patched nanoid 3.x boundary from `3.3.17` to `3.3.18`.
- The root lockfile still resolved both PostCSS dependency paths to `nanoid@3.3.17`, so the root OSV scan began failing after the advisory update.

## The Solution

- Resolve the existing PostCSS 8.5.23 and 8.5.26 dependency edges to `nanoid@3.3.18`.
- Keep this emergency prerequisite to one lockfile with no manifest, override, protected-runtime, workflow, or application-code changes.
- Leave the durable declared-floor rotation to its documented controller-bridge, payload, and cleanup sequence; the standalone Vercel runtime contains no nanoid and remains byte-identical.

## Validation

- Frozen script-disabled workspace install with pnpm 10.34.4.
- Root OSV scan: no issues found.
- Standalone Vercel runtime OSV scan: no issues found.
- `pnpm supply-chain:lockfile-lint`.
- Lockfile fixture tests: 61 passed; brace-expansion regression tests: 6 passed.
- `pnpm vercel:versions:check`.
- `pnpm vercel:production-shadow:test`: 147 passed.
- `pnpm vercel:workflow:test`: 591 passed.
- Representative `ui.mento.org` production build passed, including PostCSS and sharp-trace checks.
- `pnpm check-types`: 8 tasks passed in the pre-push hook.
- Full Trunk, Knip, ADR reminder, and `git diff --check` passed.
- Fresh-context semantic review returned no findings at 0.99 confidence; deterministic autoreview returned no findings.
- Direct browser automation was unavailable in this session. The production build and bundled Chromium workflow smoke tests passed.
- Claude Security was skipped because it requires explicit approval to send the selected diff to Anthropic; no source-code egress was authorized.

## Risk

- The lockfile is secure for frozen installs, but the manifests still declare the former `3.3.17` floor. A later non-frozen resolution could select it again until the protected-runtime override rotation lands.

## Ship Checklist

- [x] PR title follows the conventions.
- [x] Performed a self-review of my own changes.
- [x] Relevant automated checks and smoke tests pass.
- [x] Architecture decision: not applicable — this changes one resolved transitive dependency version without changing architecture.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single transitive dependency patch in the lockfile with no runtime or auth changes; residual risk is manifest floors still declaring 3.3.17 until a follow-up override update.
> 
> **Overview**
> Bumps the resolved **nanoid** version from **3.3.17** to **3.3.18** in `pnpm-lock.yaml` so frozen installs satisfy the updated [GHSA-2v37-7h3g-55p8](https://github.com/advisories/GHSA-2v37-7h3g-55p8) patched boundary for nanoid 3.x. Both **PostCSS** lockfile edges (`postcss@8.5.23` and `postcss@8.5.26`) now pull **nanoid@3.3.18**; there are no manifest, override, or application-code changes in this diff.
> 
> Declared **pnpm** override floors in `package.json` still pin `nanoid@<3.3.17` → `3.3.17`, so a later non-frozen resolve could reintroduce the old floor until that rotation lands separately.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 438baaca35e29623c00d795fcf956f4ce7390477. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->