### PR TITLE
feat(dependabot): sync protected Vercel runtime

### DIFF
--- a/.github/actions/vercel-protected-runtime/action.yml
+++ b/.github/actions/vercel-protected-runtime/action.yml
@@ -392,6 +392,7 @@ runs:
           fi
         done
         immutable_files=(
+          "$TOOLS_PATH/vercel-cli-runtime/contract.json"
           "$TOOLS_PATH/vercel-cli-runtime/package.json"
           "$TOOLS_PATH/vercel-cli-runtime/pnpm-lock.yaml"
         )
@@ -432,8 +433,22 @@ runs:
         done
         "$node_bin" "$controller_path/scripts/vercel-prebuilt.mjs" \
           check-versions --repo-root "$source_path"
+        contract_path="$controller_path/scripts/vercel-cli-runtime/contract.json"
+        pinned_vercel_version="$(
+          "$node_bin" -e '
+            const { readFileSync } = require("node:fs");
+            const contract = JSON.parse(readFileSync(process.argv[1], "utf8"));
+            if (
+              contract.schema !== "vercel-cli-runtime-contract:v1" ||
+              !/^(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)$/.test(
+                contract.vercelVersion,
+              )
+            ) process.exit(1);
+            process.stdout.write(contract.vercelVersion);
+          ' "$contract_path"
+        )"
         [ "$("$pnpm_bin" --version)" = 10.34.4 ]
-        [ "$("$node_bin" "$vercel_cli" --version)" = 56.4.1 ]
+        [ "$("$node_bin" "$vercel_cli" --version)" = "$pinned_vercel_version" ]
 
         /bin/rm -rf -- \
           "$bootstrap_cache" \

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,6 +28,17 @@ updates:
       prefix-development: chore(deps-dev)
 
     groups:
+      # The protected deployment runtime mirrors the root Vercel CLI pin. Keep
+      # routine CLI rotations isolated so the processor can apply its exact,
+      # model-free runtime synchronizer before asking a maintainer to merge.
+      vercel-cli:
+        applies-to: version-updates
+        patterns:
+          - vercel
+        update-types:
+          - minor
+          - patch
+
       frontend-core:
         applies-to: version-updates
         patterns:
@@ -145,6 +156,15 @@ updates:
       tooling:
         applies-to: version-updates
         dependency-type: development
+        patterns:
+          - "*"
+        exclude-patterns:
+          - vercel
+
+      vercel-cli-security:
+        applies-to: security-updates
+        patterns:
+          - vercel
 
       security-runtime:
         applies-to: security-updates
@@ -153,6 +173,10 @@ updates:
       security-tooling:
         applies-to: security-updates
         dependency-type: development
+        patterns:
+          - "*"
+        exclude-patterns:
+          - vercel
 
   # GitHub Actions
   - package-ecosystem: github-actions

--- a/.github/workflows/_vercel-prebuilt.yml
+++ b/.github/workflows/_vercel-prebuilt.yml
@@ -844,9 +844,11 @@ jobs:
           persist-credentials: false
           ref: ${{ github.workflow_sha }}
 
-      - name: Verify pinned Vercel prerequisites
+      # This is a non-authorizing consistency check over candidate package and
+      # lock data. The protected CLI remains sourced from the trusted controller.
+      - name: Verify candidate Vercel prerequisite consistency
         working-directory: source
-        run: node "$GITHUB_WORKSPACE/controller/scripts/vercel-prebuilt.mjs" check-versions
+        run: node "$GITHUB_WORKSPACE/controller/scripts/vercel-prebuilt.mjs" check-candidate-versions
 
       - name: Prepare fresh runner-owned Vercel pull staging
         env:

--- a/.github/workflows/dependabot-claude-review.yml
+++ b/.github/workflows/dependabot-claude-review.yml
@@ -312,14 +312,20 @@ jobs:
           trusted_root="$RUNNER_TEMP/dependabot-prepared-review"
           install -d -m 0700 "$trusted_root"
           trusted_validator="$trusted_root/dependabot-prepared-review.mjs"
+          trusted_receipts="$trusted_root/dependabot-preparation-receipts.mjs"
           resolved_sha="$(gh api "repos/$REPOSITORY/commits/$WORKFLOW_SHA" --jq .sha)"
           test "$resolved_sha" = "$WORKFLOW_SHA"
           gh api \
             -H "Accept: application/vnd.github.raw+json" \
             "repos/$REPOSITORY/contents/scripts/dependabot-prepared-review.mjs?ref=$WORKFLOW_SHA" \
             > "$trusted_validator"
+          gh api \
+            -H "Accept: application/vnd.github.raw+json" \
+            "repos/$REPOSITORY/contents/scripts/dependabot-preparation-receipts.mjs?ref=$WORKFLOW_SHA" \
+            > "$trusted_receipts"
           test -s "$trusted_validator"
-          chmod 0500 "$trusted_validator"
+          test -s "$trusted_receipts"
+          chmod 0500 "$trusted_validator" "$trusted_receipts"
           echo "path=$trusted_validator" >> "$GITHUB_OUTPUT"
 
       - name: Authenticate the append-only prepared-head lineage

--- a/.github/workflows/dependabot-prepare-repair.yml
+++ b/.github/workflows/dependabot-prepare-repair.yml
@@ -36,6 +36,7 @@ jobs:
       packet_base64: ${{ steps.packet.outputs.packet_base64 }}
       packet_json: ${{ steps.packet.outputs.packet_json }}
       packet_digest: ${{ steps.packet.outputs.packet_digest }}
+      plan_kind: ${{ steps.packet.outputs.plan_kind }}
       processor_check_id: ${{ steps.packet.outputs.processor_check_id }}
       pull_request_number: ${{ steps.packet.outputs.pull_request_number }}
       repair_attempt: ${{ steps.packet.outputs.repair_attempt }}
@@ -191,7 +192,7 @@ jobs:
       contents: read
       pull-requests: read
     outputs:
-      structured_output: ${{ steps.claude-repair.outputs.structured_output }}
+      structured_output: ${{ steps.plan-output.outputs.structured_output }}
     steps:
       - name: Check out only the exact trusted workflow source
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -222,6 +223,7 @@ jobs:
 
       - name: Plan the exact packet-bound repair
         id: claude-repair
+        if: needs.preflight.outputs.plan_kind == 'claude-repair'
         uses: anthropics/claude-code-action/base-action@be7b93b1907a4abad570368f3c74b6fe3807510b # v1.0.183
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
@@ -310,7 +312,61 @@ jobs:
             --add-dir "${{ steps.evidence.outputs.evidence_root }}"
             --json-schema '{"type":"object","additionalProperties":false,"required":["schema","repository","pullRequestNumber","parentHeadSha","baseSha","processorCheckId","packetDigest","attempt","summary","edits"],"properties":{"schema":{"const":"dependabot-repair-plan:v1"},"repository":{"const":"mento-protocol/frontend-monorepo"},"pullRequestNumber":{"type":"integer","minimum":1},"parentHeadSha":{"type":"string","pattern":"^[0-9a-f]{40}$"},"baseSha":{"type":"string","pattern":"^[0-9a-f]{40}$"},"processorCheckId":{"type":"integer","minimum":1},"packetDigest":{"type":"string","pattern":"^[0-9a-f]{64}$"},"attempt":{"type":"integer","minimum":1,"maximum":2},"summary":{"type":"string","minLength":1,"maxLength":500},"edits":{"type":"array","minItems":1,"maxItems":6,"items":{"type":"object","additionalProperties":false,"required":["path","expectedBlobSha","patch"],"properties":{"path":{"type":"string","minLength":1,"maxLength":300},"expectedBlobSha":{"type":"string","pattern":"^[0-9a-f]{40}$"},"patch":{"type":"string","description":"Valid contextual unified diff with exact hunk counts, required diff marker prefixes, and unchanged context before and after each changed run unless it touches a file boundary.","minLength":1,"maxLength":8192}}}}}}'
 
+      - name: Install the exact model-free planner pnpm
+        if: needs.preflight.outputs.plan_kind == 'protected-runtime-sync'
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v4
+        env:
+          NPM_CONFIG_REGISTRY: https://registry.npmjs.org/
+        with:
+          standalone: true
+          version: 10.34.4
+
+      - name: Prove the exact model-free planner pnpm and registry
+        if: needs.preflight.outputs.plan_kind == 'protected-runtime-sync'
+        shell: bash
+        env:
+          NPM_CONFIG_REGISTRY: https://registry.npmjs.org/
+        run: |
+          set -euo pipefail
+          test "$(pnpm --version)" = "10.34.4"
+          test "$(pnpm config get registry)" = "https://registry.npmjs.org/"
+
+      - name: Generate the protected-runtime sync plan once
+        id: protected-runtime-sync-first
+        if: needs.preflight.outputs.plan_kind == 'protected-runtime-sync'
+        shell: bash
+        env:
+          EVIDENCE_MANIFEST: ${{ steps.evidence.outputs.evidence_manifest }}
+          NPM_CONFIG_REGISTRY: https://registry.npmjs.org/
+          PACKET_BASE64: ${{ needs.preflight.outputs.packet_base64 }}
+          PROCESSOR_CHECK_ID: ${{ needs.preflight.outputs.processor_check_id }}
+        run: |
+          set -euo pipefail
+          node scripts/dependabot-protected-runtime-sync.mjs generate-plan \
+            --packet-base64 "$PACKET_BASE64" \
+            --evidence-manifest "$EVIDENCE_MANIFEST" \
+            --processor-check-id "$PROCESSOR_CHECK_ID" \
+            --github-output "$GITHUB_OUTPUT"
+
+      - name: Generate the protected-runtime sync plan again
+        id: protected-runtime-sync-second
+        if: needs.preflight.outputs.plan_kind == 'protected-runtime-sync'
+        shell: bash
+        env:
+          EVIDENCE_MANIFEST: ${{ steps.evidence.outputs.evidence_manifest }}
+          NPM_CONFIG_REGISTRY: https://registry.npmjs.org/
+          PACKET_BASE64: ${{ needs.preflight.outputs.packet_base64 }}
+          PROCESSOR_CHECK_ID: ${{ needs.preflight.outputs.processor_check_id }}
+        run: |
+          set -euo pipefail
+          node scripts/dependabot-protected-runtime-sync.mjs generate-plan \
+            --packet-base64 "$PACKET_BASE64" \
+            --evidence-manifest "$EVIDENCE_MANIFEST" \
+            --processor-check-id "$PROCESSOR_CHECK_ID" \
+            --github-output "$GITHUB_OUTPUT"
+
       - name: Require a completed exact evidence read
+        if: needs.preflight.outputs.plan_kind == 'claude-repair'
         shell: bash
         env:
           DEPENDABOT_REPAIR_EVIDENCE_MANIFEST: ${{ steps.evidence.outputs.evidence_manifest }}
@@ -319,6 +375,44 @@ jobs:
         run: |
           set -euo pipefail
           node scripts/dependabot-repair-evidence-tool-guard.mjs --verify-completion
+
+      - name: Select exactly one typed repair plan
+        id: plan-output
+        shell: bash
+        env:
+          CLAUDE_PLAN: ${{ steps.claude-repair.outputs.structured_output }}
+          FIRST_PROTECTED_RUNTIME_PLAN: ${{ steps.protected-runtime-sync-first.outputs.structured_output }}
+          PLAN_KIND: ${{ needs.preflight.outputs.plan_kind }}
+          SECOND_PROTECTED_RUNTIME_PLAN: ${{ steps.protected-runtime-sync-second.outputs.structured_output }}
+        run: |
+          set -euo pipefail
+          node --input-type=module --eval '
+            import { appendFileSync } from "node:fs";
+
+            const kind = process.env.PLAN_KIND;
+            const claude = process.env.CLAUDE_PLAN ?? "";
+            const first = process.env.FIRST_PROTECTED_RUNTIME_PLAN ?? "";
+            const second = process.env.SECOND_PROTECTED_RUNTIME_PLAN ?? "";
+            let selected;
+            if (kind === "claude-repair") {
+              if (claude.length === 0 || first.length !== 0 || second.length !== 0) {
+                throw new Error("Claude repair did not produce exactly one plan");
+              }
+              selected = claude;
+            } else if (kind === "protected-runtime-sync") {
+              if (claude.length !== 0 || first.length === 0 || first !== second) {
+                throw new Error("Protected-runtime plans are absent or non-deterministic");
+              }
+              selected = first;
+            } else {
+              throw new Error("Unknown repair plan kind");
+            }
+            JSON.parse(selected);
+            appendFileSync(
+              process.env.GITHUB_OUTPUT,
+              `structured_output<<DEPENDABOT_PLAN_EOF\n${selected}\nDEPENDABOT_PLAN_EOF\n`,
+            );
+          '
 
   validate:
     name: Validate patches without secrets or write authority
@@ -337,6 +431,32 @@ jobs:
       validated_plan_base64: ${{ steps.validate.outputs.validated_plan_base64 }}
       validated_plan_digest: ${{ steps.validate.outputs.validated_plan_digest }}
     steps:
+      - name: Check out only the exact trusted workflow source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+          ref: ${{ github.workflow_sha }}
+
+      - name: Install the exact model-free verifier pnpm
+        if: needs.preflight.outputs.plan_kind == 'protected-runtime-sync'
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v4
+        env:
+          NPM_CONFIG_REGISTRY: https://registry.npmjs.org/
+        with:
+          standalone: true
+          version: 10.34.4
+
+      - name: Prove the exact model-free verifier pnpm and registry
+        if: needs.preflight.outputs.plan_kind == 'protected-runtime-sync'
+        shell: bash
+        env:
+          NPM_CONFIG_REGISTRY: https://registry.npmjs.org/
+        run: |
+          set -euo pipefail
+          test "$(pnpm --version)" = "10.34.4"
+          test "$(pnpm config get registry)" = "https://registry.npmjs.org/"
+
       - name: Materialize the trusted preparation validator
         id: validator
         shell: bash
@@ -358,6 +478,45 @@ jobs:
           chmod 0500 "$trusted_validator"
           echo "path=$trusted_validator" >> "$GITHUB_OUTPUT"
 
+      - name: Materialize exact packet-bound verification evidence
+        id: verification-evidence
+        if: needs.preflight.outputs.plan_kind == 'protected-runtime-sync'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PACKET_BASE64: ${{ needs.preflight.outputs.packet_base64 }}
+          PACKET_DIGEST: ${{ needs.preflight.outputs.packet_digest }}
+          PROCESSOR_CHECK_ID: ${{ needs.preflight.outputs.processor_check_id }}
+          REPOSITORY: ${{ github.repository }}
+          VALIDATOR_PATH: ${{ steps.validator.outputs.path }}
+        run: |
+          set -euo pipefail
+          evidence_root="$RUNNER_TEMP/dependabot-repair-verification-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          node "$VALIDATOR_PATH" materialize-repair-evidence \
+            --repository "$REPOSITORY" \
+            --packet-base64 "$PACKET_BASE64" \
+            --packet-digest "$PACKET_DIGEST" \
+            --processor-check-id "$PROCESSOR_CHECK_ID" \
+            --output-root "$evidence_root" \
+            --github-output "$GITHUB_OUTPUT"
+
+      - name: Independently verify the protected-runtime sync plan
+        if: needs.preflight.outputs.plan_kind == 'protected-runtime-sync'
+        shell: bash
+        env:
+          EVIDENCE_MANIFEST: ${{ steps.verification-evidence.outputs.evidence_manifest }}
+          NPM_CONFIG_REGISTRY: https://registry.npmjs.org/
+          PACKET_BASE64: ${{ needs.preflight.outputs.packet_base64 }}
+          PLAN_JSON: ${{ needs.plan.outputs.structured_output }}
+          PROCESSOR_CHECK_ID: ${{ needs.preflight.outputs.processor_check_id }}
+        run: |
+          set -euo pipefail
+          node scripts/dependabot-protected-runtime-sync.mjs verify-plan \
+            --packet-base64 "$PACKET_BASE64" \
+            --evidence-manifest "$EVIDENCE_MANIFEST" \
+            --processor-check-id "$PROCESSOR_CHECK_ID" \
+            --plan-json "$PLAN_JSON"
+
       - name: Validate the bounded repair plan against exact blobs
         id: validate
         shell: bash
@@ -376,12 +535,97 @@ jobs:
             --processor-check-id "${{ needs.preflight.outputs.processor_check_id }}" \
             --github-output "$GITHUB_OUTPUT"
 
-  stage:
-    name: Stage one unreachable exact Repair App commit
-    needs: [preflight, validate]
+  candidate_cli_smoke:
+    name: Smoke the generated candidate CLI without authority
+    needs: [preflight, plan, validate]
     if: >-
       needs.preflight.result == 'success' &&
-      needs.validate.result == 'success'
+      needs.plan.result == 'success' &&
+      needs.validate.result == 'success' &&
+      needs.preflight.outputs.plan_kind == 'protected-runtime-sync'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      actions: read
+      checks: read
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Check out only the exact trusted workflow source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+          ref: ${{ github.workflow_sha }}
+
+      - name: Install the exact terminal-smoke pnpm
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v4
+        env:
+          NPM_CONFIG_REGISTRY: https://registry.npmjs.org/
+        with:
+          standalone: true
+          version: 10.34.4
+
+      - name: Prove the exact terminal-smoke pnpm and registry
+        shell: bash
+        env:
+          NPM_CONFIG_REGISTRY: https://registry.npmjs.org/
+        run: |
+          set -euo pipefail
+          test "$(pnpm --version)" = "10.34.4"
+          test "$(pnpm config get registry)" = "https://registry.npmjs.org/"
+
+      - name: Materialize exact packet-bound terminal-smoke evidence
+        id: evidence
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PACKET_BASE64: ${{ needs.preflight.outputs.packet_base64 }}
+          PACKET_DIGEST: ${{ needs.preflight.outputs.packet_digest }}
+          PROCESSOR_CHECK_ID: ${{ needs.preflight.outputs.processor_check_id }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          evidence_root="$RUNNER_TEMP/dependabot-repair-terminal-smoke-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          node scripts/dependabot-preparation-receipts.mjs materialize-repair-evidence \
+            --repository "$REPOSITORY" \
+            --packet-base64 "$PACKET_BASE64" \
+            --packet-digest "$PACKET_DIGEST" \
+            --processor-check-id "$PROCESSOR_CHECK_ID" \
+            --output-root "$evidence_root" \
+            --github-output "$GITHUB_OUTPUT"
+
+      # Candidate registry code executes only here, after authoritative plan
+      # validation, on this fresh runner. This terminal step emits no output.
+      - name: Execute the generated candidate CLI as a terminal smoke
+        shell: bash
+        env:
+          EVIDENCE_MANIFEST: ${{ steps.evidence.outputs.evidence_manifest }}
+          NPM_CONFIG_REGISTRY: https://registry.npmjs.org/
+          PACKET_BASE64: ${{ needs.preflight.outputs.packet_base64 }}
+          PROCESSOR_CHECK_ID: ${{ needs.preflight.outputs.processor_check_id }}
+          VALIDATED_PLAN_BASE64: ${{ needs.validate.outputs.validated_plan_base64 }}
+          VALIDATED_PLAN_DIGEST: ${{ needs.validate.outputs.validated_plan_digest }}
+        run: |
+          set -euo pipefail
+          node scripts/dependabot-protected-runtime-sync.mjs candidate-cli-smoke \
+            --packet-base64 "$PACKET_BASE64" \
+            --evidence-manifest "$EVIDENCE_MANIFEST" \
+            --processor-check-id "$PROCESSOR_CHECK_ID" \
+            --validated-plan-base64 "$VALIDATED_PLAN_BASE64" \
+            --validated-plan-digest "$VALIDATED_PLAN_DIGEST"
+
+  stage:
+    name: Stage one unreachable exact Repair App commit
+    needs: [preflight, validate, candidate_cli_smoke]
+    if: >-
+      always() &&
+      needs.preflight.result == 'success' &&
+      needs.validate.result == 'success' &&
+      ((needs.preflight.outputs.plan_kind == 'protected-runtime-sync' &&
+        needs.candidate_cli_smoke.result == 'success') ||
+       (needs.preflight.outputs.plan_kind != 'protected-runtime-sync' &&
+        needs.candidate_cli_smoke.result == 'skipped'))
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,6 +110,26 @@ SHA, including files larger than the Contents API limit. The publisher uses Git
 Data APIs for one exact-parent non-force commit and never executes candidate
 input.
 
+Stable same-major patch/minor updates to the unscoped `vercel` package use the
+typed `dependabot-repair-packet:v3` protected-runtime operation instead of the
+model planner. Trusted workflow-SHA code binds the exact refreshed-head
+workspace/runtime inputs and both public npm release records; changes only the
+exact Vercel regions of the root lock; regenerates the standalone lock twice
+with pnpm 10.34.4, scripts, workspace links, and pnpmfile loading disabled; and
+permits only the root package/lock plus
+`scripts/vercel-cli-runtime/{contract.json,package.json,pnpm-lock.yaml}`. An
+independent no-secret job reproduces the exact plan before the unchanged staged
+commit, Intent, non-force move, receipt, and recovery path. Major, prerelease,
+builder-key-set, override, registry, generation, or byte drift fails closed.
+Generic repairs remain exact v2 and retain every runtime/deployment deny. ALL
+CLEAR requires the requested Vercel target in both root and runtime plus its
+reachable typed operation; human squash merge remains mandatory.
+PR preview workers validate the candidate runtime tuple only as data; every
+credentialed preview build still stages its CLI from the trusted default-branch
+controller. After trusted plan validation, a fresh terminal no-output job
+performs the secretless frozen install and exact CLI version smoke; it can veto
+staging but cannot produce mutation authority.
+
 Only an exact trusted pending Refresh may start the mutation/token job. A native
 green Dependabot head skips that job and can finalize without Prepare App
 configuration. `repair-pending` preserves the original exact-head packet/run

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -277,12 +277,28 @@ slug/bot identity for prepared mutations, and operation digests. The check
 publisher is github-actions App ID 15368; its generic identity is insufficient
 without the exact terminal trusted run and canonical receipt. A Refresh needs a
 successful request on the old head and completed receipt on the exact
-two-parent result. A Repair needs the exact Processor v2 packet, a durable
-pre-mutation intent, one App-authored non-force commit with GitHub verification
+two-parent result. A Repair needs the exact Processor v2 generic packet or v3
+typed protected-runtime packet, a durable pre-mutation intent, one App-authored
+non-force commit with GitHub verification
 `verified=true` and reason `valid`, and a completed or exact-intent recovered
 receipt. Normal pre-move work and checks-only recovery each get at most two
 exact-evidence infrastructure retries. Those counters do not change the
 two-commit repair limit; refresh count is independent.
+
+The current v3 operation is the model-free `vercel-cli-runtime-sync`. It admits
+only stable same-major patch/minor Vercel updates, binds exact current-head
+workspace/runtime inputs and both npm release records, changes only the exact
+Vercel regions of the root lock, and regenerates the standalone lock twice with
+pnpm 10.34.4 without scripts, workspace links, or a pnpmfile. It may edit only
+the root package/lock and standalone Vercel contract, manifest, and lock. Generic
+v2 repair never gains runtime or deployment write
+authority. ALL CLEAR requires the requested target and its reachable typed
+operation. A maintainer still performs the squash merge.
+Preview workers validate the candidate runtime tuple only as data and continue
+to stage the credentialed build CLI from trusted default-branch controller
+source. After trusted plan validation, a fresh terminal no-output job runs the
+secretless frozen standalone install and exact CLI version smoke; it can veto
+staging but cannot produce mutation authority.
 
 A valid review finding may be included in a v2 repair packet by exact
 finding/thread ID and body digest. Only after the repaired head passes its full

--- a/docs/adr/0006-dependabot-processing-controller.md
+++ b/docs/adr/0006-dependabot-processing-controller.md
@@ -244,10 +244,13 @@ not consume repair attempts and may never use rebase or force-push.
 
 ### Repair attempts are typed and capped independently of refresh
 
-The v2 Processor packet is created only after exact structural identity,
-prepared lineage, current base, complete current-head gate, clear feedback,
-preparable policy, deterministic branch attribution or validated findings, and
-valid attempt history.
+The generic v2 Processor packet is created only after exact structural
+identity, prepared lineage, current base, complete current-head gate, clear
+feedback, preparable policy, deterministic branch attribution or validated
+findings, and valid attempt history. ADR 0007 adds an exact v3 packet for a
+model-free protected-runtime synchronization. It retains this lineage and
+attempt budget but may be actionable without failed-check evidence when the
+verified Dependabot target is not yet realized across the protected runtime.
 
 Same-head packet and Processor check publication is idempotent. The newest
 trusted exact-head receipt must match mode, disposition/output summary, attempt,
@@ -277,10 +280,12 @@ A github-actions App ID 15368 check without those bindings is insufficient.
 
 The contracts are:
 
-- `dependabot-processor:v2` and
-  `dependabot-repair-packet:v2`: exact head/base/policy/failure/finding/path
-  scope, attempt, workflow source, and packet digest. A packet-issued Processor
-  check is completed **failure**, so repair-needed state cannot unblock merge.
+- `dependabot-processor:v2` and the exact generic
+  `dependabot-repair-packet:v2` or typed `dependabot-repair-packet:v3`: exact
+  head/base/policy/path scope, attempt, workflow source, and packet digest. V2
+  binds failure/finding evidence; v3 is reserved for the deterministic
+  protected-runtime operation in ADR 0007. A packet-issued Processor check is
+  completed **failure**, so repair-needed state cannot unblock merge.
 - `dependabot-refresh:v1`: successful requested receipt on the old head and
   successful completed receipt on the new two-parent head. Completed evidence
   binds the request check ID/digest.
@@ -303,8 +308,8 @@ The collector reads every bounded review thread/reply, review, issue comment,
 and close/reopen/force-push event. Unresolved actionable feedback blocks even
 when it targets an older head.
 
-A v2 packet may bind a validated Claude finding or review thread only by exact
-ID, head/commit, and body digest. After the repaired head passes its complete
+A generic v2 packet may bind a validated Claude finding or review thread only
+by exact ID, head/commit, and body digest. After the repaired head passes its complete
 gate and clean re-review, finalize may post the repository's exact
 `Fixed in <sha> — <change>` reply and resolve only those bound threads. It
 then recollects feedback. Generic bot/github-actions comments, candidate text,

--- a/docs/adr/0007-deterministic-protected-runtime-dependency-sync.md
+++ b/docs/adr/0007-deterministic-protected-runtime-dependency-sync.md
@@ -1,0 +1,159 @@
+---
+title: Protected runtime dependency rotations use deterministic typed repair operations
+status: active
+owner: eng
+canonical: true
+last_verified: 2026-08-14
+scope: ci/dependabot-protected-runtime-sync
+date: 2026-08-14
+---
+
+# ADR 0007 — Protected runtime dependency rotations use deterministic typed repair operations
+
+**Status:** Accepted
+**Scope:** ci/dependabot-protected-runtime-sync
+
+## Context
+
+Some dependencies appear in both the ordinary workspace and a standalone,
+security-hardened runtime used by trusted GitHub Actions code. Updating only the
+workspace leaves that runtime's manifest, lockfile, and digest authority stale.
+The generic Dependabot repair planner cannot write runtime or deployment-policy
+paths because candidate-controlled evidence and model output must not be able to
+rewrite the boundary that later handles deployment credentials.
+
+The Vercel CLI is the first concrete case. Dependabot PR #753 requested
+`vercel` 56.5.0, while the protected runtime still admitted 56.4.1. The generic
+repair path correctly stayed inside its allowlist, but restored the workspace
+pin to 56.4.1 to make the existing contract pass. Merging that result would
+cause a later Dependabot run to request the same update again.
+
+Routine same-major Vercel CLI releases can still be mechanical. Their exact npm
+metadata, workspace manifests, root overrides, standalone manifest, and two
+lockfiles provide enough data for trusted code to reproduce and verify the
+required bytes without executing candidate code or granting the model broader
+write authority.
+
+## Decision
+
+The Dependabot controller supports a typed
+`dependabot-protected-runtime-sync:v1` repair operation inside the existing
+Repair protocol from ADR 0006. The first operation kind is
+`vercel-cli-runtime-sync`.
+
+The processor admits that operation only when immutable Dependabot metadata
+contains exactly one stable, monotonic, same-major patch or minor update for
+the unscoped `vercel` package. It binds the verified seed, current PR head and
+base, target version, exact current-head input blobs, exact pnpm version, and a
+fixed five-path output allowlist:
+
+- `package.json`;
+- `pnpm-lock.yaml`;
+- `scripts/vercel-cli-runtime/contract.json`;
+- `scripts/vercel-cli-runtime/package.json`; and
+- `scripts/vercel-cli-runtime/pnpm-lock.yaml`.
+
+The operation uses `dependabot-repair-packet:v3`; generic model-authored
+repairs keep the exact v2 schema. A v3 operation may exist without a failed
+check because realizing the immutable requested target across the protected
+runtime is itself the required repair. The processor cannot publish ALL CLEAR
+until the current tree reports the requested root and runtime version and its
+reachable Repair lineage contains the exact typed operation.
+
+The repair workflow routes v3 to trusted, model-free generator code from the
+exact default-branch workflow SHA. Planning and validation receive no App,
+provider, package, deployment, or write credential. The generator:
+
+1. authenticates the packet and sealed exact-blob evidence;
+2. reads the exact root workspace manifests and existing lockfiles as data;
+3. fetches only the exact current and requested public npm version metadata;
+4. rejects a changed builder dependency key set, non-exact or unsafe dependency
+   source, override drift, patched dependency, prerelease, downgrade, or major;
+5. changes only the exact Vercel importer, package, peer, and snapshot regions
+   of the root lock while preserving every other refreshed-head byte;
+6. runs exact pnpm 10.34.4 with lifecycle scripts, workspace links, and
+   pnpmfile loading disabled to regenerate the standalone lock twice and
+   requires identical bytes; and
+7. emits only bounded contextual patches for the fixed five paths.
+
+An independent no-secret validation job regenerates the result and requires
+exact plan equality. The existing unreachable App commit, Repair Intent,
+non-force ref move, completed Repair receipt, post-move recovery, prepared-head
+intake, clean re-review, gate recollection, processor approval, and ALL CLEAR
+contracts remain unchanged. The Prepare App keeps only its existing
+repository-scoped Contents and Pull requests permissions. The processor never
+merges or enables native auto-merge; a maintainer still performs the final
+squash merge.
+
+Pull-request preview workers validate the candidate contract, manifests, and
+locks only as an internally consistent data tuple. Credentialed preview builds
+keep using the protected CLI staged from trusted default-branch controller
+source. After trusted plan validation, a fresh terminal no-output job binds the
+exact validated plan, performs a secretless frozen install, and executes the
+candidate CLI's `--version` smoke. It can veto staging but emits no downstream
+authority. The exact-main controller adopts that CLI only after the reviewed
+change merges.
+
+The stable runtime verifier reads rotating values from
+`scripts/vercel-cli-runtime/contract.json`. Routine rotations therefore change
+data, manifests, and locks without editing deployment-controller code,
+workflows, tests, or runbooks. Dependabot isolates future `vercel` patch/minor
+and security updates from the broad tooling group.
+
+Any schema, metadata, registry, generation, byte, path, lineage, identity,
+signature, gate, feedback, or repair-budget mismatch fails closed. Major and
+prerelease Vercel updates, builder dependency key-set changes, override changes,
+and changes that require executable deployment-policy edits remain manual.
+
+## Alternatives considered
+
+### Broaden the generic repair allowlist
+
+Rejected. Giving a model access to runtime, workflow, or deployment-controller
+paths would let untrusted PR evidence influence the code that validates its own
+dependency state and later runs near credentials.
+
+### Keep every protected runtime update manual
+
+Rejected for stable same-major Vercel updates. It avoids new automation but
+turns reproducible manifest and lockfile synchronization into recurring human
+work and permits generic repair to undo the requested update.
+
+### Create a separate mutation workflow and receipt family
+
+Rejected. The existing staged commit, Intent, ref move, receipt, recovery, and
+prepared review protocol already provides the required authority and crash
+recovery. A parallel mutation protocol would duplicate security-sensitive code.
+
+### Copy the prior Dependabot lockfile bytes into the refreshed head
+
+Rejected. The base can advance between the Dependabot seed and repair. Trusted
+generation preserves current-base workspace changes and every non-Vercel root
+lock byte from exact current-head inputs.
+
+## Consequences
+
+- Patch and minor Vercel CLI updates can reach ALL CLEAR with the requested
+  version intact while human merge remains mandatory.
+- The processor gains a versioned adapter interface that can support another
+  protected tool only through a separately reviewed operation kind and exact
+  allowlist.
+- Public npm availability and deterministic pnpm output become planning inputs;
+  outages or output drift stop preparation instead of falling back to a model or
+  stale bytes.
+- The fixed two-Repair limit remains. PR #753 uses its existing generic repair
+  as attempt one and the typed runtime sync as attempt two.
+- The runtime contract JSON becomes reviewed authority data. Stable executable
+  validators still enforce its exact schema, hashes, version agreement, and
+  lockfile structure.
+
+## Evidence
+
+- `pnpm dependabot:process:test`
+- `node --test scripts/dependabot-protected-runtime-sync.test.mjs`
+- `pnpm vercel:versions:check`
+- `pnpm vercel:workflow:test`
+- `pnpm vercel:production-shadow:test`
+- `pnpm supply-chain:lockfile-lint`
+- PR #753 live canary: a verified typed attempt-two Repair must retain Vercel
+  56.5.0 in the root and standalone runtime before exact-head ALL CLEAR.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -47,3 +47,4 @@ adds a high-signal surface without a numbered ADR.
 | [0004](0004-one-way-vercel-build-environment-materialization.md) | Preview candidates receive only a one-way exact allowlist of Vercel-pulled variables      |
 | [0005](0005-stable-main-release-identity-and-rerun-admission.md) | Stable provider release manifests reconcile reruns; mutations remain attempt-scoped       |
 | [0006](0006-dependabot-processing-controller.md)                 | Trusted default-branch policy processes Dependabot PRs through exact-head release proof   |
+| [0007](0007-deterministic-protected-runtime-dependency-sync.md)  | Typed deterministic repairs synchronize protected runtime dependencies                    |

--- a/docs/dependabot-automation.md
+++ b/docs/dependabot-automation.md
@@ -241,11 +241,11 @@ or package credential, deployment token, or a PAT.
 
 ## Modes and handling tiers
 
-| Mode      | Classification | Packet                       | Refresh/repair/re-review | Approval/ALL CLEAR  | Merge |
-| --------- | -------------- | ---------------------------- | ------------------------ | ------------------- | ----- |
-| `observe` | Yes            | No                           | No                       | No                  | Never |
-| `assist`  | Yes            | No; non-authorizing evidence | No                       | No                  | Never |
-| `prepare` | Yes            | v2 packet                    | Eligible bounded path    | Exact finalize only | Never |
+| Mode      | Classification | Packet                        | Refresh/repair/re-review | Approval/ALL CLEAR  | Merge |
+| --------- | -------------- | ----------------------------- | ------------------------ | ------------------- | ----- |
+| `observe` | Yes            | No                            | No                       | No                  | Never |
+| `assist`  | Yes            | No; non-authorizing evidence  | No                       | No                  | Never |
+| `prepare` | Yes            | v2 generic or v3 typed packet | Eligible bounded path    | Exact finalize only | Never |
 
 Unknown values normalize to `observe` before any credential is exposed.
 
@@ -337,11 +337,14 @@ or any other collection error fails closed.
 
 ### 3. Produce and publish one bounded repair
 
-A v2 repair packet exists only when identity/lineage, current base, complete
-gate, clear feedback, deterministic attribution, preparable policy, and repair
-attempt lineage all pass. Same-head processing is idempotent. The first
-append-only Repair commit consumes attempt one; a second consumes attempt two.
-There is no third attempt.
+A generic v2 repair packet exists only when identity/lineage, current base,
+complete gate, clear feedback, deterministic attribution, preparable policy,
+and repair attempt lineage all pass. A typed v3 packet may instead represent
+one admitted deterministic protected-runtime synchronization. Its operation is
+actionable even with no failed check: ALL CLEAR would otherwise leave the
+immutable Dependabot target unrealized across the protected runtime. Same-head
+processing is idempotent. The first append-only Repair commit consumes attempt
+one; a second consumes attempt two. There is no third attempt.
 
 Processor check publication is also transition-idempotent. The newest trusted
 exact-head receipt must match mode, disposition/output summary, attempt, packet
@@ -352,8 +355,8 @@ original packet source rather than creating another repair run.
 `.github/workflows/dependabot-prepare-repair.yml` separates planning, durable
 intent, branch mutation, and recovery:
 
-1. **preflight** authenticates the exact Processor v2 packet and terminal
-   processor run;
+1. **preflight** authenticates the exact Processor v2 or v3 packet and terminal
+   processor run, then selects its exact plan kind;
 2. **plan** first runs the trusted `materialize-repair-evidence` command with a
    step-scoped read token. The command authenticates the packet and live PR,
    binds the exact base-to-head compare, re-fetches every expected file through
@@ -369,21 +372,34 @@ intent, branch mutation, and recovery:
    sealed directory and manifest. Paired pre/post hooks seal successful exact
    accesses; large files require explicit one-based bounded Read pages, and Grep
    may locate the relevant ranges. A no-token postflight assertion requires at
-   least one successful exact access before the plan job succeeds;
+   least one successful exact access before the generic plan job succeeds.
+   A `vercel-cli-runtime-sync` v3 packet takes the mutually exclusive
+   model-free path instead: trusted code reads the same exact blob evidence,
+   fetches the exact current and target public npm records, changes only the
+   Vercel regions of the root lock, runs pinned pnpm with scripts, workspace
+   links, and pnpmfile loading disabled to regenerate the standalone lock twice,
+   and emits only the packet's fixed five-path patch set;
 3. **validate** has no secret or write token. It re-fetches exact inputs by Git
    object SHA, including files larger than the Contents API limit, applies
    patches in a disposable credential-free temporary Git tree, enforces
    permitted/forbidden paths, file/edit/byte caps, exact
-   packet/head/base/check IDs, and emits a digest-bound plan;
-4. **stage** alone receives a short-lived Prepare App token and writes exact
+   packet/head/base/check IDs, and emits a digest-bound plan. For the typed v3
+   path it also regenerates independently and requires exact plan equality;
+4. **candidate CLI smoke** runs only for typed v3 after trusted validation on a
+   fresh no-output runner. It binds the canonical validated plan, performs a
+   secretless frozen standalone install with candidate scripts and workspace
+   links disabled, and requires `node <cli> --version` to equal the packet
+   target. Candidate execution is the terminal step: it can veto staging but
+   cannot change the validated plan or produce downstream authority;
+5. **stage** alone receives a short-lived Prepare App token and writes exact
    unreachable blobs, tree, and one commit without moving the branch;
-5. **intent** has no App token. It publishes `Dependabot Repair Intent`
+6. **intent** has no App token. It publishes `Dependabot Repair Intent`
    (`dependabot-repair-intent:v1`) on the staged successor, binding the packet,
    plan, old head, tree, result blobs, exact workflow run, and expected new head;
-6. **mutate** receives a fresh Prepare App token, revalidates the intent and
+7. **mutate** receives a fresh Prepare App token, revalidates the intent and
    exact current ref, then moves only that `dependabot/*` ref with
    `force=false`; and
-7. **receipt/recovery** has no App token. It publishes the completed
+8. **receipt/recovery** has no App token. It publishes the completed
    `Dependabot Repair` check, or recovers that check idempotently after a failed,
    cancelled, timed-out, action-required, or startup-failed source run only when
    the exact intent-bound commit is already the current PR head.
@@ -412,7 +428,7 @@ attempt.
 The prepared-head intake starts a new exact-head Claude review and processor
 cycle. Discard every old check, review, base, and feedback conclusion.
 
-A v2 packet may bind a validated Claude finding or review thread only by exact
+A generic v2 packet may bind a validated Claude finding or review thread only by exact
 identifier, commit/head, and body digest. After the repaired head has a clean
 re-review and complete green gate, finalize may post only:
 
@@ -463,18 +479,29 @@ binds its exact terminal trusted workflow run ID, attempt, workflow SHA, path,
 event, repository, `main` source, status, and conclusion. GitHub's self check
 URL is accepted only for the same check ID and resolved canonical run.
 
-### Processor v2 and repair packet v2
+### Processor v2 and repair packets v2/v3
 
 A packet-issued Processor check uses:
 
 `dependabot-processor:v2:pr=<n>:head=<sha>:mode=prepare:repair=<1|2>:packet=true:digest=<digest>:run=<run-id>:attempt=<run-attempt>`
 
 Its `output.text` is the exact canonical
-`dependabot-repair-packet:v2` JSON. It is deliberately a completed **failure**
-check while repair is required, so it cannot unblock merge. The packet binds
-the exact workflow run/SHA, PR/head/base, attempt, policy/risk, deterministic
-failures or finding digests, permitted/forbidden paths, caps, validation, and
-escalation.
+`dependabot-repair-packet:v2` or `dependabot-repair-packet:v3` JSON. It is
+deliberately a completed **failure** check while repair is required, so it
+cannot unblock merge. Both schemas bind the exact workflow run/SHA,
+PR/head/base, attempt, policy/risk, permitted/forbidden paths, caps, validation,
+and escalation. V2 additionally requires deterministic failure, finding, or
+feedback evidence.
+
+V3 is reserved for the exact
+`dependabot-protected-runtime-sync:v1` operation. Its current
+`vercel-cli-runtime-sync` kind binds the immutable seed Vercel row, stable
+same-major patch/minor target, exact pnpm 10.34.4, exact current-head input
+blobs, and the fixed root/runtime manifest, lockfile, and contract output paths.
+It may carry empty failure/finding/feedback arrays because the missing typed
+runtime synchronization is the actionable invariant. Mixed v2 attempt-one and
+v3 attempt-two lineage remains valid only when every packet, Intent, commit,
+receipt, operation digest, target version, and current-tree contract matches.
 
 ### Refresh v1
 
@@ -525,7 +552,7 @@ External ID:
 `dependabot-repair:v1:pr=<n>:head=<new head>:attempt=<repair attempt>:digest=<digest>:run=<run-id>:run_attempt=<run-attempt>`
 
 The check is completed success. `processorCheckId` and `packetDigest` bind the
-exact parent-head Processor failure check and canonical v2 packet.
+exact parent-head Processor failure check and canonical v2 or v3 packet.
 
 ### ALL CLEAR v1
 
@@ -619,6 +646,7 @@ or failed. Follow the managed failure issue and deployment recovery runbook.
 | Repair/recovery infrastructure failure               | Retry exact evidence twice per phase; then require investigation. |
 | Valid Claude findings                                | Treat as deterministic packet input, not infrastructure failure.  |
 | Eligible deterministic branch failure                | Publish v2 packet only when the bounded repair surface is valid.  |
+| Admitted Vercel protected-runtime target missing     | Publish exact v3 model-free sync packet; require typed proof.     |
 | Existing exact-head packet (`repair-pending`)        | Preserve its run; publish no duplicate packet/check.              |
 | No valid automatic packet (`manual-repair-required`) | Leave the lane and require human repair.                          |
 | Refresh needed                                       | Use request/completed v1 lineage; do not spend repair budget.     |

--- a/docs/dependency-overrides.md
+++ b/docs/dependency-overrides.md
@@ -31,55 +31,67 @@ patch. The checked-in manifests, lockfiles, and trusted controller now use only
 the exact reviewed nanoid 3.3.18 pair. The controller rejects the former pair,
 cross-paired hybrids, and unreviewed lockfile or override state.
 
-After changing the root Vercel pin or any root override, update this protected
-runtime in the same PR:
+Stable same-major patch and minor `vercel` updates use the processor's typed
+`vercel-cli-runtime-sync` operation. Dependabot isolates those updates in the
+`vercel-cli` group. Trusted, model-free code mirrors the target version and
+builder dependencies, changes only the exact Vercel importer/package/snapshot
+regions of the root lock, regenerates the standalone lock twice with exact pnpm
+10.34.4, updates `scripts/vercel-cli-runtime/contract.json`, and proves the
+result byte-for-byte before the existing Repair protocol may move the branch.
+The generic model repair cannot write these runtime paths.
 
-1. Mirror the root Vercel pin and complete override object into the standalone
-   manifest. If the Vercel version changed, also update
-   `PINNED_VERCEL_CLI_VERSION` in
-   `scripts/vercel-cli-runtime-contract.mjs`; the Vercel workflow structural
-   tests identify every remaining reviewed version assertion that must change:
+The typed operation rejects a changed root override, builder dependency key
+set, major, prerelease, downgrade, patched dependency, or non-registry source.
+Handle one of those rejected shapes in a separate human-reviewed PR. Keep these
+steps together in that PR:
+
+1. Fetch the target release's exact builder peer map from npm, review any key
+   or major-version change, then mirror that map, the root Vercel pin, and the
+   complete override object into the standalone manifest:
 
    ```bash
    node --input-type=module -e '
+   import { execFileSync } from "node:child_process";
    import { readFile, writeFile } from "node:fs/promises";
    const root = JSON.parse(await readFile("package.json", "utf8"));
+   const vercelVersion = root.devDependencies.vercel;
+   const peers = JSON.parse(execFileSync(
+     "npm",
+     ["view", `vercel@${vercelVersion}`, "peerDependencies", "--json"],
+     { encoding: "utf8" },
+   ));
    const path = "scripts/vercel-cli-runtime/package.json";
    const runtime = JSON.parse(await readFile(path, "utf8"));
-   runtime.dependencies.vercel = root.devDependencies.vercel;
+   runtime.dependencies = Object.fromEntries(
+     Object.entries({ ...peers, vercel: vercelVersion }).sort(([a], [b]) =>
+       a.localeCompare(b),
+     ),
+   );
    runtime.pnpm.overrides = root.pnpm.overrides;
    await writeFile(path, `${JSON.stringify(runtime, null, 2)}\n`);
    '
    ```
 
-2. Regenerate only the standalone lockfile from a fresh isolated directory:
+2. Regenerate only the standalone lockfile from a fresh isolated directory with
+   exact pnpm 10.34.4, no lifecycle scripts, no pnpmfile, and no workspace:
 
    ```bash
    runtime_dir="$(mktemp -d)"
    cp scripts/vercel-cli-runtime/package.json "$runtime_dir/package.json"
-   CI=true pnpm --dir "$runtime_dir" install --lockfile-only --ignore-scripts
+   CI=true pnpm --dir "$runtime_dir" install --lockfile-only --ignore-scripts --ignore-pnpmfile --ignore-workspace
    mv "$runtime_dir/pnpm-lock.yaml" scripts/vercel-cli-runtime/pnpm-lock.yaml
    rm -rf "$runtime_dir"
    ```
 
-3. Review the lockfile diff and calculate its exact digest:
+3. Review the manifest and lockfile diff. Update only the rotating values in
+   `scripts/vercel-cli-runtime/contract.json`: the exact Vercel version,
+   manifest/runtime-dependency/lockfile/override SHA-256 values, and npm
+   registry integrity. The stable executable validator reads and enforces that
+   exact data contract.
 
    ```bash
    shasum -a 256 scripts/vercel-cli-runtime/pnpm-lock.yaml
    ```
-
-   For a future rotation, change the manifest and lockfile state in a three-PR
-   sequence. First, land a trusted default-branch controller change that maps
-   each reviewed current/next
-   lockfile digest to the SHA-256 of its matching canonical, sorted root
-   override object. The standalone manifest must remain an exact mirror of
-   that root state, and cross-paired old-lock/new-manifest or
-   new-lock/old-manifest hybrids must reject. Candidate or PR-authored source
-   must never supply or extend this mapping. Then land the matching manifest
-   and lockfile state in a second PR, keeping the manifest's exact Vercel pin
-   and all registry-only checks intact. Immediately after that PR merges, use
-   a third cleanup PR to remove the former digest/override pair and restore the
-   single-pair contract.
 
 4. Verify the root/standalone pins, exact manifest, override mirror, reviewed
    lockfile digest, and registry-only lockfile policy:
@@ -94,6 +106,12 @@ runtime in the same PR:
 Never run a general workspace install to regenerate this lockfile. That would
 allow workspace links into a runtime whose isolation depends on a standalone
 registry-only graph.
+
+The typed processor path never copies a prior Dependabot lockfile wholesale.
+It preserves all non-Vercel root-lock bytes from the refreshed exact head, so a
+newer `main` cannot be overwritten by stale seed bytes. Its completed v3 packet, Repair
+Intent, Repair receipt, prepared-head review, and exact-head gates remain
+mandatory before ALL CLEAR. A maintainer still performs the squash merge.
 
 ### Reviewed brace-expansion state
 

--- a/docs/vercel-deployments.md
+++ b/docs/vercel-deployments.md
@@ -740,8 +740,9 @@ native Vercel:
 
 ## Pinned prerequisites
 
-- Vercel CLI: exactly `56.4.1` in the root `devDependencies` and the standalone
-  `scripts/vercel-cli-runtime/package.json` dependency. The root dependency
+- Vercel CLI: the exact version recorded in
+  `scripts/vercel-cli-runtime/contract.json` in both the root `devDependencies`
+  and standalone `scripts/vercel-cli-runtime/package.json` dependency. The root dependency
   remains available for reviewed operator commands; protected
   production-shadow and main-deployment jobs install only the standalone
   runtime. The project owner approved the dependency as part of delivering the
@@ -963,7 +964,7 @@ The production-shadow workflow uses a separate runner-owned staging boundary.
 `PROJECT_DIRECTORY` must be the directory in which the Vercel CLI writes its
 `.vercel` state. The production-shadow workflow launches the CLI from the
 monorepo root, but first materializes a trusted root `.vercel/repo.json` mapping
-and selects the literal project with `--project`. Pinned CLI 56.4.1 then writes
+and selects the literal project with `--project`. The contract-pinned CLI then writes
 the pulled environment and project settings below `apps/<target>/.vercel`, so
 the checker passes the literal `apps/<target>` directory. In this repo-linked
 mode, identity lives only in the exact root `.vercel/repo.json` mapping;
@@ -977,7 +978,7 @@ workflow constants and scoped GitHub secrets so they take precedence. A missing
 or invalid pulled file fails closed. Its machine-readable inventory is available
 directly:
 
-Production-shadow pulls intentionally omit `--git-branch`: pinned CLI 56.4.1
+Production-shadow pulls intentionally omit `--git-branch`: the contract-pinned CLI
 accepts that option only with the `preview` target. `--environment v3` or
 `--environment production` selects the exact custom or production
 configuration; the guarded source SHA, `VERCEL_GIT_COMMIT_REF=main`, and deploy
@@ -1145,16 +1146,14 @@ runtime after upload and evidence work; it refuses ambiguous or unexpected
 state.
 
 The protected production-shadow Vercel CLI is a standalone frozen install.
-Trusted controller code first requires its manifest to contain
-`vercel@56.4.1` and every CLI builder peer as exact direct dependencies,
-requires its `pnpm.overrides` object to equal the root security overrides,
-binds every byte of `scripts/vercel-cli-runtime/pnpm-lock.yaml` to the active
-lockfile SHA-256
-`2dbd0eba57b119870bcd2ba43f6cf726bb52c85d8ec03f4999030e9931e5ed36`
-paired with canonical root override SHA-256
-`11fc5e7476b6d15ddf6bf8d6956f6566346637f34e0b11e23849e92011b2bf31`.
-The checked-in runtime and trusted controller use only that pair. The
-controller rejects the former pair, cross-paired or unreviewed state, all
+Trusted controller code reads the exact active version, manifest/runtime
+dependency digests, npm registry integrity, standalone lock digest, and root
+override digest from `scripts/vercel-cli-runtime/contract.json`. It requires
+the standalone manifest to contain that exact Vercel version and every CLI
+builder dependency as exact direct dependencies, and requires its
+`pnpm.overrides` object to equal the root security overrides. The checked-in
+runtime and trusted controller use only that exact contract/manifests/lock
+tuple. The controller rejects a cross-paired or unreviewed state, all
 patched-dependency metadata, and patch artifacts. The current runtime uses
 upstream fixed `brace-expansion@2.1.4`. It copies the manifest and lockfile as
 independent runner-owned `0444`, single-link files under
@@ -1171,18 +1170,30 @@ the two reviewed package-name false positives for Vercel's unrelated `sandbox`
 CLI dependency. Root application suppressions cannot mask a standalone CLI
 vulnerability.
 
-For a future three-PR manifest and lockfile rotation, the trusted
-default-branch controller has a literal temporary mapping from each current or
-reviewed-next lockfile SHA-256 to the SHA-256 of its matching canonical, sorted
-root override object. The standalone manifest must exactly mirror that root
-override state, so old-lock/new-manifest and new-lock/old-manifest hybrids
-reject. Candidate source cannot supply or extend this mapping. The ordinary
-current-main manifest and lockfile pair therefore continues to verify until
-the payload PR changes both; then remove the old digest/override pair
-immediately in a cleanup PR so the controller returns to a single-pair binding.
-The manifest's exact
-`vercel@56.4.1` pin and every other lockfile check remain in force throughout
-the rotation.
+Stable same-major patch/minor rotations use the Dependabot processor's typed,
+model-free `vercel-cli-runtime-sync` repair. Trusted default-branch code binds
+the exact refreshed-head inputs, both exact public npm release records, root
+overrides, and pnpm 10.34.4. It changes only the exact Vercel regions of the
+root lock, preserves every other refreshed-head byte, and regenerates the
+standalone lock twice with byte-identical output. Only the root package/lock, standalone
+package/lock, and contract JSON may change. The independent validator repeats
+generation before the existing staged commit, Intent, non-force ref move, and
+Repair receipt path. Candidate source cannot supply or extend the operation or
+its allowlist. Major, prerelease, dependency-key-set, override, registry,
+generator, or byte drift fails closed for human handling.
+
+Pull-request preview workers treat the candidate contract, manifest, and locks
+as fixed-path data and verify that tuple for internal consistency. That check
+does not select or install the candidate CLI. Every credentialed preview build
+continues to stage the protected CLI from the trusted default-branch controller
+runtime, so a candidate cannot authorize the tool that validates or uploads its
+own output. The repair workflow separately proves the requested CLI with a
+secretless frozen standalone install and exact `node <cli> --version` check in
+a fresh terminal no-output job after trusted plan validation. Candidate
+execution can veto staging but cannot change the validated plan or emit
+downstream authority.
+After the reviewed PR merges, the exact-main deployment controller adopts the
+new contract and uses that protected version.
 
 The raw Vercel-pulled `.env.<target>.local` remains private and runner-owned.
 Before staging settings into candidate storage, the trusted controller parses
@@ -1343,7 +1354,7 @@ contract update rather than being accepted implicitly.
 Each command is launched at the monorepo root with an explicit literal
 `--project` argument. The controller removes `VERCEL_ORG_ID` and
 `VERCEL_PROJECT_ID` only from the CLI child environment after validating them
-and writing the trusted repo mapping; CLI 56.4.1 otherwise gives those variables
+and writing the trusted repo mapping; the contract-pinned CLI otherwise gives those variables
 precedence and loses the Root Directory. Authentication remains in the narrowly
 scoped `VERCEL_TOKEN` environment for API, pull, deploy, and alias-check steps,
 but
@@ -1774,7 +1785,7 @@ running it.
 Before any credentialed command, the worker proves the runtime root, its
 replacement-relevant parents, Node.js, pnpm, and the CLI are not candidate
 writable; it also proves the CLI resolves inside the protected directory, its
-package version is exactly `56.4.1`, and protected `node <cli> --version`
+package version is exactly the contract's `vercelVersion`, and protected `node <cli> --version`
 executes successfully. It then switches to the dedicated candidate UID and
 executes the protected pnpm launcher once before materializing or running the
 selected source, proving that every isolation ancestor is searchable by that
@@ -1824,7 +1835,7 @@ The pinned Vercel CLI commands executed from monorepo-shaped roots. Before
 path under `$VERCEL_ISOLATION_ROOT`. That tree contains only real
 `apps/ui.mento.org` directory components and an ephemeral repo-level link built
 from trusted repository variables; it contains no checked-out candidate file.
-This lets CLI `56.4.1` resolve the configured UI Root Directory without giving
+This lets the contract-pinned CLI resolve the configured UI Root Directory without giving
 the token-bearing pull command a candidate-controlled write path. The pulled
 mapping and project-local state are:
 
@@ -1856,7 +1867,7 @@ stopped. These helpers may traverse and `lstat` the candidate-owned `0700` /
 staging tree. The internal `validate-candidate-pull` controller action exists
 for this privileged check and is not an operator-facing command. The
 controller validates the ID variables but deliberately withholds them from the
-Vercel CLI child process: CLI `56.4.1` otherwise gives those variables
+Vercel CLI child process: the contract-pinned CLI otherwise gives those variables
 precedence over `repo.json` and loses the monorepo Root Directory mapping.
 
 The credentialed worker ran this sequence in one standard `ubuntu-latest` job:
@@ -1926,7 +1937,7 @@ escaping links remain rejected. The trusted handoff preserves accepted links
 without dereferencing them and changes the link ownership explicitly before
 applying the same validation again immediately before upload.
 
-CLI `56.4.1` gates its local Root Directory monorepo defaults behind
+The contract-pinned CLI gates its local Root Directory monorepo defaults behind
 `VERCEL_BUILD_MONOREPO_SUPPORT=1`. The worker supplies that trusted constant to
 the clean candidate environment so the CLI activates its Turborepo default,
 `turbo run build`, for the Root Directory project. Turbo then included upstream

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "ci:change-plan:test": "node scripts/ci-change-plan.test.mjs",
     "clean": "rm -rf .turbo && turbo run clean",
     "dependabot:process": "node scripts/dependabot-processor.mjs",
-    "dependabot:process:test": "node --test scripts/dependabot-preparation-receipts.test.mjs scripts/dependabot-processor.test.mjs scripts/dependabot-prepared-review.test.mjs scripts/dependabot-workflows.test.mjs",
+    "dependabot:process:test": "node --test scripts/dependabot-preparation-receipts.test.mjs scripts/dependabot-processor.test.mjs scripts/dependabot-protected-runtime-sync.test.mjs scripts/dependabot-prepared-review.test.mjs scripts/dependabot-workflows.test.mjs",
     "dev": "turbo run dev",
     "dev:app.mento.org": "turbo run dev --filter=app.mento.org",
     "dev:governance.mento.org": "turbo run dev --filter=governance.mento.org",

--- a/scripts/dependabot-preparation-receipts.mjs
+++ b/scripts/dependabot-preparation-receipts.mjs
@@ -18,7 +18,13 @@ import { pathToFileURL } from "node:url";
 
 export const GITHUB_ACTIONS_APP_ID = 15_368;
 export const GITHUB_WEB_FLOW_USER_ID = 19_864_447;
-export const PROCESSOR_PACKET_SCHEMA = "dependabot-repair-packet:v2";
+export const PROCESSOR_PACKET_SCHEMA_V2 = "dependabot-repair-packet:v2";
+export const PROCESSOR_PACKET_SCHEMA_V3 = "dependabot-repair-packet:v3";
+// Preserve the original export for callers that intentionally construct the
+// generic, model-planned v2 packet.
+export const PROCESSOR_PACKET_SCHEMA = PROCESSOR_PACKET_SCHEMA_V2;
+export const PROTECTED_RUNTIME_SYNC_OPERATION_SCHEMA =
+  "dependabot-protected-runtime-sync:v1";
 export const REPAIR_INTENT_SCHEMA = "dependabot-repair-intent:v1";
 export const REPAIR_PLAN_SCHEMA = "dependabot-repair-plan:v1";
 export const REPAIR_RECOVERY_SCHEMA = "dependabot-repair-recovery:v1";
@@ -40,6 +46,40 @@ const HARD_DENIED_PATHS = [
   "docs/vercel-deployments.md",
   "scripts/vercel-main-*.mjs",
 ];
+const PROTECTED_RUNTIME_SYNC_REQUIRED_PATHS = Object.freeze([
+  "package.json",
+  "pnpm-lock.yaml",
+  "scripts/vercel-cli-runtime/contract.json",
+  "scripts/vercel-cli-runtime/package.json",
+  "scripts/vercel-cli-runtime/pnpm-lock.yaml",
+]);
+const PROTECTED_RUNTIME_SYNC_INPUT_PATHS = Object.freeze([
+  "apps/app.mento.org/package.json",
+  "apps/governance.mento.org/package.json",
+  "apps/reserve.mento.org/package.json",
+  "apps/ui.mento.org/package.json",
+  "package.json",
+  "packages/eslint-config/package.json",
+  "packages/typescript-config/package.json",
+  "packages/ui/package.json",
+  "packages/vitest-config/package.json",
+  "packages/web3/package.json",
+  "pnpm-lock.yaml",
+  "pnpm-workspace.yaml",
+  "scripts/vercel-cli-runtime/contract.json",
+  "scripts/vercel-cli-runtime/package.json",
+  "scripts/vercel-cli-runtime/pnpm-lock.yaml",
+]);
+const PROTECTED_RUNTIME_SYNC_FORBIDDEN_PATHS = Object.freeze([
+  ".github/**",
+  "**/auth/**",
+  "**/deploy/**",
+  "**/deployment/**",
+  "**/policy/**",
+  "**/security/**",
+  "docs/vercel-deployments.md",
+  "scripts/vercel-main-*.mjs",
+]);
 const ALLOWED_FILE_EXTENSIONS = new Set([
   ".css",
   ".html",
@@ -622,48 +662,150 @@ function validateEvidence(packet) {
   }
 }
 
+const PROCESSOR_PACKET_V2_KEYS = Object.freeze([
+  "attemptLimit",
+  "attemptNumber",
+  "automatic",
+  "baseRef",
+  "baseSha",
+  "changedPaths",
+  "dependencyGroup",
+  "dependencyNames",
+  "escalation",
+  "expectedBlobs",
+  "failures",
+  "feedbackThreads",
+  "findings",
+  "forbiddenPaths",
+  "headRef",
+  "headSha",
+  "limits",
+  "mode",
+  "packageEcosystem",
+  "permittedPaths",
+  "preparable",
+  "pullRequestNumber",
+  "repository",
+  "requiredGateIds",
+  "requireExactHead",
+  "requireHumanApproval",
+  "riskTier",
+  "schema",
+  "updateType",
+  "validationCommands",
+  "workflowRunAttempt",
+  "workflowRunId",
+  "workflowSha",
+]);
+
+function exactStringArray(value, expected, label) {
+  boundedStringArray(value, label, expected.length);
+  if (JSON.stringify(value) !== JSON.stringify(expected)) {
+    fail(`${label} is not the exact protected-runtime set`);
+  }
+}
+
+function stableSemver(value, label) {
+  boundedString(value, label, {
+    max: 64,
+    min: 5,
+    pattern: /^(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)$/,
+  });
+  return value.split(".").map(Number);
+}
+
+function validateProtectedRuntimeSyncOperation(packet) {
+  const operation = packet.operation;
+  exactKeys(
+    operation,
+    [
+      "dependency",
+      "fromVersion",
+      "inputPaths",
+      "kind",
+      "pnpmVersion",
+      "requiredPaths",
+      "schema",
+      "sourceSeedHeadSha",
+      "targetVersion",
+      "updateType",
+    ],
+    "protected runtime sync operation",
+  );
+  if (
+    operation.schema !== PROTECTED_RUNTIME_SYNC_OPERATION_SCHEMA ||
+    operation.kind !== "vercel-cli-runtime-sync" ||
+    operation.dependency !== "vercel" ||
+    operation.pnpmVersion !== "10.34.4" ||
+    packet.packageEcosystem !== "npm" ||
+    !packet.dependencyNames.includes("vercel")
+  ) {
+    fail("protected runtime sync identity is invalid");
+  }
+  sha(operation.sourceSeedHeadSha, "operation.sourceSeedHeadSha");
+  exactStringArray(
+    operation.requiredPaths,
+    PROTECTED_RUNTIME_SYNC_REQUIRED_PATHS,
+    "operation.requiredPaths",
+  );
+  exactStringArray(
+    operation.inputPaths,
+    PROTECTED_RUNTIME_SYNC_INPUT_PATHS,
+    "operation.inputPaths",
+  );
+  exactStringArray(
+    packet.permittedPaths,
+    PROTECTED_RUNTIME_SYNC_REQUIRED_PATHS,
+    "permittedPaths",
+  );
+  exactStringArray(
+    packet.forbiddenPaths,
+    PROTECTED_RUNTIME_SYNC_FORBIDDEN_PATHS,
+    "forbiddenPaths",
+  );
+  if (
+    packet.limits.maxAddedLines !== 600 ||
+    packet.limits.maxBytes !== 64 * 1024 ||
+    packet.limits.maxChanges !== 160 ||
+    packet.limits.maxDeletedLines !== 600 ||
+    packet.limits.maxFiles !== PROTECTED_RUNTIME_SYNC_REQUIRED_PATHS.length
+  ) {
+    fail("protected runtime sync limits are invalid");
+  }
+  const from = stableSemver(operation.fromVersion, "operation.fromVersion");
+  const target = stableSemver(
+    operation.targetVersion,
+    "operation.targetVersion",
+  );
+  const derivedUpdateType =
+    from[0] === target[0] && target[1] > from[1]
+      ? "minor"
+      : from[0] === target[0] && target[1] === from[1] && target[2] > from[2]
+        ? "patch"
+        : null;
+  if (
+    derivedUpdateType === null ||
+    operation.updateType !== derivedUpdateType ||
+    packet.updateType !== derivedUpdateType
+  ) {
+    fail("protected runtime sync version transition is invalid");
+  }
+}
+
 export function validateProcessorRepairPacket(packet) {
+  plainObject(packet, "Processor repair packet");
+  const v3 = packet.schema === PROCESSOR_PACKET_SCHEMA_V3;
   exactKeys(
     packet,
-    [
-      "attemptLimit",
-      "attemptNumber",
-      "automatic",
-      "baseRef",
-      "baseSha",
-      "changedPaths",
-      "dependencyGroup",
-      "dependencyNames",
-      "escalation",
-      "expectedBlobs",
-      "failures",
-      "feedbackThreads",
-      "findings",
-      "forbiddenPaths",
-      "headRef",
-      "headSha",
-      "limits",
-      "mode",
-      "packageEcosystem",
-      "permittedPaths",
-      "preparable",
-      "pullRequestNumber",
-      "repository",
-      "requiredGateIds",
-      "requireExactHead",
-      "requireHumanApproval",
-      "riskTier",
-      "schema",
-      "updateType",
-      "validationCommands",
-      "workflowRunAttempt",
-      "workflowRunId",
-      "workflowSha",
-    ],
+    v3 ? [...PROCESSOR_PACKET_V2_KEYS, "operation"] : PROCESSOR_PACKET_V2_KEYS,
     "Processor repair packet",
   );
-  if (packet.schema !== PROCESSOR_PACKET_SCHEMA)
+  if (
+    packet.schema !== PROCESSOR_PACKET_SCHEMA_V2 &&
+    packet.schema !== PROCESSOR_PACKET_SCHEMA_V3
+  ) {
     fail("packet schema is invalid");
+  }
   repository(packet.repository);
   safeInteger(packet.pullRequestNumber, "pullRequestNumber");
   headRef(packet.headRef);
@@ -742,7 +884,9 @@ export function validateProcessorRepairPacket(packet) {
     "limits",
   );
   safeInteger(packet.limits.maxFiles, "limits.maxFiles", { max: 8 });
-  safeInteger(packet.limits.maxChanges, "limits.maxChanges", { max: 20 });
+  safeInteger(packet.limits.maxChanges, "limits.maxChanges", {
+    max: v3 ? 160 : 20,
+  });
   safeInteger(packet.limits.maxBytes, "limits.maxBytes", { max: 64 * 1024 });
   safeInteger(packet.limits.maxAddedLines, "limits.maxAddedLines", {
     max: 1_000,
@@ -752,11 +896,21 @@ export function validateProcessorRepairPacket(packet) {
   });
   validateEvidence(packet);
   if (
+    !v3 &&
     packet.failures.length === 0 &&
     packet.findings.length === 0 &&
     packet.feedbackThreads.length === 0
   ) {
     fail("packet has no actionable failure or feedback evidence");
+  }
+  if (v3) {
+    validateProtectedRuntimeSyncOperation(packet);
+    if (
+      JSON.stringify(packet.expectedBlobs.map(({ path }) => path)) !==
+      JSON.stringify(PROTECTED_RUNTIME_SYNC_INPUT_PATHS)
+    ) {
+      fail("expectedBlobs do not cover the exact protected-runtime inputs");
+    }
   }
   return packet;
 }
@@ -1497,6 +1651,10 @@ async function commandRepairPreflight(args) {
     packet_base64: Buffer.from(text).toString("base64"),
     packet_digest: payload.processorReceipt.digest,
     packet_json: text,
+    plan_kind:
+      packet.schema === PROCESSOR_PACKET_SCHEMA_V3
+        ? "protected-runtime-sync"
+        : "claude-repair",
     processor_check_id: check.id,
     pull_request_number: packet.pullRequestNumber,
     repair_attempt: packet.attemptNumber,

--- a/scripts/dependabot-preparation-receipts.test.mjs
+++ b/scripts/dependabot-preparation-receipts.test.mjs
@@ -20,6 +20,9 @@ import { fileURLToPath } from "node:url";
 
 import {
   GITHUB_WEB_FLOW_USER_ID,
+  PROCESSOR_PACKET_SCHEMA_V2,
+  PROCESSOR_PACKET_SCHEMA_V3,
+  PROTECTED_RUNTIME_SYNC_OPERATION_SCHEMA,
   applyRepairPlan,
   canonicalDigest,
   canonicalJson,
@@ -128,7 +131,7 @@ function repairPacket(overrides = {}) {
     requireExactHead: true,
     requireHumanApproval: false,
     riskTier: "automatic",
-    schema: "dependabot-repair-packet:v2",
+    schema: PROCESSOR_PACKET_SCHEMA_V2,
     updateType: "patch",
     validationCommands: ["pnpm ci:action-pins:test"],
     workflowRunAttempt: 2,
@@ -136,6 +139,83 @@ function repairPacket(overrides = {}) {
     workflowSha,
     ...overrides,
   };
+}
+
+const protectedRuntimeRequiredPaths = [
+  "package.json",
+  "pnpm-lock.yaml",
+  "scripts/vercel-cli-runtime/contract.json",
+  "scripts/vercel-cli-runtime/package.json",
+  "scripts/vercel-cli-runtime/pnpm-lock.yaml",
+];
+const protectedRuntimeInputPaths = [
+  "apps/app.mento.org/package.json",
+  "apps/governance.mento.org/package.json",
+  "apps/reserve.mento.org/package.json",
+  "apps/ui.mento.org/package.json",
+  "package.json",
+  "packages/eslint-config/package.json",
+  "packages/typescript-config/package.json",
+  "packages/ui/package.json",
+  "packages/vitest-config/package.json",
+  "packages/web3/package.json",
+  "pnpm-lock.yaml",
+  "pnpm-workspace.yaml",
+  "scripts/vercel-cli-runtime/contract.json",
+  "scripts/vercel-cli-runtime/package.json",
+  "scripts/vercel-cli-runtime/pnpm-lock.yaml",
+];
+
+function protectedRuntimePacket(overrides = {}) {
+  return repairPacket({
+    changedPaths: ["package.json", "pnpm-lock.yaml"],
+    dependencyGroup: "tooling",
+    dependencyNames: ["knip", "vercel", "@next/eslint-plugin-next"],
+    expectedBlobs: protectedRuntimeInputPaths.map((path) => ({
+      mode: "100644",
+      path,
+      sha: "e".repeat(40),
+      type: "blob",
+    })),
+    failures: [],
+    feedbackThreads: [],
+    findings: [],
+    forbiddenPaths: [
+      ".github/**",
+      "**/auth/**",
+      "**/deploy/**",
+      "**/deployment/**",
+      "**/policy/**",
+      "**/security/**",
+      "docs/vercel-deployments.md",
+      "scripts/vercel-main-*.mjs",
+    ],
+    headRef: "dependabot/npm_and_yarn/tooling-123",
+    limits: {
+      maxAddedLines: 600,
+      maxBytes: 64 * 1024,
+      maxChanges: 160,
+      maxDeletedLines: 600,
+      maxFiles: 5,
+    },
+    operation: {
+      dependency: "vercel",
+      fromVersion: "56.4.1",
+      inputPaths: protectedRuntimeInputPaths,
+      kind: "vercel-cli-runtime-sync",
+      pnpmVersion: "10.34.4",
+      requiredPaths: protectedRuntimeRequiredPaths,
+      schema: PROTECTED_RUNTIME_SYNC_OPERATION_SCHEMA,
+      sourceSeedHeadSha: "f".repeat(40),
+      targetVersion: "56.5.0",
+      updateType: "minor",
+    },
+    packageEcosystem: "npm",
+    permittedPaths: protectedRuntimeRequiredPaths,
+    schema: PROCESSOR_PACKET_SCHEMA_V3,
+    updateType: "minor",
+    ...overrides,
+  });
 }
 
 function repairReceipt(overrides = {}) {
@@ -910,6 +990,121 @@ test("processor packet permits feedback-only repair but rejects empty authority"
       ),
     /keys are not exact/,
   );
+});
+
+test("protected-runtime v3 packets permit empty repair evidence only under the exact typed contract", () => {
+  const packet = protectedRuntimePacket();
+  assert.equal(validateProcessorRepairPacket(packet), packet);
+  assert.equal(packet.failures.length, 0);
+
+  assert.throws(
+    () =>
+      validateProcessorRepairPacket({
+        ...packet,
+        schema: PROCESSOR_PACKET_SCHEMA_V2,
+      }),
+    /keys are not exact/,
+  );
+
+  const invalidPackets = [
+    {
+      label: "operation key",
+      mutate(value) {
+        value.operation.untrusted = true;
+      },
+    },
+    {
+      label: "operation schema",
+      mutate(value) {
+        value.operation.schema = "dependabot-protected-runtime-sync:v2";
+      },
+    },
+    {
+      label: "dependency",
+      mutate(value) {
+        value.operation.dependency = "next";
+      },
+    },
+    {
+      label: "major target",
+      mutate(value) {
+        value.operation.targetVersion = "57.0.0";
+        value.operation.updateType = "major";
+        value.updateType = "major";
+      },
+    },
+    {
+      label: "required path",
+      mutate(value) {
+        value.operation.requiredPaths = [
+          ...value.operation.requiredPaths,
+          "scripts/vercel-cli-runtime/extra.json",
+        ];
+      },
+    },
+    {
+      label: "input order",
+      mutate(value) {
+        value.operation.inputPaths = [...value.operation.inputPaths].reverse();
+      },
+    },
+    {
+      label: "missing expected blob",
+      mutate(value) {
+        value.expectedBlobs = value.expectedBlobs.slice(1);
+      },
+    },
+    {
+      label: "extra permitted path",
+      mutate(value) {
+        value.permittedPaths = [...value.permittedPaths, "scripts/**"];
+      },
+    },
+    {
+      label: "runtime wildcard denial",
+      mutate(value) {
+        value.forbiddenPaths = [
+          ...value.forbiddenPaths.slice(0, 5),
+          "**/runtime/**",
+          ...value.forbiddenPaths.slice(5),
+        ];
+      },
+    },
+    {
+      label: "change cap",
+      mutate(value) {
+        value.limits.maxChanges = 159;
+      },
+    },
+  ];
+  for (const { label, mutate } of invalidPackets) {
+    const value = structuredClone(packet);
+    mutate(value);
+    assert.throws(() => validateProcessorRepairPacket(value), undefined, label);
+  }
+});
+
+test("v3 operation authority remains transitively bound through unchanged repair receipts", () => {
+  const digest = canonicalDigest(protectedRuntimePacket());
+  const intent = validateRepairIntent(
+    repairIntent({
+      headRef: "dependabot/npm_and_yarn/tooling-123",
+      packetDigest: digest,
+    }),
+  );
+  const receipt = validateRepairReceipt(
+    repairReceipt({
+      headRef: intent.headRef,
+      packetDigest: digest,
+    }),
+  );
+  assert.equal(intent.packetDigest, digest);
+  assert.equal(receipt.packetDigest, digest);
+  assert.match(
+    repairIntentExternalId(intent),
+    new RegExp(`digest=[0-9a-f]{64}`),
+  );
+  assert.match(operationExternalId(receipt), /dependabot-repair:v1/);
 });
 
 test("repair plans bind packet paths and carry only bounded patches and digests", () => {

--- a/scripts/dependabot-prepared-review.mjs
+++ b/scripts/dependabot-prepared-review.mjs
@@ -4,6 +4,8 @@ import { resolve } from "node:path";
 import process from "node:process";
 import { fileURLToPath } from "node:url";
 
+import { validateProcessorRepairPacket } from "./dependabot-preparation-receipts.mjs";
+
 const SHA_PATTERN = /^[0-9a-f]{40}$/;
 const DIGEST_PATTERN = /^[0-9a-f]{64}$/;
 const REPOSITORY_PATTERN = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
@@ -345,10 +347,14 @@ function validateProcessorPacket({ expected, receipt, requestJson }) {
     check.output.text === canonicalReceiptJson(packet),
     "repair packet check output is not canonical JSON",
   );
+  try {
+    validateProcessorRepairPacket(packet);
+  } catch {
+    invariant(false, "repair packet check output is not a valid typed packet");
+  }
   const packetDigest = digestReceipt(packet);
   invariant(
     packetDigest === receipt.packetDigest &&
-      packet.schema === "dependabot-repair-packet:v2" &&
       packet.repository === expected.repository &&
       packet.pullRequestNumber === expected.pullRequestNumber &&
       packet.headSha === receipt.parentHeadSha &&

--- a/scripts/dependabot-prepared-review.test.mjs
+++ b/scripts/dependabot-prepared-review.test.mjs
@@ -154,23 +154,158 @@ function options(operation, checkId, operationDigest) {
   };
 }
 
+function processorPacket({
+  attemptNumber,
+  packetHeadSha,
+  workflowRunAttempt = 1,
+  workflowRunId,
+  ...overrides
+}) {
+  return {
+    attemptLimit: 2,
+    attemptNumber,
+    automatic: true,
+    baseRef: "main",
+    baseSha,
+    changedPaths: ["package.json", "pnpm-lock.yaml"],
+    dependencyGroup: "tooling",
+    dependencyNames: ["vercel"],
+    escalation: "manual-review",
+    expectedBlobs: [
+      {
+        mode: "100644",
+        path: "package.json",
+        sha: "a".repeat(40),
+        type: "blob",
+      },
+    ],
+    failures: [
+      {
+        attribution: "branch",
+        detailsUrl: null,
+        id: "ci",
+        name: "CI sentinel",
+      },
+    ],
+    feedbackThreads: [],
+    findings: [],
+    forbiddenPaths: [".github/**"],
+    headRef,
+    headSha: packetHeadSha,
+    limits: {
+      maxAddedLines: 20,
+      maxBytes: 8192,
+      maxChanges: 20,
+      maxDeletedLines: 20,
+      maxFiles: 1,
+    },
+    mode: "prepare",
+    packageEcosystem: "npm",
+    permittedPaths: ["package.json"],
+    preparable: true,
+    pullRequestNumber,
+    repository,
+    requiredGateIds: ["ci"],
+    requireExactHead: true,
+    requireHumanApproval: false,
+    riskTier: "automatic",
+    schema: "dependabot-repair-packet:v2",
+    updateType: "patch",
+    validationCommands: ["pnpm quality:budgets:test"],
+    workflowRunAttempt,
+    workflowRunId,
+    workflowSha,
+    ...overrides,
+  };
+}
+
+const protectedRuntimeRequiredPaths = [
+  "package.json",
+  "pnpm-lock.yaml",
+  "scripts/vercel-cli-runtime/contract.json",
+  "scripts/vercel-cli-runtime/package.json",
+  "scripts/vercel-cli-runtime/pnpm-lock.yaml",
+];
+const protectedRuntimeInputPaths = [
+  "apps/app.mento.org/package.json",
+  "apps/governance.mento.org/package.json",
+  "apps/reserve.mento.org/package.json",
+  "apps/ui.mento.org/package.json",
+  "package.json",
+  "packages/eslint-config/package.json",
+  "packages/typescript-config/package.json",
+  "packages/ui/package.json",
+  "packages/vitest-config/package.json",
+  "packages/web3/package.json",
+  "pnpm-lock.yaml",
+  "pnpm-workspace.yaml",
+  "scripts/vercel-cli-runtime/contract.json",
+  "scripts/vercel-cli-runtime/package.json",
+  "scripts/vercel-cli-runtime/pnpm-lock.yaml",
+];
+
+function protectedRuntimePacket({
+  attemptNumber,
+  packetHeadSha,
+  workflowRunId,
+}) {
+  return processorPacket({
+    attemptNumber,
+    dependencyNames: ["knip", "vercel", "@next/eslint-plugin-next"],
+    expectedBlobs: protectedRuntimeInputPaths.map((path) => ({
+      mode: "100644",
+      path,
+      sha: "a".repeat(40),
+      type: "blob",
+    })),
+    failures: [],
+    forbiddenPaths: [
+      ".github/**",
+      "**/auth/**",
+      "**/deploy/**",
+      "**/deployment/**",
+      "**/policy/**",
+      "**/security/**",
+      "docs/vercel-deployments.md",
+      "scripts/vercel-main-*.mjs",
+    ],
+    limits: {
+      maxAddedLines: 600,
+      maxBytes: 64 * 1024,
+      maxChanges: 160,
+      maxDeletedLines: 600,
+      maxFiles: 5,
+    },
+    operation: {
+      dependency: "vercel",
+      fromVersion: "56.4.1",
+      inputPaths: protectedRuntimeInputPaths,
+      kind: "vercel-cli-runtime-sync",
+      pnpmVersion: "10.34.4",
+      requiredPaths: protectedRuntimeRequiredPaths,
+      schema: "dependabot-protected-runtime-sync:v1",
+      sourceSeedHeadSha: seedHeadSha,
+      targetVersion: "56.5.0",
+      updateType: "minor",
+    },
+    packetHeadSha,
+    permittedPaths: protectedRuntimeRequiredPaths,
+    schema: "dependabot-repair-packet:v3",
+    updateType: "minor",
+    workflowRunId,
+  });
+}
+
 function repairFixture() {
   const processorRunId = 510;
   const repairRunId = 610;
   const processorCheckId = 110;
   const repairCheckId = 210;
-  const packet = {
+  const packet = processorPacket({
     attemptNumber: 1,
-    baseSha,
-    headSha: seedHeadSha,
-    mode: "prepare",
-    pullRequestNumber,
-    repository,
-    schema: "dependabot-repair-packet:v2",
-    workflowRunAttempt: 1,
+    packetHeadSha: seedHeadSha,
     workflowRunId: processorRunId,
-    workflowSha,
-  };
+  });
   const packetDigest = digestReceipt(packet);
   const processorCheck = check({
     conclusion: "failure",
@@ -362,7 +497,10 @@ function refreshFixture({
   };
 }
 
-function recoveredRepairLineageFixture({ failedRecoveryCount = 0 } = {}) {
+function recoveredRepairLineageFixture({
+  failedRecoveryCount = 0,
+  protectedRuntimeSecondRepair = false,
+} = {}) {
   assert.ok([0, 1, 2].includes(failedRecoveryCount));
   const laterHeadSha = "9".repeat(40);
   const firstProcessorRunId = 510;
@@ -381,18 +519,11 @@ function recoveredRepairLineageFixture({ failedRecoveryCount = 0 } = {}) {
     type: "Bot",
   };
 
-  const firstPacket = {
+  const firstPacket = processorPacket({
     attemptNumber: 1,
-    baseSha,
-    headSha: seedHeadSha,
-    mode: "prepare",
-    pullRequestNumber,
-    repository,
-    schema: "dependabot-repair-packet:v2",
-    workflowRunAttempt: 1,
+    packetHeadSha: seedHeadSha,
     workflowRunId: firstProcessorRunId,
-    workflowSha,
-  };
+  });
   const firstPacketDigest = digestReceipt(firstPacket);
   const firstProcessorCheck = check({
     conclusion: "failure",
@@ -520,18 +651,17 @@ function recoveredRepairLineageFixture({ failedRecoveryCount = 0 } = {}) {
   const recoveryCheck = recoveryEvidence.at(-1).check;
   const recoveryDigest = recoveryEvidence.at(-1).receiptDigest;
 
-  const secondPacket = {
-    attemptNumber: 2,
-    baseSha,
-    headSha: preparedHeadSha,
-    mode: "prepare",
-    pullRequestNumber,
-    repository,
-    schema: "dependabot-repair-packet:v2",
-    workflowRunAttempt: 1,
-    workflowRunId: secondProcessorRunId,
-    workflowSha,
-  };
+  const secondPacket = protectedRuntimeSecondRepair
+    ? protectedRuntimePacket({
+        attemptNumber: 2,
+        packetHeadSha: preparedHeadSha,
+        workflowRunId: secondProcessorRunId,
+      })
+    : processorPacket({
+        attemptNumber: 2,
+        packetHeadSha: preparedHeadSha,
+        workflowRunId: secondProcessorRunId,
+      });
   const secondPacketDigest = digestReceipt(secondPacket);
   const secondProcessorCheck = check({
     conclusion: "failure",
@@ -781,6 +911,28 @@ test("uses a successful recovery receipt after a failed receipt when later prepa
     repository,
     seedHeadSha,
   });
+});
+
+test("accepts a v2 repair followed by a packet-bound v3 protected-runtime sync", () => {
+  const fixture = recoveredRepairLineageFixture({
+    protectedRuntimeSecondRepair: true,
+  });
+  const result = validatePreparedReviewTarget(
+    {
+      ...options(
+        fixture.operation,
+        fixture.secondRepairCheckId,
+        fixture.secondReceiptDigest,
+      ),
+      headSha: fixture.laterHeadSha,
+    },
+    requestFromMap(fixture.entries),
+  );
+  assert.equal(result.repairCount, 2);
+  assert.deepEqual(result.operationDigests, [
+    fixture.recoveryDigest,
+    fixture.secondReceiptDigest,
+  ]);
 });
 
 test("accepts a continuing lineage after one failed recovery retry", () => {

--- a/scripts/dependabot-processor.mjs
+++ b/scripts/dependabot-processor.mjs
@@ -5,6 +5,7 @@
 import { readFileSync } from "node:fs";
 import process from "node:process";
 import { createHash } from "node:crypto";
+import { Buffer } from "node:buffer";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -16,6 +17,8 @@ import {
 
 export const DEPENDABOT_PROCESSOR_SCHEMA = "dependabot-processor:v2";
 export const DEPENDABOT_REPAIR_PACKET_SCHEMA = "dependabot-repair-packet:v2";
+export const DEPENDABOT_PROTECTED_RUNTIME_REPAIR_PACKET_SCHEMA =
+  "dependabot-repair-packet:v3";
 export const DEPENDABOT_POST_MERGE_SCHEMA = "dependabot-post-merge:v1";
 export const DEPENDABOT_REFRESH_SCHEMA = "dependabot-refresh:v1";
 export const DEPENDABOT_REPAIR_SCHEMA = "dependabot-repair:v1";
@@ -124,6 +127,41 @@ const PREPARATION_SENSITIVE_ACTION_PATTERN =
 const AUTONOMOUS_REPAIR_FORBIDDEN_PATH_PATTERN =
   /(?:^\.github\/|(?:^|[/_.-])(?:auth|authentication|credential|credentials|deploy|deployment|policy|runtime|security)(?:[/_.-]|$))/i;
 const RECEIPT_OUTPUT_LIMIT = 50_000;
+const PROTECTED_RUNTIME_BLOB_LIMIT = 256 * 1024;
+const PROTECTED_RUNTIME_OPERATION_SCHEMA =
+  "dependabot-protected-runtime-sync:v1";
+const VERCEL_CLI_RUNTIME_CONTRACT_SCHEMA = "vercel-cli-runtime-contract:v1";
+const VERCEL_CLI_RUNTIME_KIND = "vercel-cli-runtime-sync";
+const VERCEL_CLI_RUNTIME_PNPM_VERSION = "10.34.4";
+const VERCEL_CLI_RUNTIME_GROUPS = new Set([
+  "tooling",
+  "vercel-cli",
+  "vercel-cli-security",
+]);
+const VERCEL_CLI_RUNTIME_REQUIRED_PATHS = [
+  "package.json",
+  "pnpm-lock.yaml",
+  "scripts/vercel-cli-runtime/contract.json",
+  "scripts/vercel-cli-runtime/package.json",
+  "scripts/vercel-cli-runtime/pnpm-lock.yaml",
+];
+const VERCEL_CLI_RUNTIME_INPUT_PATHS = [
+  "apps/app.mento.org/package.json",
+  "apps/governance.mento.org/package.json",
+  "apps/reserve.mento.org/package.json",
+  "apps/ui.mento.org/package.json",
+  "package.json",
+  "packages/eslint-config/package.json",
+  "packages/typescript-config/package.json",
+  "packages/ui/package.json",
+  "packages/vitest-config/package.json",
+  "packages/web3/package.json",
+  "pnpm-lock.yaml",
+  "pnpm-workspace.yaml",
+  "scripts/vercel-cli-runtime/contract.json",
+  "scripts/vercel-cli-runtime/package.json",
+  "scripts/vercel-cli-runtime/pnpm-lock.yaml",
+];
 
 const CHECK_POLICY_DEFINITIONS = [
   {
@@ -833,6 +871,151 @@ function semverUpdateType(from, to) {
   return "patch";
 }
 
+function stableSemverParts(value) {
+  const match = /^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$/.exec(
+    String(value ?? ""),
+  );
+  return match ? match.slice(1).map(Number) : null;
+}
+
+function compareSemverParts(left, right) {
+  for (let index = 0; index < 3; index += 1) {
+    if (left[index] !== right[index]) return left[index] - right[index];
+  }
+  return 0;
+}
+
+function validVercelCliRuntimeOperation(operation) {
+  if (
+    !exactObjectKeys(operation, [
+      "dependency",
+      "fromVersion",
+      "inputPaths",
+      "kind",
+      "pnpmVersion",
+      "requiredPaths",
+      "schema",
+      "sourceSeedHeadSha",
+      "targetVersion",
+      "updateType",
+    ]) ||
+    operation.schema !== PROTECTED_RUNTIME_OPERATION_SCHEMA ||
+    operation.kind !== VERCEL_CLI_RUNTIME_KIND ||
+    operation.dependency !== "vercel" ||
+    operation.pnpmVersion !== VERCEL_CLI_RUNTIME_PNPM_VERSION ||
+    !SHA_PATTERN.test(operation.sourceSeedHeadSha ?? "") ||
+    stableJson(operation.requiredPaths) !==
+      stableJson(VERCEL_CLI_RUNTIME_REQUIRED_PATHS) ||
+    stableJson(operation.inputPaths) !==
+      stableJson(VERCEL_CLI_RUNTIME_INPUT_PATHS)
+  ) {
+    return false;
+  }
+  const from = stableSemverParts(operation.fromVersion);
+  const target = stableSemverParts(operation.targetVersion);
+  return (
+    from !== null &&
+    target !== null &&
+    from[0] === target[0] &&
+    compareSemverParts(target, from) > 0 &&
+    new Set(["patch", "minor"]).has(operation.updateType) &&
+    semverUpdateType(operation.fromVersion, operation.targetVersion) ===
+      operation.updateType
+  );
+}
+
+function vercelCliRuntimeOperationFromMetadata(metadata = {}) {
+  const dependencies = Array.isArray(metadata.dependencies)
+    ? metadata.dependencies
+    : [];
+  const vercelRows = dependencies.filter(
+    (dependency) => dependency?.name === "vercel",
+  );
+  if (vercelRows.length === 0) return null;
+  const sourceSeedHeadSha = metadata.immutableEvidence?.seedCommitSha;
+  if (
+    metadata.packageEcosystem !== "npm" ||
+    metadata.immutableEvidence?.dependencyMetadataValid !== true ||
+    metadata.groupedUpdateIntegrity?.valid !== true ||
+    !VERCEL_CLI_RUNTIME_GROUPS.has(metadata.dependencyGroup) ||
+    vercelRows.length !== 1 ||
+    !SHA_PATTERN.test(sourceSeedHeadSha ?? "")
+  ) {
+    return { eligible: false, reason: "invalid-vercel-cli-runtime-update" };
+  }
+  const [{ from, to, updateType }] = vercelRows;
+  const operation = {
+    dependency: "vercel",
+    fromVersion: from,
+    inputPaths: [...VERCEL_CLI_RUNTIME_INPUT_PATHS],
+    kind: VERCEL_CLI_RUNTIME_KIND,
+    pnpmVersion: VERCEL_CLI_RUNTIME_PNPM_VERSION,
+    requiredPaths: [...VERCEL_CLI_RUNTIME_REQUIRED_PATHS],
+    schema: PROTECTED_RUNTIME_OPERATION_SCHEMA,
+    sourceSeedHeadSha,
+    targetVersion: to,
+    updateType,
+  };
+  return validVercelCliRuntimeOperation(operation)
+    ? { eligible: true, operation }
+    : { eligible: false, reason: "invalid-vercel-cli-runtime-update" };
+}
+
+function protectedRuntimeStateMatches(protectedRuntime, operation) {
+  return (
+    protectedRuntime !== null &&
+    typeof protectedRuntime === "object" &&
+    protectedRuntime.contractSchema === VERCEL_CLI_RUNTIME_CONTRACT_SCHEMA &&
+    protectedRuntime.contractVersion === operation.targetVersion &&
+    protectedRuntime.rootVersion === operation.targetVersion &&
+    protectedRuntime.runtimeVersion === operation.targetVersion &&
+    protectedRuntime.pnpmVersion === operation.pnpmVersion
+  );
+}
+
+function validProtectedRuntimeSnapshot(protectedRuntime) {
+  return (
+    protectedRuntime !== null &&
+    typeof protectedRuntime === "object" &&
+    protectedRuntime.contractSchema === VERCEL_CLI_RUNTIME_CONTRACT_SCHEMA &&
+    stableSemverParts(protectedRuntime.contractVersion) !== null &&
+    stableSemverParts(protectedRuntime.rootVersion) !== null &&
+    stableSemverParts(protectedRuntime.runtimeVersion) !== null &&
+    protectedRuntime.pnpmVersion === VERCEL_CLI_RUNTIME_PNPM_VERSION
+  );
+}
+
+function evaluateProtectedRuntimeOperation({
+  metadata,
+  protectedRuntime,
+  repairAttempts,
+}) {
+  const candidate = vercelCliRuntimeOperationFromMetadata(metadata);
+  if (candidate === null || candidate.eligible !== true) return candidate;
+  if (!validProtectedRuntimeSnapshot(protectedRuntime)) {
+    return {
+      eligible: false,
+      operation: candidate.operation,
+      reason: "invalid-vercel-cli-runtime-snapshot",
+    };
+  }
+  const matchingProof = (repairAttempts?.protectedRuntimeOperations ?? []).find(
+    ({ operation }) =>
+      validVercelCliRuntimeOperation(operation) &&
+      stableJson(operation) === stableJson(candidate.operation),
+  );
+  const stateMatches = protectedRuntimeStateMatches(
+    protectedRuntime,
+    candidate.operation,
+  );
+  return {
+    ...candidate,
+    proof: matchingProof ?? null,
+    satisfied: matchingProof !== undefined && stateMatches,
+    stateMatches,
+  };
+}
+
 function dependencyRowsFromBody(body) {
   const rows = [];
   const pattern = /^\| \[([^\]]+)\]\([^\n)]+\) \| `([^`]+)` \| `([^`]+)` \|$/gm;
@@ -1528,7 +1711,10 @@ export function parseDependabotProcessorReceipt(check, repository) {
     !packetValid ||
     (packetIssued &&
       (!packet ||
-        packet.schema !== DEPENDABOT_REPAIR_PACKET_SCHEMA ||
+        !new Set([
+          DEPENDABOT_REPAIR_PACKET_SCHEMA,
+          DEPENDABOT_PROTECTED_RUNTIME_REPAIR_PACKET_SCHEMA,
+        ]).has(packet.schema) ||
         packet.workflowRunId !== normalized.runId ||
         packet.workflowRunAttempt !== normalized.runAttempt ||
         packet.workflowSha !== normalized.runHeadSha ||
@@ -1761,6 +1947,38 @@ function validPreparationSummary(preparation) {
       preparation.repairCount === 0
     );
   }
+  const hasProtectedRuntimeOperations = Object.hasOwn(
+    preparation,
+    "protectedRuntimeOperations",
+  );
+  const protectedRuntimeOperations = hasProtectedRuntimeOperations
+    ? preparation.protectedRuntimeOperations
+    : [];
+  if (
+    !Array.isArray(protectedRuntimeOperations) ||
+    (hasProtectedRuntimeOperations &&
+      protectedRuntimeOperations.length === 0) ||
+    protectedRuntimeOperations.some(
+      (record) =>
+        !exactObjectKeys(record, [
+          "operation",
+          "operationDigest",
+          "packetDigest",
+        ]) ||
+        !validVercelCliRuntimeOperation(record.operation) ||
+        record.operation.sourceSeedHeadSha !== preparation.seedHeadSha ||
+        !/^[0-9a-f]{64}$/.test(record.operationDigest ?? "") ||
+        !/^[0-9a-f]{64}$/.test(record.packetDigest ?? "") ||
+        !preparation.operationDigests.includes(record.operationDigest),
+    ) ||
+    new Set(
+      protectedRuntimeOperations.map(({ operationDigest }) => operationDigest),
+    ).size !== protectedRuntimeOperations.length ||
+    new Set(protectedRuntimeOperations.map(({ packetDigest }) => packetDigest))
+      .size !== protectedRuntimeOperations.length
+  ) {
+    return false;
+  }
   return (
     preparation.kind === "prepared" &&
     exactObjectKeys(preparation, [
@@ -1769,6 +1987,7 @@ function validPreparationSummary(preparation) {
       "prepareAppSlug",
       "prepareBotId",
       "prepareBotLogin",
+      ...(hasProtectedRuntimeOperations ? ["protectedRuntimeOperations"] : []),
       "refreshCount",
       "repairCount",
       "seedHeadSha",
@@ -3027,6 +3246,7 @@ function evaluateRepairAttemptGate({
   let prepareLineageValid = true;
   let preparationActor = null;
   const operationDigests = [];
+  const protectedRuntimeOperations = [];
   const bindPreparationActor = (receipt) => {
     const actor = {
       appSlug: receipt.prepareAppSlug,
@@ -3114,8 +3334,15 @@ function evaluateRepairAttemptGate({
           packetDigest === completed.packetDigest,
       );
       const parents = commitParentShas(commit);
+      const protectedRuntimeOperation =
+        processorReceipt?.packet?.schema ===
+        DEPENDABOT_PROTECTED_RUNTIME_REPAIR_PACKET_SCHEMA
+          ? processorReceipt.packet.operation
+          : null;
       if (
         !processorReceipt ||
+        (protectedRuntimeOperation !== null &&
+          !validVercelCliRuntimeOperation(protectedRuntimeOperation)) ||
         completed.parentHeadSha !== parentHeadSha ||
         completed.headSha !== commitHeadSha ||
         completed.attempt !== consumedAttempts + 1 ||
@@ -3130,7 +3357,15 @@ function evaluateRepairAttemptGate({
       consumedAttempts += 1;
       authenticatedRepairCommitCount += 1;
       bindPreparationActor(completed);
-      operationDigests.push(canonicalDigest(completed));
+      const operationDigest = canonicalDigest(completed);
+      operationDigests.push(operationDigest);
+      if (protectedRuntimeOperation !== null) {
+        protectedRuntimeOperations.push({
+          operation: protectedRuntimeOperation,
+          operationDigest,
+          packetDigest: processorReceipt.packetDigest,
+        });
+      }
       latestAppliedRepair = {
         packet: processorReceipt.packet,
         packetDigest: processorReceipt.packetDigest,
@@ -3278,6 +3513,7 @@ function evaluateRepairAttemptGate({
         ? "native"
         : "prepared",
     prepareLineageValid: reasons.length === 0 && prepareLineageValid,
+    protectedRuntimeOperations,
     refreshCommitCount,
     reasons: [...new Set(reasons)],
     receiptCheckCount: seenReceiptIds.size,
@@ -3295,6 +3531,7 @@ function recommendedDisposition({
   feedback,
   identity,
   mode,
+  protectedRuntimeOperation,
   repairAttempts,
   risk,
 }) {
@@ -3314,20 +3551,40 @@ function recommendedDisposition({
     if (!base.current) return "waiting-base-update";
     if (!risk.autoApprovable) return "manual-review";
   }
+  if (
+    preparing &&
+    protectedRuntimeOperation !== null &&
+    protectedRuntimeOperation.eligible !== true
+  ) {
+    return "manual-repair-required";
+  }
   if (checks.missing.length > 0 || checks.pending.length > 0) {
     return "waiting-checks";
   }
   if (checks.state === "pending") return "waiting-checks";
+  let branchFailures = [];
   if (checks.state === "failing") {
     const retryFailures = checks.failures.filter(
       ({ attribution }) =>
         attribution === "unknown" || attribution === "non-deterministic",
     );
     if (retryFailures.length > 0) return "waiting-retry";
-    const branchFailures = checks.failures.filter(
+    branchFailures = checks.failures.filter(
       ({ attribution }) => attribution === "branch",
     );
     if (branchFailures.length === 0) return "waiting-baseline";
+  }
+  if (preparing && protectedRuntimeOperation !== null) {
+    if (protectedRuntimeOperation.satisfied !== true) {
+      if (feedback.repairable) return "manual-repair-required";
+      if (!repairAttempts.valid || repairAttempts.currentAttempt > 2) {
+        return "manual-repair-escalated";
+      }
+      if (repairAttempts.currentHeadPacketIssued) return "repair-pending";
+      return "repair-required";
+    }
+  }
+  if (branchFailures.length > 0) {
     if (repairTouchesForbiddenPath({ checks, feedback })) {
       return "manual-repair-required";
     }
@@ -3385,6 +3642,12 @@ export function createDependabotRepairPacket(evaluation) {
   ) {
     return null;
   }
+  const protectedRuntimeOperation =
+    evaluation.protectedRuntimeOperation?.eligible === true &&
+    evaluation.protectedRuntimeOperation?.satisfied !== true
+      ? evaluation.protectedRuntimeOperation.operation
+      : null;
+  const isProtectedRuntimeSync = protectedRuntimeOperation !== null;
   const feedbackEligible =
     evaluation.feedback?.clear === true ||
     evaluation.feedback?.repairable === true;
@@ -3407,7 +3670,8 @@ export function createDependabotRepairPacket(evaluation) {
     evaluation.base?.current !== true ||
     evaluation.repairAttempts?.valid !== true ||
     evaluation.repairAttempt > 2 ||
-    forbiddenRepairEvidence ||
+    (!isProtectedRuntimeSync && forbiddenRepairEvidence) ||
+    (isProtectedRuntimeSync && evaluation.feedback?.clear !== true) ||
     evaluation.checks.missing.length > 0 ||
     evaluation.checks.pending.length > 0 ||
     evaluation.checks.failures.some(
@@ -3479,23 +3743,37 @@ export function createDependabotRepairPacket(evaluation) {
       threadId: thread.threadId,
     }))
     .slice(0, 20);
-  if (branchFailures.length === 0 && feedbackThreads.length === 0) return null;
+  if (
+    !isProtectedRuntimeSync &&
+    branchFailures.length === 0 &&
+    feedbackThreads.length === 0
+  ) {
+    return null;
+  }
   const isAction = evaluation.risk.packageEcosystem === "github-actions";
-  const limits = isAction
+  const limits = isProtectedRuntimeSync
     ? {
-        maxAddedLines: 250,
-        maxBytes: 64 * 1024,
-        maxChanges: 8,
-        maxDeletedLines: 250,
-        maxFiles: 6,
-      }
-    : {
         maxAddedLines: 600,
         maxBytes: 64 * 1024,
-        maxChanges: 16,
+        maxChanges: 160,
         maxDeletedLines: 600,
-        maxFiles: 8,
-      };
+        maxFiles: 5,
+      }
+    : isAction
+      ? {
+          maxAddedLines: 250,
+          maxBytes: 64 * 1024,
+          maxChanges: 8,
+          maxDeletedLines: 250,
+          maxFiles: 6,
+        }
+      : {
+          maxAddedLines: 600,
+          maxBytes: 64 * 1024,
+          maxChanges: 16,
+          maxDeletedLines: 600,
+          maxFiles: 8,
+        };
   const workflowContext = evaluation.workflowContext ?? {};
   const expectedBlobs = Array.isArray(evaluation.expectedBlobs)
     ? evaluation.expectedBlobs
@@ -3508,6 +3786,9 @@ export function createDependabotRepairPacket(evaluation) {
     !SHA_PATTERN.test(workflowContext.workflowSha ?? "") ||
     expectedBlobs.length < 1 ||
     expectedBlobs.length > 100 ||
+    (isProtectedRuntimeSync &&
+      stableJson(expectedBlobs.map(({ path }) => path)) !==
+        stableJson(VERCEL_CLI_RUNTIME_INPUT_PATHS)) ||
     expectedBlobs.some(
       ({ mode, path, sha, type }) =>
         typeof path !== "string" ||
@@ -3539,7 +3820,7 @@ export function createDependabotRepairPacket(evaluation) {
       "**/deploy/**",
       "**/deployment/**",
       "**/policy/**",
-      "**/runtime/**",
+      ...(isProtectedRuntimeSync ? [] : ["**/runtime/**"]),
       "**/security/**",
       "docs/vercel-deployments.md",
       "scripts/vercel-main-*.mjs",
@@ -3549,16 +3830,18 @@ export function createDependabotRepairPacket(evaluation) {
     limits,
     mode: evaluation.mode,
     packageEcosystem: evaluation.risk.packageEcosystem,
-    permittedPaths: isAction
-      ? []
-      : [
-          "package.json",
-          "pnpm-lock.yaml",
-          "pnpm-workspace.yaml",
-          "apps/**",
-          "packages/**",
-          "patches/**",
-        ],
+    permittedPaths: isProtectedRuntimeSync
+      ? [...VERCEL_CLI_RUNTIME_REQUIRED_PATHS]
+      : isAction
+        ? []
+        : [
+            "package.json",
+            "pnpm-lock.yaml",
+            "pnpm-workspace.yaml",
+            "apps/**",
+            "packages/**",
+            "patches/**",
+          ],
     pullRequestNumber: evaluation.pullRequestNumber,
     preparable: true,
     repository: evaluation.repository,
@@ -3566,8 +3849,12 @@ export function createDependabotRepairPacket(evaluation) {
     requireExactHead: true,
     requireHumanApproval: false,
     riskTier: evaluation.risk.tier,
-    schema: DEPENDABOT_REPAIR_PACKET_SCHEMA,
-    updateType: evaluation.risk.updateType,
+    schema: isProtectedRuntimeSync
+      ? DEPENDABOT_PROTECTED_RUNTIME_REPAIR_PACKET_SCHEMA
+      : DEPENDABOT_REPAIR_PACKET_SCHEMA,
+    updateType: isProtectedRuntimeSync
+      ? protectedRuntimeOperation.updateType
+      : evaluation.risk.updateType,
     validationCommands: isAction
       ? ["pnpm ci:action-pins:test", "pnpm quality:budgets:test"]
       : [
@@ -3581,6 +3868,7 @@ export function createDependabotRepairPacket(evaluation) {
     workflowRunId: workflowContext.workflowRunId,
     workflowSha: workflowContext.workflowSha,
   };
+  if (isProtectedRuntimeSync) packet.operation = protectedRuntimeOperation;
   try {
     validateProcessorRepairPacket(packet);
     return canonicalJson(packet).length <= RECEIPT_OUTPUT_LIMIT ? packet : null;
@@ -3663,6 +3951,11 @@ export function evaluateDependabotPullRequest(snapshot, options = {}) {
     pullRequest: snapshot.pullRequest ?? snapshot,
     repairAttempts,
   });
+  const protectedRuntimeOperation = evaluateProtectedRuntimeOperation({
+    metadata,
+    protectedRuntime: snapshot.protectedRuntime ?? null,
+    repairAttempts,
+  });
   const identity = feedback.forcePushed
     ? {
         ...structuralIdentity,
@@ -3677,9 +3970,13 @@ export function evaluateDependabotPullRequest(snapshot, options = {}) {
     feedback,
     identity,
     mode,
+    protectedRuntimeOperation,
     repairAttempts,
     risk,
   });
+  const expectedBlobSource = Array.isArray(snapshot.expectedBlobs)
+    ? snapshot.expectedBlobs
+    : pullRequest.files;
   const evaluation = {
     base,
     baseRef: pullRequest.baseRef,
@@ -3688,10 +3985,16 @@ export function evaluateDependabotPullRequest(snapshot, options = {}) {
       .map((file) => (typeof file === "string" ? file : file?.filename))
       .filter(Boolean)
       .sort(),
-    expectedBlobs: pullRequest.files
+    dependencies: (metadata.dependencies ?? []).map((dependency) => ({
+      from: dependency.from,
+      name: dependency.name,
+      to: dependency.to,
+      updateType: dependency.updateType,
+    })),
+    expectedBlobs: expectedBlobSource
       .map((file) => ({
         mode: typeof file === "string" ? null : (file?.mode ?? null),
-        path: typeof file === "string" ? file : file?.filename,
+        path: typeof file === "string" ? file : (file?.path ?? file?.filename),
         sha: typeof file === "string" ? null : (file?.sha ?? null),
         type: typeof file === "string" ? null : (file?.type ?? null),
       }))
@@ -3705,6 +4008,8 @@ export function evaluateDependabotPullRequest(snapshot, options = {}) {
     identity,
     dependencyGroup: metadata.dependencyGroup ?? null,
     mode,
+    protectedRuntime: snapshot.protectedRuntime ?? null,
+    protectedRuntimeOperation,
     pullRequestNumber: pullRequest.number,
     repository,
     repairAttempt: repairAttempts.currentAttempt,
@@ -5082,7 +5387,7 @@ export function createLiveGitHubAdapter({
     throw new Error("GitHub auto-merge request pagination limit exceeded");
   };
 
-  const getExpectedBlobs = async (repository, headSha, files) => {
+  const getExpectedBlobs = async (repository, headSha, paths) => {
     const response = await request(
       "GET",
       `/repos/${repository}/git/trees/${exactSha(headSha)}?recursive=1`,
@@ -5098,8 +5403,8 @@ export function createLiveGitHubAdapter({
       }
       byPath.set(entry.path, entry);
     }
-    return files.map((file) => {
-      const path = file?.filename;
+    return paths.map((value) => {
+      const path = typeof value === "string" ? value : value?.filename;
       const entry = byPath.get(path);
       return {
         mode: entry?.mode ?? null,
@@ -5108,6 +5413,83 @@ export function createLiveGitHubAdapter({
         type: entry?.type ?? null,
       };
     });
+  };
+
+  const getBoundJsonBlob = async (repository, expectedBlob) => {
+    snapshotInvariant(
+      expectedBlob?.type === "blob" &&
+        expectedBlob.mode === "100644" &&
+        SHA_PATTERN.test(expectedBlob.sha ?? ""),
+      `Protected runtime input ${expectedBlob?.path ?? "unknown"} is missing from the exact head`,
+    );
+    const response = await request(
+      "GET",
+      `/repos/${repository}/git/blobs/${expectedBlob.sha}`,
+    );
+    const data = response.data;
+    snapshotInvariant(
+      data?.encoding === "base64" &&
+        typeof data.content === "string" &&
+        Number.isSafeInteger(data.size) &&
+        data.size >= 0 &&
+        data.size <= PROTECTED_RUNTIME_BLOB_LIMIT,
+      `Protected runtime input ${expectedBlob.path} exceeds its bounded Git blob contract`,
+    );
+    const decoded = Buffer.from(data.content.replaceAll(/\s/g, ""), "base64");
+    snapshotInvariant(
+      decoded.length === data.size,
+      `Protected runtime input ${expectedBlob.path} has inconsistent Git blob bytes`,
+    );
+    try {
+      const value = JSON.parse(decoded.toString("utf8"));
+      snapshotInvariant(
+        value !== null && typeof value === "object" && !Array.isArray(value),
+        `Protected runtime input ${expectedBlob.path} is not a JSON object`,
+      );
+      return value;
+    } catch (error) {
+      if (error instanceof PullRequestSnapshotChangedError) throw error;
+      throw new PullRequestSnapshotChangedError(
+        `Protected runtime input ${expectedBlob.path} is not valid JSON`,
+      );
+    }
+  };
+
+  const getProtectedRuntimeSnapshot = async (repository, expectedBlobs) => {
+    const byPath = new Map(
+      expectedBlobs.map((expectedBlob) => [expectedBlob.path, expectedBlob]),
+    );
+    const completeInputSet =
+      byPath.size === VERCEL_CLI_RUNTIME_INPUT_PATHS.length &&
+      VERCEL_CLI_RUNTIME_INPUT_PATHS.every((path) => {
+        const expectedBlob = byPath.get(path);
+        return (
+          expectedBlob?.type === "blob" &&
+          expectedBlob.mode === "100644" &&
+          SHA_PATTERN.test(expectedBlob.sha ?? "")
+        );
+      });
+    if (!completeInputSet) return null;
+    const [rootPackage, runtimePackage, contract] = await Promise.all([
+      getBoundJsonBlob(repository, byPath.get("package.json")),
+      getBoundJsonBlob(
+        repository,
+        byPath.get("scripts/vercel-cli-runtime/package.json"),
+      ),
+      getBoundJsonBlob(
+        repository,
+        byPath.get("scripts/vercel-cli-runtime/contract.json"),
+      ),
+    ]);
+    return {
+      contractSchema: contract.schema ?? null,
+      contractVersion: contract.vercelVersion ?? null,
+      pnpmVersion:
+        /^pnpm@(.+)$/.exec(String(rootPackage.packageManager ?? ""))?.[1] ??
+        null,
+      rootVersion: rootPackage.devDependencies?.vercel ?? null,
+      runtimeVersion: runtimePackage.dependencies?.vercel ?? null,
+    };
   };
 
   const collectPullRequestSnapshot = async (repository, number) => {
@@ -5122,14 +5504,35 @@ export function createLiveGitHubAdapter({
       initialFeedback.headSha === headSha,
       `PR #${number} changed while feedback was collected`,
     );
+    const preliminaryMetadata = deriveImmutableDependabotMetadata({
+      commits,
+      files,
+      headRef: raw.head.ref,
+      headSha,
+    });
+    const protectedRuntimeCandidate =
+      vercelCliRuntimeOperationFromMetadata(preliminaryMetadata);
+    const expectedBlobPaths =
+      protectedRuntimeCandidate?.eligible === true
+        ? VERCEL_CLI_RUNTIME_INPUT_PATHS
+        : files;
     const [baseAncestry, expectedBlobs] = await Promise.all([
       getCurrentBaseAncestry({
         baseRef: raw.base.ref,
         headSha,
         repository,
       }),
-      getExpectedBlobs(repository, headSha, files),
+      getExpectedBlobs(repository, headSha, expectedBlobPaths),
     ]);
+    const collectionBase = evaluateCurrentBaseGate({
+      ancestry: baseAncestry,
+      baselineSha: baseAncestry.currentBaseSha,
+      pullRequest: normalizePullRequest(raw),
+    });
+    const protectedRuntime =
+      protectedRuntimeCandidate?.eligible === true && collectionBase.current
+        ? await getProtectedRuntimeSnapshot(repository, expectedBlobs)
+        : null;
     const baselineSha = baseAncestry.currentBaseSha;
     const commitHeadShas = [
       ...new Set(
@@ -5183,16 +5586,21 @@ export function createLiveGitHubAdapter({
       },
       body: finalRaw.body ?? "",
       draft: finalRaw.draft,
-      files: files.map((file, index) => ({
-        additions: file.additions,
-        changes: file.changes,
-        deletions: file.deletions,
-        filename: file.filename,
-        mode: expectedBlobs[index]?.mode ?? null,
-        sha: expectedBlobs[index]?.sha ?? null,
-        status: file.status,
-        type: expectedBlobs[index]?.type ?? null,
-      })),
+      files: files.map((file) => {
+        const expectedBlob = expectedBlobs.find(
+          ({ path }) => path === file.filename,
+        );
+        return {
+          additions: file.additions,
+          changes: file.changes,
+          deletions: file.deletions,
+          filename: file.filename,
+          mode: expectedBlob?.mode ?? null,
+          sha: expectedBlob?.sha ?? null,
+          status: file.status,
+          type: expectedBlob?.type ?? null,
+        };
+      }),
       head: {
         ref: finalRaw.head.ref,
         repo: { fullName: finalRaw.head.repo?.full_name },
@@ -5213,12 +5621,7 @@ export function createLiveGitHubAdapter({
       title: finalRaw.title,
       updated_at: finalRaw.updated_at,
     };
-    const metadata = deriveImmutableDependabotMetadata({
-      commits: lineageCommits,
-      files,
-      headRef: pullRequest.head.ref,
-      headSha,
-    });
+    const metadata = preliminaryMetadata;
     return {
       baseAncestry,
       baseline: { checks: baselineChecks, sha: baselineSha },
@@ -5236,6 +5639,7 @@ export function createLiveGitHubAdapter({
         verified: commit.commit?.verification?.verified === true,
         verificationReason: commit.commit?.verification?.reason ?? null,
       })),
+      expectedBlobs,
       expectedHeadSha: headSha,
       feedback: {
         actionableThreadCount: feedback.actionableThreadCount,
@@ -5276,6 +5680,7 @@ export function createLiveGitHubAdapter({
         updatedAt: feedback.updatedAt,
       },
       metadata,
+      protectedRuntime,
       prepareActor: validPrepareActor({
         prepareAppSlug: prepareActor.appSlug,
         prepareBotId: prepareActor.botId,
@@ -5917,9 +6322,15 @@ function evaluationForCandidate(evaluation) {
 
 function preparationSummary(result) {
   const attempts = result.repairAttempts;
+  const protectedRuntimeOperations = [
+    ...(attempts.protectedRuntimeOperations ?? []),
+  ];
   const common = {
     kind: attempts.preparationKind,
     operationDigests: [...attempts.operationDigests],
+    ...(protectedRuntimeOperations.length > 0
+      ? { protectedRuntimeOperations }
+      : {}),
     refreshCount: attempts.refreshCommitCount,
     repairCount: attempts.authenticatedRepairCommitCount,
     seedHeadSha: result.identity.automaticSeedHeadSha,

--- a/scripts/dependabot-processor.test.mjs
+++ b/scripts/dependabot-processor.test.mjs
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { Buffer } from "node:buffer";
 import { execFileSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
@@ -16,6 +17,7 @@ import {
   DEPENDABOT_ALL_CLEAR_SCHEMA,
   DEPENDABOT_CHECK_POLICY,
   DEPENDABOT_PROCESSOR_SCHEMA,
+  DEPENDABOT_PROTECTED_RUNTIME_REPAIR_PACKET_SCHEMA,
   DEPENDABOT_REFRESH_SCHEMA,
   DEPENDABOT_REPAIR_PACKET_SCHEMA,
   DEPENDABOT_REPAIR_SCHEMA,
@@ -71,6 +73,30 @@ const PACKAGE_BLOB = {
   sha: OTHER_SHA,
   type: "blob",
 };
+const VERCEL_REQUIRED_PATHS = [
+  "package.json",
+  "pnpm-lock.yaml",
+  "scripts/vercel-cli-runtime/contract.json",
+  "scripts/vercel-cli-runtime/package.json",
+  "scripts/vercel-cli-runtime/pnpm-lock.yaml",
+];
+const VERCEL_INPUT_PATHS = [
+  "apps/app.mento.org/package.json",
+  "apps/governance.mento.org/package.json",
+  "apps/reserve.mento.org/package.json",
+  "apps/ui.mento.org/package.json",
+  "package.json",
+  "packages/eslint-config/package.json",
+  "packages/typescript-config/package.json",
+  "packages/ui/package.json",
+  "packages/vitest-config/package.json",
+  "packages/web3/package.json",
+  "pnpm-lock.yaml",
+  "pnpm-workspace.yaml",
+  "scripts/vercel-cli-runtime/contract.json",
+  "scripts/vercel-cli-runtime/package.json",
+  "scripts/vercel-cli-runtime/pnpm-lock.yaml",
+];
 
 function digest(value) {
   return createHash("sha256").update(stableJson(value)).digest("hex");
@@ -350,6 +376,7 @@ function repairReceiptCheck({
   attempt = 1,
   baseSha = BASE_SHA,
   headSha = OTHER_SHA,
+  headRef = "dependabot/github_actions/github-actions-routine-123",
   id = 30_001,
   packetDigest,
   parentHeadSha = HEAD_SHA,
@@ -359,7 +386,7 @@ function repairReceiptCheck({
   const receipt = {
     attempt,
     baseSha,
-    headRef: "dependabot/github_actions/github-actions-routine-123",
+    headRef,
     headSha,
     packetDigest: packetDigest ?? "a".repeat(64),
     parentHeadSha,
@@ -410,6 +437,216 @@ function completeChecks({
 
 function actionBody(name = "actions/setup-node", from = "6.0.0", to = "6.1.0") {
   return `Bumps the github-actions group with 1 update:\n\n| Package | From | To |\n| --- | --- | --- |\n| [${name}](https://github.com/${name}) | \`${from}\` | \`${to}\` |`;
+}
+
+function toolingBody({
+  duplicateVercel = false,
+  vercelFrom = "56.4.1",
+  vercelTo = "56.5.0",
+} = {}) {
+  const rows = [
+    ["knip", "6.31.0", "6.32.0"],
+    ["vercel", vercelFrom, vercelTo],
+    ["@next/eslint-plugin-next", "16.2.12", "16.3.0"],
+    ...(duplicateVercel ? [["vercel", vercelFrom, vercelTo]] : []),
+  ];
+  return `Bumps the tooling group with ${rows.length} updates:\n\n| Package | From | To |\n| --- | --- | --- |\n${rows
+    .map(
+      ([name, from, to]) =>
+        `| [${name}](https://www.npmjs.com/package/${name}) | \`${from}\` | \`${to}\` |`,
+    )
+    .join("\n")}`;
+}
+
+function vercelMetadata({
+  duplicateVercel = false,
+  group = "tooling",
+  vercelFrom = "56.4.1",
+  vercelTo = "56.5.0",
+} = {}) {
+  const parsed = parseDependabotMetadata({
+    body: toolingBody({ duplicateVercel, vercelFrom, vercelTo }),
+    files: [
+      "package.json",
+      "packages/eslint-config/package.json",
+      "pnpm-lock.yaml",
+    ],
+    headRef: "dependabot/npm_and_yarn/tooling-31c5cf6265",
+  });
+  return {
+    ...parsed,
+    dependencyGroup: group,
+    immutableEvidence: {
+      currentHeadMatches: true,
+      dependencyMetadataValid: parsed.groupedUpdateIntegrity.valid,
+      seedCommitSha: HEAD_SHA,
+      seedCommitTrusted: true,
+      source: "dependabot-commit-message",
+      valid: true,
+    },
+  };
+}
+
+function vercelExpectedBlobs() {
+  return VERCEL_INPUT_PATHS.map((path) => ({
+    mode: "100644",
+    path,
+    sha: createHash("sha1").update(path).digest("hex"),
+    type: "blob",
+  }));
+}
+
+function preparedCommit(sha, parent) {
+  return {
+    authorId: PREPARE_ACTOR.botId,
+    authorLogin: PREPARE_ACTOR.botLogin,
+    authorType: "Bot",
+    ...GITHUB_SYSTEM_COMMITTER,
+    parents: [parent],
+    sha,
+    verified: true,
+    verificationReason: "valid",
+  };
+}
+
+function vercelSnapshot({
+  commits,
+  headSha = HEAD_SHA,
+  metadata = vercelMetadata(),
+  protectedVersion = "56.4.1",
+  repairHistoryChecks,
+} = {}) {
+  const expectedBlobs = vercelExpectedBlobs();
+  const expectedByPath = new Map(
+    expectedBlobs.map((entry) => [entry.path, entry]),
+  );
+  const changedPaths = [
+    "package.json",
+    "packages/eslint-config/package.json",
+    "pnpm-lock.yaml",
+  ];
+  return snapshot({
+    baseAncestry: {
+      aheadBy: commits?.length ?? 1,
+      baseCommitSha: BASE_SHA,
+      behindBy: 0,
+      currentBaseIsAncestor: true,
+      currentBaseSha: BASE_SHA,
+      headSha,
+      mergeBaseSha: BASE_SHA,
+      status: "ahead",
+    },
+    checks: completeChecks({ headSha }),
+    commits: commits ?? [
+      {
+        authorLogin: "dependabot[bot]",
+        committerLogin: "dependabot[bot]",
+        sha: HEAD_SHA,
+        verified: true,
+      },
+    ],
+    expectedBlobs,
+    expectedHeadSha: headSha,
+    metadata,
+    protectedRuntime: {
+      contractSchema: "vercel-cli-runtime-contract:v1",
+      contractVersion: protectedVersion,
+      pnpmVersion: "10.34.4",
+      rootVersion: protectedVersion,
+      runtimeVersion: protectedVersion,
+    },
+    pullRequest: {
+      body: toolingBody(),
+      files: changedPaths.map((filename) => ({
+        filename,
+        mode: expectedByPath.get(filename).mode,
+        sha: expectedByPath.get(filename).sha,
+        status: "modified",
+        type: expectedByPath.get(filename).type,
+      })),
+      head: {
+        ref: "dependabot/npm_and_yarn/tooling-31c5cf6265",
+        repo: { fullName: REPOSITORY },
+        sha: headSha,
+      },
+    },
+    repairHistoryChecks,
+  });
+}
+
+function legacyNpmRepairPacket({ headSha = HEAD_SHA } = {}) {
+  const body =
+    "Bumps the tooling group with 1 update:\n\n| Package | From | To |\n| --- | --- | --- |\n| [knip](https://www.npmjs.com/package/knip) | `6.31.0` | `6.32.0` |";
+  const parsed = parseDependabotMetadata({
+    body,
+    files: [PACKAGE_BLOB],
+    headRef: "dependabot/npm_and_yarn/tooling-31c5cf6265",
+  });
+  const result = evaluateDependabotPullRequest(
+    snapshot({
+      checks: completeChecks({ conclusions: { ci: "failure" }, headSha }),
+      expectedHeadSha: headSha,
+      metadata: {
+        ...parsed,
+        immutableEvidence: {
+          dependencyMetadataValid: true,
+          seedCommitSha: HEAD_SHA,
+          valid: true,
+        },
+      },
+      pullRequest: {
+        body,
+        head: {
+          ref: "dependabot/npm_and_yarn/tooling-31c5cf6265",
+          repo: { fullName: REPOSITORY },
+          sha: headSha,
+        },
+      },
+    }),
+    {
+      mode: "prepare",
+      repository: REPOSITORY,
+      workflowContext: WORKFLOW_CONTEXT,
+    },
+  );
+  assert.equal(result.repairPacket?.schema, DEPENDABOT_REPAIR_PACKET_SCHEMA);
+  return result.repairPacket;
+}
+
+function vercelAfterLegacyRepair({ protectedVersion = "56.4.1" } = {}) {
+  const legacyPacket = legacyNpmRepairPacket();
+  const processorCheck = processorRepairReceipt(1, {
+    headSha: HEAD_SHA,
+    packet: legacyPacket,
+    packetEncoding: "canonical",
+  });
+  const repairCheck = repairReceiptCheck({
+    attempt: 1,
+    headRef: "dependabot/npm_and_yarn/tooling-31c5cf6265",
+    headSha: OTHER_SHA,
+    packetDigest: rawDigest(processorCheck.outputText),
+    parentHeadSha: HEAD_SHA,
+    processorCheckId: processorCheck.id,
+  });
+  return {
+    legacyPacket,
+    processorCheck,
+    repairCheck,
+    snapshot: vercelSnapshot({
+      commits: [
+        {
+          authorLogin: "dependabot[bot]",
+          committerLogin: "dependabot[bot]",
+          sha: HEAD_SHA,
+          verified: true,
+        },
+        preparedCommit(OTHER_SHA, HEAD_SHA),
+      ],
+      headSha: OTHER_SHA,
+      protectedVersion,
+      repairHistoryChecks: [processorCheck, repairCheck],
+    }),
+  };
 }
 
 function cursorReview(commitSha = HEAD_SHA, issueCount = 1) {
@@ -3136,6 +3373,291 @@ test("evaluates exact observe, assist, and prepare dispositions and v2 repair pa
     ).repairPacket,
     null,
   );
+});
+
+test("a green #753-like legacy repair requires a typed Vercel runtime sync", () => {
+  const legacy = vercelAfterLegacyRepair();
+  const result = evaluateDependabotPullRequest(legacy.snapshot, {
+    mode: "prepare",
+    repository: REPOSITORY,
+    workflowContext: WORKFLOW_CONTEXT,
+  });
+
+  assert.equal(result.repairAttempt, 2);
+  assert.equal(result.disposition, "repair-required");
+  assert.deepEqual(result.dependencies, vercelMetadata().dependencies);
+  assert.equal(
+    result.repairPacket?.schema,
+    DEPENDABOT_PROTECTED_RUNTIME_REPAIR_PACKET_SCHEMA,
+  );
+  assert.deepEqual(result.repairPacket?.operation, {
+    dependency: "vercel",
+    fromVersion: "56.4.1",
+    inputPaths: VERCEL_INPUT_PATHS,
+    kind: "vercel-cli-runtime-sync",
+    pnpmVersion: "10.34.4",
+    requiredPaths: VERCEL_REQUIRED_PATHS,
+    schema: "dependabot-protected-runtime-sync:v1",
+    sourceSeedHeadSha: HEAD_SHA,
+    targetVersion: "56.5.0",
+    updateType: "minor",
+  });
+  assert.deepEqual(
+    result.repairPacket?.expectedBlobs.map(({ path }) => path),
+    VERCEL_INPUT_PATHS,
+  );
+  assert.deepEqual(result.repairPacket?.permittedPaths, VERCEL_REQUIRED_PATHS);
+  assert.deepEqual(result.repairPacket?.limits, {
+    maxAddedLines: 600,
+    maxBytes: 65_536,
+    maxChanges: 160,
+    maxDeletedLines: 600,
+    maxFiles: 5,
+  });
+
+  const alignedWithoutProof = evaluateDependabotPullRequest(
+    vercelAfterLegacyRepair({ protectedVersion: "56.5.0" }).snapshot,
+    {
+      mode: "prepare",
+      repository: REPOSITORY,
+      workflowContext: WORKFLOW_CONTEXT,
+    },
+  );
+  assert.equal(alignedWithoutProof.disposition, "repair-required");
+  assert.equal(
+    alignedWithoutProof.repairPacket?.schema,
+    DEPENDABOT_PROTECTED_RUNTIME_REPAIR_PACKET_SCHEMA,
+  );
+});
+
+test("a reachable typed Vercel receipt and exact target state permit preparation", async () => {
+  const legacy = vercelAfterLegacyRepair();
+  const selected = evaluateDependabotPullRequest(legacy.snapshot, {
+    mode: "prepare",
+    repository: REPOSITORY,
+    workflowContext: WORKFLOW_CONTEXT,
+  });
+  assert.notEqual(selected.repairPacket, null);
+  const processorCheck = processorRepairReceipt(2, {
+    headSha: OTHER_SHA,
+    id: 10_002,
+    packet: selected.repairPacket,
+    packetEncoding: "canonical",
+  });
+  const repairCheck = repairReceiptCheck({
+    attempt: 2,
+    headRef: "dependabot/npm_and_yarn/tooling-31c5cf6265",
+    headSha: SECOND_HEAD_SHA,
+    id: 30_002,
+    packetDigest: rawDigest(processorCheck.outputText),
+    parentHeadSha: OTHER_SHA,
+    processorCheckId: processorCheck.id,
+  });
+  const prepared = vercelSnapshot({
+    commits: [
+      {
+        authorLogin: "dependabot[bot]",
+        committerLogin: "dependabot[bot]",
+        sha: HEAD_SHA,
+        verified: true,
+      },
+      preparedCommit(OTHER_SHA, HEAD_SHA),
+      preparedCommit(SECOND_HEAD_SHA, OTHER_SHA),
+    ],
+    headSha: SECOND_HEAD_SHA,
+    protectedVersion: "56.5.0",
+    repairHistoryChecks: [
+      legacy.processorCheck,
+      legacy.repairCheck,
+      processorCheck,
+      repairCheck,
+    ],
+  });
+  const result = evaluateDependabotPullRequest(prepared, {
+    mode: "prepare",
+    repository: REPOSITORY,
+    workflowContext: WORKFLOW_CONTEXT,
+  });
+
+  assert.equal(result.disposition, "prepare-candidate");
+  assert.equal(result.repairPacket, null);
+  assert.equal(result.repairAttempts.currentAttempt, 3);
+  assert.deepEqual(result.repairAttempts.protectedRuntimeOperations, [
+    {
+      operation: selected.repairPacket.operation,
+      operationDigest: digest(
+        repairCheck.outputText ? JSON.parse(repairCheck.outputText) : null,
+      ),
+      packetDigest: rawDigest(processorCheck.outputText),
+    },
+  ]);
+
+  let approved = false;
+  let allClearReceipt = null;
+  const currentSnapshot = () => {
+    const current = structuredClone(prepared);
+    if (approved) withCurrentProcessorApproval(current);
+    return current;
+  };
+  await processDependabotSweep({
+    adapter: {
+      approvePullRequest: async () => {
+        approved = true;
+        return processorApprovalResult();
+      },
+      collectPullRequestSnapshot: async () => currentSnapshot(),
+      dismissPullRequestApproval: async () =>
+        assert.fail("the protected runtime candidate must remain approved"),
+      getOutstandingDependabotAutoMergeRequests: async () => [],
+      getOutstandingDependabotProcessorApprovals: async () =>
+        approved
+          ? [
+              {
+                approvalId: 7001,
+                headSha: SECOND_HEAD_SHA,
+                pullRequestNumber: 123,
+              },
+            ]
+          : [],
+      publishAllClear: async ({ receipt }) => {
+        allClearReceipt = receipt;
+        return { id: 50_002 };
+      },
+      publishAllClearInvalidation: async () =>
+        assert.fail("the protected runtime candidate must not be invalidated"),
+      publishProcessorCheck: async () => ({ id: 50_001 }),
+    },
+    input: {
+      mode: "prepare",
+      outstandingAutoMergeRequests: [],
+      pullRequests: [prepared],
+      repository: REPOSITORY,
+      workflowContext: WORKFLOW_CONTEXT,
+    },
+    phase: "finalize",
+    publishChecks: true,
+    workflowContext: WORKFLOW_CONTEXT,
+  });
+  assert.deepEqual(
+    allClearReceipt?.preparation.protectedRuntimeOperations,
+    result.repairAttempts.protectedRuntimeOperations,
+  );
+  const mismatchedSeedReceipt = structuredClone(allClearReceipt);
+  mismatchedSeedReceipt.preparation.protectedRuntimeOperations[0].operation.sourceSeedHeadSha =
+    OTHER_SHA;
+  assert.equal(
+    parseDependabotAllClearReceipt(
+      trustedReceiptCheck({
+        externalId: `${DEPENDABOT_ALL_CLEAR_SCHEMA}:pr=123:head=${SECOND_HEAD_SHA}:base=${BASE_SHA}:digest=${digest(mismatchedSeedReceipt)}:run=${WORKFLOW_CONTEXT.workflowRunId}:attempt=${WORKFLOW_CONTEXT.workflowRunAttempt}`,
+        headSha: SECOND_HEAD_SHA,
+        id: 50_003,
+        name: "Dependabot ALL CLEAR",
+        receipt: mismatchedSeedReceipt,
+        workflowContext: WORKFLOW_CONTEXT,
+        workflowPath: ".github/workflows/dependabot-process.yml",
+      }),
+      REPOSITORY,
+    ),
+    null,
+  );
+});
+
+test("Vercel runtime sync waits for gates and fails closed on unsafe inputs", () => {
+  const pending = vercelSnapshot();
+  pending.checks = completeChecks().slice(0, -1);
+  assert.equal(
+    evaluateDependabotPullRequest(pending, {
+      mode: "prepare",
+      repository: REPOSITORY,
+      workflowContext: WORKFLOW_CONTEXT,
+    }).disposition,
+    "waiting-checks",
+  );
+  const retry = vercelSnapshot();
+  retry.checks = completeChecks({ conclusions: { "e2e-celo": "failure" } });
+  assert.equal(
+    evaluateDependabotPullRequest(retry, {
+      mode: "prepare",
+      repository: REPOSITORY,
+      workflowContext: WORKFLOW_CONTEXT,
+    }).disposition,
+    "waiting-retry",
+  );
+
+  for (const metadata of [
+    vercelMetadata({ vercelTo: "57.0.0" }),
+    vercelMetadata({ vercelTo: "56.5.0-rc.1" }),
+    vercelMetadata({ duplicateVercel: true }),
+  ]) {
+    const result = evaluateDependabotPullRequest(vercelSnapshot({ metadata }), {
+      mode: "prepare",
+      repository: REPOSITORY,
+      workflowContext: WORKFLOW_CONTEXT,
+    });
+    assert.equal(result.disposition, "manual-repair-required");
+    assert.equal(result.repairPacket, null);
+  }
+
+  const missingBlob = vercelSnapshot();
+  missingBlob.expectedBlobs = missingBlob.expectedBlobs.slice(1);
+  const missingResult = evaluateDependabotPullRequest(missingBlob, {
+    mode: "prepare",
+    repository: REPOSITORY,
+    workflowContext: WORKFLOW_CONTEXT,
+  });
+  assert.equal(missingResult.disposition, "manual-repair-required");
+  assert.equal(missingResult.repairPacket, null);
+
+  const legacy = vercelAfterLegacyRepair();
+  const secondPacket = {
+    ...legacy.legacyPacket,
+    attemptNumber: 2,
+    headSha: OTHER_SHA,
+  };
+  const secondProcessorCheck = processorRepairReceipt(2, {
+    headSha: OTHER_SHA,
+    id: 10_002,
+    packet: secondPacket,
+    packetEncoding: "canonical",
+  });
+  const secondRepairCheck = repairReceiptCheck({
+    attempt: 2,
+    headRef: "dependabot/npm_and_yarn/tooling-31c5cf6265",
+    headSha: SECOND_HEAD_SHA,
+    id: 30_002,
+    packetDigest: rawDigest(secondProcessorCheck.outputText),
+    parentHeadSha: OTHER_SHA,
+    processorCheckId: secondProcessorCheck.id,
+  });
+  const exhausted = evaluateDependabotPullRequest(
+    vercelSnapshot({
+      commits: [
+        {
+          authorLogin: "dependabot[bot]",
+          committerLogin: "dependabot[bot]",
+          sha: HEAD_SHA,
+          verified: true,
+        },
+        preparedCommit(OTHER_SHA, HEAD_SHA),
+        preparedCommit(SECOND_HEAD_SHA, OTHER_SHA),
+      ],
+      headSha: SECOND_HEAD_SHA,
+      repairHistoryChecks: [
+        legacy.processorCheck,
+        legacy.repairCheck,
+        secondProcessorCheck,
+        secondRepairCheck,
+      ],
+    }),
+    {
+      mode: "prepare",
+      repository: REPOSITORY,
+      workflowContext: WORKFLOW_CONTEXT,
+    },
+  );
+  assert.equal(exhausted.repairAttempts.currentAttempt, 3);
+  assert.equal(exhausted.disposition, "manual-repair-escalated");
+  assert.equal(exhausted.repairPacket, null);
 });
 
 test("constructed repair packets fail closed when schema-invalid or oversized", () => {
@@ -7910,6 +8432,251 @@ test("live auto-merge disable fails before mutation unless the exact target is t
     /not the current single repository auto-merge request/,
   );
   assert.equal(mutationCalled, false);
+});
+
+function liveVercelSnapshotFetch({
+  current = true,
+  includeContract = true,
+} = {}) {
+  const expectedBlobs = vercelExpectedBlobs();
+  const currentBaseSha = current ? BASE_SHA : MERGE_SHA;
+  const blobDocuments = new Map([
+    [
+      expectedBlobs.find(({ path }) => path === "package.json").sha,
+      {
+        devDependencies: { vercel: "56.4.1" },
+        packageManager: "pnpm@10.34.4",
+      },
+    ],
+    [
+      expectedBlobs.find(
+        ({ path }) => path === "scripts/vercel-cli-runtime/package.json",
+      ).sha,
+      { dependencies: { vercel: "56.4.1" } },
+    ],
+    [
+      expectedBlobs.find(
+        ({ path }) => path === "scripts/vercel-cli-runtime/contract.json",
+      ).sha,
+      {
+        schema: "vercel-cli-runtime-contract:v1",
+        vercelVersion: "56.4.1",
+      },
+    ],
+  ]);
+  const rawPullRequest = {
+    base: {
+      ref: "main",
+      repo: { full_name: REPOSITORY },
+      sha: currentBaseSha,
+    },
+    body: toolingBody(),
+    draft: false,
+    head: {
+      ref: "dependabot/npm_and_yarn/tooling-31c5cf6265",
+      repo: { full_name: REPOSITORY },
+      sha: HEAD_SHA,
+    },
+    labels: [],
+    merge_commit_sha: null,
+    merged: false,
+    node_id: "PR_node",
+    number: 123,
+    state: "open",
+    title: "chore(deps): bump the tooling group",
+    updated_at: "2026-08-10T10:00:00Z",
+    user: { login: "dependabot[bot]" },
+  };
+  return async (url) => {
+    const parsed = new URL(url);
+    const path = parsed.pathname;
+    if (url.endsWith("/graphql")) {
+      return new Response(
+        JSON.stringify({
+          data: {
+            repository: {
+              pullRequest: {
+                autoMergeRequest: null,
+                headRefOid: HEAD_SHA,
+                id: "PR_node",
+                isDraft: false,
+                mergeStateStatus: "CLEAN",
+                reviewDecision: "APPROVED",
+                reviewThreads: {
+                  nodes: [],
+                  pageInfo: { endCursor: null, hasNextPage: false },
+                },
+                updatedAt: "2026-08-10T10:00:00Z",
+              },
+            },
+          },
+        }),
+        { status: 200 },
+      );
+    }
+    if (path === `/repos/${REPOSITORY}/pulls/123`) {
+      return new Response(JSON.stringify(rawPullRequest), { status: 200 });
+    }
+    if (path === `/repos/${REPOSITORY}/pulls/123/files`) {
+      return new Response(
+        JSON.stringify([
+          { filename: "package.json", status: "modified" },
+          {
+            filename: "packages/eslint-config/package.json",
+            status: "modified",
+          },
+          { filename: "pnpm-lock.yaml", status: "modified" },
+        ]),
+        { status: 200 },
+      );
+    }
+    if (path === `/repos/${REPOSITORY}/pulls/123/commits`) {
+      return new Response(
+        JSON.stringify([
+          {
+            author: { login: "dependabot[bot]" },
+            commit: {
+              message: toolingBody(),
+              verification: { reason: "valid", verified: true },
+            },
+            committer: { login: "web-flow" },
+            parents: [{ sha: BASE_SHA }],
+            sha: HEAD_SHA,
+          },
+        ]),
+        { status: 200 },
+      );
+    }
+    if (
+      path === `/repos/${REPOSITORY}/pulls/123/reviews` ||
+      path === `/repos/${REPOSITORY}/issues/123/comments` ||
+      path === `/repos/${REPOSITORY}/issues/123/events`
+    ) {
+      return new Response(JSON.stringify([]), { status: 200 });
+    }
+    if (path === `/repos/${REPOSITORY}/commits/main`) {
+      return new Response(JSON.stringify({ sha: currentBaseSha }), {
+        status: 200,
+      });
+    }
+    if (
+      path === `/repos/${REPOSITORY}/compare/${currentBaseSha}...${HEAD_SHA}`
+    ) {
+      return new Response(
+        JSON.stringify(
+          current
+            ? {
+                ahead_by: 1,
+                base_commit: { sha: currentBaseSha },
+                behind_by: 0,
+                merge_base_commit: { sha: currentBaseSha },
+                status: "ahead",
+              }
+            : {
+                ahead_by: 1,
+                base_commit: { sha: currentBaseSha },
+                behind_by: 1,
+                merge_base_commit: { sha: BASE_SHA },
+                status: "diverged",
+              },
+        ),
+        { status: 200 },
+      );
+    }
+    if (path === `/repos/${REPOSITORY}/git/trees/${HEAD_SHA}`) {
+      return new Response(
+        JSON.stringify({
+          tree: includeContract
+            ? expectedBlobs
+            : expectedBlobs.filter(
+                ({ path: blobPath }) =>
+                  blobPath !== "scripts/vercel-cli-runtime/contract.json",
+              ),
+          truncated: false,
+        }),
+        { status: 200 },
+      );
+    }
+    const blobSha = /\/git\/blobs\/([0-9a-f]{40})$/.exec(path)?.[1];
+    if (blobSha && blobDocuments.has(blobSha)) {
+      const content = JSON.stringify(blobDocuments.get(blobSha));
+      return new Response(
+        JSON.stringify({
+          content: Buffer.from(content).toString("base64"),
+          encoding: "base64",
+          size: Buffer.byteLength(content),
+        }),
+        { status: 200 },
+      );
+    }
+    if (path.endsWith("/check-runs")) {
+      return new Response(JSON.stringify({ check_runs: [] }), { status: 200 });
+    }
+    if (path.endsWith("/statuses")) {
+      return new Response(JSON.stringify([]), { status: 200 });
+    }
+    assert.fail(`Unexpected request: ${url}`);
+  };
+}
+
+test("live snapshot collection binds Vercel operation inputs and parsed target state", async () => {
+  const adapter = createLiveGitHubAdapter({
+    fetchImpl: liveVercelSnapshotFetch(),
+    token: "test-token",
+  });
+  const collected = await adapter.collectPullRequestSnapshot(REPOSITORY, 123);
+  assert.deepEqual(
+    collected.expectedBlobs.map(({ path }) => path),
+    VERCEL_INPUT_PATHS,
+  );
+  assert.deepEqual(
+    collected.metadata.dependencies,
+    vercelMetadata().dependencies,
+  );
+  assert.deepEqual(collected.protectedRuntime, {
+    contractSchema: "vercel-cli-runtime-contract:v1",
+    contractVersion: "56.4.1",
+    pnpmVersion: "10.34.4",
+    rootVersion: "56.4.1",
+    runtimeVersion: "56.4.1",
+  });
+});
+
+test("a stale Vercel head can refresh before newly introduced runtime inputs exist", async () => {
+  const staleAdapter = createLiveGitHubAdapter({
+    fetchImpl: liveVercelSnapshotFetch({
+      current: false,
+      includeContract: false,
+    }),
+    token: "test-token",
+  });
+  const stale = await staleAdapter.collectPullRequestSnapshot(REPOSITORY, 123);
+  assert.equal(stale.protectedRuntime, null);
+  assert.equal(
+    evaluateDependabotPullRequest(stale, {
+      mode: "prepare",
+      repository: REPOSITORY,
+      workflowContext: WORKFLOW_CONTEXT,
+    }).disposition,
+    "refresh-required",
+  );
+
+  const currentAdapter = createLiveGitHubAdapter({
+    fetchImpl: liveVercelSnapshotFetch({ includeContract: false }),
+    token: "test-token",
+  });
+  const current = await currentAdapter.collectPullRequestSnapshot(
+    REPOSITORY,
+    123,
+  );
+  assert.equal(current.protectedRuntime, null);
+  const evaluated = evaluateDependabotPullRequest(current, {
+    mode: "prepare",
+    repository: REPOSITORY,
+    workflowContext: WORKFLOW_CONTEXT,
+  });
+  assert.equal(evaluated.disposition, "manual-repair-required");
+  assert.equal(evaluated.repairPacket, null);
 });
 
 test("live snapshot collection rejects a PR head race after files, commits, and checks were read", async () => {

--- a/scripts/dependabot-protected-runtime-sync.mjs
+++ b/scripts/dependabot-protected-runtime-sync.mjs
@@ -1,0 +1,1717 @@
+#!/usr/bin/env node
+
+import { Buffer } from "node:buffer";
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import {
+  accessSync,
+  appendFileSync,
+  constants,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
+import process from "node:process";
+import { pathToFileURL } from "node:url";
+import { isDeepStrictEqual } from "node:util";
+
+import {
+  canonicalJson,
+  parseCanonicalJson,
+  rawDigest,
+  validateValidatedRepairPlan,
+  validateProcessorRepairPacket,
+  validateRepairPlan,
+} from "./dependabot-preparation-receipts.mjs";
+import { assertVercelCliRuntimeContract } from "./vercel-cli-runtime-contract.mjs";
+
+const PACKET_SCHEMA = "dependabot-repair-packet:v3";
+const OPERATION_SCHEMA = "dependabot-protected-runtime-sync:v1";
+const CONTRACT_SCHEMA = "vercel-cli-runtime-contract:v1";
+const PLAN_SCHEMA = "dependabot-repair-plan:v1";
+const EVIDENCE_SCHEMA = "dependabot-repair-evidence:v1";
+const EXACT_PNPM_VERSION = "10.34.4";
+const HEX_SHA = /^[0-9a-f]{40}$/u;
+const HEX_DIGEST = /^[0-9a-f]{64}$/u;
+const SAFE_EVIDENCE_NAME = /^[a-z][a-z0-9-]{0,60}\.(?:json|patch|txt)$/u;
+const STABLE_SEMVER =
+  /^(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)$/u;
+const REGISTRY_INTEGRITY = /^sha512-[A-Za-z0-9+/]{86}==$/u;
+const MAX_METADATA_BYTES = 1024 * 1024;
+const MAX_EVIDENCE_BLOB_BYTES = 8 * 1024 * 1024;
+const MAX_EVIDENCE_BLOBS_BYTES = 24 * 1024 * 1024;
+const MAX_PATCH_BYTES = 8_192;
+const MAX_PLAN_BYTES = 64 * 1024;
+
+export const PROTECTED_RUNTIME_SYNC_REQUIRED_PATHS = Object.freeze([
+  "package.json",
+  "pnpm-lock.yaml",
+  "scripts/vercel-cli-runtime/contract.json",
+  "scripts/vercel-cli-runtime/package.json",
+  "scripts/vercel-cli-runtime/pnpm-lock.yaml",
+]);
+
+export const PROTECTED_RUNTIME_SYNC_INPUT_PATHS = Object.freeze([
+  "apps/app.mento.org/package.json",
+  "apps/governance.mento.org/package.json",
+  "apps/reserve.mento.org/package.json",
+  "apps/ui.mento.org/package.json",
+  "package.json",
+  "packages/eslint-config/package.json",
+  "packages/typescript-config/package.json",
+  "packages/ui/package.json",
+  "packages/vitest-config/package.json",
+  "packages/web3/package.json",
+  "pnpm-lock.yaml",
+  "pnpm-workspace.yaml",
+  "scripts/vercel-cli-runtime/contract.json",
+  "scripts/vercel-cli-runtime/package.json",
+  "scripts/vercel-cli-runtime/pnpm-lock.yaml",
+]);
+
+const CONTRACT_KEYS = Object.freeze([
+  "lockfileSha256",
+  "manifestSha256",
+  "overridesSha256",
+  "registryIntegrity",
+  "runtimeDependenciesSha256",
+  "schema",
+  "vercelVersion",
+]);
+
+function fail(message) {
+  throw new Error(`Protected runtime sync rejected: ${message}`);
+}
+
+function exactKeys(value, expected, label) {
+  if (
+    value === null ||
+    typeof value !== "object" ||
+    Array.isArray(value) ||
+    JSON.stringify(Object.keys(value).sort()) !==
+      JSON.stringify([...expected].sort())
+  ) {
+    fail(`${label} keys are invalid`);
+  }
+}
+
+function sha256(value) {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function prettyJson(value) {
+  return `${JSON.stringify(value, null, 2)}\n`;
+}
+
+function canonicalStringMap(value, label) {
+  if (
+    value === null ||
+    typeof value !== "object" ||
+    Array.isArray(value) ||
+    Object.entries(value).some(
+      ([key, entry]) =>
+        typeof key !== "string" ||
+        key.length === 0 ||
+        typeof entry !== "string" ||
+        entry.length === 0,
+    )
+  ) {
+    fail(`${label} is not an exact string map`);
+  }
+  return Object.fromEntries(
+    Object.entries(value).toSorted(([left], [right]) =>
+      left.localeCompare(right),
+    ),
+  );
+}
+
+function stringMapDigest(value, label) {
+  return sha256(JSON.stringify(canonicalStringMap(value, label)));
+}
+
+function semverParts(value, label) {
+  if (!STABLE_SEMVER.test(value ?? "")) fail(`${label} is not stable semver`);
+  return value.split(".").map(Number);
+}
+
+function compareSemver(left, right) {
+  for (let index = 0; index < 3; index += 1) {
+    if (left[index] !== right[index]) return left[index] - right[index];
+  }
+  return 0;
+}
+
+function deriveUpdateType(fromVersion, targetVersion) {
+  const from = semverParts(fromVersion, "fromVersion");
+  const target = semverParts(targetVersion, "targetVersion");
+  if (from[0] !== target[0] || compareSemver(target, from) <= 0) return null;
+  if (target[1] > from[1]) return "minor";
+  if (target[1] === from[1] && target[2] > from[2]) return "patch";
+  return null;
+}
+
+function parseJsonBytes(bytes, label) {
+  try {
+    return JSON.parse(bytes.toString("utf8"));
+  } catch {
+    fail(`${label} is not JSON`);
+  }
+}
+
+function decodePacket(packetBase64) {
+  if (
+    typeof packetBase64 !== "string" ||
+    packetBase64.length < 4 ||
+    packetBase64.length > 96 * 1024 ||
+    !/^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/u.test(
+      packetBase64,
+    )
+  ) {
+    fail("packet base64 is invalid");
+  }
+  const bytes = Buffer.from(packetBase64, "base64");
+  if (bytes.toString("base64") !== packetBase64) {
+    fail("packet base64 is not canonical");
+  }
+  const packetText = bytes.toString("utf8");
+  if (!Buffer.from(packetText, "utf8").equals(bytes)) {
+    fail("packet is not strict UTF-8");
+  }
+  const packet = parseCanonicalJson(packetText, "protected runtime packet");
+  validateProcessorRepairPacket(packet);
+  if (
+    packet.schema !== PACKET_SCHEMA ||
+    packet.operation?.schema !== OPERATION_SCHEMA ||
+    packet.operation.kind !== "vercel-cli-runtime-sync" ||
+    packet.operation.dependency !== "vercel" ||
+    packet.operation.pnpmVersion !== EXACT_PNPM_VERSION ||
+    JSON.stringify(packet.operation.requiredPaths) !==
+      JSON.stringify(PROTECTED_RUNTIME_SYNC_REQUIRED_PATHS) ||
+    JSON.stringify(packet.operation.inputPaths) !==
+      JSON.stringify(PROTECTED_RUNTIME_SYNC_INPUT_PATHS)
+  ) {
+    fail("packet operation is not the exact Vercel runtime sync contract");
+  }
+  const derivedUpdateType = deriveUpdateType(
+    packet.operation.fromVersion,
+    packet.operation.targetVersion,
+  );
+  if (
+    derivedUpdateType === null ||
+    derivedUpdateType !== packet.operation.updateType ||
+    derivedUpdateType !== packet.updateType ||
+    !HEX_SHA.test(packet.operation.sourceSeedHeadSha ?? "")
+  ) {
+    fail(
+      "packet version transition is not an authorized patch or minor update",
+    );
+  }
+  return { packet, packetDigest: rawDigest(packetText), packetText };
+}
+
+function safeEvidencePath(root, name) {
+  if (!SAFE_EVIDENCE_NAME.test(name ?? "")) {
+    fail("evidence filename is invalid");
+  }
+  const candidate = resolve(root, name);
+  if (
+    relative(root, candidate).startsWith(`..${sep}`) ||
+    relative(root, candidate) === ".."
+  ) {
+    fail("evidence file escapes its sealed root");
+  }
+  return candidate;
+}
+
+function loadEvidence({
+  evidenceManifestPath,
+  packet,
+  packetDigest,
+  processorCheckId,
+}) {
+  if (!isAbsolute(evidenceManifestPath)) {
+    fail("evidence manifest path is not absolute");
+  }
+  const manifestPath = resolve(evidenceManifestPath);
+  const manifestEntry = lstatSync(manifestPath);
+  if (!manifestEntry.isFile() || manifestEntry.isSymbolicLink()) {
+    fail("evidence manifest is not a regular file");
+  }
+  const manifestBytes = readFileSync(manifestPath);
+  if (manifestBytes.byteLength > 256 * 1024) {
+    fail("evidence manifest is oversized");
+  }
+  const manifest = parseJsonBytes(manifestBytes, "evidence manifest");
+  exactKeys(
+    manifest,
+    [
+      "baseSha",
+      "evidenceRoot",
+      "files",
+      "headSha",
+      "packetDigest",
+      "processorCheckId",
+      "pullRequestNumber",
+      "repository",
+      "schema",
+      "workflowRunAttempt",
+      "workflowRunId",
+      "workflowSha",
+    ],
+    "evidence manifest",
+  );
+  if (
+    manifest.schema !== EVIDENCE_SCHEMA ||
+    manifest.repository !== packet.repository ||
+    manifest.pullRequestNumber !== packet.pullRequestNumber ||
+    manifest.headSha !== packet.headSha ||
+    manifest.baseSha !== packet.baseSha ||
+    manifest.workflowSha !== packet.workflowSha ||
+    manifest.workflowRunId !== packet.workflowRunId ||
+    manifest.workflowRunAttempt !== packet.workflowRunAttempt ||
+    manifest.packetDigest !== packetDigest ||
+    manifest.processorCheckId !== processorCheckId
+  ) {
+    fail("evidence manifest identity does not match the packet");
+  }
+  const declaredRoot = resolve(manifest.evidenceRoot ?? "");
+  if (
+    !isAbsolute(manifest.evidenceRoot ?? "") ||
+    join(declaredRoot, "manifest.json") !== manifestPath
+  ) {
+    fail("evidence manifest is not inside its exact sealed root");
+  }
+  const rootEntry = lstatSync(declaredRoot);
+  if (!rootEntry.isDirectory() || rootEntry.isSymbolicLink()) {
+    fail("evidence root is not a regular directory");
+  }
+  const root = realpathSync(declaredRoot);
+  if (join(root, "manifest.json") !== realpathSync(manifestPath)) {
+    fail("evidence manifest canonical path escaped its sealed root");
+  }
+  if (!Array.isArray(manifest.files) || manifest.files.length > 150) {
+    fail("evidence inventory is invalid");
+  }
+  const expectedByPath = new Map(
+    packet.expectedBlobs.map((entry) => [entry.path, entry]),
+  );
+  const blobs = new Map();
+  let totalBytes = 0;
+  for (const entry of manifest.files) {
+    if (entry?.kind !== "git-blob") continue;
+    exactKeys(
+      entry,
+      ["bytes", "digest", "kind", "mediaType", "name", "source"],
+      "Git blob evidence entry",
+    );
+    exactKeys(
+      entry.source,
+      ["gitBlobSha", "mode", "path", "treeSha"],
+      "Git blob evidence source",
+    );
+    const expected = expectedByPath.get(entry.source.path);
+    if (
+      expected === undefined ||
+      expected.sha !== entry.source.gitBlobSha ||
+      expected.mode !== entry.source.mode ||
+      entry.source.treeSha === undefined ||
+      !HEX_SHA.test(entry.source.treeSha) ||
+      blobs.has(entry.source.path) ||
+      !Number.isSafeInteger(entry.bytes) ||
+      entry.bytes < 1 ||
+      entry.bytes > MAX_EVIDENCE_BLOB_BYTES ||
+      !HEX_DIGEST.test(entry.digest ?? "")
+    ) {
+      fail(`Git blob evidence is not packet-bound: ${entry.source.path ?? ""}`);
+    }
+    const path = safeEvidencePath(root, entry.name);
+    const fileEntry = lstatSync(path);
+    if (
+      !fileEntry.isFile() ||
+      fileEntry.isSymbolicLink() ||
+      realpathSync(path) !== path ||
+      (fileEntry.mode & 0o022) !== 0
+    ) {
+      fail(`Git blob evidence file is unsafe: ${entry.name}`);
+    }
+    const bytes = readFileSync(path);
+    totalBytes += bytes.byteLength;
+    if (
+      bytes.byteLength !== entry.bytes ||
+      sha256(bytes) !== entry.digest ||
+      totalBytes > MAX_EVIDENCE_BLOBS_BYTES
+    ) {
+      fail(`Git blob evidence bytes are invalid: ${entry.name}`);
+    }
+    blobs.set(entry.source.path, {
+      bytes,
+      expectedBlobSha: expected.sha,
+      mode: expected.mode,
+    });
+  }
+  if (
+    blobs.size !== PROTECTED_RUNTIME_SYNC_INPUT_PATHS.length ||
+    PROTECTED_RUNTIME_SYNC_INPUT_PATHS.some((path) => !blobs.has(path))
+  ) {
+    fail("evidence does not contain the exact protected-runtime input set");
+  }
+  return blobs;
+}
+
+function parseContract(bytes, label) {
+  const contract = parseJsonBytes(bytes, label);
+  exactKeys(contract, CONTRACT_KEYS, label);
+  if (
+    contract.schema !== CONTRACT_SCHEMA ||
+    !STABLE_SEMVER.test(contract.vercelVersion ?? "") ||
+    !HEX_DIGEST.test(contract.manifestSha256 ?? "") ||
+    !HEX_DIGEST.test(contract.runtimeDependenciesSha256 ?? "") ||
+    !HEX_DIGEST.test(contract.lockfileSha256 ?? "") ||
+    !HEX_DIGEST.test(contract.overridesSha256 ?? "") ||
+    !REGISTRY_INTEGRITY.test(contract.registryIntegrity ?? "")
+  ) {
+    fail(`${label} is invalid`);
+  }
+  return contract;
+}
+
+function assertNoPatchedDependencies(metadata, label) {
+  if (metadata?.pnpm?.patchedDependencies !== undefined) {
+    fail(`${label} admits patchedDependencies`);
+  }
+}
+
+function validateCurrentInputs(blobs, operation) {
+  const rootPackageBytes = blobs.get("package.json").bytes;
+  const rootPackage = parseJsonBytes(rootPackageBytes, "root package manifest");
+  const runtimePackageBytes = blobs.get(
+    "scripts/vercel-cli-runtime/package.json",
+  ).bytes;
+  const runtimePackage = parseJsonBytes(
+    runtimePackageBytes,
+    "Vercel runtime manifest",
+  );
+  const runtimeLockBytes = blobs.get(
+    "scripts/vercel-cli-runtime/pnpm-lock.yaml",
+  ).bytes;
+  const contract = parseContract(
+    blobs.get("scripts/vercel-cli-runtime/contract.json").bytes,
+    "Vercel runtime contract",
+  );
+  assertNoPatchedDependencies(rootPackage, "root package manifest");
+  assertNoPatchedDependencies(runtimePackage, "Vercel runtime manifest");
+  if (
+    rootPackage.packageManager !== `pnpm@${EXACT_PNPM_VERSION}` ||
+    (rootPackage.devDependencies?.vercel !== operation.fromVersion &&
+      rootPackage.devDependencies?.vercel !== operation.targetVersion)
+  ) {
+    fail("root Vercel version is neither the packet source nor target");
+  }
+  if (
+    contract.vercelVersion !== operation.fromVersion ||
+    runtimePackage.dependencies?.vercel !== operation.fromVersion ||
+    sha256(runtimePackageBytes) !== contract.manifestSha256 ||
+    sha256(runtimeLockBytes) !== contract.lockfileSha256 ||
+    stringMapDigest(
+      runtimePackage.dependencies,
+      "current runtime dependencies",
+    ) !== contract.runtimeDependenciesSha256 ||
+    stringMapDigest(rootPackage.pnpm?.overrides, "root overrides") !==
+      contract.overridesSha256 ||
+    !isDeepStrictEqual(
+      runtimePackage.pnpm?.overrides,
+      rootPackage.pnpm?.overrides,
+    )
+  ) {
+    fail("current protected runtime does not match its sealed contract");
+  }
+  const currentLockText = runtimeLockBytes.toString("utf8");
+  if (
+    !currentLockText.includes(
+      `\n  vercel@${operation.fromVersion}:\n    resolution: {integrity: ${contract.registryIntegrity}}`,
+    ) ||
+    /(?:specifier|version):\s*(?:workspace:|link:|file:|git\+|github:)|\btarball:|\brepo:|\btype:\s*git\b/u.test(
+      currentLockText,
+    )
+  ) {
+    fail("current standalone runtime lockfile is not registry-only");
+  }
+  const workspaceBytes = blobs.get("pnpm-workspace.yaml").bytes;
+  const workspaceText = workspaceBytes.toString("utf8");
+  if (
+    !workspaceText.startsWith("packages:\n") ||
+    !workspaceText.includes("  - apps/*\n") ||
+    !workspaceText.includes("  - packages/*\n") ||
+    /(?:^|\n)\s*(?:patchedDependencies|registries|registry|configDependencies|hooks):/u.test(
+      workspaceText,
+    )
+  ) {
+    fail("workspace manifest is outside the bound root-generation contract");
+  }
+  return { contract, rootPackage, runtimePackage };
+}
+
+export function validateRegistryTransition({
+  currentRuntimeDependencies,
+  fromVersion,
+  sourceMetadata,
+  targetMetadata,
+  targetVersion,
+  updateType,
+}) {
+  const validateMetadata = (metadata, version, label) => {
+    if (
+      metadata === null ||
+      typeof metadata !== "object" ||
+      Array.isArray(metadata) ||
+      metadata.name !== "vercel" ||
+      metadata.version !== version ||
+      metadata.dist?.tarball !==
+        `https://registry.npmjs.org/vercel/-/vercel-${version}.tgz` ||
+      !REGISTRY_INTEGRITY.test(metadata.dist?.integrity ?? "")
+    ) {
+      fail(`${label} registry metadata is not exact`);
+    }
+    return {
+      bin: canonicalStringMap(metadata.bin ?? {}, `${label} Vercel bins`),
+      dependencies: canonicalStringMap(
+        metadata.dependencies,
+        `${label} Vercel dependencies`,
+      ),
+      engines: canonicalStringMap(metadata.engines, `${label} Vercel engines`),
+      integrity: metadata.dist.integrity,
+      optionalDependencies: canonicalStringMap(
+        metadata.optionalDependencies ?? {},
+        `${label} Vercel optional dependencies`,
+      ),
+      peers: canonicalStringMap(
+        metadata.peerDependencies,
+        `${label} Vercel builder peers`,
+      ),
+      peerDependenciesMeta: metadata.peerDependenciesMeta ?? {},
+    };
+  };
+  if (deriveUpdateType(fromVersion, targetVersion) !== updateType) {
+    fail("registry metadata does not match the authorized Vercel transition");
+  }
+  const source = validateMetadata(sourceMetadata, fromVersion, "source");
+  const target = validateMetadata(targetMetadata, targetVersion, "target");
+  const current = canonicalStringMap(
+    currentRuntimeDependencies,
+    "current runtime dependencies",
+  );
+  if (current.vercel !== fromVersion) {
+    fail("current runtime Vercel version does not match the packet source");
+  }
+  const currentPeerKeys = Object.keys(current)
+    .filter((name) => name !== "vercel")
+    .sort();
+  if (
+    JSON.stringify(Object.keys(source.peers)) !==
+      JSON.stringify(currentPeerKeys) ||
+    JSON.stringify(Object.keys(target.peers)) !==
+      JSON.stringify(currentPeerKeys) ||
+    !isDeepStrictEqual(
+      source.peers,
+      Object.fromEntries(currentPeerKeys.map((name) => [name, current[name]])),
+    )
+  ) {
+    fail("target Vercel builder peer keyset changed");
+  }
+  for (const name of currentPeerKeys) {
+    const currentParts = semverParts(current[name], `current builder ${name}`);
+    const targetParts = semverParts(
+      target.peers[name],
+      `target builder ${name}`,
+    );
+    if (
+      currentParts[0] !== targetParts[0] ||
+      compareSemver(targetParts, currentParts) < 0 ||
+      source.dependencies[name] !== source.peers[name] ||
+      target.dependencies[name] !== target.peers[name]
+    ) {
+      fail(
+        `target Vercel builder peer is not an exact same-major update: ${name}`,
+      );
+    }
+  }
+  const withoutBuilderPeers = (dependencies) =>
+    Object.fromEntries(
+      Object.entries(dependencies).filter(
+        ([name]) => !currentPeerKeys.includes(name),
+      ),
+    );
+  if (
+    !isDeepStrictEqual(
+      withoutBuilderPeers(source.dependencies),
+      withoutBuilderPeers(target.dependencies),
+    ) ||
+    !isDeepStrictEqual(
+      source.optionalDependencies,
+      target.optionalDependencies,
+    ) ||
+    !isDeepStrictEqual(
+      source.peerDependenciesMeta,
+      target.peerDependenciesMeta,
+    ) ||
+    !isDeepStrictEqual(source.engines, target.engines) ||
+    !isDeepStrictEqual(source.bin, target.bin)
+  ) {
+    fail("Vercel preserved metadata shape changed");
+  }
+  return {
+    bin: target.bin,
+    engines: target.engines,
+    sourceIntegrity: source.integrity,
+    sourcePeers: source.peers,
+    targetIntegrity: target.integrity,
+    targetPeers: target.peers,
+  };
+}
+
+const REGISTRY_FETCH_SOURCE = String.raw`
+  import https from "node:https";
+  const target = process.argv[1];
+  const request = https.request(target, {
+    headers: { accept: "application/json", "user-agent": "mento-protected-runtime-sync/1" },
+    method: "GET",
+  }, (response) => {
+    const contentType = response.headers["content-type"] ?? "";
+    if (
+      response.statusCode !== 200 ||
+      response.headers.location !== undefined ||
+      !/^application\/json(?:;|$)/i.test(contentType)
+    ) process.exit(21);
+    const chunks = [];
+    let bytes = 0;
+    response.on("data", (chunk) => {
+      bytes += chunk.length;
+      if (bytes > ${MAX_METADATA_BYTES}) process.exit(22);
+      chunks.push(chunk);
+    });
+    response.on("end", () => process.stdout.write(Buffer.concat(chunks)));
+  });
+  request.setTimeout(30_000, () => request.destroy(new Error("timeout")));
+  request.on("error", () => process.exit(23));
+  request.end();
+`;
+
+function sanitizedEnvironment(root, executableDirectories = []) {
+  const home = join(root, "home");
+  const cache = join(root, "cache");
+  const config = join(root, "config");
+  const data = join(root, "data");
+  const pnpmHome = join(root, "pnpm-home");
+  const temp = join(root, "tmp");
+  for (const directory of [home, cache, config, data, pnpmHome, temp]) {
+    mkdirSync(directory, { recursive: true, mode: 0o700 });
+  }
+  const npmrc = join(config, "npmrc");
+  writeFileSync(
+    npmrc,
+    "registry=https://registry.npmjs.org/\nalways-auth=false\nmanage-package-manager-versions=false\n",
+    { mode: 0o600 },
+  );
+  return {
+    CI: "true",
+    COREPACK_ENABLE_DOWNLOAD_PROMPT: "0",
+    COREPACK_ENABLE_PROJECT_SPEC: "0",
+    HOME: home,
+    LANG: "C.UTF-8",
+    LC_ALL: "C.UTF-8",
+    NPM_CONFIG_ALWAYS_AUTH: "false",
+    NPM_CONFIG_CACHE: cache,
+    NPM_CONFIG_REGISTRY: "https://registry.npmjs.org/",
+    NPM_CONFIG_USERCONFIG: npmrc,
+    PATH: [
+      ...executableDirectories,
+      dirname(process.execPath),
+      "/usr/local/bin",
+      "/usr/bin",
+      "/bin",
+    ].join(":"),
+    PNPM_HOME: pnpmHome,
+    PNPM_PACKAGE_MANAGER_SELF_UPDATE_CHECK: "false",
+    TMPDIR: temp,
+    XDG_CACHE_HOME: cache,
+    XDG_CONFIG_HOME: config,
+    XDG_DATA_HOME: data,
+  };
+}
+
+export function fetchExactRegistryMetadata(targetVersion, temporaryRoot) {
+  semverParts(targetVersion, "targetVersion");
+  const url = `https://registry.npmjs.org/vercel/${targetVersion}`;
+  const result = spawnSync(
+    process.execPath,
+    ["--input-type=module", "--eval", REGISTRY_FETCH_SOURCE, url],
+    {
+      encoding: "utf8",
+      env: sanitizedEnvironment(join(temporaryRoot, "registry")),
+      maxBuffer: MAX_METADATA_BYTES,
+      stdio: ["ignore", "pipe", "pipe"],
+      timeout: 40_000,
+    },
+  );
+  if (
+    result.status !== 0 ||
+    result.signal !== null ||
+    Buffer.byteLength(result.stdout ?? "") > MAX_METADATA_BYTES
+  ) {
+    fail("exact public npm registry metadata fetch failed");
+  }
+  return parseJsonBytes(Buffer.from(result.stdout), "registry metadata");
+}
+
+function resolvePathCommand(name) {
+  // eslint-disable-next-line turbo/no-undeclared-env-vars -- The standalone workflow resolves the exact PATH executable outside Turbo.
+  for (const directory of (process.env.PATH ?? "").split(":")) {
+    if (directory.length === 0) continue;
+    const candidate = resolve(directory, name);
+    try {
+      accessSync(candidate, constants.X_OK);
+      return candidate;
+    } catch {
+      // Continue through the bounded PATH inventory.
+    }
+  }
+  fail(`${name} is not in PATH`);
+}
+
+function resolveExactPnpm(verificationRoot) {
+  const command = resolvePathCommand("pnpm");
+  mkdirSync(verificationRoot, { recursive: true, mode: 0o700 });
+  const version = spawnSync(command, ["--version"], {
+    cwd: verificationRoot,
+    encoding: "utf8",
+    env: sanitizedEnvironment(join(verificationRoot, "environment"), [
+      dirname(command),
+    ]),
+    stdio: ["ignore", "pipe", "pipe"],
+    timeout: 30_000,
+  });
+  if (version.status !== 0 || version.stdout.trim() !== EXACT_PNPM_VERSION) {
+    fail(`pnpm ${EXACT_PNPM_VERSION} is not the exact PATH executable`);
+  }
+  return command;
+}
+
+function materializeInputs(root, blobs) {
+  for (const path of PROTECTED_RUNTIME_SYNC_INPUT_PATHS) {
+    const destination = join(root, path);
+    mkdirSync(dirname(destination), { recursive: true, mode: 0o700 });
+    writeFileSync(destination, blobs.get(path).bytes, { mode: 0o600 });
+  }
+}
+
+function runPnpmInstall({ command, root, ignoreWorkspace, environmentRoot }) {
+  const store = join(environmentRoot, "store");
+  mkdirSync(store, { recursive: true, mode: 0o700 });
+  const args = [
+    "install",
+    "--lockfile-only",
+    "--ignore-scripts",
+    "--ignore-pnpmfile",
+    "--registry=https://registry.npmjs.org/",
+    "--store-dir",
+    store,
+  ];
+  if (ignoreWorkspace) args.push("--ignore-workspace");
+  const result = spawnSync(command, args, {
+    cwd: root,
+    encoding: "utf8",
+    env: sanitizedEnvironment(environmentRoot, [dirname(command)]),
+    maxBuffer: 4 * 1024 * 1024,
+    stdio: ["ignore", "pipe", "pipe"],
+    timeout: 4 * 60_000,
+  });
+  if (result.status !== 0 || result.signal !== null) {
+    const diagnostic = `${result.stderr ?? ""}\n${result.stdout ?? ""}`
+      .trim()
+      .slice(0, 1_000);
+    fail(
+      `pnpm lock regeneration failed (status=${String(result.status)}, signal=${String(result.signal)}): ${diagnostic}`,
+    );
+  }
+}
+
+function verifyFrozenRootLock({
+  blobs,
+  command,
+  environmentRoot,
+  lockfileBytes,
+  packageBytes,
+  root,
+}) {
+  mkdirSync(root, { recursive: true, mode: 0o700 });
+  materializeInputs(root, blobs);
+  writeFileSync(join(root, "package.json"), packageBytes, { mode: 0o600 });
+  writeFileSync(join(root, "pnpm-lock.yaml"), lockfileBytes, { mode: 0o600 });
+  const store = join(environmentRoot, "store");
+  mkdirSync(store, { recursive: true, mode: 0o700 });
+  const result = spawnSync(
+    command,
+    [
+      "install",
+      "--frozen-lockfile",
+      "--lockfile-only",
+      "--ignore-scripts",
+      "--ignore-pnpmfile",
+      "--registry=https://registry.npmjs.org/",
+      "--store-dir",
+      store,
+    ],
+    {
+      cwd: root,
+      encoding: "utf8",
+      env: sanitizedEnvironment(environmentRoot, [dirname(command)]),
+      maxBuffer: 4 * 1024 * 1024,
+      stdio: ["ignore", "pipe", "pipe"],
+      timeout: 4 * 60_000,
+    },
+  );
+  if (result.status !== 0 || result.signal !== null) {
+    fail(
+      `surgically transformed root lockfile is not frozen-consistent: ${(result.stderr ?? "").slice(0, 500)}`,
+    );
+  }
+  if (!readFileSync(join(root, "pnpm-lock.yaml")).equals(lockfileBytes)) {
+    fail("frozen root consistency check changed the surgical lockfile");
+  }
+}
+
+function targetRuntimePackage(
+  currentRuntimePackage,
+  rootOverrides,
+  peers,
+  targetVersion,
+) {
+  const currentPeerOrder = Object.keys(
+    currentRuntimePackage.dependencies,
+  ).filter((name) => name !== "vercel");
+  const dependencies = Object.fromEntries([
+    ...currentPeerOrder.map((name) => [name, peers[name]]),
+    ["vercel", targetVersion],
+  ]);
+  return {
+    ...currentRuntimePackage,
+    dependencies,
+    pnpm: { overrides: rootOverrides },
+  };
+}
+
+export function rotateRootPackageBytes(rootPackageBytes, targetVersion) {
+  semverParts(targetVersion, "target root Vercel version");
+  const rootPackage = parseJsonBytes(rootPackageBytes, "root package");
+  if (
+    rootPackage.packageManager !== `pnpm@${EXACT_PNPM_VERSION}` ||
+    typeof rootPackage.devDependencies?.vercel !== "string"
+  ) {
+    fail("root package is outside the exact pnpm and Vercel contract");
+  }
+  rootPackage.devDependencies.vercel = targetVersion;
+  return Buffer.from(prettyJson(rootPackage));
+}
+
+function escapeRegex(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
+}
+
+function exactLineOffsets(text, line, start, end) {
+  const needle = `${line}\n`;
+  const offsets = [];
+  let cursor = start;
+  while (cursor < end) {
+    const offset = text.indexOf(needle, cursor);
+    if (offset === -1 || offset >= end) break;
+    if (offset === 0 || text[offset - 1] === "\n") offsets.push(offset);
+    cursor = offset + needle.length;
+  }
+  return offsets;
+}
+
+function indentedBlock(text, { end, header, indent, label, start }) {
+  const headerLine = `${" ".repeat(indent)}${header}`;
+  const offsets = exactLineOffsets(text, headerLine, start, end);
+  if (offsets.length !== 1) {
+    fail(`${label} is missing or ambiguous`);
+  }
+  const blockStart = offsets[0];
+  let blockEnd = end;
+  let cursor = blockStart + headerLine.length + 1;
+  while (cursor < end) {
+    const lineEnd = text.indexOf("\n", cursor);
+    if (lineEnd === -1 || lineEnd >= end) break;
+    const line = text.slice(cursor, lineEnd);
+    if (line.length > 0) {
+      const leading = /^ */u.exec(line)[0].length;
+      if (leading <= indent) {
+        blockEnd = cursor;
+        break;
+      }
+    }
+    cursor = lineEnd + 1;
+  }
+  return { end: blockEnd, start: blockStart };
+}
+
+function topLevelSection(text, name) {
+  return indentedBlock(text, {
+    end: text.length,
+    header: `${name}:`,
+    indent: 0,
+    label: `${name} lockfile section`,
+    start: 0,
+  });
+}
+
+function decodeYamlKey(value, label) {
+  if (/^[A-Za-z0-9@/_.-]+$/u.test(value)) return value;
+  if (/^'[^']+'$/u.test(value)) return value.slice(1, -1);
+  fail(`${label} contains an unsupported YAML key`);
+}
+
+function parseExactScalarMap(text, block, indent, label) {
+  const headerEnd = text.indexOf("\n", block.start) + 1;
+  const result = {};
+  for (const line of text.slice(headerEnd, block.end).split("\n")) {
+    if (line.length === 0) continue;
+    const match = new RegExp(`^ {${indent}}([^:]+): (.+)$`, "u").exec(line);
+    if (!match) fail(`${label} is not an exact scalar map`);
+    const key = decodeYamlKey(match[1], label);
+    if (Object.hasOwn(result, key)) fail(`${label} contains a duplicate key`);
+    result[key] = match[2];
+  }
+  return canonicalStringMap(result, label);
+}
+
+function inspectRootVercelLock({
+  bin,
+  engines,
+  integrity,
+  lockfileText,
+  peers,
+  version,
+}) {
+  const importers = topLevelSection(lockfileText, "importers");
+  const rootImporter = indentedBlock(lockfileText, {
+    ...importers,
+    header: ".:",
+    indent: 2,
+    label: "root importer",
+  });
+  const devDependencies = indentedBlock(lockfileText, {
+    ...rootImporter,
+    header: "devDependencies:",
+    indent: 4,
+    label: "root devDependencies",
+  });
+  const importer = indentedBlock(lockfileText, {
+    ...devDependencies,
+    header: "vercel:",
+    indent: 6,
+    label: "root importer Vercel block",
+  });
+  const importerText = lockfileText.slice(importer.start, importer.end);
+  const importerMatch = new RegExp(
+    `^      vercel:\n        specifier: ${escapeRegex(version)}\n        version: ${escapeRegex(version)}([^\n]*)\n$`,
+    "u",
+  ).exec(importerText);
+  if (
+    !importerMatch ||
+    (importerMatch[1] !== "" && !/^\(.+\)$/u.test(importerMatch[1]))
+  ) {
+    fail("root importer Vercel block does not match registry metadata");
+  }
+  const peerSuffix = importerMatch[1];
+
+  const packages = topLevelSection(lockfileText, "packages");
+  const packageHeaders = [
+    ...lockfileText
+      .slice(packages.start, packages.end)
+      .matchAll(/^ {2}vercel@([^:\n(]+):$/gmu),
+  ];
+  if (packageHeaders.length !== 1 || packageHeaders[0][1] !== version) {
+    fail("root packages Vercel block is missing or ambiguous");
+  }
+  const packageBlock = indentedBlock(lockfileText, {
+    ...packages,
+    header: `vercel@${version}:`,
+    indent: 2,
+    label: "root packages Vercel block",
+  });
+  const packageText = lockfileText.slice(packageBlock.start, packageBlock.end);
+  const resolution = `    resolution: {integrity: ${integrity}}\n`;
+  if (
+    packageText.split(resolution).length !== 2 ||
+    !packageText.startsWith(`  vercel@${version}:\n`) ||
+    Object.keys(engines).length !== 1 ||
+    engines.node === undefined ||
+    !packageText.includes(`    engines: {node: '${engines.node}'}\n`) ||
+    packageText.includes("    hasBin: true\n") !== Object.keys(bin).length > 0
+  ) {
+    fail("root packages Vercel metadata does not match the registry");
+  }
+  const peerBlock = indentedBlock(lockfileText, {
+    ...packageBlock,
+    header: "peerDependencies:",
+    indent: 4,
+    label: "root packages Vercel peerDependencies",
+  });
+  const lockedPeers = parseExactScalarMap(
+    lockfileText,
+    peerBlock,
+    6,
+    "root packages Vercel peerDependencies",
+  );
+  if (!isDeepStrictEqual(lockedPeers, peers)) {
+    fail("root packages Vercel peers do not match registry metadata");
+  }
+
+  const snapshots = topLevelSection(lockfileText, "snapshots");
+  const snapshotHeaders = [
+    ...lockfileText
+      .slice(snapshots.start, snapshots.end)
+      .matchAll(/^ {2}vercel@([^:\n(]+)([^:\n]*):$/gmu),
+  ];
+  if (
+    snapshotHeaders.length !== 1 ||
+    snapshotHeaders[0][1] !== version ||
+    snapshotHeaders[0][2] !== peerSuffix
+  ) {
+    fail("root snapshots Vercel block is missing or ambiguous");
+  }
+  const snapshot = indentedBlock(lockfileText, {
+    ...snapshots,
+    header: `vercel@${version}${peerSuffix}:`,
+    indent: 2,
+    label: "root snapshots Vercel block",
+  });
+  return { importer, packageBlock, peerBlock, peerSuffix, snapshot };
+}
+
+export function rotateRootLockBytes({
+  bin,
+  currentVersion,
+  engines,
+  lockfileBytes,
+  sourceIntegrity,
+  sourcePeers,
+  sourceVersion,
+  targetIntegrity,
+  targetPeers,
+  targetVersion,
+}) {
+  const lockfileText = lockfileBytes.toString("utf8");
+  if (
+    !Buffer.from(lockfileText, "utf8").equals(lockfileBytes) ||
+    !lockfileText.endsWith("\n") ||
+    lockfileText.includes("\r")
+  ) {
+    fail("root lockfile is not canonical UTF-8 with LF endings");
+  }
+  if (currentVersion === targetVersion) {
+    inspectRootVercelLock({
+      bin,
+      engines,
+      integrity: targetIntegrity,
+      lockfileText,
+      peers: targetPeers,
+      version: targetVersion,
+    });
+    return lockfileBytes;
+  }
+  if (currentVersion !== sourceVersion) {
+    fail("root lockfile version is neither packet source nor target");
+  }
+  const source = inspectRootVercelLock({
+    bin,
+    engines,
+    integrity: sourceIntegrity,
+    lockfileText,
+    peers: sourcePeers,
+    version: sourceVersion,
+  });
+  const importerText = lockfileText
+    .slice(source.importer.start, source.importer.end)
+    .replace(`specifier: ${sourceVersion}\n`, `specifier: ${targetVersion}\n`)
+    .replace(
+      `version: ${sourceVersion}${source.peerSuffix}\n`,
+      `version: ${targetVersion}${source.peerSuffix}\n`,
+    );
+  let packageText = lockfileText.slice(
+    source.packageBlock.start,
+    source.packageBlock.end,
+  );
+  packageText = packageText
+    .replace(`  vercel@${sourceVersion}:\n`, `  vercel@${targetVersion}:\n`)
+    .replace(
+      `    resolution: {integrity: ${sourceIntegrity}}\n`,
+      `    resolution: {integrity: ${targetIntegrity}}\n`,
+    );
+  const sourcePeerText = lockfileText.slice(
+    source.peerBlock.start,
+    source.peerBlock.end,
+  );
+  let targetPeerText = sourcePeerText;
+  for (const name of Object.keys(sourcePeers)) {
+    const yamlName = name.startsWith("@") ? `'${name}'` : name;
+    const fromLine = `      ${yamlName}: ${sourcePeers[name]}\n`;
+    const toLine = `      ${yamlName}: ${targetPeers[name]}\n`;
+    if (!sourcePeerText.includes(fromLine)) {
+      fail(`root packages Vercel peer line is missing: ${name}`);
+    }
+    targetPeerText = targetPeerText.replace(fromLine, toLine);
+  }
+  packageText = packageText.replace(sourcePeerText, targetPeerText);
+  const snapshotText = lockfileText
+    .slice(source.snapshot.start, source.snapshot.end)
+    .replace(
+      `  vercel@${sourceVersion}${source.peerSuffix}:\n`,
+      `  vercel@${targetVersion}${source.peerSuffix}:\n`,
+    );
+  const replacements = [
+    { ...source.importer, value: importerText },
+    { ...source.packageBlock, value: packageText },
+    { ...source.snapshot, value: snapshotText },
+  ].toSorted((left, right) => right.start - left.start);
+  let targetText = lockfileText;
+  for (const replacement of replacements) {
+    targetText =
+      targetText.slice(0, replacement.start) +
+      replacement.value +
+      targetText.slice(replacement.end);
+  }
+  inspectRootVercelLock({
+    bin,
+    engines,
+    integrity: targetIntegrity,
+    lockfileText: targetText,
+    peers: targetPeers,
+    version: targetVersion,
+  });
+  return Buffer.from(targetText);
+}
+
+export function createRuntimeContract({
+  integrity,
+  lockfileBytes,
+  manifestBytes,
+  overrides,
+  runtimeDependencies,
+  targetVersion,
+}) {
+  return {
+    lockfileSha256: sha256(lockfileBytes),
+    manifestSha256: sha256(manifestBytes),
+    overridesSha256: stringMapDigest(overrides, "target overrides"),
+    registryIntegrity: integrity,
+    runtimeDependenciesSha256: stringMapDigest(
+      runtimeDependencies,
+      "target runtime dependencies",
+    ),
+    schema: CONTRACT_SCHEMA,
+    vercelVersion: targetVersion,
+  };
+}
+
+function generateOnce({
+  blobs,
+  metadataContract,
+  operation,
+  pnpmCommand,
+  runRoot,
+}) {
+  const root = join(runRoot, "root");
+  const runtime = join(runRoot, "runtime");
+  mkdirSync(root, { recursive: true, mode: 0o700 });
+  mkdirSync(runtime, { recursive: true, mode: 0o700 });
+  const currentRootPackageBytes = blobs.get("package.json").bytes;
+  const currentRootPackage = parseJsonBytes(
+    currentRootPackageBytes,
+    "current root package",
+  );
+  const rootPackageBytes =
+    currentRootPackage.devDependencies.vercel === operation.targetVersion
+      ? currentRootPackageBytes
+      : rotateRootPackageBytes(
+          currentRootPackageBytes,
+          operation.targetVersion,
+        );
+  const rootPackage = parseJsonBytes(rootPackageBytes, "target root package");
+  const rootLockBytes = rotateRootLockBytes({
+    bin: metadataContract.bin,
+    currentVersion: currentRootPackage.devDependencies.vercel,
+    engines: metadataContract.engines,
+    lockfileBytes: blobs.get("pnpm-lock.yaml").bytes,
+    sourceIntegrity: metadataContract.sourceIntegrity,
+    sourcePeers: metadataContract.sourcePeers,
+    sourceVersion: operation.fromVersion,
+    targetIntegrity: metadataContract.targetIntegrity,
+    targetPeers: metadataContract.targetPeers,
+    targetVersion: operation.targetVersion,
+  });
+  verifyFrozenRootLock({
+    blobs,
+    command: pnpmCommand,
+    environmentRoot: join(runRoot, "root-frozen-env"),
+    lockfileBytes: rootLockBytes,
+    packageBytes: rootPackageBytes,
+    root,
+  });
+
+  const currentRuntimePackage = parseJsonBytes(
+    blobs.get("scripts/vercel-cli-runtime/package.json").bytes,
+    "runtime package",
+  );
+  const runtimePackage = targetRuntimePackage(
+    currentRuntimePackage,
+    rootPackage.pnpm.overrides,
+    metadataContract.targetPeers,
+    operation.targetVersion,
+  );
+  const runtimePackageBytes = Buffer.from(prettyJson(runtimePackage));
+  writeFileSync(join(runtime, "package.json"), runtimePackageBytes, {
+    mode: 0o600,
+  });
+  runPnpmInstall({
+    command: pnpmCommand,
+    environmentRoot: join(runRoot, "runtime-env"),
+    ignoreWorkspace: true,
+    root: runtime,
+  });
+  const runtimeLockBytes = readFileSync(join(runtime, "pnpm-lock.yaml"));
+  const contract = createRuntimeContract({
+    integrity: metadataContract.targetIntegrity,
+    lockfileBytes: runtimeLockBytes,
+    manifestBytes: runtimePackageBytes,
+    overrides: rootPackage.pnpm.overrides,
+    runtimeDependencies: runtimePackage.dependencies,
+    targetVersion: operation.targetVersion,
+  });
+  const contractBytes = Buffer.from(prettyJson(contract));
+  const contractPath = join(runtime, "contract.json");
+  writeFileSync(contractPath, contractBytes, { mode: 0o600 });
+  const assertedRuntime = join(root, "scripts", "vercel-cli-runtime");
+  mkdirSync(assertedRuntime, { recursive: true, mode: 0o700 });
+  writeFileSync(join(assertedRuntime, "package.json"), runtimePackageBytes, {
+    mode: 0o600,
+  });
+  writeFileSync(join(assertedRuntime, "pnpm-lock.yaml"), runtimeLockBytes, {
+    mode: 0o600,
+  });
+  writeFileSync(join(assertedRuntime, "contract.json"), contractBytes, {
+    mode: 0o600,
+  });
+  assertVercelCliRuntimeContract({
+    contractPath: join(assertedRuntime, "contract.json"),
+    lockfilePath: join(assertedRuntime, "pnpm-lock.yaml"),
+    packageJsonPath: join(assertedRuntime, "package.json"),
+    rootPackageJsonPath: join(root, "package.json"),
+  });
+  const escapedVersion = operation.targetVersion.replaceAll(".", "\\.");
+  const escapedIntegrity = metadataContract.targetIntegrity.replace(
+    /[.*+?^${}()|[\]\\]/gu,
+    "\\$&",
+  );
+  if (
+    !new RegExp(
+      `\\n  vercel@${escapedVersion}:\\n    resolution: \\{integrity: ${escapedIntegrity}\\}`,
+      "u",
+    ).test(rootLockBytes.toString("utf8"))
+  ) {
+    fail("regenerated root lockfile does not bind target registry integrity");
+  }
+  return new Map([
+    ["package.json", rootPackageBytes],
+    ["pnpm-lock.yaml", rootLockBytes],
+    ["scripts/vercel-cli-runtime/contract.json", contractBytes],
+    ["scripts/vercel-cli-runtime/package.json", runtimePackageBytes],
+    ["scripts/vercel-cli-runtime/pnpm-lock.yaml", runtimeLockBytes],
+  ]);
+}
+
+function verifyFrozenStandaloneRuntime({
+  generated,
+  pnpmCommand,
+  targetVersion,
+  verificationRoot,
+}) {
+  const runtimeRoot = join(verificationRoot, "runtime");
+  mkdirSync(runtimeRoot, { recursive: true, mode: 0o700 });
+  for (const path of [
+    "scripts/vercel-cli-runtime/contract.json",
+    "scripts/vercel-cli-runtime/package.json",
+    "scripts/vercel-cli-runtime/pnpm-lock.yaml",
+  ]) {
+    writeFileSync(
+      runtimeRoot + sep + path.split("/").at(-1),
+      generated.get(path),
+      {
+        mode: 0o600,
+      },
+    );
+  }
+  const environmentRoot = join(verificationRoot, "environment");
+  const store = join(environmentRoot, "store");
+  mkdirSync(store, { recursive: true, mode: 0o700 });
+  const install = spawnSync(
+    pnpmCommand,
+    [
+      "install",
+      "--frozen-lockfile",
+      "--ignore-scripts",
+      "--ignore-pnpmfile",
+      "--ignore-workspace",
+      "--package-import-method",
+      "copy",
+      "--registry=https://registry.npmjs.org/",
+      "--store-dir",
+      store,
+    ],
+    {
+      cwd: runtimeRoot,
+      encoding: "utf8",
+      env: sanitizedEnvironment(environmentRoot, [dirname(pnpmCommand)]),
+      maxBuffer: 4 * 1024 * 1024,
+      stdio: ["ignore", "pipe", "pipe"],
+      timeout: 8 * 60_000,
+    },
+  );
+  if (install.status !== 0 || install.signal !== null) {
+    fail(
+      `frozen standalone runtime installation failed: ${(install.stderr ?? "").slice(0, 500)}`,
+    );
+  }
+  const modulesRoot = realpathSync(join(runtimeRoot, "node_modules"));
+  const cliPath = realpathSync(
+    join(runtimeRoot, "node_modules", "vercel", "dist", "index.js"),
+  );
+  const cliRelative = relative(modulesRoot, cliPath);
+  const cliEntry = lstatSync(cliPath);
+  if (
+    cliRelative === ".." ||
+    cliRelative.startsWith(`..${sep}`) ||
+    !cliEntry.isFile() ||
+    cliEntry.isSymbolicLink()
+  ) {
+    fail("installed Vercel CLI escaped the frozen standalone runtime");
+  }
+  const version = spawnSync(process.execPath, [cliPath, "--version"], {
+    cwd: runtimeRoot,
+    encoding: "utf8",
+    env: sanitizedEnvironment(join(verificationRoot, "cli-environment")),
+    maxBuffer: 1024 * 1024,
+    stdio: ["ignore", "pipe", "pipe"],
+    timeout: 30_000,
+  });
+  if (
+    version.status !== 0 ||
+    version.signal !== null ||
+    version.stdout.trim() !== targetVersion
+  ) {
+    fail("installed Vercel CLI does not execute the exact target version");
+  }
+}
+
+function assertSameOutputs(first, second) {
+  for (const path of PROTECTED_RUNTIME_SYNC_REQUIRED_PATHS) {
+    if (!first.get(path)?.equals(second.get(path))) {
+      fail(`isolated regeneration is not byte-identical: ${path}`);
+    }
+  }
+}
+
+export function createUnifiedPatch({
+  oldBytes,
+  newBytes,
+  path,
+  temporaryRoot,
+}) {
+  const oldPath = join(temporaryRoot, "old");
+  const newPath = join(temporaryRoot, "new");
+  mkdirSync(temporaryRoot, { recursive: true, mode: 0o700 });
+  writeFileSync(oldPath, oldBytes, { mode: 0o600 });
+  writeFileSync(newPath, newBytes, { mode: 0o600 });
+  const diff = spawnSync(
+    "/usr/bin/diff",
+    [
+      "-U",
+      "1",
+      "--label",
+      `a/${path}`,
+      "--label",
+      `b/${path}`,
+      oldPath,
+      newPath,
+    ],
+    {
+      encoding: "utf8",
+      env: sanitizedEnvironment(join(temporaryRoot, "diff-env")),
+      maxBuffer: MAX_PATCH_BYTES + 1,
+      stdio: ["ignore", "pipe", "pipe"],
+    },
+  );
+  if (diff.status !== 1 || diff.signal !== null || diff.stderr !== "") {
+    fail(`contextual diff failed for ${path}`);
+  }
+  const patch = diff.stdout;
+  if (
+    !patch.startsWith(`--- a/${path}\n+++ b/${path}\n`) ||
+    Buffer.byteLength(patch) > MAX_PATCH_BYTES ||
+    !/^@@ -[0-9]+(?:,[0-9]+)? \+[0-9]+(?:,[0-9]+)? @@/mu.test(patch)
+  ) {
+    fail(`contextual U1 patch is invalid or oversized: ${path}`);
+  }
+  return patch;
+}
+
+function buildPlan({
+  blobs,
+  generated,
+  packet,
+  packetDigest,
+  processorCheckId,
+  temporaryRoot,
+}) {
+  const edits = [];
+  for (const path of PROTECTED_RUNTIME_SYNC_REQUIRED_PATHS) {
+    const old = blobs.get(path);
+    const next = generated.get(path);
+    if (old.bytes.equals(next)) continue;
+    edits.push({
+      expectedBlobSha: old.expectedBlobSha,
+      patch: createUnifiedPatch({
+        newBytes: next,
+        oldBytes: old.bytes,
+        path,
+        temporaryRoot: join(temporaryRoot, `diff-${edits.length}`),
+      }),
+      path,
+    });
+  }
+  if (edits.length === 0) fail("regeneration produced no required-path edits");
+  const plan = {
+    attempt: packet.attemptNumber,
+    baseSha: packet.baseSha,
+    edits,
+    packetDigest,
+    parentHeadSha: packet.headSha,
+    processorCheckId,
+    pullRequestNumber: packet.pullRequestNumber,
+    repository: packet.repository,
+    schema: PLAN_SCHEMA,
+    summary: `Synchronize the protected Vercel CLI runtime from ${packet.operation.fromVersion} to ${packet.operation.targetVersion} with exact registry-derived builder peers and pnpm ${EXACT_PNPM_VERSION}.`,
+  };
+  validateRepairPlan(plan, { packet, packetDigest, processorCheckId });
+  if (Buffer.byteLength(canonicalJson(plan)) > MAX_PLAN_BYTES) {
+    fail("canonical repair plan is oversized");
+  }
+  return plan;
+}
+
+export function generateProtectedRuntimeRepairPlan({
+  evidenceManifestPath,
+  fetchMetadata = fetchExactRegistryMetadata,
+  inspectArtifacts,
+  packetBase64,
+  processorCheckId,
+}) {
+  if (!Number.isSafeInteger(processorCheckId) || processorCheckId < 1) {
+    fail("processor check ID is invalid");
+  }
+  const temporaryRoot = mkdtempSync(
+    join(tmpdir(), "dependabot-protected-runtime-sync-"),
+  );
+  try {
+    const { packet, packetDigest } = decodePacket(packetBase64);
+    const blobs = loadEvidence({
+      evidenceManifestPath,
+      packet,
+      packetDigest,
+      processorCheckId,
+    });
+    const current = validateCurrentInputs(blobs, packet.operation);
+    const sourceMetadata = fetchMetadata(
+      packet.operation.fromVersion,
+      join(temporaryRoot, "source-metadata"),
+    );
+    const targetMetadata = fetchMetadata(
+      packet.operation.targetVersion,
+      join(temporaryRoot, "target-metadata"),
+    );
+    const metadataContract = validateRegistryTransition({
+      currentRuntimeDependencies: current.runtimePackage.dependencies,
+      fromVersion: packet.operation.fromVersion,
+      sourceMetadata,
+      targetMetadata,
+      targetVersion: packet.operation.targetVersion,
+      updateType: packet.operation.updateType,
+    });
+    if (
+      metadataContract.sourceIntegrity !== current.contract.registryIntegrity
+    ) {
+      fail(
+        "source registry integrity does not match the sealed runtime contract",
+      );
+    }
+    const pnpmCommand = resolveExactPnpm(
+      join(temporaryRoot, "pnpm-version-proof"),
+    );
+    const first = generateOnce({
+      blobs,
+      metadataContract,
+      operation: packet.operation,
+      pnpmCommand,
+      runRoot: join(temporaryRoot, "generation-1"),
+    });
+    const second = generateOnce({
+      blobs,
+      metadataContract,
+      operation: packet.operation,
+      pnpmCommand,
+      runRoot: join(temporaryRoot, "generation-2"),
+    });
+    assertSameOutputs(first, second);
+    const plan = buildPlan({
+      blobs,
+      generated: first,
+      packet,
+      packetDigest,
+      processorCheckId,
+      temporaryRoot: join(temporaryRoot, "patches"),
+    });
+    if (inspectArtifacts !== undefined) {
+      if (typeof inspectArtifacts !== "function") {
+        fail("artifact inspection callback is invalid");
+      }
+      inspectArtifacts({
+        generated: first,
+        packet,
+        packetDigest,
+        plan,
+        pnpmCommand,
+        temporaryRoot,
+      });
+    }
+    return plan;
+  } finally {
+    rmSync(temporaryRoot, { force: true, recursive: true });
+  }
+}
+
+function decodeCanonicalBase64(value, label) {
+  if (
+    typeof value !== "string" ||
+    value.length < 4 ||
+    value.length > 96 * 1024 ||
+    !/^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/u.test(
+      value,
+    )
+  ) {
+    fail(`${label} base64 is invalid`);
+  }
+  const bytes = Buffer.from(value, "base64");
+  if (bytes.toString("base64") !== value) {
+    fail(`${label} base64 is not canonical`);
+  }
+  const text = bytes.toString("utf8");
+  if (!Buffer.from(text, "utf8").equals(bytes)) {
+    fail(`${label} is not strict UTF-8`);
+  }
+  return text;
+}
+
+export function assertValidatedPlanMatchesRegeneration({
+  generated,
+  packetBase64,
+  processorCheckId,
+  regeneratedPlan,
+  validatedPlanBase64,
+  validatedPlanDigest,
+}) {
+  if (!HEX_DIGEST.test(validatedPlanDigest ?? "")) {
+    fail("validated plan digest is invalid");
+  }
+  const validatedText = decodeCanonicalBase64(
+    validatedPlanBase64,
+    "validated plan",
+  );
+  if (rawDigest(validatedText) !== validatedPlanDigest) {
+    fail("validated plan digest does not match its canonical bytes");
+  }
+  const { packet, packetDigest } = decodePacket(packetBase64);
+  const validated = parseCanonicalJson(validatedText, "validated repair plan");
+  validateValidatedRepairPlan(validated, {
+    packet,
+    packetDigest,
+    processorCheckId,
+  });
+  const projectedPlan = {
+    ...validated,
+    edits: validated.edits.map((edit) => ({
+      expectedBlobSha: edit.expectedBlobSha,
+      patch: edit.patch,
+      path: edit.path,
+    })),
+    schema: PLAN_SCHEMA,
+  };
+  if (canonicalJson(projectedPlan) !== canonicalJson(regeneratedPlan)) {
+    fail("validated plan is not the exact terminal-smoke regeneration");
+  }
+  for (const edit of validated.edits) {
+    const content = generated.get(edit.path);
+    if (content === undefined || rawDigest(content) !== edit.contentDigest) {
+      fail(`validated plan content digest changed before smoke: ${edit.path}`);
+    }
+  }
+  return validated;
+}
+
+function argsMap(values) {
+  if (values.length % 2 !== 0)
+    fail("CLI arguments must be exact name/value pairs");
+  const result = new Map();
+  for (let index = 0; index < values.length; index += 2) {
+    const name = values[index];
+    const value = values[index + 1];
+    if (!name.startsWith("--") || result.has(name)) {
+      fail("CLI arguments contain an unknown shape or duplicate");
+    }
+    result.set(name, value);
+  }
+  return result;
+}
+
+function exactArgs(args, expected) {
+  if (
+    JSON.stringify([...args.keys()].sort()) !==
+    JSON.stringify([...expected].sort())
+  ) {
+    fail("CLI arguments are not the exact command contract");
+  }
+}
+
+function requiredArg(args, name) {
+  const value = args.get(name);
+  if (value === undefined || value.length === 0) fail(`${name} is required`);
+  return value;
+}
+
+function checkIdArg(args) {
+  const raw = requiredArg(args, "--processor-check-id");
+  if (!/^[1-9][0-9]{0,15}$/u.test(raw)) fail("processor check ID is invalid");
+  const value = Number(raw);
+  if (!Number.isSafeInteger(value)) fail("processor check ID is invalid");
+  return value;
+}
+
+function writeStructuredOutput(path, canonicalPlan) {
+  if (
+    !isAbsolute(path) ||
+    canonicalPlan.includes("\nDEPENDABOT_SYNC_PLAN_EOF\n")
+  ) {
+    fail("GitHub output path or payload is invalid");
+  }
+  appendFileSync(
+    path,
+    `structured_output<<DEPENDABOT_SYNC_PLAN_EOF\n${canonicalPlan}\nDEPENDABOT_SYNC_PLAN_EOF\n`,
+    { encoding: "utf8" },
+  );
+}
+
+function commandGeneratePlan(args) {
+  exactArgs(args, [
+    "--evidence-manifest",
+    "--github-output",
+    "--packet-base64",
+    "--processor-check-id",
+  ]);
+  const plan = generateProtectedRuntimeRepairPlan({
+    evidenceManifestPath: requiredArg(args, "--evidence-manifest"),
+    packetBase64: requiredArg(args, "--packet-base64"),
+    processorCheckId: checkIdArg(args),
+  });
+  writeStructuredOutput(
+    requiredArg(args, "--github-output"),
+    canonicalJson(plan),
+  );
+}
+
+function commandVerifyPlan(args) {
+  exactArgs(args, [
+    "--evidence-manifest",
+    "--packet-base64",
+    "--plan-json",
+    "--processor-check-id",
+  ]);
+  const suppliedText = requiredArg(args, "--plan-json");
+  const supplied = parseCanonicalJson(suppliedText, "supplied repair plan");
+  const regenerated = generateProtectedRuntimeRepairPlan({
+    evidenceManifestPath: requiredArg(args, "--evidence-manifest"),
+    packetBase64: requiredArg(args, "--packet-base64"),
+    processorCheckId: checkIdArg(args),
+  });
+  if (canonicalJson(regenerated) !== canonicalJson(supplied)) {
+    fail("supplied repair plan is not the exact independent regeneration");
+  }
+}
+
+function commandCandidateCliSmoke(args) {
+  exactArgs(args, [
+    "--evidence-manifest",
+    "--packet-base64",
+    "--processor-check-id",
+    "--validated-plan-base64",
+    "--validated-plan-digest",
+  ]);
+  generateProtectedRuntimeRepairPlan({
+    evidenceManifestPath: requiredArg(args, "--evidence-manifest"),
+    packetBase64: requiredArg(args, "--packet-base64"),
+    processorCheckId: checkIdArg(args),
+    inspectArtifacts: ({
+      generated,
+      packet,
+      plan,
+      pnpmCommand,
+      temporaryRoot,
+    }) => {
+      assertValidatedPlanMatchesRegeneration({
+        generated,
+        packetBase64: requiredArg(args, "--packet-base64"),
+        processorCheckId: checkIdArg(args),
+        regeneratedPlan: plan,
+        validatedPlanBase64: requiredArg(args, "--validated-plan-base64"),
+        validatedPlanDigest: requiredArg(args, "--validated-plan-digest"),
+      });
+      verifyFrozenStandaloneRuntime({
+        generated,
+        pnpmCommand,
+        targetVersion: packet.operation.targetVersion,
+        verificationRoot: join(temporaryRoot, "frozen-verification"),
+      });
+    },
+  });
+}
+
+async function main() {
+  const [command, ...rest] = process.argv.slice(2);
+  const args = argsMap(rest);
+  if (command === "generate-plan") return commandGeneratePlan(args);
+  if (command === "verify-plan") return commandVerifyPlan(args);
+  if (command === "candidate-cli-smoke") return commandCandidateCliSmoke(args);
+  fail(`unknown command: ${command ?? ""}`);
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  await main();
+}

--- a/scripts/dependabot-protected-runtime-sync.test.mjs
+++ b/scripts/dependabot-protected-runtime-sync.test.mjs
@@ -314,13 +314,14 @@ function gitShow(commit, path) {
   });
 }
 
-function pr753Fixture() {
+function protectedRuntimeFixture({ useHistoricalPr753Objects = false } = {}) {
   const root = mkdtempSync(join(tmpdir(), "protected-runtime-pr753-"));
   const evidenceRoot = join(root, "evidence");
   mkdirSync(evidenceRoot, { mode: 0o700 });
   const bytesByPath = new Map();
   for (const path of PROTECTED_RUNTIME_SYNC_INPUT_PATHS) {
     const bytes =
+      !useHistoricalPr753Objects ||
       path === "scripts/vercel-cli-runtime/contract.json"
         ? readFileSync(join(REPOSITORY_ROOT, path))
         : gitShow(PR_753_REPAIRED_HEAD, path);
@@ -369,7 +370,7 @@ function pr753Fixture() {
       "scripts/vercel-main-*.mjs",
     ],
     headRef: "dependabot/npm_and_yarn/tooling-123",
-    headSha: PR_753_REPAIRED_HEAD,
+    headSha: useHistoricalPr753Objects ? PR_753_REPAIRED_HEAD : "a".repeat(40),
     limits: {
       maxAddedLines: 600,
       maxBytes: 64 * 1024,
@@ -386,7 +387,9 @@ function pr753Fixture() {
       pnpmVersion: "10.34.4",
       requiredPaths: PROTECTED_RUNTIME_SYNC_REQUIRED_PATHS,
       schema: "dependabot-protected-runtime-sync:v1",
-      sourceSeedHeadSha: PR_753_IMMUTABLE_SOURCE,
+      sourceSeedHeadSha: useHistoricalPr753Objects
+        ? PR_753_IMMUTABLE_SOURCE
+        : "e".repeat(40),
       targetVersion: TARGET_VERSION,
       updateType: "minor",
     },
@@ -455,8 +458,12 @@ function pr753Fixture() {
   };
 }
 
+function pr753Fixture() {
+  return protectedRuntimeFixture({ useHistoricalPr753Objects: true });
+}
+
 test("terminal CLI smoke rejects validated-plan and content drift", () => {
-  const fixture = pr753Fixture();
+  const fixture = protectedRuntimeFixture();
   try {
     const packetText = Buffer.from(fixture.packetBase64, "base64").toString(
       "utf8",

--- a/scripts/dependabot-protected-runtime-sync.test.mjs
+++ b/scripts/dependabot-protected-runtime-sync.test.mjs
@@ -1,0 +1,640 @@
+import assert from "node:assert/strict";
+import { Buffer } from "node:buffer";
+import { execFileSync, spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import process from "node:process";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+import {
+  assertValidatedPlanMatchesRegeneration,
+  createRuntimeContract,
+  createUnifiedPatch,
+  generateProtectedRuntimeRepairPlan,
+  PROTECTED_RUNTIME_SYNC_INPUT_PATHS,
+  PROTECTED_RUNTIME_SYNC_REQUIRED_PATHS,
+  rotateRootLockBytes,
+  rotateRootPackageBytes,
+  validateRegistryTransition,
+} from "./dependabot-protected-runtime-sync.mjs";
+import { canonicalJson } from "./dependabot-preparation-receipts.mjs";
+
+const REPOSITORY_ROOT = fileURLToPath(new URL("..", import.meta.url));
+const FROM_VERSION = "56.4.1";
+const TARGET_VERSION = "56.5.0";
+const TARGET_INTEGRITY =
+  "sha512-wAKpT8DFSbnwlgbS711fbvxGjOfQeb1n+NcaBaSC4onq9eJAjbPfERrjrKE4GDsV8dkoBo0627lp0QxbLCGFiw==";
+const PR_753_SEED = "374c0899cdadf5be3197bcabe1549af82bdf36df";
+const PR_753_IMMUTABLE_SOURCE = "87b50107da06b3d22d6e4a70a43027e48838a4ab";
+const PR_753_REPAIRED_HEAD = "7e15d2d5596e81364e44d6d46dd1b212351cc070";
+const PR_753_TARGET_ROOT_PACKAGE_SHA256 =
+  "4be4c1dc5ffb0fbf2b9c8d8aceb214da348c1c94d6bbb34fb0946092c4e9dc8c";
+const PR_753_TARGET_RUNTIME_PACKAGE_SHA256 =
+  "623f415ef559c635964cd2f3e046df222b8177edfdad2c04ab7163b524c50738";
+const PR_753_TARGET_RUNTIME_LOCK_SHA256 =
+  "c512b310653b45f654e8d9204a84fbeea4159617020e242f90ab31b8919da921";
+const HAS_PR_753_OBJECTS =
+  spawnSync("git", ["cat-file", "-e", `${PR_753_SEED}^{commit}`], {
+    cwd: REPOSITORY_ROOT,
+    stdio: "ignore",
+  }).status === 0 &&
+  spawnSync("git", ["cat-file", "-e", `${PR_753_REPAIRED_HEAD}^{commit}`], {
+    cwd: REPOSITORY_ROOT,
+    stdio: "ignore",
+  }).status === 0;
+
+function sha256(value) {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function gitBlobSha(value) {
+  const bytes = Buffer.isBuffer(value) ? value : Buffer.from(value);
+  return createHash("sha1")
+    .update(`blob ${bytes.byteLength}\0`)
+    .update(bytes)
+    .digest("hex");
+}
+
+function registryMetadata(version) {
+  assert.ok([FROM_VERSION, TARGET_VERSION].includes(version));
+  const currentDependencies = JSON.parse(
+    readFileSync(
+      join(REPOSITORY_ROOT, "scripts", "vercel-cli-runtime", "package.json"),
+      "utf8",
+    ),
+  ).dependencies;
+  const peers = Object.fromEntries(
+    Object.entries(currentDependencies)
+      .filter(([name]) => name !== "vercel")
+      .map(([name, entryVersion]) => [
+        name,
+        name === "@vercel/python" && version === FROM_VERSION
+          ? "6.51.0"
+          : name === "@vercel/python"
+            ? "6.51.1"
+            : entryVersion,
+      ]),
+  );
+  return {
+    bin: { vc: "dist/vc.js", vercel: "dist/vc.js" },
+    dependencies: { ...peers },
+    dist: {
+      integrity:
+        version === TARGET_VERSION
+          ? TARGET_INTEGRITY
+          : activeSourceContract().registryIntegrity,
+      tarball: `https://registry.npmjs.org/vercel/-/vercel-${version}.tgz`,
+    },
+    engines: { node: ">= 18" },
+    name: "vercel",
+    peerDependencies: peers,
+    peerDependenciesMeta: Object.fromEntries(
+      Object.keys(peers).map((name) => [name, { optional: true }]),
+    ),
+    version,
+  };
+}
+
+function activeSourceContract() {
+  return JSON.parse(
+    readFileSync(
+      join(REPOSITORY_ROOT, "scripts", "vercel-cli-runtime", "contract.json"),
+      "utf8",
+    ),
+  );
+}
+
+function sourceMetadata() {
+  return registryMetadata(FROM_VERSION);
+}
+
+function targetMetadata() {
+  return registryMetadata(TARGET_VERSION);
+}
+
+test("registry transition accepts only exact stable same-major builder peers", () => {
+  const currentRuntimeDependencies = JSON.parse(
+    readFileSync(
+      join(REPOSITORY_ROOT, "scripts", "vercel-cli-runtime", "package.json"),
+      "utf8",
+    ),
+  ).dependencies;
+  const metadata = targetMetadata();
+  const result = validateRegistryTransition({
+    currentRuntimeDependencies,
+    fromVersion: FROM_VERSION,
+    sourceMetadata: sourceMetadata(),
+    targetMetadata: metadata,
+    targetVersion: TARGET_VERSION,
+    updateType: "minor",
+  });
+  assert.equal(result.targetIntegrity, TARGET_INTEGRITY);
+  assert.equal(result.targetPeers["@vercel/python"], "6.51.1");
+
+  for (const invalid of [
+    { ...metadata, version: "57.0.0" },
+    {
+      ...metadata,
+      peerDependencies: { ...metadata.peerDependencies, injected: "1.0.0" },
+    },
+    {
+      ...metadata,
+      dependencies: { ...metadata.dependencies, "@vercel/python": "6.51.0" },
+    },
+    {
+      ...metadata,
+      peerDependencies: {
+        ...metadata.peerDependencies,
+        "@vercel/python": "5.99.0",
+      },
+    },
+  ]) {
+    assert.throws(
+      () =>
+        validateRegistryTransition({
+          currentRuntimeDependencies,
+          fromVersion: FROM_VERSION,
+          sourceMetadata: sourceMetadata(),
+          targetMetadata: invalid,
+          targetVersion: TARGET_VERSION,
+          updateType: "minor",
+        }),
+      /Protected runtime sync rejected/,
+    );
+  }
+
+  for (const invalid of [
+    { ...metadata, engines: { node: ">= 20" } },
+    { ...metadata, bin: { vercel: "dist/other.js" } },
+  ]) {
+    assert.throws(
+      () =>
+        validateRegistryTransition({
+          currentRuntimeDependencies,
+          fromVersion: FROM_VERSION,
+          sourceMetadata: sourceMetadata(),
+          targetMetadata: invalid,
+          targetVersion: TARGET_VERSION,
+          updateType: "minor",
+        }),
+      /preserved metadata shape changed|non-builder dependency shape changed/u,
+    );
+  }
+});
+
+test("runtime contract binds exact manifest, dependency, lock, override, and registry bytes", () => {
+  const manifestBytes = Buffer.from("manifest\n");
+  const lockfileBytes = Buffer.from("lock\n");
+  const runtimeDependencies = {
+    "@vercel/python": "6.51.1",
+    vercel: TARGET_VERSION,
+  };
+  const overrides = { "hono@<4.12.34": "4.12.34" };
+  const contract = createRuntimeContract({
+    integrity: TARGET_INTEGRITY,
+    lockfileBytes,
+    manifestBytes,
+    overrides,
+    runtimeDependencies,
+    targetVersion: TARGET_VERSION,
+  });
+  assert.deepEqual(Object.keys(contract), [
+    "lockfileSha256",
+    "manifestSha256",
+    "overridesSha256",
+    "registryIntegrity",
+    "runtimeDependenciesSha256",
+    "schema",
+    "vercelVersion",
+  ]);
+  assert.equal(contract.manifestSha256, sha256(manifestBytes));
+  assert.equal(contract.lockfileSha256, sha256(lockfileBytes));
+  assert.equal(contract.registryIntegrity, TARGET_INTEGRITY);
+  assert.equal(contract.vercelVersion, TARGET_VERSION);
+});
+
+test("repair patches use bounded U1 context", () => {
+  const root = mkdtempSync(join(tmpdir(), "protected-runtime-patch-"));
+  try {
+    const patch = createUnifiedPatch({
+      newBytes: Buffer.from("one\ntarget\nthree\n"),
+      oldBytes: Buffer.from("one\nsource\nthree\n"),
+      path: "package.json",
+      temporaryRoot: root,
+    });
+    assert.match(patch, /^--- a\/package\.json\n\+\+\+ b\/package\.json\n@@/u);
+    assert.match(patch, /@@ -1,3 \+1,3 @@/u);
+    assert.ok(Buffer.byteLength(patch) <= 8_192);
+  } finally {
+    rmSync(root, { force: true, recursive: true });
+  }
+});
+
+test(
+  "PR #753 historical package rotation exactly restores H1 bytes",
+  { skip: !HAS_PR_753_OBJECTS },
+  () => {
+    const historicalH2 = gitShow(PR_753_REPAIRED_HEAD, "package.json");
+    const historicalH1 = gitShow(PR_753_SEED, "package.json");
+    assert.deepEqual(
+      rotateRootPackageBytes(historicalH2, TARGET_VERSION),
+      historicalH1,
+    );
+    assert.equal(sha256(historicalH1), PR_753_TARGET_ROOT_PACKAGE_SHA256);
+  },
+);
+
+test(
+  "PR #753 surgical root-lock rotation changes only the authenticated Vercel regions",
+  { skip: !HAS_PR_753_OBJECTS },
+  () => {
+    const source = sourceMetadata();
+    const target = targetMetadata();
+    const rotated = rotateRootLockBytes({
+      bin: target.bin,
+      currentVersion: FROM_VERSION,
+      engines: target.engines,
+      lockfileBytes: gitShow(PR_753_REPAIRED_HEAD, "pnpm-lock.yaml"),
+      sourceIntegrity: source.dist.integrity,
+      sourcePeers: source.peerDependencies,
+      sourceVersion: FROM_VERSION,
+      targetIntegrity: target.dist.integrity,
+      targetPeers: target.peerDependencies,
+      targetVersion: TARGET_VERSION,
+    });
+    assert.deepEqual(rotated, gitShow(PR_753_SEED, "pnpm-lock.yaml"));
+    assert.equal(
+      rotateRootLockBytes({
+        bin: target.bin,
+        currentVersion: TARGET_VERSION,
+        engines: target.engines,
+        lockfileBytes: rotated,
+        sourceIntegrity: source.dist.integrity,
+        sourcePeers: source.peerDependencies,
+        sourceVersion: FROM_VERSION,
+        targetIntegrity: target.dist.integrity,
+        targetPeers: target.peerDependencies,
+        targetVersion: TARGET_VERSION,
+      }),
+      rotated,
+    );
+  },
+);
+
+test("root package rotation preserves unrelated current-base scripts byte-for-byte", () => {
+  const currentBytes = readFileSync(join(REPOSITORY_ROOT, "package.json"));
+  const current = JSON.parse(currentBytes.toString("utf8"));
+  const rotated = JSON.parse(
+    rotateRootPackageBytes(currentBytes, TARGET_VERSION).toString("utf8"),
+  );
+  assert.equal(rotated.devDependencies.vercel, TARGET_VERSION);
+  assert.equal(
+    rotated.scripts["dependabot:process:test"],
+    current.scripts["dependabot:process:test"],
+  );
+  rotated.devDependencies.vercel = current.devDependencies.vercel;
+  assert.deepEqual(rotated, current);
+});
+
+function gitShow(commit, path) {
+  return execFileSync("git", ["show", `${commit}:${path}`], {
+    cwd: REPOSITORY_ROOT,
+    encoding: null,
+    maxBuffer: 4 * 1024 * 1024,
+  });
+}
+
+function pr753Fixture() {
+  const root = mkdtempSync(join(tmpdir(), "protected-runtime-pr753-"));
+  const evidenceRoot = join(root, "evidence");
+  mkdirSync(evidenceRoot, { mode: 0o700 });
+  const bytesByPath = new Map();
+  for (const path of PROTECTED_RUNTIME_SYNC_INPUT_PATHS) {
+    const bytes =
+      path === "scripts/vercel-cli-runtime/contract.json"
+        ? readFileSync(join(REPOSITORY_ROOT, path))
+        : gitShow(PR_753_REPAIRED_HEAD, path);
+    bytesByPath.set(path, bytes);
+  }
+  const refreshedRootPackage = JSON.parse(
+    bytesByPath.get("package.json").toString("utf8"),
+  );
+  const currentRootPackage = JSON.parse(
+    readFileSync(join(REPOSITORY_ROOT, "package.json"), "utf8"),
+  );
+  refreshedRootPackage.scripts["dependabot:process:test"] =
+    currentRootPackage.scripts["dependabot:process:test"];
+  bytesByPath.set(
+    "package.json",
+    Buffer.from(`${JSON.stringify(refreshedRootPackage, null, 2)}\n`),
+  );
+  const expectedBlobs = PROTECTED_RUNTIME_SYNC_INPUT_PATHS.map((path) => ({
+    mode: "100644",
+    path,
+    sha: gitBlobSha(bytesByPath.get(path)),
+    type: "blob",
+  }));
+  const packet = {
+    attemptLimit: 2,
+    attemptNumber: 2,
+    automatic: true,
+    baseRef: "main",
+    baseSha: "b".repeat(40),
+    changedPaths: ["package.json", "pnpm-lock.yaml"],
+    dependencyGroup: "tooling",
+    dependencyNames: ["knip", "vercel", "@next/eslint-plugin-next"],
+    escalation: "manual-review",
+    expectedBlobs,
+    failures: [],
+    feedbackThreads: [],
+    findings: [],
+    forbiddenPaths: [
+      ".github/**",
+      "**/auth/**",
+      "**/deploy/**",
+      "**/deployment/**",
+      "**/policy/**",
+      "**/security/**",
+      "docs/vercel-deployments.md",
+      "scripts/vercel-main-*.mjs",
+    ],
+    headRef: "dependabot/npm_and_yarn/tooling-123",
+    headSha: PR_753_REPAIRED_HEAD,
+    limits: {
+      maxAddedLines: 600,
+      maxBytes: 64 * 1024,
+      maxChanges: 160,
+      maxDeletedLines: 600,
+      maxFiles: 5,
+    },
+    mode: "prepare",
+    operation: {
+      dependency: "vercel",
+      fromVersion: FROM_VERSION,
+      inputPaths: PROTECTED_RUNTIME_SYNC_INPUT_PATHS,
+      kind: "vercel-cli-runtime-sync",
+      pnpmVersion: "10.34.4",
+      requiredPaths: PROTECTED_RUNTIME_SYNC_REQUIRED_PATHS,
+      schema: "dependabot-protected-runtime-sync:v1",
+      sourceSeedHeadSha: PR_753_IMMUTABLE_SOURCE,
+      targetVersion: TARGET_VERSION,
+      updateType: "minor",
+    },
+    packageEcosystem: "npm",
+    permittedPaths: PROTECTED_RUNTIME_SYNC_REQUIRED_PATHS,
+    preparable: true,
+    pullRequestNumber: 753,
+    repository: "mento-protocol/frontend-monorepo",
+    requiredGateIds: ["build-and-test"],
+    requireExactHead: true,
+    requireHumanApproval: false,
+    riskTier: "manual-review",
+    schema: "dependabot-repair-packet:v3",
+    updateType: "minor",
+    validationCommands: ["pnpm dependabot:process:test"],
+    workflowRunAttempt: 1,
+    workflowRunId: 753,
+    workflowSha: "c".repeat(40),
+  };
+  const packetText = canonicalJson(packet);
+  const packetDigest = sha256(packetText);
+  const files = [];
+  for (const [index, expected] of expectedBlobs.entries()) {
+    const name = `blob-${String(index).padStart(3, "0")}.txt`;
+    const bytes = bytesByPath.get(expected.path);
+    const filePath = join(evidenceRoot, name);
+    writeFileSync(filePath, bytes, { mode: 0o400 });
+    chmodSync(filePath, 0o400);
+    files.push({
+      bytes: bytes.byteLength,
+      digest: sha256(bytes),
+      kind: "git-blob",
+      mediaType: "text/plain",
+      name,
+      source: {
+        gitBlobSha: expected.sha,
+        mode: expected.mode,
+        path: expected.path,
+        treeSha: "d".repeat(40),
+      },
+    });
+  }
+  const manifest = {
+    baseSha: packet.baseSha,
+    evidenceRoot,
+    files,
+    headSha: packet.headSha,
+    packetDigest,
+    processorCheckId: 753,
+    pullRequestNumber: packet.pullRequestNumber,
+    repository: packet.repository,
+    schema: "dependabot-repair-evidence:v1",
+    workflowRunAttempt: packet.workflowRunAttempt,
+    workflowRunId: packet.workflowRunId,
+    workflowSha: packet.workflowSha,
+  };
+  const manifestPath = join(evidenceRoot, "manifest.json");
+  writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, {
+    mode: 0o400,
+  });
+  chmodSync(manifestPath, 0o400);
+  return {
+    cleanup: () => rmSync(root, { force: true, recursive: true }),
+    evidenceManifestPath: manifestPath,
+    packetBase64: Buffer.from(packetText).toString("base64"),
+  };
+}
+
+test("terminal CLI smoke rejects validated-plan and content drift", () => {
+  const fixture = pr753Fixture();
+  try {
+    const packetText = Buffer.from(fixture.packetBase64, "base64").toString(
+      "utf8",
+    );
+    const packet = JSON.parse(packetText);
+    const generatedContent = Buffer.from("generated target bytes\n");
+    const expectedBlobSha = packet.expectedBlobs.find(
+      ({ path }) => path === "package.json",
+    ).sha;
+    const plan = {
+      attempt: packet.attemptNumber,
+      baseSha: packet.baseSha,
+      edits: [
+        {
+          expectedBlobSha,
+          patch: "exact generated patch",
+          path: "package.json",
+        },
+      ],
+      packetDigest: sha256(packetText),
+      parentHeadSha: packet.headSha,
+      processorCheckId: 753,
+      pullRequestNumber: packet.pullRequestNumber,
+      repository: packet.repository,
+      schema: "dependabot-repair-plan:v1",
+      summary: "Bind the terminal smoke to one validated plan.",
+    };
+    const validated = {
+      ...plan,
+      edits: plan.edits.map((edit) => ({
+        contentDigest: sha256(generatedContent),
+        expectedBlobSha: edit.expectedBlobSha,
+        mode: "100644",
+        patch: edit.patch,
+        path: edit.path,
+        type: "blob",
+      })),
+      schema: "dependabot-validated-repair-plan:v1",
+    };
+    const assertBound = (candidate) => {
+      const canonical = canonicalJson(candidate);
+      return assertValidatedPlanMatchesRegeneration({
+        generated: new Map([["package.json", generatedContent]]),
+        packetBase64: fixture.packetBase64,
+        processorCheckId: 753,
+        regeneratedPlan: plan,
+        validatedPlanBase64: Buffer.from(canonical).toString("base64"),
+        validatedPlanDigest: sha256(canonical),
+      });
+    };
+    assert.equal(assertBound(validated).schema, validated.schema);
+    assert.throws(
+      () =>
+        assertBound({
+          ...validated,
+          edits: [{ ...validated.edits[0], patch: "registry drift" }],
+        }),
+      /not the exact terminal-smoke regeneration/u,
+    );
+    assert.throws(
+      () =>
+        assertBound({
+          ...validated,
+          edits: [{ ...validated.edits[0], contentDigest: "0".repeat(64) }],
+        }),
+      /content digest changed before smoke/u,
+    );
+  } finally {
+    fixture.cleanup();
+  }
+});
+
+test(
+  "PR #753 regenerates exact authenticated seed root bytes and all five protected files",
+  {
+    skip:
+      // eslint-disable-next-line turbo/no-undeclared-env-vars -- This explicit opt-in keeps the networked exact-pnpm fixture out of default unit runs.
+      process.env.PROTECTED_RUNTIME_SYNC_INTEGRATION !== "1" ||
+      !HAS_PR_753_OBJECTS,
+  },
+  () => {
+    const fixture = pr753Fixture();
+    const outputRoot = mkdtempSync(
+      join(tmpdir(), "protected-runtime-pr753-output-"),
+    );
+    try {
+      const plan = generateProtectedRuntimeRepairPlan({
+        evidenceManifestPath: fixture.evidenceManifestPath,
+        fetchMetadata: registryMetadata,
+        packetBase64: fixture.packetBase64,
+        processorCheckId: 753,
+      });
+      assert.deepEqual(
+        plan.edits.map(({ path }) => path),
+        PROTECTED_RUNTIME_SYNC_REQUIRED_PATHS,
+      );
+      for (const edit of plan.edits) {
+        const destination = join(outputRoot, edit.path);
+        mkdirSync(dirname(destination), { recursive: true });
+        const source =
+          edit.path === "scripts/vercel-cli-runtime/contract.json"
+            ? readFileSync(join(REPOSITORY_ROOT, edit.path))
+            : edit.path === "package.json"
+              ? (() => {
+                  const historical = JSON.parse(
+                    gitShow(PR_753_REPAIRED_HEAD, edit.path).toString("utf8"),
+                  );
+                  const current = JSON.parse(
+                    readFileSync(join(REPOSITORY_ROOT, edit.path), "utf8"),
+                  );
+                  historical.scripts["dependabot:process:test"] =
+                    current.scripts["dependabot:process:test"];
+                  return Buffer.from(
+                    `${JSON.stringify(historical, null, 2)}\n`,
+                  );
+                })()
+              : gitShow(PR_753_REPAIRED_HEAD, edit.path);
+        writeFileSync(destination, source);
+        const applied = spawnSync("/usr/bin/patch", ["-p1"], {
+          cwd: outputRoot,
+          encoding: "utf8",
+          input: edit.patch,
+          stdio: ["pipe", "pipe", "pipe"],
+        });
+        assert.equal(applied.status, 0, applied.stderr);
+      }
+      const targetRootPackage = readFileSync(join(outputRoot, "package.json"));
+      const targetRootLock = readFileSync(join(outputRoot, "pnpm-lock.yaml"));
+      const expectedRefreshedPackage = JSON.parse(
+        gitShow(PR_753_REPAIRED_HEAD, "package.json").toString("utf8"),
+      );
+      const currentBasePackage = JSON.parse(
+        readFileSync(join(REPOSITORY_ROOT, "package.json"), "utf8"),
+      );
+      expectedRefreshedPackage.scripts["dependabot:process:test"] =
+        currentBasePackage.scripts["dependabot:process:test"];
+      const expectedCurrentBasePackage = rotateRootPackageBytes(
+        Buffer.from(`${JSON.stringify(expectedRefreshedPackage, null, 2)}\n`),
+        TARGET_VERSION,
+      );
+      assert.deepEqual(targetRootPackage, expectedCurrentBasePackage);
+      assert.equal(
+        JSON.parse(targetRootPackage.toString("utf8")).devDependencies.knip,
+        "^6.32.0",
+      );
+      assert.match(
+        targetRootLock.toString("utf8"),
+        new RegExp(
+          `\\n  vercel@${TARGET_VERSION.replaceAll(".", "\\.")}:\\n    resolution: \\{integrity: ${TARGET_INTEGRITY.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&")}\\}`,
+          "u",
+        ),
+      );
+      assert.match(
+        gitShow(
+          PR_753_REPAIRED_HEAD,
+          "packages/eslint-config/package.json",
+        ).toString("utf8"),
+        /"@next\/eslint-plugin-next": "\^16\.3\.0"/u,
+      );
+      assert.equal(
+        sha256(
+          readFileSync(
+            join(outputRoot, "scripts", "vercel-cli-runtime", "package.json"),
+          ),
+        ),
+        PR_753_TARGET_RUNTIME_PACKAGE_SHA256,
+      );
+      assert.equal(
+        sha256(
+          readFileSync(
+            join(outputRoot, "scripts", "vercel-cli-runtime", "pnpm-lock.yaml"),
+          ),
+        ),
+        PR_753_TARGET_RUNTIME_LOCK_SHA256,
+      );
+    } finally {
+      fixture.cleanup();
+      rmSync(outputRoot, { force: true, recursive: true });
+    }
+  },
+);

--- a/scripts/dependabot-workflows.test.mjs
+++ b/scripts/dependabot-workflows.test.mjs
@@ -185,6 +185,36 @@ test("npm group routing isolates sensitive dependencies and covers the workspace
   );
   const enumeratedGroups = ["frontend-core", "web3-stack", "ui-styling"];
   const productionMisc = npmConfig.groups["production-misc"];
+  assert.deepEqual(npmConfig.groups["vercel-cli"], {
+    "applies-to": "version-updates",
+    patterns: ["vercel"],
+    "update-types": ["minor", "patch"],
+  });
+  assert.deepEqual(npmConfig.groups["vercel-cli-security"], {
+    "applies-to": "security-updates",
+    patterns: ["vercel"],
+  });
+  assert.ok(
+    npmConfig.groups.tooling["exclude-patterns"].includes("vercel"),
+    "the broad development group must not absorb Vercel CLI rotations",
+  );
+  assert.ok(
+    npmConfig.groups["security-tooling"]["exclude-patterns"].includes("vercel"),
+    "the broad security group must not absorb Vercel CLI security rotations",
+  );
+  for (const dependencyType of ["production", "development"]) {
+    for (const updateType of ["minor", "patch"]) {
+      assert.equal(
+        firstDependabotGroup(
+          npmConfig.groups,
+          "vercel",
+          dependencyType,
+          updateType,
+        ),
+        "vercel-cli",
+      );
+    }
+  }
   assert.deepEqual(productionMisc.patterns, ["*"]);
   assert.deepEqual(npmConfig.cooldown, {
     "default-days": 7,
@@ -294,7 +324,7 @@ test("embedded workflow JavaScript parses before GitHub executes it", () => {
     [processorPath, 3],
     [dependabotReviewPath, 6],
     [preparedIntakePath, 1],
-    [repairPath, 2],
+    [repairPath, 3],
   ]);
   for (const [path, expectedCount] of expectedModuleCounts) {
     const modules = [
@@ -1353,6 +1383,7 @@ test("repair planning, validation, mutation, and receipt publication stay isolat
   const preflight = repair.jobs.preflight;
   const plan = repair.jobs.plan;
   const validate = repair.jobs.validate;
+  const candidateCliSmoke = repair.jobs.candidate_cli_smoke;
   const stage = repair.jobs.stage;
   const intent = repair.jobs.intent;
   const mutate = repair.jobs.mutate;
@@ -1367,6 +1398,7 @@ test("repair planning, validation, mutation, and receipt publication stay isolat
   assert.deepEqual(preflight.permissions, readPermissions);
   assert.deepEqual(plan.permissions, readPermissions);
   assert.deepEqual(validate.permissions, readPermissions);
+  assert.deepEqual(candidateCliSmoke.permissions, readPermissions);
   assert.deepEqual(stage.permissions, readPermissions);
   assert.deepEqual(mutate.permissions, readPermissions);
   assert.deepEqual(intent.permissions, {
@@ -1397,10 +1429,18 @@ test("repair planning, validation, mutation, and receipt publication stay isolat
   assert.match(envelope.run, /processorReceipt/);
   assert.match(envelope.run, /retryCount/);
 
-  const checkout = plan.steps[0];
-  const evidence = plan.steps[1];
-  const planner = plan.steps[2];
-  const evidenceCompletion = plan.steps[3];
+  const checkout = plan.steps.find(
+    (step) => step.name === "Check out only the exact trusted workflow source",
+  );
+  const evidence = plan.steps.find(
+    (step) => step.name === "Materialize exact packet-bound repair evidence",
+  );
+  const planner = plan.steps.find(
+    (step) => step.name === "Plan the exact packet-bound repair",
+  );
+  const evidenceCompletion = plan.steps.find(
+    (step) => step.name === "Require a completed exact evidence read",
+  );
   assert.equal(plan.name, "Produce a bounded sealed-evidence repair plan");
   assert.deepEqual(checkout.with, {
     "fetch-depth": 1,
@@ -1426,6 +1466,10 @@ test("repair planning, validation, mutation, and receipt publication stay isolat
   assert.match(evidence.run, /--github-output "\$GITHUB_OUTPUT"/);
 
   assert.equal(planner.uses, claudeBaseAction);
+  assert.equal(
+    planner.if,
+    "needs.preflight.outputs.plan_kind == 'claude-repair'",
+  );
   assert.equal(Object.hasOwn(planner.with, "github_token"), false);
   assert.equal(Object.hasOwn(planner.with, "allowed_bots"), false);
   assert.equal(Object.hasOwn(planner.with, "additional_permissions"), false);
@@ -1557,6 +1601,86 @@ test("repair planning, validation, mutation, and receipt publication stay isolat
     evidenceCompletion.run,
     /dependabot-repair-evidence-tool-guard\.mjs --verify-completion/,
   );
+  assert.equal(
+    evidenceCompletion.if,
+    "needs.preflight.outputs.plan_kind == 'claude-repair'",
+  );
+
+  assert.equal(
+    preflight.outputs.plan_kind,
+    "${{ steps.packet.outputs.plan_kind }}",
+  );
+  assert.equal(
+    plan.outputs.structured_output,
+    "${{ steps.plan-output.outputs.structured_output }}",
+  );
+  const modelFreePnpm = plan.steps.find(
+    (step) => step.name === "Install the exact model-free planner pnpm",
+  );
+  const modelFreePnpmProof = plan.steps.find(
+    (step) =>
+      step.name === "Prove the exact model-free planner pnpm and registry",
+  );
+  const firstModelFreePlan = plan.steps.find(
+    (step) => step.name === "Generate the protected-runtime sync plan once",
+  );
+  const secondModelFreePlan = plan.steps.find(
+    (step) => step.name === "Generate the protected-runtime sync plan again",
+  );
+  const planOutput = plan.steps.find(
+    (step) => step.name === "Select exactly one typed repair plan",
+  );
+  assert.equal(
+    modelFreePnpm.if,
+    "needs.preflight.outputs.plan_kind == 'protected-runtime-sync'",
+  );
+  assert.equal(
+    modelFreePnpm.uses,
+    "pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86",
+  );
+  assert.deepEqual(modelFreePnpm.with, {
+    standalone: true,
+    version: "10.34.4",
+  });
+  assert.deepEqual(modelFreePnpm.env, {
+    NPM_CONFIG_REGISTRY: "https://registry.npmjs.org/",
+  });
+  assert.match(modelFreePnpmProof.run, /pnpm --version.*10\.34\.4/s);
+  assert.match(
+    modelFreePnpmProof.run,
+    /pnpm config get registry.*https:\/\/registry\.npmjs\.org\//s,
+  );
+  for (const generator of [firstModelFreePlan, secondModelFreePlan]) {
+    assert.equal(
+      generator.if,
+      "needs.preflight.outputs.plan_kind == 'protected-runtime-sync'",
+    );
+    assert.deepEqual(Object.keys(generator.env).sort(), [
+      "EVIDENCE_MANIFEST",
+      "NPM_CONFIG_REGISTRY",
+      "PACKET_BASE64",
+      "PROCESSOR_CHECK_ID",
+    ]);
+    assert.equal(
+      generator.env.NPM_CONFIG_REGISTRY,
+      "https://registry.npmjs.org/",
+    );
+    assert.match(
+      generator.run,
+      /dependabot-protected-runtime-sync\.mjs generate-plan[\s\S]*--packet-base64[\s\S]*--evidence-manifest[\s\S]*--processor-check-id[\s\S]*--github-output/,
+    );
+    assert.doesNotMatch(
+      JSON.stringify(generator),
+      /CLAUDE|secrets\.|github\.token|GH_TOKEN|PREPARE_APP|VERCEL_TOKEN|write/,
+    );
+  }
+  assert.match(planOutput.run, /first\.length === 0 \|\| first !== second/);
+  assert.match(planOutput.run, /claude\.length !== 0/);
+  assert.match(planOutput.run, /Unknown repair plan kind/);
+  assert.doesNotMatch(
+    JSON.stringify(planOutput),
+    /secrets\.|github\.token|GH_TOKEN|PREPARE_APP|VERCEL_TOKEN/,
+  );
 
   assert.doesNotMatch(
     JSON.stringify(validate),
@@ -1566,6 +1690,105 @@ test("repair planning, validation, mutation, and receipt publication stay isolat
     validate.steps.at(-1).run,
     /validate-repair-plan[\s\S]*--packet-base64[\s\S]*--plan-json/,
   );
+  const validateCheckout = validate.steps.find(
+    (step) => step.name === "Check out only the exact trusted workflow source",
+  );
+  assert.deepEqual(validateCheckout.with, {
+    "fetch-depth": 1,
+    "persist-credentials": false,
+    ref: "${{ github.workflow_sha }}",
+  });
+  const verificationEvidence = validate.steps.find(
+    (step) =>
+      step.name === "Materialize exact packet-bound verification evidence",
+  );
+  const modelFreeVerify = validate.steps.find(
+    (step) =>
+      step.name === "Independently verify the protected-runtime sync plan",
+  );
+  assert.equal(
+    verificationEvidence.if,
+    "needs.preflight.outputs.plan_kind == 'protected-runtime-sync'",
+  );
+  assert.equal(verificationEvidence.env.GH_TOKEN, "${{ github.token }}");
+  assert.match(
+    verificationEvidence.run,
+    /materialize-repair-evidence[\s\S]*--packet-digest[\s\S]*--processor-check-id/,
+  );
+  assert.equal(
+    modelFreeVerify.if,
+    "needs.preflight.outputs.plan_kind == 'protected-runtime-sync'",
+  );
+  assert.match(
+    modelFreeVerify.run,
+    /dependabot-protected-runtime-sync\.mjs verify-plan[\s\S]*--packet-base64[\s\S]*--evidence-manifest[\s\S]*--processor-check-id[\s\S]*--plan-json/,
+  );
+  assert.doesNotMatch(
+    JSON.stringify(modelFreeVerify),
+    /CLAUDE|secrets\.|github\.token|GH_TOKEN|PREPARE_APP|VERCEL_TOKEN|write/,
+  );
+  assert.doesNotMatch(
+    modelFreeVerify.run,
+    /candidate-cli-smoke|--frozen-lockfile|node_modules\/vercel/,
+  );
+
+  assert.deepEqual(candidateCliSmoke.needs, ["preflight", "plan", "validate"]);
+  assert.match(candidateCliSmoke.if, /plan_kind == 'protected-runtime-sync'/);
+  assert.match(candidateCliSmoke.if, /needs\.validate\.result == 'success'/);
+  assert.equal(Object.hasOwn(candidateCliSmoke, "outputs"), false);
+  const smokeCheckout = candidateCliSmoke.steps[0];
+  assert.equal(
+    smokeCheckout.name,
+    "Check out only the exact trusted workflow source",
+  );
+  assert.deepEqual(smokeCheckout.with, {
+    "fetch-depth": 1,
+    "persist-credentials": false,
+    ref: "${{ github.workflow_sha }}",
+  });
+  const smokeEvidence = candidateCliSmoke.steps.find(
+    (step) =>
+      step.name === "Materialize exact packet-bound terminal-smoke evidence",
+  );
+  assert.equal(smokeEvidence.env.GH_TOKEN, "${{ github.token }}");
+  assert.match(smokeEvidence.run, /materialize-repair-evidence/);
+  const terminalSmoke = candidateCliSmoke.steps.at(-1);
+  assert.equal(
+    terminalSmoke.name,
+    "Execute the generated candidate CLI as a terminal smoke",
+  );
+  assert.deepEqual(Object.keys(terminalSmoke.env).sort(), [
+    "EVIDENCE_MANIFEST",
+    "NPM_CONFIG_REGISTRY",
+    "PACKET_BASE64",
+    "PROCESSOR_CHECK_ID",
+    "VALIDATED_PLAN_BASE64",
+    "VALIDATED_PLAN_DIGEST",
+  ]);
+  assert.equal(
+    terminalSmoke.env.VALIDATED_PLAN_BASE64,
+    "${{ needs.validate.outputs.validated_plan_base64 }}",
+  );
+  assert.equal(
+    terminalSmoke.env.VALIDATED_PLAN_DIGEST,
+    "${{ needs.validate.outputs.validated_plan_digest }}",
+  );
+  assert.match(
+    terminalSmoke.run,
+    /dependabot-protected-runtime-sync\.mjs candidate-cli-smoke[\s\S]*--packet-base64[\s\S]*--evidence-manifest[\s\S]*--processor-check-id[\s\S]*--validated-plan-base64[\s\S]*--validated-plan-digest/,
+  );
+  assert.doesNotMatch(
+    JSON.stringify(terminalSmoke),
+    /GITHUB_OUTPUT|GH_TOKEN|github\.token|secrets\.|PREPARE_APP|VERCEL_TOKEN|DEPLOYMENT|PACKAGE/,
+  );
+  assert.deepEqual(stage.needs, [
+    "preflight",
+    "validate",
+    "candidate_cli_smoke",
+  ]);
+  assert.match(stage.if, /^always\(\)/);
+  assert.match(stage.if, /candidate_cli_smoke\.result == 'success'/);
+  assert.match(stage.if, /candidate_cli_smoke\.result == 'skipped'/);
 
   for (const appJob of [stage, mutate]) {
     const repairToken = appJob.steps.find(
@@ -1863,6 +2086,18 @@ test("Dependabot Claude review follows only authenticated intake runs", () => {
   assert.match(
     preparedValidator.run,
     /contents\/scripts\/dependabot-prepared-review\.mjs\?ref=\$WORKFLOW_SHA/,
+  );
+  assert.match(
+    preparedValidator.run,
+    /trusted_receipts="\$trusted_root\/dependabot-preparation-receipts\.mjs"/,
+  );
+  assert.match(
+    preparedValidator.run,
+    /contents\/scripts\/dependabot-preparation-receipts\.mjs\?ref=\$WORKFLOW_SHA/,
+  );
+  assert.match(
+    preparedValidator.run,
+    /test -s "\$trusted_receipts"[\s\S]*chmod 0500 "\$trusted_validator" "\$trusted_receipts"/,
   );
   assert.equal(
     preparedLineage.if,

--- a/scripts/vercel-cli-runtime-contract.mjs
+++ b/scripts/vercel-cli-runtime-contract.mjs
@@ -1,40 +1,31 @@
 import { createHash } from "node:crypto";
-import { readFileSync } from "node:fs";
+import { lstatSync, readFileSync, realpathSync } from "node:fs";
+import { dirname, relative, resolve, sep } from "node:path";
+import { fileURLToPath } from "node:url";
 import { isDeepStrictEqual } from "node:util";
 
-export const PINNED_VERCEL_CLI_VERSION = "56.4.1";
-const PINNED_VERCEL_CLI_RUNTIME_DEPENDENCIES = Object.freeze({
-  "@vercel/backends": "0.8.25",
-  "@vercel/container": "0.0.5",
-  "@vercel/elysia": "0.1.102",
-  "@vercel/express": "0.1.116",
-  "@vercel/fastify": "0.1.105",
-  "@vercel/go": "3.10.2",
-  "@vercel/h3": "0.1.111",
-  "@vercel/hono": "0.2.105",
-  "@vercel/hydrogen": "1.4.0",
-  "@vercel/koa": "0.1.85",
-  "@vercel/nestjs": "0.2.106",
-  "@vercel/next": "4.20.4",
-  "@vercel/node": "5.8.26",
-  "@vercel/python": "6.51.0",
-  "@vercel/redwood": "2.5.0",
-  "@vercel/remix-builder": "5.9.1",
-  "@vercel/ruby": "2.5.1",
-  "@vercel/rust": "1.4.0",
-  "@vercel/static-build": "2.11.8",
-  vercel: PINNED_VERCEL_CLI_VERSION,
-});
-// This reviewed pair binds the current August 2026 security-floor runtime. It
-// raises the brace-expansion, DOMPurify, fast-uri, Hono, ip-address, js-yaml,
-// nanoid, PostCSS, socket.io-parser, Undici, and uuid floors and retires the
-// local brace-expansion@2.1.2 patch in favor of upstream 2.1.4. It includes the
-// override moving Next to ^16.2.12 alongside the catalog (PR #715) and the
-// nanoid 3.3.18 floor.
-const PINNED_VERCEL_CLI_RUNTIME_LOCKFILE_SHA256 =
-  "2dbd0eba57b119870bcd2ba43f6cf726bb52c85d8ec03f4999030e9931e5ed36";
-const PINNED_VERCEL_CLI_RUNTIME_OVERRIDE_SHA256 =
-  "11fc5e7476b6d15ddf6bf8d6956f6566346637f34e0b11e23849e92011b2bf31";
+const CONTRACT_SCHEMA = "vercel-cli-runtime-contract:v1";
+const CONTRACT_KEYS = Object.freeze([
+  "lockfileSha256",
+  "manifestSha256",
+  "overridesSha256",
+  "registryIntegrity",
+  "runtimeDependenciesSha256",
+  "schema",
+  "vercelVersion",
+]);
+const DEFAULT_CONTRACT_PATH = new URL(
+  "./vercel-cli-runtime/contract.json",
+  import.meta.url,
+);
+const HEX_DIGEST = /^[0-9a-f]{64}$/u;
+const STABLE_SEMVER =
+  /^(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)$/u;
+const REGISTRY_INTEGRITY = /^sha512-[A-Za-z0-9+/]{86}==$/u;
+const MAX_CONTRACT_BYTES = 64 * 1024;
+const MAX_ROOT_MANIFEST_BYTES = 1024 * 1024;
+const MAX_RUNTIME_MANIFEST_BYTES = 256 * 1024;
+const MAX_RUNTIME_LOCKFILE_BYTES = 8 * 1024 * 1024;
 
 function hasExactObjectKeys(value, expectedKeys) {
   if (value === null || typeof value !== "object" || Array.isArray(value)) {
@@ -49,57 +40,294 @@ function hasExactObjectKeys(value, expectedKeys) {
   );
 }
 
-function canonicalOverrideSha256(overrides) {
+function sha256(value) {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function canonicalStringMapSha256(value, label) {
   if (
-    overrides === null ||
-    typeof overrides !== "object" ||
-    Array.isArray(overrides) ||
-    Object.entries(overrides).some(
-      ([name, value]) =>
+    value === null ||
+    typeof value !== "object" ||
+    Array.isArray(value) ||
+    Object.entries(value).some(
+      ([name, entry]) =>
         typeof name !== "string" ||
         name.length === 0 ||
-        typeof value !== "string" ||
-        value.length === 0,
+        typeof entry !== "string" ||
+        entry.length === 0,
     )
   ) {
-    throw new Error("Trusted root Vercel CLI overrides are invalid");
+    throw new Error(`${label} is invalid`);
   }
   const canonical = Object.fromEntries(
-    Object.entries(overrides).toSorted(([left], [right]) =>
+    Object.entries(value).toSorted(([left], [right]) =>
       left.localeCompare(right),
     ),
   );
-  return createHash("sha256").update(JSON.stringify(canonical)).digest("hex");
+  return sha256(JSON.stringify(canonical));
 }
+
+function filesystemPath(value) {
+  return value instanceof URL ? fileURLToPath(value) : value;
+}
+
+function readBoundedRegularFile(filePath, { label, maximumBytes, rootPath }) {
+  try {
+    const resolvedPath = resolve(filesystemPath(filePath));
+    const entry = lstatSync(resolvedPath);
+    if (
+      !entry.isFile() ||
+      entry.isSymbolicLink() ||
+      entry.size < 1 ||
+      entry.size > maximumBytes
+    ) {
+      throw new Error("unsafe file");
+    }
+    if (rootPath !== undefined) {
+      const requestedRoot = resolve(filesystemPath(rootPath));
+      const rootEntry = lstatSync(requestedRoot);
+      if (!rootEntry.isDirectory() || rootEntry.isSymbolicLink()) {
+        throw new Error("unsafe root");
+      }
+      const requestedRelative = relative(requestedRoot, resolvedPath);
+      if (
+        requestedRelative === ".." ||
+        requestedRelative.startsWith(`..${sep}`) ||
+        requestedRelative.length === 0
+      ) {
+        throw new Error("escaped root");
+      }
+      const resolvedRoot = realpathSync(requestedRoot);
+      const canonicalPath = realpathSync(resolvedPath);
+      const fromRoot = relative(resolvedRoot, canonicalPath);
+      if (
+        canonicalPath !== resolve(resolvedRoot, requestedRelative) ||
+        fromRoot === ".." ||
+        fromRoot.startsWith(`..${sep}`) ||
+        fromRoot.length === 0
+      ) {
+        throw new Error("escaped root");
+      }
+    }
+    const contents = readFileSync(resolvedPath);
+    if (contents.byteLength !== entry.size) throw new Error("file changed");
+    return contents;
+  } catch {
+    throw new Error(`${label} is unreadable or unsafe`);
+  }
+}
+
+function readContract(contractPath = DEFAULT_CONTRACT_PATH, rootPath) {
+  let contract;
+  try {
+    contract = JSON.parse(
+      readBoundedRegularFile(contractPath, {
+        label: "Trusted Vercel CLI runtime contract",
+        maximumBytes: MAX_CONTRACT_BYTES,
+        rootPath,
+      }).toString("utf8"),
+    );
+  } catch {
+    throw new Error("Trusted Vercel CLI runtime contract is unreadable");
+  }
+  if (
+    !hasExactObjectKeys(contract, CONTRACT_KEYS) ||
+    contract.schema !== CONTRACT_SCHEMA ||
+    !STABLE_SEMVER.test(contract.vercelVersion ?? "") ||
+    !HEX_DIGEST.test(contract.manifestSha256 ?? "") ||
+    !HEX_DIGEST.test(contract.runtimeDependenciesSha256 ?? "") ||
+    !HEX_DIGEST.test(contract.lockfileSha256 ?? "") ||
+    !HEX_DIGEST.test(contract.overridesSha256 ?? "") ||
+    !REGISTRY_INTEGRITY.test(contract.registryIntegrity ?? "")
+  ) {
+    throw new Error("Trusted Vercel CLI runtime contract is invalid");
+  }
+  return Object.freeze(contract);
+}
+
+function escapeRegex(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
+}
+
+function yamlDependencyKey(name) {
+  return name.startsWith("@") ? `'${name}'` : name;
+}
+
+function yamlResolutionKey(name, resolution) {
+  const value = `${name}@${resolution}`;
+  return name.startsWith("@") ? `'${value}'` : value;
+}
+
+function exactIndentedBlock(text, header, label) {
+  const needle = `${header}\n`;
+  const starts = [];
+  let cursor = 0;
+  while (cursor < text.length) {
+    const offset = text.indexOf(needle, cursor);
+    if (offset === -1) break;
+    if (offset === 0 || text[offset - 1] === "\n") starts.push(offset);
+    cursor = offset + needle.length;
+  }
+  if (starts.length !== 1) throw new Error(`${label} is missing or ambiguous`);
+  const indent = /^ */u.exec(header)[0].length;
+  const start = starts[0];
+  let end = text.length;
+  cursor = start + needle.length;
+  while (cursor < text.length) {
+    const lineEnd = text.indexOf("\n", cursor);
+    if (lineEnd === -1) break;
+    const line = text.slice(cursor, lineEnd);
+    if (line.length > 0 && /^ */u.exec(line)[0].length <= indent) {
+      end = cursor;
+      break;
+    }
+    cursor = lineEnd + 1;
+  }
+  return text.slice(start, end);
+}
+
+function assertExactSnapshot(text, header, label) {
+  const inline = `${header} {}`;
+  const inlineMatches = text
+    .split("\n")
+    .filter((line) => line === inline).length;
+  if (inlineMatches === 1 && !text.includes(`${header}\n`)) return;
+  if (inlineMatches !== 0) throw new Error(`${label} is missing or ambiguous`);
+  exactIndentedBlock(text, header, label);
+}
+
+function assertExactRuntimeDependencyLock(lockfileText, dependencies) {
+  const importersStart = lockfileText.indexOf("\nimporters:\n");
+  const packagesStart = lockfileText.indexOf("\npackages:\n");
+  const snapshotsStart = lockfileText.indexOf("\nsnapshots:\n");
+  if (
+    importersStart < 0 ||
+    packagesStart <= importersStart ||
+    snapshotsStart <= packagesStart ||
+    lockfileText.indexOf("\nimporters:\n", importersStart + 1) !== -1 ||
+    lockfileText.indexOf("\npackages:\n", packagesStart + 1) !== -1 ||
+    lockfileText.indexOf("\nsnapshots:\n", snapshotsStart + 1) !== -1
+  ) {
+    throw new Error("Trusted Vercel CLI runtime lockfile sections are invalid");
+  }
+  const importerText = lockfileText.slice(importersStart, packagesStart);
+  const packagesText = lockfileText.slice(packagesStart, snapshotsStart);
+  const snapshotsText = lockfileText.slice(snapshotsStart);
+  const importerNames = [
+    ...importerText.matchAll(/^ {6}('[^']+'|[A-Za-z0-9@/_.-]+):$/gmu),
+  ].map((match) =>
+    match[1].startsWith("'") ? match[1].slice(1, -1) : match[1],
+  );
+  if (
+    new Set(importerNames).size !== importerNames.length ||
+    !isDeepStrictEqual(
+      importerNames.toSorted(),
+      Object.keys(dependencies).toSorted(),
+    )
+  ) {
+    throw new Error(
+      "Trusted Vercel CLI runtime lockfile importer dependencies are not exact",
+    );
+  }
+  for (const [name, version] of Object.entries(dependencies)) {
+    if (!STABLE_SEMVER.test(version)) {
+      throw new Error(
+        "Trusted Vercel CLI runtime dependency is not exact semver",
+      );
+    }
+    const importerKey = escapeRegex(yamlDependencyKey(name));
+    const escapedVersion = escapeRegex(version);
+    const matches = [
+      ...importerText.matchAll(
+        new RegExp(
+          `^      ${importerKey}:\\n        specifier: ${escapedVersion}\\n        version: (${escapedVersion}(?:\\([^\\n]+\\))?)$`,
+          "gmu",
+        ),
+      ),
+    ];
+    if (matches.length !== 1) {
+      throw new Error(
+        `Trusted Vercel CLI runtime lockfile importer is stale: ${name}`,
+      );
+    }
+    const resolution = matches[0][1];
+    const packageBlock = exactIndentedBlock(
+      packagesText,
+      `  ${yamlResolutionKey(name, version)}:`,
+      `Trusted Vercel CLI runtime package ${name}`,
+    );
+    if (
+      !/^ {4}resolution: \{integrity: sha512-[A-Za-z0-9+/]{86}==\}$/mu.test(
+        packageBlock,
+      )
+    ) {
+      throw new Error(
+        `Trusted Vercel CLI runtime package resolution is invalid: ${name}`,
+      );
+    }
+    assertExactSnapshot(
+      snapshotsText,
+      `  ${yamlResolutionKey(name, resolution)}:`,
+      `Trusted Vercel CLI runtime snapshot ${name}`,
+    );
+  }
+}
+
+const ACTIVE_CONTRACT = readContract();
+
+export const PINNED_VERCEL_CLI_VERSION = ACTIVE_CONTRACT.vercelVersion;
 
 export function assertVercelCliRuntimeContract({
   rootPackageJsonPath,
   packageJsonPath,
   lockfilePath,
+  contractPath = DEFAULT_CONTRACT_PATH,
+  runtimeRootPath,
 }) {
-  const rootPackageMetadata = JSON.parse(
-    readFileSync(rootPackageJsonPath, "utf8"),
+  const repositoryRoot = dirname(resolve(filesystemPath(rootPackageJsonPath)));
+  const runtimeFilesRoot = runtimeRootPath ?? repositoryRoot;
+  const contract = readContract(
+    contractPath,
+    contractPath === DEFAULT_CONTRACT_PATH ? undefined : runtimeFilesRoot,
   );
-  const packageMetadata = JSON.parse(readFileSync(packageJsonPath, "utf8"));
+  const rootPackageMetadata = JSON.parse(
+    readBoundedRegularFile(rootPackageJsonPath, {
+      label: "Trusted root package manifest",
+      maximumBytes: MAX_ROOT_MANIFEST_BYTES,
+      rootPath: repositoryRoot,
+    }).toString("utf8"),
+  );
+  const packageContents = readBoundedRegularFile(packageJsonPath, {
+    label: "Trusted Vercel CLI runtime manifest",
+    maximumBytes: MAX_RUNTIME_MANIFEST_BYTES,
+    rootPath: runtimeFilesRoot,
+  });
+  const packageMetadata = JSON.parse(packageContents.toString("utf8"));
+  const lockfileContents = readBoundedRegularFile(lockfilePath, {
+    label: "Trusted Vercel CLI runtime lockfile",
+    maximumBytes: MAX_RUNTIME_LOCKFILE_BYTES,
+    rootPath: runtimeFilesRoot,
+  });
   const rootPnpm = rootPackageMetadata.pnpm;
   const rootOverrides = rootPnpm?.overrides;
-  if (
-    rootPackageMetadata.devDependencies?.vercel !== PINNED_VERCEL_CLI_VERSION
-  ) {
+  if (rootPackageMetadata.devDependencies?.vercel !== contract.vercelVersion) {
     throw new Error("Trusted root Vercel CLI contract is invalid");
   }
   let rootOverridesSha256;
   try {
-    rootOverridesSha256 = canonicalOverrideSha256(rootOverrides);
+    rootOverridesSha256 = canonicalStringMapSha256(
+      rootOverrides,
+      "Trusted root Vercel CLI overrides",
+    );
   } catch {
     throw new Error("Trusted root Vercel CLI contract is invalid");
   }
-  const lockfileContents = readFileSync(lockfilePath);
-  const lockfileDigest = createHash("sha256")
-    .update(lockfileContents)
-    .digest("hex");
-  if (lockfileDigest !== PINNED_VERCEL_CLI_RUNTIME_LOCKFILE_SHA256) {
+  const lockfileDigest = sha256(lockfileContents);
+  if (lockfileDigest !== contract.lockfileSha256) {
     throw new Error("Trusted Vercel CLI runtime lockfile is not exact");
+  }
+  if (sha256(packageContents) !== contract.manifestSha256) {
+    throw new Error("Trusted Vercel CLI runtime manifest is not exact");
   }
   if (
     !hasExactObjectKeys(packageMetadata, [
@@ -115,31 +343,46 @@ export function assertVercelCliRuntimeContract({
     packageMetadata.private !== true ||
     packageMetadata.description !==
       "Standalone pinned Vercel CLI runtime for protected GitHub Actions deployments" ||
-    !hasExactObjectKeys(
-      packageMetadata.dependencies,
-      Object.keys(PINNED_VERCEL_CLI_RUNTIME_DEPENDENCIES),
-    ) ||
-    !isDeepStrictEqual(
-      packageMetadata.dependencies,
-      PINNED_VERCEL_CLI_RUNTIME_DEPENDENCIES,
-    ) ||
     !hasExactObjectKeys(packageMetadata.pnpm, ["overrides"]) ||
     !isDeepStrictEqual(packageMetadata.pnpm.overrides, rootOverrides) ||
     packageMetadata.pnpm.patchedDependencies !== undefined ||
-    rootPnpm.patchedDependencies !== undefined
+    rootPnpm.patchedDependencies !== undefined ||
+    packageMetadata.dependencies?.vercel !== contract.vercelVersion
   ) {
     throw new Error("Trusted Vercel CLI runtime manifest is not exact");
   }
-  if (rootOverridesSha256 !== PINNED_VERCEL_CLI_RUNTIME_OVERRIDE_SHA256) {
+  let runtimeDependenciesSha256;
+  try {
+    runtimeDependenciesSha256 = canonicalStringMapSha256(
+      packageMetadata.dependencies,
+      "Trusted Vercel CLI runtime dependencies",
+    );
+  } catch {
+    throw new Error("Trusted Vercel CLI runtime manifest is not exact");
+  }
+  if (runtimeDependenciesSha256 !== contract.runtimeDependenciesSha256) {
+    throw new Error("Trusted Vercel CLI runtime manifest is not exact");
+  }
+  if (rootOverridesSha256 !== contract.overridesSha256) {
     throw new Error(
       "Trusted Vercel CLI runtime lockfile and overrides are not an approved pair",
     );
   }
   const lockfileText = lockfileContents.toString("utf8");
+  const escapedVersion = contract.vercelVersion.replaceAll(".", "\\.");
+  const escapedIntegrity = contract.registryIntegrity.replace(
+    /[.*+?^${}()|[\]\\]/gu,
+    "\\$&",
+  );
+  assertExactRuntimeDependencyLock(lockfileText, packageMetadata.dependencies);
   if (
     !lockfileText.startsWith("lockfileVersion: '9.0'\n") ||
     !new RegExp(
-      `\\n      vercel:\\n        specifier: ${PINNED_VERCEL_CLI_VERSION}\\n        version: ${PINNED_VERCEL_CLI_VERSION}(?:\\(|\\n)`,
+      `\\n      vercel:\\n        specifier: ${escapedVersion}\\n        version: ${escapedVersion}(?:\\(|\\n)`,
+      "u",
+    ).test(lockfileText) ||
+    !new RegExp(
+      `\\n  vercel@${escapedVersion}:\\n    resolution: \\{integrity: ${escapedIntegrity}\\}`,
       "u",
     ).test(lockfileText) ||
     /(?:specifier|version):\s*(?:workspace:|link:|file:|git\+|github:)|\btarball:|\brepo:|\btype:\s*git\b/u.test(
@@ -151,6 +394,6 @@ export function assertVercelCliRuntimeContract({
 
   return {
     lockfileSha256: lockfileDigest,
-    vercel: PINNED_VERCEL_CLI_RUNTIME_DEPENDENCIES.vercel,
+    vercel: contract.vercelVersion,
   };
 }

--- a/scripts/vercel-cli-runtime/contract.json
+++ b/scripts/vercel-cli-runtime/contract.json
@@ -1,0 +1,9 @@
+{
+  "lockfileSha256": "2dbd0eba57b119870bcd2ba43f6cf726bb52c85d8ec03f4999030e9931e5ed36",
+  "manifestSha256": "b0cd7723f59cfe35c3c2a7336274433ac3483131c4af3f1ab580ae2871f33860",
+  "overridesSha256": "11fc5e7476b6d15ddf6bf8d6956f6566346637f34e0b11e23849e92011b2bf31",
+  "registryIntegrity": "sha512-+CIEa0qcKm1RNBRhOvpo2l/yz28LMKSDuGeAYGx4/EkYyR5VOrXJZYV52WvqVARcxBAbH3Un2RRin8YGXMlcNg==",
+  "runtimeDependenciesSha256": "33b2fa6237e67ead47bef50d310679162e7e41bf1116db8909224d9370c7c176",
+  "schema": "vercel-cli-runtime-contract:v1",
+  "vercelVersion": "56.4.1"
+}

--- a/scripts/vercel-prebuilt-workflow.mjs
+++ b/scripts/vercel-prebuilt-workflow.mjs
@@ -1624,7 +1624,7 @@ export function environmentForVercelCli(environment, allowedNames = []) {
     if (value === undefined || value === "") continue;
     cliEnvironment[name] = requiredText(value, name, { maximum: 32_768 });
   }
-  // CLI 56.4.1 gives these variables precedence over repo.json and would lose
+  // The pinned CLI gives these variables precedence over repo.json and would lose
   // the monorepo Root Directory mapping. The controller has already validated
   // the IDs and materialized them in the trusted repo link.
   delete cliEnvironment.VERCEL_ORG_ID;
@@ -2234,14 +2234,18 @@ export function stageTrustedPnpmRuntimeManifest({ controllerRoot, toolsRoot }) {
 }
 
 function validatePinnedVercelCliRuntimeFiles({
+  contractPath,
   rootPackageJsonPath,
   packageJsonPath,
   lockfilePath,
+  runtimeRootPath,
 }) {
   return assertVercelCliRuntimeContract({
+    contractPath,
     rootPackageJsonPath,
     packageJsonPath,
     lockfilePath,
+    runtimeRootPath,
   });
 }
 
@@ -2325,8 +2329,16 @@ export function stageTrustedVercelCliRuntimeManifest({
     expectedUid: currentUid,
     expectedGid: currentGid,
   });
+  const sourceContract = assertProtectedRuntimeDescendant({
+    root: canonicalControllerRoot,
+    path: join(sourceRoot, "contract.json"),
+    directory: false,
+    expectedUid: currentUid,
+    expectedGid: currentGid,
+  });
   assertNoVercelCliRuntimePatchArtifacts(sourceRoot);
   validatePinnedVercelCliRuntimeFiles({
+    contractPath: sourceContract.path,
     rootPackageJsonPath: rootPackageJson.path,
     packageJsonPath: sourcePackageJson.path,
     lockfilePath: sourceLockfile.path,
@@ -2347,6 +2359,7 @@ export function stageTrustedVercelCliRuntimeManifest({
       expectedGid: currentGid,
     });
     for (const [name, source] of [
+      ["contract.json", sourceContract],
       ["package.json", sourcePackageJson],
       ["pnpm-lock.yaml", sourceLockfile],
     ]) {
@@ -2372,6 +2385,7 @@ export function stageTrustedVercelCliRuntimeManifest({
       rootPackageJsonPath: rootPackageJson.path,
       packageJsonPath: join(runtimeRoot, "package.json"),
       lockfilePath: join(runtimeRoot, "pnpm-lock.yaml"),
+      runtimeRootPath: runtimeRoot,
     });
     return runtimeRoot;
   } catch (error) {
@@ -2455,6 +2469,7 @@ export function trustedStandaloneVercelCliPath({ controllerRoot, toolsRoot }) {
     rootPackageJsonPath: rootPackageJson.path,
     packageJsonPath: runtimePackageJson.path,
     lockfilePath: runtimeLockfile.path,
+    runtimeRootPath: runtimeRoot,
   });
 
   const virtualStoreRoot = join(runtimeRoot, "node_modules", ".pnpm");
@@ -2726,7 +2741,8 @@ export function trustedVercelCliPath(toolsPath) {
     !packageEntry.isFile() ||
     packageEntry.uid !== currentUid ||
     (packageEntry.mode & 0o022) !== 0 ||
-    JSON.parse(readFileSync(packagePath, "utf8")).version !== "56.4.1"
+    JSON.parse(readFileSync(packagePath, "utf8")).version !==
+      PINNED_VERCEL_CLI_VERSION
   ) {
     throw new Error("Trusted Vercel CLI version is not the pinned release");
   }
@@ -3366,7 +3382,10 @@ export function assertPrebuiltOutput({
   } catch {
     throw new Error("Prebuilt output is missing its Vercel CLI build record");
   }
-  if (buildRecord.target !== "preview" || buildRecord.cliVersion !== "56.4.1") {
+  if (
+    buildRecord.target !== "preview" ||
+    buildRecord.cliVersion !== PINNED_VERCEL_CLI_VERSION
+  ) {
     throw new Error(
       "Prebuilt output target or pinned Vercel CLI version is invalid",
     );

--- a/scripts/vercel-prebuilt-workflow.test.mjs
+++ b/scripts/vercel-prebuilt-workflow.test.mjs
@@ -68,6 +68,7 @@ import {
   validateSourceCheckout,
   withValidatedPrebuiltUpload,
 } from "./vercel-prebuilt-workflow.mjs";
+import { PINNED_VERCEL_CLI_VERSION } from "./vercel-cli-runtime-contract.mjs";
 import { sharpRuntimePlatform } from "./next-sharp-output-tracing.mjs";
 
 const SHA = "0123456789abcdef0123456789abcdef01234567";
@@ -198,7 +199,10 @@ function uploadFixture(logicalTarget = "ui") {
   );
   writeFileSync(
     join(outputDirectory, "builds.json"),
-    JSON.stringify({ target: "preview", cliVersion: "56.4.1" }),
+    JSON.stringify({
+      target: "preview",
+      cliVersion: PINNED_VERCEL_CLI_VERSION,
+    }),
   );
   writeSharpRuntimeArtifacts(outputDirectory);
   mkdirSync(join(outputDirectory, "static", "nested"), { recursive: true });
@@ -2138,7 +2142,7 @@ test("standalone Vercel CLI runtime is exact, override-aligned, and independentl
     mkdirSync(sourceRoot, { recursive: true });
     mkdirSync(toolsRoot, { mode: 0o755 });
     copyFileSync(join(REPOSITORY_ROOT, "package.json"), rootPackagePath);
-    for (const file of ["package.json", "pnpm-lock.yaml"]) {
+    for (const file of ["contract.json", "package.json", "pnpm-lock.yaml"]) {
       copyFileSync(
         join(REPOSITORY_ROOT, "scripts", "vercel-cli-runtime", file),
         join(sourceRoot, file),
@@ -2162,7 +2166,7 @@ test("standalone Vercel CLI runtime is exact, override-aligned, and independentl
       runtimeRoot,
       join(realpathSync(toolsRoot), "vercel-cli-runtime"),
     );
-    for (const file of ["package.json", "pnpm-lock.yaml"]) {
+    for (const file of ["contract.json", "package.json", "pnpm-lock.yaml"]) {
       const source = join(sourceRoot, file);
       const destination = join(runtimeRoot, file);
       const sourceEntry = lstatSync(source);
@@ -2199,7 +2203,10 @@ test("standalone Vercel CLI runtime is exact, override-aligned, and independentl
       },
       {
         ...originalManifest,
-        dependencies: { injected: "1.0.0", vercel: "56.4.1" },
+        dependencies: {
+          injected: "1.0.0",
+          vercel: PINNED_VERCEL_CLI_VERSION,
+        },
       },
       {
         ...originalManifest,
@@ -2247,7 +2254,10 @@ test("standalone Vercel CLI runtime is exact, override-aligned, and independentl
         "importers:\n\n  .:",
         "importers:\n\n  injected:\n    dependencies: {}\n\n  .:",
       ),
-      originalLockfile.replace("specifier: 56.4.1", "specifier: workspace:*"),
+      originalLockfile.replace(
+        `specifier: ${PINNED_VERCEL_CLI_VERSION}`,
+        "specifier: workspace:*",
+      ),
       originalLockfile.replace(
         "resolution: {integrity:",
         "resolution: {tarball: https://packages.example/vercel.tgz, integrity:",
@@ -2371,7 +2381,7 @@ test("installed root Vercel CLI executes the exact pinned release", () => {
       },
       stdio: ["ignore", "pipe", "pipe"],
     }).trim(),
-    "56.4.1",
+    PINNED_VERCEL_CLI_VERSION,
   );
 });
 
@@ -2387,7 +2397,7 @@ test("standalone Vercel CLI resolver enforces and executes the exact protected l
       join(REPOSITORY_ROOT, "package.json"),
       join(controllerRoot, "package.json"),
     );
-    for (const file of ["package.json", "pnpm-lock.yaml"]) {
+    for (const file of ["contract.json", "package.json", "pnpm-lock.yaml"]) {
       copyFileSync(
         join(REPOSITORY_ROOT, "scripts", "vercel-cli-runtime", file),
         join(sourceRoot, file),
@@ -2410,7 +2420,7 @@ test("standalone Vercel CLI resolver enforces and executes the exact protected l
       runtimeRoot,
       "node_modules",
       ".pnpm",
-      "vercel@56.4.1",
+      `vercel@${PINNED_VERCEL_CLI_VERSION}`,
       "node_modules",
       "vercel",
     );
@@ -2422,14 +2432,17 @@ test("standalone Vercel CLI resolver enforces and executes the exact protected l
     );
     writeFileSync(
       join(packageRoot, "package.json"),
-      `${JSON.stringify({ name: "vercel", version: "56.4.1" })}\n`,
+      `${JSON.stringify({
+        name: "vercel",
+        version: PINNED_VERCEL_CLI_VERSION,
+      })}\n`,
       { mode: 0o644 },
     );
     writeFileSync(
       cliPath,
       [
         'if (process.argv[2] !== "--version") process.exit(2);',
-        'process.stdout.write("56.4.1\\n");',
+        `process.stdout.write("${PINNED_VERCEL_CLI_VERSION}\\n");`,
         "",
       ].join("\n"),
       { mode: 0o644 },
@@ -2445,7 +2458,7 @@ test("standalone Vercel CLI resolver enforces and executes the exact protected l
         encoding: "utf8",
         stdio: ["ignore", "pipe", "pipe"],
       }).trim(),
-      "56.4.1",
+      PINNED_VERCEL_CLI_VERSION,
     );
 
     chmodSync(cliPath, 0o666);
@@ -2724,7 +2737,7 @@ test("trusted Vercel CLI must be exact-versioned and runner-protected", () => {
     writeFileSync(cliPath, "export {};\n");
     writeFileSync(
       join(packagePath, "package.json"),
-      JSON.stringify({ version: "56.4.1" }),
+      JSON.stringify({ version: PINNED_VERCEL_CLI_VERSION }),
     );
     assert.equal(trustedVercelCliPath(toolsPath), realpathSync(cliPath));
 
@@ -2735,7 +2748,7 @@ test("trusted Vercel CLI must be exact-versioned and runner-protected", () => {
     assert.throws(() => trustedVercelCliPath(toolsPath), /pinned release/);
     writeFileSync(
       join(packagePath, "package.json"),
-      JSON.stringify({ version: "56.4.1" }),
+      JSON.stringify({ version: PINNED_VERCEL_CLI_VERSION }),
     );
 
     chmodSync(toolsPath, 0o777);
@@ -3522,7 +3535,10 @@ test("pulled project and prebuilt output bind the configured UI root and build I
     );
     writeFileSync(
       join(outputDirectory, "builds.json"),
-      JSON.stringify({ target: "preview", cliVersion: "56.4.1" }),
+      JSON.stringify({
+        target: "preview",
+        cliVersion: PINNED_VERCEL_CLI_VERSION,
+      }),
     );
     writeSharpRuntimeArtifacts(outputDirectory);
     assert.equal(

--- a/scripts/vercel-prebuilt-workflows.test.mjs
+++ b/scripts/vercel-prebuilt-workflows.test.mjs
@@ -3,6 +3,7 @@ import { readFileSync } from "node:fs";
 import { test } from "node:test";
 
 import { parse } from "yaml";
+import { PINNED_VERCEL_CLI_VERSION } from "./vercel-cli-runtime-contract.mjs";
 
 function read(relativePath) {
   return readFileSync(new URL(`../${relativePath}`, import.meta.url), "utf8");
@@ -380,39 +381,34 @@ test("prebuilt authenticates a locked Linux pnpm binary before cache or candidat
   assert.deepEqual(Object.keys(runtimeLock.packages), ["pnpm@10.34.4"]);
   assert.deepEqual(Object.keys(runtimeLock.snapshots), ["pnpm@10.34.4"]);
   assert.equal(runtimeLock.importers["."].dependencies.pnpm.version, "10.34.4");
-  assert.deepEqual(vercelCliRuntimeManifest.dependencies, {
-    "@vercel/backends": "0.8.25",
-    "@vercel/container": "0.0.5",
-    "@vercel/elysia": "0.1.102",
-    "@vercel/express": "0.1.116",
-    "@vercel/fastify": "0.1.105",
-    "@vercel/go": "3.10.2",
-    "@vercel/h3": "0.1.111",
-    "@vercel/hono": "0.2.105",
-    "@vercel/hydrogen": "1.4.0",
-    "@vercel/koa": "0.1.85",
-    "@vercel/nestjs": "0.2.106",
-    "@vercel/next": "4.20.4",
-    "@vercel/node": "5.8.26",
-    "@vercel/python": "6.51.0",
-    "@vercel/redwood": "2.5.0",
-    "@vercel/remix-builder": "5.9.1",
-    "@vercel/ruby": "2.5.1",
-    "@vercel/rust": "1.4.0",
-    "@vercel/static-build": "2.11.8",
-    vercel: "56.4.1",
-  });
+  assert.equal(
+    vercelCliRuntimeManifest.dependencies.vercel,
+    PINNED_VERCEL_CLI_VERSION,
+  );
+  assert.ok(
+    Object.entries(vercelCliRuntimeManifest.dependencies)
+      .filter(([name]) => name !== "vercel")
+      .every(
+        ([name, version]) =>
+          name.startsWith("@vercel/") &&
+          /^(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)$/.test(
+            version,
+          ),
+      ),
+  );
   assert.equal(vercelCliRuntimeManifest.scripts, undefined);
   assert.deepEqual(
     vercelCliRuntimeManifest.pnpm.overrides,
     manifest.pnpm.overrides,
   );
-  assert.equal(manifest.devDependencies.vercel, "56.4.1");
+  assert.equal(manifest.devDependencies.vercel, PINNED_VERCEL_CLI_VERSION);
   assert.equal(
     vercelCliRuntimeLock.importers["."].dependencies.vercel.specifier,
-    "56.4.1",
+    PINNED_VERCEL_CLI_VERSION,
   );
-  assert.ok(vercelCliRuntimeLock.packages["vercel@56.4.1"]);
+  assert.ok(
+    vercelCliRuntimeLock.packages[`vercel@${PINNED_VERCEL_CLI_VERSION}`],
+  );
   assert.doesNotMatch(rootOsvConfig, /GHSA-gj8w-mvpf-x27x/);
   // Retired with the local brace-expansion patch and the ip-address floor
   // bump — both advisories are fixed by upstream releases now.
@@ -697,14 +693,15 @@ test("main-only controller is restored after every candidate-code phase", () => 
   );
   assert.ok(
     names.indexOf("Restore trusted controller after source installation") <
-      names.indexOf("Verify pinned Vercel prerequisites"),
+      names.indexOf("Verify candidate Vercel prerequisite consistency"),
   );
   const versionCheck = steps.find(
-    ({ name }) => name === "Verify pinned Vercel prerequisites",
+    ({ name }) => name === "Verify candidate Vercel prerequisite consistency",
   );
+  assert.equal(versionCheck["working-directory"], "source");
   assert.match(
     versionCheck.run,
-    /controller\/scripts\/vercel-prebuilt\.mjs" check-versions/,
+    /controller\/scripts\/vercel-prebuilt\.mjs" check-candidate-versions/,
   );
   const contract = steps.find(
     ({ name }) =>
@@ -739,7 +736,7 @@ test("monorepo CLI and trusted env validation use their exact roots", () => {
       name === "Validate same-repository branch reachability and exact HEAD",
   );
   const prerequisites = steps.find(
-    ({ name }) => name === "Verify pinned Vercel prerequisites",
+    ({ name }) => name === "Verify candidate Vercel prerequisite consistency",
   );
   const environmentValidation = steps.find(
     ({ name }) =>

--- a/scripts/vercel-prebuilt.mjs
+++ b/scripts/vercel-prebuilt.mjs
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
 
 import { createHash } from "node:crypto";
-import { readFileSync } from "node:fs";
+import { lstatSync, readFileSync, realpathSync } from "node:fs";
 import process from "node:process";
-import { join, resolve } from "node:path";
+import { join, relative, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { assertVercelCliRuntimeContract } from "./vercel-cli-runtime-contract.mjs";
@@ -13,6 +13,41 @@ export const VERCEL_TARGETS = ["app", "governance", "reserve", "ui"];
 
 const DEPLOYMENT_ID_PATTERN = /^[A-Za-z0-9_-]+$/;
 const REPOSITORY_PATTERN = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
+const MAX_ROOT_PACKAGE_BYTES = 1024 * 1024;
+const MAX_ROOT_LOCKFILE_BYTES = 16 * 1024 * 1024;
+
+function readBoundedCandidatePath(repoRoot, path, maximumBytes, label) {
+  try {
+    const requestedRoot = resolve(repoRoot);
+    const rootEntry = lstatSync(requestedRoot);
+    if (!rootEntry.isDirectory() || rootEntry.isSymbolicLink()) {
+      throw new Error("unsafe root");
+    }
+    const root = realpathSync(requestedRoot);
+    const candidate = resolve(requestedRoot, path);
+    const canonicalCandidate = realpathSync(candidate);
+    const expectedCandidate = resolve(root, path);
+    const fromRoot = relative(root, canonicalCandidate);
+    const entry = lstatSync(candidate);
+    if (
+      fromRoot === ".." ||
+      fromRoot.startsWith(`..${sep}`) ||
+      fromRoot.length === 0 ||
+      !entry.isFile() ||
+      entry.isSymbolicLink() ||
+      entry.size < 1 ||
+      entry.size > maximumBytes ||
+      canonicalCandidate !== expectedCandidate
+    ) {
+      throw new Error("unsafe file");
+    }
+    const contents = readFileSync(candidate);
+    if (contents.byteLength !== entry.size) throw new Error("file changed");
+    return contents;
+  } catch {
+    throw new Error(`${label} is unreadable or unsafe`);
+  }
+}
 
 export function assertValidDeploymentId(deploymentId) {
   if (typeof deploymentId !== "string" || deploymentId.length === 0) {
@@ -194,13 +229,22 @@ export function readResolvedNextVersion(lockfile) {
   return match[1];
 }
 
-export function assertDeploymentIdPrerequisites(repoRoot) {
+function assertDeploymentIdPrerequisitesWithContract(repoRoot, contractPath) {
   const packageJson = JSON.parse(
-    readFileSync(join(repoRoot, "package.json"), "utf8"),
+    readBoundedCandidatePath(
+      repoRoot,
+      "package.json",
+      MAX_ROOT_PACKAGE_BYTES,
+      "Root package manifest",
+    ).toString("utf8"),
   );
-  const nextVersion = readResolvedNextVersion(
-    readFileSync(join(repoRoot, "pnpm-lock.yaml"), "utf8"),
-  );
+  const rootLockfile = readBoundedCandidatePath(
+    repoRoot,
+    "pnpm-lock.yaml",
+    MAX_ROOT_LOCKFILE_BYTES,
+    "Root lockfile",
+  ).toString("utf8");
+  const nextVersion = readResolvedNextVersion(rootLockfile);
   const vercelVersion = packageJson.devDependencies?.vercel;
 
   if (
@@ -215,6 +259,15 @@ export function assertDeploymentIdPrerequisites(repoRoot) {
   if (!isVersionGreaterThan(vercelVersion, "50.3.3")) {
     throw new Error("Pinned Vercel CLI is too old for custom deployment IDs");
   }
+  const escapedVercelVersion = vercelVersion.replaceAll(".", "\\.");
+  if (
+    !new RegExp(
+      `\\n      vercel:\\n        specifier: ${escapedVercelVersion}\\n        version: ${escapedVercelVersion}(?:\\(|\\n)`,
+      "u",
+    ).test(rootLockfile)
+  ) {
+    throw new Error("Root Vercel manifest and lockfile are inconsistent");
+  }
 
   const runtimePackageJsonPath = join(
     repoRoot,
@@ -223,6 +276,7 @@ export function assertDeploymentIdPrerequisites(repoRoot) {
     "package.json",
   );
   const vercelCliRuntime = assertVercelCliRuntimeContract({
+    ...(contractPath === undefined ? {} : { contractPath }),
     rootPackageJsonPath: join(repoRoot, "package.json"),
     packageJsonPath: runtimePackageJsonPath,
     lockfilePath: join(
@@ -234,6 +288,20 @@ export function assertDeploymentIdPrerequisites(repoRoot) {
   });
 
   return { next: nextVersion, vercel: vercelVersion, vercelCliRuntime };
+}
+
+export function assertDeploymentIdPrerequisites(repoRoot) {
+  return assertDeploymentIdPrerequisitesWithContract(repoRoot, undefined);
+}
+
+// This check proves only that candidate package and lock data agree with the
+// candidate's own digest-bound runtime contract. It does not select the
+// protected CLI or grant deployment authority; those remain controller-owned.
+export function assertCandidateDeploymentIdPrerequisites(repoRoot) {
+  return assertDeploymentIdPrerequisitesWithContract(
+    repoRoot,
+    join(repoRoot, "scripts", "vercel-cli-runtime", "contract.json"),
+  );
 }
 
 function parseArguments(argv) {
@@ -297,9 +365,17 @@ if (isCliEntrypoint()) {
         ),
       )}\n`,
     );
+  } else if (command === "check-candidate-versions") {
+    process.stdout.write(
+      `${JSON.stringify(
+        assertCandidateDeploymentIdPrerequisites(
+          resolve(options["repo-root"] ?? process.cwd()),
+        ),
+      )}\n`,
+    );
   } else {
     throw new Error(
-      "Usage: vercel-prebuilt.mjs deployment-id|main-release-id|main-candidate-deployment-id|assert-output|check-versions",
+      "Usage: vercel-prebuilt.mjs deployment-id|main-release-id|main-candidate-deployment-id|assert-output|check-versions|check-candidate-versions",
     );
   }
 }

--- a/scripts/vercel-prebuilt.test.mjs
+++ b/scripts/vercel-prebuilt.test.mjs
@@ -7,6 +7,7 @@ import {
   mkdtempSync,
   readFileSync,
   rmSync,
+  symlinkSync,
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
@@ -16,6 +17,7 @@ import { test } from "node:test";
 import { fileURLToPath } from "node:url";
 
 import {
+  assertCandidateDeploymentIdPrerequisites,
   assertDeploymentIdPrerequisites,
   assertPrebuiltDeploymentId,
   assertValidDeploymentId,
@@ -26,7 +28,10 @@ import {
   isVersionGreaterThan,
   VERCEL_TARGETS,
 } from "./vercel-prebuilt.mjs";
-import { assertVercelCliRuntimeContract } from "./vercel-cli-runtime-contract.mjs";
+import {
+  assertVercelCliRuntimeContract,
+  PINNED_VERCEL_CLI_VERSION,
+} from "./vercel-cli-runtime-contract.mjs";
 import {
   assertSharpOutputTrace,
   isSharpManifestPath,
@@ -42,12 +47,14 @@ const scriptPath = fileURLToPath(
   new URL("./vercel-prebuilt.mjs", import.meta.url),
 );
 const COMMIT_SHA = "0123456789abcdef0123456789abcdef01234567";
-const FORMER_VERCEL_CLI_RUNTIME_LOCKFILE_SHA256 =
-  "957ccb3b8431add07a144e77966b4a05733aaca6f21cd071c937861fc10189d4";
 const FORMER_VERCEL_CLI_RUNTIME_OVERRIDE_SHA256 =
   "301165d803f4cc7db4524ea3a7a02b33db772505c04fdc9025860b244bcb447b";
-const ACTIVE_VERCEL_CLI_RUNTIME_LOCKFILE_SHA256 =
-  "2dbd0eba57b119870bcd2ba43f6cf726bb52c85d8ec03f4999030e9931e5ed36";
+const activeVercelCliRuntimeContract = JSON.parse(
+  readFileSync(
+    join(repoRoot, "scripts", "vercel-cli-runtime", "contract.json"),
+    "utf8",
+  ),
+);
 
 function deploymentId(overrides = {}) {
   return generateVercelDeploymentId({
@@ -70,6 +77,10 @@ function createVersionContractFixture() {
       join(runtimeRoot, file),
     );
   }
+  copyFileSync(
+    join(repoRoot, "scripts", "vercel-cli-runtime", "contract.json"),
+    join(runtimeRoot, "contract.json"),
+  );
   return fixtureRoot;
 }
 
@@ -246,15 +257,15 @@ test("resolved Next.js and exact Vercel CLI satisfy custom-ID prerequisites", ()
   const prerequisites = assertDeploymentIdPrerequisites(repoRoot);
   const expected = {
     next: "16.2.12",
-    vercel: "56.4.1",
+    vercel: PINNED_VERCEL_CLI_VERSION,
     vercelCliRuntime: {
       lockfileSha256: prerequisites.vercelCliRuntime.lockfileSha256,
-      vercel: "56.4.1",
+      vercel: PINNED_VERCEL_CLI_VERSION,
     },
   };
   assert.equal(
     prerequisites.vercelCliRuntime.lockfileSha256,
-    ACTIVE_VERCEL_CLI_RUNTIME_LOCKFILE_SHA256,
+    activeVercelCliRuntimeContract.lockfileSha256,
   );
   assert.deepEqual(prerequisites, expected);
   assert.deepEqual(
@@ -268,7 +279,161 @@ test("resolved Next.js and exact Vercel CLI satisfy custom-ID prerequisites", ()
     expected,
   );
   assert.equal(isVersionGreaterThan("16.2.10", "16.2.0-canary.15"), true);
-  assert.equal(isVersionGreaterThan("56.4.1", "50.3.3"), true);
+  assert.equal(isVersionGreaterThan(PINNED_VERCEL_CLI_VERSION, "50.3.3"), true);
+});
+
+test("candidate-only version check accepts a self-consistent rotation without changing controller authority", () => {
+  const fixtureRoot = createVersionContractFixture();
+  const runtimeRoot = join(fixtureRoot, "scripts", "vercel-cli-runtime");
+  const targetVersion = "56.5.0";
+  const targetIntegrity =
+    "sha512-wAKpT8DFSbnwlgbS711fbvxGjOfQeb1n+NcaBaSC4onq9eJAjbPfERrjrKE4GDsV8dkoBo0627lp0QxbLCGFiw==";
+  try {
+    const rootPackagePath = join(fixtureRoot, "package.json");
+    const rootPackage = JSON.parse(readFileSync(rootPackagePath, "utf8"));
+    rootPackage.devDependencies.vercel = targetVersion;
+    writeFileSync(rootPackagePath, `${JSON.stringify(rootPackage, null, 2)}\n`);
+    const rootLockPath = join(fixtureRoot, "pnpm-lock.yaml");
+    writeFileSync(
+      rootLockPath,
+      readFileSync(rootLockPath, "utf8")
+        .replaceAll(PINNED_VERCEL_CLI_VERSION, targetVersion)
+        .replaceAll("6.51.0", "6.51.1")
+        .replaceAll(
+          activeVercelCliRuntimeContract.registryIntegrity,
+          targetIntegrity,
+        ),
+    );
+
+    const runtimePackagePath = join(runtimeRoot, "package.json");
+    const runtimePackage = JSON.parse(readFileSync(runtimePackagePath, "utf8"));
+    runtimePackage.dependencies["@vercel/python"] = "6.51.1";
+    runtimePackage.dependencies.vercel = targetVersion;
+    const runtimePackageBytes = `${JSON.stringify(runtimePackage, null, 2)}\n`;
+    writeFileSync(runtimePackagePath, runtimePackageBytes);
+    const runtimeLockPath = join(runtimeRoot, "pnpm-lock.yaml");
+    const runtimeLockBytes = readFileSync(runtimeLockPath, "utf8")
+      .replaceAll(PINNED_VERCEL_CLI_VERSION, targetVersion)
+      .replaceAll("6.51.0", "6.51.1")
+      .replaceAll(
+        activeVercelCliRuntimeContract.registryIntegrity,
+        targetIntegrity,
+      );
+    writeFileSync(runtimeLockPath, runtimeLockBytes);
+    const contract = {
+      lockfileSha256: createHash("sha256")
+        .update(runtimeLockBytes)
+        .digest("hex"),
+      manifestSha256: createHash("sha256")
+        .update(runtimePackageBytes)
+        .digest("hex"),
+      overridesSha256: canonicalOverrideSha256(rootPackage.pnpm.overrides),
+      registryIntegrity: targetIntegrity,
+      runtimeDependenciesSha256: canonicalOverrideSha256(
+        runtimePackage.dependencies,
+      ),
+      schema: "vercel-cli-runtime-contract:v1",
+      vercelVersion: targetVersion,
+    };
+    writeFileSync(
+      join(runtimeRoot, "contract.json"),
+      `${JSON.stringify(contract, null, 2)}\n`,
+    );
+
+    const candidate = assertCandidateDeploymentIdPrerequisites(fixtureRoot);
+    assert.equal(candidate.vercel, targetVersion);
+    assert.equal(candidate.vercelCliRuntime.vercel, targetVersion);
+    assert.equal(
+      PINNED_VERCEL_CLI_VERSION,
+      activeVercelCliRuntimeContract.vercelVersion,
+    );
+    assert.notEqual(PINNED_VERCEL_CLI_VERSION, targetVersion);
+    assert.equal(
+      JSON.parse(
+        execFileSync(
+          process.execPath,
+          [scriptPath, "check-candidate-versions", "--repo-root", fixtureRoot],
+          { encoding: "utf8" },
+        ),
+      ).vercel,
+      targetVersion,
+    );
+    assert.throws(
+      () => assertDeploymentIdPrerequisites(fixtureRoot),
+      /root Vercel CLI contract is invalid/,
+    );
+  } finally {
+    rmSync(fixtureRoot, { force: true, recursive: true });
+  }
+});
+
+test("candidate runtime contract rejects a manifest dependency with stale lock resolution", () => {
+  const fixtureRoot = createVersionContractFixture();
+  const runtimeRoot = join(fixtureRoot, "scripts", "vercel-cli-runtime");
+  try {
+    const packagePath = join(runtimeRoot, "package.json");
+    const packageMetadata = JSON.parse(readFileSync(packagePath, "utf8"));
+    packageMetadata.dependencies["@vercel/python"] = "6.51.1";
+    const packageBytes = `${JSON.stringify(packageMetadata, null, 2)}\n`;
+    writeFileSync(packagePath, packageBytes);
+    const contractPath = join(runtimeRoot, "contract.json");
+    const contract = JSON.parse(readFileSync(contractPath, "utf8"));
+    contract.manifestSha256 = createHash("sha256")
+      .update(packageBytes)
+      .digest("hex");
+    contract.runtimeDependenciesSha256 = canonicalOverrideSha256(
+      packageMetadata.dependencies,
+    );
+    writeFileSync(contractPath, `${JSON.stringify(contract, null, 2)}\n`);
+    assert.throws(
+      () => assertCandidateDeploymentIdPrerequisites(fixtureRoot),
+      /lockfile importer is stale: @vercel\/python/u,
+    );
+  } finally {
+    rmSync(fixtureRoot, { force: true, recursive: true });
+  }
+});
+
+test("candidate fixed-path checks reject symlinks, devices, and oversized inputs", () => {
+  const symlinkFixture = createVersionContractFixture();
+  try {
+    const rootPackagePath = join(symlinkFixture, "package.json");
+    const savedPackagePath = join(symlinkFixture, "saved-package.json");
+    writeFileSync(savedPackagePath, readFileSync(rootPackagePath));
+    rmSync(rootPackagePath);
+    symlinkSync(savedPackagePath, rootPackagePath);
+    assert.throws(
+      () => assertCandidateDeploymentIdPrerequisites(symlinkFixture),
+      /Root package manifest is unreadable or unsafe/u,
+    );
+  } finally {
+    rmSync(symlinkFixture, { force: true, recursive: true });
+  }
+
+  assert.throws(
+    () =>
+      assertVercelCliRuntimeContract({
+        contractPath: "/dev/null",
+        lockfilePath: "/dev/null",
+        packageJsonPath: "/dev/null",
+        rootPackageJsonPath: "/dev/null",
+      }),
+    /runtime contract is unreadable/u,
+  );
+
+  const oversizedFixture = createVersionContractFixture();
+  try {
+    writeFileSync(
+      join(oversizedFixture, "scripts", "vercel-cli-runtime", "contract.json"),
+      "x".repeat(64 * 1024 + 1),
+    );
+    assert.throws(
+      () => assertCandidateDeploymentIdPrerequisites(oversizedFixture),
+      /runtime contract is unreadable/u,
+    );
+  } finally {
+    rmSync(oversizedFixture, { force: true, recursive: true });
+  }
 });
 
 test("trusted controller accepts only the active Vercel CLI runtime pair", () => {
@@ -287,11 +452,17 @@ test("trusted controller accepts only the active Vercel CLI runtime pair", () =>
       "vercel-cli-runtime",
       "pnpm-lock.yaml",
     ),
+    contractPath: join(
+      fixtureRoot,
+      "scripts",
+      "vercel-cli-runtime",
+      "contract.json",
+    ),
   };
   try {
     const activeDigest =
       assertVercelCliRuntimeContract(contractPaths).lockfileSha256;
-    assert.equal(activeDigest, ACTIVE_VERCEL_CLI_RUNTIME_LOCKFILE_SHA256);
+    assert.equal(activeDigest, activeVercelCliRuntimeContract.lockfileSha256);
     const activeLockfile = readFileSync(contractPaths.lockfilePath, "utf8");
     const activeOverrides = JSON.parse(
       readFileSync(contractPaths.rootPackageJsonPath, "utf8"),
@@ -302,10 +473,6 @@ test("trusted controller accepts only the active Vercel CLI runtime pair", () =>
       ...activeOverrides,
       "nanoid@<3.3.18": "3.3.19",
     };
-    assert.equal(
-      createHash("sha256").update(formerLockfile).digest("hex"),
-      FORMER_VERCEL_CLI_RUNTIME_LOCKFILE_SHA256,
-    );
     assert.equal(
       canonicalOverrideSha256(formerOverrides),
       FORMER_VERCEL_CLI_RUNTIME_OVERRIDE_SHA256,
@@ -319,7 +486,7 @@ test("trusted controller accepts only the active Vercel CLI runtime pair", () =>
         overrides: formerOverrides,
       },
       {
-        expected: /lockfile and overrides are not an approved pair/,
+        expected: /runtime manifest is not exact/,
         lockfile: activeLockfile,
         name: "active lockfile with former overrides",
         overrides: formerOverrides,
@@ -337,7 +504,7 @@ test("trusted controller accepts only the active Vercel CLI runtime pair", () =>
         overrides: activeOverrides,
       },
       {
-        expected: /lockfile and overrides are not an approved pair/,
+        expected: /runtime manifest is not exact/,
         lockfile: activeLockfile,
         name: "unreviewed overrides",
         overrides: unknownOverrides,
@@ -373,7 +540,7 @@ test("version check rejects standalone pin, override, patch, and lockfile drift"
       },
     },
     {
-      expected: /lockfile and overrides are not an approved pair/,
+      expected: /runtime manifest is not exact/,
       mutate(fixtureRoot) {
         for (const path of [
           join(fixtureRoot, "package.json"),

--- a/scripts/vercel-production-shadow-workflow.test.mjs
+++ b/scripts/vercel-production-shadow-workflow.test.mjs
@@ -4,6 +4,7 @@ import { test } from "node:test";
 import { parse } from "yaml";
 
 import { validateVercelBuildCredentialBoundary } from "./vercel-build-environment.mjs";
+import { PINNED_VERCEL_CLI_VERSION } from "./vercel-cli-runtime-contract.mjs";
 import {
   buildProductionShadowBuildArguments,
   buildProductionShadowDeployArguments,
@@ -366,29 +367,22 @@ test("protected build runtime installs the exact standalone Vercel CLI without w
   );
   assert.ok(runtime);
   const runtimeBlock = runtime.run;
-  assert.deepEqual(vercelCliRuntimePackage.dependencies, {
-    "@vercel/backends": "0.8.25",
-    "@vercel/container": "0.0.5",
-    "@vercel/elysia": "0.1.102",
-    "@vercel/express": "0.1.116",
-    "@vercel/fastify": "0.1.105",
-    "@vercel/go": "3.10.2",
-    "@vercel/h3": "0.1.111",
-    "@vercel/hono": "0.2.105",
-    "@vercel/hydrogen": "1.4.0",
-    "@vercel/koa": "0.1.85",
-    "@vercel/nestjs": "0.2.106",
-    "@vercel/next": "4.20.4",
-    "@vercel/node": "5.8.26",
-    "@vercel/python": "6.51.0",
-    "@vercel/redwood": "2.5.0",
-    "@vercel/remix-builder": "5.9.1",
-    "@vercel/ruby": "2.5.1",
-    "@vercel/rust": "1.4.0",
-    "@vercel/static-build": "2.11.8",
-    vercel: "56.4.1",
-  });
-  assert.equal(rootPackage.devDependencies.vercel, "56.4.1");
+  assert.equal(
+    vercelCliRuntimePackage.dependencies.vercel,
+    PINNED_VERCEL_CLI_VERSION,
+  );
+  assert.ok(
+    Object.entries(vercelCliRuntimePackage.dependencies)
+      .filter(([name]) => name !== "vercel")
+      .every(
+        ([name, version]) =>
+          name.startsWith("@vercel/") &&
+          /^(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)$/.test(
+            version,
+          ),
+      ),
+  );
+  assert.equal(rootPackage.devDependencies.vercel, PINNED_VERCEL_CLI_VERSION);
   assert.deepEqual(
     vercelCliRuntimePackage.pnpm.overrides,
     rootPackage.pnpm.overrides,
@@ -425,8 +419,9 @@ test("protected build runtime installs the exact standalone Vercel CLI without w
   assert.match(runtimeBlock, /stat -c %h "\$installed_file"\)" != 1/);
   assert.match(
     runtimeBlock,
-    /"\$\("\$node_bin" "\$vercel_cli" --version\)" = 56\.4\.1/,
+    /"\$\("\$node_bin" "\$vercel_cli" --version\)" = "\$pinned_vercel_version"/,
   );
+  assert.match(runtimeBlock, /vercel-cli-runtime\/contract\.json/);
   assert.ok(
     runtimeBlock.indexOf("stage-vercel-cli-runtime") <
       runtimeBlock.indexOf('"$pnpm_bin" --dir "$vercel_runtime_root" install'),

--- a/scripts/vercel-production-shadow.mjs
+++ b/scripts/vercel-production-shadow.mjs
@@ -40,6 +40,7 @@ import { fileURLToPath } from "node:url";
 import { stripVTControlCharacters } from "node:util";
 
 import { assertPrebuiltDeploymentId } from "./vercel-prebuilt.mjs";
+import { PINNED_VERCEL_CLI_VERSION } from "./vercel-cli-runtime-contract.mjs";
 import { assertSafeOutputTree } from "./vercel-output-validator.mjs";
 import {
   parseVercelPulledEnvironment,
@@ -1778,7 +1779,7 @@ export function assertProductionShadowOutput({
   }
   if (
     buildRecord.target !== expectedTarget ||
-    buildRecord.cliVersion !== "56.4.1"
+    buildRecord.cliVersion !== PINNED_VERCEL_CLI_VERSION
   ) {
     throw new Error("Prebuilt output target or Vercel CLI version is invalid");
   }
@@ -2458,7 +2459,7 @@ export function writePilotSummary({
     `- Workflow run: ${requireString(runUrl, "Workflow run URL")}`,
     `- Exact deployment SHA: \`${normalizedSha}\``,
     `- Whole workflow duration: ${totalWorkflowDuration} ms`,
-    "- Pinned Vercel CLI: `56.4.1`",
+    `- Pinned Vercel CLI: \`${PINNED_VERCEL_CLI_VERSION}\``,
     "- Project Root Directories verified: `apps/app.mento.org`, `apps/governance.mento.org`, `apps/reserve.mento.org`, `apps/ui.mento.org`",
     "",
     "| Target | Build target | Deployment ID / URL | Runtime/browser | Protected mappings | Turbo cache | Timing | Result |",

--- a/scripts/vercel-production-shadow.test.mjs
+++ b/scripts/vercel-production-shadow.test.mjs
@@ -65,6 +65,7 @@ import {
   waitForHealthyUrls,
   writePilotSummary,
 } from "./vercel-production-shadow.mjs";
+import { PINNED_VERCEL_CLI_VERSION } from "./vercel-cli-runtime-contract.mjs";
 import {
   getVercelBuildRequirements,
   parseVercelPulledEnvironment,
@@ -234,7 +235,7 @@ function productionOutputFixture(logicalTarget = "governance") {
     join(outputDirectory, "builds.json"),
     JSON.stringify({
       target: logicalTarget === "app" ? "v3" : "production",
-      cliVersion: "56.4.1",
+      cliVersion: PINNED_VERCEL_CLI_VERSION,
     }),
   );
   return {
@@ -1241,7 +1242,7 @@ test("repo-linked settings use exact repo identity for all four targets", () => 
         join(output, "builds.json"),
         JSON.stringify({
           target: target === "app" ? "v3" : "production",
-          cliVersion: "56.4.1",
+          cliVersion: PINNED_VERCEL_CLI_VERSION,
         }),
       );
       assert.deepEqual(
@@ -1781,7 +1782,7 @@ test("runner pull staging, candidate copy, and upload proof reject external refe
         join(output, "builds.json"),
         JSON.stringify({
           target: target === "app" ? "v3" : "production",
-          cliVersion: "56.4.1",
+          cliVersion: PINNED_VERCEL_CLI_VERSION,
         }),
         { mode: 0o600 },
       );
@@ -2019,7 +2020,10 @@ test("handoff enforces distinct candidate and runner ownership contracts", () =>
     );
     writeFileSync(
       join(candidateOutput, "builds.json"),
-      JSON.stringify({ target: "production", cliVersion: "56.4.1" }),
+      JSON.stringify({
+        target: "production",
+        cliVersion: PINNED_VERCEL_CLI_VERSION,
+      }),
       { mode: 0o600 },
     );
     const functionsDirectory = join(candidateOutput, "functions");
@@ -2224,7 +2228,10 @@ test("handoff final validation rejects a copied-link tamper", () => {
     );
     writeFileSync(
       join(candidateOutput, "builds.json"),
-      JSON.stringify({ target: "production", cliVersion: "56.4.1" }),
+      JSON.stringify({
+        target: "production",
+        cliVersion: PINNED_VERCEL_CLI_VERSION,
+      }),
       { mode: 0o600 },
     );
     const targetFunction = join(candidateOutput, "functions", "target.func");
@@ -2578,7 +2585,7 @@ test("trusted builds reject every post-build project-link mutation before deploy
           join(output, "builds.json"),
           JSON.stringify({
             target: target === "app" ? "v3" : "production",
-            cliVersion: "56.4.1",
+            cliVersion: PINNED_VERCEL_CLI_VERSION,
           }),
         );
 


### PR DESCRIPTION
## The Problem

Dependabot PR #753 requested Vercel CLI 56.5.0, but the protected standalone deployment runtime still admitted 56.4.1. The generic repair planner cannot write runtime or deployment-policy paths, so it correctly stayed inside its allowlist and restored the root Vercel pin to 56.4.1. Merging that repair would discard the requested upgrade and cause a later Dependabot run to propose it again.

## The Solution

Add a typed, model-free `vercel-cli-runtime-sync` repair inside the existing staged Repair protocol.

- isolate future Vercel patch/minor updates from the broad tooling group;
- bind the verified Dependabot seed, exact current head/base, 15 protected inputs, source and target npm records, and a fixed five-path output allowlist;
- preserve every non-Vercel root lock byte while rotating only the authenticated Vercel regions;
- regenerate the standalone runtime lock twice with exact pnpm 10.34.4 and require identical bytes;
- independently revalidate the plan without secrets or write authority;
- run the generated CLI only in a fresh terminal no-authority job, bound to the validated plan and content digests;
- keep the existing unreachable App commit, Repair Intent, non-force ref move, receipt/recovery, prepared review, approval, and human-merge-only ALL CLEAR contracts; and
- require a reachable typed operation plus exact root/runtime target state before ALL CLEAR.

The generic v2 repair path remains unchanged. ADR 0007 records the new trust boundary and fail-closed policy.

## Validation

- Exact networked PR #753 fixture with pnpm 10.34.4: 8/8 passed. It retained knip 6.32.0 and Next ESLint 16.3.0, restored root Vercel 56.5.0, generated runtime Vercel 56.5.0 and `@vercel/python` 6.51.1, and produced the expected runtime lock SHA-256 `c512b310653b45f654e8d9204a84fbeea4159617020e242f90ab31b8919da921`.
- `pnpm dependabot:process:test`: 257 passed, 1 intentional network-fixture skip, including stale-head refresh before the new contract exists and current-head fail-closed coverage.
- `pnpm vercel:primitives:test`: 66/66 passed.
- `pnpm vercel:workflow:test`: 591/591 passed.
- `pnpm vercel:preview:test`: 271/271 passed.
- `pnpm vercel:production-shadow:test`: 147/147 passed.
- `pnpm vercel:versions:check` and `pnpm supply-chain:lockfile-lint`: passed.
- `pnpm quality:budgets:test`: 53/53 passed.
- `pnpm check-types`: 8/8 tasks passed.
- `pnpm ci:action-pins`, `pnpm ci:change-plan:test`, `pnpm pr:description:test`, and `pnpm adr:check --include-untracked`: passed.
- `trunk check` on all 34 changed/new files and `git diff --check`: passed.
- Independent security review found no concrete high, medium, or low defect. Candidate execution remains isolated from durable authority.
- Local official Claude Security gate: unavailable before scanning because the host Claude CLI reported `OAuth session expired and could not be refreshed`. The PR's GitHub-hosted Claude review uses its separate repository credential.

Material risks: planning depends on public npm availability and deterministic pnpm output, so registry outages or drift fail closed. PR #753 has already consumed one repair commit; this typed sync is its final automatic repair attempt. Live success still requires this PR to merge, exact-main CI and Vercel post-merge proof, then a refreshed #753 reaching exact-head ALL CLEAR with Vercel 56.5.0 intact.

## Ship Checklist

- [x] PR title follows the [conventions](https://www.notion.so/Git-Branching-and-Commit-Message-Conventions-18f66f7d06444cfcbac5725ffbc7c04a?pvs=4#9355048863c549ef92fe210a8a1298aa)
- [x] Performed a self-review of my own changes
- [x] Relevant automated checks and smoke tests pass
- [x] Architecture decision: [ADR 0007](docs/adr/0007-deterministic-protected-runtime-dependency-sync.md)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches Dependabot repair authority, protected deployment runtime, and supply-chain lock generation; mistakes could block merges or desync credentialed deploy tooling from reviewed pins.
> 
> **Overview**
> Adds a **typed `vercel-cli-runtime-sync` path** so same-major Vercel patch/minor Dependabot updates can sync the root workspace and the protected standalone CLI runtime without the generic model repair undoing the requested version.
> 
> The processor gains **`dependabot-repair-packet:v3`** with a fixed five-path allowlist (root `package.json` / lock, runtime contract, manifest, lock). It can emit a repair packet when the Dependabot target is missing from the protected runtime even with a green gate. **ALL CLEAR** now requires matching root/runtime versions plus a reachable typed repair receipt in lineage.
> 
> **`dependabot-prepare-repair.yml`** branches on `plan_kind`: Claude planning for v2, or trusted **`dependabot-protected-runtime-sync.mjs`** (double deterministic generation, independent verify, terminal candidate CLI smoke before staging). Dependabot config isolates `vercel` into dedicated groups.
> 
> **Vercel pinning** moves from hardcoded versions to **`scripts/vercel-cli-runtime/contract.json`**; the protected runtime action treats contract files as immutable and checks CLI `--version` against the contract. Preview builds still stage CLI from trusted controller source; candidate tuple is validated as data only. ADR 0007 and related docs/runbooks describe the trust boundary.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 06da7c691e59e41fef8466c38d846659158a9f32. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->