### PR TITLE
fix(dependabot): reserve Vercel update slot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,7 +18,9 @@ updates:
       # a malicious release that gets yanked days after publication.
       semver-patch-days: 7
 
-    open-pull-requests-limit: 5
+    # The five npm PRs open when the isolated Vercel lane launched exhausted
+    # the prior limit. Keep one additional slot for that dedicated rotation.
+    open-pull-requests-limit: 6
 
     labels:
       - dependencies

--- a/docs/adr/0007-deterministic-protected-runtime-dependency-sync.md
+++ b/docs/adr/0007-deterministic-protected-runtime-dependency-sync.md
@@ -141,8 +141,11 @@ lock byte from exact current-head inputs.
 - Public npm availability and deterministic pnpm output become planning inputs;
   outages or output drift stop preparation instead of falling back to a model or
   stale bytes.
-- The fixed two-Repair limit remains. PR #753 uses its existing generic repair
-  as attempt one and the typed runtime sync as attempt two.
+- The npm open-pull-request limit rises from five to six so the isolated Vercel
+  CLI group can open under the five-PR pressure observed during rollout.
+- The fixed two-Repair limit remains. Mixed generic and typed repair lineage is
+  covered by the historical PR #753 fixtures; a new isolated Vercel PR can use
+  the typed runtime sync as its first repair.
 - The runtime contract JSON becomes reviewed authority data. Stable executable
   validators still enforce its exact schema, hashes, version agreement, and
   lockfile structure.
@@ -155,5 +158,5 @@ lock byte from exact current-head inputs.
 - `pnpm vercel:workflow:test`
 - `pnpm vercel:production-shadow:test`
 - `pnpm supply-chain:lockfile-lint`
-- PR #753 live canary: a verified typed attempt-two Repair must retain Vercel
-  56.5.0 in the root and standalone runtime before exact-head ALL CLEAR.
+- Isolated Vercel live canary: a verified typed Repair must retain Vercel 56.5.0
+  in the root and standalone runtime before exact-head ALL CLEAR.

--- a/docs/dependabot-automation.md
+++ b/docs/dependabot-automation.md
@@ -43,6 +43,9 @@ Keep these properties true in code, workflows, rulesets, and operation:
   job.
 - Only one ALL CLEAR candidate occupies the lane. Keep it occupied through the
   human merge and the exact merge SHA's default-branch CI and release proof.
+- Keep the npm open-pull-request limit at six or higher. Five npm PRs were
+  already open when the isolated Vercel lane launched, so the former limit
+  prevented that rotation from reaching the processor.
 - ALL CLEAR is current evidence, not a timeless authorization. GitHub must still
   enforce current-base and ruleset state when the maintainer clicks Merge.
 

--- a/scripts/dependabot-workflows.test.mjs
+++ b/scripts/dependabot-workflows.test.mjs
@@ -185,9 +185,8 @@ test("npm group routing isolates sensitive dependencies and covers the workspace
   );
   const enumeratedGroups = ["frontend-core", "web3-stack", "ui-styling"];
   const productionMisc = npmConfig.groups["production-misc"];
-  assert.equal(
-    npmConfig["open-pull-requests-limit"],
-    6,
+  assert.ok(
+    npmConfig["open-pull-requests-limit"] >= 6,
     "the isolated Vercel CLI lane must have capacity beyond the observed five-PR pressure set",
   );
   assert.deepEqual(npmConfig.groups["vercel-cli"], {

--- a/scripts/dependabot-workflows.test.mjs
+++ b/scripts/dependabot-workflows.test.mjs
@@ -185,6 +185,11 @@ test("npm group routing isolates sensitive dependencies and covers the workspace
   );
   const enumeratedGroups = ["frontend-core", "web3-stack", "ui-styling"];
   const productionMisc = npmConfig.groups["production-misc"];
+  assert.equal(
+    npmConfig["open-pull-requests-limit"],
+    6,
+    "the isolated Vercel CLI lane must have capacity beyond the observed five-PR pressure set",
+  );
   assert.deepEqual(npmConfig.groups["vercel-cli"], {
     "applies-to": "version-updates",
     patterns: ["vercel"],


### PR DESCRIPTION
## The Problem

The isolated `vercel-cli` Dependabot group could not open after #773 merged because five npm Dependabot pull requests exhausted the existing limit of five. Dependabot closed and deleted #753, split its two remaining tooling updates into #775, and left the Vercel 56.5.0 rotation without an open pull request for processor verification.

## The Solution

- Raise the npm open-pull-request limit from five to six so the isolated Vercel rotation can enter the processor.
- Add a structural test for that capacity floor.
- Update the Dependabot runbook and ADR to record the observed capacity failure and the isolated replacement canary.

## Validation

- `pnpm dependabot:process:test` — 257 passed, 1 intentional network fixture skipped, 0 failed.
- `node --test scripts/dependabot-workflows.test.mjs` — 35 passed.
- `pnpm adr:check` — passed.
- Scoped Trunk check and `git diff --check` — passed.
- Autoreview deterministic guardrail — clean; the semantic pass found one overstatement, which was corrected before the final clean pass.
- Claude Security did not start because the local Claude authentication session was unavailable to the helper; no source was sent and this is not a scanner finding.

## Risk

This permits one additional open npm Dependabot pull request. The processor remains serialized, never merges or enables auto-merge, and still requires a maintainer merge after exact-head ALL CLEAR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only change allowing one more concurrent npm Dependabot PR; merge and processor controls are unchanged.
> 
> **Overview**
> Raises the npm **`open-pull-requests-limit`** from **5** to **6** so the isolated **`vercel-cli`** Dependabot group can open while other npm rotations already occupy five slots.
> 
> Adds a structural assertion in **`dependabot-workflows.test.mjs`** and updates the Dependabot runbook and ADR 0007 to document the capacity failure and the isolated Vercel canary expectations (including that a new isolated PR may use typed runtime sync as its first repair).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6cce4e812e0074f1b3e9a590fa1da96c27165d3. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->