### PR TITLE
fix(dependabot): admit typed Vercel runtime feedback

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -124,6 +124,12 @@ builder-key-set, override, registry, generation, or byte drift fails closed.
 Generic repairs remain exact v2 and retain every runtime/deployment deny. ALL
 CLEAR requires the requested Vercel target in both root and runtime plus its
 reachable typed operation; human squash merge remains mandatory.
+The typed operation may carry exact Cursor runtime-mismatch threads only when
+each structured finding names the same source and target versions, the root
+`package.json` path, and the trusted seed or current review commit. Every other
+unresolved finding stays manual. The packet binds each accepted comment and
+body digest. Finalize replies and resolves it only after the typed Repair
+receipt, complete green gates, and clean exact-head re-review.
 PR preview workers validate the candidate runtime tuple only as data; every
 credentialed preview build still stages its CLI from the trusted default-branch
 controller. After trusted plan validation, a fresh terminal no-output job

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -294,6 +294,11 @@ the root package/lock and standalone Vercel contract, manifest, and lock. Generi
 v2 repair never gains runtime or deployment write
 authority. ALL CLEAR requires the requested target and its reachable typed
 operation. A maintainer still performs the squash merge.
+The typed operation may bind exact Cursor runtime-mismatch threads only when
+each structured finding names the same source and target versions, root
+`package.json` path, and trusted seed or current review commit. Every other
+unresolved finding stays manual. Finalize replies and resolves the bound thread
+only after the typed Repair receipt, green gates, and clean re-review.
 Preview workers validate the candidate runtime tuple only as data and continue
 to stage the credentialed build CLI from trusted default-branch controller
 source. After trusted plan validation, a fresh terminal no-output job runs the
@@ -301,8 +306,9 @@ secretless frozen standalone install and exact CLI version smoke; it can veto
 staging but cannot produce mutation authority.
 
 A valid review finding may be included in a v2 repair packet by exact
-finding/thread ID and body digest. Only after the repaired head passes its full
-gate and clean re-review may finalize post
+finding/thread ID and body digest. The exact typed Vercel mismatch above can use
+the same receipt-bound remediation path in v3. Only after the repaired head
+passes its full gate and clean re-review may finalize post
 `Fixed in <current-head prefix> — <change>` and resolve those exact
 packet-bound threads. Generic github-actions or bot comments never establish
 lineage or satisfy feedback.

--- a/README.md
+++ b/README.md
@@ -430,8 +430,11 @@ when green, prepared, but automatic repair never writes `.github/**`; a failure
 that needs that surface becomes `manual-repair-required`. Sensitive
 self-reviewing Actions; workflow-policy, deployment, authentication, credential,
 or security changes; unknown metadata; force-pushed histories; human vetoes;
-unresolved feedback; and exhausted repairs remain blocked. The ALL CLEAR receipt
-keeps the dependency risk/update metadata for the human decision.
+unresolved feedback outside an exact packet-bound repair; and exhausted repairs
+remain blocked. The typed Vercel sync can bind only the structured Cursor
+runtime-mismatch finding that matches its exact versions, path, and review
+commit. The ALL CLEAR receipt keeps the dependency risk/update metadata for the
+human decision.
 
 Configure the repository-scoped Prepare App with variables
 `DEPENDABOT_PROCESSOR_PREPARE_APP_CLIENT_ID`,
@@ -463,8 +466,9 @@ The authority receipts are `Dependabot Refresh`
 old/new/base commits, workflow SHA/run/attempt, App bot identity when used, and
 operation digests. Refresh requires an old-head request plus the exact
 two-parent result and does not consume the two-repair budget. Repair requires a
-v2 Processor packet, a durable packet/plan/tree-bound intent before the exact
-ref move, and one exact-parent App commit whose GitHub verification is valid.
+v2 generic or v3 typed Processor packet, a durable packet/plan/tree-bound intent
+before the exact ref move, and one exact-parent App commit whose GitHub
+verification is valid.
 If the run fails, is cancelled, times out, needs action, or has a startup
 failure after the ref move, a checks-only recovery revalidates the exact intent
 and current head before publishing the completed receipt. Normal pre-move work

--- a/docs/adr/0007-deterministic-protected-runtime-dependency-sync.md
+++ b/docs/adr/0007-deterministic-protected-runtime-dependency-sync.md
@@ -60,6 +60,16 @@ runtime is itself the required repair. The processor cannot publish ALL CLEAR
 until the current tree reports the requested root and runtime version and its
 reachable Repair lineage contains the exact typed operation.
 
