### PR TITLE
fix(dependabot): accept GitHub-signed repair commits

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,8 +127,9 @@ request receipt on the old head and a successful completed receipt on the new
 two-parent head. A repair stages an unreachable exact-parent commit, publishes a
 packet/plan/tree-bound intent without the App token, moves the exact ref with a
 fresh token, and publishes the completed receipt without it. The commit must
-have the exact App bot identity and GitHub verification `verified=true` with
-reason `valid`. A failed, cancelled, timed-out, action-required, or
+have the exact App bot author, either the exact App bot or GitHub's exact
+`web-flow` system signer as committer, and GitHub verification `verified=true`
+with reason `valid`. A failed, cancelled, timed-out, action-required, or
 startup-failed post-move run may only enter the bounded exact-intent recovery
 path. Normal pre-move work and checks-only recovery each get at most two
 exact-evidence infrastructure retries, independent of the two-commit repair

--- a/docs/adr/0006-dependabot-processing-controller.md
+++ b/docs/adr/0006-dependabot-processing-controller.md
@@ -3,14 +3,14 @@ title: A trusted controller prepares exact-head Dependabot pull requests for hum
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-08-13
+last_verified: 2026-08-14
 scope: ci/dependabot-processing
 date: 2026-08-10
 ---
 
 # ADR 0006 — A trusted controller prepares exact-head Dependabot pull requests for human merge
 
-**Status:** Accepted, amended Aug 13 2026
+**Status:** Accepted, amended Aug 14 2026
 **Scope:** ci/dependabot-processing
 
 ## Context
@@ -103,8 +103,9 @@ For prepared heads, the workflow materializes
 - a Refresh commit whose first parent is the prior head and whose second parent
   is the receipt's actual applied base, plus its successful old-head request and
   verified bounded request-to-update base-race evidence;
-- a Repair commit whose single parent is the packet head and whose author and
-  committer match the live configured App bot ID/login; and
+- a Repair commit whose single parent is the packet head, whose author matches
+  the live configured App bot ID/login, and whose committer is either that bot
+  or GitHub's exact `web-flow` system signer; and
 - a bounded operation chain rooted in a verified Dependabot seed.
 
 The Claude job checks out only the trusted workflow source. It restricts
@@ -215,8 +216,10 @@ code:
    completion idempotently. An intent whose staged commit never became the PR
    head is inert.
 
-Repair commits must have the exact Prepare App bot author/committer identity and
-GitHub verification `verified=true` with reason `valid`. Mutation and recovery
+Repair commits must have the exact Prepare App bot author, either that bot or
+GitHub's exact `web-flow` system signer as committer, and GitHub verification
+`verified=true` with reason `valid`. This models GitHub's server-signed App
+commit shape without accepting an arbitrary committer. Mutation and recovery
 never install dependencies or execute the new tree. `Dependabot Prepared Head
 Dispatch` accepts a successful completed receipt for prepared-head intake. It
 accepts those exact retryable non-success Repair sources only to dispatch the

--- a/docs/dependabot-automation.md
+++ b/docs/dependabot-automation.md
@@ -3,7 +3,7 @@ title: Dependabot Processing
 status: active
 owner: eng
 canonical: true
-last_verified: 2026-08-13
+last_verified: 2026-08-14
 scope: ci/dependabot-processing
 ---
 
@@ -389,12 +389,15 @@ intent, branch mutation, and recovery:
    the exact intent-bound commit is already the current PR head.
 
 The staged tree is never executed. The Repair commit must have the configured
-Prepare App bot author/committer identity and GitHub verification
-`verified=true` with reason `valid`. A staged intent is inert if its commit did
-not become the PR head. `Dependabot Prepared Head Dispatch` sends prepared-head
-intake only from a successful completed Repair receipt. Only the exact retryable
-non-success conclusions above may trigger bounded retry or the checks-only
-recovery path; they never establish completion authority by themselves.
+Prepare App bot as its exact author and either that bot or GitHub's exact
+`web-flow` system user as its committer, with GitHub verification
+`verified=true` and reason `valid`. GitHub uses `web-flow` when it server-signs
+a Git Data commit created by an App without custom author, committer, or
+signature fields. A staged intent is inert if its commit did not become the PR
+head. `Dependabot Prepared Head Dispatch` sends prepared-head intake only from
+a successful completed Repair receipt. Only the exact retryable non-success
+conclusions above may trigger bounded retry or the checks-only recovery path;
+they never establish completion authority by themselves.
 
 Infrastructure retry count is separate from the two-commit repair attempt. A
 normal failure before the ref move re-authenticates and redispatches the exact

