### PR TITLE
fix(vercel): bridge nanoid runtime floor

### DIFF
--- a/docs/dependency-overrides.md
+++ b/docs/dependency-overrides.md
@@ -27,8 +27,9 @@ outside the reviewed lockfile.
 
 The workspace and standalone runtime resolve legacy v2 consumers to upstream
 `brace-expansion@2.1.4`. The August 2026 rotation retired the former local 2.1.2
-patch. The trusted controller now accepts only the current patchless
-lockfile/override pair.
+patch. The checked-in manifests and lockfiles remain on the current patchless
+pair while the trusted controller temporarily also admits the exact reviewed
+nanoid 3.3.18 successor pair. It rejects both cross-paired hybrids.
 
 After changing the root Vercel pin or any root override, update this protected
 runtime in the same PR:
@@ -102,9 +103,10 @@ manifest declares a local patch. The lockfile lint rejects patched-dependency
 metadata and every affected release, including pnpm aliases, so a broad OSV
 correction cannot hide a future direct or aliased vulnerable entry.
 
-The controller's default contract contains only the current patchless pair.
-Retired patch metadata remains only in negative regression fixtures; do not
-restore the patch to either manifest.
+During the nanoid 3.3.18 rotation, the controller's default contract contains
+only the current and reviewed-next patchless pairs and rejects their cross-pair
+hybrids. Retired patch metadata remains only in negative regression fixtures;
+do not restore the patch to either manifest.
 
 ## Wormhole Connect (`@wormhole-foundation/wormhole-connect`)
 

--- a/docs/vercel-deployments.md
+++ b/docs/vercel-deployments.md
@@ -1148,15 +1148,21 @@ The protected production-shadow Vercel CLI is a standalone frozen install.
 Trusted controller code first requires its manifest to contain
 `vercel@56.4.1` and every CLI builder peer as exact direct dependencies,
 requires its `pnpm.overrides` object to equal the root security overrides,
-binds every byte of `scripts/vercel-cli-runtime/pnpm-lock.yaml` to the reviewed
-SHA-256
-`83351216a20b4f2dd2bf22732b74d6a7448624ff53af14c7573354b0d8342d5e`,
-and binds the canonical root overrides to
-`d07212824ebc4b41e13f76d8d5da2aeba0ca6cd64379b15ad3a816c80ddfe68f`.
-The controller accepts only that pair and rejects all patched-dependency
-metadata and patch artifacts. The current runtime uses upstream fixed
-`brace-expansion@2.1.4`. It copies the manifest and lockfile as independent
-runner-owned `0444`, single-link files under
+binds every byte of `scripts/vercel-cli-runtime/pnpm-lock.yaml` to a literal
+controller-owned mapping. During the nanoid 3.3.18 rotation, that temporary
+mapping accepts only the current lockfile SHA-256
+`957ccb3b8431add07a144e77966b4a05733aaca6f21cd071c937861fc10189d4`
+paired with canonical root override SHA-256
+`301165d803f4cc7db4524ea3a7a02b33db772505c04fdc9025860b244bcb447b`,
+or the reviewed-next lockfile SHA-256
+`2dbd0eba57b119870bcd2ba43f6cf726bb52c85d8ec03f4999030e9931e5ed36`
+paired with canonical root override SHA-256
+`11fc5e7476b6d15ddf6bf8d6956f6566346637f34e0b11e23849e92011b2bf31`.
+The checked-in runtime remains on the current pair until the payload PR changes
+both root and standalone states. The controller rejects cross-paired states,
+all patched-dependency metadata, and patch artifacts. The current runtime uses
+upstream fixed `brace-expansion@2.1.4`. It copies the manifest and lockfile as
+independent runner-owned `0444`, single-link files under
 `$TOOLS_PATH/vercel-cli-runtime`; CI never generates or updates that lockfile.
 The protected pnpm runtime installs there with `--frozen-lockfile`,
 `--ignore-scripts`, `--ignore-workspace`, and `--package-import-method copy`.