+An automated reviewer can report the incomplete runtime synchronization before
+the typed repair runs. The processor admits that feedback only when every
+actionable thread is an exact structured Cursor `Incomplete Vercel CLI runtime
+sync` finding. The finding must bind the operation's source and target versions,
+root `package.json` path, and trusted seed or current review commit. The v3
+packet binds its comment, commit, and body digest. Any different or additional
+feedback remains manual. Finalize can reply and resolve the accepted thread only
+after the typed Repair receipt, complete green gates, and clean exact-head
+re-review.
+
 The repair workflow routes v3 to trusted, model-free generator code from the
 exact default-branch workflow SHA. Planning and validation receive no App,
 provider, package, deployment, or write credential. The generator:

--- a/docs/dependabot-automation.md
+++ b/docs/dependabot-automation.md
@@ -442,6 +442,13 @@ again. Generic github-actions comments/replies, unbound bot output, or a model
 claim never satisfy feedback. Automated `Won't fix` is not permitted; that
 decision remains human.
 
+A v3 Vercel runtime sync may bind an exact Cursor thread only when its
+structured `Incomplete Vercel CLI runtime sync` finding names the operation's
+source and target versions, root `package.json` path, and trusted seed or
+current review commit. All actionable threads must match that contract. Any
+other unresolved feedback makes the typed operation manual. The completed typed
+Repair then uses the same digest-bound reply and resolution flow above.
+
 For historical Codex feedback, `Reviewed commit` binds the parent review's own
 `reviewCommitSha`, not the repaired current head. Its unresolved historical
 thread still blocks; a resolved historical thread clears. If an exact
@@ -502,9 +509,11 @@ V3 is reserved for the exact
 same-major patch/minor target, exact pnpm 10.34.4, exact current-head input
 blobs, and the fixed root/runtime manifest, lockfile, and contract output paths.
 It may carry empty failure/finding/feedback arrays because the missing typed
-runtime synchronization is the actionable invariant. Mixed v2 attempt-one and
-v3 attempt-two lineage remains valid only when every packet, Intent, commit,
-receipt, operation digest, target version, and current-tree contract matches.
+runtime synchronization is the actionable invariant. It may instead carry only
+the exact matching Cursor runtime-mismatch threads described above. Mixed v2
+attempt-one and v3 attempt-two lineage remains valid only when every packet,
+Intent, commit, receipt, operation digest, target version, and current-tree
+contract matches.
 
 ### Refresh v1
 

--- a/scripts/dependabot-processor.mjs
+++ b/scripts/dependabot-processor.mjs
@@ -688,6 +688,66 @@ function boundedFeedbackBlocker(blocker) {
   };
 }
 