--- a/scripts/dependabot-preparation-receipts.mjs
+++ b/scripts/dependabot-preparation-receipts.mjs
@@ -17,6 +17,7 @@ import process from "node:process";
 import { pathToFileURL } from "node:url";
 
 export const GITHUB_ACTIONS_APP_ID = 15_368;
+export const GITHUB_WEB_FLOW_USER_ID = 19_864_447;
 export const PROCESSOR_PACKET_SCHEMA = "dependabot-repair-packet:v2";
 export const REPAIR_INTENT_SCHEMA = "dependabot-repair-intent:v1";
 export const REPAIR_PLAN_SCHEMA = "dependabot-repair-plan:v1";
@@ -2716,6 +2717,14 @@ export function nextInfrastructureRetry(retryCount) {
 }
 
 export function validateRepairCommit(commit, intent) {
+  const exactPrepareCommitter =
+    commit.committer?.id === intent.prepareBotId &&
+    commit.committer?.login === intent.prepareBotLogin &&
+    commit.committer?.type === "Bot";
+  const exactGitHubSystemCommitter =
+    commit.committer?.id === GITHUB_WEB_FLOW_USER_ID &&
+    commit.committer?.login === "web-flow" &&
+    commit.committer?.type === "User";
   if (
     commit.sha !== intent.headSha ||
     commit.parents?.length !== 1 ||
@@ -2726,9 +2735,7 @@ export function validateRepairCommit(commit, intent) {
     commit.author?.id !== intent.prepareBotId ||
     commit.author?.login !== intent.prepareBotLogin ||
     commit.author?.type !== "Bot" ||
-    commit.committer?.id !== intent.prepareBotId ||
-    commit.committer?.login !== intent.prepareBotLogin ||
-    commit.committer?.type !== "Bot"
+    (!exactPrepareCommitter && !exactGitHubSystemCommitter)
   ) {
     fail("staged repair commit is not an exact Prepare App append");
   }

--- a/scripts/dependabot-preparation-receipts.test.mjs
+++ b/scripts/dependabot-preparation-receipts.test.mjs
@@ -19,6 +19,7 @@ import { test } from "node:test";
 import { fileURLToPath } from "node:url";
 
 import {
+  GITHUB_WEB_FLOW_USER_ID,
   applyRepairPlan,
   canonicalDigest,
   canonicalJson,
@@ -324,7 +325,7 @@ test("repair and recovery titles bind bounded infrastructure retry state", () =>
   );
 });
 
-test("staging and recovery reject an unsigned Prepare App repair commit", () => {
+test("staging and recovery bind the Prepare author, GitHub signer, and verification", () => {
   const intent = repairIntent();
   const commit = {
     author: {
@@ -337,14 +338,39 @@ test("staging and recovery reject an unsigned Prepare App repair commit", () => 
       verification: { reason: "valid", verified: true },
     },
     committer: {
-      id: intent.prepareBotId,
-      login: intent.prepareBotLogin,
-      type: "Bot",
+      id: GITHUB_WEB_FLOW_USER_ID,
+      login: "web-flow",
+      type: "User",
     },
     parents: [{ sha: intent.parentHeadSha }],
     sha: intent.headSha,
   };
   assert.equal(validateRepairCommit(commit, intent), commit);
+  assert.equal(
+    validateRepairCommit(
+      {
+        ...commit,
+        committer: {
+          id: intent.prepareBotId,
+          login: intent.prepareBotLogin,
+          type: "Bot",
+        },
+      },
+      intent,
+    ).sha,
+    intent.headSha,
+  );
+  for (const committer of [
+    { id: GITHUB_WEB_FLOW_USER_ID + 1, login: "web-flow", type: "User" },
+    { id: GITHUB_WEB_FLOW_USER_ID, login: "attacker", type: "User" },
+    { id: GITHUB_WEB_FLOW_USER_ID, login: "web-flow", type: "Bot" },
+    { id: intent.prepareBotId, login: intent.prepareBotLogin, type: "User" },
+  ]) {
+    assert.throws(
+      () => validateRepairCommit({ ...commit, committer }, intent),
+      /exact Prepare App append/,
+    );
+  }
   assert.throws(
     () =>
       validateRepairCommit(

--- a/scripts/dependabot-prepared-review.mjs
+++ b/scripts/dependabot-prepared-review.mjs
@@ -11,6 +11,7 @@ const HEAD_REF_PATTERN = /^dependabot\/[A-Za-z0-9._/-]{1,220}$/;
 const REPAIR_PATH_PATTERN =
   /^(?!\/)(?!.*(?:^|\/)\.\.(?:\/|$))[A-Za-z0-9._@+/-]{1,300}$/;
 const GITHUB_ACTIONS_APP_ID = 15368;
+const GITHUB_WEB_FLOW_USER_ID = 19864447;
 const RECEIPT_OUTPUT_LIMIT = 50_000;
 const LINEAGE_LIMIT = 24;
 const CHECK_PAGE_SIZE = 100;
@@ -471,6 +472,24 @@ function validateDependabotSeed(commit) {
       commit.commit?.verification?.verified === true &&
       commit.commit?.verification?.reason === "valid",
     "prepared lineage is not rooted in a verified Dependabot seed",
+  );
+}
+
+function hasExactPrepareAuthorship(commit, expected) {
+  const exactPrepareAuthor =
+    commit.author?.id === expected.prepareBotId &&
+    commit.author?.login === expected.prepareBotLogin &&
+    commit.author?.type === "Bot";
+  const exactPrepareCommitter =
+    commit.committer?.id === expected.prepareBotId &&
+    commit.committer?.login === expected.prepareBotLogin &&
+    commit.committer?.type === "Bot";
+  const exactGitHubSystemCommitter =
+    commit.committer?.id === GITHUB_WEB_FLOW_USER_ID &&
+    commit.committer?.login === "web-flow" &&
+    commit.committer?.type === "User";
+  return (
+    exactPrepareAuthor && (exactPrepareCommitter || exactGitHubSystemCommitter)
   );
 }
 
@@ -987,24 +1006,11 @@ export function validatePreparedReviewTarget(options, requestJson) {
         repository: expected.repository,
         requestJson,
       });
-      const exactPrepareAuthor =
-        commit.author?.id === expected.prepareBotId &&
-        commit.author?.login === expected.prepareBotLogin &&
-        commit.author?.type === "Bot";
-      const exactPrepareCommitter =
-        commit.committer?.id === expected.prepareBotId &&
-        commit.committer?.login === expected.prepareBotLogin &&
-        commit.committer?.type === "Bot";
-      const verifiedWebFlowCommitter =
-        commit.committer?.id === 19864447 &&
-        commit.committer?.login === "web-flow" &&
-        commit.committer?.type === "User";
       invariant(
         commit.parents.length === 2 &&
           commit.parents[0]?.sha === parentHeadSha &&
           commit.parents[1]?.sha === current.receipt.baseSha &&
-          exactPrepareAuthor &&
-          (exactPrepareCommitter || verifiedWebFlowCommitter) &&
+          hasExactPrepareAuthorship(commit, expected) &&
           commit.commit?.verification?.verified === true &&
           commit.commit?.verification?.reason === "valid",
         "refresh is not the exact append-only two-parent merge",
@@ -1022,12 +1028,7 @@ export function validatePreparedReviewTarget(options, requestJson) {
         repairCount <= 2 &&
           commit.parents.length === 1 &&
           commit.parents[0]?.sha === parentHeadSha &&
-          commit.author?.id === expected.prepareBotId &&
-          commit.author?.login === expected.prepareBotLogin &&
-          commit.author?.type === "Bot" &&
-          commit.committer?.id === expected.prepareBotId &&
-          commit.committer?.login === expected.prepareBotLogin &&
-          commit.committer?.type === "Bot" &&
+          hasExactPrepareAuthorship(commit, expected) &&
           commit.commit?.verification?.verified === true &&
           commit.commit?.verification?.reason === "valid",
         "repair commit is not an exact Prepare App append",

--- a/scripts/dependabot-prepared-review.test.mjs
+++ b/scripts/dependabot-prepared-review.test.mjs
@@ -28,6 +28,11 @@ const workflowSha = "5".repeat(40);
 const prepareAppSlug = "mento-dependabot-prepare";
 const prepareBotId = 987654;
 const prepareBotLogin = "mento-dependabot-prepare[bot]";
+const githubSystemCommitter = {
+  id: 19864447,
+  login: "web-flow",
+  type: "User",
+};
 
 function read(relativePath) {
   return readFileSync(new URL(`../${relativePath}`, import.meta.url), "utf8");
@@ -210,7 +215,7 @@ function repairFixture() {
   const repairCommit = {
     author: { id: prepareBotId, login: prepareBotLogin, type: "Bot" },
     commit: { verification: { reason: "valid", verified: true } },
-    committer: { id: prepareBotId, login: prepareBotLogin, type: "Bot" },
+    committer: githubSystemCommitter,
     parents: [{ sha: seedHeadSha }],
     sha: preparedHeadSha,
   };
@@ -634,7 +639,7 @@ function recoveredRepairLineageFixture({ failedRecoveryCount = 0 } = {}) {
       {
         author: actor,
         commit: { verification: { reason: "valid", verified: true } },
-        committer: actor,
+        committer: githubSystemCommitter,
         parents: [{ sha: preparedHeadSha }],
         sha: laterHeadSha,
       },
@@ -644,7 +649,7 @@ function recoveredRepairLineageFixture({ failedRecoveryCount = 0 } = {}) {
       {
         author: actor,
         commit: { verification: { reason: "valid", verified: true } },
-        committer: actor,
+        committer: githubSystemCommitter,
         parents: [{ sha: seedHeadSha }],
         sha: preparedHeadSha,
       },
@@ -722,6 +727,33 @@ test("accepts an exact App-authored repair rooted in a verified Dependabot seed"
     repository,
     seedHeadSha,
   });
+});
+
+test("also accepts an exact App bot as the verified Repair committer", () => {
+  const fixture = repairFixture();
+  const path = `repos/${repository}/commits/${preparedHeadSha}`;
+  const entries = fixture.entries.map(([key, value]) =>
+    key === path
+      ? [
+          key,
+          {
+            ...value,
+            committer: {
+              id: prepareBotId,
+              login: prepareBotLogin,
+              type: "Bot",
+            },
+          },
+        ]
+      : [key, value],
+  );
+  assert.equal(
+    validatePreparedReviewTarget(
+      options(fixture.operation, fixture.checkId, fixture.receiptDigest),
+      requestFromMap(entries),
+    ).repairCount,
+    1,
+  );
 });
 
 test("uses a successful recovery receipt after a failed receipt when later prepared lineage continues", () => {
@@ -1400,6 +1432,29 @@ test("rejects a repair commit whose bot identity is only asserted in receipt JSO
       ),
     /repair commit is not an exact Prepare App append/,
   );
+});
+
+test("rejects inexact GitHub system committers on a Repair commit", () => {
+  const path = `repos/${repository}/commits/${preparedHeadSha}`;
+  for (const committer of [
+    { ...githubSystemCommitter, id: githubSystemCommitter.id + 1 },
+    { ...githubSystemCommitter, login: "attacker" },
+    { ...githubSystemCommitter, type: "Bot" },
+  ]) {
+    const fixture = repairFixture();
+    const entries = fixture.entries.map(([key, value]) =>
+      key === path ? [key, { ...value, committer }] : [key, value],
+    );
+    assert.throws(
+      () =>
+        validatePreparedReviewTarget(
+          options(fixture.operation, fixture.checkId, fixture.receiptDigest),
+          requestFromMap(entries),
+        ),
+      /repair commit is not an exact Prepare App append/,
+      JSON.stringify(committer),
+    );
+  }
 });
 
 test("rejects unsigned and invalid-reason Repair commits", () => {

--- a/scripts/dependabot-processor.mjs
+++ b/scripts/dependabot-processor.mjs
@@ -59,7 +59,7 @@ const CHECK_SOURCE_RESOLUTION_CONCURRENCY = 8;
 const REFRESH_SUCCESSOR_POLL_ATTEMPTS = 5;
 const REFRESH_SNAPSHOT_RACE_ATTEMPTS = 5;
 const REFRESH_SUCCESSOR_POLL_INTERVAL_MS = 2_000;
-const GITHUB_WEB_FLOW_BOT_ID = 19_864_447;
+const GITHUB_WEB_FLOW_USER_ID = 19_864_447;
 const PROCESSOR_APPROVAL_PULL_LIMIT = 100;
 const PROCESSOR_APPROVAL_REVIEW_LIMIT = 2_000;
 const PROCESSOR_APPROVAL_RESULT_LIMIT = 1_000;
@@ -727,9 +727,19 @@ function commitActorMatchesPrepareBot(commit, receipt, role) {
 }
 
 function commitMatchesPrepareBot(commit, receipt) {
+  const committer = normalizedCommitActor(commit, "committer");
+  const exactPrepareCommitter = commitActorMatchesPrepareBot(
+    commit,
+    receipt,
+    "committer",
+  );
+  const exactGitHubSystemCommitter =
+    committer.id === GITHUB_WEB_FLOW_USER_ID &&
+    committer.login === "web-flow" &&
+    committer.type === "User";
   return (
     commitActorMatchesPrepareBot(commit, receipt, "author") &&
-    commitActorMatchesPrepareBot(commit, receipt, "committer")
+    (exactPrepareCommitter || exactGitHubSystemCommitter)
   );
 }
 
@@ -743,19 +753,8 @@ function commitHasValidVerification(commit) {
 }
 
 function commitMatchesAuthenticatedRefresh(commit, receipt) {
-  const committer = normalizedCommitActor(commit, "committer");
-  const exactPrepareCommitter = commitActorMatchesPrepareBot(
-    commit,
-    receipt,
-    "committer",
-  );
-  const exactWebFlowCommitter =
-    committer.id === GITHUB_WEB_FLOW_BOT_ID &&
-    committer.login === "web-flow" &&
-    committer.type === "User";
   return (
-    commitActorMatchesPrepareBot(commit, receipt, "author") &&
-    (exactPrepareCommitter || exactWebFlowCommitter) &&
+    commitMatchesPrepareBot(commit, receipt) &&
     commitHasValidVerification(commit)
   );
 }

--- a/scripts/dependabot-processor.test.mjs
+++ b/scripts/dependabot-processor.test.mjs
@@ -60,6 +60,11 @@ const PREPARE_ACTOR = {
   botId: 91_001,
   botLogin: "mento-dependabot-prepare[bot]",
 };
+const GITHUB_SYSTEM_COMMITTER = {
+  committerId: 19_864_447,
+  committerLogin: "web-flow",
+  committerType: "User",
+};
 const PACKAGE_BLOB = {
   filename: "package.json",
   mode: "100644",
@@ -3491,9 +3496,7 @@ test("typed repair receipts require valid verification and consume one attempt o
         authorId: PREPARE_ACTOR.botId,
         authorLogin: PREPARE_ACTOR.botLogin,
         authorType: "Bot",
-        committerId: PREPARE_ACTOR.botId,
-        committerLogin: PREPARE_ACTOR.botLogin,
-        committerType: "Bot",
+        ...GITHUB_SYSTEM_COMMITTER,
         parents: [HEAD_SHA],
         sha: OTHER_SHA,
         verified: true,
@@ -3549,6 +3552,29 @@ test("typed repair receipts require valid verification and consume one attempt o
       `${label}: ${stableJson(untrusted.repairAttempts.reasons)}`,
     );
     assert.equal(untrusted.repairPacket, null, label);
+  }
+
+  for (const replacement of [
+    { committerId: GITHUB_SYSTEM_COMMITTER.committerId + 1 },
+    { committerLogin: "attacker" },
+    { committerType: "Bot" },
+  ]) {
+    const wrongSystemCommitter = structuredClone(repaired);
+    Object.assign(wrongSystemCommitter.commits[1], replacement);
+    const wrongSystemCommitterResult = evaluateDependabotPullRequest(
+      wrongSystemCommitter,
+      {
+        mode: "prepare",
+        repository: REPOSITORY,
+        workflowContext: WORKFLOW_CONTEXT,
+      },
+    );
+    assert.equal(wrongSystemCommitterResult.identity.valid, false);
+    assert.ok(
+      wrongSystemCommitterResult.repairAttempts.reasons.includes(
+        "invalid-repair-transition",
+      ),
+    );
   }
 
   const forged = structuredClone(repaired);
@@ -5023,9 +5049,7 @@ test("finalize remediates only the exact packet-bound review thread", async () =
     authorId: PREPARE_ACTOR.botId,
     authorLogin: PREPARE_ACTOR.botLogin,
     authorType: "Bot",
-    committerId: PREPARE_ACTOR.botId,
-    committerLogin: PREPARE_ACTOR.botLogin,
-    committerType: "Bot",
+    ...GITHUB_SYSTEM_COMMITTER,
     parents: [HEAD_SHA],
     sha: OTHER_SHA,
     verified: true,


### PR DESCRIPTION
## The Problem

The Prepare App creates repair commits through GitHub's Git Data API without custom identity fields so GitHub can sign them. GitHub returns the exact App bot as the author and its `web-flow` system user as the committer. The Repair validators required both actors to be the App bot, so a valid staged commit failed before Repair Intent publication or any ref move.

## The Solution

- Accept the exact GitHub server-signed shape in the staging/recovery validator, processor lineage, and prepared-review lineage: the configured Prepare App bot must remain the author; the committer must be either that bot or GitHub's exact `web-flow` user ID `19864447`; verification must remain `verified=true` with reason `valid`.
- Preserve the existing exact SHA, parent, tree, receipt, packet, and workflow bindings.
- Make the live `web-flow` shape canonical in tests, retain the exact-App alternative, and reject wrong signer IDs, logins, types, authors, and verification states across all three consumers.
- Update the Dependabot runbook, ADR, and agent contract to match GitHub's server-signed commit behavior.

## Validation

- `pnpm dependabot:process:test` — 242/242 pass
- `node --check` on all six changed JavaScript files — pass
- `trunk check --no-fix` on all nine changed files — no issues
- `git diff --check` — pass
- `pnpm adr:check` — pass
- Fresh-context Codex autoreview — no findings, 0.97 confidence
- Deterministic local autoreview — no findings
- Pre-push hooks — Trunk checked 1,225 files, all eight type-check tasks passed, and Knip passed with existing configuration hints

## Risk

The identity rule adds only GitHub's exact system signer while retaining exact App authorship and verified-signature checks. It does not add merge, auto-merge, approval, or receipt authority. The live processor remains in `observe` until this fix is merged, exact-main release proof completes, and the contained canary is restarted.

The external Claude Security scan was not run because no affirmative approval was recorded to send the selected diff to Anthropic. The fresh-context and deterministic local security reviews were clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes identity rules on the Dependabot repair trust boundary; scope is narrow (exact `web-flow` plus existing verification) but incorrect matching could admit or reject valid repair lineage.
> 
> **Overview**
> **Repair commit identity** now matches GitHub’s server-signed Git Data shape: the Prepare App bot must still be the **author**, but the **committer** may be either that bot or GitHub’s exact `web-flow` user (`19864447`), with `verified=true` and reason `valid` unchanged.
> 
> The same rule is applied in **`validateRepairCommit`** (staging/recovery), **`dependabot-processor.mjs`** lineage checks, and **`dependabot-prepared-review.mjs`** (shared `hasExactPrepareAuthorship` for refresh and repair). Tests use `web-flow` as the canonical committer, keep the App-bot committer path, and reject wrong signer id/login/type and bad verification. **AGENTS.md**, the ADR, and the Dependabot runbook are updated to document this.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c4a8795ee7dd840d7576eaa05b4ed7236745c2e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->