### PR TITLE
Fix FPMM MAX liquidity amount behavior

### DIFF
--- a/apps/app.mento.org/app/components/pools/add-liquidity-form.test.tsx
+++ b/apps/app.mento.org/app/components/pools/add-liquidity-form.test.tsx
@@ -165,9 +165,11 @@ const pool: PoolDisplay = {
 };
 
 const walletEURm = parseUnits("2199.275594139894034278", 18);
-const walletUSDm = parseUnits("1677.027867285683156092", 18);
-const canonicalEURm = parseUnits("1938.824449465635730703", 18);
-const canonicalUSDm = parseUnits("1677.027867285683156092", 18);
+const walletUSDm = parseUnits("2500", 18);
+const desiredEURm = walletEURm;
+const desiredUSDm = parseUnits("1902.37338893100833975", 18);
+const actualEURm = parseUnits("2199.275594139894034178", 18);
+const actualUSDm = parseUnits("1902.37338893100833965", 18);
 
 let currentQuote: Record<string, unknown>;
 let currentAddBuild: Record<string, unknown>;
@@ -188,10 +190,10 @@ function makeAddBuild({ approvals }: { approvals: boolean }) {
       ? { params: { to: USDM, data: "0xapprove-usdm", value: "0" } }
       : undefined,
     addLiquidity: {
-      amountADesired: canonicalEURm,
-      amountBDesired: canonicalUSDm,
-      amountAMin: minimumAmount(canonicalEURm),
-      amountBMin: minimumAmount(canonicalUSDm),
+      amountADesired: desiredEURm,
+      amountBDesired: desiredUSDm,
+      amountAMin: minimumAmount(actualEURm),
+      amountBMin: minimumAmount(actualUSDm),
       params: {
         to: "0x00000000000000000000000000000000000000bb",
         data: "0xcanonical-add-liquidity",
@@ -237,16 +239,18 @@ describe("AddLiquidityForm canonical transaction flows", () => {
     mocks.allowances.set(USDM, 0n);
 
     currentQuote = {
-      amountA: canonicalEURm,
-      amountB: canonicalUSDm,
+      amountA: actualEURm,
+      amountB: actualUSDm,
+      amountADesired: desiredEURm,
+      amountBDesired: desiredUSDm,
       liquidity: 1n,
       totalSupply: 10_000n,
       reserve0: parseUnits("2000", 18),
       reserve1: parseUnits("1730", 18),
       requestId: 1,
       requestKind: "max",
-      surplus0: walletEURm - canonicalEURm,
-      surplus1: walletUSDm - canonicalUSDm,
+      surplus0: walletEURm - actualEURm,
+      surplus1: walletUSDm - actualUSDm,
     };
     currentAddBuild = makeAddBuild({ approvals: true });
     currentZapPreviewBuild = makeZapBuild({
@@ -319,7 +323,11 @@ describe("AddLiquidityForm canonical transaction flows", () => {
 
   afterEach(() => cleanup());
 
-  it("uses one Router-clipped MAX quote for inputs, summary, approvals, and calldata", async () => {
+  it("uses actual MAX transfers for display and desired amounts for approvals and calldata", async () => {
+    const actualOnlyEURmAllowance = actualEURm + 50n;
+    const actualOnlyUSDmAllowance = actualUSDm + 50n;
+    mocks.allowances.set(EURM, actualOnlyEURmAllowance);
+    mocks.allowances.set(USDM, actualOnlyUSDmAllowance);
     const previewBuild = makeAddBuild({ approvals: true });
     const capturedBuild = makeAddBuild({ approvals: true });
     const freshBuild = makeAddBuild({ approvals: false });
@@ -335,14 +343,14 @@ describe("AddLiquidityForm canonical transaction flows", () => {
       expect(
         (screen.getByLabelText("Deposit amount in EURm") as HTMLInputElement)
           .value,
-      ).toBe("1938.824449465635730703");
+      ).toBe("2199.275594139894034178");
       expect(
         (screen.getByLabelText("Deposit amount in USDm") as HTMLInputElement)
           .value,
-      ).toBe("1677.027867285683156092");
+      ).toBe("1902.37338893100833965");
     });
-    expect(screen.getByText("1,938.824449465635730703")).toBeTruthy();
-    expect(screen.getByText("1,677.027867285683156092")).toBeTruthy();
+    expect(screen.getByText("2,199.275594139894034178")).toBeTruthy();
+    expect(screen.getByText("1,902.37338893100833965")).toBeTruthy();
     expect(mocks.useLiquidityQuote).toHaveBeenLastCalledWith(
       expect.objectContaining({
         request: expect.objectContaining({
@@ -363,13 +371,61 @@ describe("AddLiquidityForm canonical transaction flows", () => {
       expect(mocks.buildAddLiquidityTransaction).toHaveBeenCalledTimes(3),
     );
     for (const call of mocks.buildAddLiquidityTransaction.mock.calls) {
-      expect(call).toEqual([canonicalEURm, canonicalUSDm, OWNER, 0.3]);
+      expect(call).toEqual([desiredEURm, desiredUSDm, OWNER, 0.3]);
     }
+    expect(capturedBuild.addLiquidity).toEqual(
+      expect.objectContaining({
+        amountADesired: desiredEURm,
+        amountBDesired: desiredUSDm,
+        amountAMin: minimumAmount(actualEURm),
+        amountBMin: minimumAmount(actualUSDm),
+      }),
+    );
     expect(sentTransactions).toEqual([
       capturedBuild.approvalA?.params,
       capturedBuild.approvalB?.params,
       freshBuild.addLiquidity.params,
     ]);
+  });
+
+  it("shows the paired requirement when MAX exceeds the other token balance", async () => {
+    mocks.balances.set(USDM, 0n);
+    currentQuote = {
+      ...currentQuote,
+      surplus1: 0n,
+    };
+
+    render(<AddLiquidityForm pool={pool} />);
+    fireEvent.click(screen.getByRole("button", { name: "MAX EURm" }));
+
+    await waitFor(() => {
+      expect(
+        (screen.getByLabelText("Deposit amount in EURm") as HTMLInputElement)
+          .value,
+      ).toBe("2199.275594139894034178");
+      expect(
+        (screen.getByLabelText("Deposit amount in USDm") as HTMLInputElement)
+          .value,
+      ).toBe("1902.37338893100833965");
+    });
+    expect(screen.getAllByText("Insufficient USDm balance")).toHaveLength(2);
+    expect(
+      (
+        screen.getByRole("button", {
+          name: "Insufficient USDm balance",
+        }) as HTMLButtonElement
+      ).disabled,
+    ).toBe(true);
+    expect(mocks.useLiquidityQuote).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        request: expect.objectContaining({
+          kind: "max",
+          token: 0,
+          token0Balance: walletEURm,
+          token1Balance: 0n,
+        }),
+      }),
+    );
   });
 
   it.each([

--- a/apps/app.mento.org/app/components/pools/add-liquidity-form.tsx
+++ b/apps/app.mento.org/app/components/pools/add-liquidity-form.tsx
@@ -107,8 +107,8 @@ function isBuildAlignedWithQuote(
 ): boolean {
   const details = build.addLiquidity;
   return (
-    isWithinOneWei(details.amountADesired, quote.amountA) &&
-    isWithinOneWei(details.amountBDesired, quote.amountB) &&
+    details.amountADesired === quote.amountADesired &&
+    details.amountBDesired === quote.amountBDesired &&
     isWithinOneWei(
       details.amountAMin,
       getMinimumAmount(quote.amountA, slippage),
@@ -346,8 +346,8 @@ export function AddLiquidityForm({
     )
       return;
     buildTransaction(
-      currentQuote.amountA,
-      currentQuote.amountB,
+      currentQuote.amountADesired,
+      currentQuote.amountBDesired,
       address,
       slippage,
     );
@@ -427,8 +427,7 @@ export function AddLiquidityForm({
     if (
       token0Balance === undefined ||
       token1Balance === undefined ||
-      token0Balance === 0n ||
-      token1Balance === 0n
+      token0Balance === 0n
     )
       return;
 
@@ -448,7 +447,6 @@ export function AddLiquidityForm({
     if (
       token0Balance === undefined ||
       token1Balance === undefined ||
-      token0Balance === 0n ||
       token1Balance === 0n
     )
       return;
@@ -709,7 +707,9 @@ export function AddLiquidityForm({
           !refreshedQuote ||
           refreshedQuote.requestId !== capturedQuote.requestId ||
           refreshedQuote.amountA !== capturedQuote.amountA ||
-          refreshedQuote.amountB !== capturedQuote.amountB
+          refreshedQuote.amountB !== capturedQuote.amountB ||
+          refreshedQuote.amountADesired !== capturedQuote.amountADesired ||
+          refreshedQuote.amountBDesired !== capturedQuote.amountBDesired
         ) {
           throw new Error(POOL_RATIO_CHANGED_ERROR);
         }
@@ -717,8 +717,8 @@ export function AddLiquidityForm({
         // Rebuild at click time and use this exact result for approvals. The
         // stateful preview build may still belong to a previous quote.
         const capturedBuild = await buildTransaction(
-          capturedQuote.amountA,
-          capturedQuote.amountB,
+          capturedQuote.amountADesired,
+          capturedQuote.amountBDesired,
           address,
           capturedSlippage,
         );
@@ -738,7 +738,7 @@ export function AddLiquidityForm({
 
         if (
           capturedBuild.approvalA &&
-          capturedQuote.amountA > allowances.token0
+          capturedQuote.amountADesired > allowances.token0
         ) {
           const approvalParams = capturedBuild.approvalA.params;
           steps.push({
@@ -750,7 +750,7 @@ export function AddLiquidityForm({
 
         if (
           capturedBuild.approvalB &&
-          capturedQuote.amountB > allowances.token1
+          capturedQuote.amountBDesired > allowances.token1
         ) {
           const approvalParams = capturedBuild.approvalB.params;
           steps.push({
@@ -779,14 +779,17 @@ export function AddLiquidityForm({
               !postApprovalQuote ||
               postApprovalQuote.requestId !== capturedQuote.requestId ||
               postApprovalQuote.amountA !== capturedQuote.amountA ||
-              postApprovalQuote.amountB !== capturedQuote.amountB
+              postApprovalQuote.amountB !== capturedQuote.amountB ||
+              postApprovalQuote.amountADesired !==
+                capturedQuote.amountADesired ||
+              postApprovalQuote.amountBDesired !== capturedQuote.amountBDesired
             ) {
               throw new Error(POOL_RATIO_CHANGED_ERROR);
             }
 
             const freshBuild = await buildTransaction(
-              capturedQuote.amountA,
-              capturedQuote.amountB,
+              capturedQuote.amountADesired,
+              capturedQuote.amountBDesired,
               address,
               capturedSlippage,
             );

--- a/packages/web3/src/features/pools/hooks/use-liquidity-quote.test.tsx
+++ b/packages/web3/src/features/pools/hooks/use-liquidity-quote.test.tsx
@@ -131,7 +131,7 @@ describe("useLiquidityQuote", () => {
             kind: "max",
             token: 0,
             token0Balance: 1_000n,
-            token1Balance: 1_000n,
+            token1Balance: 0n,
           },
         }),
       { wrapper },
@@ -149,10 +149,12 @@ describe("useLiquidityQuote", () => {
     expect(result.current.data).toMatchObject({
       amountA: 1_000n,
       amountB: 500n,
+      amountADesired: 1_000n,
+      amountBDesired: 500n,
       reserve0: 2_000n,
       reserve1: 1_000n,
       surplus0: 0n,
-      surplus1: 500n,
+      surplus1: 0n,
     });
   });
 
@@ -193,12 +195,14 @@ describe("useLiquidityQuote", () => {
     expect(result.current.data).toMatchObject({
       amountA: 10n * 10n ** 18n,
       amountB: 5n * 10n ** 18n,
+      amountADesired: 10n * 10n ** 18n,
+      amountBDesired: 5n * 10n ** 18n,
       reserve0: 2n * 10n ** 18n,
       reserve1: 1n * 10n ** 18n,
     });
   });
 
-  it("lets the Router choose token1 as the limiting MAX side", async () => {
+  it("keeps token1 MAX binding when token0 cannot cover the required pair", async () => {
     liveReserves = [1_000n, 2_000n, 0n];
 
     const { result } = renderHook(
@@ -210,7 +214,7 @@ describe("useLiquidityQuote", () => {
             id: 2,
             kind: "max",
             token: 1,
-            token0Balance: 1_000n,
+            token0Balance: 100n,
             token1Balance: 1_000n,
           },
         }),
@@ -222,14 +226,14 @@ describe("useLiquidityQuote", () => {
     expect(result.current.data).toMatchObject({
       amountA: 500n,
       amountB: 1_000n,
-      surplus0: 500n,
+      amountADesired: 500n,
+      amountBDesired: 1_000n,
+      surplus0: 0n,
       surplus1: 0n,
     });
   });
 
-  it("re-quotes a clipped-amount0 MAX pair until it is a Router fixed point", async () => {
-    // reserve1/reserve0 = 333x, so the floor round-trip after an amount0 clip
-    // drops amount1 well past the form's 1-wei build-alignment tolerance.
+  it("keeps token0 MAX binding when token1 cannot cover the required pair", async () => {
     liveReserves = [3n, 1_000n, 0n];
 
     const { result } = renderHook(
@@ -250,25 +254,27 @@ describe("useLiquidityQuote", () => {
 
     await waitFor(() => expect(result.current.data).toBeTruthy());
 
-    // First quote clips amount0: (3, 900) -> (2, 900). That pair is not what
-    // addLiquidity would execute, so the hook re-quotes it: (2, 900) -> (2, 666).
-    expect(mocks.quoteAddLiquidity).toHaveBeenCalledTimes(2);
+    expect(mocks.quoteAddLiquidity).toHaveBeenCalledTimes(1);
     expect(mocks.quoteAddLiquidity).toHaveBeenLastCalledWith(
       pool.poolAddr,
       pool.token0.address,
-      2n,
+      3n,
       pool.token1.address,
-      900n,
+      1_000n,
     );
     expect(result.current.data).toMatchObject({
-      amountA: 2n,
-      amountB: 666n,
-      surplus0: 1n,
-      surplus1: 234n,
+      amountA: 3n,
+      amountB: 1_000n,
+      amountADesired: 3n,
+      amountBDesired: 1_000n,
+      surplus0: 0n,
+      surplus1: 0n,
     });
   });
 
-  it("does not re-quote when the Router kept amount0 as passed", async () => {
+  it("rounds the token0 counterpart up so token1 MAX is exhausted", async () => {
+    liveReserves = [3n, 1_000n, 0n];
+
     const { result } = renderHook(
       () =>
         useLiquidityQuote({
@@ -277,9 +283,9 @@ describe("useLiquidityQuote", () => {
           request: {
             id: 6,
             kind: "max",
-            token: 0,
-            token0Balance: 1_000n,
-            token1Balance: 1_000n,
+            token: 1,
+            token0Balance: 0n,
+            token1Balance: 900n,
           },
         }),
       { wrapper },
@@ -288,13 +294,22 @@ describe("useLiquidityQuote", () => {
     await waitFor(() => expect(result.current.data).toBeTruthy());
 
     expect(mocks.quoteAddLiquidity).toHaveBeenCalledTimes(1);
+    expect(mocks.quoteAddLiquidity).toHaveBeenCalledWith(
+      pool.poolAddr,
+      pool.token0.address,
+      3n,
+      pool.token1.address,
+      900n,
+    );
     expect(result.current.data).toMatchObject({
-      amountA: 1_000n,
-      amountB: 500n,
+      amountA: 2n,
+      amountB: 900n,
+      amountADesired: 3n,
+      amountBDesired: 900n,
     });
   });
 
-  it("keeps a Router-clipped driver amount canonical", async () => {
+  it("keeps desired transaction inputs separate from Router transfer amounts", async () => {
     mocks.quoteAddLiquidity.mockResolvedValue({
       amountA: 8n * 10n ** 18n,
       amountB: 4n * 10n ** 18n,
@@ -322,6 +337,8 @@ describe("useLiquidityQuote", () => {
     expect(result.current.data).toMatchObject({
       amountA: 8n * 10n ** 18n,
       amountB: 4n * 10n ** 18n,
+      amountADesired: 10n * 10n ** 18n,
+      amountBDesired: 5n * 10n ** 18n,
     });
   });
 
@@ -408,7 +425,7 @@ describe("getDesiredBalancedLiquidityAmounts", () => {
     });
   });
 
-  it("passes both wallet balances to the live Router for MAX", () => {
+  it("derives MAX from the selected wallet balance and live reserves", () => {
     expect(
       getDesiredBalancedLiquidityAmounts(
         {
@@ -419,9 +436,24 @@ describe("getDesiredBalancedLiquidityAmounts", () => {
           token1Balance: 456n,
         },
         pool,
-        999n,
-        1n,
+        3n,
+        10n,
       ),
-    ).toEqual({ amount0: 123n, amount1: 456n });
+    ).toEqual({ amount0: 123n, amount1: 410n });
+
+    expect(
+      getDesiredBalancedLiquidityAmounts(
+        {
+          id: 4,
+          kind: "max",
+          token: 1,
+          token0Balance: 123n,
+          token1Balance: 456n,
+        },
+        pool,
+        10n,
+        3n,
+      ),
+    ).toEqual({ amount0: 1_520n, amount1: 456n });
   });
 });

--- a/packages/web3/src/features/pools/hooks/use-liquidity-quote.ts
+++ b/packages/web3/src/features/pools/hooks/use-liquidity-quote.ts
@@ -27,6 +27,8 @@ export type LiquidityQuoteRequest =
 export interface LiquidityQuoteResult {
   amountA: bigint;
   amountB: bigint;
+  amountADesired: bigint;
+  amountBDesired: bigint;
   liquidity: bigint;
   totalSupply: bigint;
   reserve0: bigint;
@@ -48,10 +50,15 @@ export interface BalancedLiquidityAmounts {
   amount1: bigint;
 }
 
+function divideRoundingUp(numerator: bigint, denominator: bigint): bigint {
+  return (numerator + denominator - 1n) / denominator;
+}
+
 /**
- * Calculates the desired pair in pool contract order. MAX deliberately sends
- * both balances to the Router so its live quote, including integer rounding,
- * chooses the largest feasible pair and the limiting token.
+ * Calculates the desired pair in pool contract order. The selected token is
+ * always the binding amount. The counterpart follows the live reserve ratio,
+ * even when the wallet cannot cover it, so the UI can show the actual amount
+ * required to exhaust the selected token.
  */
 export function getDesiredBalancedLiquidityAmounts(
   request: LiquidityQuoteRequest,
@@ -60,8 +67,19 @@ export function getDesiredBalancedLiquidityAmounts(
   reserve1: bigint,
 ): BalancedLiquidityAmounts {
   if (request.kind === "max") {
+    if (request.token === 0) {
+      return {
+        amount0: request.token0Balance,
+        amount1:
+          reserve0 > 0n ? (request.token0Balance * reserve1) / reserve0 : 0n,
+      };
+    }
+
     return {
-      amount0: request.token0Balance,
+      amount0:
+        reserve1 > 0n
+          ? divideRoundingUp(request.token1Balance * reserve0, reserve1)
+          : 0n,
       amount1: request.token1Balance,
     };
   }
@@ -78,7 +96,8 @@ export function getDesiredBalancedLiquidityAmounts(
   }
 
   return {
-    amount0: reserve1 > 0n ? (driverWei * reserve0) / reserve1 : 0n,
+    amount0:
+      reserve1 > 0n ? divideRoundingUp(driverWei * reserve0, reserve1) : 0n,
     amount1: driverWei,
   };
 }
@@ -97,7 +116,9 @@ export function useLiquidityQuote({
     request?.kind !== "manual" || manualAmount === debouncedManualAmount;
   const isValidRequest =
     request?.kind === "max"
-      ? request.token0Balance > 0n && request.token1Balance > 0n
+      ? request.token === 0
+        ? request.token0Balance > 0n
+        : request.token1Balance > 0n
       : request?.kind === "manual"
         ? !!manualAmount && Number(manualAmount) > 0
         : false;
@@ -142,7 +163,7 @@ export function useLiquidityQuote({
 
       // The Router is authoritative: it applies the current reserve ratio and
       // can clip either desired amount. Everything downstream uses its result.
-      const [initialQuote, lpBalance] = await Promise.all([
+      const [quote, lpBalance] = await Promise.all([
         sdk.liquidity.quoteAddLiquidity(
           pool.poolAddr as Address,
           pool.token0.address as Address,
@@ -153,24 +174,6 @@ export function useLiquidityQuote({
         sdk.liquidity.getLPTokenBalance(pool.poolAddr, LP_TOTAL_SUPPLY_HOLDER),
       ]);
 
-      // A quote where the Router clipped amount0 is not a fixed point of its
-      // own math: fed back in (as the SDK's build step and addLiquidity itself
-      // both do), the Router re-derives amount1 as
-      // floor(amount0 * reserve1 / reserve0), up to reserve1/reserve0 wei
-      // below the quoted amount1. Re-quote once so the captured pair is
-      // exactly what executes on-chain — the add-liquidity form rejects any
-      // quote-vs-build drift beyond 1 wei as a pool-ratio change.
-      const quote =
-        initialQuote.amountA === amount0
-          ? initialQuote
-          : await sdk.liquidity.quoteAddLiquidity(
-              pool.poolAddr as Address,
-              pool.token0.address as Address,
-              initialQuote.amountA,
-              pool.token1.address as Address,
-              initialQuote.amountB,
-            );
-
       const token0Balance =
         request.kind === "max" ? request.token0Balance : quote.amountA;
       const token1Balance =
@@ -179,6 +182,8 @@ export function useLiquidityQuote({
       return {
         amountA: quote.amountA,
         amountB: quote.amountB,
+        amountADesired: amount0,
+        amountBDesired: amount1,
         liquidity: quote.liquidity,
         totalSupply: lpBalance.totalSupply,
         reserve0,


### PR DESCRIPTION
## The Problem

- Balanced FPMM liquidity MAX reduced the selected token amount to the largest pair covered by both wallet balances. This hid how much of the paired token was required to exhaust the token the user selected.

## The Solution

- Keep the selected MAX token as the binding wallet amount and derive the paired requirement from the latest pool reserves.
- Preserve Router transfer amounts separately from desired calldata inputs so display, balance validation, slippage minima, approvals, and transaction construction use the correct representation.
- Keep insufficient paired requirements visible and disable submission with the existing balance error.

## Validation

- `pnpm --filter @repo/web3 test` — 216 tests passed with 98.62% statement coverage.
- `pnpm --filter app.mento.org test` — 199 tests passed.
- `pnpm --filter @repo/web3 check-types` — passed.
- `pnpm --filter app.mento.org check-types` — passed.
- `trunk fmt <changed files>` and `trunk check --fix <changed files>` — passed.
- `pnpm adr:check` and `pnpm pr:description:test` — passed.
- Repository pre-push hook — Trunk, all-workspace type checks, web3 build, and Knip passed.
- Browser-verified on a seeded local Monad fork: MAX preserved the selected full wallet amount, displayed the paired requirement, blocked an insufficient paired balance, and allowed the reverse MAX direction when funded.
- Nine-lens local specialist review and post-fix fresh-context autoreview — no remaining actionable findings.
- External Codex helper and Claude Security source scan skipped because explicit source-egress approval was not provided; the local security specialist reported no findings.

## Architecture Decision

Not applicable — this is a focused liquidity quote and form behavior correction that does not introduce a long-lived architecture, workflow, or trust-boundary decision.

## Ship Checklist

- [x] PR title follows the conventions.
- [x] Performed a self-review of my own changes.
- [x] Relevant automated checks and smoke tests pass.
- [x] Architecture decision addressed above.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes on-chain liquidity inputs, approvals, and slippage minima for balanced add flows; behavior is well covered by web3 and app tests but mistakes could mis-approve or submit wrong amounts.
> 
> **Overview**
> **Balanced MAX** no longer shrinks the selected token to the largest pair both wallets can fund. The chosen side stays at full wallet balance; the paired amount comes from live reserves (with **ceil** rounding when token1 drives MAX), and MAX works when only that side has a non-zero balance.
> 
> `LiquidityQuoteResult` now carries **`amountADesired` / `amountBDesired`** alongside Router **`amountA` / `amountB`**. The add-liquidity form shows and validates balances against the Router amounts, while previews, approvals, calldata, and quote/build alignment use the desired pair; the hook drops the second re-quote pass that tried to canonicalize clipped MAX pairs.
> 
> Tests cover the split representations, insufficient paired balance on MAX, and updated MAX binding cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e063d4706a44de69a944e9fc0b1b2f5c6cb2b6ac. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->