+const CURSOR_FIX_LINKS_PATTERN = new RegExp(
+  [
+    '^<div><a href="https://cursor\\.com/open\\?link=[A-Za-z0-9_-]+" target="_blank" rel="noopener noreferrer">',
+    '<picture><source media="\\(prefers-color-scheme: dark\\)" srcset="https://cursor\\.com/assets/images/fix-in-cursor-dark\\.png">',
+    '<source media="\\(prefers-color-scheme: light\\)" srcset="https://cursor\\.com/assets/images/fix-in-cursor-light\\.png">',
+    '<img alt="Fix in Cursor" width="115" height="28" src="https://cursor\\.com/assets/images/fix-in-cursor-dark\\.png"></picture></a>',
+    '&nbsp;<a href="https://cursor\\.com/agents\\?link=[A-Za-z0-9_-]+" target="_blank" rel="noopener noreferrer">',
+    '<picture><source media="\\(prefers-color-scheme: dark\\)" srcset="https://cursor\\.com/assets/images/fix-in-web-dark\\.png">',
+    '<source media="\\(prefers-color-scheme: light\\)" srcset="https://cursor\\.com/assets/images/fix-in-web-light\\.png">',
+    '<img alt="Fix in Web" width="99" height="28" src="https://cursor\\.com/assets/images/fix-in-web-dark\\.png"></picture></a></div>\\n\\n\\n([\\s\\S]*)$',
+  ].join(""),
+);
+
+function exactCursorBugbotSuffix(suffix, reviewCommitSha) {
+  const locations =
+    /^<!-- BUGBOT_BUG_ID: [0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12} -->\n\n<!-- LOCATIONS START\npackage\.json#L[0-9]+(?:-L[0-9]+)?\npnpm-lock\.yaml#L[0-9]+(?:-L[0-9]+)?\nLOCATIONS END -->\n([\s\S]*)$/.exec(
+      suffix,
+    );
+  if (locations === null) return false;
+  const additionalLocation =
+    /^<details>\n<summary>Additional Locations \(1\)<\/summary>\n\n- \[`pnpm-lock\.yaml#L[0-9]+(?:-L[0-9]+)?`\]\(https:\/\/github\.com\/[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+\/blob\/([0-9a-f]{40})\/pnpm-lock\.yaml#L[0-9]+(?:-L[0-9]+)?\)\n\n<\/details>\n\n([\s\S]*)$/.exec(
+      locations[1],
+    );
+  if (
+    additionalLocation === null ||
+    additionalLocation[1] !== reviewCommitSha
+  ) {
+    return false;
+  }
+  const fixLinks = CURSOR_FIX_LINKS_PATTERN.exec(additionalLocation[2]);
+  if (fixLinks === null) return false;
+  const footer =
+    /^<sup>Reviewed by \[Cursor Bugbot\]\(https:\/\/cursor\.com\/bugbot\) for commit ([0-9a-f]{40})\. Configure \[here\]\(https:\/\/www\.cursor\.com\/dashboard\/bugbot\)\.<\/sup>\n*$/.exec(
+      fixLinks[1],
+    );
+  return footer !== null && footer[1] === reviewCommitSha;
+}
+
+function vercelCliRuntimeSyncFinding(body, reviewCommitSha) {
+  const match =
+    /^### Incomplete Vercel CLI runtime sync\n\n\*\*High Severity\*\*\n\n<!-- DESCRIPTION START -->\nRoot `vercel` is now `([^`]+)`, but `scripts\/vercel-cli-runtime` still pins `([^`]+)` and `contract\.json` still records `vercelVersion` `([^`]+)`\. `assertVercelCliRuntimeContract` requires those to match, so `check-versions` fails and protected deploy workflows keep the old CLI\.\n<!-- DESCRIPTION END -->\n\n([\s\S]*)$/.exec(
+      String(body ?? ""),
+    );
+  if (
+    match === null ||
+    match[2] !== match[3] ||
+    stableSemverParts(match[1]) === null ||
+    stableSemverParts(match[2]) === null ||
+    !SHA_PATTERN.test(reviewCommitSha ?? "") ||
+    !exactCursorBugbotSuffix(match[4], reviewCommitSha)
+  ) {
+    return null;
+  }
+  return {
+    fromVersion: match[2],
+    kind: VERCEL_CLI_RUNTIME_KIND,
+    targetVersion: match[1],
+  };
+}
+
 function boundedActionableThread({ root, thread, trustedBotEnvelope }) {
   const actor = feedbackActor(root?.actor);
   const source =
@@ -698,16 +758,22 @@ function boundedActionableThread({ root, thread, trustedBotEnvelope }) {
         : actor.login === "claude"
           ? "claude"
           : "check";
+  const path =
+    typeof thread?.path === "string" && thread.path.length <= 300
+      ? thread.path
+      : null;
+  const protectedRuntimeFinding =
+    source === "cursor" && path === "package.json"
+      ? vercelCliRuntimeSyncFinding(root?.body, root?.reviewCommitSha)
+      : null;
   return {
     bodyDigest: feedbackBodyDigest(String(root?.body ?? "")),
     line:
       Number.isSafeInteger(thread?.line) && thread.line > 0
         ? thread.line
         : null,
-    path:
-      typeof thread?.path === "string" && thread.path.length <= 300
-        ? thread.path
-        : null,
+    path,
+    ...(protectedRuntimeFinding === null ? {} : { protectedRuntimeFinding }),
     reviewCommitSha: SHA_PATTERN.test(root?.reviewCommitSha ?? "")
       ? root.reviewCommitSha
       : null,
@@ -3525,10 +3591,47 @@ function evaluateRepairAttemptGate({
   return packet;
 }
 
+function protectedRuntimeFeedbackMatchesOperation({
+  feedback,
+  headSha,
+  operation,
+}) {
+  if (feedback?.clear === true) return true;
+  if (
+    feedback?.repairable !== true ||
+    !validVercelCliRuntimeOperation(operation) ||
+    !SHA_PATTERN.test(headSha ?? "")
+  ) {
+    return false;
+  }
+  const actionableThreads = Array.isArray(feedback.actionableThreads)
+    ? feedback.actionableThreads
+    : [];
+  const allowedReviewCommits = new Set([headSha, operation.sourceSeedHeadSha]);
+  return (
+    actionableThreads.length > 0 &&
+    actionableThreads.every(
+      ({ path, protectedRuntimeFinding, reviewCommitSha, source }) =>
+        source === "cursor" &&
+        path === "package.json" &&
+        allowedReviewCommits.has(reviewCommitSha) &&
+        exactObjectKeys(protectedRuntimeFinding, [
+          "fromVersion",
+          "kind",
+          "targetVersion",
+        ]) &&
+        protectedRuntimeFinding.kind === operation.kind &&
+        protectedRuntimeFinding.fromVersion === operation.fromVersion &&
+        protectedRuntimeFinding.targetVersion === operation.targetVersion,
+    )
+  );
+}
+
 function recommendedDisposition({
   base,
   checks,
   feedback,
+  headSha,
   identity,
   mode,
   protectedRuntimeOperation,
@@ -3576,7 +3679,16 @@ function recommendedDisposition({
   }
   if (preparing && protectedRuntimeOperation !== null) {
     if (protectedRuntimeOperation.satisfied !== true) {
-      if (feedback.repairable) return "manual-repair-required";
+      if (
+        feedback.repairable &&
+        !protectedRuntimeFeedbackMatchesOperation({
+          feedback,
+          headSha,
+          operation: protectedRuntimeOperation.operation,
+        })
+      ) {
+        return "manual-repair-required";
+      }
       if (!repairAttempts.valid || repairAttempts.currentAttempt > 2) {
         return "manual-repair-escalated";
       }
@@ -3671,7 +3783,12 @@ export function createDependabotRepairPacket(evaluation) {
     evaluation.repairAttempts?.valid !== true ||
     evaluation.repairAttempt > 2 ||
     (!isProtectedRuntimeSync && forbiddenRepairEvidence) ||
-    (isProtectedRuntimeSync && evaluation.feedback?.clear !== true) ||
+    (isProtectedRuntimeSync &&
+      !protectedRuntimeFeedbackMatchesOperation({
+        feedback: evaluation.feedback,
+        headSha: evaluation.headSha,
+        operation: protectedRuntimeOperation,
+      })) ||
     evaluation.checks.missing.length > 0 ||
     evaluation.checks.pending.length > 0 ||
     evaluation.checks.failures.some(
@@ -3968,6 +4085,7 @@ export function evaluateDependabotPullRequest(snapshot, options = {}) {
     base,
     checks,
     feedback,
+    headSha: pullRequest.headSha,
     identity,
     mode,
     protectedRuntimeOperation,

--- a/scripts/dependabot-processor.test.mjs
+++ b/scripts/dependabot-processor.test.mjs
@@ -326,6 +326,7 @@ function refreshReceiptCheck(
   state,
   {
     baseSha = BASE_SHA,
+    headRef = "dependabot/github_actions/github-actions-routine-123",
     headSha = state === "requested" ? HEAD_SHA : OTHER_SHA,
     id = state === "requested" ? 20_001 : 20_002,
     parentHeadSha = HEAD_SHA,
@@ -337,7 +338,7 @@ function refreshReceiptCheck(
 ) {
   const requested = {
     baseSha,
-    headRef: "dependabot/github_actions/github-actions-routine-123",
+    headRef,
     headSha: null,
     parentHeadSha,
     prepareAppSlug: PREPARE_ACTOR.appSlug,
@@ -458,6 +459,10 @@ function toolingBody({
     .join("\n")}`;
 }
 
+function vercelCliBody({ vercelFrom = "56.4.1", vercelTo = "56.5.0" } = {}) {
+  return `Bumps the vercel-cli group with 1 update:\n\n| Package | From | To |\n| --- | --- | --- |\n| [vercel](https://www.npmjs.com/package/vercel) | \`${vercelFrom}\` | \`${vercelTo}\` |`;
+}
+
 function vercelMetadata({
   duplicateVercel = false,
   group = "tooling",
@@ -476,6 +481,29 @@ function vercelMetadata({
   return {
     ...parsed,
     dependencyGroup: group,
+    immutableEvidence: {
+      currentHeadMatches: true,
+      dependencyMetadataValid: parsed.groupedUpdateIntegrity.valid,
+      seedCommitSha: HEAD_SHA,
+      seedCommitTrusted: true,
+      source: "dependabot-commit-message",
+      valid: true,
+    },
+  };
+}
+
+function vercelCliMetadata({
+  vercelFrom = "56.4.1",
+  vercelTo = "56.5.0",
+} = {}) {
+  const body = vercelCliBody({ vercelFrom, vercelTo });
+  const parsed = parseDependabotMetadata({
+    body,
+    files: ["package.json", "pnpm-lock.yaml"],
+    headRef: "dependabot/npm_and_yarn/vercel-cli-986014f9a1",
+  });
+  return {
+    ...parsed,
     immutableEvidence: {
       currentHeadMatches: true,
       dependencyMetadataValid: parsed.groupedUpdateIntegrity.valid,
@@ -510,21 +538,26 @@ function preparedCommit(sha, parent) {
 }
 
 function vercelSnapshot({
+  body = toolingBody(),
+  changedPaths = [
+    "package.json",
+    "packages/eslint-config/package.json",
+    "pnpm-lock.yaml",
+  ],
   commits,
+  contractVersion,
+  headRef = "dependabot/npm_and_yarn/tooling-31c5cf6265",
   headSha = HEAD_SHA,
   metadata = vercelMetadata(),
   protectedVersion = "56.4.1",
   repairHistoryChecks,
+  rootVersion,
+  runtimeVersion,
 } = {}) {
   const expectedBlobs = vercelExpectedBlobs();
   const expectedByPath = new Map(
     expectedBlobs.map((entry) => [entry.path, entry]),
   );
-  const changedPaths = [
-    "package.json",
-    "packages/eslint-config/package.json",
-    "pnpm-lock.yaml",
-  ];
   return snapshot({
     baseAncestry: {
       aheadBy: commits?.length ?? 1,
@@ -550,13 +583,13 @@ function vercelSnapshot({
     metadata,
     protectedRuntime: {
       contractSchema: "vercel-cli-runtime-contract:v1",
-      contractVersion: protectedVersion,
+      contractVersion: contractVersion ?? protectedVersion,
       pnpmVersion: "10.34.4",
-      rootVersion: protectedVersion,
-      runtimeVersion: protectedVersion,
+      rootVersion: rootVersion ?? protectedVersion,
+      runtimeVersion: runtimeVersion ?? protectedVersion,
     },
     pullRequest: {
-      body: toolingBody(),
+      body,
       files: changedPaths.map((filename) => ({
         filename,
         mode: expectedByPath.get(filename).mode,
@@ -565,12 +598,29 @@ function vercelSnapshot({
         type: expectedByPath.get(filename).type,
       })),
       head: {
-        ref: "dependabot/npm_and_yarn/tooling-31c5cf6265",
+        ref: headRef,
         repo: { fullName: REPOSITORY },
         sha: headSha,
       },
     },
     repairHistoryChecks,
+  });
+}
+
+function vercelCliSnapshot({
+  contractVersion = "56.4.1",
+  runtimeVersion = "56.4.1",
+  ...overrides
+} = {}) {
+  return vercelSnapshot({
+    body: vercelCliBody(),
+    changedPaths: ["package.json", "pnpm-lock.yaml"],
+    contractVersion,
+    headRef: "dependabot/npm_and_yarn/vercel-cli-986014f9a1",
+    metadata: vercelCliMetadata(),
+    rootVersion: "56.5.0",
+    runtimeVersion,
+    ...overrides,
   });
 }
 
@@ -657,6 +707,44 @@ function cursorReview(commitSha = HEAD_SHA, issueCount = 1) {
     id: 21,
     state: "COMMENTED",
   };
+}
+
+function vercelRuntimeSyncCursorBody({
+  fromVersion = "56.4.1",
+  reviewCommitSha = HEAD_SHA,
+  targetVersion = "56.5.0",
+} = {}) {
+  return `### Incomplete Vercel CLI runtime sync\n\n**High Severity**\n\n<!-- DESCRIPTION START -->\nRoot \`vercel\` is now \`${targetVersion}\`, but \`scripts/vercel-cli-runtime\` still pins \`${fromVersion}\` and \`contract.json\` still records \`vercelVersion\` \`${fromVersion}\`. \`assertVercelCliRuntimeContract\` requires those to match, so \`check-versions\` fails and protected deploy workflows keep the old CLI.\n<!-- DESCRIPTION END -->\n\n<!-- BUGBOT_BUG_ID: fbce8aba-b010-4b72-8d4a-bf6acb9ea14d -->\n\n<!-- LOCATIONS START\npackage.json#L76-L77\npnpm-lock.yaml#L221-L223\nLOCATIONS END -->\n<details>\n<summary>Additional Locations (1)</summary>\n\n- [\`pnpm-lock.yaml#L221-L223\`](https://github.com/mento-protocol/frontend-monorepo/blob/${reviewCommitSha}/pnpm-lock.yaml#L221-L223)\n\n</details>\n\n<div><a href="https://cursor.com/open?link=fixture" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/fix-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/fix-in-cursor-light.png"><img alt="Fix in Cursor" width="115" height="28" src="https://cursor.com/assets/images/fix-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?link=fixture" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/fix-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/fix-in-web-light.png"><img alt="Fix in Web" width="99" height="28" src="https://cursor.com/assets/images/fix-in-web-dark.png"></picture></a></div>\n\n\n<sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ${reviewCommitSha}. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>\n`;
+}
+
+function vercelRuntimeSyncCursorFeedback({
+  body = vercelRuntimeSyncCursorBody(),
+  path = "package.json",
+} = {}) {
+  return classifyDependabotFeedback({
+    headSha: HEAD_SHA,
+    reviews: [cursorReview()],
+    threads: [
+      {
+        comments: [
+          {
+            actor: { association: "NONE", login: "cursor", type: "Bot" },
+            body,
+            createdAt: "2026-08-10T10:00:00Z",
+            id: 11,
+            replyToId: null,
+            reviewCommitSha: HEAD_SHA,
+            reviewId: 21,
+          },
+        ],
+        id: "thread-vercel-runtime-sync",
+        line: 77,
+        outdated: false,
+        path,
+        resolved: false,
+      },
+    ],
+  });
 }
 
 function codexReviewBody(headSha = HEAD_SHA) {
@@ -2634,6 +2722,35 @@ test("feedback classifier binds Cursor summaries to actionable inline roots and 
   assert.match(result.blockers[0].bodyDigest, /^[0-9a-f]{64}$/);
 });
 
+test("feedback classifier recognizes only the exact Cursor Vercel runtime mismatch", () => {
+  const exact = vercelRuntimeSyncCursorFeedback();
+  assert.deepEqual(exact.actionableThreads[0].protectedRuntimeFinding, {
+    fromVersion: "56.4.1",
+    kind: "vercel-cli-runtime-sync",
+    targetVersion: "56.5.0",
+  });
+  for (const feedback of [
+    vercelRuntimeSyncCursorFeedback({ path: "pnpm-lock.yaml" }),
+    vercelRuntimeSyncCursorFeedback({
+      body: vercelRuntimeSyncCursorBody().replace(
+        "protected deploy workflows keep the old CLI",
+        "a different problem remains",
+      ),
+    }),
+    vercelRuntimeSyncCursorFeedback({
+      body: `${vercelRuntimeSyncCursorBody()}\n### Another actionable concern`,
+    }),
+    vercelRuntimeSyncCursorFeedback({
+      body: vercelRuntimeSyncCursorBody({ reviewCommitSha: OTHER_SHA }),
+    }),
+  ]) {
+    assert.equal(
+      "protectedRuntimeFinding" in feedback.actionableThreads[0],
+      false,
+    );
+  }
+});
+
 test("resolved current-head roots clear only with the exact repository reply formats", () => {
   const root = {
     actor: { association: "NONE", login: "cursor", type: "Bot" },
@@ -3427,6 +3544,263 @@ test("a green #753-like legacy repair requires a typed Vercel runtime sync", () 
   assert.equal(
     alignedWithoutProof.repairPacket?.schema,
     DEPENDABOT_PROTECTED_RUNTIME_REPAIR_PACKET_SCHEMA,
+  );
+});
+
+test("the exact Cursor runtime mismatch is packet-bound to the typed Vercel sync", () => {
+  const evaluateWithFeedback = (feedback) => {
+    const candidate = vercelCliSnapshot();
+    candidate.feedback = { ...candidate.feedback, ...feedback };
+    return evaluateDependabotPullRequest(candidate, {
+      mode: "prepare",
+      repository: REPOSITORY,
+      workflowContext: WORKFLOW_CONTEXT,
+    });
+  };
+
+  const exact = evaluateWithFeedback(vercelRuntimeSyncCursorFeedback());
+  assert.equal(exact.disposition, "repair-required");
+  assert.equal(
+    exact.repairPacket?.schema,
+    DEPENDABOT_PROTECTED_RUNTIME_REPAIR_PACKET_SCHEMA,
+  );
+  assert.deepEqual(exact.repairPacket?.feedbackThreads, [
+    {
+      commentId: 11,
+      commitSha: HEAD_SHA,
+      digest: exact.feedback.actionableThreads[0].bodyDigest,
+      line: 77,
+      path: "package.json",
+      source: "cursor",
+      threadId: "thread-vercel-runtime-sync",
+    },
+  ]);
+
+  const wrongSource = structuredClone(vercelRuntimeSyncCursorFeedback());
+  wrongSource.actionableThreads[0].source = "claude";
+  const wrongCommit = structuredClone(vercelRuntimeSyncCursorFeedback());
+  wrongCommit.actionableThreads[0].reviewCommitSha = OTHER_SHA;
+  for (const feedback of [
+    vercelRuntimeSyncCursorFeedback({
+      body: vercelRuntimeSyncCursorBody({ targetVersion: "56.5.1" }),
+    }),
+    vercelRuntimeSyncCursorFeedback({
+      body: "### Different package.json finding",
+    }),
+    wrongSource,
+    wrongCommit,
+  ]) {
+    const blocked = evaluateWithFeedback(feedback);
+    assert.equal(blocked.disposition, "manual-repair-required");
+    assert.equal(blocked.repairPacket, null);
+  }
+});
+
+test("typed Vercel sync fails closed when another actionable thread is present", () => {
+  const mixedFeedback = classifyDependabotFeedback({
+    headSha: HEAD_SHA,
+    reviews: [cursorReview(HEAD_SHA, 2)],
+    threads: [
+      {
+        comments: [
+          {
+            actor: { association: "NONE", login: "cursor", type: "Bot" },
+            body: vercelRuntimeSyncCursorBody(),
+            createdAt: "2026-08-10T10:00:00Z",
+            id: 11,
+            replyToId: null,
+            reviewCommitSha: HEAD_SHA,
+            reviewId: 21,
+          },
+        ],
+        id: "thread-vercel-runtime-sync",
+        line: 77,
+        outdated: false,
+        path: "package.json",
+        resolved: false,
+      },
+      {
+        comments: [
+          {
+            actor: { association: "NONE", login: "cursor", type: "Bot" },
+            body: "### Unrelated package.json finding",
+            createdAt: "2026-08-10T10:01:00Z",
+            id: 12,
+            replyToId: null,
+            reviewCommitSha: HEAD_SHA,
+            reviewId: 21,
+          },
+        ],
+        id: "thread-unrelated-finding",
+        line: 78,
+        outdated: false,
+        path: "package.json",
+        resolved: false,
+      },
+    ],
+  });
+  const candidate = vercelCliSnapshot();
+  candidate.feedback = { ...candidate.feedback, ...mixedFeedback };
+
+  const result = evaluateDependabotPullRequest(candidate, {
+    mode: "prepare",
+    repository: REPOSITORY,
+    workflowContext: WORKFLOW_CONTEXT,
+  });
+
+  assert.equal(result.feedback.actionableThreadCount, 2);
+  assert.equal(result.disposition, "manual-repair-required");
+  assert.equal(result.repairPacket, null);
+});
+
+test("typed Vercel sync remediates its seed-bound Cursor thread after refresh", async () => {
+  const headRef = "dependabot/npm_and_yarn/vercel-cli-986014f9a1";
+  const requestCheck = refreshReceiptCheck("requested", { headRef });
+  const completedCheck = refreshReceiptCheck("completed", { headRef });
+  const sourceFeedback = vercelRuntimeSyncCursorFeedback();
+  const refreshed = vercelCliSnapshot({
+    commits: [
+      {
+        authorLogin: "dependabot[bot]",
+        committerLogin: "dependabot[bot]",
+        sha: HEAD_SHA,
+        verified: true,
+      },
+      {
+        authorId: PREPARE_ACTOR.botId,
+        authorLogin: PREPARE_ACTOR.botLogin,
+        authorType: "Bot",
+        ...GITHUB_SYSTEM_COMMITTER,
+        parents: [HEAD_SHA, BASE_SHA],
+        sha: OTHER_SHA,
+        verified: true,
+        verificationReason: "valid",
+      },
+    ],
+    headSha: OTHER_SHA,
+    repairHistoryChecks: [requestCheck, completedCheck],
+  });
+  refreshed.feedback = { ...refreshed.feedback, ...sourceFeedback };
+
+  const unboundReview = structuredClone(refreshed);
+  unboundReview.feedback.actionableThreads[0].reviewCommitSha = SECOND_HEAD_SHA;
+  const blocked = evaluateDependabotPullRequest(unboundReview, {
+    mode: "prepare",
+    repository: REPOSITORY,
+    workflowContext: WORKFLOW_CONTEXT,
+  });
+  assert.equal(blocked.disposition, "manual-repair-required");
+  assert.equal(blocked.repairPacket, null);
+
+  const selected = evaluateDependabotPullRequest(refreshed, {
+    mode: "prepare",
+    repository: REPOSITORY,
+    workflowContext: WORKFLOW_CONTEXT,
+  });
+  assert.equal(selected.disposition, "repair-required");
+  assert.equal(
+    selected.repairPacket?.schema,
+    DEPENDABOT_PROTECTED_RUNTIME_REPAIR_PACKET_SCHEMA,
+  );
+  assert.equal(selected.repairPacket?.operation.sourceSeedHeadSha, HEAD_SHA);
+  assert.equal(selected.repairPacket?.feedbackThreads[0].commitSha, HEAD_SHA);
+
+  const packetCheck = processorRepairReceipt(1, {
+    headSha: OTHER_SHA,
+    id: 10_401,
+    packet: selected.repairPacket,
+    packetEncoding: "canonical",
+  });
+  const repairCheck = repairReceiptCheck({
+    attempt: 1,
+    headRef,
+    headSha: SECOND_HEAD_SHA,
+    id: 30_401,
+    packetDigest: rawDigest(packetCheck.outputText),
+    parentHeadSha: OTHER_SHA,
+    processorCheckId: packetCheck.id,
+  });
+  const repaired = vercelCliSnapshot({
+    commits: [
+      refreshed.commits[0],
+      refreshed.commits[1],
+      preparedCommit(SECOND_HEAD_SHA, OTHER_SHA),
+    ],
+    contractVersion: "56.5.0",
+    headSha: SECOND_HEAD_SHA,
+    repairHistoryChecks: [
+      requestCheck,
+      completedCheck,
+      packetCheck,
+      repairCheck,
+    ],
+    runtimeVersion: "56.5.0",
+  });
+  repaired.feedback = { ...repaired.feedback, ...sourceFeedback };
+
+  const remediationProbe = evaluateDependabotPullRequest(repaired, {
+    mode: "prepare",
+    repository: REPOSITORY,
+    workflowContext: WORKFLOW_CONTEXT,
+  });
+  assert.equal(
+    remediationProbe.disposition,
+    "feedback-remediation-required",
+    stableJson({
+      feedback: remediationProbe.feedback,
+      identity: remediationProbe.identity,
+      repairAttempts: remediationProbe.repairAttempts,
+    }),
+  );
+
+  const replies = [];
+  const resolved = [];
+  const result = await processDependabotSweep({
+    adapter: {
+      approvePullRequest: async () =>
+        assert.fail("feedback remediation must re-review before approval"),
+      collectPullRequestSnapshot: async () => repaired,
+      dismissPullRequestApproval: async () => {},
+      getOutstandingDependabotAutoMergeRequests: async () => [],
+      getOutstandingDependabotProcessorApprovals:
+        noOutstandingProcessorApprovals,
+      publishAllClear: async () =>
+        assert.fail("feedback remediation must not publish ALL CLEAR"),
+      publishAllClearInvalidation: async () => {},
+      publishProcessorCheck: async () => ({ id: 53_401 }),
+      replyToReviewComment: async (input) => replies.push(input),
+      resolveReviewThread: async ({ threadId }) => resolved.push(threadId),
+    },
+    input: {
+      mode: "prepare",
+      outstandingAutoMergeRequests: [],
+      pullRequests: [repaired],
+      repository: REPOSITORY,
+      workflowContext: WORKFLOW_CONTEXT,
+    },
+    phase: "finalize",
+    publishChecks: true,
+    workflowContext: WORKFLOW_CONTEXT,
+  });
+
+  assert.equal(replies.length, 1);
+  assert.equal(replies[0].commentId, 11);
+  assert.match(replies[0].body, /^Fixed in 555555555555/);
+  assert.match(
+    replies[0].body,
+    new RegExp(`packet=${rawDigest(packetCheck.outputText)}`),
+  );
+  assert.deepEqual(resolved, ["thread-vercel-runtime-sync"]);
+  assert.deepEqual(
+    result.mutations.filter(({ kind }) => kind === "feedback-remediated"),
+    [
+      {
+        headSha: SECOND_HEAD_SHA,
+        kind: "feedback-remediated",
+        pullRequestNumber: 123,
+        threadId: "thread-vercel-runtime-sync",
+      },
+    ],
   );
 });
 


### PR DESCRIPTION
## The Problem

- PR #777 contains the expected Cursor finding for an incomplete Vercel protected-runtime sync.
- The processor treats any unresolved review thread as a manual block before it can issue the deterministic v3 repair packet.
- This prevents the typed workflow from updating the protected runtime to the requested Vercel version.

## The Solution

- Recognize only the complete Cursor Bugbot body for the Vercel runtime-sync finding.
- Bind the finding to the exact source version, target version, root path, and trusted review commit.
- Permit the matching thread in the typed v3 packet.
- Reply to and resolve that exact packet-bound thread only after the Repair receipt, green gates, and clean re-review.
- Keep malformed, appended, unrelated, or additional feedback on the manual path.

## Validation

- `pnpm dependabot:process:test` — 261 passed, 1 existing opt-in fixture skipped, 0 failed.
- `node --test scripts/dependabot-processor.test.mjs` — 140 passed, 0 failed.
- `trunk check` on all seven changed files — no issues.
- `pnpm adr:check` — passed.
- Fresh-context Codex autoreview — clean after fixing one P1 trailing-content finding.
- Deterministic local autoreview — clean.
- Claude Security bridge — not run because the local Claude process could not read its macOS keychain credential. No credential workaround was used.

## Material Risk

- The Cursor body parser intentionally fails closed if Cursor changes its generated metadata or UI suffix.
- Any unmatched review feedback remains manual.

## Architecture Decision

- Updated `docs/adr/0007-deterministic-protected-runtime-dependency-sync.md` to record the exact feedback exception and its receipt-bound remediation.

## Ship Checklist

- [x] PR title follows the conventions.
- [x] Performed a self-review of my own changes.
- [x] Relevant automated checks and smoke tests pass.
- [x] Architecture decision updated: ADR 0007.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Dependabot prepare/disposition and feedback parsing on a security-sensitive controller; the strict Cursor body matcher fails closed on format drift but a bug could admit wrong threads or block valid repairs.
> 
> **Overview**
> **Unblocks the v3 `vercel-cli-runtime-sync` path** when Cursor Bugbot reports the expected “Incomplete Vercel CLI runtime sync” finding instead of treating any open review thread as a manual veto.
> 
> The processor now **parses only a fully structured Cursor comment** (title, severity, description with matching `from`/`contract` versions, `package.json` thread path, and trusted review commit in the Bugbot footer/locations). Matching threads get a **`protectedRuntimeFinding`** and can be **included in the v3 repair packet** with digest-bound `feedbackThreads`. Disposition and packet eligibility use **`protectedRuntimeFeedbackMatchesOperation`**: clear feedback still passes; otherwise **every actionable thread must match the typed operation** (versions, kind, seed/current head). Wrong path, extra findings, version skew, or unrelated threads stay **`manual-repair-required`**.
> 
> Docs (ADR 0007, runbooks, agent guides) record the same contract: finalize may reply and resolve **only** packet-bound threads after typed Repair, green gates, and clean re-review.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72574d40ab5ead57996943086083ed8c3fae8379. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->