--- a/scripts/vercel-cli-runtime-contract.mjs
+++ b/scripts/vercel-cli-runtime-contract.mjs
@@ -28,12 +28,35 @@ const PINNED_VERCEL_CLI_RUNTIME_DEPENDENCIES = Object.freeze({
 // This reviewed pair binds the current August 2026 security-floor runtime. It
 // raises the brace-expansion, DOMPurify, fast-uri, Hono, ip-address, js-yaml,
 // nanoid, PostCSS, socket.io-parser, Undici, and uuid floors and retires the
-// local brace-expansion@2.1.2 patch in favor of upstream 2.1.4. Rotated for
-// the next override moving to ^16.2.12 alongside the catalog (PR #715).
-const PINNED_VERCEL_CLI_RUNTIME_LOCKFILE_SHA256 =
+// local brace-expansion@2.1.2 patch in favor of upstream 2.1.4. It also includes
+// the override moving Next to ^16.2.12 alongside the catalog (PR #715).
+const CURRENT_VERCEL_CLI_RUNTIME_LOCKFILE_SHA256 =
   "957ccb3b8431add07a144e77966b4a05733aaca6f21cd071c937861fc10189d4";
-const PINNED_VERCEL_CLI_RUNTIME_OVERRIDE_SHA256 =
+const CURRENT_VERCEL_CLI_RUNTIME_OVERRIDE_SHA256 =
   "301165d803f4cc7db4524ea3a7a02b33db772505c04fdc9025860b244bcb447b";
+
+// This reviewed successor raises only the nanoid floor from 3.3.17 to 3.3.18.
+// The controller must land this bridge before the matching root and standalone
+// payload. Remove the current pair immediately after that payload is proven on
+// the default branch.
+const NEXT_VERCEL_CLI_RUNTIME_LOCKFILE_SHA256 =
+  "2dbd0eba57b119870bcd2ba43f6cf726bb52c85d8ec03f4999030e9931e5ed36";
+const NEXT_VERCEL_CLI_RUNTIME_OVERRIDE_SHA256 =
+  "11fc5e7476b6d15ddf6bf8d6956f6566346637f34e0b11e23849e92011b2bf31";
+
+// This controller-owned mapping permits only each reviewed lockfile with its
+// matching canonical root override object. Candidate or PR-authored source
+// cannot supply or extend it.
+const TRUSTED_VERCEL_CLI_RUNTIME_STATES = Object.freeze([
+  Object.freeze({
+    lockfileSha256: CURRENT_VERCEL_CLI_RUNTIME_LOCKFILE_SHA256,
+    overridesSha256: CURRENT_VERCEL_CLI_RUNTIME_OVERRIDE_SHA256,
+  }),
+  Object.freeze({
+    lockfileSha256: NEXT_VERCEL_CLI_RUNTIME_LOCKFILE_SHA256,
+    overridesSha256: NEXT_VERCEL_CLI_RUNTIME_OVERRIDE_SHA256,
+  }),
+]);
 
 function hasExactObjectKeys(value, expectedKeys) {
   if (value === null || typeof value !== "object" || Array.isArray(value)) {
@@ -97,7 +120,10 @@ export function assertVercelCliRuntimeContract({
   const lockfileDigest = createHash("sha256")
     .update(lockfileContents)
     .digest("hex");
-  if (lockfileDigest !== PINNED_VERCEL_CLI_RUNTIME_LOCKFILE_SHA256) {
+  const trustedRuntimeState = TRUSTED_VERCEL_CLI_RUNTIME_STATES.find(
+    (state) => state.lockfileSha256 === lockfileDigest,
+  );
+  if (trustedRuntimeState === undefined) {
     throw new Error("Trusted Vercel CLI runtime lockfile is not exact");
   }
   if (
@@ -129,7 +155,7 @@ export function assertVercelCliRuntimeContract({
   ) {
     throw new Error("Trusted Vercel CLI runtime manifest is not exact");
   }
-  if (rootOverridesSha256 !== PINNED_VERCEL_CLI_RUNTIME_OVERRIDE_SHA256) {
+  if (rootOverridesSha256 !== trustedRuntimeState.overridesSha256) {
     throw new Error(
       "Trusted Vercel CLI runtime lockfile and overrides are not an approved pair",
     );

--- a/scripts/vercel-prebuilt.test.mjs
+++ b/scripts/vercel-prebuilt.test.mjs
@@ -41,8 +41,10 @@ const scriptPath = fileURLToPath(
   new URL("./vercel-prebuilt.mjs", import.meta.url),
 );
 const COMMIT_SHA = "0123456789abcdef0123456789abcdef01234567";
-const PINNED_VERCEL_CLI_RUNTIME_LOCKFILE_SHA256 =
+const CURRENT_VERCEL_CLI_RUNTIME_LOCKFILE_SHA256 =
   "957ccb3b8431add07a144e77966b4a05733aaca6f21cd071c937861fc10189d4";
+const NEXT_VERCEL_CLI_RUNTIME_LOCKFILE_SHA256 =
+  "2dbd0eba57b119870bcd2ba43f6cf726bb52c85d8ec03f4999030e9931e5ed36";
 
 function deploymentId(overrides = {}) {
   return generateVercelDeploymentId({
@@ -66,6 +68,34 @@ function createVersionContractFixture() {
     );
   }
   return fixtureRoot;
+}
+
+function nextNanoidOverrides(overrides) {
+  const next = { ...overrides };
+  assert.equal(next["nanoid@<3.3.17"], "3.3.17");
+  delete next["nanoid@<3.3.17"];
+  next["nanoid@<3.3.18"] = "3.3.18";
+  return next;
+}
+
+function nextNanoidLockfile(lockfile) {
+  const next = lockfile.replace(
+    "  nanoid@<3.3.17: 3.3.17\n",
+    "  nanoid@<3.3.18: 3.3.18\n",
+  );
+  assert.notEqual(next, lockfile);
+  return next;
+}
+
+function writeRuntimeOverrides({ fixtureRoot, overrides }) {
+  for (const path of [
+    join(fixtureRoot, "package.json"),
+    join(fixtureRoot, "scripts", "vercel-cli-runtime", "package.json"),
+  ]) {
+    const packageMetadata = JSON.parse(readFileSync(path, "utf8"));
+    packageMetadata.pnpm.overrides = overrides;
+    writeFileSync(path, `${JSON.stringify(packageMetadata, null, 2)}\n`);
+  }
 }
 
 test("generated IDs satisfy every Vercel constraint for every target", () => {
@@ -212,7 +242,7 @@ test("resolved Next.js and exact Vercel CLI satisfy custom-ID prerequisites", ()
   };
   assert.equal(
     prerequisites.vercelCliRuntime.lockfileSha256,
-    PINNED_VERCEL_CLI_RUNTIME_LOCKFILE_SHA256,
+    CURRENT_VERCEL_CLI_RUNTIME_LOCKFILE_SHA256,
   );
   assert.deepEqual(prerequisites, expected);
   assert.deepEqual(
@@ -229,7 +259,7 @@ test("resolved Next.js and exact Vercel CLI satisfy custom-ID prerequisites", ()
   assert.equal(isVersionGreaterThan("56.4.1", "50.3.3"), true);
 });
 
-test("trusted controller accepts only the pinned Vercel CLI runtime pair", () => {
+test("trusted controller accepts only matching current and next Vercel CLI runtime pairs", () => {
   const fixtureRoot = createVersionContractFixture();
   const contractPaths = {
     rootPackageJsonPath: join(fixtureRoot, "package.json"),
@@ -247,13 +277,39 @@ test("trusted controller accepts only the pinned Vercel CLI runtime pair", () =>
     ),
   };
   try {
-    const repositoryDigest =
+    const currentDigest =
       assertVercelCliRuntimeContract(contractPaths).lockfileSha256;
-    assert.equal(repositoryDigest, PINNED_VERCEL_CLI_RUNTIME_LOCKFILE_SHA256);
-    const repositoryLockfile = readFileSync(contractPaths.lockfilePath, "utf8");
+    assert.equal(currentDigest, CURRENT_VERCEL_CLI_RUNTIME_LOCKFILE_SHA256);
+    const currentLockfile = readFileSync(contractPaths.lockfilePath, "utf8");
+    const currentOverrides = JSON.parse(
+      readFileSync(contractPaths.rootPackageJsonPath, "utf8"),
+    ).pnpm.overrides;
+    const nextLockfile = nextNanoidLockfile(currentLockfile);
+    const nextOverrides = nextNanoidOverrides(currentOverrides);
+
+    writeRuntimeOverrides({ fixtureRoot, overrides: nextOverrides });
+    writeFileSync(contractPaths.lockfilePath, nextLockfile);
+    assert.equal(
+      assertVercelCliRuntimeContract(contractPaths).lockfileSha256,
+      NEXT_VERCEL_CLI_RUNTIME_LOCKFILE_SHA256,
+    );
+
+    for (const [overrides, lockfile] of [
+      [currentOverrides, nextLockfile],
+      [nextOverrides, currentLockfile],
+    ]) {
+      writeRuntimeOverrides({ fixtureRoot, overrides });
+      writeFileSync(contractPaths.lockfilePath, lockfile);
+      assert.throws(
+        () => assertVercelCliRuntimeContract(contractPaths),
+        /lockfile and overrides are not an approved pair/,
+      );
+    }
+
+    writeRuntimeOverrides({ fixtureRoot, overrides: nextOverrides });
     writeFileSync(
       contractPaths.lockfilePath,
-      `${repositoryLockfile}\n# unreviewed digest\n`,
+      `${nextLockfile}\n# unreviewed digest\n`,
     );
     assert.throws(
       () => assertVercelCliRuntimeContract(contractPaths),


### PR DESCRIPTION
## The Problem

The protected standalone Vercel CLI runtime accepts one exact lockfile and root-override digest pair. Raising the nanoid security floor from 3.3.17 to 3.3.18 changes both digests, so changing the payload first would make trusted default-branch deployment jobs reject the new runtime. Accepting the two digests independently would also admit unsafe cross-paired states.

## The Solution

Add a temporary controller-owned mapping for exactly two reviewed states:

- current lock `957ccb3b...` with current canonical overrides `301165d8...`
- next lock `2dbd0eba...` with next canonical overrides `11fc5e74...`

The contract still requires the standalone manifest to mirror the root overrides exactly. It accepts both complete pairs, rejects both cross-pairs and unknown lock bytes, and keeps patched dependencies forbidden. The checked-in root and standalone manifests and lockfiles do not change in this PR. A payload PR will move both manifests and the standalone lock together, followed immediately by a cleanup PR that removes the old pair.

## Validation

- focused runtime-contract tests: 16/16
- `pnpm vercel:versions:check`
- `pnpm supply-chain:lockfile-lint`
- `pnpm vercel:production-shadow:test`: 147/147
- `pnpm vercel:workflow:test`: 591/591
- Trunk on all four changed files
- `pnpm adr:check`
- `git diff --check`
- structured autoreview: one accepted P3 docs correction, clean bounded re-review, deterministic guard clean

No browser check applies because this PR changes only a deployment admission contract, tests, and runbooks. Claude Security was not run because sending the selected source diff to Anthropic has not been authorized.

## Risk

The bridge temporarily permits two exact reviewed runtime states. Candidate input cannot add a state, and every mismatched or unknown pair still fails closed. The next two PRs must complete the payload rotation and remove the former pair promptly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes deployment admission for the protected Vercel CLI runtime (supply-chain gate); scope is bounded to two hard-coded reviewed pairs with cross-pair rejection, but a mistake in the mapping could block deploys or delay the rotation cleanup.
> 
> **Overview**
> Adds a **temporary two-state admission bridge** in `assertVercelCliRuntimeContract` so the protected Vercel CLI runtime can rotate the **nanoid** override floor (3.3.17 → 3.3.18) without breaking default-branch deploys.
> 
> Instead of one fixed lockfile + root-override digest, the controller now owns `TRUSTED_VERCEL_CLI_RUNTIME_STATES`: the **current** checked-in pair and a **reviewed-next** pair whose only override delta is nanoid. Lockfile bytes must match a known entry, and canonical root overrides must match **that** entry’s override hash—**cross-paired** lock/override combinations still fail closed. Patched-dependency rules are unchanged.
> 
> **This PR does not** change root or standalone manifests/lockfiles; a follow-up payload PR will land the new state, then a cleanup PR drops the old pair.
> 
> Tests in `vercel-prebuilt.test.mjs` exercise both approved pairs, cross-pair rejection, and unknown lock bytes. Runbooks in `dependency-overrides.md` and `vercel-deployments.md` document the rotation sequence and the new SHA mapping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9cd5d575c2bbe63e589971e07139c6fe1f799c9c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->